### PR TITLE
Video files that start with a fadein always have a black preview.

### DIFF
--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -21,4 +21,20 @@ class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
       assert_equal "image/jpeg", image.mime_type
     end
   end
+
+  test "previewing an MP4 video that seeks for some time" do
+    # Add metadata to the blob
+    metadata = extract_metadata_from(@blob)
+    @blob.update(metadata: metadata)
+
+    ActiveStorage::Previewer::VideoPreviewer.new(@blob).preview do |attachable|
+      assert_equal "image/jpeg", attachable[:content_type]
+      assert_equal "video.jpg", attachable[:filename]
+
+      image = MiniMagick::Image.read(attachable[:io])
+      assert_equal 640, image.width
+      assert_equal 480, image.height
+      assert_equal "image/jpeg", image.mime_type
+    end
+  end
 end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Use the duration metadata for seek to the 10% position of the total
length to create a preview image. When missing use the default first
frame or if the ceil is beyond the total length of the video.

### Other Information

This pull request is backwards compatible.