### PR TITLE
Use optimized subclass of StringInquirer for Rails.env

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -70,6 +70,7 @@ module ActiveSupport
     autoload :OrderedHash
     autoload :OrderedOptions
     autoload :StringInquirer
+    autoload :EnvironmentInquirer
     autoload :TaggedLogging
     autoload :XmlMini
     autoload :ArrayInquirer

--- a/activesupport/lib/active_support/core_ext/string/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/string/inquiry.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/string_inquirer"
+require "active_support/environment_inquirer"
 
 class String
   # Wraps the current string in the <tt>ActiveSupport::StringInquirer</tt> class,

--- a/activesupport/lib/active_support/environment_inquirer.rb
+++ b/activesupport/lib/active_support/environment_inquirer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "active_support/string_inquirer"
+
+module ActiveSupport
+  class EnvironmentInquirer < StringInquirer #:nodoc:
+    DEFAULT_ENVIRONMENTS = ["development", "test", "production"]
+    def initialize(env)
+      super(env)
+
+      DEFAULT_ENVIRONMENTS.each do |default|
+        instance_variable_set :"@#{default}", env == default
+      end
+    end
+
+    DEFAULT_ENVIRONMENTS.each do |env|
+      class_eval "def #{env}?; @#{env}; end"
+    end
+  end
+end

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -70,14 +70,14 @@ module Rails
     #   Rails.env.development? # => true
     #   Rails.env.production? # => false
     def env
-      @_env ||= ActiveSupport::StringInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
+      @_env ||= ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
     end
 
     # Sets the Rails environment.
     #
     #   Rails.env = "staging" # => "staging"
     def env=(environment)
-      @_env = ActiveSupport::StringInquirer.new(environment)
+      @_env = ActiveSupport::EnvironmentInquirer.new(environment)
     end
 
     # Returns all Rails groups for loading based on:


### PR DESCRIPTION
This adds a StringInquirer subclass EnvironmentInquirer that predefines the three default environments as query methods, in order to avoid dispatching through `method_missing` for every call to those methods. The original StringInquirer was not modified due to the side effects of having new env-related methods on it. This new class was not implemented using lazy method definition to avoid the open-ended possibility of defining a new method for all query calls. The three default environments should cover a high percentage of real-world uses, and users with custom environments could add their own to this class.

Fixes #37803.

This is a follow-up to #37808 which seemed to be missing a require, causing CI to fail once it was merged (though I thought that PR was green at some point. 🤔 