### PR TITLE
fix StiAutoloading example code

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -230,6 +230,7 @@ module StiPreload
       def preload_sti
         types_in_db = \
           base_class.
+            unscoped.
             select(inheritance_column).
             distinct.
             pluck(inheritance_column).


### PR DESCRIPTION
### Summary

without the `.unscoped` call the example code can break if a base model happens to have a default scope (see #38771)

