### PR TITLE
Add playsinline boolean attribute to actionview tag helper

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -19,9 +19,9 @@ module ActionView
                               enabled formnovalidate hidden indeterminate inert
                               ismap itemscope loop multiple muted nohref
                               noresize noshade novalidate nowrap open
-                              pauseonexit readonly required reversed scoped
-                              seamless selected sortable truespeed typemustmatch
-                              visible).to_set
+                              pauseonexit playsinline readonly required reversed
+                              scoped seamless selected sortable truespeed
+                              typemustmatch visible).to_set
 
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map(&:to_sym))
       BOOLEAN_ATTRIBUTES.freeze

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -13,15 +13,11 @@ module ActionView
       include CaptureHelper
       include OutputSafetyHelper
 
-      BOOLEAN_ATTRIBUTES = %w(allowfullscreen async autofocus autoplay checked
-                              compact controls declare default defaultchecked
-                              defaultmuted defaultselected defer disabled
-                              enabled formnovalidate hidden indeterminate inert
-                              ismap itemscope loop multiple muted nohref
-                              noresize noshade novalidate nowrap open
-                              pauseonexit playsinline readonly required reversed
-                              scoped seamless selected sortable truespeed
-                              typemustmatch visible).to_set
+      BOOLEAN_ATTRIBUTES = %w(allowfullscreen allowpaymentrequest async autofocus
+                              autoplay checked controls default defer disabled
+                              formnovalidate hidden ismap itemscope loop multiple
+                              muted nomodule novalidate open playsinline readonly
+                              readonly required reversed selected).to_set
 
       BOOLEAN_ATTRIBUTES.merge(BOOLEAN_ATTRIBUTES.map(&:to_sym))
       BOOLEAN_ATTRIBUTES.freeze


### PR DESCRIPTION
### Summary
Up until recently we've added to the BOOLEAN_ATTRIBUTES constant as required in local projects, however, https://github.com/rails/rails/commit/25ed6627ddac95a95f1d58d3202518544cebdd35 means that is no longer possible given that it is a frozen hash. 

The list of attributes we've added has shrunken over time, and it now seems that a single value `playsinline` is missing from the constant. 

This PR adds the `playsinline` value to `ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES`