### PR TITLE
Enable HashTransformKeys and HashTransformValues cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -213,6 +213,12 @@ Lint/DeprecatedClassMethods:
 Style/ParenthesesAroundCondition:
   Enabled: true
 
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Style/RedundantBegin:
   Enabled: true
 

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -928,12 +928,9 @@ module ActionMailer
       end
 
       def apply_defaults(headers)
-        default_values = self.class.default.map do |key, value|
-          [
-            key,
-            compute_default(value)
-          ]
-        end.to_h
+        default_values = self.class.default.transform_values do |value|
+          compute_default(value)
+        end
 
         headers_with_defaults = headers.reverse_merge(default_values)
         headers_with_defaults[:subject] ||= default_i18n_subject

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -178,8 +178,8 @@ module ActionDispatch
         end
 
         def requirements_for_missing_keys_check
-          @requirements_for_missing_keys_check ||= requirements.each_with_object({}) do |(key, regex), hash|
-            hash[key] = /\A#{regex}\Z/
+          @requirements_for_missing_keys_check ||= requirements.transform_values do |regex|
+            /\A#{regex}\Z/
           end
         end
 

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -158,7 +158,7 @@ module ActionDispatch
       #   # => {"session_id"=>"e29b9ea315edf98aad94cc78c34cc9b2", "foo" => "bar"}
       def update(hash)
         load_for_write!
-        @delegate.update stringify_keys(hash)
+        @delegate.update hash.stringify_keys
       end
 
       # Deletes given key from the session.
@@ -233,14 +233,8 @@ module ActionDispatch
         def load!
           id, session = @by.load_session @req
           options[:id] = id
-          @delegate.replace(stringify_keys(session))
+          @delegate.replace(session.stringify_keys)
           @loaded = true
-        end
-
-        def stringify_keys(other)
-          other.each_with_object({}) { |(key, value), hash|
-            hash[key.to_s] = value
-          }
         end
     end
   end

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -51,8 +51,8 @@ module ActionDispatch
             if params.has_key?(:tempfile)
               ActionDispatch::Http::UploadedFile.new(params)
             else
-              params.each_with_object({}) do |(key, val), new_hash|
-                new_hash[key] = normalize_encode_params(val)
+              params.transform_values do |val|
+                normalize_encode_params(val)
               end.with_indifferent_access
             end
           else

--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -425,9 +425,9 @@ module ActionView
         end
 
         def escape_units(units)
-          Hash[units.map do |k, v|
-            [k, ERB::Util.html_escape(v)]
-          end]
+          units.transform_values do |v|
+            ERB::Util.html_escape(v)
+          end
         end
 
         def wrap_with_output_safety_handling(number, raise_on_invalid, &block)

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -445,7 +445,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_default_scope_select_ignored_by_grouped_aggregations
-    assert_equal Hash[Developer.all.group_by(&:salary).map { |s, d| [s, d.count] }],
+    assert_equal Developer.all.group_by(&:salary).transform_values(&:count),
                  DeveloperWithSelect.group(:salary).count
   end
 


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/38530.

These are new in RuboCop 0.80.0, and enforce a style we already prefer for performance reasons (see df81f2e5f5df46c9c1db27530bbd301b6e23c4a7).