### PR TITLE
Updates to ActiveJob::Exceptions.retry_on with jitter documentation [skip ci]

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -69,9 +69,9 @@
 
     *Vlado Cingel*
 
-*   Add jitter to :exponentially_longer.
+*   Add jitter to `ActiveJob::Exceptions.retry_on`.
 
-    ActiveJob::Exceptions.retry_on with :exponentially_longer now uses a random amount of jitter in order to
+    `ActiveJob::Exceptions.retry_on` now uses a random amount of jitter in order to
     prevent the [thundering herd effect](https://en.wikipedia.org/wiki/Thundering_herd_problem). Defaults to
     15% (represented as 0.15) but overridable via the `:jitter` option when using `retry_on`.
     Jitter is applied when an `Integer`, `ActiveSupport::Duration` or `:exponentially_longer`, is passed to the `wait` argument in `retry_on`.

--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -23,7 +23,7 @@ module ActiveJob
       # ==== Options
       # * <tt>:wait</tt> - Re-enqueues the job with a delay specified either in seconds (default: 3 seconds),
       #   as a computing proc that the number of executions so far as an argument, or as a symbol reference of
-      #   <tt>:exponentially_longer</tt>, which applies the wait algorithm of <tt>((executions**4) + (Kernel.rand((executions**4) * jitter))) + 2</tt>
+      #   <tt>:exponentially_longer</tt>, which applies the wait algorithm of <tt>((executions**4) + (Kernel.rand * (executions**4) * jitter)) + 2</tt>
       #   (first wait ~3s, then ~18s, then ~83s, etc)
       # * <tt>:attempts</tt> - Re-enqueues the job the specified number of times (default: 5 attempts)
       # * <tt>:queue</tt> - Re-enqueues the job on a different queue


### PR DESCRIPTION
Documentation updates for `ActiveJob::Exceptions.retry_on` with respect to changes in #38545

1. The existing changelog could give the impression that the `jitter` is applied only to `exponentially_longer` wait argument. Updated the changelog to imply that the jitter is generic to most arguments and not limited to `exponentially_longer`.
2. Method documentation update for new set of changes in #38545. Should have been a part of #38545 but I missed adding them. I will try to be more diligent in terms of documentation going forward. :) 