### PR TITLE
Deprecate `spec_name` and use `name` for configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Deprecate `spec_name` in favor of `name` on database configurations
+
+    The accessors for `spec_name` on `configs_for` and `DatabaseConfig` are deprecated. Please use `name` instead.
+
+    Deprecated behavior:
+
+    ```ruby
+    db_config = ActiveRecord::Base.configs_for(env_name: "development", spec_name: "primary")
+    db_config.spec_name
+    ```
+
+    New behavior:
+
+    ```ruby
+    db_config = ActiveRecord::Base.configs_for(env_name: "development", name: "primary")
+    db_config.name
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Add additional database-specific rake tasks for multi-database users
 
     Previously, `rails db:create`, `rails db:drop`, and `rails db:migrate` were the only rails tasks that could operate on a single

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -130,12 +130,12 @@ module ActiveRecord
       def schema_migration # :nodoc:
         @schema_migration ||= begin
                                 conn = self
-                                spec_name = conn.pool.db_config.spec_name
-                                name = "#{spec_name}::SchemaMigration"
+                                name = conn.pool.db_config.name
+                                schema_migration_name = "#{name}::SchemaMigration"
 
                                 Class.new(ActiveRecord::SchemaMigration) do
-                                  define_singleton_method(:name) { name }
-                                  define_singleton_method(:to_s) { name }
+                                  define_singleton_method(:name) { schema_migration_name }
+                                  define_singleton_method(:to_s) { schema_migration_name }
 
                                   connection_handler.connection_pool_names.each do |pool_name|
                                     if conn.pool == connection_handler.retrieve_connection_pool(pool_name)

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -203,7 +203,7 @@ module ActiveRecord
     #
     #  ActiveRecord::Base.connection_db_config
     #    #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-    #      @spec_name="primary", @config={pool: 5, timeout: 5000, database: "db/development.sqlite3", adapter: "sqlite3"}>
+    #      @name="primary", @config={pool: 5, timeout: 5000, database: "db/development.sqlite3", adapter: "sqlite3"}>
     #
     # Use only for reading.
     def connection_db_config

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -43,9 +43,9 @@ module ActiveRecord
       #
       #   #<ActiveRecord::DatabaseConfigurations:0x00007fd1acbdf800 @configurations=[
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10 @env_name="development",
-      #       @spec_name="primary", @config={adapter: "sqlite3", database: "db/development.sqlite3"}>,
+      #       @name="primary", @config={adapter: "sqlite3", database: "db/development.sqlite3"}>,
       #     #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbdea90 @env_name="production",
-      #       @spec_name="primary", @config={adapter: "sqlite3", database: "db/production.sqlite3"}>
+      #       @name="primary", @config={adapter: "sqlite3", database: "db/production.sqlite3"}>
       #   ]>
       def self.configurations=(config)
         @@configurations = ActiveRecord::DatabaseConfigurations.new(config)

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -22,7 +22,7 @@ module ActiveRecord
     # Collects the configs for the environment and optionally the specification
     # name passed in. To include replica configurations pass <tt>include_replicas: true</tt>.
     #
-    # If a spec name is provided a single DatabaseConfig object will be
+    # If a name is provided a single DatabaseConfig object will be
     # returned, otherwise an array of DatabaseConfig objects will be
     # returned that corresponds with the environment and type requested.
     #
@@ -30,15 +30,20 @@ module ActiveRecord
     #
     # * <tt>env_name:</tt> The environment name. Defaults to +nil+ which will collect
     #   configs for all environments.
-    # * <tt>spec_name:</tt> The specification name (i.e. primary, animals, etc.). Defaults
+    # * <tt>name:</tt> The db name name (i.e. primary, animals, etc.). Defaults
     #   to +nil+. If no +env_name+ is specified the config for the default env and the
-    #   passed +spec_name+ will be returned.
+    #   passed +name+ will be returned.
     # * <tt>include_replicas:</tt> Determines whether to include replicas in
     #   the returned list. Most of the time we're only iterating over the write
     #   connection (i.e. migrations don't need to run for the write and read connection).
     #   Defaults to +false+.
-    def configs_for(env_name: nil, spec_name: nil, include_replicas: false)
-      env_name ||= default_env if spec_name
+    def configs_for(env_name: nil, spec_name: nil, name: nil, include_replicas: false)
+      if spec_name
+        name = spec_name
+        ActiveSupport::Deprecation.warn("The kwarg `spec_name` is deprecated in favor of `name`. `spec_name` will be removed in Rails 6.2")
+      end
+
+      env_name ||= default_env if name
       configs = env_with_configs(env_name)
 
       unless include_replicas
@@ -47,9 +52,9 @@ module ActiveRecord
         end
       end
 
-      if spec_name
+      if name
         configs.find do |db_config|
-          db_config.spec_name == spec_name
+          db_config.name == name
         end
       else
         configs
@@ -76,7 +81,7 @@ module ActiveRecord
     def find_db_config(env)
       configurations.find do |db_config|
         db_config.env_name == env.to_s ||
-          (db_config.for_current_env? && db_config.spec_name == env.to_s)
+          (db_config.for_current_env? && db_config.name == env.to_s)
       end
     end
 
@@ -86,7 +91,7 @@ module ActiveRecord
         memo.merge(db_config.env_name => db_config.configuration_hash.stringify_keys)
       end
     end
-    deprecate to_h: "You can use `ActiveRecord::Base.configurations.configs_for(env_name: 'env', spec_name: 'primary').configuration_hash` to get the configuration hashes."
+    deprecate to_h: "You can use `ActiveRecord::Base.configurations.configs_for(env_name: 'env', name: 'primary').configuration_hash` to get the configuration hashes."
 
     # Checks if the application's configurations are empty.
     #
@@ -174,8 +179,8 @@ module ActiveRecord
       end
 
       def walk_configs(env_name, config)
-        config.map do |spec_name, sub_config|
-          build_db_config_from_raw_config(env_name, spec_name.to_s, sub_config)
+        config.map do |name, sub_config|
+          build_db_config_from_raw_config(env_name, name.to_s, sub_config)
         end
       end
 
@@ -184,7 +189,7 @@ module ActiveRecord
 
         if db_config
           config = db_config.configuration_hash.dup
-          db_config = DatabaseConfigurations::HashConfig.new(db_config.env_name, db_config.spec_name, config)
+          db_config = DatabaseConfigurations::HashConfig.new(db_config.env_name, db_config.name, config)
           db_config.owner_name = pool_name.to_s
           db_config
         else
@@ -202,45 +207,45 @@ module ActiveRecord
         configs = configs_for(include_replicas: true)
 
         configs.group_by(&:env_name).map do |env, config|
-          namespaces = config.map(&:spec_name)
-          if namespaces.size > 1
-            "#{env}: #{namespaces.join(", ")}"
+          names = config.map(&:name)
+          if names.size > 1
+            "#{env}: #{names.join(", ")}"
           else
             env
           end
         end.join("\n")
       end
 
-      def build_db_config_from_raw_config(env_name, spec_name, config)
+      def build_db_config_from_raw_config(env_name, name, config)
         case config
         when String
-          build_db_config_from_string(env_name, spec_name, config)
+          build_db_config_from_string(env_name, name, config)
         when Hash
-          build_db_config_from_hash(env_name, spec_name, config.symbolize_keys)
+          build_db_config_from_hash(env_name, name, config.symbolize_keys)
         else
           raise InvalidConfigurationError, "'{ #{env_name} => #{config} }' is not a valid configuration. Expected '#{config}' to be a URL string or a Hash."
         end
       end
 
-      def build_db_config_from_string(env_name, spec_name, config)
+      def build_db_config_from_string(env_name, name, config)
         url = config
         uri = URI.parse(url)
         if uri.scheme
-          UrlConfig.new(env_name, spec_name, url)
+          UrlConfig.new(env_name, name, url)
         else
           raise InvalidConfigurationError, "'{ #{env_name} => #{config} }' is not a valid configuration. Expected '#{config}' to be a URL string or a Hash."
         end
       end
 
-      def build_db_config_from_hash(env_name, spec_name, config)
+      def build_db_config_from_hash(env_name, name, config)
         if config.has_key?(:url)
           url = config[:url]
           config_without_url = config.dup
           config_without_url.delete :url
 
-          UrlConfig.new(env_name, spec_name, url, config_without_url)
+          UrlConfig.new(env_name, name, url, config_without_url)
         else
-          HashConfig.new(env_name, spec_name, config)
+          HashConfig.new(env_name, name, config)
         end
       end
 
@@ -248,22 +253,22 @@ module ActiveRecord
         configs.map do |config|
           next config if config.is_a?(UrlConfig) || config.env_name != current_env
 
-          url_config = environment_url_config(current_env, config.spec_name, config.configuration_hash)
+          url_config = environment_url_config(current_env, config.name, config.configuration_hash)
           url_config || config
         end
       end
 
-      def environment_url_config(env, spec_name, config)
-        url = environment_value_for(spec_name)
+      def environment_url_config(env, name, config)
+        url = environment_value_for(name)
         return unless url
 
-        UrlConfig.new(env, spec_name, url, config)
+        UrlConfig.new(env, name, url, config)
       end
 
-      def environment_value_for(spec_name)
-        spec_env_key = "#{spec_name.upcase}_DATABASE_URL"
-        url = ENV[spec_env_key]
-        url ||= ENV["DATABASE_URL"] if spec_name == "primary"
+      def environment_value_for(name)
+        name_env_key = "#{name.upcase}_DATABASE_URL"
+        url = ENV[name_env_key]
+        url ||= ENV["DATABASE_URL"] if name == "primary"
         url
       end
 

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -6,12 +6,15 @@ module ActiveRecord
     # UrlConfig respectively. It will never return a DatabaseConfig object,
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
-      attr_reader :env_name, :spec_name
+      attr_reader :env_name, :name, :spec_name
+      deprecate :spec_name, "spec_name accessors are deprecated and will be removed in Rails 6.2, please use name instead."
+
       attr_accessor :owner_name
 
-      def initialize(env_name, spec_name)
+      def initialize(env_name, name)
         @env_name = env_name
-        @spec_name = spec_name
+        @name = name
+        @spec_name = name
       end
 
       def config

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -12,12 +12,12 @@ module ActiveRecord
     # Becomes:
     #
     #   #<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fd1acbded10
-    #     @env_name="development", @spec_name="primary", @config={database: "db_name"}>
+    #     @env_name="development", @name="primary", @config={database: "db_name"}>
     #
     # ==== Options
     #
     # * <tt>:env_name</tt> - The Rails environment, i.e. "development".
-    # * <tt>:spec_name</tt> - The specification name. In a standard two-tier
+    # * <tt>:name</tt> - The specification name. In a standard two-tier
     #   database configuration this will default to "primary". In a multiple
     #   database three-tier database configuration this corresponds to the name
     #   used in the second tier, for example "primary_readonly".
@@ -25,8 +25,8 @@ module ActiveRecord
     #   database adapter, name, and other important information for database
     #   connections.
     class HashConfig < DatabaseConfig
-      def initialize(env_name, spec_name, config)
-        super(env_name, spec_name)
+      def initialize(env_name, name, config)
+        super(env_name, name)
         @config = config.symbolize_keys
       end
 

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -13,14 +13,14 @@ module ActiveRecord
     # Becomes:
     #
     #   #<ActiveRecord::DatabaseConfigurations::UrlConfig:0x00007fdc3238f340
-    #     @env_name="default_env", @spec_name="primary",
+    #     @env_name="default_env", @name="primary",
     #     @config={adapter: "postgresql", database: "foo", host: "localhost"},
     #     @url="postgres://localhost/foo">
     #
     # ==== Options
     #
     # * <tt>:env_name</tt> - The Rails environment, ie "development".
-    # * <tt>:spec_name</tt> - The specification name. In a standard two-tier
+    # * <tt>:name</tt> - The specification name. In a standard two-tier
     #   database configuration this will default to "primary". In a multiple
     #   database three-tier database configuration this corresponds to the name
     #   used in the second tier, for example "primary_readonly".
@@ -31,8 +31,8 @@ module ActiveRecord
     class UrlConfig < HashConfig
       attr_reader :url
 
-      def initialize(env_name, spec_name, url, config = {})
-        super(env_name, spec_name, config)
+      def initialize(env_name, name, url, config = {})
+        super(env_name, name, config)
 
         @url = url
         @config.merge!(build_url_hash)

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -131,7 +131,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           ActiveSupport.on_load(:active_record) do
             db_config = ActiveRecord::Base.configurations.configs_for(
               env_name: Rails.env,
-              spec_name: "primary",
+              name: "primary",
             )
             filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
               "primary",

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -26,10 +26,10 @@ db_namespace = namespace :db do
       ActiveRecord::Tasks::DatabaseTasks.create_all
     end
 
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-      desc "Create #{spec_name} database for current environment"
-      task spec_name => :load_config do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Create #{name} database for current environment"
+      task name => :load_config do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Tasks::DatabaseTasks.create(db_config)
       end
     end
@@ -45,10 +45,10 @@ db_namespace = namespace :db do
       ActiveRecord::Tasks::DatabaseTasks.drop_all
     end
 
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-      desc "Drop #{spec_name} database for current environment"
-      task spec_name => [:load_config, :check_protected_environments] do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Drop #{name} database for current environment"
+      task name => [:load_config, :check_protected_environments] do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Tasks::DatabaseTasks.drop(db_config)
       end
     end
@@ -107,10 +107,10 @@ db_namespace = namespace :db do
   end
 
   namespace :migrate do
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-      desc "Migrate #{spec_name} database for current environment"
-      task spec_name => :load_config do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Migrate #{name} database for current environment"
+      task name => :load_config do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
       end
@@ -148,11 +148,11 @@ db_namespace = namespace :db do
     end
 
     namespace :up do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        task spec_name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        task name => :load_config do
           raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
 
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
 
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
@@ -182,11 +182,11 @@ db_namespace = namespace :db do
     end
 
     namespace :down do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        task spec_name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        task name => :load_config do
           raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
 
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
 
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
@@ -209,10 +209,10 @@ db_namespace = namespace :db do
     end
 
     namespace :status do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        desc "Display status of migrations for #{spec_name} database"
-        task spec_name => :load_config do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Display status of migrations for #{name} database"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.migrate_status
         end
@@ -274,10 +274,10 @@ db_namespace = namespace :db do
   end
 
   namespace :abort_if_pending_migrations do
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-      # desc "Raises an error if there are pending migrations for #{spec_name} database"
-      task spec_name => :load_config do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: spec_name)
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      # desc "Raises an error if there are pending migrations for #{name} database"
+      task name => :load_config do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Base.establish_connection(db_config)
 
         pending_migrations = ActiveRecord::Base.connection.migration_context.open.pending_migrations
@@ -287,7 +287,7 @@ db_namespace = namespace :db do
           pending_migrations.each do |pending_migration|
             puts "  %4d %s" % [pending_migration.version, pending_migration.name]
           end
-          abort %{Run `rails db:migrate:#{spec_name}` to update your database then try again.}
+          abort %{Run `rails db:migrate:#{name}` to update your database then try again.}
         end
       end
     end
