### PR TITLE
Add support for `if_not_exists` to indexes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add support for `if_not_exists` option for adding index.
+
+    The `add_index` method respects `if_not_exists` option. If it is set to true
+    index won't be added.
+
+    Usage:
+
+    ```
+      add_index :users, :account_id, if_not_exists: true
+    ```
+
+    The `if_not_exists` option passed to `create_table` also gets propogated to indexes
+    created within that migration so that if table and its indexes exist then there is no
+    attempt to create them again.
+
+    *Prathamesh Sonpatki*
+
 *   Dump the schema or structure of a database when calling db:migrate:name
 
     In previous versions of Rails, `rails db:migrate` would dump the schema of the database. In Rails 6, that holds true (`rails db:migrate` dumps all databases' schemas), but `rails db:migrate:name` does not share that behavior.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -360,7 +360,9 @@ module ActiveRecord
       end
 
       def add_index(table_name, column_name, options = {}) #:nodoc:
-        index_name, index_type, index_columns, _, index_algorithm, index_using, comment = add_index_options(table_name, column_name, **options)
+        return if options[:if_not_exists] && index_exists?(table_name, column_name, options)
+
+        index_name, index_type, index_columns, _, _, index_algorithm, index_using, comment = add_index_options(table_name, column_name, **options)
         sql = +"CREATE #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} ON #{quote_table_name(table_name)} (#{index_columns}) #{index_algorithm}"
         execute add_sql_comment!(sql, comment)
       end
@@ -673,7 +675,7 @@ module ActiveRecord
         end
 
         def add_index_for_alter(table_name, column_name, options = {})
-          index_name, index_type, index_columns, _, index_algorithm, index_using = add_index_options(table_name, column_name, **options)
+          index_name, index_type, index_columns, _, _, index_algorithm, index_using = add_index_options(table_name, column_name, **options)
           index_algorithm[0, 0] = ", " if index_algorithm.present?
           "ADD #{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})#{index_algorithm}"
         end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -62,7 +62,7 @@ module ActiveRecord
           end
 
           def index_in_create(table_name, column_name, options)
-            index_name, index_type, index_columns, _, _, index_using, comment = @conn.add_index_options(table_name, column_name, **options)
+            index_name, index_type, index_columns, _, _, _, index_using, comment = @conn.add_index_options(table_name, column_name, **options)
             add_sql_comment!((+"#{index_type} INDEX #{quote_column_name(index_name)} #{index_using} (#{index_columns})"), comment)
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -442,8 +442,8 @@ module ActiveRecord
         end
 
         def add_index(table_name, column_name, options = {}) #:nodoc:
-          index_name, index_type, index_columns_and_opclasses, index_options, index_algorithm, index_using, comment = add_index_options(table_name, column_name, **options)
-          execute("CREATE #{index_type} INDEX #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns_and_opclasses})#{index_options}").tap do
+          index_name, index_type, index_columns_and_opclasses, index_if_not_exists_clause, index_options, index_algorithm, index_using, comment = add_index_options(table_name, column_name, **options)
+          execute("CREATE #{index_type} #{index_if_not_exists_clause} #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns_and_opclasses})#{index_options}").tap do
             execute "COMMENT ON INDEX #{quote_column_name(index_name)} IS #{quote(comment)}" if comment
           end
         end

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -61,6 +61,15 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
     expected = "CREATE  INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10)) ALGORITHM = COPY"
     assert_equal expected, add_index(:people, :last_name, length: 10, using: :btree, algorithm: :copy)
 
+    with_real_execute do
+      add_index(:people, :first_name)
+      assert index_exists?(:people, :first_name)
+
+      assert_nothing_raised do
+        add_index(:people, :first_name, if_not_exists: true)
+      end
+    end
+
     assert_raise ArgumentError do
       add_index(:people, :last_name, algorithm: :coyp)
     end

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -67,6 +67,9 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     expected = %(CREATE  INDEX  "index_people_on_last_name" ON "people"  ("last_name" NULLS FIRST))
     assert_equal expected, add_index(:people, :last_name, order: "NULLS FIRST")
 
+    expected = %(CREATE  INDEX IF NOT EXISTS  "index_people_on_last_name" ON "people"  ("last_name"))
+    assert_equal expected, add_index(:people, :last_name, if_not_exists: true)
+
     assert_raise ArgumentError do
       add_index(:people, :last_name, algorithm: :copy)
     end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -355,6 +355,16 @@ module ActiveRecord
         end
       end
 
+      def test_index_with_if_not_exists
+        with_example_table do
+          @conn.add_index "ex", "id"
+
+          assert_nothing_raised do
+            @conn.add_index "ex", "id", if_not_exists: true
+          end
+        end
+      end
+
       def test_non_unique_index
         with_example_table do
           @conn.add_index "ex", "id", name: "fun"

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -72,6 +72,14 @@ module ActiveRecord
         connection.add_index(table_name, "foo", name: good_index_name)
       end
 
+      def test_add_index_which_already_exists_does_not_raise_error
+        connection.add_index(table_name, "foo", if_not_exists: true)
+
+        assert_nothing_raised do
+          connection.add_index(table_name, "foo", if_not_exists: true)
+        end
+      end
+
       def test_internal_index_with_name_matching_database_limit
         good_index_name = "x" * connection.index_name_length
         connection.add_index(table_name, "foo", name: good_index_name, internal: true)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -155,6 +155,23 @@ class MigrationTest < ActiveRecord::TestCase
     connection.drop_table :testings, if_exists: true
   end
 
+  def test_create_table_with_indexes_and_if_not_exists_true
+    connection = Person.connection
+    connection.create_table :testings, force: true do |t|
+      t.references :people
+      t.string :foo
+    end
+
+    assert_nothing_raised do
+      connection.create_table :testings, if_not_exists: true do |t|
+        t.references :people
+        t.string :foo
+      end
+    end
+  ensure
+    connection.drop_table :testings, if_exists: true
+  end
+
   def test_create_table_with_force_true_does_not_drop_nonexisting_table
     # using a copy as we need the drop_table method to
     # continue to work for the ensure block of the test


### PR DESCRIPTION
### Summary

When we try to create a table which already exists which also adds
indexes, then the `if_not_exists` option passed to `create_table` is
not extended to indexes. So the migration results into an error if the
table and indexes already exist.
This change extends the `if_not_exists` support to `add_index` so that
if the migration tries to create a table which also has existing
indexes, error won't be raised.
Also as a side-effect individual `add_index` calls will also accept
`if_not_exists` option and respect it henceforth.


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

```
### Test

def test_create_table_with_indexes_and_if_not_exists_true
    connection = Person.connection
    connection.create_table :testings, force: true do |t|
      t.references :people
      t.string :foo
    end

    assert_nothing_raised do
      connection.create_table :testings, if_not_exists: true do |t|
        t.references :people
        t.string :foo
      end
    end
  ensure
    connection.drop_table :testings, if_exists: true
  end

### Failure

Error:
MigrationTest#test_create_table_with_indexes_and_if_not_exists_true:
ActiveRecord::StatementInvalid: SQLite3::SQLException: index index_testings_on_people_id already exists
    /Users/prathamesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sqlite3-1.4.2/lib/sqlite3/database.rb:147:in `initialize'
    /Users/prathamesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sqlite3-1.4.2/lib/sqlite3/database.rb:147:in `new'
    /Users/prathamesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sqlite3-1.4.2/lib/sqlite3/database.rb:147:in `prepare'
    /Users/prathamesh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sqlite3-1.4.2/lib/sqlite3/database.rb:193:in `execute'
    /Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:30:in `block (2 levels) in execute'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
    /Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:29:in `block in execute'
    /Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:691:in `block (2 levels) in log'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
    /Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:690:in `block in log'
    /Users/prathamesh/Projects/sources/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /Users/prathamesh/Projects/sources/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:682:in `log'
```