### PR TITLE
`expires_in` `extras` documentation

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -237,6 +237,11 @@ module ActionController
     #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds
     #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds, stale_if_error: 5.minutes
     #
+    # HTTP Cache-Control Extensions other values: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    # Each `extra` key-value pair will get concatonated into the `Cache-Control` header in the response:
+    #
+    #   expires_in 3.hours, public: true, "s-maxage": 3.hours, "no-transform": true
+    #
     # The method will also ensure an HTTP Date header for client compatibility.
     def expires_in(seconds, options = {})
       response.cache_control.merge!(

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -238,7 +238,7 @@ module ActionController
     #   expires_in 3.hours, public: true, stale_while_revalidate: 60.seconds, stale_if_error: 5.minutes
     #
     # HTTP Cache-Control Extensions other values: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-    # Each `extra` key-value pair will get concatonated into the `Cache-Control` header in the response:
+    # Any additional key-value pairs are concatenated onto the `Cache-Control` header in the response:
     #
     #   expires_in 3.hours, public: true, "s-maxage": 3.hours, "no-transform": true
     #


### PR DESCRIPTION
Wanted to find how to add `s-maxage` and stumbled across this feature.

Wanted to document it for others, but many proxies like Akamai are very insistent on using `s-maxage` rather than `max-age`.

### Summary

Document `extras` feature of `expires_in`

