### PR TITLE
Extend `ActionView::Helpers#translate` to yield

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `ActionView::Helpers::TranslationHelper#translate` accepts a block, yielding
+    the translated text and the fully resolved translation key:
+
+        <%= translate(".relative_key") do |translation, resolved_key| %>
+          <span title="<%= resolved_key %>"><%= translation %></span>
+        <% end %>
+
+    *Sean Doyle*
+
 *   Deprecate template names with `.`
 
     *John Hawthorn*

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -57,6 +57,17 @@ module ActionView
       # that include HTML tags so that you know what kind of output to expect
       # when you call translate in a template and translators know which keys
       # they can provide HTML values for.
+      #
+      # Finally, to access the translated text along with the fully resolved
+      # translation key, <tt>translate</tt> accepts a block:
+      #
+      #     <%= translate(".relative_key") do |translation, resolved_key| %>
+      #       <span title="<%= resolved_key %>"><%= translation %></span>
+      #     <% end %>
+      #
+      # This enables annotate translated text to be aware of the scope it was
+      # resolved against.
+      #
       def translate(key, **options)
         unless options[:default].nil?
           remaining_defaults = Array.wrap(options.delete(:default)).compact
@@ -74,6 +85,9 @@ module ActionView
           i18n_raise = true
         end
 
+        fully_resolved_key = scope_key_by_partial(key)
+        translated_text = options.fetch(:default, "")
+
         if html_safe_translation_key?(key)
           html_safe_options = options.dup
           options.except(*I18n::RESERVED_KEYS).each do |name, value|
@@ -81,14 +95,20 @@ module ActionView
               html_safe_options[name] = ERB::Util.html_escape(value.to_s)
             end
           end
-          translation = I18n.translate(scope_key_by_partial(key), **html_safe_options.merge(raise: i18n_raise))
+          translation = I18n.translate(fully_resolved_key, **html_safe_options.merge(raise: i18n_raise))
           if translation.respond_to?(:map)
-            translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
+            translated_text = translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
           else
-            translation.respond_to?(:html_safe) ? translation.html_safe : translation
+            translated_text = translation.respond_to?(:html_safe) ? translation.html_safe : translation
           end
         else
-          I18n.translate(scope_key_by_partial(key), **options.merge(raise: i18n_raise))
+          translated_text = I18n.translate(fully_resolved_key, **options.merge(raise: i18n_raise))
+        end
+
+        if block_given?
+          yield(translated_text, fully_resolved_key)
+        else
+          translated_text
         end
       rescue I18n::MissingTranslationData => e
         if remaining_defaults.present?
@@ -106,7 +126,13 @@ module ActionView
 
           return title unless ActionView::Base.debug_missing_translation
 
-          content_tag("span", keys.last.to_s.titleize, class: "translation_missing", title: title)
+          translated_fallback = content_tag("span", keys.last.to_s.titleize, class: "translation_missing", title: title)
+
+          if block_given?
+            yield(translated_fallback, scope_key_by_partial(key))
+          else
+            translated_fallback
+          end
         end
       end
       alias :t :translate

--- a/actionview/test/fixtures/translations/templates/found_yield_block.html.erb
+++ b/actionview/test/fixtures/translations/templates/found_yield_block.html.erb
@@ -1,0 +1,3 @@
+<%= t('.foo') do |translation, key| %>
+  <%= key %>: <%= translation %>
+<% end %>

--- a/actionview/test/fixtures/translations/templates/found_yield_single_argument.html.erb
+++ b/actionview/test/fixtures/translations/templates/found_yield_single_argument.html.erb
@@ -1,0 +1,3 @@
+<%= t('.foo') do |translation| %>
+  <%= translation %>
+<% end %>

--- a/actionview/test/fixtures/translations/templates/missing_with_default_yield_block.erb
+++ b/actionview/test/fixtures/translations/templates/missing_with_default_yield_block.erb
@@ -1,0 +1,3 @@
+<%= translate(".missing", default: "Default") do |translation, key| %>
+  <%= key %>: <%= translation %>
+<% end %>

--- a/actionview/test/fixtures/translations/templates/missing_with_default_yield_single_argument_block.erb
+++ b/actionview/test/fixtures/translations/templates/missing_with_default_yield_single_argument_block.erb
@@ -1,0 +1,3 @@
+<%= translate(".missing", default: "Default") do |translation| %>
+  <%= translation %>
+<% end %>

