### PR TITLE
Add a database configuration DSL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add a database configurations DSL
+
+    Applications can now use `config/database.rb` over `config/database.yml`.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Fix `rewhere` to truly overwrite collided where clause by new where clause.
 
     ```ruby

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record/database_configurations/builder"
 require "active_record/database_configurations/database_config"
 require "active_record/database_configurations/hash_config"
 require "active_record/database_configurations/url_config"
@@ -15,8 +16,21 @@ module ActiveRecord
     attr_reader :configurations
     delegate :any?, to: :configurations
 
+    class << self
+      attr_accessor :builder
+
+      def configure(&blk) # :nodoc:
+        @builder ||= Builder.new
+        @builder.instance_eval(&blk)
+      end
+    end
+
     def initialize(configurations = {})
-      @configurations = build_configs(configurations)
+      if self.class.builder
+        @configurations = self.class.builder.configurations
+      else
+        @configurations = build_configs(configurations)
+      end
     end
 
     # Collects the configs for the environment and optionally the specification

--- a/activerecord/lib/active_record/database_configurations/builder.rb
+++ b/activerecord/lib/active_record/database_configurations/builder.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "active_record/database_configurations/builder/config"
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class Builder < BasicObject # :nodoc:
+      attr_reader :configurations
+
+      def initialize(dummy: false)
+        @configurations = []
+        @dummy = dummy
+        @env_name = nil
+      end
+
+      def env(env_name)
+        original_env_name = @env_name
+        @env_name = env_name
+        yield
+      ensure
+        @env_name = original_env_name
+      end
+
+      # Build a new config and add it to the configurations list
+      def config(name, inherited_db_config = nil, &blk)
+        config = Config.new(@env_name, name, [inherited_db_config].compact, false)
+        config.evaluate(&blk) unless @dummy
+
+        @configurations.concat config.db_configs
+      end
+
+      # Build a config to be used as a default for other configs
+      def build(inherited_db_config = nil, &blk)
+        return if @dummy
+
+        config = Config.new(@env_name, nil, [inherited_db_config].compact, false)
+        config.evaluate(&blk)
+        config.db_configs.first
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/database_configurations/builder/block_context.rb
+++ b/activerecord/lib/active_record/database_configurations/builder/block_context.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class Builder < BasicObject
+      class BlockContext < BasicObject
+        attr_reader :hash
+
+        def initialize(config, hash) # :nodoc:
+          @config = config
+          @hash = hash
+        end
+
+        # Builds a HashConfig and adds it to the configurations list.
+        def shard(*args, &blk)
+          @config.shard(*args, &blk)
+        end
+
+        # Builds a HashConfig as a replica and adds it to the configurations
+        # list.
+        def replica(*args, &blk)
+          @config.replica(*args, &blk)
+        end
+
+        def method_missing(k, v) # :nodoc:
+          @hash[k] = v
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/database_configurations/builder/config.rb
+++ b/activerecord/lib/active_record/database_configurations/builder/config.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "active_record/database_configurations/builder/block_context"
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class Builder < BasicObject
+      class Config # :nodoc:
+        def initialize(env_name, name, default_db_configs, replica)
+          @env_name = env_name.to_s
+          @name = name.to_s
+
+          @block_context = BlockContext.new(self, build_hash(default_db_configs, replica))
+
+          @subconfigs = []
+        end
+
+        def shard(subname, default_db_config = nil, &blk)
+          add_subconfig("shard_#{subname}", default_db_config, false, &blk)
+        end
+
+        def replica(suffix = nil, default_db_config = nil, &blk)
+          name_suffix = suffix ? "replica_#{suffix}" : "replica"
+          add_subconfig(name_suffix, default_db_config, true, &blk)
+        end
+
+        def evaluate(&blk)
+          @block_context.instance_eval(&blk)
+        end
+
+        def db_configs
+          configs = [build_db_config]
+          configs.concat(@subconfigs.flat_map(&:db_configs))
+          configs
+        end
+
+        private
+          def add_subconfig(name_suffix, default_db_config, replica, &blk)
+            name = [@name, name_suffix].join("_")
+
+            default_db_configs = [build_db_config]
+            default_db_configs << default_db_config if default_db_config
+
+            subconfig = Config.new(@env_name, name, default_db_configs, replica)
+            subconfig.evaluate(&blk) if block_given?
+
+            @subconfigs << subconfig
+          end
+
+          def build_db_config
+            hash = @block_context.hash
+            if hash.has_key?(:url)
+              config_without_url = hash.dup
+              url = config_without_url.delete :url
+
+              UrlConfig.new(@env_name, @name, url, config_without_url)
+            else
+              HashConfig.new(@env_name, @name, hash)
+            end
+          end
+
+          def build_hash(default_db_configs, replica)
+            hash = {}
+
+            default_db_configs.each do |db_config|
+              hash.merge!(db_config.configuration_hash)
+            end
+
+            hash[:replica] = true if replica
+
+            hash
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -151,13 +151,7 @@ module ActiveRecord
       def setup_initial_database_yaml
         return {} unless defined?(Rails)
 
-        begin
-          Rails.application.config.load_database_yaml
-        rescue
-          $stderr.puts "Rails couldn't infer whether you are using multiple databases from your database.yml and can't generate the tasks for the non-primary databases. If you'd like to use this feature, please simplify your ERB."
-
-          {}
-        end
+        Rails.application.config.load_dummy_databases
       end
 
       def for_each(databases)

--- a/activerecord/test/cases/database_configurations/builder_test.rb
+++ b/activerecord/test/cases/database_configurations/builder_test.rb
@@ -1,0 +1,468 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  class DatabaseConfigurations
+    class BuilderTest < ActiveRecord::TestCase
+      setup do
+        ActiveRecord::DatabaseConfigurations.builder = ActiveRecord::DatabaseConfigurations::Builder.new
+      end
+
+      teardown do
+        ActiveRecord::DatabaseConfigurations.builder = nil
+      end
+
+      def test_can_create_basic_configuration
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              adapter "sqlite3"
+              database "test/db/primary.sqlite3"
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3" }, config.configuration_hash)
+      end
+
+      def test_can_create_basic_replica_configuration
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              adapter "sqlite3"
+              database "test/db/primary.sqlite3"
+
+              replica
+            end
+          end
+        end
+
+        assert_equal 2, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_not_predicate config, :replica?
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3" }, config.configuration_hash)
+
+        config = configs.last
+        assert_equal "development", config.env_name
+        assert_equal "primary_replica", config.name
+        assert_predicate config, :replica?
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", replica: true }, config.configuration_hash)
+      end
+
+      def test_can_merge_default_configuration
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+            database "test/db/primary.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default) do
+              pool 5
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", pool: 5 }, config.configuration_hash)
+      end
+
+      def test_can_merge_default_configuration_for_multiple_configurations
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default) do
+              database "test/db/primary.sqlite3"
+              pool 5
+
+              replica do
+                database "test/db/readonly.sqlite3"
+                random 10
+              end
+            end
+          end
+        end
+
+        assert_equal 2, configs.length
+
+        config_a = configs.first
+        assert_equal "development", config_a.env_name
+        assert_equal "primary", config_a.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", pool: 5 }, config_a.configuration_hash)
+
+        config_b = configs.last
+        assert_equal "development", config_b.env_name
+        assert_equal "primary_replica", config_b.name
+        assert_predicate config_b, :replica?
+        assert_equal({ adapter: "sqlite3", database: "test/db/readonly.sqlite3", replica: true, random: 10, pool: 5 }, config_b.configuration_hash)
+      end
+
+      def test_can_merge_default_configurations_for_multiple_configurations
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+            database "test/db/primary.sqlite3"
+          end
+
+          default_other = build do
+            adapter "sqlite3"
+            database "test/db/other.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default) do
+              pool 5
+            end
+
+            config(:other, default_other) do
+              random 10
+            end
+          end
+        end
+
+        assert_equal 2, configs.length
+
+        config_a = configs.first
+        assert_equal "development", config_a.env_name
+        assert_equal "primary", config_a.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", pool: 5 }, config_a.configuration_hash)
+
+        config_b = configs.last
+        assert_equal "development", config_b.env_name
+        assert_equal "other", config_b.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/other.sqlite3", random: 10 }, config_b.configuration_hash)
+      end
+
+      def test_can_base_default_on_another_default
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+          end
+
+          default_other = build(default) do
+            database "test/db/other.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default_other) do
+              pool 5
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/other.sqlite3", pool: 5 }, config.configuration_hash)
+      end
+
+      def test_can_override_default_in_another_default
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+            database "test/db/primary.sqlite3"
+          end
+
+          default_other = build(default) do
+            database "test/db/other.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default_other) do
+              pool 5
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/other.sqlite3", pool: 5 }, config.configuration_hash)
+      end
+
+      def test_can_override_default_in_config
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+            database "test/db/primary.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default) do
+              database "test/db/other.sqlite3"
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/other.sqlite3" }, config.configuration_hash)
+      end
+
+      def test_can_create_configs_for_multiple_envs
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+            database "test/db/primary.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default) do
+              pool 5
+            end
+          end
+
+          env(:test) do
+            config(:primary, default) do
+              random 10
+            end
+          end
+        end
+
+        assert_equal 2, configs.length
+
+        config_dev = configs.first
+        assert_equal "development", config_dev.env_name
+        assert_equal "primary", config_dev.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", pool: 5 }, config_dev.configuration_hash)
+
+        config_test = configs.last
+        assert_equal "test", config_test.env_name
+        assert_equal "primary", config_test.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", random: 10 }, config_test.configuration_hash)
+      end
+
+      def test_can_support_nested_hashes
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            adapter "sqlite3"
+            database "test/db/primary.sqlite3"
+          end
+
+          env(:development) do
+            config(:primary, default) do
+              properties({ a: "a", b: "b" })
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ adapter: "sqlite3", database: "test/db/primary.sqlite3", properties: { a: "a", b: "b" } }, config.configuration_hash)
+      end
+
+      def test_creates_url_configs_when_url_key_provided
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              url "sqlite3:///foo_test"
+              pool 5
+            end
+          end
+        end
+
+        assert_equal 1, configs.length
+
+        config = configs.first
+        assert_equal "development", config.env_name
+        assert_equal "primary", config.name
+        assert_equal({ pool: 5, adapter: "sqlite3", database: "/foo_test" }, config.configuration_hash)
+      end
+
+      def test_can_config_multiple_named_replicas
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              database "test/db/primary.sqlite3"
+
+              replica(:one)
+              replica(:two)
+            end
+          end
+        end
+
+        assert_equal ["primary", "primary_replica_one", "primary_replica_two"], configs.map(&:name).sort
+      end
+
+      def test_order_of_overrides
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          default = build do
+            default true
+            default_replica false
+            primary false
+            replicas false
+          end
+
+          default_replica = build do
+            default_replica true
+            replicas false
+          end
+
+          env(:development) do
+            # primary can override default
+            config(:primary, default) do
+              primary true
+              default_replica false
+              replicas false
+
+              # :replica_one inherits from primary, can override primary
+              replica(:one) do
+                replicas true
+              end
+
+              # :replica_two inherits from primary, overrides anything in
+              # primary from default_replica, can also override in
+              # the block.
+              replica(:two, default_replica) do
+                replicas true
+              end
+            end
+          end
+        end
+
+        assert_equal [
+          { default: true, default_replica: false, primary: true, replicas: false },
+          { default: true, default_replica: false, primary: true, replicas: true, replica: true },
+          { default: true, default_replica: true, primary: true, replicas: true, replica: true }
+        ], configs.map(&:configuration_hash)
+      end
+
+      def test_using_ruby_in_blocks_to_generate_configs
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              2.times do |i|
+                replica(:"replica_#{i}")
+              end
+            end
+          end
+        end
+
+        assert_equal 3, configs.count
+      end
+
+      def test_using_shard
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              database "default_development"
+              pool 5
+
+              shard(:one) do
+                database "shard_one_development"
+              end
+            end
+          end
+        end
+
+        assert_equal ["primary", "primary_shard_one"], configs.map(&:name)
+
+        assert_equal [
+          { database: "default_development", pool: 5 },
+          { database: "shard_one_development", pool: 5 }
+        ], configs.map(&:configuration_hash)
+      end
+
+      def test_using_shard_with_nested_replica
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              database "default_development"
+              pool 5
+              replica
+
+              shard(:one) do
+                database "shard_one_development"
+                replica
+              end
+            end
+          end
+        end
+
+        assert_equal ["primary", "primary_replica", "primary_shard_one", "primary_shard_one_replica"], configs.map(&:name)
+
+        assert_equal [
+          { database: "default_development", pool: 5 },
+          { database: "default_development", pool: 5, replica: true },
+          { database: "shard_one_development", pool: 5 },
+          { database: "shard_one_development", pool: 5, replica: true }
+        ], configs.map(&:configuration_hash)
+      end
+
+      def test_using_shard_with_additional_properties
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          env(:development) do
+            config(:primary) do
+              database "default_development"
+              pool 5
+
+              shard(:one) do
+                database "shard_one_development"
+                pool 10
+                username "toor"
+              end
+            end
+          end
+        end
+
+        assert_equal ["primary", "primary_shard_one"], configs.map(&:name)
+
+        assert_equal [
+          { database: "default_development", pool: 5 },
+          { database: "shard_one_development", pool: 10, username: "toor" },
+        ], configs.map(&:configuration_hash)
+      end
+
+      def test_using_shard_with_defaults
+        configs = ActiveRecord::DatabaseConfigurations.configure do
+          shard_default = build do
+            sharded true
+          end
+
+          env(:development) do
+            config(:primary) do
+              database "default_development"
+
+              shard(:one, shard_default) do
+                database "shard_one_development"
+              end
+            end
+          end
+        end
+
+        assert_equal ["primary", "primary_shard_one"], configs.map(&:name)
+
+        assert_equal [
+          { database: "default_development" },
+          { database: "shard_one_development", sharded: true }
+        ], configs.map(&:configuration_hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to define database configurations in an
application using a Ruby DSL. This would allow applications with much
more complex configurations use Ruby over YAML. One of the advantages is
we can avoid making the YAML parsing for database configuration objects
more complex.

The defined behavior will use the `database.yml` file if present. If
there is no `database.yml` and there is a `database.rb` Rails will use
the Ruby file.

The structure of the Ruby config is very similar to the YAML. It
supports default settings that can get merged into the configurations to
avoid duplicating the same lines. It uses a dummy kwarg to avoid parsing
the configuration hash before boot just like the dummy database yaml.

To create a configuration DSL, delete your `database.yml` and add a
`database.rb`.

A database.yml that looks like this:

```yaml
default: &default
  adapter: mysql2
  encoding: utf8mb4
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  username: root
  password:
  socket: /tmp/mysql.sock

