### PR TITLE
Correct the parameter name for deserialize

### DIFF
--- a/activejob/lib/active_job/serializers/object_serializer.rb
+++ b/activejob/lib/active_job/serializers/object_serializer.rb
@@ -39,7 +39,7 @@ module ActiveJob
       end
 
       # Deserializes an argument from a JSON primitive type.
-      def deserialize(_argument)
+      def deserialize(json)
         raise NotImplementedError
       end
 


### PR DESCRIPTION
### Summary

This trivial change only renames the argument so that it more closely matches the documentation.

Per discussion in https://github.com/rails/rails/issues/38629#issuecomment-594186129

Attn: @rafaelfranca 