### PR TITLE
Use tempfile when writing schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/file/atomic"
+
 module ActiveRecord
   module ConnectionAdapters
     class SchemaCache
@@ -141,7 +143,7 @@ module ActiveRecord
       def dump_to(filename)
         clear!
         connection.data_sources.each { |table| add(table) }
-        open(filename, "wb") { |f|
+        File.atomic_write(filename) { |f|
           if filename.end_with?(".dump")
             f.write(Marshal.dump(self))
           else


### PR DESCRIPTION

This avoids situations where the schema cache is read by
another process when the file is only partially written,
by first writing to a tempfile, and then renaming at the
end.
