### PR TITLE
Fix callbacks types documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/callbacks.rb
+++ b/activerecord/lib/active_record/callbacks.rb
@@ -83,8 +83,8 @@ module ActiveRecord
   #
   # == Types of callbacks
   #
-  # There are four types of callbacks accepted by the callback macros: Method references (symbol), callback objects,
-  # inline methods (using a proc). Method references and callback objects
+  # There are three types of callbacks accepted by the callback macros: Method references (symbol), callback objects,
+  # and inline methods (using a proc). Method references and callback objects
   # are the recommended approaches, inline methods using a proc are sometimes appropriate (such as for
   # creating mix-ins).
   #


### PR DESCRIPTION
There are three types of callbacks accepted, not four.
Inline eval methods (using a string) was removed but the count wasn't updated.  https://github.com/rails/rails/commit/c792354adcbf8c966f274915c605c6713b840548#diff-4d98b2b13d234be797fec061cdf54fc2