### PR TITLE
Remove unused space from disk controller of activestorage

### DIFF
--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -40,7 +40,6 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
       end
     end
 
-
     def decode_verified_key
       ActiveStorage.verifier.verified(params[:encoded_key], purpose: :blob_key)
     end


### PR DESCRIPTION
### Summary

Only removing a blank line on `activestorage` gem.