### PR TITLE
Remove convenience class alias

### DIFF
--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -43,7 +43,7 @@ module Arel
   end
 
   def self.arel_node?(value) # :nodoc:
-    value.is_a?(Arel::Node) || value.is_a?(Arel::Attribute) || value.is_a?(Arel::Nodes::SqlLiteral)
+    value.is_a?(Arel::Nodes::Node) || value.is_a?(Arel::Attribute) || value.is_a?(Arel::Nodes::SqlLiteral)
   end
 
   def self.fetch_attribute(value, &block) # :nodoc:
@@ -59,7 +59,4 @@ module Arel
       fetch_attribute(value.expr, &block)
     end
   end
-
-  ## Convenience Alias
-  Node = Arel::Nodes::Node # :nodoc:
 end

--- a/activerecord/test/cases/arel/nodes/node_test.rb
+++ b/activerecord/test/cases/arel/nodes/node_test.rb
@@ -5,7 +5,7 @@ require_relative "../helper"
 module Arel
   class TestNode < Arel::Test
     def test_includes_factory_methods
-      assert Node.new.respond_to?(:create_join)
+      assert Arel::Nodes::Node.new.respond_to?(:create_join)
     end
 
     def test_all_nodes_are_nodes


### PR DESCRIPTION
This convenience class is only used twice in Arel. We can easily write
it out instead.

cc/ @tenderlove 