### PR TITLE
Fixed an issue where tinyint could not be mapped to boolean in MySQL 8.0.19

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fixed an issue where tinyint could not be mapped to boolean in MySQL 8.0.19.
+
+    *Seiya Ouchi*
+
 *   Dump the schema or structure of a database when calling db:migrate:name
 
     In previous versions of Rails, `rails db:migrate` would dump the schema of the database. In Rails 6, that holds true (`rails db:migrate` dumps all databases' schemas), but `rails db:migrate:name` does not share that behavior.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -547,7 +547,7 @@ module ActiveRecord
           register_integer_type m, %r(^smallint)i,  limit: 2
           register_integer_type m, %r(^tinyint)i,   limit: 1
 
-          m.register_type %r(^tinyint\(1\))i, Type::Boolean.new if emulate_booleans
+          m.register_type %r(^tinyint)i, Type::Boolean.new if emulate_booleans
           m.alias_type %r(year)i,          "integer"
           m.alias_type %r(bit)i,           "binary"
 

--- a/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
@@ -21,6 +21,8 @@ if current_adapter?(:Mysql2Adapter)
           emulate_booleans(true) do
             assert_lookup_type :boolean, "tinyint(1)"
             assert_lookup_type :boolean, "TINYINT(1)"
+            assert_lookup_type :boolean, "tinyint"
+            assert_lookup_type :boolean, "TINYINT"
           end
         end
 
@@ -52,6 +54,8 @@ if current_adapter?(:Mysql2Adapter)
           emulate_booleans(false) do
             assert_lookup_type :integer, "tinyint(1)"
             assert_lookup_type :integer, "TINYINT(1)"
+            assert_lookup_type :integer, "tinyint"
+            assert_lookup_type :integer, "TINYINT"
             assert_lookup_type :integer, "year"
             assert_lookup_type :integer, "YEAR"
           end

--- a/activerecord/test/cases/connection_adapters/type_lookup_test.rb
+++ b/activerecord/test/cases/connection_adapters/type_lookup_test.rb
@@ -76,7 +76,6 @@ unless current_adapter?(:PostgreSQLAdapter) # PostgreSQL does not use type strin
         def test_integer_types
           assert_lookup_type :integer, "integer"
           assert_lookup_type :integer, "INTEGER"
-          assert_lookup_type :integer, "tinyint"
           assert_lookup_type :integer, "smallint"
           assert_lookup_type :integer, "bigint"
         end


### PR DESCRIPTION
### Summary
  - When using MySQL 8.0.19, tinyint is not mapping to boolean throuth ActiveRecord
  - This is probably due to the following changes.

### Other Information
cited from https://mysqlserverteam.com/the-mysql-8-0-19-maintenance-release-is-generally-available/

> Remove integer display width from SHOW CREATE output (WL#13528) This work by Jon Olav Hauglid changes SHOW CREATE to not output integer display width unless ZEROFILL is also used. Without ZEROFILL, integer display width has no effect. This work is a logical consequence of deprecating the display width attribute for integer types (WL#13127).