### PR TITLE
Randomize jitter

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -151,7 +151,7 @@ module ActiveJob
 
       def determine_jitter_for_delay(delay, jitter)
         return 0.0 if jitter.zero?
-        Kernel.rand(delay * jitter)
+        Kernel.rand * delay * jitter
       end
 
       def executions_for(exceptions)


### PR DESCRIPTION
### Summary:

The `jitter` option to `ActiveJob#retry_on` was added in this PR #31872 and relevant updates made in #38003 and #37923. Thanks to these changes, the thundering herd issue is taken care of.

Currently, an issue with the `jitter` option is that even when non zero jitter values are provided, the resultant wait time may not be random. This is a case for many combinations of wait types and values (some of them with default argument value combinations).

For some set of arguments provided, the jitter values fetched from `Kernel.rand` are not randomized. For instance, in the `determine_jitter_for_delay(delay, jitter)` method, when `delay * jitter` results in a value between 1 and 2, `Kernel.rand` will always be `0`. It may provide false positive to the user that a random jitter will be added to the `wait` time. And a situation may occur where there may be a possibility of thundering herd problem.

Some examples for reference,

1. With wait time,
-> `retry_on(*exceptions, jitter: 0.6)` will always result in `delay_jitter` as 0 and `wait` as 3 seconds for the first attempt after failure.

2. With exponential wait time,
-> `retry_on(*exceptions, wait: :exponentially_longer, jitter: 1.2)` will always result in `delay_jitter` as 0 and `wait` as 3 seconds for the first attempt after failure.

Also, with a positive numeric argument, `Kernel.rand` returns an integer which reduces the possible set of returned values and thus, resulting in a higher probability that a value will be repeated. Eg: `Kernel.rand(2.4)` will only have 2 possible values, 0 and 1.

### Proposed solution:

This PR attempts to pass a range to `Kernel.rand` beginning with 0 to the `jitter_multiplier`. With positive float values, the return value will be a random float number from the range.


- Includes test cases to verify random wait time when the jitter_multiplier is between 1 and 2.
- Updated relevant test cases stubbing the `Kernel.rand` method, refactored some by removing unwanted stubs for `Kernel.rand` method where jitter is falsey.


PS: This happens to be my first PR on Rails repository. Apologies if I've missed something obvious.