### PR TITLE
Update code snippets to suggest the use of strong parameters

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -543,7 +543,7 @@ By default, adding values to the flash will make them available to the next requ
 ```ruby
 class ClientsController < ApplicationController
   def create
-    @client = Client.new(params[:client])
+    @client = Client.new(client_params)
     if @client.save
       # ...
     else
@@ -567,7 +567,7 @@ class CommentsController < ApplicationController
   end
 
   def create
-    @comment = Comment.new(params[:comment])
+    @comment = Comment.new(comment_params)
     if @comment.save
       flash[:notice] = "Thanks for your comment!"
       if params[:remember_name]


### PR DESCRIPTION
### Summary

Examples for `flash` and `session` had code that would might end up raising `ForbiddenAttributesErrors`. Tweak the code to suggest the use of strong parameters.

### Other Information

I'm not sure what would be more helpful, the examples as-is are a little bit more direct and simple. But I did do a double-take when I saw them, which to me seemed like a good reason to make the change.

I could see someone copy-pasting this and being confused at the error that's raised. But now the examples are missing definitions for the `client_`/`comment_params` methods, so… I'm not sure what's better. 🤷‍♂ 