@@ -310,7 +310,7 @@ db_namespace = namespace :db do
       end
 
     rescue ActiveRecord::NoDatabaseError
-      ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.name)
       ActiveRecord::Tasks::DatabaseTasks.load_schema(
         db_config,
         ActiveRecord::Base.schema_format,
@@ -404,22 +404,22 @@ db_namespace = namespace :db do
     end
 
     namespace :dump do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record for #{spec_name} database"
-        task spec_name => :load_config do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, spec_name: spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record for #{name} database"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :ruby)
-          db_namespace["schema:dump:#{spec_name}"].reenable
+          db_namespace["schema:dump:#{name}"].reenable
         end
       end
     end
 
     namespace :load do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        desc "Loads a schema.rb file into the #{spec_name} database"
-        task spec_name => :load_config do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, spec_name: spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Loads a schema.rb file into the #{name} database"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :ruby, ENV["SCHEMA"])
         end
       end
@@ -431,7 +431,7 @@ db_namespace = namespace :db do
         ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
           ActiveRecord::Base.establish_connection(db_config)
           filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
-            db_config.spec_name,
+            db_config.name,
             schema_cache_path: db_config.schema_cache_path,
           )
           ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(
@@ -445,7 +445,7 @@ db_namespace = namespace :db do
       task clear: :load_config do
         ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
           filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
-            db_config.spec_name,
+            db_config.name,
             schema_cache_path: db_config.schema_cache_path,
           )
           ActiveRecord::Tasks::DatabaseTasks.clear_schema_cache(
@@ -477,22 +477,22 @@ db_namespace = namespace :db do
     end
 
     namespace :dump do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        desc "Dumps the #{spec_name} database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
-        task spec_name => :load_config do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, spec_name: spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Dumps the #{name} database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :sql)
-          db_namespace["structure:dump:#{spec_name}"].reenable
+          db_namespace["structure:dump:#{name}"].reenable
         end
       end
     end
 
     namespace :load do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-        desc "Recreates the #{spec_name} database from the structure.sql file"
-        task spec_name => :load_config do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, spec_name: spec_name)
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Recreates the #{name} database from the structure.sql file"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :sql, ENV["SCHEMA"])
         end
       end
