### PR TITLE
[guides] Update missing translation example

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1145,7 +1145,7 @@ In other contexts you might want to change this behavior, though. E.g. the defau
 module I18n
   class JustRaiseExceptionHandler < ExceptionHandler
     def call(exception, locale, key, options)
-      if exception.is_a?(MissingTranslationData)
+      if exception.is_a?(MissingTranslation)
         raise exception.to_exception
       else
         super
@@ -1162,7 +1162,7 @@ This would re-raise only the `MissingTranslationData` exception, passing all oth
 However, if you are using `I18n::Backend::Pluralization` this handler will also raise `I18n::MissingTranslationData: translation missing: en.i18n.plural.rule` exception that should normally be ignored to fall back to the default pluralization rule for English locale. To avoid this you may use additional check for translation key:
 
 ```ruby
-if exception.is_a?(MissingTranslationData) && key.to_s != 'i18n.plural.rule'
+if exception.is_a?(MissingTranslation) && key.to_s != 'i18n.plural.rule'
   raise exception.to_exception
 else
   super


### PR DESCRIPTION
### Summary

The Rails Guides contain an example of how to raise for a missing
translation when `I18n.t` is called from anywhere, including
non-ActionView contexts. The example builds a custom exception handler
that catches and raises any instance of `I18n::MissingTranslationData`
and passes on any other exception to be handled by `I18n` as normally
happens.

Unfortunately, while `I18n::MissingTranslationData` is what eventually
should be raised for a missing translation, the initial exception the
handler sees is actually `I18n::MissingTranslation`, and
`MissingTranslationData` is the product of calling `#to_exception` on
that exception object. As a result, the example in the guides ends up
not raising for missing translations, silently resulting in the return
of the missing translation key. This issue appears to have first been captured in this issue: https://github.com/rails/rails/issues/13429.

This change updates the guides to with a working example, catching
`I18n::MissingTranslation` which results in a raise of
`I18n::MissingTranslationData` with the missing key.

Close #13429