### PR TITLE
Fix AJ wrong deprecation message on `after_callbacks_if_terminated`:

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -72,7 +72,7 @@ module ActionController
 
   private
     # A hook invoked every time a before callback is halted.
-    def halted_callback_hook(filter)
+    def halted_callback_hook(filter, _)
       ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)
     end
 

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -179,7 +179,10 @@ module ActiveJob
     end
 
     private
-      def warn_against_after_callbacks_execution_deprecation(callbacks) # :nodoc:
+      def halted_callback_hook(_filter, name) # :nodoc:
+        return super unless %i(enqueue perform).include?(name.to_sym)
+        callbacks = public_send("_#{name}_callbacks")
+
         if !self.class.skip_after_callbacks_if_terminated && callbacks.any? { |c| c.kind == :after }
           ActiveSupport::Deprecation.warn(<<~EOM)
             In Rails 6.2, `after_enqueue`/`after_perform` callbacks no longer run if `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
@@ -187,6 +190,8 @@ module ActiveJob
             in the new 6.1 framework defaults initializer.
           EOM
         end
+
+        super
       end
   end
 end

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -65,8 +65,6 @@ module ActiveJob
       if successfully_enqueued
         self
       else
-        warn_against_after_callbacks_execution_deprecation(_enqueue_callbacks)
-
         if self.class.return_false_on_aborted_enqueue
           false
         else

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -43,14 +43,10 @@ module ActiveJob
       self.executions = (executions || 0) + 1
 
       deserialize_arguments_if_needed
-      successfully_performed = false
 
-      job = run_callbacks :perform do
-        perform(*arguments).tap { successfully_performed = true }
+      run_callbacks :perform do
+        perform(*arguments)
       end
-
-      warn_against_after_callbacks_execution_deprecation(_perform_callbacks) unless successfully_performed
-      job
     rescue => exception
       rescue_with_handler(exception) || raise
     end

--- a/activejob/lib/active_job/instrumentation.rb
+++ b/activejob/lib/active_job/instrumentation.rb
@@ -29,7 +29,7 @@ module ActiveJob
           "#{operation}.active_job", payload.merge(adapter: queue_adapter, job: self), &enhanced_block
       end
 
-      def halted_callback_hook(_)
+      def halted_callback_hook(*)
         super
         @_halted_callback_hook_called = true
       end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   [Breaking change] `ActiveSupport::Callbacks#halted_callback_hook` now receive a 2nd argument:
+
+    `ActiveSupport::Callbacks#halted_callback_hook` now receive the name of the callback
+    being halted as second argument.
+    This change will allow you to differentiate which callbacks halted the chain
+    and act accordingly.
+
+    ```ruby
+      class Book < ApplicationRecord
+        before_save { throw(:abort) }
+        before_create { throw(:abort) }
+
+        def halted_callback_hook(filter, callback_name)
+          Rails.logger.info("Book couldn't be #{callback_name}d")
+        end
+
+        Book.create # => "Book couldn't be created"
+        book.save # => "Book couldn't be saved"
+      end
+    ```
+
+    *Edouard Chin*
+
 *   Support `prepend` with `ActiveSupport::Concern`.
 
     Allows a module with `extend ActiveSupport::Concern` to be prepended.
@@ -14,7 +37,7 @@
           prepend Imposter
         end
 
-    Class methods are prepended to the base class, concerning is also 
+    Class methods are prepended to the base class, concerning is also
     updated: `concerning :Imposter, prepend: true do`.
 
     *Jason Karns, Elia Schito*

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -143,7 +143,7 @@ module ActiveSupport
       # A hook invoked every time a before callback is halted.
       # This can be overridden in ActiveSupport::Callbacks implementors in order
       # to provide better debugging/logging.
-      def halted_callback_hook(filter)
+      def halted_callback_hook(filter, name)
       end
 
       module Conditionals # :nodoc:
@@ -159,17 +159,17 @@ module ActiveSupport
         Environment = Struct.new(:target, :halted, :value)
 
         class Before
-          def self.build(callback_sequence, user_callback, user_conditions, chain_config, filter)
+          def self.build(callback_sequence, user_callback, user_conditions, chain_config, filter, name)
             halted_lambda = chain_config[:terminator]
 
             if user_conditions.any?
-              halting_and_conditional(callback_sequence, user_callback, user_conditions, halted_lambda, filter)
+              halting_and_conditional(callback_sequence, user_callback, user_conditions, halted_lambda, filter, name)
             else
-              halting(callback_sequence, user_callback, halted_lambda, filter)
+              halting(callback_sequence, user_callback, halted_lambda, filter, name)
             end
           end
 
