### PR TITLE
Do not raise on model destroy if attachment reflection is missing

### DIFF
--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -49,7 +49,7 @@ class ActiveStorage::Attachment < ActiveRecord::Base
 
 
     def dependent
-      record.attachment_reflections[name]&.options[:dependent]
+      record.attachment_reflections[name]&.options&.[](:dependent)
     end
 end
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -542,6 +542,30 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "destroying dependent custom attachment on destroy" do
+    [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ].tap do |blobs|
+      attachments = [
+        ActiveStorage::Attachment.create!(
+          name: "custom",
+          record: @user,
+          blob: blobs.first
+        ),
+        ActiveStorage::Attachment.create!(
+          name: "custom",
+          record: @user,
+          blob: blobs.second
+        )
+      ]
+
+      perform_enqueued_jobs do
+        @user.destroy!
+      end
+
+      assert_not ActiveStorage::Attachment.exists?(attachments.first.id)
+      assert_not ActiveStorage::Attachment.exists?(attachments.second.id)
+    end
+  end
+
   test "not purging independent attachment on destroy" do
     [ create_blob(filename: "funky.mp4"), create_blob(filename: "town.mp4") ].tap do |blobs|
       @user.vlogs.attach blobs

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -511,6 +511,22 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "destroying dependent custom attachment on destroy" do
+    create_blob(filename: "funky.jpg").tap do |blob|
+      attachment = ActiveStorage::Attachment.create!(
+        name: "special",
+        record: @user,
+        blob: blob
+      )
+
+      perform_enqueued_jobs do
+        @user.destroy!
+      end
+
+      assert_not ActiveStorage::Attachment.exists?(attachment.id)
+    end
+  end
+
   test "not purging independent attachment on destroy" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.cover_photo.attach blob

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -122,6 +122,22 @@ class User < ActiveRecord::Base
 
   has_many_attached :highlights
   has_many_attached :vlogs, dependent: false, service: :local
+
+  has_one \
+    :custom_special_attachment,
+    -> { where(name: :special) },
+    class_name: "ActiveStorage::Attachment",
+    as: :record,
+    inverse_of: :record,
+    dependent: :destroy
+
+  has_many \
+    :custom_attachments,
+    -> { where(name: :custom) },
+    class_name: "ActiveStorage::Attachment",
+    as: :record,
+    inverse_of: :record,
+    dependent: :destroy
 end
 
 class Group < ActiveRecord::Base


### PR DESCRIPTION
### Summary

If there is no attachment reflection it should not fail. The existing check was one step too short.

It can happen when custom attachments are defined in a model like this:

```rb
class User
      has_many \
        :custom_attachments,
        -> { where(%("name" ^@ 'custom_')) },
        as: :record,
        class_name: 'ActiveStorage::Attachment',
        dependent: :destroy
end
```

Then there is no attachment reflection and currently it fails with:

```
NoMethodError (undefined method `[]' for nil:NilClass):

activestorage (6.0.2.1) app/models/active_storage/attachment.rb:46:in `dependent'
activestorage (6.0.2.1) app/models/active_storage/attachment.rb:41:in `purge_dependent_blob_later'
```