@@ -515,19 +515,19 @@ db_namespace = namespace :db do
       should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
       ActiveRecord::Schema.verbose = false
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
-        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :ruby)
+        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.name, :ruby)
         ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :ruby, filename)
       end
     ensure
       if should_reconnect
-        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, spec_name: "primary"))
+        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: "primary"))
       end
     end
 
     # desc "Recreate the test database from an existent structure.sql file"
     task load_structure: %w(db:test:purge) do
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
-        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.spec_name, :sql)
+        filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.name, :sql)
         ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :sql, filename)
       end
     end
@@ -546,26 +546,26 @@ db_namespace = namespace :db do
       end
     end
 
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |spec_name|
-      # desc "Recreate the #{spec_name} test database"
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      # desc "Recreate the #{name} test database"
       namespace :load do
-        task spec_name => "db:test:purge:#{spec_name}" do
+        task name => "db:test:purge:#{name}" do
           case ActiveRecord::Base.schema_format
           when :ruby
-            db_namespace["test:load_schema:#{spec_name}"].invoke
+            db_namespace["test:load_schema:#{name}"].invoke
           when :sql
-            db_namespace["test:load_structure:#{spec_name}"].invoke
+            db_namespace["test:load_structure:#{name}"].invoke
           end
         end
       end
 
-      # desc "Recreate the #{spec_name} test database from an existent schema.rb file"
+      # desc "Recreate the #{name} test database from an existent schema.rb file"
       namespace :load_schema do
-        task spec_name => "db:test:purge:#{spec_name}" do
+        task name => "db:test:purge:#{name}" do
           should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
           ActiveRecord::Schema.verbose = false
-          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(spec_name, :ruby)
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", spec_name: spec_name)
+          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(name, :ruby)
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :ruby, filename)
         ensure
           if should_reconnect
@@ -574,27 +574,27 @@ db_namespace = namespace :db do
         end
       end
 
-      # desc "Recreate the #{spec_name} test database from an existent structure.sql file"
+      # desc "Recreate the #{name} test database from an existent structure.sql file"
       namespace :load_structure do
-        task spec_name => "db:test:purge:#{spec_name}" do
-          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(spec_name, :sql)
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", spec_name: spec_name)
+        task name => "db:test:purge:#{name}" do
+          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(name, :sql)
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :sql, filename)
         end
       end
 
