### PR TITLE
Avoid implying that `#results` selector will only match a `div` element in the Working with JavaScript guide

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -48,7 +48,7 @@ fetch("/test")
   });
 ```
 
-This code fetches data from "/test", and then appends the result to the `div`
+This code fetches data from "/test", and then appends the result to the element
 with an id of `results`.
 
 Rails provides quite a bit of built-in support for building web pages with this


### PR DESCRIPTION
### Summary

The sample code above this sentence uses the selector `#results` which will match any element with the `id` attribute of `results`, but the sentence was previously implying that it had to be specifically a `div` element.