### PR TITLE
Fix text overflow in guides (box containing chapter names)

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -254,7 +254,8 @@ body {
   right: 0;
   background: #FFF;
   padding: 1em 1.5em 1em 1.25em;
-  width: 20em;
+  width: 17em;
+  overflow: scroll;
   font-size: 0.9285em;
   line-height: 1.3846em;
   margin-right: 1em;
@@ -281,7 +282,7 @@ body {
 }
 
 #header .wrapper, #topNav .wrapper, #feature .wrapper {padding-left: 1em; max-width: 960px;}
-#feature .wrapper {max-width: 720px; padding-right: 23em; position: relative; z-index: 0;}
+#feature .wrapper {max-width: 640px; overflow: scroll; padding-right: 23em; position: relative; z-index: 0;}
 
 @media screen and (max-width: 960px) {
   #container .wrapper { padding-right: 23em; }

--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -255,7 +255,8 @@ body {
   left: 0;
   background: #FFF;
   padding: 1em 1.5em 1em 1.25em;
-  width: 20em;
+  width: 17em;
+  overflow: scroll;
   font-size: 0.9285em;
   line-height: 1.3846em;
   margin-left: 1em;
@@ -282,7 +283,7 @@ body {
 }
 
 #header .wrapper, #topNav .wrapper, #feature .wrapper {padding-right: 1em; max-width: 960px;}
-#feature .wrapper {max-width: 720px; padding-left: 23em; position: relative; z-index: 0;}
+#feature .wrapper {max-width: 640px; overflow: scroll; padding-left: 23em; position: relative; z-index: 0;}
 
 @media screen and (max-width: 960px) {
   #container .wrapper { padding-left: 23em; }


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This PR resolves [issue #37363](https://github.com/rails/rails/issues/37363), which still persists (verifiable by visiting the page [Caching with Rails: An Overview](https://guides.rubyonrails.org/caching_with_rails.html)).
To resolve it, an <b>overflow</b> property has been added to the corressponding css.