-      # desc "Empty the #{spec_name} test database"
+      # desc "Empty the #{name} test database"
       namespace :purge do
-        task spec_name => %w(load_config check_protected_environments) do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", spec_name: spec_name)
+        task name => %w(load_config check_protected_environments) do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
           ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
         end
       end
 
-      # desc 'Load the #{spec_name} database test schema'
+      # desc 'Load the #{name} database test schema'
       namespace :prepare do
-        task spec_name => :load_config do
-          db_namespace["test:load:#{spec_name}"].invoke
+        task name => :load_config do
+          db_namespace["test:load:#{name}"].invoke
         end
       end
     end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -106,6 +106,11 @@ module ActiveRecord
       def spec
         @spec ||= "primary"
       end
+      deprecate :spec, "spec_name accessors are deprecated and will be removed in Rails 6.2, please use name instead."
+
+      def name
+        @name ||= "primary"
+      end
 
       def seed_loader
         @seed_loader ||= Rails.application
@@ -116,9 +121,9 @@ module ActiveRecord
           @current_config = options[:config]
         else
           env_name = options[:env] || env
-          spec_name = options[:spec] || "primary"
+          name = options[:spec] || "primary"
 
-          @current_config ||= ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)&.configuration_hash
+          @current_config ||= ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)&.configuration_hash
         end
       end
       deprecate :current_config
@@ -164,7 +169,7 @@ module ActiveRecord
         return if database_configs.count == 1
 
         database_configs.each do |db_config|
-          yield db_config.spec_name
+          yield db_config.name
         end
       end
 
@@ -175,15 +180,15 @@ module ActiveRecord
           dbs_list = []
 
           db_configs.each do |db|
-            dbs_list << "#{command}:#{db.spec_name}"
+            dbs_list << "#{command}:#{db.name}"
           end
 
           raise "You're using a multiple database application. To use `#{command}` you must run the namespaced task with a VERSION. Available tasks are #{dbs_list.to_sentence}."
         end
       end
 
-      def create_current(environment = env, spec_name = nil)
-        each_current_configuration(environment, spec_name) { |db_config| create(db_config) }
+      def create_current(environment = env, name = nil)
+        each_current_configuration(environment, name) { |db_config| create(db_config) }
         ActiveRecord::Base.establish_connection(environment.to_sym)
       end
 
@@ -261,8 +266,8 @@ module ActiveRecord
         ENV["VERSION"].to_i if ENV["VERSION"] && !ENV["VERSION"].empty?
       end
 
-      def charset_current(env_name = env, spec_name = spec)
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def charset_current(env_name = env, db_name = name)
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: db_name)
         charset(db_config)
       end
 
@@ -271,8 +276,8 @@ module ActiveRecord
         database_adapter_for(db_config, *arguments).charset
       end
 
-      def collation_current(env_name = env, spec_name = spec)
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def collation_current(env_name = env, db_name = name)
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: db_name)
         collation(db_config)
       end
 
@@ -308,7 +313,7 @@ module ActiveRecord
       end
 
       def load_schema(db_config, format = ActiveRecord::Base.schema_format, file = nil) # :nodoc:
-        file ||= dump_filename(db_config.spec_name, format)
+        file ||= dump_filename(db_config.name, format)
 
         verbose_was, Migration.verbose = Migration.verbose, verbose? && ENV["VERBOSE"]
         check_schema_file(file)
@@ -329,16 +334,16 @@ module ActiveRecord
         Migration.verbose = verbose_was
       end
 
-      def schema_up_to_date?(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = nil, spec_name = nil)
+      def schema_up_to_date?(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = nil, name = nil)
         db_config = resolve_configuration(configuration)
 
-        if environment || spec_name
-          ActiveSupport::Deprecation.warn("`environment` and `spec_name` will be removed as parameters in 6.2.0, you may now pass an ActiveRecord::DatabaseConfigurations::DatabaseConfig as `configuration` instead.")
+        if environment || name
+          ActiveSupport::Deprecation.warn("`environment` and `name` will be removed as parameters in 6.2.0, you may now pass an ActiveRecord::DatabaseConfigurations::DatabaseConfig as `configuration` instead.")
         end
 
-        spec_name ||= db_config.spec_name
+        name ||= db_config.name
 
-        file ||= dump_filename(spec_name, format)
+        file ||= dump_filename(name, format)
 
         return true unless File.exist?(file)
 
@@ -348,7 +353,7 @@ module ActiveRecord
       end
 
       def reconstruct_from_schema(db_config, format = ActiveRecord::Base.schema_format, file = nil) # :nodoc:
-        file ||= dump_filename(db_config.spec_name, format)
+        file ||= dump_filename(db_config.name, format)
 
         check_schema_file(file)
 
@@ -367,7 +372,7 @@ module ActiveRecord
 
       def dump_schema(db_config, format = ActiveRecord::Base.schema_format) # :nodoc:
         require "active_record/schema_dumper"
-        filename = dump_filename(db_config.spec_name, format)
+        filename = dump_filename(db_config.name, format)
         connection = ActiveRecord::Base.connection
 
         case format
@@ -399,21 +404,21 @@ module ActiveRecord
         end
       end
 
-      def dump_filename(namespace, format = ActiveRecord::Base.schema_format)
-        filename = if namespace == "primary"
+      def dump_filename(name, format = ActiveRecord::Base.schema_format)
+        filename = if name == "primary"
           schema_file_type(format)
         else
