### PR TITLE
Perform enqueued jobs only once

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `ActiveJob::TestCase#perform_enqueued_jobs` without a block removes performed jobs from the queue.
+
+    That way the helper can be called multiple times and not perform a job invocation multiple times.
+
+    ```ruby
+    def test_jobs
+      HelloJob.perform_later("rafael")
+      perform_enqueued_jobs
+      HelloJob.perform_later("david")
+      perform_enqueued_jobs # only runs with "david"
+    end
+    ```
+
 *   `ActiveJob::TestCase#perform_enqueued_jobs` will no longer perform retries:
 
     When calling `perform_enqueued_jobs` without a block, the adapter will

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -641,6 +641,7 @@ module ActiveJob
 
       def flush_enqueued_jobs(only: nil, except: nil, queue: nil, at: nil)
         enqueued_jobs_with(only: only, except: except, queue: queue, at: at) do |payload|
+          queue_adapter.enqueued_jobs.delete(payload)
           queue_adapter.performed_jobs << payload
           instantiate_job(payload).perform_now
         end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -1872,6 +1872,7 @@ class PerformedJobsTest < ActiveJob::TestCase
       HelloJob.perform_later
     end
 
+    assert_equal 0, queue_adapter.enqueued_jobs.count
     assert_equal 2, queue_adapter.performed_jobs.count
   end
 
@@ -1884,6 +1885,7 @@ class PerformedJobsTest < ActiveJob::TestCase
     HelloJob.perform_later
     assert_performed_with(job: HelloJob)
 
+    assert_equal 2, queue_adapter.enqueued_jobs.count
     assert_equal 2, queue_adapter.performed_jobs.count
   end
 


### PR DESCRIPTION
### Summary

Move jobs from `queue_adapter.enqueued_jobs` to `queue_adapter.performed_jobs` when using `perform_enqueued_jobs` without a block.

### Other Information

The first commit fixes a test that was mistaken, at least to my understanding, because it was enqueuing one job, performing it, then performing it again and enqueuing another job (not performed), and the resulting assertion was that two jobs were performed. While it's true, I think it was a mistake because it was trying to copy the same test with the block form: https://github.com/rails/rails/blob/f735a2167c8921dce4ed25b4701987e393820ff9/activejob/test/cases/test_helper_test.rb#L1867-L1873

See also https://github.com/rails/rails/pull/33635/commits/2ec60fb8186ad3b227341b7d1874e3f13bd34279

So the second perform should have been after the second enqueue, and it would have shown the issue I'm trying to fix here, that the first enqueue was performed twice, the second once, and that there was three performs overall.

cc @byroot @Edouard-chin @rafaelfranca