### PR TITLE
Allow to pass metadata in ActiveRecord::Result

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -740,6 +740,14 @@ module ActiveRecord
 
         def build_statement_pool
         end
+
+        def metadata
+          ActiveRecord::Result::DEFAULT_EMPTY_METADATA
+        end
+
+        def build_result(columns, rows, column_types = {})
+          ActiveRecord::Result.new(columns, rows, column_types, metadata)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -54,17 +54,17 @@ module ActiveRecord
           if without_prepared_statement?(binds)
             execute_and_free(sql, name) do |result|
               if result
-                ActiveRecord::Result.new(result.fields, result.to_a)
+                build_result(result.fields, result.to_a)
               else
-                ActiveRecord::Result.new([], [])
+                build_result([], [])
               end
             end
           else
             exec_stmt_and_free(sql, name, binds, cache_stmt: prepare) do |_, result|
               if result
-                ActiveRecord::Result.new(result.fields, result.to_a)
+                build_result(result.fields, result.to_a)
               else
-                ActiveRecord::Result.new([], [])
+                build_result([], [])
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -103,7 +103,7 @@ module ActiveRecord
               fmod  = result.fmod i
               types[fname] = get_oid_type(ftype, fmod, fname)
             end
-            ActiveRecord::Result.new(fields, result.values, types)
+            build_result(fields, result.values, types)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -63,7 +63,7 @@ module ActiveRecord
                 records = stmt.to_a
               end
 
-              ActiveRecord::Result.new(cols, records)
+              build_result(cols, records)
             end
           end
         end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -50,7 +50,8 @@ module ActiveRecord
 
       payload = {
         record_count: result_set.length,
-        class_name: name
+        class_name: name,
+        result_set: result_set
       }
 
       message_bus.instrument("instantiation.active_record", payload) do

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -34,13 +34,16 @@ module ActiveRecord
   class Result
     include Enumerable
 
-    attr_reader :columns, :rows, :column_types
+    DEFAULT_EMPTY_METADATA = {}.freeze
 
-    def initialize(columns, rows, column_types = {})
+    attr_reader :columns, :rows, :column_types, :metadata
+
+    def initialize(columns, rows, column_types = {}, metadata = DEFAULT_EMPTY_METADATA)
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
       @column_types = column_types
+      @metadata     = metadata.freeze
     end
 
     # Returns true if this result set includes the column named +name+

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -126,6 +126,13 @@ module ActiveRecord
       assert_instance_of(ActiveRecord::Result, result)
     end
 
+    def test_exec_query_returns_result_with_empty_metadata
+      result = @connection.exec_query "SELECT 1"
+      assert_instance_of(ActiveRecord::Result, result)
+      assert_equal({}, result.metadata)
+      assert_predicate(result.metadata, :frozen?)
+    end
+
     if current_adapter?(:Mysql2Adapter)
       def test_charset
         assert_not_nil @connection.charset

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1168,6 +1168,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
 
     assert_equal Developer.all.to_a.count, payload[:record_count]
     assert_equal Developer.name, payload[:class_name]
+    assert_instance_of ActiveRecord::Result, payload[:result_set]
   end
 
   def messages_for(name)

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -101,5 +101,15 @@ module ActiveRecord
 
       assert_equal [[1.1, 2.2], [3.3, 4.4]], result.cast_values("col1" => Type::Float.new)
     end
+
+    test "accepts optional metadata" do
+      result = Result.new([], [])
+      assert_equal({}, result.metadata)
+      assert_predicate(result.metadata, :frozen?)
+
+      result = Result.new([], [], {}, { foo: :bar })
+      assert_equal({ foo: :bar }, result.metadata)
+      assert_predicate(result.metadata, :frozen?)
+    end
   end
 end


### PR DESCRIPTION
At Shopify, we're about to leverage mysql's client session tracking (https://github.com/brianmario/mysql2/pull/1092) and pass around some metadata from MySQL server to the client. That metadata is per connection and is fetched with something like `@connection.session_track(Mysql2::Client::SESSION_TRACK_SYSTEM_VARIABLES)`.

I'd like `ActiveRecord::Result` (and eventually maybe records themselves) to retain that metadata so that we can link it to records and instrument with ActiveSupport::Notifications.

I've took a stab at trying to abstract it in a way that it's not tied to MySQL. I'm open to suggestions for what would be a better design.

cc @bibstha @sirupsen @rafaelfranca @Edouard-chin @byroot 