### PR TITLE
Fix exceptions raised/rescued in dev by IPAddr

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -33,7 +33,7 @@ module Rails
         @filter_parameters                       = []
         @filter_redirect                         = []
         @helpers_paths                           = []
-        @hosts                                   = Array(([IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0"), ".localhost"] if Rails.env.development?))
+        @hosts                                   = Array(([".localhost", IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0")] if Rails.env.development?))
         @public_file_server                      = ActiveSupport::OrderedOptions.new
         @public_file_server.enabled              = true
         @public_file_server.index_name           = "index"


### PR DESCRIPTION
4 IPAddr::InvalidAddressError exceptions are raised and rescued during every request when the HostAuthorization middleware attempts to compare an IPAddr with a "localhost" string.

We can fix this by putting "localhost" first in the list, which will short-circuit the HostAuthorization check and cause no exceptions to be rescued.

Example rescued exceptions:

```
#1: IPAddr::InvalidAddressError - "invalid address"
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:651:in `in6_addr'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:586:in `initialize'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:606:in `new'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:606:in `coerce_other'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:174:in `include?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:27:in `block in allows?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:25:in `any?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:25:in `allows?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:98:in `authorized?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:84:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/rack-mini-profiler-1.1.4/lib/mini_profiler/profiler.rb:296:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/sentry-raven-2.13.0/lib/raven/integrations/rack.rb:51:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/railties-6.0.2/lib/rails/engine.rb:526:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/railties-6.0.2/lib/rails/railtie.rb:190:in `public_send'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/railties-6.0.2/lib/rails/railtie.rb:190:in `method_missing'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/configuration.rb:228:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/server.rb:681:in `handle_request'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/server.rb:472:in `process_client'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/server.rb:328:in `block in run'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/thread_pool.rb:134:in `block in spawn_thread'

#2: IPAddr::InvalidAddressError - "invalid address: localhost"
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:598:in `rescue in initialize'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:557:in `initialize'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:606:in `new'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:606:in `coerce_other'
  /Users/nateberkopec/.rubies/ruby-2.7.0/lib/ruby/2.7.0/ipaddr.rb:174:in `include?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:27:in `block in allows?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:25:in `any?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:25:in `allows?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:98:in `authorized?'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/actionpack-6.0.2/lib/action_dispatch/middleware/host_authorization.rb:84:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/rack-mini-profiler-1.1.4/lib/mini_profiler/profiler.rb:296:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/sentry-raven-2.13.0/lib/raven/integrations/rack.rb:51:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/railties-6.0.2/lib/rails/engine.rb:526:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/railties-6.0.2/lib/rails/railtie.rb:190:in `public_send'
  /Users/nateberkopec/.gem/ruby/2.7.0/gems/railties-6.0.2/lib/rails/railtie.rb:190:in `method_missing'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/configuration.rb:228:in `call'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/server.rb:681:in `handle_request'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/server.rb:472:in `process_client'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/server.rb:328:in `block in run'
  /Users/nateberkopec/.gem/ruby/2.7.0/bundler/gems/puma-7e691845ddf6/lib/puma/thread_pool.rb:134:in `block in spawn_thread'
```
