### PR TITLE
Resets the `ActiveRecord::Base` connection after `rails db:migrate:name`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Reset the `ActiveRecord::Base` connection after `rails db:migrate:name`
+
+    When `rails db:migrate` has finished, it ensures the `ActiveRecord::Base` connection is reset to its original configuration. Going forward, `rails db:migrate:name` will have the same behavior.
+
+    *Kyle Thompson*
+
 *   Disallow calling `connected_to` on subclasses of `ActiveRecord::Base`.
 
     Behavior has not changed here but the previous API could be misleading to people who thought it would switch connections for only that class. `connected_to` switches the context from which we are getting connections, not the connections themselves.

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -110,9 +110,12 @@ db_namespace = namespace :db do
     ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
       desc "Migrate #{name} database for current environment"
       task name => :load_config do
+        original_db_config = ActiveRecord::Base.connection_db_config
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
+      ensure
+        ActiveRecord::Base.establish_connection(original_db_config)
       end
     end
 

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -325,6 +325,25 @@ module ApplicationTests
         end
       end
 
+      test "db:migrate:name sets the connection back to its original state" do
+        Dir.chdir(app_path) do
+          dummy_task = <<~RUBY
+            task foo: :environment do
+              Book.first
+            end
+          RUBY
+          app_file("Rakefile", dummy_task, "a+")
+
+          generate_models_for_animals
+
+          rails("db:migrate:primary")
+
+          assert_nothing_raised do
+            rails("db:migrate:animals", "foo")
+          end
+        end
+      end
+
       test "db:migrate and db:schema:dump and db:schema:load works on all databases" do
         require "#{app_path}/config/environment"
         db_migrate_and_schema_dump_and_load "schema"


### PR DESCRIPTION
### Summary

While working on https://github.com/rails/rails/pull/38586, I noticed that there was a slight additional inconsistency in the `rails db:migrate:name` commands. While `rails db:migrate` was resetting the `ActiveRecord::Base` connection back to the original configuration, `rails db:migrate:name` was not.

With these changes, the behaviors will line up going forward.