### PR TITLE
Support creating variants of `webp` images out of the box

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for creating variants of `WebP` images out of the box.
+
+    *Dino Maric*
+    
 *   Only enqueue analysis jobs for blobs with non-null analyzer classes.
 
     *Gannon McGibbon*

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -38,6 +38,7 @@ module ActiveStorage
       image/bmp
       image/vnd.adobe.photoshop
       image/vnd.microsoft.icon
+      image/webp
     )
 
     config.active_storage.content_types_to_serve_as_binary = %w(

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -900,7 +900,7 @@ You can find more detailed configuration options in the
    config.active_storage.paths[:ffprobe] = '/usr/local/bin/ffprobe'
    ```
 
-* `config.active_storage.variable_content_types` accepts an array of strings indicating the content types that Active Storage can transform through ImageMagick. The default is `%w(image/png image/gif image/jpg image/jpeg image/pjpeg image/tiff image/bmp image/vnd.adobe.photoshop image/vnd.microsoft.icon)`.
+* `config.active_storage.variable_content_types` accepts an array of strings indicating the content types that Active Storage can transform through ImageMagick. The default is `%w(image/png image/gif image/jpg image/jpeg image/pjpeg image/tiff image/bmp image/vnd.adobe.photoshop image/vnd.microsoft.icon image/webp)`.
 
 * `config.active_storage.content_types_to_serve_as_binary` accepts an array of strings indicating the content types that Active Storage will always serve as an attachment, rather than inline. The default is `%w(text/html
 text/javascript image/svg+xml application/postscript application/x-shockwave-flash text/xml application/xml application/xhtml+xml application/mathml+xml text/cache-manifest)`.


### PR DESCRIPTION
This PR adds `image/webp` to the default array of variable content
types. 
Without this commit if we want to "handle" webp images
overwriting `config.active_storage.variable_content_types` was
necessary.
