### PR TITLE
Fix a typo in AbsenceValidator

### DIFF
--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -11,7 +11,7 @@ module ActiveModel
 
     module HelperMethods
       # Validates that the specified attributes are blank (as defined by
-      # Object#blank?). Happens by default on save.
+      # Object#present?). Happens by default on save.
       #
       #   class Person < ActiveRecord::Base
       #     validates_absence_of :first_name


### PR DESCRIPTION
### Summary

Fix a typo. We checked by using `Object.present?` https://github.com/rails/rails/blob/aeac447b0ca750294fc0556bd0b9842ecce5ad0f/activemodel/lib/active_model/validations/absence.rb#L8

### Other Information

N/A
