### PR TITLE
Revert "Merge pull request #38658 from eileencodes/refactor-for-each-…

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -26,9 +26,10 @@ db_namespace = namespace :db do
       ActiveRecord::Tasks::DatabaseTasks.create_all
     end
 
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-      desc "Create #{db_config.name} database for current environment"
-      task db_config.name => :load_config do
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Create #{name} database for current environment"
+      task name => :load_config do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Tasks::DatabaseTasks.create(db_config)
       end
     end
@@ -44,9 +45,10 @@ db_namespace = namespace :db do
       ActiveRecord::Tasks::DatabaseTasks.drop_all
     end
 
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-      desc "Drop #{db_config.name} database for current environment"
-      task db_config.name => [:load_config, :check_protected_environments] do
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Drop #{name} database for current environment"
+      task name => [:load_config, :check_protected_environments] do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Tasks::DatabaseTasks.drop(db_config)
       end
     end
@@ -105,32 +107,33 @@ db_namespace = namespace :db do
   end
 
   namespace :_dump do
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
       # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false
-      task db_config.name do
+      task name do
         if ActiveRecord::Base.dump_schema_after_migration
           case ActiveRecord::Base.schema_format
-          when :ruby then db_namespace["schema:dump:#{db_config.name}"].invoke
-          when :sql  then db_namespace["structure:dump:#{db_config.name}"].invoke
+          when :ruby then db_namespace["schema:dump:#{name}"].invoke
+          when :sql  then db_namespace["structure:dump:#{name}"].invoke
           else
             raise "unknown schema format #{ActiveRecord::Base.schema_format}"
           end
         end
         # Allow this task to be called as many times as required. An example is the
         # migrate:redo task, which calls other two internally that depend on this one.
-        db_namespace["_dump:#{db_config.name}"].reenable
+        db_namespace["_dump:#{name}"].reenable
       end
     end
   end
 
   namespace :migrate do
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-      desc "Migrate #{db_config.name} database for current environment"
-      task db_config.name => :load_config do
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Migrate #{name} database for current environment"
+      task name => :load_config do
         original_db_config = ActiveRecord::Base.connection_db_config
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Base.establish_connection(db_config)
         ActiveRecord::Tasks::DatabaseTasks.migrate
-        db_namespace["_dump:#{db_config.name}"].invoke
+        db_namespace["_dump:#{name}"].invoke
       ensure
         ActiveRecord::Base.establish_connection(original_db_config)
       end
@@ -168,9 +171,11 @@ db_namespace = namespace :db do
     end
 
     namespace :up do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        task name => :load_config do
           raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
+
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
 
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
@@ -200,9 +205,11 @@ db_namespace = namespace :db do
     end
 
     namespace :down do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        task name => :load_config do
           raise "VERSION is required" if !ENV["VERSION"] || ENV["VERSION"].empty?
+
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
 
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.check_target_version
@@ -225,9 +232,10 @@ db_namespace = namespace :db do
     end
 
     namespace :status do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        desc "Display status of migrations for #{db_config.name} database"
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Display status of migrations for #{name} database"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.migrate_status
         end
@@ -289,9 +297,10 @@ db_namespace = namespace :db do
   end
 
   namespace :abort_if_pending_migrations do
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-      # desc "Raises an error if there are pending migrations for #{db_config.name} database"
-      task db_config.name => :load_config do
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      # desc "Raises an error if there are pending migrations for #{name} database"
+      task name => :load_config do
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)
         ActiveRecord::Base.establish_connection(db_config)
 
         pending_migrations = ActiveRecord::Base.connection.migration_context.open.pending_migrations
@@ -301,7 +310,7 @@ db_namespace = namespace :db do
           pending_migrations.each do |pending_migration|
             puts "  %4d %s" % [pending_migration.version, pending_migration.name]
           end
-          abort %{Run `rails db:migrate:#{db_config.name}` to update your database then try again.}
+          abort %{Run `rails db:migrate:#{name}` to update your database then try again.}
         end
       end
     end
@@ -322,6 +331,7 @@ db_namespace = namespace :db do
       if ActiveRecord::Base.dump_schema_after_migration
         ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, ActiveRecord::Base.schema_format)
       end
