### PR TITLE
Remove unused argument

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -157,7 +157,7 @@ module ActiveRecord
 
         with_handler(role, &blk)
       elsif shard
-        with_shard(connection_specification_name, shard, role || current_role, prevent_writes, &blk)
+        with_shard(shard, role || current_role, prevent_writes, &blk)
       elsif role
         with_role(role, prevent_writes, &blk)
       else
@@ -303,7 +303,7 @@ module ActiveRecord
         end
       end
 
-      def with_shard(connection_specification_name, pool_key, role, prevent_writes)
+      def with_shard(pool_key, role, prevent_writes)
         old_pool_key = current_pool_key
 
         with_role(role, prevent_writes) do


### PR DESCRIPTION
This was leftover in debugging we did to support `shard` in
`connected_to`. We don't need this because `with_shard` already has
access to `connection_specification_name` because they are in the same
class.