### PR TITLE
Fix warning: method redefined

### DIFF
--- a/activejob/test/support/delayed_job/delayed/backend/test.rb
+++ b/activejob/test/support/delayed_job/delayed/backend/test.rb
@@ -21,7 +21,7 @@ module Delayed
 
         include Delayed::Backend::Base
 
-        cattr_accessor :id, default: 0
+        cattr_accessor :id, default: 0, instance_accessor: false
 
         def initialize(hash = {})
           self.attempts = 0


### PR DESCRIPTION
No need to define attr_accessor if same name is defined
with cattr_accessor.

see [log](https://buildkite.com/rails/rails/builds/67541#3a7bfc74-6841-41ee-bc02-951dabd5cd9a/1050-1051).