### PR TITLE
Treat .rb templates like .ruby templates

### DIFF
--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -14,7 +14,7 @@ module ActionView #:nodoc:
         base.register_template_handler :erb, ERB.new
         base.register_template_handler :html, Html.new
         base.register_template_handler :builder, Builder.new
-        base.register_template_handler :ruby, lambda { |_, source| source }
+        base.register_template_handler :rb, :ruby, lambda { |_, source| source }
       end
 
       @@template_handlers = {}


### PR DESCRIPTION
This seems to have been an oversight, since the .ruby extension is uncommon and often not syntax highlighted.