### PR TITLE
Stop recommending RailsInstaller in favor of RubyInstaller

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -80,7 +80,7 @@ your prompt will look something like `c:\source_code>`
 Before you install Rails, you should check to make sure that your system has the
 proper prerequisites installed. These include:
 
-* Ruby 
+* Ruby
 * SQLite3
 * Node.js
 * Yarn
@@ -100,21 +100,18 @@ ruby 2.5.0
 Rails requires Ruby version 2.5.0 or later. If the version number returned is
 less than that number (such as 2.3.7, or 1.8.7), you'll need to install a fresh copy of Ruby.
 
-TIP: To quickly install Ruby and Ruby on Rails on your system in Windows, you can use
-[Rails Installer](http://railsinstaller.org). For more installation methods for most
-Operating Systems take a look at [ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/).
+To install Rails on Windows, you'll first need to install [Ruby Installer](https://rubyinstaller.org/).
 
-If you are working on Windows, you should also install the
-[Ruby Installer Development Kit](https://rubyinstaller.org/downloads/).
+For more installation methods for most Operating Systems take a look at
+[ruby-lang.org](https://www.ruby-lang.org/en/documentation/installation/).
 
 #### Installing SQLite3
 
 You will also need an installation of the SQLite3 database.
 Many popular UNIX-like OSes ship with an acceptable version of SQLite3.
-On Windows, if you installed Rails through Rails Installer, you
-already have SQLite installed. Others can find installation instructions
-at the [SQLite3 website](https://www.sqlite.org).
-Verify that it is correctly installed and in your PATH:
+Others can find installation instructions at the [SQLite3 website](https://www.sqlite.org).
+
+Verify that it is correctly installed and in your load `PATH`:
 
 ```bash
 $ sqlite3 --version
@@ -126,10 +123,10 @@ The program should report its version.
 
 Finally, you'll need Node.js and Yarn installed to manage your application's JavaScript.
 
-Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and 
+Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and
 verify it's installed correctly with the following command:
 
-```bash 
+```bash
 $ node --version
 ```
 


### PR DESCRIPTION
RailsInstaller is no longer maintained and its latest supported Ruby
version is 2.3 which Rails no longer supports.

In contrast, RubyInstaller supports Ruby 2.7, 2.6, 2.5, 2.4, 2.3, and 2.2 which
are the only Ruby versions necessary for Rails 6.x and 5.x at this point.

I'm aware that WSL is also an option. We can address this in a later PR, for now
I want to address outdated information for Windows users. WSL is a thorny topic
since WSL2 isn't available in stable Windows releaases and WSL1 has severe
performance problems [documented by @SamSaffron][1].

[1]: https://twitter.com/samsaffron/status/1233537759580770313

Fixes #38654