### PR TITLE
Update to listen 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 
 # Active Support
 gem "dalli"
-gem "listen", ">= 3.0.5", "< 3.2", require: false
+gem "listen", "~> 3.2", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
 gem "rexml", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,10 +292,9 @@ GEM
       mustache
       nokogiri
     libxml-ruby (3.1.0)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
+    listen (3.2.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -420,7 +419,6 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.16)
       ffi (~> 1.9)
-    ruby_dep (1.5.0)
     rubyzip (2.0.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
@@ -560,7 +558,7 @@ DEPENDENCIES
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)
   libxml-ruby
-  listen (>= 3.0.5, < 3.2)
+  listen (~> 3.2)
   minitest-bisect
   minitest-reporters
   minitest-retry

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1591,7 +1591,7 @@ evented file system monitor to detect changes when `config.cache_classes` is
 
 ```ruby
 group :development do
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '~> 3.2'
 end
 ```
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -53,7 +53,7 @@ group :development do
   <%- end -%>
 <%- end -%>
 <% if depend_on_listen? -%>
-  gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'listen', '~> 3.2'
 <% end -%>
 <% if spring_install? -%>
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring


### PR DESCRIPTION
### Summary

This is a backport of https://github.com/rails/rails/pull/37788 to 6.0-stable.

`listen` 3.2, among other fixes, removes the [unmaintained](https://github.com/e2/ruby_dep/pull/37) `ruby_dep` dependency, which incorrectly shows warnings when running on TruffleRuby:
```
$ bundle exec rails s
RubyDep: WARNING: Your Ruby may not be supported.
RubyDep: WARNING: Your Ruby is: 2.6.2 'truffleruby' (unrecognized). If you need this version supported, please open an issue at http://github.com/e2/ruby_dep
RubyDep: WARNING: (To disable warnings, see:http://github.com/e2/ruby_dep/wiki/Disabling-warnings )
=> Booting Puma
=> Rails 6.0.1 application starting in development 
=> Run `rails server --help` for more startup options
Puma starting in single mode...
* Version 4.3.0 (truffleruby 19.3.0 - ruby 2.6.2), codename: Mysterious Traveller
* Min threads: 5, max threads: 5
* Environment: development
* Listening on tcp://127.0.0.1:3000
* Listening on tcp://[::1]:3000
Use Ctrl-C to stop
```

I am not aware of any issue by using a newer version of `listen`.

https://github.com/guard/listen/releases/tag/v3.2.0 are the release notes and https://github.com/guard/listen/issues/465 is the issue asking for this new release.

ddddedc487912e33edb7d78aec6bcf99b1312c6d is the commit that added the `< 3.2` version constraint. I guess that was just precaution (3.2 did not exist back then).