### PR TITLE
Remove :rdoc Rake task in generated plugin

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   No longer include `rake rdoc` task when generating plugins.
+
+    To generate docs, use the `rdoc lib` command instead.
+
+    *Jonathan Hefner*
+
 *   Allow relative paths with trailing slashes to be passed to `rails test`.
 
     *Eugene Kenny*

--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
@@ -1,13 +1,4 @@
 require "bundler/setup"
-require "rdoc/task"
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = '<%= camelized_modules %>'
-  rdoc.options << '--line-numbers'
-  rdoc.rdoc_files.include('README.md')
-  rdoc.rdoc_files.include('lib/**/*.rb')
-end
 <% if engine? && !options[:skip_active_record] && with_dummy_app? -%>
 
 APP_RAKEFILE = File.expand_path("<%= dummy_path -%>/Rakefile", __dir__)

--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -1,4 +1,5 @@
 /.bundle/
+/doc/
 /log/*.log
 /pkg/
 /tmp/


### PR DESCRIPTION
The `rdoc lib` command produces nearly the same output as `rake rdoc`.  The `rdoc lib` command also has the benefit of being standard, whereas Rake subcommands can vary from project to project.  Since the purpose of either command is to support local development, as opposed to generating official docs for consumption by e.g. rubygems, the standard command seems preferable.

Note that the `rdoc` command outputs to the `doc/` directory by default, so this commit also adds that directory to the plugin `.gitignore` file.
