### PR TITLE
Refactor for_each(databases) code

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -169,7 +169,7 @@ module ActiveRecord
         return if database_configs.count == 1
 
         database_configs.each do |db_config|
-          yield db_config.name
+          yield db_config
         end
       end
 


### PR DESCRIPTION
While working on something else I noticed this code was duplicated. It
was returning `name` from `for_each` and then we'd have to lookup the
`db_config` again from the `name` and `env`. We can instead just return
`db_config` from `for_each` and clean up these tasks a little bit.