### PR TITLE
Fix documentIsActive return value being cached

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -500,7 +500,7 @@ consumer.subscriptions.create("AppearanceChannel", {
   },
 
   update() {
-    this.documentIsActive ? this.appear() : this.away()
+    this.documentIsActive() ? this.appear() : this.away()
   },
 
   appear() {
@@ -527,7 +527,7 @@ consumer.subscriptions.create("AppearanceChannel", {
     document.removeEventListener("visibilitychange", this.update)
   },
 
-  get documentIsActive() {
+  documentIsActive() {
     return document.visibilityState == "visible" && document.hasFocus()
   },
 


### PR DESCRIPTION
### Summary

The appearance example currently provided in the action cable guide does not work as expected as the getter `documentIsActive` is not called whenever the `update()` method is executed. It's only executed once. The return value from this single run is used for all future executions of `update()`. When changed from getter to regular method call, it works fine.

### Other Information

Tested in latest stable Chrome, Firefox and Safari (Mac Versions).

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
