### PR TITLE
Fixed to require `active_support/core_ext/numeric/time` where `hour` is defined.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -3,7 +3,7 @@
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
 
-require "active_support/core_ext/integer/time"
+require "active_support/core_ext/numeric/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
### Summary

Fixed `enviroment/test` generation test failed after deleting `active_support/core_ext/numeric/time` from `require active_support/core_ext/integer/time`.

`active_support/core_ext/integer/time` is not defined `hours`, so require `active_support/core_ext/numeric/time`.

railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt

``` ruby
  # Configure public file server for tests with Cache-Control for performance.
  config.public_file_server.enabled = true
  config.public_file_server.headers = {
    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
  }
```

failed test
```
Failure:
--
  | PluginGeneratorTest#test_ensure_that_tests_works_in_full_mode [test/generators/plugin_generator_test.rb:245]:
  | Expected /1 runs, 1 assertions, 0 failures, 0 errors/ to match "/usr/local/bundle/gems/sassc-rails-2.1.2/lib/sassc/rails/functions.rb:7: warning: method redefined; discarding old asset_data_url\n/usr/local/bundle/gems/sprockets-4.0.0/lib/sprockets/sass_processor.rb:274: warning: previous definition of asset_data_url was here\n/usr/local/bundle/gems/sassc-rails-2.1.2/lib/sassc/rails/compressor.rb:7: warning: method redefined; discarding old initialize\n/usr/local/bundle/gems/sprockets-4.0.0/lib/sprockets/sass_compressor.rb:39: warning: previous definition of initialize was here\n/usr/local/bundle/gems/sassc-rails-2.1.2/lib/sassc/rails/compressor.rb:17: warning: method redefined; discarding old call\n/usr/local/bundle/gems/sprockets-4.0.0/lib/sprockets/sass_compressor.rb:49: warning: previous definition of call was here\n/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:370: warning: assigned but unused variable - pathlen\n/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:51: warning: method redefined; discarding old initialize\n/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:58: warning: method redefined; discarding old add_cert\n/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:58: warning: method redefined; discarding old add_file\n/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/ssl_config.rb:58: warning: method redefined; discarding old add_path\n/rails/railties/test/fixtures/tmp/bukkits/test/dummy/config/environments/test.rb:22:in `block in <top (required)>': undefined method `hour' for 1:Integer (NoMethodError)\n\tfrom /rails/railties/lib/rails/railtie.rb:217:in `instance_eval'\n\tfrom /rails/railties/lib/rails/railtie.rb:217:in `configure'\n\tfrom /rails/railties/test/fixtures/tmp/bukkits/test/dummy/config/environments/test.rb:8:in `<top (required)>'\n\tfrom
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

ref: https://github.com/rails/rails/pull/38710

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
