### PR TITLE
refactor: arel fetch_attribute to get the atrribute node from binary module.

### DIFF
--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -51,11 +51,8 @@ module Arel
     when Arel::Nodes::Between, Arel::Nodes::In, Arel::Nodes::NotIn, Arel::Nodes::Equality,
          Arel::Nodes::NotEqual, Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual,
          Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual
-      if value.left.is_a?(Arel::Attributes::Attribute)
-        yield value.left
-      elsif value.right.is_a?(Arel::Attributes::Attribute)
-        yield value.right
-      end
+      attribute_value = value.detect_attribute
+      yield attribute_value if attribute_value
     when Arel::Nodes::Or
       fetch_attribute(value.left, &block) && fetch_attribute(value.right, &block)
     when Arel::Nodes::Grouping

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -11,6 +11,14 @@ module Arel # :nodoc: all
         @right = right
       end
 
+      def detect_attribute
+        if self.left.is_a?(Arel::Attributes::Attribute)
+          self.left
+        elsif self.right.is_a?(Arel::Attributes::Attribute)
+          self.right
+        end
+      end
+
       def initialize_copy(other)
         super
         @left  = @left.clone if @left


### PR DESCRIPTION
Reason for doing this change is to pull the node specific changes to
module itself and to not infer on the attributes, rather than assign
responsibility to the member functions to do so.


### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->