### PR TITLE
Use instance level attribute names

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,9 +1,18 @@
+*   Used instance attributes for inspection and pretty print.
+
+    When aliasing is done and we inspect for the object, then only
+    the class level objects are used for query and inspection and
+    aliased columns skips from the representation. Marked changes in
+    inspection and pretty print to include this. Fixes #38727
+
+    *Yash Ladha*
+
 *   Fix insert_all with enum values
 
     Fixes #38716.
 
     *Joel Blum*
-    
+
 *   Add support for `db:rollback:name` for multiple database applications.
 
     Multiple database applications will now raise if `db:rollback` is call and recommend using the `db:rollback:[NAME]` to rollback migrations.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -523,7 +523,7 @@ module ActiveRecord
       # We check defined?(@attributes) not to issue warnings if the object is
       # allocated but not initialized.
       inspection = if defined?(@attributes) && @attributes
-        self.class.attribute_names.collect do |name|
+        self.attribute_names.collect do |name|
           if has_attribute?(name)
             attr = _read_attribute(name)
             value = if attr.nil?
@@ -548,7 +548,7 @@ module ActiveRecord
       return super if custom_inspect_method_defined?
       pp.object_address_group(self) do
         if defined?(@attributes) && @attributes
-          attr_names = self.class.attribute_names.select { |name| has_attribute?(name) }
+          attr_names = self.attribute_names.select { |name| has_attribute?(name) }
           pp.seplist(attr_names, proc { pp.text "," }) do |attr_name|
             pp.breakable " "
             pp.group(1) do

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -18,7 +18,12 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_inspect_instance
     topic = topics(:first)
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_s(:db)}", bonus_time: "#{topic.bonus_time.to_s(:db)}", last_read: "#{topic.last_read.to_s(:db)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_s(:db)}", updated_at: "#{topic.updated_at.to_s(:db)}">), topic.inspect
+    assert_equal %(#<Topic written_on: "#{topic.written_on.to_s(:db)}", bonus_time: "#{topic.bonus_time.to_s(:db)}", last_read: "#{topic.last_read.to_s(:db)}", created_at: "#{topic.created_at.to_s(:db)}", updated_at: "#{topic.updated_at.to_s(:db)}", id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil>), topic.inspect
+  end
+
+  def test_inspect_aliased_column_names
+    topic = Topic.select("author_name AS name").take
+    assert_equal %(#<Topic name: "David", id: nil>), topic.inspect
   end
 
   def test_inspect_new_instance
@@ -66,6 +71,16 @@ class CoreTest < ActiveRecord::TestCase
     PRETTY
     assert actual.start_with?(expected.split("XXXXXX").first)
     assert actual.end_with?(expected.split("XXXXXX").last)
+  end
+
+  def test_pretty_print_aliased_column
+    topic = Topic.select("author_name AS name").take
+    actual = +""
+    PP.pp(topic, StringIO.new(actual))
+    expected = <<~PRETTY
+      #<Topic:0x\\w+ name: "David", id: nil>
+    PRETTY
+    assert_match(/\A#{expected}\z/, actual)
   end
 
   def test_pretty_print_persisted


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Fixes #38727

Previosly we were using the class method for fetching the column names
and not considering the local query based aliasing in column names.
Using the instance level method covers up for it.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->