### PR TITLE
AJ `perform_enqueued_jobs` shouldn't perform job retries: 

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   `ActiveJob::TestCase#perform_enqueued_jobs` will no longer perform retries:
+
+    When calling `perform_enqueued_jobs` without a block, the adapter will
+    now perform jobs that are **already** in the queue. Jobs that will end up in
+    the queue afterwards won't be performed.
+
+    This change only affects `perform_enqueued_jobs` when no block is given.
+
+    *Edouard Chin*
+
 *   Add queue name support to Que adapter
 
     *Brad Nauta*, *Wojciech Wnętrzak*

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -641,8 +641,8 @@ module ActiveJob
 
       def flush_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil)
         enqueued_jobs_with(only: only, except: except, queue: queue, at: at) do |payload|
-          instantiate_job(payload).perform_now
           queue_adapter.performed_jobs << payload
+          instantiate_job(payload).perform_now
         end
       end
 

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -602,7 +602,7 @@ module ActiveJob
       def jobs_with(jobs, only: nil, except: nil, queue: nil, at: nil)
         validate_option(only: only, except: except)
 
-        jobs.count do |job|
+        jobs.dup.count do |job|
           job_class = job.fetch(:job)
 
           if only

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -909,6 +909,16 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_performed_jobs 0
   end
 
+  def test_perform_enqueued_jobs_properly_count_job_that_raises
+    RaisingJob.perform_later("NotImplementedError")
+
+    assert_raises(NotImplementedError) do
+      perform_enqueued_jobs(only: RaisingJob)
+    end
+
+    assert_equal(1, performed_jobs.size)
+  end
+
   def test_assert_performed_jobs
     assert_nothing_raised do
       assert_performed_jobs 1 do

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -919,6 +919,17 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_equal(1, performed_jobs.size)
   end
 
+  def test_perform_enqueued_jobs_dont_perform_retries
+    RaisingJob.perform_later
+
+    assert_nothing_raised do
+      perform_enqueued_jobs(only: RaisingJob)
+    end
+
+    assert_equal(1, performed_jobs.size)
+    assert_equal(2, enqueued_jobs.size)
+  end
+
   def test_assert_performed_jobs
     assert_nothing_raised do
       assert_performed_jobs 1 do
@@ -1877,13 +1888,13 @@ class PerformedJobsTest < ActiveJob::TestCase
   end
 
   test "TestAdapter respect max attempts" do
-    RaisingJob.perform_later
-
-    assert_raises(RaisingJob::MyError) do
-      perform_enqueued_jobs
+    perform_enqueued_jobs(only: RaisingJob) do
+      assert_raises(RaisingJob::MyError) do
+        RaisingJob.perform_later
+      end
     end
 
-    assert_equal 2, queue_adapter.enqueued_jobs.count
+    assert_equal 2, queue_adapter.performed_jobs.count
   end
 end
 

--- a/activejob/test/jobs/raising_job.rb
+++ b/activejob/test/jobs/raising_job.rb
@@ -5,7 +5,7 @@ class RaisingJob < ActiveJob::Base
 
   retry_on(MyError, attempts: 2)
 
-  def perform
-    raise MyError
+  def perform(error = "RaisingJob::MyError")
+    raise error.constantize
   end
 end


### PR DESCRIPTION
AJ `perform_enqueued_jobs` shouldn't perform job retries:

- ### Problem

  If we use `perform_enqueued_jobs` without a block, a job that
  uses a retry mechanism to reeenqueue itself would get performed
  right away.
  This behaviour make sense when using `perform_enqueued_jobs` with
  a block.

  However I'm expecting `perform_enqueued_jobs` without a block to
  perform jobs that are **already** in the queue not the ones that
  will get enqueued afterwards.

  ### Solution

  Dup the array of jobs given to avoid future mutation.


cc/ @etiennebarrie @rafaelfranca @casperisfine