### PR TITLE
Simplify route score

### DIFF
--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -110,18 +110,11 @@ module ActionDispatch
       end
 
       def score(supplied_keys)
-        required_keys = path.required_names
-
-        required_keys.each do |k|
+        path.required_names.each do |k|
           return -1 unless supplied_keys.include?(k)
         end
 
-        score = 0
-        path.names.each do |k|
-          score += 1 if supplied_keys.include?(k)
-        end
-
-        score + (required_defaults.length * 2)
+        (required_defaults.length * 2) + path.names.count { |k| supplied_keys.include?(k) }
       end
 
       def parts


### PR DESCRIPTION
### Summary

Simplify `ActionDispatch::Journey::Route#score` slightly. This PR uses `count` with a block to get rid of the temporary local variable and is a tiny performance win.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
end

module ActionDispatch
  module Journey
    class Route
      def fast_score(supplied_keys)
        path.required_names.each do |k|
          return -1 unless supplied_keys.include?(k)
        end

        (required_defaults.length * 2) + path.names.count { |k| supplied_keys.include?(k) }
      end
    end
  end
end

defaults = { controller: "pages", action: "show", name: "whatever" }

path = ActionDispatch::Journey::Path::Pattern.from_string "/page/:id(/:action)(.:format)"
route = ActionDispatch::Journey::Route.new name: "name", path: path, required_defaults: [:controller, :action, :id], defaults: defaults
knowledge = { "id" => true, "controller" => true, "action" => true }

Benchmark.ips do |x|
  x.report("score")      { route.score(knowledge) }
  x.report("fast_score") { route.fast_score(knowledge)  }
  x.compare!
end
```
### Results
```
Warming up --------------------------------------
               score   120.665k i/100ms
          fast_score   127.329k i/100ms
Calculating -------------------------------------
               score      1.624M (± 2.6%) i/s -      8.205M in   5.055595s
          fast_score      1.717M (± 2.5%) i/s -      8.658M in   5.045315s

Comparison:
          fast_score:  1717338.9 i/s
               score:  1624243.3 i/s - 1.06x  slower
```