--- a/actionview/test/fixtures/translations/templates/missing_yield_block.erb
+++ b/actionview/test/fixtures/translations/templates/missing_yield_block.erb
@@ -1,0 +1,3 @@
+<%= t('.missing') do |translation, key| %>
+  <%= key %>: <%= translation %>
+<% end %>

--- a/actionview/test/fixtures/translations/templates/missing_yield_single_argument_block.erb
+++ b/actionview/test/fixtures/translations/templates/missing_yield_single_argument_block.erb
@@ -1,0 +1,3 @@
+<%= t('.missing') do |translation| %>
+  <%= translation %>
+<% end %>

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -20,6 +20,8 @@ class TranslationHelperTest < ActiveSupport::TestCase
       translations: {
         templates: {
           found: { foo: "Foo" },
+          found_yield_single_argument: { foo: "Foo" },
+          found_yield_block: { foo: "Foo" },
           array: { foo: { bar: "Foo Bar" } },
           default: { foo: "Foo" }
         },
@@ -136,6 +138,14 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal "Foo", view.render(template: "translations/templates/found").strip
   end
 
+  def test_finds_translation_scoped_by_partial_yielding_single_argument_block
+    assert_equal "Foo", view.render(template: "translations/templates/found_yield_single_argument").strip
+  end
+
+  def test_finds_translation_scoped_by_partial_yielding_translation_and_key
+    assert_equal "translations.templates.found_yield_block.foo: Foo", view.render(template: "translations/templates/found_yield_block").strip
+  end
+
   def test_finds_array_of_translations_scoped_by_partial
     assert_equal "Foo Bar", @view.render(template: "translations/templates/array").strip
   end
@@ -147,6 +157,26 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_missing_translation_scoped_by_partial
     expected = '<span class="translation_missing" title="translation missing: en.translations.templates.missing.missing">Missing</span>'
     assert_equal expected, view.render(template: "translations/templates/missing").strip
+  end
+
+  def test_missing_translation_scoped_by_partial_yield_block
+    expected = 'translations.templates.missing_yield_block.missing: <span class="translation_missing" title="translation missing: en.translations.templates.missing_yield_block.missing">Missing</span>'
+    assert_equal expected, view.render(template: "translations/templates/missing_yield_block").strip
+  end
+
+  def test_missing_translation_with_default_scoped_by_partial_yield_block
+    expected = "translations.templates.missing_with_default_yield_block.missing: Default"
+    assert_equal expected, view.render(template: "translations/templates/missing_with_default_yield_block").strip
+  end
+
+  def test_missing_translation_scoped_by_partial_yield_single_argument_block
+    expected = '<span class="translation_missing" title="translation missing: en.translations.templates.missing_yield_single_argument_block.missing">Missing</span>'
+    assert_equal expected, view.render(template: "translations/templates/missing_yield_single_argument_block").strip
+  end
+
+  def test_missing_translation_with_default_scoped_by_partial_yield_single_argument_block
+    expected = "Default"
+    assert_equal expected, view.render(template: "translations/templates/missing_with_default_yield_single_argument_block").strip
   end
 
   def test_translate_does_not_mark_plain_text_as_safe_html


### PR DESCRIPTION
This commit extends the `ActionView::Helpers#translate` (and by way of
alias, `#t`) helper methods to accept blocks.

When invoked with a block, the `translate` call will yield the
translated text as its first block argument, along with the resolved
translation key as its second:

```erb
<%= translate(".key") do |translation, resolved_key| %>
  <span data-i18n-key="<%= resolved_key %>"><%= translation %></span>
<% end %>
```

In cases where relative translation keys are foregone in lieu of fully
qualified keys, or if the caller is not interested in the resolved key,
the second block argument can be omitted:

```erb
<%= translate("action.template.key") do |translation| %>
  <p><%= translation %></p>
  <p><%= translation %>, but a second time</p>
<% end %>
```

A benefit of yielding the translation is that it enabled template-local
variable re-use. Alternatively, [`Object#tap`][tap] could be used.

Prior to this commit, however, the resolution of the translation key was
internal to `ActionView`, and unavailable to the caller (unless they
were willing to explicitly determine the resolved key themselves). By
making it available as a block parameter, it could be used to annotate
the translated value in the resulting elements.

[tap]: https://ruby-doc.org/core-2.7.0/Object.html#method-i-tap

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
