### PR TITLE
Remove extra loop in view_assigns

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -64,12 +64,12 @@ module AbstractController
     # You can overwrite this configuration per controller.
     def view_assigns
       protected_vars = _protected_ivars
-      variables      = instance_variables
 
-      variables.reject! { |s| protected_vars.include? s }
-      variables.each_with_object({}) { |name, hash|
-        hash[name.slice(1, name.length)] = instance_variable_get(name)
-      }
+      instance_variables.each_with_object({}) do |name, hash|
+        unless protected_vars.include?(name)
+          hash[name[1..-1]] = instance_variable_get(name)
+        end
+      end
     end
 
   private

--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -67,7 +67,7 @@ module AbstractController
 
       instance_variables.each_with_object({}) do |name, hash|
         unless protected_vars.include?(name)
-          hash[name[1..-1]] = instance_variable_get(name)
+          hash[name.slice(1, name.length)] = instance_variable_get(name)
         end
       end
     end


### PR DESCRIPTION
### Summary

Remove an extra loop from `view_assigns`. Instead of rejecting first and then populating the hash, add a conditional inside the `each_with_object` loop. Also, use `[1..-1]` instead of `slice` to get the instance variable name without the `@`.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
end

module AbstractController
  module Rendering
    def fast_view_assigns
      protected_vars = _protected_ivars

      instance_variables.each_with_object({}) do |name, hash|
        unless protected_vars.include?(name)
          hash[name[1..-1]] = instance_variable_get(name)
        end
      end
    end
  end
end

class ApplicationController < ActionController::Base
end

controller = ApplicationController.new
controller.perform_caching = false
controller.locale = :en
controller.logger = Logger.new(STDOUT)
controller.action_name = :index
controller.params = { a: 1, b: 2 }
controller.etag_with_template_digest = "some_etag"
controller._wrapper_options = { a: 1 }
controller.action_has_layout = true
controller._helper_methods = %i[:validate_something]
controller._view_cache_dependencies = 1
controller._renderers = ApplicationController.renderer
controller.include_all_helpers = true
controller.default_url_options = { param: "value" }

Benchmark.ips do |x|
  x.report("view_assigns")      { controller.view_assigns }
  x.report("fast_view_assigns") { controller.fast_view_assigns }
  x.compare!
end
```
### Results
```
Warming up --------------------------------------
        view_assigns    15.796k i/100ms
   fast_view_assigns    17.734k i/100ms
Calculating -------------------------------------
        view_assigns    173.365k (± 9.3%) i/s -    868.780k in   5.060972s
   fast_view_assigns    200.177k (± 5.3%) i/s -      1.011M in   5.065013s

Comparison:
   fast_view_assigns:   200176.8 i/s
        view_assigns:   173365.4 i/s - 1.15x  slower
```


