### PR TITLE
Generate `aria-label` in calls to `rich_text_area`

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Generate `aria-label` in calls to `rich_text_area`
+    
+    Extend the `rich_text_area` element to accept the `label: true` option to
+    generates an appropriate `aria-label` value in the same way that a call to
+    `form.label(:attribute)` would.
+
+    *Sean Doyle*
+
 *   Add method to confirm rich text content existence by adding `?` after content name.
 
     *Kyohei Toyoda*

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -46,6 +46,22 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
+
+      translate_label = options.delete("label")
+
+      if !options.key?("aria-label") && translate_label
+        aria_label ||= ActionView::Helpers::Tags::Translator.new(
+          @object,
+          @object_name,
+          @method_name,
+          scope: "helpers.label",
+        ).translate
+
+        aria_label ||= @method_name.humanize
+
+        options["aria-label"] = aria_label
+      end
+
       @template_object.rich_text_area_tag(options.delete("name"), editable_value, options)
     end
 
@@ -60,6 +76,8 @@ module ActionView::Helpers
     #
     # ==== Options
     # * <tt>:class</tt> - Defaults to "trix-content" which ensures default styling is applied.
+    # * <tt>:label</tt> - When `true`, attempts to translate the contents of the `<trix-editor>` element's
+    #                     `aria-label` attribute
     #
     # ==== Example
     #   form_with(model: @message) do |form|

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -23,6 +23,16 @@ class ActionText::FormHelperTest < ActionView::TestCase
         }
       }
     )
+
+    I18n.backend.store_translations("label",
+      helpers: {
+        label: {
+          message: {
+            title: "Story title"
+          }
+        }
+      }
+    )
   end
 
   test "form with rich text area" do
@@ -106,6 +116,38 @@ class ActionText::FormHelperTest < ActionView::TestCase
       '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
         '<input type="hidden" name="message[title]" id="message_title_trix_input_message" />' \
         '<trix-editor placeholder="Story title" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
+
+  test "form with rich text area having aria-label with locale" do
+    I18n.with_locale :label do
+      form_with model: Message.new, scope: :message do |form|
+        form.rich_text_area :title, label: true
+      end
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" />' \
+        '<trix-editor aria-label="Story title" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
+
+  test "form with rich text area label: true does not override aria-label" do
+    I18n.with_locale :label do
+      form_with model: Message.new, scope: :message do |form|
+        form.rich_text_area :title, label: true, "aria-label" => "not translated"
+      end
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" />' \
+        '<trix-editor aria-label="not translated" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
       output_buffer


### PR DESCRIPTION
Summary
===

Prior to this commit, calls to `rich_text_area` would generate
`<trix-editor>` elements that are largely inaccessible by default.

When either parent `<label>` elements or `<label
for="rich-text-field-id">` receive focus, the underlying `<trix-editor>`
elements do not receive focus in the same way that browser-default
fields like `<input>` and `<textarea>` do.

When a `<trix-editor>` that lacks an `aria-label` attribute receives
focus, accessibility tools cannot detect its appropriate label text.

The newly introduced [`fill_in_rich_text_area`][fill_in_rich_text_area]
will [resolve its `locator` argument based on an element's
`aria-label`][locator-aria-label]. This is going to be a helpful tool to
ensure that tests can add coverage in a way that depends on the presence
of the `aria-label` field.

This commit takes that idea a step further, and extends the
`rich_text_area` element to accept the `label: true` option, which
generates an appropriate `aria-label` value in the same way that a call
to `form.label(:attribute)` would.

Ideally, this generation would happen by default, but for the sake of
backwards compatibility, the behavior is opt-in instead of opt-out.

If an `aria-label` attribute is passed to the `rich_text_field`, the
`label` option is ignored.

In either case, the `label` option is never passed along to the
HTML that the `rich_text_area` generates.

[fill_in_rich_text_area]: https://github.com/rails/rails/blob/0105fd4a1ec5579fbc824c7a864794ba90351c39/actiontext/lib/action_text/system_test_helper.rb#L5-L29
[locator-aria-label]: https://github.com/rails/rails/blob/0105fd4a1ec5579fbc824c7a864794ba90351c39/actiontext/lib/action_text/system_test_helper.rb#L44