### PR TITLE
Use type attribute in ActionView::Helpers::JavaScriptHelper#javascript_tag example

### DIFF
--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -49,10 +49,10 @@ module ActionView
       # +html_options+ may be a hash of attributes for the <tt>\<script></tt>
       # tag.
       #
-      #   javascript_tag "alert('All is good')", defer: 'defer'
+      #   javascript_tag "alert('All is good')", type: 'application/javascript'
       #
       # Returns:
-      #   <script defer="defer">
+      #   <script type="application/javascript">
       #   //<![CDATA[
       #   alert('All is good')
       #   //]]>
@@ -61,7 +61,7 @@ module ActionView
       # Instead of passing the content as an argument, you can also use a block
       # in which case, you pass your +html_options+ as the first parameter.
       #
-      #   <%= javascript_tag defer: 'defer' do -%>
+      #   <%= javascript_tag type: 'application/javascript' do -%>
       #     alert('All is good')
       #   <% end -%>
       #


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/38556

It seems `defer` is not a valid script tag attribute for inline scripts.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script