### PR TITLE
Prevent schema_cache leaking connections between threads

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Prevent schema_cache leaking connections between threads
+
+    49b6b21 changed schema_cache to be per-connection-pool rather than per-connection. However, the schema_cache still maintained an internal reference to a single connection. This reference was replaced each time the schema_cache was requested, but the change would affect all threads. Under some circumstances, this resulted in multiple threads trying to use the same connection.
+
+    This change switches back to a single SchemaCache instance per connection, and also introduces a new SchemaCacheData class. A single instance of SchemaCacheData is shared between all SchemaCache instances for a pool.
+
+    *David Taylor*
+
 *   Add support for horizontal sharding to `connects_to` and `connected_to`.
 
     Applications can now connect to multiple shards and switch between their shards in an application. Note that the shard swapping is still a manual process as this change does not include an API for automatic shard swapping.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -26,7 +26,6 @@ module ActiveRecord
       end
 
       def set_schema_cache(cache)
-        # The pool's cache should not have a connection attached
         self.schema_cache = SchemaCache.new(nil, data: cache.data)
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -21,14 +21,13 @@ module ActiveRecord
 
   module ConnectionAdapters
     module AbstractPool # :nodoc:
-      def get_schema_cache(connection)
-        self.schema_cache ||= SchemaCache.new(connection)
-        schema_cache.connection = connection
-        schema_cache
+      def get_schema_cache
+        self.schema_cache ||= SchemaCache.new(nil)
       end
 
       def set_schema_cache(cache)
-        self.schema_cache = cache
+        # The pool's cache should not have a connection attached
+        self.schema_cache = SchemaCache.new(nil, data: cache.data)
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -195,11 +195,12 @@ module ActiveRecord
       end
 
       def schema_cache
-        @pool.get_schema_cache(self)
+        @schema_cache ||= SchemaCache.new(self)
+        @schema_cache.data = @pool.get_schema_cache.data
+        @schema_cache
       end
 
       def schema_cache=(cache)
-        cache.connection = self
         @pool.set_schema_cache(cache)
       end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -113,7 +113,7 @@ module ActiveRecord
 
         # We can't verify queries get executed because the database version gets
         # cached in both MySQL and PostgreSQL outside of the schema cache.
-        assert_nil cache.instance_variable_get(:@database_version)
+        assert_nil cache.data.instance_variable_get(:@database_version)
         assert_equal @database_version.to_s, cache.database_version.to_s
       end
 
@@ -158,7 +158,7 @@ module ActiveRecord
         @cache.clear!
 
         assert_equal 0, @cache.size
-        assert_nil @cache.instance_variable_get(:@database_version)
+        assert_nil @cache.data.instance_variable_get(:@database_version)
       end
 
       def test_marshal_dump_and_load

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -521,6 +521,18 @@ module ActiveRecord
         pool.checkin connection
       end
 
+      def test_concurrent_schema_cache
+        first_schema_cache = pool.connection.schema_cache
+
+        second_schema_cache = nil
+        Thread.new do
+          second_schema_cache = pool.connection.schema_cache
+        end.join
+
+        assert_not_equal first_schema_cache.connection, second_schema_cache.connection
+        assert_equal first_schema_cache.data, second_schema_cache.data
+      end
+
       def test_concurrent_connection_establishment
         assert_operator @pool.connections.size, :<=, 1
 


### PR DESCRIPTION
At Discourse, we have been seeing some unexpected behaviour in our Sidekiq worker processes, which run jobs in a multi-threaded environment. We were seeing multiple threads accessing the same database connections concurrently.

The root cause appears to be 49b6b211, which changed schema_cache to be per-pool rather than per-connection. However, the schema_cache still maintains an internal reference to a single connection. This reference [was replaced](https://github.com/rails/rails/commit/49b6b211a922f73d0b083e7e4d2f0a91bd44da90#diff-7735c67f539e7d1e2908a4d5d8909c24R25-R27) each time the schema_cache was requested, but the change would affect all threads. Under some circumstances, this can result in multiple threads trying to use the same connection.

This commit switches back to a single SchemaCache instance per connection, but also introduces a new SchemaCacheData class. A single instance of SchemaCacheData is shared between all SchemaCache instances for a pool.

cc @SamSaffron 