### PR TITLE
Simplify fixture resolver

### DIFF
--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -27,33 +27,16 @@ module ActionView #:nodoc:
     end
 
     private
-      def query(path, exts, _, locals, cache:)
-        regex = build_regex(path, exts)
-
-        @hash.select do |_path, _|
-          ("/" + _path).match?(regex)
-        end.map do |_path, source|
-          handler, format, variant = extract_handler_and_format_and_variant(_path)
-
-          Template.new(source, _path, handler,
-            virtual_path: path.virtual,
-            format: format,
-            variant: variant,
-            locals: locals
-          )
-        end.sort_by do |t|
-          match = ("/" + t.identifier).match(regex)
-          EXTENSIONS.keys.reverse.map do |ext|
-            if ext == :variants && exts[ext] == :any
-              match[ext].nil? ? 0 : 1
-            elsif match[ext].nil?
-              exts[ext].length
-            else
-              found = match[ext].to_sym
-              exts[ext].index(found)
-            end
-          end
+      def find_candidate_template_paths(path)
+        @hash.keys.select do |fixture|
+          fixture.start_with?(path.virtual)
+        end.map do |fixture|
+          "/#{fixture}"
         end
+      end
+
+      def source_for_template(template)
+        @hash[template[1..template.size]]
       end
   end
 


### PR DESCRIPTION
Previously FixtureResolver had a copy-pasted version of the filtering already done by OptimizedFileSystemResolver. This PR replaces this by extracting the two places actual filesystem operations into separate methods and overriding those.

It would be nice to not rely on overriding methods at all, and to extract the actual filtering into a separate, reusable class, but I don't want to do that until some other changes are made to the
filtering.

This should also make FixtureResolver much more accurate to OptimizedFileSystemResolver, by also creating and caching the UnboundTemplate classes, which de-duplicate templates.

Because it's now more accurate, this also needed to fix a bad test which it broke 😅.