### PR TITLE
Allow `rails new . --master` to point to master branch

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -90,6 +90,7 @@ module Rails
 
         class_option :edge,                type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository"
+
         class_option :master,              type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository master branch"
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -90,6 +90,8 @@ module Rails
 
         class_option :edge,                type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository"
+        class_option :master,              type: :boolean, default: false,
+                                           desc: "Set up the #{name} with Gemfile pointing to Rails repository master branch"
 
         class_option :rc,                  type: :string, default: nil,
                                            desc: "Path to file containing extra configuration options for rails command"
@@ -283,6 +285,10 @@ module Rails
           [
             GemfileEntry.github("rails", "rails/rails")
           ]
+        elsif options.master?
+          [
+            GemfileEntry.github("rails", "rails/rails", "master")
+          ]
         else
           [GemfileEntry.version("rails",
                             rails_version_specifier,
@@ -312,7 +318,7 @@ module Rails
       def webpacker_gemfile_entry
         return [] if options[:skip_javascript]
 
-        if options.dev? || options.edge?
+        if options.dev? || options.edge? || options.master?
           GemfileEntry.github "webpacker", "rails/webpacker", nil, "Use development version of Webpacker"
         else
           GemfileEntry.version "webpacker", "~> 4.0", "Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -46,7 +46,7 @@ end
 group :development do
 <%- unless options.api? -%>
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  <%- if options.dev? || options.edge? -%>
+  <%- if options.dev? || options.edge? || options.master? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
   gem 'web-console', '>= 3.3.0'

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= '# ' if options.dev? || options.edge? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
+  <%= '# ' if options.dev? || options.edge? || options.master? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
+<%= '# ' if options.dev? || options.edge? || options.master? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
 <% else -%>
 # Specify your gem's dependencies in <%= name %>.gemspec.
 gemspec


### PR DESCRIPTION
## Background

Currently the `rails new` generator supports options `--dev` and `--edge`.

`--dev` points to one’s local rails setup and `--edge` points to the latest stable Rails branch.

However, in the Rails community we often think of the ‘edge’ as the latest merged master. We can see as much in Shopify’s fantastic article showing how they point to the latest master version of Rails: https://engineering.shopify.com/blogs/engineering/living-on-the-edge-of-rails

![alt](https://i.imgur.com/AH4Sevl.png)

I would originally have recommended changing ‘edge’ to point to master, as it has tripped me up on numerous occasions now.

## Change

I would rather add the desired functionality than change the current edge functionality.

Therefore this PR adds the `--master` flag.

It is intended to do exactly as `edge` does, simply with the change that it points to Rails’ master branch instead of latest stable (i.e. 6_0_stable)

## Okay, but really why?

Whenever developers see a new feature in Rails, such as the recently committed horizontal sharding (which prompted my PR) #38531 , we would love to spin up a new Rails App to try out these new features. ❤️

This command would allow us to jump right in with no configuration and offer our testing of the features, even those of us who aren’t able to spend a lot of time on OSS support. 🙏