### PR TITLE
Removed unnecessary require 'core_ext/numeric/time'.

### DIFF
--- a/activesupport/lib/active_support/core_ext/integer/time.rb
+++ b/activesupport/lib/active_support/core_ext/integer/time.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/duration"
-require "active_support/core_ext/numeric/time"
 
 class Integer
   # Returns a Duration instance matching the number of months provided.


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Previously it depended on `core_ext/numeric/time`, but now it doesn't, so we removed require.

Previous code

``` ruby
class Integer
  def months
    ActiveSupport::Duration.new(self * 30.days, [[:months, self]])
  end
  alias :month :months
  def years
    ActiveSupport::Duration.new(self * 365.25.days, [[:years, self]])
  end
  alias :year :years
end
```

Now the code

``` ruby
class Integer
  def months
    ActiveSupport::Duration.months(self)
  end
  alias :month :months

  def years
    ActiveSupport::Duration.years(self)
  end
  alias :year :years
end
```

After deleting require, I ran it with console, but no error occurred.

``` ruby
irb(main):001:0> require 'active_support/core_ext/integer/time.rb'
=> true
irb(main):002:0> 1.month
=> 1 month
irb(main):003:0> 1.year
=> 1 year
```


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

PR with require added: https://github.com/rails/rails/pull/8532
PR with dependencies removed for `core_ext/numeric /time`: https://github.com/rails/rails/pull/27610
