### PR TITLE
Raise error when non-existent enum used in query

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+* Raise error when non-existent enum used in query
+  
+  This change will raise an error when a non-existent enum is passed to a query. Previously
+  with MySQL this would return an unrelated record. Fixes #38687.
+    ```ruby
+    class User < ActiveRecord::Base
+      enum status: { active: 0, non_active: 1 }
+    end
+    User.where(status: :non_existing_status)
+    => ArgumentError ('non_existing_status' is not a valid status)
+    ```
+  *Atul Kanswal *
+
 *   Dump the schema or structure of a database when calling db:migrate:name
 
     In previous versions of Rails, `rails db:migrate` would dump the schema of the database. In Rails 6, that holds true (`rails db:migrate` dumps all databases' schemas), but `rails db:migrate:name` does not share that behavior.

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -140,6 +140,7 @@ module ActiveRecord
       end
 
       def serialize(value)
+        assert_valid_value(value)
         mapping.fetch(value, value)
       end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -59,6 +59,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where(status: [written]).first
     assert_not_equal @book, Book.where("status <> ?", published).first
     assert_equal @book, Book.where("status <> ?", written).first
+    assert_empty Book.where(status: nil)
   end
 
   test "find via where with symbols" do
@@ -69,6 +70,8 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
     assert_equal books(:ddd), Book.where(read_status: :forgotten).first
+    exception = assert_raises(ArgumentError) { Book.where(status: :not_defined).first }
+    assert_match(/'not_defined' is not a valid status/, exception.message)
   end
 
   test "find via where with strings" do
@@ -79,6 +82,8 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where.not(status: "published").first
     assert_equal @book, Book.where.not(status: "written").first
     assert_equal books(:ddd), Book.where(read_status: "forgotten").first
+    exception = assert_raises(ArgumentError) { Book.where(status: "not_defined").first }
+    assert_match(/'not_defined' is not a valid status/, exception.message)
   end
 
   test "build from scope" do


### PR DESCRIPTION
This behaviour is in
rails/activerecord/lib/active_record/enum.rb #serialize(value) line no 143
if value is not present in mapping we are sending the value back ,
which in mysql returns unrelated record

**Going Forward we will raise error if enum value not present.**

### Summary
A non-exist enum string , gets unrelated record in MySQL.
This pull request solves the issue by setting a value nil, if it is not present among the enum.
This solves the following issue mentioned with example below
https://github.com/rails/rails/issues/38687
### Other Information
```
class User < ActiveRecord::Base
  enum status: { active: 0, non_active: 1 }
 end
 User.where(status: :non_existing_status)
 => ArgumentError ('non_existing_status' is not a valid status)
```


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