+
     rescue ActiveRecord::NoDatabaseError
       ActiveRecord::Tasks::DatabaseTasks.create_current(db_config.env_name, db_config.name)
       ActiveRecord::Tasks::DatabaseTasks.load_schema(
@@ -417,20 +427,22 @@ db_namespace = namespace :db do
     end
 
     namespace :dump do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record for #{db_config.name} database"
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Creates a db/schema.rb file that is portable against any DB supported by Active Record for #{name} database"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :ruby)
-          db_namespace["schema:dump:#{db_config.name}"].reenable
+          db_namespace["schema:dump:#{name}"].reenable
         end
       end
     end
 
     namespace :load do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        desc "Loads a schema.rb file into the #{db_config.name} database"
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Loads a schema.rb file into the #{name} database"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :ruby, ENV["SCHEMA"])
         end
       end
@@ -488,20 +500,22 @@ db_namespace = namespace :db do
     end
 
     namespace :dump do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        desc "Dumps the #{db_config.name} database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Dumps the #{name} database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Base.establish_connection(db_config)
           ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :sql)
-          db_namespace["structure:dump:#{db_config.name}"].reenable
+          db_namespace["structure:dump:#{name}"].reenable
         end
       end
     end
 
     namespace :load do
-      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-        desc "Recreates the #{db_config.name} database from the structure.sql file"
-        task db_config.name => :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Recreates the #{name} database from the structure.sql file"
+        task name => :load_config do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :sql, ENV["SCHEMA"])
         end
       end
@@ -555,26 +569,26 @@ db_namespace = namespace :db do
       end
     end
 
-    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |db_config|
-      # desc "Recreate the #{db_config.name} test database"
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      # desc "Recreate the #{name} test database"
       namespace :load do
-        task db_config.name => "db:test:purge:#{db_config.name}" do
+        task name => "db:test:purge:#{name}" do
           case ActiveRecord::Base.schema_format
           when :ruby
-            db_namespace["test:load_schema:#{db_config.name}"].invoke
+            db_namespace["test:load_schema:#{name}"].invoke
           when :sql
-            db_namespace["test:load_structure:#{db_config.name}"].invoke
+            db_namespace["test:load_structure:#{name}"].invoke
           end
         end
       end
 
-      # desc "Recreate the #{db_config.name} test database from an existent schema.rb file"
+      # desc "Recreate the #{name} test database from an existent schema.rb file"
       namespace :load_schema do
-        task db_config.name => "db:test:purge:#{db_config.name}" do
+        task name => "db:test:purge:#{name}" do
           should_reconnect = ActiveRecord::Base.connection_pool.active_connection?
           ActiveRecord::Schema.verbose = false
-          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.name, :ruby)
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: db_config.name)
+          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(name, :ruby)
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :ruby, filename)
         ensure
           if should_reconnect
@@ -585,25 +599,25 @@ db_namespace = namespace :db do
 
       # desc "Recreate the #{name} test database from an existent structure.sql file"
       namespace :load_structure do
-        task db_config.name => "db:test:purge:#{db_config.name}" do
-          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.name, :sql)
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: db_config.name)
+        task name => "db:test:purge:#{name}" do
+          filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(name, :sql)
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, :sql, filename)
         end
       end
 
       # desc "Empty the #{name} test database"
       namespace :purge do
-        task db_config.name => %w(load_config check_protected_environments) do
-          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: db_config.name)
+        task name => %w(load_config check_protected_environments) do
+          db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
           ActiveRecord::Tasks::DatabaseTasks.purge(db_config)
         end
       end
 
       # desc 'Load the #{name} database test schema'
       namespace :prepare do
-        task db_config.name => :load_config do
-          db_namespace["test:load:#{db_config.name}"].invoke
+        task name => :load_config do
+          db_namespace["test:load:#{name}"].invoke
         end
       end
     end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -169,7 +169,7 @@ module ActiveRecord
         return if database_configs.count == 1
 
         database_configs.each do |db_config|
-          yield db_config
+          yield db_config.name
         end
       end
 


### PR DESCRIPTION
…databases-code"

This reverts commit 9a5bc246d75595ae320a72c63a1df44ce6f63717, reversing
changes made to 227ff44e36ff9753fc5577335a333514949883fc.

I realized afterwards that this was written this way for a reason and it
wasn't accidental. The databases loaded in `for_each` are not complete
database configs because these are generated from the database yaml
before the Rails env is loaded. So we actually do need to refetch the
correct database configuration objects after we've loaded the Rails env.