-          def self.halting_and_conditional(callback_sequence, user_callback, user_conditions, halted_lambda, filter)
+          def self.halting_and_conditional(callback_sequence, user_callback, user_conditions, halted_lambda, filter, name)
             callback_sequence.before do |env|
               target = env.target
               value  = env.value
@@ -179,7 +179,7 @@ module ActiveSupport
                 result_lambda = -> { user_callback.call target, value }
                 env.halted = halted_lambda.call(target, result_lambda)
                 if env.halted
-                  target.send :halted_callback_hook, filter
+                  target.send :halted_callback_hook, filter, name
                 end
               end
 
@@ -188,7 +188,7 @@ module ActiveSupport
           end
           private_class_method :halting_and_conditional
 
-          def self.halting(callback_sequence, user_callback, halted_lambda, filter)
+          def self.halting(callback_sequence, user_callback, halted_lambda, filter, name)
             callback_sequence.before do |env|
               target = env.target
               value  = env.value
@@ -197,9 +197,8 @@ module ActiveSupport
               unless halted
                 result_lambda = -> { user_callback.call target, value }
                 env.halted = halted_lambda.call(target, result_lambda)
-
                 if env.halted
-                  target.send :halted_callback_hook, filter
+                  target.send :halted_callback_hook, filter, name
                 end
               end
 
@@ -337,7 +336,7 @@ module ActiveSupport
 
           case kind
           when :before
-            Filters::Before.build(callback_sequence, user_callback.make_lambda, user_conditions, chain_config, @filter)
+            Filters::Before.build(callback_sequence, user_callback.make_lambda, user_conditions, chain_config, @filter, name)
           when :after
             Filters::After.build(callback_sequence, user_callback.make_lambda, user_conditions, chain_config)
           when :around

--- a/activesupport/test/callbacks_test.rb
+++ b/activesupport/test/callbacks_test.rb
@@ -609,7 +609,7 @@ module CallbacksTest
       set_callback :save, :after, :third
     end
 
-    attr_reader :history, :saved, :halted
+    attr_reader :history, :saved, :halted, :callback_name
     def initialize
       @history = []
     end
@@ -639,8 +639,9 @@ module CallbacksTest
       end
     end
 
-    def halted_callback_hook(filter)
+    def halted_callback_hook(filter, name)
       @halted = filter
+      @callback_name = name
     end
   end
 
@@ -823,6 +824,7 @@ module CallbacksTest
       terminator = CallbackTerminator.new
       terminator.save
       assert_equal :second, terminator.halted
+      assert_equal :save, terminator.callback_name
     end
 
     def test_block_never_called_if_terminated

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -127,6 +127,25 @@ which formats your action accepts, i.e.
   format.any(:xml, :json) { render request.format.to_sym => @people }
 ```
 
+### `ActiveSupport::Callbacks#halted_callback_hook` now receive a second argument
+
+Active Support allows you to override the `halted_callback_hook` whenever a callback
+halts the chain. This method now receive a second argument which is the name of the callback being halted.
+If you have classes that override this method, make sure it accepts two arguments. Note that this is a breaking
+change without a prior deprecation cycle (for performance reasons).
+
+Example:
+
+```ruby
+  class Book < ApplicationRecord
+    before_save { throw(:abort) }
+    before_create { throw(:abort) }
+
+    def halted_callback_hook(filter, callback_name) # => This method now accepts 2 arguments instead of 1
+      Rails.logger.info("Book couldn't be #{callback_name}d")
+    end
+  end
+```
 
 Upgrading from Rails 5.2 to Rails 6.0
 -------------------------------------


### PR DESCRIPTION
The first commit is a feature I'm adding to ActiveSupport callbacks which I use in the second commit.

Fix AJ wrong deprecation message on `after_callbacks_if_terminated`:

- ### Problem

  In some cirumstances, the deprecation message to warn that AJ won't
  run `after_(enqueue/perform)` callbacks when the chain is halted
  by a `throw(:abort)` will be thrown even though no `throw(:abort)`
  was thrown.

  ```ruby
    run_callback(:foo) do
      ...
    end
  ```

  There is two possible way for the callback body to not be executed:

  1) `before` callback throw a `abort`
  2) `before` callback raises an error which is rescued by an
     around callback (See associated test in this commit for
     an example)

  When 2) happen we don't want to output a deprecation message,
  because what the message says isn't true and doesn't apply.

  ### Solution

  In order to differentiate between 1) and 2), I have added
  a `halted_callback_hook` which is called by ActiveSupport callback
  whenever the callback chain is halted.

cc/ @rafaelfranca @casperisfine @etiennebarrie 