### PR TITLE
String#blank? handles invalid byte sequence

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -127,6 +127,9 @@ class String
         BLANK_RE.match?(self)
       rescue Encoding::CompatibilityError
         ENCODED_BLANKS[self.encoding].match?(self)
+      rescue ArgumentError => e
+        return false if e.message.match?("invalid byte sequence in UTF-8")
+        raise
       end
   end
 end

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -17,7 +17,7 @@ class BlankTest < ActiveSupport::TestCase
   end
 
   BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, " ".encode("UTF-16LE") ]
-  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
+  NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", "\xCA", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
 
   def test_blank
     BLANK.each { |v| assert_equal true, v.blank?,  "#{v.inspect} should be blank" }


### PR DESCRIPTION
### Summary

Calling `blank?` on a `String` with an invalid byte sequence raises an `ArgumentError`. Perhaps this is expected, but how do people feel about rescuing the exception and returning `false`? 

This came up on one of my clients' projects when trying to write a [custom validator](https://guides.rubyonrails.org/active_record_validations.html#performing-custom-validations) checking for malformed CSVs that blew up in [ActiveModel::EachValidator#validate](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validator.rb#L148) which calls [blank?](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/validator.rb#L15).