### PR TITLE
Remove unnecessary creation of new hash config

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -184,17 +184,13 @@ module ActiveRecord
         end
       end
 
-      def resolve_symbol_connection(env_name, pool_name)
-        db_config = find_db_config(env_name)
-
-        if db_config
-          config = db_config.configuration_hash.dup
-          db_config = DatabaseConfigurations::HashConfig.new(db_config.env_name, db_config.name, config)
+      def resolve_symbol_connection(name, pool_name)
+        if db_config = find_db_config(name)
           db_config.owner_name = pool_name.to_s
           db_config
         else
           raise AdapterNotSpecified, <<~MSG
-            The `#{env_name}` database is not configured for the `#{default_env}` environment.
+            The `#{name}` database is not configured for the `#{default_env}` environment.
 
               Available databases configurations are:
 


### PR DESCRIPTION
This line was creating a new hash config, but we should always have a
hash config to lookup at this point.

Previously we needed this code because the pool name was merged into the
hash. Now it's an accessor on the db_config, so we have no reason to
create a new hash config.