### PR TITLE
Set source association when setting a through association (fix for #33155)

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -71,6 +71,15 @@ module ActiveRecord
           replace_keys(record)
 
           self.target = record
+
+          through_reflection = self.reflection.active_record.reflections.values.find { |r| r.through_reflection && r.through_reflection.name == self.reflection.name }
+          if through_reflection && !through_reflection.collection?
+            through_target = record.send(through_reflection.name)
+            if through_target
+              source_target_name = through_reflection.source_reflection.name
+              owner.send("#{source_target_name}=", through_target)
+            end
+          end
         end
 
         def update_counters(by)

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "active_record/associations/set_through_association_source_target"
+
 module ActiveRecord
   module Associations
     # = Active Record Belongs To Association
     class BelongsToAssociation < SingularAssociation #:nodoc:
+      include SetThroughAssociationSourceTarget
+
       def handle_dependency
         return unless load_target
 
@@ -72,14 +76,7 @@ module ActiveRecord
 
           self.target = record
 
-          through_reflection = self.reflection.active_record.reflections.values.find { |r| r.through_reflection && r.through_reflection.name == self.reflection.name }
-          if through_reflection && !through_reflection.collection?
-            through_target = record.send(through_reflection.name)
-            if through_target
-              source_target_name = through_reflection.source_reflection.name
-              owner.send("#{source_target_name}=", through_target)
-            end
-          end
+          set_through_association_source_target(record)
         end
 
         def update_counters(by)

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -65,6 +65,15 @@ module ActiveRecord
           end
 
           self.target = record
+
+          through_reflection = self.reflection.active_record.reflections.values.find { |r| r.through_reflection && r.through_reflection.name == self.reflection.name }
+          if through_reflection
+            through_target = record.send(through_reflection.name)
+            if through_target
+              source_target_name = through_reflection.source_reflection.name
+              owner.send("#{source_target_name}=", through_target)
+            end
+          end
         end
 
         # The reason that the save param for replace is false, if for create (not just build),

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require "active_record/associations/set_through_association_source_target"
+
 module ActiveRecord
   module Associations
     # = Active Record Has One Association
     class HasOneAssociation < SingularAssociation #:nodoc:
       include ForeignAssociation
+      include SetThroughAssociationSourceTarget
+
 
       def handle_dependency
         case options[:dependent]
@@ -66,14 +70,7 @@ module ActiveRecord
 
           self.target = record
 
-          through_reflection = self.reflection.active_record.reflections.values.find { |r| r.through_reflection && r.through_reflection.name == self.reflection.name }
-          if through_reflection
-            through_target = record.send(through_reflection.name)
-            if through_target
-              source_target_name = through_reflection.source_reflection.name
-              owner.send("#{source_target_name}=", through_target)
-            end
-          end
+          set_through_association_source_target(record)
         end
 
         # The reason that the save param for replace is false, if for create (not just build),

--- a/activerecord/lib/active_record/associations/set_through_association_source_target.rb
+++ b/activerecord/lib/active_record/associations/set_through_association_source_target.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Associations
+    module SetThroughAssociationSourceTarget
+      def set_through_association_source_target(record)
+        through_reflection = self.reflection.active_record.reflections.values.find { |r|
+          r.through_reflection && r.through_reflection.name == self.reflection.name
+        }
+        if through_reflection && !through_reflection.collection?
+          through_target = record.send(through_reflection.source_reflection.name)
+          if through_target
+            target_name = through_reflection.name
+            owner.send("#{target_name}=", through_target)
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -103,6 +103,21 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal club.id, member.current_membership.club_id
   end
 
+  def test_assigning_a_belongs_to_through_record_also_assigns_the_source_record
+    # setting ids is needed here because of `self.primary_key=` in models
+    minivan = Minivan.new(name: "A minivan", minivan_id: 999)
+    dashboard = Dashboard.new(name: "A dashboard", dashboard_id: 1000)
+    speedometer = Speedometer.new(dashboard: dashboard, speedometer_id: 1001)
+
+    minivan.speedometer = speedometer
+
+    assert_equal dashboard, minivan.dashboard
+
+    minivan.save!
+    minivan.reload
+
+    assert_equal dashboard, minivan.dashboard
+  end
 
   def test_assigning_a_has_one_through_record_also_assigns_the_source_record
     club = Club.new(name: "Da Club")

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -103,6 +103,22 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal club.id, member.current_membership.club_id
   end
 
+
+  def test_assigning_a_has_one_through_record_also_assigns_the_source_record
+    club = Club.new(name: "Da Club")
+    membership = CurrentMembership.new(club: club)
+    member = Member.new(name: "Sean Griffin")
+
+    member.current_membership = membership
+
+    assert_equal club, member.club
+
+    club.save!
+    club.reload
+
+    assert_equal club, member.club
+  end
+
   def test_replace_target_record
     new_club = Club.create(name: "Marx Bros")
     @member.club = new_club


### PR DESCRIPTION
### Summary

This PR implements a fix for #33155. When setting a through association we don't set a source association, which might be confusing, because the same piece of code will return different results for a saved and unsaved record.

My take on it is to set the source association just after the through association is set.

One thing to note is that it only fixes the problem for singular associations. I think that fixing `has_many` should be also doable, but I'm not sure if that wouldn't be to big of a change as collections already work in a similar way regardless if it's a `has_many` or `has_many :through` association.

The work on this is sponsored by @PrecisionNutrition