### PR TITLE
Deduplicate Module#module_parent_name cache

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/introspection.rb
+++ b/activesupport/lib/active_support/core_ext/module/introspection.rb
@@ -10,7 +10,7 @@ class Module
     if defined?(@parent_name)
       @parent_name
     else
-      parent_name = name =~ /::[^:]+\Z/ ? $`.freeze : nil
+      parent_name = name =~ /::[^:]+\Z/ ? -$` : nil
       @parent_name = parent_name unless frozen?
       parent_name
     end


### PR DESCRIPTION
While profiling our application I noticed some duplicated strings being retained by `Module#module_parent_name`:

```

211  "Admin"
--
  209  gems/rails-6d0895a48947/activesupport/lib/active_support/core_ext/module/introspection.rb:13
```

Since it's already frozen, it's better to use `String#-@`, this way the existing string in the constant table is reused.

Not a big saving, but quite a simple patch so worth it in my opinion.

cc @rafaelfranca @Edouard-chin @etiennebarrie @paracycle @Morriar 