### PR TITLE
Reproduce scope leak when using 'unscoped' in a before_validation callback

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -36,12 +36,14 @@ require "models/family_tree"
 require "models/section"
 require "models/seminar"
 require "models/session"
+require "models/house"
+require "models/lounge"
 
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
            :owners, :pets, :toys, :jobs, :references, :companies, :members, :author_addresses,
            :subscribers, :books, :subscriptions, :developers, :categorizations, :essays,
-           :categories_posts, :clubs, :memberships, :organizations
+           :categories_posts, :clubs, :memberships, :organizations, :houses
 
   # Dummies to force column loads so query counts are clean.
   def setup
@@ -1510,6 +1512,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     fall.save!
     fall.reload
     assert_equal sections, fall.sections.sort_by(&:id)
+  end
+
+  def test_unscoped_in_before_validation_does_not_leak_existing_scopes
+    houses(:mansion).lounges.large.create(colour: "purple")
+    assert_not_includes Lounge::last_before_validation_query, Lounge::LARGE_CLAUSE
   end
 
   private

--- a/activerecord/test/fixtures/houses.yml
+++ b/activerecord/test/fixtures/houses.yml
@@ -1,0 +1,2 @@
+mansion:
+  id: 3

--- a/activerecord/test/models/house.rb
+++ b/activerecord/test/models/house.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class House < ActiveRecord::Base
+  has_many :lounges, :dependent => :destroy, :inverse_of => :house
+end

--- a/activerecord/test/models/lounge.rb
+++ b/activerecord/test/models/lounge.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Lounge < ActiveRecord::Base
+  belongs_to :house, :optional => true
+
+  before_validation :max_two_purple
+
+  scope :purple, -> { where(:colour => "purple") }
+  scope :red, -> { where(:colour => "red") }
+  LARGE_CLAUSE = "size > 25"
+  scope :large, -> { where(LARGE_CLAUSE) }
+  scope :humongous, -> { where("size > 70") }
+
+  @@last_before_validation_query = ""
+
+  def self.last_before_validation_query
+    @@last_before_validation_query
+  end
+
+  private
+
+  def max_two_purple
+    unrelated_scope = Lounge.unscoped { house.lounges.humongous.red }
+
+    Lounge.unscoped do
+      @@last_before_validation_query = unrelated_scope.purple.to_sql
+      errors.add(:colour, "Sorry, only two purple lounges are allowed") if Lounge.purple.count > 2
+    end
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1116,6 +1116,14 @@ ActiveRecord::Schema.define do
   create_table :non_primary_keys, force: true, id: false do |t|
     t.integer :id
   end
+
+  create_table :houses, force: true
+
+  create_table :lounges, force: true do |t|
+    t.integer :house_id
+    t.string :colour
+    t.integer :size
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
### Summary

In Rails 6, a scope leaks through `unscoped` when used within a `before_validation` callback. See [issue 38741](https://github.com/rails/rails/issues/38741) for details. `test_unscoped_in_before_validation_does_not_leak_existing_scopes` reproduces this.