### PR TITLE
Fix confusing wording in Asset Pipeline guide [ci skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -516,10 +516,10 @@ was a controller called "projects", which generated an
 `app/assets/stylesheets/projects.scss` file.
 
 In development mode, or if the asset pipeline is disabled, when this file is
-requested it is processed by the processor provided by the `sass` gem and then
-sent back to the browser as CSS. When asset pipelining is enabled, this file is
-preprocessed and placed in the `public/assets` directory for serving by either
-the Rails app or web server.
+requested it is processed by the processor provided by the `sass-rails` gem and
+then sent back to the browser as CSS. When asset pipelining is enabled, this
+file is preprocessed and placed in the `public/assets` directory for serving by
+either the Rails app or web server.
 
 Additional layers of preprocessing can be requested by adding other extensions,
 where each extension is processed in a right-to-left manner. These should be

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -42,8 +42,8 @@ gem 'sass-rails'
 ```
 
 Using the `--skip-sprockets` option will prevent Rails from adding
-this to your `Gemfile`, so if you later want to enable
-the asset pipeline you will have to add that gem to your `Gemfile`. Also,
+this gem, so if you later want to enable the asset pipeline
+you will have to add it to your `Gemfile` manually. Also,
 creating an application with the `--skip-sprockets` option will generate
 a slightly different `config/application.rb` file, with a require statement
 for the sprockets railtie that is commented-out. You will have to remove

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -510,17 +510,16 @@ might concatenate three CSS files together this way:
 ### Preprocessing
 
 The file extensions used on an asset determine what preprocessing is applied.
-When a controller or a scaffold is generated with the default Rails gemset, a
-CoffeeScript file and a SCSS file are generated in place of a regular JavaScript
-and CSS file. The example used before was a controller called "projects", which
-generated an `app/assets/stylesheets/projects.scss` file.
+When a controller or a scaffold is generated with the default Rails gemset, an
+SCSS file is generated in place of a regular CSS file. The example used before
+was a controller called "projects", which generated an
+`app/assets/stylesheets/projects.scss` file.
 
-In development mode, or if the asset pipeline is disabled, when these files are
-requested they are processed by the processors provided by the `coffee-script`
-and `sass` gems and then sent back to the browser as JavaScript and CSS
-respectively. When asset pipelining is enabled, these files are preprocessed and
-placed in the `public/assets` directory for serving by either the Rails app or
-web server.
+In development mode, or if the asset pipeline is disabled, when this file is
+requested it is processed by the processor provided by the `sass` gem and then
+sent back to the browser as CSS. When asset pipelining is enabled, this file is
+preprocessed and placed in the `public/assets` directory for serving by either
+the Rails app or web server.
 
 Additional layers of preprocessing can be requested by adding other extensions,
 where each extension is processed in a right-to-left manner. These should be

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -34,7 +34,7 @@ $ rails new appname --skip-sprockets
 ```
 
 Rails automatically adds the `sass-rails` gem to your `Gemfile`, which is used
-by Sprockets for asset compression:
+by Sprockets for Sass compilation:
 
 ```ruby
 gem 'sass-rails'

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -41,8 +41,8 @@ gem 'sass-rails'
 ```
 
 Using the `--skip-sprockets` option will prevent Rails from adding
-them to your `Gemfile`, so if you later want to enable
-the asset pipeline you will have to add those gems to your `Gemfile`. Also,
+this to your `Gemfile`, so if you later want to enable
+the asset pipeline you will have to add that gem to your `Gemfile`. Also,
 creating an application with the `--skip-sprockets` option will generate
 a slightly different `config/application.rb` file, with a require statement
 for the sprockets railtie that is commented-out. You will have to remove

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -33,8 +33,9 @@ passing the `--skip-sprockets` option.
 $ rails new appname --skip-sprockets
 ```
 
-Rails automatically adds the `sass-rails` gem to your `Gemfile`, which is used
-by Sprockets for Sass compilation:
+Rails automatically adds the [`sass-rails`](https://github.com/rails/sass-rails)
+gem to your `Gemfile`, which is used by Sprockets for
+[Sass](https://sass-lang.com) compilation:
 
 ```ruby
 gem 'sass-rails'


### PR DESCRIPTION
### Summary

While looking into https://github.com/rails/rails/issues/38307, I noticed some confusing wording in the Asset Pipeline guide:
https://github.com/rails/rails/blob/aeac447b0ca750294fc0556bd0b9842ecce5ad0f/guides/source/asset_pipeline.md#L36-L45

Specifically
> adding _them_ to your `Gemfile`

and
> add _those_ gems

is confusing because the preceding paragraph only mentions _one_ gem (`sass-rails`). I discovered that this is a result of removing mentions of `uglifier` and `coffee-rails` from that paragraph in https://github.com/rails/rails/pull/35994.

So I've opened this PR as a follow-up to https://github.com/rails/rails/pull/35994 to clean up the confusing wording that was left in the guide.

### Other Information

While I was in there, I also clarified the purpose of the `sass-rails` gem and added links to https://github.com/rails/sass-rails and https://sass-lang.com.