### PR TITLE
Dasherize hash keys in class_names

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `class_names` helper dasherizes hash keys.
+
+    *Justin Kenyon*, *Joel Hawksley*
+
 *   `ActionView::Helpers::TranslationHelper#translate` returns nil when
     passed `default: nil` without a translation matching `I18n#translate`.
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -297,6 +297,8 @@ module ActionView
       #    # => "foo bar"
       #   class_names({ foo: true, bar: false })
       #    # => "foo"
+      #   class_names(foo_bar: true)
+      #    # => "foo-bar"
       #   class_names(nil, false, 123, "", "foo", { bar: true })
       #    # => "123 foo bar"
       def class_names(*args)
@@ -340,7 +342,7 @@ module ActionView
             case tag_value
             when Hash
               tag_value.each do |key, val|
-                tag_values << key.to_s if val && key.present?
+                tag_values << key.to_s.dasherize if val && key.present?
               end
             when Array
               tag_values.concat build_tag_values(*tag_value)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -348,6 +348,7 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "song play", class_names({ "song": true, "play": true })
     assert_equal "", class_names({ "song": false, "play": false })
     assert_equal "123", class_names(nil, "", false, 123, { "song": false, "play": false })
+    assert_equal "song-play", class_names(song_play: true)
   end
 
   def test_content_tag_with_data_attributes


### PR DESCRIPTION
### Summary

This change updates class_names to dasherize hash keys
in the same way Rails already does for data- and aria-
attributes.

This is a follow up to https://github.com/rails/rails/pull/37918.

Co-authored-by: Justin Kenyon <kenyonj@github.com>