### PR TITLE
Fix error in deprecation

### DIFF
--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -6,16 +6,19 @@ module ActiveRecord
     # UrlConfig respectively. It will never return a DatabaseConfig object,
     # as this is the parent class for the types of database configuration objects.
     class DatabaseConfig # :nodoc:
-      attr_reader :env_name, :name, :spec_name
-      deprecate spec_name: "please use name instead"
+      attr_reader :env_name, :name
 
       attr_accessor :owner_name
 
       def initialize(env_name, name)
         @env_name = env_name
         @name = name
-        @spec_name = name
       end
+
+      def spec_name
+        @name
+      end
+      deprecate spec_name: "please use name instead"
 
       def config
         raise NotImplementedError


### PR DESCRIPTION
When I implemented the deprecation for #38536 I left in the setter in
the initalizer. This meant that objects returned had both `@name` and
`@spec_name` set and objects looked like this:

```
<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fe0f7100c68
  @env_name="development",
  @name="primary",
  @spec_name="primary",
  @config={
    :adapter=>"mysql2",
    :database=>"recipes_app_development"
  }
>
```

Since we don't use the kwarg to create the hash config and we have the
reader for reading off the object or selecting from the configurations
objects list we can remove this so the object looks like:

```
<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007fe0f7100c68
  @env_name="development",
  @name="primary",
  @config={
    :adapter=>"mysql2",
    :database=>"recipes_app_development"
  }
>
```