### PR TITLE
Extract building ActiveRecord::Result into a method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -740,6 +740,10 @@ module ActiveRecord
 
         def build_statement_pool
         end
+
+        def build_result(columns, rows, column_types = {})
+          ActiveRecord::Result.new(columns, rows, column_types)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -54,17 +54,17 @@ module ActiveRecord
           if without_prepared_statement?(binds)
             execute_and_free(sql, name) do |result|
               if result
-                ActiveRecord::Result.new(result.fields, result.to_a)
+                build_result(result.fields, result.to_a)
               else
-                ActiveRecord::Result.new([], [])
+                build_result([], [])
               end
             end
           else
             exec_stmt_and_free(sql, name, binds, cache_stmt: prepare) do |_, result|
               if result
-                ActiveRecord::Result.new(result.fields, result.to_a)
+                build_result(result.fields, result.to_a)
               else
-                ActiveRecord::Result.new([], [])
+                build_result([], [])
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -103,7 +103,7 @@ module ActiveRecord
               fmod  = result.fmod i
               types[fname] = get_oid_type(ftype, fmod, fname)
             end
-            ActiveRecord::Result.new(fields, result.values, types)
+            build_result(fields, result.values, types)
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -63,7 +63,7 @@ module ActiveRecord
                 records = stmt.to_a
               end
 
-              ActiveRecord::Result.new(cols, records)
+              build_result(cols, records)
             end
           end
         end


### PR DESCRIPTION
Extracting the construction of `ActiveRecord::Result` into a method like `build_result` will allow apps to hook into the method and add other connection-specific data to the Result instance.

Related: https://github.com/rails/rails/pull/38660