### PR TITLE
[ci skip] Documentation: Use yml extension for locale files example

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -558,25 +558,25 @@ For example, your `config/locales` directory could look like this:
 
 ```
 |-defaults
-|---es.rb
-|---en.rb
+|---es.yml
+|---en.yml
 |-models
 |---book
-|-----es.rb
-|-----en.rb
+|-----es.yml
+|-----en.yml
 |-views
 |---defaults
-|-----es.rb
-|-----en.rb
+|-----es.yml
+|-----en.yml
 |---books
-|-----es.rb
-|-----en.rb
+|-----es.yml
+|-----en.yml
 |---users
-|-----es.rb
-|-----en.rb
+|-----es.yml
+|-----en.yml
 |---navigation
-|-----es.rb
-|-----en.rb
+|-----es.yml
+|-----en.yml
 ```
 
 This way, you can separate model and model attribute names from text inside views, and all of this from the "defaults" (e.g. date and time formats). Other stores for the i18n library could provide different means of such separation.


### PR DESCRIPTION
### Summary

The default extension we use for locale files is `.yml`. This patch reflects this in the documentation example.