### PR TITLE
Quotation mark for gems with options in Gemfile template:

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -14,7 +14,7 @@ ruby <%= "'#{RUBY_VERSION}'" -%>
 <%= gem.commented_out ? '# ' : '' %>gem '<%= gem.name %>'<%= %(, '#{gem.version}') if gem.version -%>
 <% if gem.options.any? -%>
 , <%= gem.options.map { |k,v|
-  "#{k}: #{v.inspect}" }.join(', ') %>
+  "#{k}: #{v.inspect.gsub('"', '\'')}" }.join(', ') %>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
Use the same quote (') for gems with extra options used by  AppGenerator
in the Gemfile template.