### PR TITLE
Include rack-mini-profiler gem by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `rack-mini-profiler` gem to the default `Gemfile`.
+
+    `rack-mini-profiler` displays performance information such as SQL time and flame graphs.
+    It's enabled by default in development environment, but can be enabled in production as well.
+    See the gem [README](https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md) for information on how to enable it in production.
+
+    *Osama Sayegh*
+
 *   `rails stats` will now count TypeScript files toward JavaScript stats.
 
     *Joshua Cody*

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -51,6 +51,8 @@ group :development do
   <%- else -%>
   gem 'web-console', '>= 3.3.0'
   <%- end -%>
+  # Display performance information such as SQL time and flame graphs for each request in your browser. Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  gem 'rack-mini-profiler', '~> 2.0.0'
 <%- end -%>
 <% if depend_on_listen? -%>
   gem 'listen', '~> 3.2'


### PR DESCRIPTION
### Summary

Gem repo: https://github.com/MiniProfiler/rack-mini-profiler

~2 years ago @schneems sent PR https://github.com/rails/rails/pull/29911 to include `rack-mini-profiler` in the default `Gemfile` and it was merged. However, the PR was later reverted because `rack-mini-profiler` patched several Rails methods to get the information it needed. Fast forward to today and version `2.0.0` of `rack-mini-profiler` is released and it doesn't patch any Rails methods by default and subscribes to various events from `ActiveSupport::Notifications` to get the information it needs.

More context in https://github.com/rails/rails/pull/29911#issuecomment-548602761, and https://github.com/MiniProfiler/rack-mini-profiler/pull/418#issuecomment-592663343

cc @rafaelfranca @SamSaffron