### PR TITLE
Disable colorize logging of SQL and reduce unnecessary invocation of sql_color matching

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -44,7 +44,7 @@ module ActiveRecord
       end
 
       name = colorize_payload_name(name, payload[:name])
-      sql  = color(sql, sql_color(sql), true)
+      sql  = color(sql, sql_color(sql), true) if colorize_logging
 
       debug "  #{name}  #{sql}#{binds}"
     end

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -96,6 +96,16 @@ class LogSubscriberTest < ActiveRecord::TestCase
     end
   end
 
+  def test_logging_sql_coloration_disabled
+    logger = TestDebugLogSubscriber.new
+    logger.colorize_logging = false
+
+    SQL_COLORINGS.each do |verb, color_regex|
+      logger.sql(Event.new(0.9, sql: verb.to_s))
+      assert_no_match(/#{REGEXP_BOLD}#{color_regex}#{verb}#{REGEXP_CLEAR}/i, logger.debugs.last)
+    end
+  end
+
   def test_basic_payload_name_logging_coloration_generic_sql
     logger = TestDebugLogSubscriber.new
     logger.colorize_logging = true


### PR DESCRIPTION
When the `colorize_logging` is disabled, logs do not colorize the SQL queries. But the `sql_color` method is always invoked which due to regex matching results in slow queries.

This PR fixes #38685 and removes unnecessary invocation of `sql_color` method when `colorize_logging` is disabled