-          "#{namespace}_#{schema_file_type(format)}"
+          "#{name}_#{schema_file_type(format)}"
         end
 
         ENV["SCHEMA"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
       end
 
-      def cache_dump_filename(namespace, schema_cache_path: nil)
-        filename = if namespace == "primary"
+      def cache_dump_filename(name, schema_cache_path: nil)
+        filename = if name == "primary"
           "schema_cache.yml"
         else
-          "#{namespace}_schema_cache.yml"
+          "#{name}_schema_cache.yml"
         end
 
         schema_cache_path || ENV["SCHEMA_CACHE"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
@@ -484,13 +489,13 @@ module ActiveRecord
           task.is_a?(String) ? task.constantize : task
         end
 
-        def each_current_configuration(environment, spec_name = nil)
+        def each_current_configuration(environment, name = nil)
           environments = [environment]
           environments << "test" if environment == "development" && !ENV["DATABASE_URL"]
 
           environments.each do |env|
             ActiveRecord::Base.configurations.configs_for(env_name: env).each do |db_config|
-              next if spec_name && spec_name != db_config.spec_name
+              next if name && name != db_config.name
 
               yield db_config
             end

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -43,7 +43,7 @@ module ActiveRecord
           return unless database = options[:database]
           config = ActiveRecord::Base.configurations.configs_for(
             env_name: Rails.env,
-            spec_name: database,
+            name: database
           )
           config&.migrations_paths
         end

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -145,7 +145,7 @@ module ActiveRecord
 
       def test_not_specifying_database_name_for_cross_database_selects
         assert_nothing_raised do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
           ActiveRecord::Base.establish_connection(db_config.configuration_hash.except(:database))
 
           config = ARTest.test_configuration_hashes

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -22,7 +22,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_bad_connection
     assert_raise ActiveRecord::NoDatabaseError do
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       configuration = db_config.configuration_hash.merge(database: "inexistent_activerecord_unittest")
       connection = ActiveRecord::Base.mysql2_connection(configuration)
       connection.drop_table "ex", if_exists: true

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -21,14 +21,14 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_database_exists_returns_false_if_database_does_not_exist
-    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
     config = db_config.configuration_hash.merge(database: "inexistent_activerecord_unittest")
     assert_not ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(config),
       "expected database to not exist"
   end
 
   def test_database_exists_returns_true_when_the_database_exists
-    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
     assert ActiveRecord::ConnectionAdapters::Mysql2Adapter.database_exists?(db_config.configuration_hash),
       "expected database #{db_config.database} to exist"
   end
@@ -248,7 +248,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_read_timeout_exception
-    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 
     ActiveRecord::Base.establish_connection(
       db_config.configuration_hash.merge("read_timeout" => 1)
@@ -281,7 +281,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_doesnt_error_when_a_use_query_is_called_while_preventing_writes
     @connection_handler.while_preventing_writes do
-      db_name = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").database
+      db_name = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").database
       assert_nil @conn.execute("USE #{db_name}")
     end
   end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
       def test_bad_connection
         assert_raise ActiveRecord::NoDatabaseError do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
           configuration = db_config.configuration_hash.merge(database: "should_not_exist-cinco-dog-db")
           connection = ActiveRecord::Base.postgresql_connection(configuration)
           connection.exec_query("SELECT 1")
@@ -32,7 +32,7 @@ module ActiveRecord
       end
 
       def test_database_exists_returns_true_when_the_database_exists
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         assert ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(db_config.configuration_hash),
           "expected database #{db_config.database} to exist"
       end
@@ -477,7 +477,7 @@ module ActiveRecord
         end
 
         def connection_without_insert_returning
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
           ActiveRecord::Base.postgresql_connection(db_config.configuration_hash.merge(insert_returning: false))
         end
     end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -36,7 +36,7 @@ module ActiveRecord
       end
 
       def test_database_exists_returns_true_when_database_exists
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         assert SQLite3Adapter.database_exists?(db_config.configuration_hash),
           "expected #{db_config.database} to exist"
       end
@@ -545,7 +545,7 @@ module ActiveRecord
       end
 
       def test_statement_closed
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         db = ::SQLite3::Database.new(db_config.database)
 
         statement = ::SQLite3::Statement.new(db,

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -106,7 +106,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
     end
 
     def with_connection(options = {})
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       conn_options = options.reverse_merge(
         database: in_memory_db? ? "file::memory:" : db_config.database
       )

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       def setup
         @handler = ConnectionHandler.new
         @owner_name = "ActiveRecord::Base"
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         @pool = @handler.establish_connection(db_config)
       end
 
@@ -28,7 +28,7 @@ module ActiveRecord
         ENV["RACK_ENV"]  = original_rack_env
       end
 
-      def test_establish_connection_uses_config_hash_with_spec_name
+      def test_establish_connection_uses_config_hash_with_name
         old_config = ActiveRecord::Base.configurations
         config = { "readonly" => { "adapter" => "sqlite3", "pool" => "5" } }
         ActiveRecord::Base.configurations = config
@@ -213,7 +213,7 @@ module ActiveRecord
         ActiveRecord::Base.configurations.configs_for.each do |db_config|
           assert_instance_of ActiveRecord::DatabaseConfigurations::HashConfig, db_config
           assert_instance_of String, db_config.env_name
-          assert_instance_of String, db_config.spec_name
+          assert_instance_of String, db_config.name
 
           db_config.configuration_hash.keys.each do |key|
             assert_instance_of Symbol, key
@@ -427,7 +427,7 @@ module ActiveRecord
           wr.binmode
 
           pid = fork do
-            config_hash = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").configuration_hash.merge(database: file.path)
+            config_hash = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash.merge(database: file.path)
             ActiveRecord::Base.establish_connection(config_hash)
 
             pid2 = fork do

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
         @rw_handler = @handlers[:writing]
         @ro_handler = @handlers[:reading]
         @owner_name = "ActiveRecord::Base"
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         @rw_pool = @handlers[:writing].establish_connection(db_config)
         @ro_pool = @handlers[:reading].establish_connection(db_config)
       end
@@ -100,11 +100,11 @@ module ActiveRecord
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
           assert_equal "db/primary.sqlite3", pool.db_config.database
-          assert_equal "default", pool.db_config.spec_name
+          assert_equal "default", pool.db_config.name
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base")
           assert_equal "db/readonly.sqlite3", pool.db_config.database
-          assert_equal "readonly", pool.db_config.spec_name
+          assert_equal "readonly", pool.db_config.name
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -19,7 +19,7 @@ module ActiveRecord
 
       def resolve_config(config, env_name = ActiveRecord::ConnectionHandling::DEFAULT_ENV.call)
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        configs.configs_for(env_name: env_name, spec_name: "primary")&.configuration_hash
+        configs.configs_for(env_name: env_name, name: "primary")&.configuration_hash
       end
 
       def resolve_db_config(spec, config)
@@ -370,7 +370,7 @@ module ActiveRecord
         }
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "primary").configuration_hash
+        actual = configs.configs_for(env_name: "default_env", name: "primary").configuration_hash
         expected = {
           adapter:  "postgresql",
           database: "foo",
@@ -381,7 +381,7 @@ module ActiveRecord
         assert_equal expected, actual
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "animals").configuration_hash
+        actual = configs.configs_for(env_name: "default_env", name: "animals").configuration_hash
         expected = { pool: 5 }
 
         assert_equal expected, actual
@@ -400,11 +400,11 @@ module ActiveRecord
         }
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "primary").configuration_hash
+        actual = configs.configs_for(env_name: "default_env", name: "primary").configuration_hash
         assert_equal "primary", actual[:database]
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
-        actual = configs.configs_for(env_name: "default_env", spec_name: "animals").configuration_hash
+        actual = configs.configs_for(env_name: "default_env", name: "animals").configuration_hash
         assert_equal "animals", actual[:database]
       ensure
         ENV.delete("PRIMARY_DATABASE_URL")

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -202,7 +202,7 @@ module ActiveRecord
         @pool.disconnect!
 
         config = @db_config.configuration_hash.merge(idle_timeout: "0.02")
