### PR TITLE
Remove keys from local_cache in RedisCacheStore#delete_matched

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove entries from local cache on `RedisCacheStore#delete_matched`
+
+    Fixes #38627
+
+    *ojab*
+
 *   [Breaking change] `ActiveSupport::Callbacks#halted_callback_hook` now receive a 2nd argument:
 
     `ActiveSupport::Callbacks#halted_callback_hook` now receive the name of the callback

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -506,7 +506,11 @@ module ActiveSupport
       #
       # Some implementations may not support this method.
       def delete_matched(matcher, options = nil)
-        raise NotImplementedError.new("#{self.class.name} does not support delete_matched")
+        options = merged_options(options)
+
+        instrument :delete_matched, matcher do
+          delete_matched_entries(matcher, **options)
+        end
       end
 
       # Increments an integer value in the cache.

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -153,6 +153,14 @@ module ActiveSupport
             super
           end
 
+          def delete_matched_entries(matcher, **options)
+            keys = super
+
+            keys.each { |key| local_cache.delete_entry(key, **options) } if local_cache && keys.present?
+
+            keys
+          end
+
           def delete_entry(key, **options)
             local_cache.delete_entry(key, **options) if local_cache
             super

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -102,6 +102,18 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_delete_matched
+    @cache.with_local_cache do
+      @cache.write("foo", "bar")
+      @cache.write("fop", "bar")
+      @cache.write("bar", "foo")
+      @cache.delete_matched("fo*")
+      assert_nil @cache.read("foo")
+      assert_nil @cache.read("fop")
+      assert_equal @cache.read("bar"), "foo"
+    end
+  end
+
   def test_local_cache_of_exist
     @cache.with_local_cache do
       @cache.write("foo", "bar")

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -260,14 +260,6 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   end
 
   class DeleteMatchedTest < StoreTest
-    test "deletes keys matching glob" do
-      @cache.write("foo", "bar")
-      @cache.write("fu", "baz")
-      @cache.delete_matched("foo*")
-      assert_not @cache.exist?("foo")
-      assert @cache.exist?("fu")
-    end
-
     test "fails with regexp matchers" do
       assert_raise ArgumentError do
         @cache.delete_matched(/OO/i)


### PR DESCRIPTION
Fixes #38627

### Summary

Right now `RedisCacheStore#delete_matched` doesn't delete entries in local cache, which is wrong. Fix it.