### PR TITLE
Inflection support default_locale and fallbacks

### DIFF
--- a/activesupport/lib/active_support/i18n.rb
+++ b/activesupport/lib/active_support/i18n.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/hash/except"
 require "active_support/core_ext/hash/slice"
 begin
   require "i18n"
+  require "i18n/backend/fallbacks"
 rescue LoadError => e
   $stderr.puts "The i18n gem is not available. Please add it to your Gemfile and run bundle install"
   raise e

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -64,6 +64,13 @@ module ActiveSupport
         @__instance__[locale] ||= new
       end
 
+      def self.instance_or_fallback(locale)
+        I18n.fallbacks[locale].each do |k|
+          return @__instance__[k] if @__instance__.key?(k)
+        end
+        instance(locale)
+      end
+
       attr_reader :plurals, :singulars, :uncountables, :humans, :acronyms
 
       attr_reader :acronyms_camelize_regex, :acronyms_underscore_regex # :nodoc:
@@ -248,7 +255,7 @@ module ActiveSupport
       if block_given?
         yield Inflections.instance(locale)
       else
-        Inflections.instance(locale)
+        Inflections.instance_or_fallback(locale)
       end
     end
   end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -33,6 +33,12 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal "", ActiveSupport::Inflector.pluralize("")
   end
 
+  def test_pluralize_with_fallback
+    I18n.stub(:default_locale, :"en-GB") do
+      assert_equal "days", ActiveSupport::Inflector.pluralize("days")
+    end
+  end
+
   test "uncountability of ascii word" do
     word = "HTTP"
     ActiveSupport::Inflector.inflections do |inflect|


### PR DESCRIPTION
### Summary

Currently, the inflector does not make use of I18n default locale or fallbacks. This PR could be divided into two if we decide we want to discuss these things independently. For example, using Rails 6.0.2.1:

~~~cmd
rails new randomtest
cd randomtest
./bin/rails console
Running via Spring preloader in process 23434
Loading development environment (Rails 6.0.2.1)
irb(main):001:0> 'day'.pluralize(:en)
=> "days"
irb(main):002:0> 'day'.pluralize(:'en-GB')
=> "day"
irb(main):003:0> 
~~~

It would be quite nice if the inflector would use the default fallback system (or whatever fallback system is configured) in the i18n gem as described in https://github.com/ruby-i18n/i18n/wiki/Fallbacks in order to choose a suitable inflector.

I'm sure there are many ways to go about that, but I've baked one option into this PR. I'd like some feedback primarily on whether the community agrees that we should use I18n defaults and fallbacks for the inflector. And if so, we should discuss if we want something like my implementation here or something else entirely.

Even if we don't go this route, I believe we need to do something to allow people an alternative to the hack described in #28972

### Other Information

See prior issue: #28972
See stackoverflow question which I believe is answered wrongly: https://stackoverflow.com/questions/43728567/with-regional-locale-pluralize-doesnt-work-but-translate-does