### PR TITLE
Properly close a tag to avoid errors with some ruby versions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -8,7 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  <%-# Spring executes the reloaders when files change. %>
+  <%-# Spring executes the reloaders when files change. -%>
   <%- if spring_install? -%>
   config.cache_classes = false
   config.action_view.cache_template_loading = true


### PR DESCRIPTION
fixes #38639 
### Summary
It raises an error while running 'rails new' with ruby version 2.5.0

It's my first time so I hope I got the contribution flow right. I felt repeating my self to many times for such a simple contribution.