### PR TITLE
Action Text: create renderer on demand

### DIFF
--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -49,6 +49,15 @@ module ActionController
       new(controller, env, defaults)
     end
 
+    # Create a renderer using this controller and the current request.
+    def current
+      if env = ActionDispatch::Current.rack_env
+        new env
+      else
+        self
+      end
+    end
+
     # Create a new renderer for the same controller but with a new env.
     def new(env = {})
       self.class.new controller, env, defaults

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -57,6 +57,7 @@ module ActionDispatch
     autoload :RequestId
     autoload :Callbacks
     autoload :Cookies
+    autoload :CurrentRackEnv
     autoload :ActionableExceptions
     autoload :DebugExceptions
     autoload :DebugLocks
@@ -72,6 +73,7 @@ module ActionDispatch
     autoload :Static
   end
 
+  autoload :Current
   autoload :Journey
   autoload :MiddlewareStack, "action_dispatch/middleware/stack"
   autoload :Routing

--- a/actionpack/lib/action_dispatch/current.rb
+++ b/actionpack/lib/action_dispatch/current.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "active_support/current_attributes"
+
+class ActionDispatch::Current < ActiveSupport::CurrentAttributes #:nodoc:
+  # Set by ActionDispatch::CurrentRackEnv middleware.
+  attribute :rack_env
+end

--- a/actionpack/lib/action_dispatch/middleware/current_rack_env.rb
+++ b/actionpack/lib/action_dispatch/middleware/current_rack_env.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  # Makes the current Rack env available via ActionDispatch::Current.rack_env.
+  # Used by ApplicationController.renderer.current to provide a renderer
+  # instance for the current request's Rack environment.
+  #
+  # (Must be inserted after the Executor middleware, since that manages the
+  # ActiveSupport::CurrentAttributes lifecycle.)
+  class CurrentRackEnv # :nodoc:
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      ::ActionDispatch::Current.rack_env = env
+      @app.call env
+    end
+  end
+end

--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -46,6 +46,15 @@ class RendererTest < ActiveSupport::TestCase
     assert_equal "Hello world!", content
   end
 
+  test "rendering with a current renderer" do
+    ActionDispatch::Current.rack_env = { key: "value" }
+
+    renderer = ApplicationController.renderer.current
+    content  = renderer.render inline: "<%= request.env['key'] %>"
+
+    assert_equal "value", content
+  end
+
   test "rendering with a controller class" do
     assert_equal "Hello world!", ApplicationController.render("test/hello_world")
   end

--- a/actiontext/lib/action_text.rb
+++ b/actiontext/lib/action_text.rb
@@ -13,9 +13,11 @@ module ActionText
   autoload :Attachment
   autoload :Attribute
   autoload :Content
+  autoload :Current
   autoload :Fragment
   autoload :HtmlConversion
   autoload :PlainTextConversion
+  autoload :Rendering
   autoload :Serialization
   autoload :TrixAttachment
 

--- a/actiontext/lib/action_text/attachments/trix_conversion.rb
+++ b/actiontext/lib/action_text/attachments/trix_conversion.rb
@@ -28,7 +28,7 @@ module ActionText
       private
         def trix_attachment_content
           if partial_path = attachable.try(:to_trix_content_attachment_partial_path)
-            ActionText::Content.renderer.render(partial: partial_path, object: self, as: model_name.element)
+            ActionText::Content.render(partial: partial_path, object: self, as: model_name.element)
           end
         end
     end

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -1,12 +1,8 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/attribute_accessors_per_thread"
-
 module ActionText
   class Content
-    include Serialization
-
-    thread_cattr_accessor :renderer
+    include Rendering, Serialization
 
     attr_reader :fragment
 
@@ -88,7 +84,7 @@ module ActionText
     end
 
     def to_rendered_html_with_layout
-      renderer.render(partial: "action_text/content/layout", locals: { content: self })
+      render partial: "action_text/content/layout", locals: { content: self }
     end
 
     def to_s

--- a/actiontext/lib/action_text/current.rb
+++ b/actiontext/lib/action_text/current.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "active_support/current_attributes"
+
+class ActionText::Current < ActiveSupport::CurrentAttributes #:nodoc:
+  # Memoizes ActionText::Content.renderer.current, the renderer for
+  # the current request. The memoized render is kept on Current so it's
+  # automatically reset after each request/job.
+  attribute :renderer_for_current_request
+end

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -49,10 +49,6 @@ module ActionText
       ActiveSupport.on_load(:action_text_content) do
         self.renderer = ApplicationController.renderer
       end
-
-      ActiveSupport.on_load(:action_controller_base) do
-        before_action { ActionText::Content.renderer = ApplicationController.renderer.new(request.env) }
-      end
     end
 
     initializer "action_text.system_test_helper" do

--- a/actiontext/lib/action_text/rendering.rb
+++ b/actiontext/lib/action_text/rendering.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+require "active_support/core_ext/module/attribute_accessors_per_thread"
+require "active_support/core_ext/module/delegation"
+require "active_support/core_ext/object/try"
+
+module ActionText
+  module Rendering #:nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      thread_cattr_accessor :renderer, instance_accessor: false
+
+      singleton_class.delegate :render, to: :current_renderer
+      delegate :render, to: :class
+    end
+
+    class_methods do
+      def current_renderer
+        # Memoize the current renderer since it may be used many times
+        # per request and costs a fair bit to create.
+        #
+        # Memoize on Current so it's automatically cleaned up after
+        # requests/jobs finish.
+        ::ActionText::Current.renderer_for_current_request ||= renderer.try(:current) || renderer
+      end
+    end
+  end
+end

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -43,6 +43,7 @@ module Rails
 
           middleware.use ::Rack::Runtime
           middleware.use ::Rack::MethodOverride unless config.api_only
+          middleware.use ::ActionDispatch::CurrentRackEnv
           middleware.use ::ActionDispatch::RequestId
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -33,6 +33,7 @@ module ApplicationTests
         "ActiveSupport::Cache::Strategy::LocalCache",
         "Rack::Runtime",
         "Rack::MethodOverride",
+        "ActionDispatch::CurrentRackEnv",
         "ActionDispatch::RequestId",
         "ActionDispatch::RemoteIp",
         "Rails::Rack::Logger",
@@ -67,6 +68,7 @@ module ApplicationTests
         "ActionDispatch::Executor",
         "ActiveSupport::Cache::Strategy::LocalCache",
         "Rack::Runtime",
+        "ActionDispatch::CurrentRackEnv",
         "ActionDispatch::RequestId",
         "ActionDispatch::RemoteIp",
         "Rails::Rack::Logger",
@@ -96,6 +98,9 @@ module ApplicationTests
         # Serving public/ doesn't invoke user code, so it should skip
         # locks etc
         %w(ActionDispatch::Executor ActionDispatch::Static),
+
+        # ActionDispatch::Current must be reset
+        %w(ActionDispatch::CurrentRackEnv ActionDispatch::Executor),
 
         # Errors during reload must be reported
         %w(ActionDispatch::Reloader ActionDispatch::ShowExceptions ActionDispatch::DebugExceptions),


### PR DESCRIPTION
No longer creates a fresh renderer in a before_action callback.
Trims memory overhead for controllers that don't use Action Text.
Addresses #36963.

Action Text obtains a renderer for the current request by calling
`#current` on `renderer`, if implemented.

`ActionController::Renderer#current` implements that by creating a
renderer for `ActionDispatch::Current.rack_env`, the current Rack
environment, which is set by a builtin middleware.

Action Text memoizes the renderer for the current request as well,
since it may be reused frequently within a single request.