### PR TITLE
Fix perform_enqueued_jobs without a block inside other helpers

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -119,15 +119,15 @@ module ActiveJob
     #   end
     def assert_enqueued_jobs(number, only: nil, except: nil, queue: nil, &block)
       if block_given?
-        original_count = enqueued_jobs_with(only: only, except: except, queue: queue)
+        original_jobs = enqueued_jobs_with(only: only, except: except, queue: queue)
 
         assert_nothing_raised(&block)
 
-        new_count = enqueued_jobs_with(only: only, except: except, queue: queue)
+        new_jobs = enqueued_jobs_with(only: only, except: except, queue: queue)
 
-        actual_count = new_count - original_count
+        actual_count = (new_jobs - original_jobs).count
       else
-        actual_count = enqueued_jobs_with(only: only, except: except, queue: queue)
+        actual_count = enqueued_jobs_with(only: only, except: except, queue: queue).count
       end
 
       assert_equal number, actual_count, "#{number} jobs expected, but #{actual_count} were enqueued"
@@ -279,7 +279,7 @@ module ActiveJob
 
         performed_jobs_size = new_count - original_count
       else
-        performed_jobs_size = performed_jobs_with(only: only, except: except, queue: queue)
+        performed_jobs_size = performed_jobs_with(only: only, except: except, queue: queue).count
       end
 
       assert_equal number, performed_jobs_size, "#{number} jobs expected, but #{performed_jobs_size} were performed"
@@ -385,11 +385,11 @@ module ActiveJob
       potential_matches = []
 
       if block_given?
-        original_enqueued_jobs_count = enqueued_jobs.count
+        original_enqueued_jobs = enqueued_jobs.dup
 
         assert_nothing_raised(&block)
 
-        jobs = enqueued_jobs.drop(original_enqueued_jobs_count)
+        jobs = enqueued_jobs - original_enqueued_jobs
       else
         jobs = enqueued_jobs
       end
@@ -602,7 +602,7 @@ module ActiveJob
       def jobs_with(jobs, only: nil, except: nil, queue: nil, at: nil)
         validate_option(only: only, except: except)
 
-        jobs.dup.count do |job|
+        jobs.dup.select do |job|
           job_class = job.fetch(:job)
 
           if only
@@ -644,7 +644,7 @@ module ActiveJob
           queue_adapter.enqueued_jobs.delete(payload)
           queue_adapter.performed_jobs << payload
           instantiate_job(payload).perform_now
-        end
+        end.count
       end
 
       def prepare_args_for_assertion(args)

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -961,6 +961,19 @@ class PerformedJobsTest < ActiveJob::TestCase
     assert_equal(0, enqueued_jobs.size)
   end
 
+  def test_perform_enqueued_jobs_without_block_works_with_other_helpers
+    NestedJob.perform_later
+    assert_equal(0, performed_jobs.size)
+    assert_equal(1, enqueued_jobs.size)
+    assert_enqueued_jobs(1) do
+      assert_enqueued_with(job: LoggingJob) do
+        perform_enqueued_jobs
+      end
+    end
+    assert_equal(1, performed_jobs.size)
+    assert_equal(1, enqueued_jobs.size)
+  end
+
   def test_perform_enqueued_jobs_without_block_only_performs_once
     JobBuffer.clear
     RescueJob.perform_later("no exception")


### PR DESCRIPTION
### Summary

In #38749, I broke the behavior of `assert_enqueued_with` when using `perform_enqueued_jobs` inside the block. That's because the implementation wasn't expecting the queue to be mutated beyond jobs being added at the end. I missed that sorry. 😬 

### Other Information

`assert_enqueued_with` with a block ignores all the jobs enqueued before the block for its assertions by counting the number of jobs and dropping the n first elements from the Array, but since we're now mutating the Array in `perform_enqueued_jobs` without a block, it's broken.

This uses another implementation which is correct when the array is mutated, by getting a duplicated array of jobs, then removing them from the original array.

I don't think that requires a changelog.

cc @byroot @Edouard-chin @rafaelfranca
