### PR TITLE
Include parameterize [ci skip]

### DIFF
--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -109,7 +109,7 @@ module RailsGuides
                   hierarchy = hierarchy[0, 3] + [node]
                 end
 
-                node[:id] = dom_id(hierarchy) unless node[:id]
+                node[:id] = dom_id(hierarchy).parameterize unless node[:id]
                 node.inner_html = "#{node_index(hierarchy)} #{node.inner_html}"
               end
             end


### PR DESCRIPTION
### Summary

The inclusion of `parameterize` when generating the guide ids can help deal with other improper special characters that are often used in other languages ​​such as accented letters, among others.

### Other Information

I thought that this insertion could be done further down the call hierarchy but this location is interesting because it applies to both headers and the index but I'm open for suggestions.