### PR TITLE
Add ActiveSupport::Duration conversion methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveSupport::Duration` conversion methods
+
+    `in_seconds`, `in_minutes`, `in_hours`, `in_days`, `in_weeks`, `in_months`, and `in_years` return the respective duration covered.
+
+    *Jason York*
+
 *   Fixed issue in `ActiveSupport::Cache::RedisCacheStore` not passing options
     to `read_multi` causing `fetch_multi` to not work properly
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -349,48 +349,48 @@ module ActiveSupport
     def to_i
       @value.to_i
     end
-    alias :to_seconds :to_i
+    alias :in_seconds :to_i
 
     # Returns the amount of minutes a duration covers as a float
     #
-    #   1.day.to_minutes # => 1440.0
-    def to_minutes
-      to_seconds / SECONDS_PER_MINUTE.to_f
+    #   1.day.in_minutes # => 1440.0
+    def in_minutes
+      in_seconds / SECONDS_PER_MINUTE.to_f
     end
 
     # Returns the amount of hours a duration covers as a float
     #
-    #   1.day.to_hours # => 24.0
-    def to_hours
-      to_seconds / SECONDS_PER_HOUR.to_f
+    #   1.day.in_hours # => 24.0
+    def in_hours
+      in_seconds / SECONDS_PER_HOUR.to_f
     end
 
     # Returns the amount of days a duration covers as a float
     #
-    #   12.hours.to_days # => 0.5
-    def to_days
-      to_seconds / SECONDS_PER_DAY.to_f
+    #   12.hours.in_days # => 0.5
+    def in_days
+      in_seconds / SECONDS_PER_DAY.to_f
     end
 
     # Returns the amount of weeks a duration covers as a float
     #
-    #   2.months.to_weeks # => 8.696
-    def to_weeks
-      to_seconds / SECONDS_PER_WEEK.to_f
+    #   2.months.in_weeks # => 8.696
+    def in_weeks
+      in_seconds / SECONDS_PER_WEEK.to_f
     end
 
     # Returns the amount of months a duration covers as a float
     #
-    #   9.weeks.to_months # => 2.07
-    def to_months
-      to_seconds / SECONDS_PER_MONTH.to_f
+    #   9.weeks.in_months # => 2.07
+    def in_months
+      in_seconds / SECONDS_PER_MONTH.to_f
     end
 
     # Returns the amount of years a duration covers as a float
     #
-    #   30.days.to_years # => 0.082
-    def to_years
-      to_seconds / SECONDS_PER_YEAR.to_f
+    #   30.days.in_years # => 0.082
+    def in_years
+      in_seconds / SECONDS_PER_YEAR.to_f
     end
 
     # Returns +true+ if +other+ is also a Duration instance, which has the

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -349,6 +349,49 @@ module ActiveSupport
     def to_i
       @value.to_i
     end
+    alias :to_seconds :to_i
+
+    # Returns the amount of minutes a duration covers as a float
+    #
+    #   1.day.to_minutes # => 1440.0
+    def to_minutes
+      to_seconds / SECONDS_PER_MINUTE.to_f
+    end
+
+    # Returns the amount of hours a duration covers as a float
+    #
+    #   1.day.to_hours # => 24.0
+    def to_hours
+      to_seconds / SECONDS_PER_HOUR.to_f
+    end
+
+    # Returns the amount of days a duration covers as a float
+    #
+    #   12.hours.to_days # => 0.5
+    def to_days
+      to_seconds / SECONDS_PER_DAY.to_f
+    end
+
+    # Returns the amount of weeks a duration covers as a float
+    #
+    #   2.months.to_weeks # => 8.696
+    def to_weeks
+      to_seconds / SECONDS_PER_WEEK.to_f
+    end
+
+    # Returns the amount of months a duration covers as a float
+    #
+    #   9.weeks.to_months # => 2.07
+    def to_months
+      to_seconds / SECONDS_PER_MONTH.to_f
+    end
+
+    # Returns the amount of years a duration covers as a float
+    #
+    #   30.days.to_years # => 0.082
+    def to_years
+      to_seconds / SECONDS_PER_YEAR.to_f
+    end
 
     # Returns +true+ if +other+ is also a Duration instance, which has the
     # same parts as this one.

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -46,6 +46,36 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "1", 1.second.to_s
   end
 
+  def test_to_minutes
+    assert_in_delta 1440.0, 1.day.to_minutes
+    assert_in_delta 0.5, 30.seconds.to_minutes
+  end
+
+  def test_to_hours
+    assert_in_delta 24.0, 1.day.to_hours
+    assert_in_delta 336.0, 2.weeks.to_hours
+  end
+
+  def test_to_days
+    assert_in_delta 0.5, 12.hours.to_days
+    assert_in_delta 30.437, 1.month.to_days
+  end
+
+  def test_to_weeks
+    assert_in_delta 8.696, 2.months.to_weeks
+    assert_in_delta 52.178, 1.year.to_weeks
+  end
+
+  def test_to_months
+    assert_in_delta 2.07, 9.weeks.to_months
+    assert_in_delta 12.0, 1.year.to_months
+  end
+
+  def test_to_years
+    assert_in_delta 0.082, 30.days.to_years
+    assert_in_delta 1.0, 365.days.to_years
+  end
+
   def test_eql
     rubinius_skip "Rubinius' #eql? definition relies on #instance_of? " \
                   "which behaves oddly for the sake of backward-compatibility."

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -46,34 +46,39 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "1", 1.second.to_s
   end
 
-  def test_to_minutes
-    assert_in_delta 1440.0, 1.day.to_minutes
-    assert_in_delta 0.5, 30.seconds.to_minutes
+  def test_in_seconds
+    assert_equal 86400.0, 1.day.in_seconds
+    assert_equal 1.week.to_i, 1.week.in_seconds
   end
 
-  def test_to_hours
-    assert_in_delta 24.0, 1.day.to_hours
-    assert_in_delta 336.0, 2.weeks.to_hours
+  def test_in_minutes
+    assert_in_delta 1440.0, 1.day.in_minutes
+    assert_in_delta 0.5, 30.seconds.in_minutes
   end
 
-  def test_to_days
-    assert_in_delta 0.5, 12.hours.to_days
-    assert_in_delta 30.437, 1.month.to_days
+  def test_in_hours
+    assert_in_delta 24.0, 1.day.in_hours
+    assert_in_delta 336.0, 2.weeks.in_hours
   end
 
-  def test_to_weeks
-    assert_in_delta 8.696, 2.months.to_weeks
-    assert_in_delta 52.178, 1.year.to_weeks
+  def test_in_days
+    assert_in_delta 0.5, 12.hours.in_days
+    assert_in_delta 30.437, 1.month.in_days
   end
 
-  def test_to_months
-    assert_in_delta 2.07, 9.weeks.to_months
-    assert_in_delta 12.0, 1.year.to_months
+  def test_in_weeks
+    assert_in_delta 8.696, 2.months.in_weeks
+    assert_in_delta 52.178, 1.year.in_weeks
   end
 
-  def test_to_years
-    assert_in_delta 0.082, 30.days.to_years
-    assert_in_delta 1.0, 365.days.to_years
+  def test_in_months
+    assert_in_delta 2.07, 9.weeks.in_months
+    assert_in_delta 12.0, 1.year.in_months
+  end
+
+  def test_in_years
+    assert_in_delta 0.082, 30.days.in_years
+    assert_in_delta 1.0, 365.days.in_years
   end
 
   def test_eql


### PR DESCRIPTION
### Summary

This provides ActiveSupport::Duration the ability to return the current duration value in additional units (minutes, hours, days, weeks, months, years).

### Other Information

Groups discussion link:
https://groups.google.com/forum/?fromgroups#!topic/rubyonrails-core/igPRs1_mfKU


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
