### PR TITLE
Update minimal required ruby version to avoid a crash on 'rails new'

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "WebSocket framework for Rails."
   s.description = "Structure many real-time application concerns into channels over a single WebSocket connection."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/actioncable/lib/rails/generators/channel/channel_generator.rb
+++ b/actioncable/lib/rails/generators/channel/channel_generator.rb
@@ -33,7 +33,7 @@ module Rails
           @_file_name ||= super.sub(/_channel\z/i, "")
         end
 
-        # FIXME: Change these files to symlinks once RubyGems 2.5.0 is required.
+        # FIXME: Change these files to symlinks once RubyGems 2.5.1 is required.
         def generate_application_cable_files
           return if behavior != :invoke
 

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Inbound email handling framework."
   s.description = "Receive and process incoming emails in Rails applications."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license  = "MIT"
 

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Email composition and delivery framework (part of Rails)."
   s.description = "Email on Rails. Compose, deliver, and test emails using the familiar controller/view pattern. First-class support for multipart email and attachments."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Web-flow and rendering framework putting the VC in MVC (part of Rails)."
   s.description = "Web apps on Rails. Simple, battle-tested conventions for building and testing MVC web applications. Works with any Rack-compatible server."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Rich text framework."
   s.description = "Edit and display rich text in Rails applications."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license  = "MIT"
 

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Rendering framework putting the V in MVC (part of Rails)."
   s.description = "Simple, battle-tested conventions and helpers for building web pages."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/activejob/activejob.gemspec
+++ b/activejob/activejob.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Job framework with pluggable queues."
   s.description = "Declare job classes that can be run by a variety of queuing backends."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/activemodel/activemodel.gemspec
+++ b/activemodel/activemodel.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "A toolkit for building modeling frameworks (part of Rails)."
   s.description = "A toolkit for building modeling frameworks like Active Record. Rich support for attributes, callbacks, validations, serialization, internationalization, and testing."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/activerecord/activerecord.gemspec
+++ b/activerecord/activerecord.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Object-relational mapper framework (part of Rails)."
   s.description = "Databases on Rails. Build a persistent domain model by mapping database tables to Ruby classes. Strong conventions for associations, validations, aggregations, migrations, and testing come baked-in."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Local and cloud file storage framework."
   s.description = "Attach cloud and local files in Rails applications."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework."
   s.description = "A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. Rich support for multibyte strings, internationalization, time zones, and testing."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -150,7 +150,7 @@ Event.where("payload->>'kind' = ?", "user_renamed")
 * [type definition](https://www.postgresql.org/docs/current/static/rangetypes.html)
 * [functions and operators](https://www.postgresql.org/docs/current/static/functions-range.html)
 
-This type is mapped to Ruby [`Range`](https://ruby-doc.org/core-2.5.0/Range.html) objects.
+This type is mapped to Ruby [`Range`](https://ruby-doc.org/core-2.5.1/Range.html) objects.
 
 ```ruby
 # db/migrate/20130923065404_create_events.rb
@@ -367,7 +367,7 @@ user.save!
 * [type definition](https://www.postgresql.org/docs/current/static/datatype-net-types.html)
 
 The types `inet` and `cidr` are mapped to Ruby
-[`IPAddr`](https://ruby-doc.org/stdlib-2.5.0/libdoc/ipaddr/rdoc/IPAddr.html)
+[`IPAddr`](https://ruby-doc.org/stdlib-2.5.1/libdoc/ipaddr/rdoc/IPAddr.html)
 objects. The `macaddr` type is mapped to normal text.
 
 ```ruby

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -450,7 +450,7 @@ $ bin/rails destroy model Oops
 $ bin/rails about
 About your application's environment
 Rails version             6.0.0
-Ruby version              2.5.0 (x86_64-linux)
+Ruby version              2.5.1 (x86_64-linux)
 RubyGems version          2.7.3
 Rack version              2.0.4
 JavaScript Runtime        Node.js (V8)

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -94,10 +94,10 @@ current version of Ruby installed:
 
 ```bash
 $ ruby -v
-ruby 2.5.0
+ruby 2.5.1
 ```
 
-Rails requires Ruby version 2.5.0 or later. If the version number returned is
+Rails requires Ruby version 2.5.1 or later. If the version number returned is
 less than that number (such as 2.3.7, or 1.8.7), you'll need to install a fresh copy of Ruby.
 
 TIP: To quickly install Ruby and Ruby on Rails on your system in Windows, you can use

--- a/rails.gemspec
+++ b/rails.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Full-stack web application framework."
   s.description = "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration."
 
-  s.required_ruby_version     = ">= 2.5.0"
+  s.required_ruby_version     = ">= 2.5.1"
   s.required_rubygems_version = ">= 1.8.11"
 
   s.license = "MIT"

--- a/railties/lib/rails/ruby_version_check.rb
+++ b/railties/lib/rails/ruby_version_check.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0") && RUBY_ENGINE == "ruby"
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.1") && RUBY_ENGINE == "ruby"
   desc = defined?(RUBY_DESCRIPTION) ? RUBY_DESCRIPTION : "ruby #{RUBY_VERSION} (#{RUBY_RELEASE_DATE})"
   abort <<-end_message
 
-    Rails 6 requires Ruby 2.5.0 or newer.
+    Rails 6 requires Ruby 2.5.1 or newer.
 
     You're running
       #{desc}
 
-    Please upgrade to Ruby 2.5.0 or newer to continue.
+    Please upgrade to Ruby 2.5.1 or newer to continue.
 
   end_message
 end

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary     = "Tools for creating, working with, and running Rails applications."
   s.description = "Rails internals: application bootup, plugins, generators, and rake tasks."
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.5.1"
 
   s.license = "MIT"
 


### PR DESCRIPTION
fixes #38649 

### Summary
It can be very frustrating to follow the guides and getting a crash with an error message that does not lead to a quick and keep on going solution.
Following the guides, installing ruby 2.5.0 and launch a new rails project crashes with `NameError: uninitialized constant URI::Generic`.
I have tried with ruby 2.5.1 and I could successfully create a new project. So one possible solution is to update the guides and all the dependencies to **avoid newcomers disappointment**.

### Other Information
I feel that I'm touching to many files for a new contributor, if it's true I could use some guidance to make this happen.
