### PR TITLE
Add activerecord/db/ to gitignore

### DIFF
--- a/activerecord/.gitignore
+++ b/activerecord/.gitignore
@@ -1,4 +1,4 @@
-/db/
 /sqlnet.log
 /test/config.yml
+/test/db/
 /test/fixtures/*.sqlite*

--- a/activerecord/.gitignore
+++ b/activerecord/.gitignore
@@ -1,3 +1,4 @@
+/db/
 /sqlnet.log
 /test/config.yml
 /test/fixtures/*.sqlite*

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -108,7 +108,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
     def with_connection(options = {})
       db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       conn_options = options.reverse_merge(
-        database: in_memory_db? ? "file::memory:" : db_config.database
+        database: in_memory_db? ? "db/file::memory:" : db_config.database
       )
       conn = ActiveRecord::Base.sqlite3_connection(conn_options)
 

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -108,7 +108,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
     def with_connection(options = {})
       db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
       conn_options = options.reverse_merge(
-        database: in_memory_db? ? "db/file::memory:" : db_config.database
+        database: in_memory_db? ? "test/db/file::memory:" : db_config.database
       )
       conn = ActiveRecord::Base.sqlite3_connection(conn_options)
 

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -47,14 +47,14 @@ module ActiveRecord
 
         config = {
           "default_env" => {
-            "readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" },
-            "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+            "readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" },
+            "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
           },
           "another_env" => {
-            "readonly" => { "adapter" => "sqlite3", "database" => "db/bad-readonly.sqlite3" },
-            "primary"  => { "adapter" => "sqlite3", "database" => "db/bad-primary.sqlite3" }
+            "readonly" => { "adapter" => "sqlite3", "database" => "test/db/bad-readonly.sqlite3" },
+            "primary"  => { "adapter" => "sqlite3", "database" => "test/db/bad-primary.sqlite3" }
           },
-          "common" => { "adapter" => "sqlite3", "database" => "db/common.sqlite3" }
+          "common" => { "adapter" => "sqlite3", "database" => "test/db/common.sqlite3" }
         }
         @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
@@ -63,13 +63,13 @@ module ActiveRecord
         @handler.establish_connection(:readonly)
 
         assert_not_nil pool = @handler.retrieve_connection_pool("readonly")
-        assert_equal "db/readonly.sqlite3", pool.db_config.database
+        assert_equal "test/db/readonly.sqlite3", pool.db_config.database
 
         assert_not_nil pool = @handler.retrieve_connection_pool("primary")
-        assert_equal "db/primary.sqlite3", pool.db_config.database
+        assert_equal "test/db/primary.sqlite3", pool.db_config.database
 
         assert_not_nil pool = @handler.retrieve_connection_pool("common")
-        assert_equal "db/common.sqlite3", pool.db_config.database
+        assert_equal "test/db/common.sqlite3", pool.db_config.database
       ensure
         ActiveRecord::Base.configurations = @prev_configs
         ENV["RAILS_ENV"] = previous_env
@@ -78,7 +78,7 @@ module ActiveRecord
       unless in_memory_db?
         def test_establish_connection_with_primary_works_without_deprecation
           old_config = ActiveRecord::Base.configurations
-          config = { "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" } }
+          config = { "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" } }
           ActiveRecord::Base.configurations = config
 
           @handler.establish_connection(:primary)
@@ -93,7 +93,7 @@ module ActiveRecord
 
         def test_retrieve_connection_shows_primary_deprecation_warning_when_established_on_active_record_base
           old_config = ActiveRecord::Base.configurations
-          config = { "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" } }
+          config = { "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" } }
           ActiveRecord::Base.configurations = config
 
           ActiveRecord::Base.establish_connection(:primary)
@@ -110,24 +110,23 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-              "readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" }
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+              "readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" }
             },
             "another_env" => {
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/another-primary.sqlite3" },
-              "readonly" => { "adapter" => "sqlite3", "database" => "db/another-readonly.sqlite3" }
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/another-primary.sqlite3" },
+              "readonly" => { "adapter" => "sqlite3", "database" => "test/db/another-readonly.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
           ActiveRecord::Base.establish_connection
 
-          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.db_config.database
+          assert_match "test/db/primary.sqlite3", ActiveRecord::Base.connection.pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
           ActiveRecord::Base.establish_connection(:arunit)
-          FileUtils.rm_rf "db"
         end
 
         def test_establish_connection_using_2_level_config_defaults_to_default_env_primary_db
@@ -135,22 +134,21 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "adapter" => "sqlite3", "database" => "db/primary.sqlite3"
+              "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3"
             },
             "another_env" => {
-              "adapter" => "sqlite3", "database" => "db/bad-primary.sqlite3"
+              "adapter" => "sqlite3", "database" => "test/db/bad-primary.sqlite3"
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
           ActiveRecord::Base.establish_connection
 
-          assert_match "db/primary.sqlite3", ActiveRecord::Base.connection.pool.db_config.database
+          assert_match "test/db/primary.sqlite3", ActiveRecord::Base.connection.pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ENV["RAILS_ENV"] = previous_env
           ActiveRecord::Base.establish_connection(:arunit)
-          FileUtils.rm_rf "db"
         end
 
         def test_remove_connection_is_deprecated
@@ -167,28 +165,28 @@ module ActiveRecord
       end
 
       def test_establish_connection_using_two_level_configurations
-        config = { "development" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" } }
+        config = { "development" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" } }
         @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
         @handler.establish_connection(:development)
 
         assert_not_nil pool = @handler.retrieve_connection_pool("development")
-        assert_equal "db/primary.sqlite3", pool.db_config.database
+        assert_equal "test/db/primary.sqlite3", pool.db_config.database
       ensure
         ActiveRecord::Base.configurations = @prev_configs
       end
 
       def test_establish_connection_using_top_level_key_in_two_level_config
         config = {
-          "development" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-          "development_readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" }
+          "development" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+          "development_readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" }
         }
         @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
         @handler.establish_connection(:development_readonly)
 
         assert_not_nil pool = @handler.retrieve_connection_pool("development_readonly")
-        assert_equal "db/readonly.sqlite3", pool.db_config.database
+        assert_equal "test/db/readonly.sqlite3", pool.db_config.database
       ensure
         ActiveRecord::Base.configurations = @prev_configs
       end
@@ -199,13 +197,13 @@ module ActiveRecord
           development: {
             primary: {
               adapter: "sqlite3",
-              database: "db/development.sqlite3",
+              database: "test/db/development.sqlite3",
             },
           },
           test: {
             primary: {
               adapter: "sqlite3",
-              database: "db/test.sqlite3",
+              database: "test/db/test.sqlite3",
             },
           },
         }

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -90,8 +90,8 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3", "replica" => true },
-              "default"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+              "readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3", "replica" => true },
+              "default"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
@@ -99,11 +99,11 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { writing: :default, reading: :readonly })
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal "db/primary.sqlite3", pool.db_config.database
+          assert_equal "test/db/primary.sqlite3", pool.db_config.database
           assert_equal "default", pool.db_config.name
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal "db/readonly.sqlite3", pool.db_config.database
+          assert_equal "test/db/readonly.sqlite3", pool.db_config.database
           assert_equal "readonly", pool.db_config.name
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -116,8 +116,8 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" },
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+              "readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" },
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
@@ -145,7 +145,6 @@ module ActiveRecord
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
-          FileUtils.rm_rf("db")
         end
 
         def test_establish_connection_using_3_levels_config_with_non_default_handlers
@@ -153,8 +152,8 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" },
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+              "readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" },
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
@@ -162,10 +161,10 @@ module ActiveRecord
           ActiveRecord::Base.connects_to(database: { default: :primary, readonly: :readonly })
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:default].retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal "db/primary.sqlite3", pool.db_config.database
+          assert_equal "test/db/primary.sqlite3", pool.db_config.database
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:readonly].retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal "db/readonly.sqlite3", pool.db_config.database
+          assert_equal "test/db/readonly.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -193,7 +192,7 @@ module ActiveRecord
 
         def test_switching_connections_with_database_config_hash
           previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
-          config = { adapter: "sqlite3", database: "db/readonly.sqlite3" }
+          config = { adapter: "sqlite3", database: "test/db/readonly.sqlite3" }
 
           ActiveRecord::Base.connects_to(database: { writing: config })
           assert_equal :writing, ActiveRecord::Base.current_role
@@ -230,8 +229,8 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "animals" => { adapter: "sqlite3", database: "db/animals.sqlite3" },
-              "primary" => { adapter: "sqlite3", database: "db/primary.sqlite3" }
+              "animals" => { adapter: "sqlite3", database: "test/db/animals.sqlite3" },
+              "primary" => { adapter: "sqlite3", database: "test/db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
@@ -256,8 +255,8 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "animals" => { adapter: "sqlite3", database: "db/animals.sqlite3" },
-              "primary" => { adapter: "sqlite3", database: "db/primary.sqlite3" }
+              "animals" => { adapter: "sqlite3", database: "test/db/animals.sqlite3" },
+              "primary" => { adapter: "sqlite3", database: "test/db/primary.sqlite3" }
             }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
@@ -279,7 +278,7 @@ module ActiveRecord
 
         def test_connects_to_with_single_configuration
           config = {
-            "development" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
+            "development" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
@@ -296,15 +295,15 @@ module ActiveRecord
 
         def test_connects_to_using_top_level_key_in_two_level_config
           config = {
-            "development" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-            "development_readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" }
+            "development" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+            "development_readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
           ActiveRecord::Base.connects_to database: { writing: :development, reading: :development_readonly }
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base")
-          assert_equal "db/readonly.sqlite3", pool.db_config.database
+          assert_equal "test/db/readonly.sqlite3", pool.db_config.database
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -312,8 +311,8 @@ module ActiveRecord
 
         def test_connects_to_returns_array_of_established_connections
           config = {
-            "development" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-            "development_readonly" => { "adapter" => "sqlite3", "database" => "db/readonly.sqlite3" }
+            "development" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+            "development_readonly" => { "adapter" => "sqlite3", "database" => "test/db/readonly.sqlite3" }
           }
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+              "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
             }
           }
 
@@ -52,7 +52,7 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+              "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
             }
           }
 
@@ -77,7 +77,7 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+              "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
             }
           }
 
@@ -96,7 +96,6 @@ module ActiveRecord
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
-          FileUtils.rm_rf "db"
         end
       end
     end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -30,8 +30,8 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3" },
             }
           }
 
@@ -46,11 +46,11 @@ module ActiveRecord
           default_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :default)
 
           assert_equal base_pool, default_pool
-          assert_equal "db/primary.sqlite3", default_pool.db_config.database
+          assert_equal "test/db/primary.sqlite3", default_pool.db_config.database
           assert_equal "primary", default_pool.db_config.name
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
-          assert_equal "db/primary_shard_one.sqlite3", pool.db_config.database
+          assert_equal "test/db/primary_shard_one.sqlite3", pool.db_config.database
           assert_equal "primary_shard_one", pool.db_config.name
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -63,10 +63,10 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-              "primary_replica"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3", "replica" => true },
-              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
-              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3", "replica" => true }
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+              "primary_replica"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3", "replica" => true },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3" },
+              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3", "replica" => true }
             }
           }
 
@@ -80,21 +80,21 @@ module ActiveRecord
           default_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :default)
           base_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
           assert_equal base_writing_pool, default_writing_pool
-          assert_equal "db/primary.sqlite3", default_writing_pool.db_config.database
+          assert_equal "test/db/primary.sqlite3", default_writing_pool.db_config.database
           assert_equal "primary", default_writing_pool.db_config.name
 
           default_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", :default)
           base_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base")
           assert_equal base_reading_pool, default_reading_pool
-          assert_equal "db/primary.sqlite3", default_reading_pool.db_config.database
+          assert_equal "test/db/primary.sqlite3", default_reading_pool.db_config.database
           assert_equal "primary_replica", default_reading_pool.db_config.name
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
-          assert_equal "db/primary_shard_one.sqlite3", pool.db_config.database
+          assert_equal "test/db/primary_shard_one.sqlite3", pool.db_config.database
           assert_equal "primary_shard_one", pool.db_config.name
 
           assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
-          assert_equal "db/primary_shard_one.sqlite3", pool.db_config.database
+          assert_equal "test/db/primary_shard_one.sqlite3", pool.db_config.database
           assert_equal "primary_shard_one_replica", pool.db_config.name
         ensure
           ActiveRecord::Base.configurations = @prev_configs
@@ -107,10 +107,10 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-              "primary_replica"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3", "replica" => true },
-              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
-              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3", "replica" => true }
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+              "primary_replica"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3", "replica" => true },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3" },
+              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3", "replica" => true }
             }
           }
 
@@ -168,7 +168,6 @@ module ActiveRecord
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
-          FileUtils.rm_rf("db")
         end
 
         def test_retrieves_proper_connection_with_nested_connected_to
@@ -176,10 +175,10 @@ module ActiveRecord
 
           config = {
             "default_env" => {
-              "primary"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-              "primary_replica"  => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3", "replica" => true },
-              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3" },
-              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "db/primary_shard_one.sqlite3", "replica" => true }
+              "primary"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+              "primary_replica"  => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3", "replica" => true },
+              "primary_shard_one" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3" },
+              "primary_shard_one_replica" => { "adapter" => "sqlite3", "database" => "test/db/primary_shard_one.sqlite3", "replica" => true }
             }
           }
 
@@ -216,7 +215,6 @@ module ActiveRecord
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
           ENV["RAILS_ENV"] = previous_env
-          FileUtils.rm_rf("db")
         end
 
         def test_connected_to_raises_without_a_shard_or_role

--- a/activerecord/test/cases/test_databases_test.rb
+++ b/activerecord/test/cases/test_databases_test.rb
@@ -9,7 +9,7 @@ class TestDatabasesTest < ActiveRecord::TestCase
       previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
       prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
         "arunit" => {
-          "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+          "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
         }
       }
 
@@ -25,14 +25,13 @@ class TestDatabasesTest < ActiveRecord::TestCase
       ActiveRecord::Base.configurations = prev_configs
       ActiveRecord::Base.establish_connection(:arunit)
       ENV["RAILS_ENV"] = previous_env
-      FileUtils.rm_rf("db")
     end
 
     def test_create_databases_after_fork
       previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
       prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
         "arunit" => {
-          "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+          "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
         }
       }
 
@@ -52,15 +51,14 @@ class TestDatabasesTest < ActiveRecord::TestCase
       ActiveRecord::Base.configurations = prev_configs
       ActiveRecord::Base.establish_connection(:arunit)
       ENV["RAILS_ENV"] = previous_env
-      FileUtils.rm_rf("db")
     end
 
     def test_order_of_configurations_isnt_changed_by_test_databases
       previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "arunit"
       prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, {
         "arunit" => {
-          "primary" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" },
-          "replica" => { "adapter" => "sqlite3", "database" => "db/primary.sqlite3" }
+          "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" },
+          "replica" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" }
         }
       }
 
@@ -76,7 +74,6 @@ class TestDatabasesTest < ActiveRecord::TestCase
       ActiveRecord::Base.configurations = prev_configs
       ActiveRecord::Base.establish_connection(:arunit)
       ENV["RAILS_ENV"] = previous_env
-      FileUtils.rm_rf("db")
     end
   end
 end


### PR DESCRIPTION
After running `bundle exec rake test:sqlite3` and `bundle exec rake test:sqlite3_mem`
on my VM I noticed that it had created untracked files:

```bash
vagrant@ubuntu-bionic:/rails/activerecord$ git status
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        db/
        file::memory:
```

To prevent them from being accidentally committed I put 'file::memory:' to
`activerecord/db/` folder and added the folder to .gitignore
Also, we could consider fixing this by removing `db/` folder in each test that
creates the folder.

Edited: Additionally renamed 'db' to 'test/db' in Active Record's tests.

It would be great if someone confirms that it happens not only on my VM.