### PR TITLE
Update dependency definition of the "pg" gem

### DIFF
--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -14,7 +14,7 @@ module Rails
       def gem_for_database(database = options[:database])
         case database
         when "mysql"          then ["mysql2", ["~> 0.5"]]
-        when "postgresql"     then ["pg", ["~> 1.2"]
+        when "postgresql"     then ["pg", ["~> 1.2"]]
         when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -14,7 +14,7 @@ module Rails
       def gem_for_database(database = options[:database])
         case database
         when "mysql"          then ["mysql2", ["~> 0.5"]]
-        when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
+        when "postgresql"     then ["pg", ["~> 1.2"]
         when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "frontbase"      then ["ruby-frontbase", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -558,7 +558,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcpostgresql-adapter"
     else
-      assert_gem "pg", "'>= 0.18', '< 2.0'"
+      assert_gem "pg", "'~> 1.2'"
     end
   end
 


### PR DESCRIPTION
### Summary

Update dependency definition of the "pg" gem

### Other Information

Newly created Rails apps with postgresql database selected has a definition, `gem "pg", ">= 0.18", "< 2.0"` in Gemfile. Current version of this gem as this request was written is 1.2.x. Its minimum Ruby version required is 2.2*. I propose this clearer definition to be placed this template.

* https://rubygems.org/gems/pg