-        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.spec_name, config)
+        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
 
         pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", db_config)
         @pool = ConnectionPool.new(pool_config)
@@ -230,7 +230,7 @@ module ActiveRecord
         @pool.disconnect!
 
         config = @db_config.configuration_hash.merge(idle_timeout: -5)
-        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.spec_name, config)
+        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
         pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", db_config)
         @pool = ConnectionPool.new(pool_config)
         idle_conn = @pool.checkout

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -25,22 +25,22 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_equal ["arunit"], configs.map(&:env_name)
   end
 
-  def test_configs_for_getter_with_spec_name
+  def test_configs_for_getter_with_name
     previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit2"
 
-    config = ActiveRecord::Base.configurations.configs_for(spec_name: "primary")
+    config = ActiveRecord::Base.configurations.configs_for(name: "primary")
 
     assert_equal "arunit2", config.env_name
-    assert_equal "primary", config.spec_name
+    assert_equal "primary", config.name
   ensure
     ENV["RAILS_ENV"] = previous_env
   end
 
-  def test_configs_for_getter_with_env_and_spec_name
-    config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+  def test_configs_for_getter_with_env_and_name
+    config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 
     assert_equal "arunit", config.env_name
-    assert_equal "primary", config.spec_name
+    assert_equal "primary", config.name
   end
 
   def test_default_hash_returns_config_hash_from_default_env
@@ -48,7 +48,7 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     ENV["RAILS_ENV"] = "arunit"
 
     assert_deprecated do
-      assert_equal ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").configuration_hash, ActiveRecord::Base.configurations.default_hash
+      assert_equal ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash, ActiveRecord::Base.configurations.default_hash
     end
   ensure
     ENV["RAILS_ENV"] = original_rails_env
@@ -58,7 +58,7 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     config = ActiveRecord::Base.configurations.find_db_config("arunit2")
 
     assert_equal "arunit2", config.env_name
-    assert_equal "primary", config.spec_name
+    assert_equal "primary", config.name
   end
 
   def test_to_h_turns_db_config_object_back_into_a_hash_and_is_deprecated
@@ -118,7 +118,7 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_deprecated do
       db_config = ActiveRecord::Base.configurations.fetch("arunit").first
       assert_equal "arunit", db_config.env_name
-      assert_equal "primary", db_config.spec_name
+      assert_equal "primary", db_config.name
     end
   end
 
@@ -130,7 +130,7 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
   end
 
   def test_deprecated_config_method
-    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 
     assert_equal db_config.configuration_hash.stringify_keys, assert_deprecated { db_config.config }
   end
@@ -138,6 +138,22 @@ class LegacyDatabaseConfigurationsTest < ActiveRecord::TestCase
   def test_unsupported_method_raises
     assert_raises NotImplementedError do
       ActiveRecord::Base.configurations.select { |a| a == "foo" }
+    end
+  end
+
+  def test_spec_name_in_configs_for_is_deprecated
+    assert_deprecated do
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+
+      assert_equal "primary", db_config.name
+    end
+  end
+
+  def test_spec_name_getter_is_deprecated
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+
+    assert_deprecated do
+      assert_equal "primary", db_config.spec_name
     end
   end
 end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -81,7 +81,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     }
 
     ActiveRecord::Base.connected_to(role: :reading) do
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       ActiveRecord::Base.establish_connection(db_config)
     end
 
@@ -105,7 +105,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       }
 
       ActiveRecord::Base.connected_to(role: :reading) do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         ActiveRecord::Base.establish_connection(db_config)
       end
 
@@ -446,7 +446,7 @@ class QueryCacheTest < ActiveRecord::TestCase
   def test_cache_is_available_when_using_a_not_connected_connection
     skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
     with_temporary_connection_pool do
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").dup
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").dup
       db_config.owner_name = "test2"
       ActiveRecord::Base.connection_handler.establish_connection(db_config)
       assert_not_predicate Task, :connected?
@@ -590,7 +590,7 @@ class QueryCacheTest < ActiveRecord::TestCase
       }
 
       ActiveRecord::Base.connected_to(role: :reading) do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         ActiveRecord::Base.establish_connection(db_config)
       end
 

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -58,7 +58,7 @@ module ActiveRecord
       end
 
       def test_pool_has_reaper
-        config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         pool_config = PoolConfig.new("primary", config)
         pool = ConnectionPool.new(pool_config)
 

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -458,8 +458,8 @@ module ActiveRecord
     end
 
     private
-      def config_for(env_name, spec_name)
-        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def config_for(env_name, name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)
       end
 
       def with_stubbed_configurations_establish_connection
@@ -575,8 +575,8 @@ module ActiveRecord
     end
 
     private
-      def config_for(env_name, spec_name)
-        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def config_for(env_name, name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)
       end
 
       def with_stubbed_configurations_establish_connection
@@ -766,8 +766,8 @@ module ActiveRecord
     end
 
     private
-      def config_for(env_name, spec_name)
-        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def config_for(env_name, name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)
       end
 
       def with_stubbed_configurations
@@ -867,8 +867,8 @@ module ActiveRecord
     end
 
     private
-      def config_for(env_name, spec_name)
-        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def config_for(env_name, name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)
       end
 
       def with_stubbed_configurations
@@ -1067,7 +1067,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :purge,
-        [ActiveRecord::Base.configurations.configs_for(env_name: "production", spec_name: "primary")]
+        [ActiveRecord::Base.configurations.configs_for(env_name: "production", name: "primary")]
       ) do
         assert_called_with(ActiveRecord::Base, :establish_connection, [:production]) do
           ActiveRecord::Tasks::DatabaseTasks.purge_current("production")
@@ -1087,7 +1087,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :purge,
-        [ActiveRecord::Base.configurations.configs_for(env_name: "development", spec_name: "primary")]
+        [ActiveRecord::Base.configurations.configs_for(env_name: "development", name: "primary")]
       ) do
         ActiveRecord::Tasks::DatabaseTasks.purge_all
       end
@@ -1122,7 +1122,7 @@ module ActiveRecord
         assert_operator AuthorAddress.count, :>, 0
 
         old_configurations = ActiveRecord::Base.configurations
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         configurations = { development: db_config.configuration_hash }
         ActiveRecord::Base.configurations = configurations
 
