### PR TITLE
Refactor invert predicate

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -137,18 +137,10 @@ module ActiveRecord
           case node
           when NilClass
             raise ArgumentError, "Invalid argument for .where.not(), got nil."
-          when Arel::Nodes::In
-            Arel::Nodes::NotIn.new(node.left, node.right)
-          when Arel::Nodes::IsNotDistinctFrom
-            Arel::Nodes::IsDistinctFrom.new(node.left, node.right)
-          when Arel::Nodes::IsDistinctFrom
-            Arel::Nodes::IsNotDistinctFrom.new(node.left, node.right)
-          when Arel::Nodes::Equality
-            Arel::Nodes::NotEqual.new(node.left, node.right)
           when String
             Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new(node))
           else
-            Arel::Nodes::Not.new(node)
+            node.invert
           end
         end
 

--- a/activerecord/lib/arel/nodes/equality.rb
+++ b/activerecord/lib/arel/nodes/equality.rb
@@ -6,13 +6,22 @@ module Arel # :nodoc: all
       def operator; :== end
       alias :operand1 :left
       alias :operand2 :right
+
+      def invert
+        Arel::Nodes::NotEqual.new(left, right)
+      end
     end
 
-    %w{
-      IsDistinctFrom
-      IsNotDistinctFrom
-    }.each do |name|
-      const_set name, Class.new(Equality)
+    class IsDistinctFrom < Equality
+      def invert
+        Arel::Nodes::IsNotDistinctFrom.new(left, right)
+      end
+    end
+
+    class IsNotDistinctFrom < Equality
+      def invert
+        Arel::Nodes::IsDistinctFrom.new(left, right)
+      end
     end
   end
 end

--- a/activerecord/lib/arel/nodes/in.rb
+++ b/activerecord/lib/arel/nodes/in.rb
@@ -3,6 +3,9 @@
 module Arel # :nodoc: all
   module Nodes
     class In < Equality
+      def invert
+        Arel::Nodes::NotIn.new(left, right)
+      end
     end
   end
 end

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -27,6 +27,10 @@ module Arel # :nodoc: all
         Nodes::And.new [self, right]
       end
 
+      def invert
+        Arel::Nodes::Not.new(self)
+      end
+
       # FIXME: this method should go away.  I don't like people calling
       # to_sql on non-head nodes.  This forces us to walk the AST until we
       # can find a node that has a "relation" member.

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -88,22 +88,19 @@ class ActiveRecord::Relation
     end
 
     test "invert replaces each part of the predicate with its inverse" do
-      random_object = Object.new
       original = WhereClause.new([
         table["id"].in([1, 2, 3]),
         table["id"].eq(1),
         table["id"].is_not_distinct_from(1),
         table["id"].is_distinct_from(2),
-        "sql literal",
-        random_object
+        "sql literal"
       ])
       expected = WhereClause.new([
         table["id"].not_in([1, 2, 3]),
         table["id"].not_eq(1),
         table["id"].is_distinct_from(1),
         table["id"].is_not_distinct_from(2),
-        Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new("sql literal")),
-        Arel::Nodes::Not.new(random_object)
+        Arel::Nodes::Not.new(Arel::Nodes::SqlLiteral.new("sql literal"))
       ])
 
       assert_equal expected, original.invert(:nor)


### PR DESCRIPTION
Instead of doing a case statement here we can have each of the objects
respond to `invert`. This means that when adding new objects we don't
need to increase this case statement, it's more object oriented, and
let's be fair, it looks better too.

Aaron and I stumbled upon this while working on some performance
work in Arel.

I removed `random_object` from the invert test because we don't support
random objects. If you pass a random object to Arel, it should raise,
not be inverted.

Co-authored-by: Aaron Patterson <aaron.patterson@gmail.com>

cc/ @tenderlove 