### PR TITLE
Fix `rescue_from` documentation in Action Cable Overview guide [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -132,7 +132,8 @@ verified_user = User.find_by(id: cookies.encrypted['_session']['user_id'])
 
 By default, unhandled exceptions are caught and logged to Rails' logger. If you would like to
 globally intercept these exceptions and report them to an external bug tracking service, for
-example, you can do so with `rescue_from`.
+example, you can do so with
+[`rescue_from`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html#method-i-rescue_from).
 
 ```ruby
 # app/channels/application_cable/connection.rb
@@ -198,9 +199,8 @@ end
 
 #### Exception Handling
 
-As with `ActionCable::Connection::Base`, you can also use
-[`rescue_from`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html)
-on a specific channel to handle raised exceptions:
+As with `ActionCable::Connection::Base`, you can also use `rescue_from` on a
+specific channel to handle raised exceptions:
 
 ```ruby
 # app/channels/chat_channel.rb

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -132,7 +132,7 @@ verified_user = User.find_by(id: cookies.encrypted['_session']['user_id'])
 
 By default, unhandled exceptions are caught and logged to Rails' logger. If you would like to
 globally intercept these exceptions and report them to an external bug tracking service, for
-example, you can do so with `rescue_with`.
+example, you can do so with `rescue_from`.
 
 ```ruby
 # app/channels/application_cable/connection.rb
@@ -199,7 +199,7 @@ end
 #### Exception Handling
 
 As with `ActionCable::Connection::Base`, you can also use
-[`rescue_with`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html)
+[`rescue_from`](https://api.rubyonrails.org/classes/ActiveSupport/Rescuable/ClassMethods.html)
 on a specific channel to handle raised exceptions:
 
 ```ruby


### PR DESCRIPTION
### Summary

This corrects a minor typo made in d2571e560c62116f60429c933d0c41a0e249b58b (https://github.com/rails/rails/pull/34917). The docs mentioned `rescue_with`, but the actual method name is `rescue_from` (`with` is one of its parameters), as seen in the examples just below these two sentences.

### Other Information

I also noticed that we were linking to the `rescue_from` API docs in the second mention of `rescue_from`. I think it's conventional to link to an external reference the first time the subject is mentioned, so I moved this link accordingly.