@@ -1257,8 +1257,8 @@ module ActiveRecord
     end
 
     private
-      def config_for(env_name, spec_name)
-        ActiveRecord::Base.configurations.configs_for(env_name: env_name, spec_name: spec_name)
+      def config_for(env_name, name)
+        ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: name)
       end
 
       def with_stubbed_configurations
@@ -1295,7 +1295,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :charset,
-        [ActiveRecord::Base.configurations.configs_for(env_name: "production", spec_name: "primary")]
+        [ActiveRecord::Base.configurations.configs_for(env_name: "production", name: "primary")]
       ) do
         ActiveRecord::Tasks::DatabaseTasks.charset_current("production", "primary")
       end
@@ -1328,7 +1328,7 @@ module ActiveRecord
       assert_called_with(
         ActiveRecord::Tasks::DatabaseTasks,
         :collation,
-        [ActiveRecord::Base.configurations.configs_for(env_name: "production", spec_name: "primary")]
+        [ActiveRecord::Base.configurations.configs_for(env_name: "production", name: "primary")]
       ) do
         ActiveRecord::Tasks::DatabaseTasks.collation_current("production", "primary")
       end

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -13,7 +13,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
         }
       }
 
-      base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       expected_database = "#{base_db_config.database}-2"
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
@@ -37,7 +37,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       }
 
       idx = 42
-      base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary")
+      base_db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       expected_database = "#{base_db_config.database}-#{idx}"
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
@@ -47,7 +47,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       end
 
       # Updates the database configuration
-      assert_equal expected_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", spec_name: "primary").database
+      assert_equal expected_database, ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").database
     ensure
       ActiveRecord::Base.configurations = prev_configs
       ActiveRecord::Base.establish_connection(:arunit)
@@ -65,10 +65,10 @@ class TestDatabasesTest < ActiveRecord::TestCase
       }
 
       idx = 42
-      base_configs_order = ActiveRecord::Base.configurations.configs_for(env_name: "arunit").map(&:spec_name)
+      base_configs_order = ActiveRecord::Base.configurations.configs_for(env_name: "arunit").map(&:name)
 
       ActiveRecord::Tasks::DatabaseTasks.stub(:reconstruct_from_schema, ->(db_config, _, _) {
-        assert_equal base_configs_order, ActiveRecord::Base.configurations.configs_for(env_name: "arunit").map(&:spec_name)
+        assert_equal base_configs_order, ActiveRecord::Base.configurations.configs_for(env_name: "arunit").map(&:name)
       }) do
         ActiveSupport::Testing::Parallelization.after_fork_hooks.each { |cb| cb.call(idx) }
       end

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -102,7 +102,7 @@ module Rails
       # first time around to show a consistent error message to people
       # relying on 2-level database configuration.
 
-      @db_config = configurations.configs_for(env_name: environment, spec_name: database)
+      @db_config = configurations.configs_for(env_name: environment, name: database)
 
       unless @db_config
         raise ActiveRecord::AdapterNotSpecified,

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -95,7 +95,7 @@ module Rails
 
     # The name of the database adapter for the current environment.
     property "Database adapter" do
-      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary").adapter
+      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary").adapter
     end
 
     property "Database schema version" do

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -236,8 +236,8 @@ module ApplicationTests
       orig_rails_env, Rails.env = Rails.env, "development"
       ActiveRecord::Base.establish_connection
       assert ActiveRecord::Base.connection
