### PR TITLE
Rails::Command.invoke wants kwargs, so give it kwargs

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -254,7 +254,7 @@ module Rails
           command, *args = Shellwords.split(command)
           in_root do
             silence_warnings do
-              ::Rails::Command.invoke(command, args, options)
+              ::Rails::Command.invoke(command, args, **options)
             end
           end
         else


### PR DESCRIPTION
This fixes an exception when generating a new app on Ruby 2.8.  Before
this commit, I get this exception:

```
$ be ruby railties/exe/rails new ~/git/fix-bug --dev
...
...
Traceback (most recent call last):
	31: from railties/exe/rails:10:in `<main>'
	30: from railties/exe/rails:10:in `require'
	29: from /Users/aaron/git/rails/railties/lib/rails/cli.rb:18:in `<top (required)>'
	28: from /Users/aaron/git/rails/railties/lib/rails/command.rb:45:in `invoke'
	27: from /Users/aaron/git/rails/railties/lib/rails/command/base.rb:69:in `perform'
	26: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	25: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	24: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	23: from /Users/aaron/git/rails/railties/lib/rails/commands/application/application_command.rb:26:in `perform'
	22: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	21: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/group.rb:232:in `dispatch'
	20: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `invoke_all'
	19: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `map'
	18: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `each'
	17: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/invocation.rb:134:in `block in invoke_all'
	16: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	15: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	14: from (eval):1:in `run_webpack'
	13: from /Users/aaron/git/rails/railties/lib/rails/generators/app_base.rb:419:in `run_webpack'
	12: from /Users/aaron/git/rails/railties/lib/rails/generators/actions.rb:255:in `rails_command'
	11: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/actions.rb:197:in `in_root'
	10: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/actions.rb:187:in `inside'
	 9: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/2.8.0/fileutils.rb:139:in `cd'
	 8: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/2.8.0/fileutils.rb:139:in `chdir'
	 7: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/actions.rb:187:in `block in inside'
	 6: from /Users/aaron/.rbenv/versions/ruby-trunk/lib/ruby/gems/2.8.0/gems/thor-1.0.1/lib/thor/actions.rb:197:in `block in in_root'
	 5: from /Users/aaron/git/rails/railties/lib/rails/generators/actions.rb:256:in `block in rails_command'
	 4: from /Users/aaron/git/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:15:in `silence_warnings'
	 3: from /Users/aaron/git/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:28:in `with_warnings'
	 2: from /Users/aaron/git/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:15:in `block in silence_warnings'
	 1: from /Users/aaron/git/rails/railties/lib/rails/generators/actions.rb:257:in `block (2 levels) in rails_command'
/Users/aaron/git/rails/railties/lib/rails/command.rb:31:in `invoke': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
```

After this commit, things seem to work.
