### PR TITLE
Add X-Original-To to mail using Mailgun recipient

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Mailgun ingress now passes through the envelope recipient as `X-Original-To`.
+
+    *Rikki Pitt*
+
 *   Deprecate `Rails.application.credentials.action_mailbox.api_key` and `MAILGUN_INGRESS_API_KEY` in favor of `Rails.application.credentials.action_mailbox.signing_key` and `MAILGUN_INGRESS_SIGNING_KEY`.
 
     *Matthijs Vos*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -51,9 +51,9 @@ module ActionMailbox
 
     private
       def mail
-        mail = Mail.from_source(params.require("body-mime"))
-        mail.header["X-Original-To"] = params.require(:recipient) unless params.require(:recipient).blank?
-        mail.to_s
+        params.require("body-mime").tap do |raw_email|
+          raw_email.prepend("X-Original-To: ", params.require(:recipient), "\n") if params.key?(:recipient)
+        end
       end
 
       def authenticate

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -46,10 +46,16 @@ module ActionMailbox
     before_action :authenticate
 
     def create
-      ActionMailbox::InboundEmail.create_and_extract_message_id! params.require("body-mime")
+      ActionMailbox::InboundEmail.create_and_extract_message_id! mail
     end
 
     private
+      def mail
+        mail = Mail.from_source(params.require("body-mime"))
+        mail.header['X-Original-To'] = params.require(:recipient) unless params.require(:recipient).blank?
+        mail.to_s
+      end
+
       def authenticate
         head :unauthorized unless authenticated?
       end

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -52,7 +52,7 @@ module ActionMailbox
     private
       def mail
         mail = Mail.from_source(params.require("body-mime"))
-        mail.header['X-Original-To'] = params.require(:recipient) unless params.require(:recipient).blank?
+        mail.header["X-Original-To"] = params.require(:recipient) unless params.require(:recipient).blank?
         mail.to_s
       end
 

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -14,8 +14,7 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
         timestamp: 1539112500,
         token: "7VwW7k6Ak7zcTwoSoNm7aTtbk1g67MKAnsYLfUB7PdszbgR5Xi",
         signature: "ef24c5225322217bb065b80bb54eb4f9206d764e3e16abab07f0a64d1cf477cc",
-        "body-mime" => file_fixture("../files/welcome.eml").read,
-        recipient: "replies@example.com"
+        "body-mime" => file_fixture("../files/welcome.eml").read
       }
     end
 

--- a/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mailgun/inbound_emails_controller_test.rb
@@ -42,7 +42,7 @@ class ActionMailbox::Ingresses::Mailgun::InboundEmailsControllerTest < ActionDis
 
     inbound_email = ActionMailbox::InboundEmail.last
     mail = Mail.from_source(inbound_email.raw_email.download)
-    assert_equal "replies@example.com", mail.header['X-Original-To'].decoded
+    assert_equal "replies@example.com", mail.header["X-Original-To"].decoded
   end
 
   test "rejecting a delayed inbound email from Mailgun" do


### PR DESCRIPTION
Certain mail providers strip out the BCC field in emails, therefore,
ActionMailbox can miss valid messages.

However, the Mailgun provider does pass the BCC recipient as a parameter
in the inbound payload separate to the `body-mime`.

This PR is adds preliminary tests and code to start the conversation
around modifying the `raw_email`. Note: Some of the old tests now fail
due to the fact that I'm using the Mail gem to add the `X-Original-To`
header.

Advice welcome.

Related to #38446

CC: @jeremy and @kaspth