### PR TITLE
Fix variable not initialized warnings

### DIFF
--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -8,24 +8,10 @@ class ConcernTest < ActiveSupport::TestCase
     extend ActiveSupport::Concern
 
     class_methods do
+      attr_accessor :included_ran, :prepended_ran
+
       def baz
         "baz"
-      end
-
-      def included_ran=(value)
-        @included_ran = value
-      end
-
-      def included_ran
-        @included_ran
-      end
-
-      def prepended_ran=(value)
-        @prepended_ran = value
-      end
-
-      def prepended_ran
-        @prepended_ran
       end
     end
 


### PR DESCRIPTION
Tickled by ActiveSupport tests.

see [log](https://buildkite.com/rails/rails/builds/67513#a3e8c197-881d-481e-9a64-7fd178c07c04/1008-1015)
```
activesupport/test/concern_test.rb:20: warning: instance variable
@included_ran not initialized

activesupport/test/concern_test.rb:28: warning: instance variable
@prepended_ran not initialized
```