### PR TITLE
Add Array#except_index

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -233,5 +233,13 @@
 
     *Jordan Thomas*
 
+*   `except_index` would return the new array exclude passed indices.
+
+        ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0, 1, -1) # => ["c", "d", "e", "f", "g"]
+        ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, -2..-1) # => ["c", "d", "e", "f"]
+        ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, 3, -2..-1) # => ["c", "e", "f"]
+
+    *Alex Golubenko*
+
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -53,15 +53,19 @@ class Array
     excluding(*elements)
   end
 
-  # Returns a copy of the Array excluding the specified indiciec.
+  # Returns a copy of the Array excluding the specified indicies.
   #
   #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0, 1, -1) # => ["c", "d", "e", "f", "g"]
   #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, -2..-1) # => ["c", "d", "e", "f"]
   #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, 3, -2..-1) # => ["c", "e", "f"]
-  def except_index(*indexes)
+  def except_index(*indicies)
     to_delete = Array.new(length)
-    indexes.each do |ind|
-      ind.is_a?(Range) ? ind.each { |i| to_delete[i] = true } : to_delete[ind] = true
+    indicies.each do |ind|
+      if ind.is_a?(Range)
+        ind.each { |i| i > length ? break : to_delete[i] = true }
+      else
+        to_delete[ind] = true
+      end
     end
     reject.with_index { |_, ind| to_delete[ind] }
   end

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -53,6 +53,17 @@ class Array
     excluding(*elements)
   end
 
+  # Returns a copy of the Array excluding the specified indiciec.
+  #
+  #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0, 1, -1) # => ["c", "d", "e", "f", "g"]
+  #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, -2..-1) # => ["c", "d", "e", "f"]
+  #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, 3, -2..-1) # => ["c", "e", "f"]
+  def except_index(*indexes)
+    indexes.each_with_object(dup) do |ind, obj|
+      ind.is_a?(Range) ? ind.each { |i| obj[i] = false } : obj[ind] = false
+    end.select(&:itself)
+  end
+
   # Equal to <tt>self[1]</tt>.
   #
   #   %w( a b c d e ).second # => "b"

--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -59,9 +59,11 @@ class Array
   #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, -2..-1) # => ["c", "d", "e", "f"]
   #   ["a", "b", "c", "d", "e", "f", "g", "h"].except_index(0..1, 3, -2..-1) # => ["c", "e", "f"]
   def except_index(*indexes)
-    indexes.each_with_object(dup) do |ind, obj|
-      ind.is_a?(Range) ? ind.each { |i| obj[i] = false } : obj[ind] = false
-    end.select(&:itself)
+    to_delete = Array.new(length)
+    indexes.each do |ind|
+      ind.is_a?(Range) ? ind.each { |i| to_delete[i] = true } : to_delete[ind] = true
+    end
+    reject.with_index { |_, ind| to_delete[ind] }
   end
 
   # Equal to <tt>self[1]</tt>.

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -54,5 +54,6 @@ class AccessTest < ActiveSupport::TestCase
     assert_equal %w( c d e f g ), array.except_index(0, 1, -1)
     assert_equal %w( c d e f ), array.except_index(0..1, -2..-1)
     assert_equal %w( c e f ), array.except_index(0..1, 3, -2..-1)
+    assert_equal %w( a ), array.except_index(-7..-1)
   end
 end

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -47,4 +47,12 @@ class AccessTest < ActiveSupport::TestCase
   def test_without
     assert_equal [1, 2, 4], [1, 2, 3, 4, 5].without(3, 5)
   end
+
+  def test_except_index
+    array = %w( a b c d e f g h )
+
+    assert_equal %w( c d e f g ), array.except_index(0, 1, -1)
+    assert_equal %w( c d e f ), array.except_index(0..1, -2..-1)
+    assert_equal %w( c e f ), array.except_index(0..1, 3, -2..-1)
+  end
 end


### PR DESCRIPTION
### Summary

The main idea is to implement a method that we can use to exclude elements from the array by their indices.

For example: 
```ruby
%w( a b c d e f).except_index(0, -1) 
=> ["b", "c", "d", "e"]

%w( a b c d e f g h ).except_index(0..1, 3, -2..-1)
=> ["c", "e", "f"]
```

### Other Information
As you can see from Benchmark comparison with `excluding` it has a good performance.
```ruby
require 'benchmark'
a = Array.new(100_000) { ('a'..'z').to_a[rand(26)] }
b = Array.new(10_000) { rand(26) }
c = Array.new(10_000) { ('a'..'z').to_a[rand(26)] }
Benchmark.bm(10_000) do |x|
  x.report('except_index') { a.except_index(*b) }
  x.report('excluding') { a.excluding(*c) }
end

user           system      total        real
except_index  0.020736   0.000274   0.021010 (  0.021981)
excluding     0.018958   0.000264   0.019222 (  0.019495)
```

I also have opened a [discussion](https://groups.google.com/forum/?fromgroups=#!topic/rubyonrails-core/RwCpJ9u6rAo)