### PR TITLE
Dumps the schema or structure of a database when calling db:migrate:name

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Dump the schema or structure of a database when calling db:migrate:name
+
+    In previous versions of Rails, `rails db:migrate` would dump the schema of the database. In Rails 6, that holds true (`rails db:migrate` dumps all databases' schemas), but `rails db:migrate:name` does not share that behavior.
+
+    Going forward, calls to `rails db:migrate:name` will dump the schema (or structure) of the database being migrated.
+
+    *Kyle Thompson*
+
 *   Reset the `ActiveRecord::Base` connection after `rails db:migrate:name`
 
     When `rails db:migrate` has finished, it ensures the `ActiveRecord::Base` connection is reset to its original configuration. Going forward, `rails db:migrate:name` will have the same behavior.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -106,6 +106,25 @@ db_namespace = namespace :db do
     db_namespace["_dump"].reenable
   end
 
+  namespace :_dump do
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false
+      task name do
+        if ActiveRecord::Base.dump_schema_after_migration
+          case ActiveRecord::Base.schema_format
+          when :ruby then db_namespace["schema:dump:#{name}"].invoke
+          when :sql  then db_namespace["structure:dump:#{name}"].invoke
+          else
+            raise "unknown schema format #{ActiveRecord::Base.schema_format}"
+          end
+        end
+        # Allow this task to be called as many times as required. An example is the
+        # migrate:redo task, which calls other two internally that depend on this one.
+        db_namespace["_dump:#{name}"].reenable
+      end
+    end
+  end
+
   namespace :migrate do
     ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
       desc "Migrate #{name} database for current environment"
@@ -114,6 +133,7 @@ db_namespace = namespace :db do
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
+        db_namespace["_dump:#{name}"].invoke
       ensure
         ActiveRecord::Base.establish_connection(original_db_config)
       end


### PR DESCRIPTION
### Summary

In previous versions of Rails, `rails db:migrate` would dump the schema of the database. In Rails 6, that holds true (`rails db:migrate` dumps all databases' schemas), but `rails db:migrate:name` does not share that behavior.

Going forward, this change would have calls to `rails db:migrate:name` dump the schema (or structure) of the database being migrated (builds on the work in #38449)