-      assert_match(/#{ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary").database}/, ActiveRecord::Base.connection_db_config.database)
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+      assert_match(/#{ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary").database}/, ActiveRecord::Base.connection_db_config.database)
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
       assert_match(/#{db_config.database}/, ActiveRecord::Base.connection_db_config.database)
     ensure
       ActiveRecord::Base.remove_connection

--- a/railties/test/application/initializers/hooks_test.rb
+++ b/railties/test/application/initializers/hooks_test.rb
@@ -54,7 +54,7 @@ module ApplicationTests
     test "after_initialize runs after frameworks have been initialized" do
       $activerecord_configuration = nil
       add_to_config <<-RUBY
-        config.after_initialize { $activerecord_configuration = ActiveRecord::Base.configurations.configs_for(env_name: "development", spec_name: "primary") }
+        config.after_initialize { $activerecord_configuration = ActiveRecord::Base.configurations.configs_for(env_name: "development", name: "primary") }
       RUBY
 
       require "#{app_path}/config/environment"

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -51,7 +51,7 @@ module ApplicationTests
 
       test "db:create and db:drop without database URL" do
         require "#{app_path}/config/environment"
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
         db_create_and_drop db_config.database
       end
 
@@ -333,7 +333,7 @@ module ApplicationTests
 
       test "db:migrate and db:migrate:status without database_url" do
         require "#{app_path}/config/environment"
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
         db_migrate_and_status db_config.database
       end
 
@@ -450,7 +450,7 @@ module ApplicationTests
 
       test "db:fixtures:load without database_url" do
         require "#{app_path}/config/environment"
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, spec_name: "primary")
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary")
         db_fixtures_load db_config.database
       end
 
@@ -578,7 +578,7 @@ module ApplicationTests
           require "#{app_path}/app/models/book"
           # if structure is not loaded correctly, exception would be raised
           assert_equal 0, Book.count
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", spec_name: "primary")
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: "primary")
           assert_match db_config.database, ActiveRecord::Base.connection_db_config.database
         end
       end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -154,7 +154,7 @@ module ApplicationTests
         end
       end
 
-      def db_test_prepare_spec_name(spec_name, schema_format)
+      def db_test_prepare_name(name, schema_format)
         add_to_config "config.active_record.schema_format = :#{schema_format}"
         require "#{app_path}/config/environment"
 
@@ -162,24 +162,24 @@ module ApplicationTests
           generate_models_for_animals
 
           if schema_format == "ruby"
-            dump_command = "db:schema:dump:#{spec_name}"
+            dump_command = "db:schema:dump:#{name}"
           else
-            dump_command = "db:structure:dump:#{spec_name}"
+            dump_command = "db:structure:dump:#{name}"
           end
 
-          rails("db:migrate:#{spec_name}", dump_command)
+          rails("db:migrate:#{name}", dump_command)
 
-          output = rails("db:test:prepare:#{spec_name}", "--trace")
+          output = rails("db:test:prepare:#{name}", "--trace")
           if schema_format == "ruby"
-            assert_match(/Execute db:test:load_schema:#{spec_name}/, output)
+            assert_match(/Execute db:test:load_schema:#{name}/, output)
           else
-            assert_match(/Execute db:test:load_structure:#{spec_name}/, output)
+            assert_match(/Execute db:test:load_structure:#{name}/, output)
           end
 
           ar_tables = lambda { rails("runner", "-e", "test", "p ActiveRecord::Base.connection.tables").strip }
           animals_tables = lambda { rails("runner",  "-e", "test", "p AnimalsBase.connection.tables").strip }
 
-          if spec_name == "primary"
+          if name == "primary"
             assert_equal ["schema_migrations", "ar_internal_metadata", "books"].sort, JSON.parse(ar_tables[]).sort
             assert_equal "[]", animals_tables[]
           else
@@ -249,7 +249,7 @@ module ApplicationTests
           output = rails("db:prepare")
 
           ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-            if db_config.spec_name == "primary"
+            if db_config.name == "primary"
               assert_match(/CreateBooks: migrated/, output)
             else
               assert_match(/CreateDogs: migrated/, output)
@@ -297,14 +297,14 @@ module ApplicationTests
       test "db:create and db:drop works on all databases for env" do
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-          db_create_and_drop db_config.spec_name, db_config.database
+          db_create_and_drop db_config.name, db_config.database
         end
       end
 
       test "db:create:namespace and db:drop:namespace works on specified databases" do
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-          db_create_and_drop_namespace db_config.spec_name, db_config.database
+          db_create_and_drop_namespace db_config.name, db_config.database
         end
       end
 
@@ -335,46 +335,46 @@ module ApplicationTests
         db_migrate_and_schema_dump_and_load "structure"
       end
 
-      test "db:migrate:spec_name and db:schema:dump:spec_name and db:schema:load:spec_name works for the primary database" do
+      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the primary database" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_dump_and_load_one_database("schema", "primary")
       end
 
-      test "db:migrate:spec_name and db:schema:dump:spec_name and db:schema:load:spec_name works for the animals database" do
+      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the animals database" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_dump_and_load_one_database("schema", "animals")
       end
 
-      test "db:migrate:spec_name and db:structure:dump:spec_name and db:structure:load:spec_name works for the primary database" do
+      test "db:migrate:name and db:structure:dump:name and db:structure:load:name works for the primary database" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_dump_and_load_one_database("structure", "primary")
       end
 
-      test "db:migrate:spec_name and db:structure:dump:spec_name and db:structure:load:spec_name works for the animals database" do
+      test "db:migrate:name and db:structure:dump:name and db:structure:load:name works for the animals database" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_dump_and_load_one_database("structure", "animals")
       end
 
-      test "db:test:prepare:spec_name works for the primary database with a ruby schema" do
-        db_test_prepare_spec_name("primary", "ruby")
+      test "db:test:prepare:name works for the primary database with a ruby schema" do
+        db_test_prepare_name("primary", "ruby")
       end
 
-      test "db:test:prepare:spec_name works for the animals database with a ruby schema" do
-        db_test_prepare_spec_name("animals", "ruby")
+      test "db:test:prepare:name works for the animals database with a ruby schema" do
+        db_test_prepare_name("animals", "ruby")
       end
 
-      test "db:test:prepare:spec_name works for the primary database with a sql schema" do
-        db_test_prepare_spec_name("primary", "sql")
+      test "db:test:prepare:name works for the primary database with a sql schema" do
+        db_test_prepare_name("primary", "sql")
       end
 
-      test "db:test:prepare:spec_name works for the animals database with a sql schema" do
-        db_test_prepare_spec_name("animals", "sql")
+      test "db:test:prepare:name works for the animals database with a sql schema" do
+        db_test_prepare_name("animals", "sql")
       end
 
       test "db:migrate:namespace works" do
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-          db_migrate_namespaced db_config.spec_name
+          db_migrate_namespaced db_config.name
         end
       end
 
@@ -414,8 +414,8 @@ module ApplicationTests
       test "db:migrate:status:namespace works" do
         require "#{app_path}/config/environment"
         ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).each do |db_config|
-          db_migrate_namespaced db_config.spec_name
-          db_migrate_status_namespaced db_config.spec_name
+          db_migrate_namespaced db_config.name
+          db_migrate_status_namespaced db_config.name
         end
       end
 

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -966,7 +966,7 @@ module ApplicationTests
 
           class EnvironmentTest < ActiveSupport::TestCase
             def test_environment
-              test_db = ActiveRecord::Base.configurations.configs_for(env_name: #{env.dump}, spec_name: "primary").database
+              test_db = ActiveRecord::Base.configurations.configs_for(env_name: #{env.dump}, name: "primary").database
               db_file = ActiveRecord::Base.connection_db_config.database
               assert_match(test_db, db_file)
               assert_equal #{env.dump}, ENV["RAILS_ENV"]


### PR DESCRIPTION
If anyone has a better idea that isn't spec name or namespace, let me know 😄 

cc/ @rafaelfranca @matthewd @tenderlove @seejohnrun @jhawthorn @kytrinyx 

---

I have so. many. regrets. about using `spec_name` for database
configurations and now I'm finally putting this mistake to an end.

Back when I started multi-db work I assumed that eventually
`connection_specification_name` (sometimes called `spec_name`) and
`spec_name` for configurations would one day be the same thing. After
2 years I no longer believe they will ever be the same thing.

This PR deprecates `spec_name` on database configurations in favor of
`namespace`. It's the same behavior, just a better name, or at least a
less confusing name.

`connection_specification_name` refers to the parent class name (ie
ActiveRecord::Base, AnimalsBase, etc) that holds the connection for it's
models. In some places like ConnectionHandler it shortens this to
`spec_name`, hence the major confusion.

Recently I've been working with some new folks on database stuff and
connection management and realize how confusing it was to explain that
`db_config.spec_name` was not `spec_name` and
`connection_specification_name`. Worse than that one is a symbole while
the other is a class name. This was made even more complicated by the
fact that `ActiveRecord::Base` used `primary` as the
`connection_specification_name` until #38190.

After spending 2 years with connection management I don't believe that
we can ever use the symbols from the database configs as a way to
connect the database without the class name being _somewhere_ because
a db_config does not know who it's owner class is until it's been
connected and a model has no idea what db_config belongs to it until
it's connected. The model is the only way to tie a primary/writer config
to a replica/reader config. This could change in the future but I don't
see value in adding a class name to the db_configs before connection or
telling a model what config belongs to it before connection. That would
probably break a lot of application assumptions. If we do ever end up in
that world, we can use namespace, because tbh `spec_name` and
`connection_specification_name` were always confusing to me.