### PR TITLE
check for metadata table support

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -111,6 +111,10 @@ module ActiveRecord
         @config[:replica] || false
       end
 
+      def use_metadata_table?
+        @config.fetch(:use_metadata_table, true)
+      end
+
       # Determines whether writes are currently being prevents.
       #
       # Returns true if the connection is a replica, or if +prevent_writes+

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -6,8 +6,15 @@ require "active_record/scoping/named"
 module ActiveRecord
   # This class is used to create a table that keeps track of values and keys such
   # as which environment migrations were run in.
+  #
+  # It is possible to enable or disable this functionality by setting the
+  # adapter configuration option `use_metadata_table` to false
   class InternalMetadata < ActiveRecord::Base # :nodoc:
     class << self
+      def enabled?
+        ActiveRecord::Base.connection.use_metadata_table?
+      end
+
       def _internal?
         true
       end
@@ -21,15 +28,21 @@ module ActiveRecord
       end
 
       def []=(key, value)
+        return unless enabled?
+
         find_or_initialize_by(key: key).update!(value: value)
       end
 
       def [](key)
+        return unless enabled?
+
         where(key: key).pluck(:value).first
       end
 
       # Creates an internal metadata table with columns +key+ and +value+
       def create_table
+        return unless enabled?
+
         unless table_exists?
           key_options = connection.internal_string_options_for_primary_key
 
@@ -42,6 +55,8 @@ module ActiveRecord
       end
 
       def drop_table
+        return unless enabled?
+
         connection.drop_table table_name, if_exists: true
       end
     end

--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -7,8 +7,8 @@ module ActiveRecord
   # This class is used to create a table that keeps track of values and keys such
   # as which environment migrations were run in.
   #
-  # It is possible to enable or disable this functionality by setting the
-  # adapter configuration option `use_metadata_table` to false
+  # This is enabled by default. To disable this functionality set
+  # `use_metadata_table` to false in your database configuration.
   class InternalMetadata < ActiveRecord::Base # :nodoc:
     class << self
       def enabled?

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -190,10 +190,11 @@ module ActiveRecord
     end
   end
 
-  class EnvironmentStorageError < ActiveRecordError #:nodoc:
+  class EnvironmentStorageError < ActiveRecordError # :nodoc:
     def initialize
       msg = +"You are attempting to store the environment in a database where metadata is disabled.\n"
-      msg << "Check your database configuration to see if this is inteded."
+      msg << "Check your database configuration to see if this is intended."
+      super(msg)
     end
   end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -190,6 +190,13 @@ module ActiveRecord
     end
   end
 
+  class EnvironmentStorageError < ActiveRecordError #:nodoc:
+    def initialize
+      msg = +"You are attempting to store the environment in a database where metadata is disabled.\n"
+      msg << "Check your database configuration to see if this is inteded."
+    end
+  end
+
   # = Active Record Migrations
   #
   # Migrations can manage the evolution of a schema used by several physical
@@ -1143,6 +1150,7 @@ module ActiveRecord
     end
 
     def last_stored_environment
+      return nil unless ActiveRecord::InternalMetadata.enabled?
       return nil if current_version == 0
       raise NoEnvironmentInSchemaError unless ActiveRecord::InternalMetadata.table_exists?
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -8,6 +8,7 @@ databases = ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml
 db_namespace = namespace :db do
   desc "Set the environment value for the database"
   task "environment:set" => :load_config do
+    raise ActiveRecord::EnvironmentStorageError unless ActiveRecord::InternalMetadata.enabled?
     ActiveRecord::InternalMetadata.create_table
     ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.connection.migration_context.current_environment
   end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -348,7 +348,10 @@ module ActiveRecord
         return true unless File.exist?(file)
 
         ActiveRecord::Base.establish_connection(db_config)
+
+        return false unless ActiveRecord::InternalMetadata.enabled?
         return false unless ActiveRecord::InternalMetadata.table_exists?
+
         ActiveRecord::InternalMetadata[:schema_sha1] == schema_sha1(file)
       end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -640,6 +640,16 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal "bar", ActiveRecord::InternalMetadata[:foo]
   end
 
+  def test_internal_metadata_not_used_when_not_enabled
+    ActiveRecord::InternalMetadata.stub(:enabled?, false) do
+      migrations_path = MIGRATIONS_ROOT + "/valid"
+
+      migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+      migrator.up
+      assert_not ActiveRecord::InternalMetadata[:environment]
+    end
+  end
+
   def test_proper_table_name_on_migration
     reminder_class = new_isolated_reminder_class
     migration = ActiveRecord::Migration.new

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -641,13 +641,26 @@ class MigrationTest < ActiveRecord::TestCase
   end
 
   def test_internal_metadata_not_used_when_not_enabled
-    ActiveRecord::InternalMetadata.stub(:enabled?, false) do
-      migrations_path = MIGRATIONS_ROOT + "/valid"
+    ActiveRecord::InternalMetadata.drop_table
+    original_config = ActiveRecord::Base.connection.instance_variable_get("@config")
 
-      migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
-      migrator.up
-      assert_not ActiveRecord::InternalMetadata[:environment]
-    end
+    modified_config = original_config.dup.merge(use_metadata_table: false)
+
+    ActiveRecord::Base.connection
+      .instance_variable_set("@config", modified_config)
+
+    assert_not ActiveRecord::InternalMetadata.enabled?
+    assert_not ActiveRecord::InternalMetadata.table_exists?
+
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    migrator = ActiveRecord::MigrationContext.new(migrations_path, @schema_migration)
+    migrator.up
+
+    assert_not ActiveRecord::InternalMetadata[:environment]
+    assert_not ActiveRecord::InternalMetadata.table_exists?
+  ensure
+    ActiveRecord::Base.connection.instance_variable_set("@config", original_config)
+    ActiveRecord::InternalMetadata.create_table
   end
 
   def test_proper_table_name_on_migration

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1258,6 +1258,16 @@ development:
 
 Change the username and password in the `development` section as appropriate.
 
+#### Configuring Metadata Storage
+
+By default Rails will store information about your environment and schema in an internal table. If you do not want this table to be created, and are willing to give up the protections it provides (useful when working with a shared database and a database user that can not create tables).
+
+```yaml
+development:
+  adapter: postgresql
+  use_metadata_table: false
+```
+
 ### Creating Rails Environments
 
 By default Rails ships with three environments: "development", "test", and "production". While these are sufficient for most use cases, there are circumstances when you want more environments.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1260,7 +1260,12 @@ Change the username and password in the `development` section as appropriate.
 
 #### Configuring Metadata Storage
 
-By default Rails will store information about your environment and schema in an internal table. If you do not want this table to be created, and are willing to give up the protections it provides (useful when working with a shared database and a database user that can not create tables).
+By default Rails will store information about your Rails environment and schema
+in an internal table named `ar_internal_metadata`.
+
+To turn this off per connection, set `use_metadata_table` in your database
+configuration. This is useful when working with a shared database and/or
+database user that cannot create tables.
 
 ```yaml
 development:


### PR DESCRIPTION
### Summary
Adds a new attribute to a database connection called `supports_metadata_table` that allows metadata table interaction to be disabled per database. This is helpful in situations like the one described in this issue https://github.com/rails/rails/issues/38750 where a database's records , but not the schema may be updated by the rails app