development:
  primary:
    <<: *default
    database: recipes_development
  primary_replica:
    <<: *default
    database: recipes_development
    replica: true
```

Would be written in the Ruby DSL like this:

```ruby
ActiveRecord::DatabaseConfigurations.configure do
  default = build do
    adapter "mysql2"
    encoding "utf8mb4"
    pool ENV.fetch("RAILS_MAX_THREADS") { 5 }
    username "root"
    password ""
    socket "/tmp/mysql.sock"
  end

  for_env(:development) do
    add(:primary, default) do
      database "recipes_development"

      replica
    end
  end
end
```

The Ruby example from above will return 2 configurations; one named
`primary` and one named `primary_replica`. If we passed a name to
`replica` like `replica(:one)` it would create a replica named
`primary_replica_one`. One of the benefits of using the Ruby DSL over
the YAML is we can ignore the default configuration. In YAML since we
don't know what someone will name their default we must always include
it the configurations list when calling
`ActiveRecord::Base.configurations`. When using the Ruby DSL we know
which ones are the default settings so it can be ignored.

If `dummy: true` is passed to the builder we'll skip evaluating the
block and return a list of configurations with `env_name` and `name`
set while `configuration_hash` will be empty.

In the future Rails should provide a generator option to use the Ruby
DSL over YAML and a task that can convert a YAML file into the Ruby DSL.
For now, this PR adds support for the DSL and replacement of the YAML
file will be manual.

The aim of this PR is not to replace YAML but to give an option for
more complex database configurations.

The main benefits of using the Ruby DSL are:

1) Can use simple Ruby to create multiple databases, ex:

```ruby
add(:primary) do
  database "my_database"

  10.times do |int|
    replica("#{int}")
  end
end
```

Or write out conditionals:

```ruby
add(:primary) do
  database Rails.config.some_value ? "my_database" : "your_database"
end
```

2) The Ruby DSL leaves the `default` config definitions out of the
`configurations` list. This isn't possible with YAML because we don't
know what the name of the default will be, it can be anything.

3) Reduces repetition by supporting nested configurations. This will
allow us to tie replicas to their primaries and eventually simplify
`connects_to` to only be `connects_to :primary`. This will never be
possible with the 3-tier YAML configuration.

4) The flexibility of YAML + ERB makes it difficult to "guess" where we
are in the levels. Adding a 4th level to YAML configurations for replicas
or shards is untenable without a stricter solution. The Ruby DSL makes it
easier to build complex configurations programmatically.

Co-authored-by: @eileencodes 

cc / @rafaelfranca @tenderlove @dhh 