### PR TITLE
Backport fix for possible XSS vector in JS escape helper to 4-2-stable

### DIFF
--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -10,7 +10,9 @@ module ActionView
         "\n"    => '\n',
         "\r"    => '\n',
         '"'     => '\\"',
-        "'"     => "\\'"
+        "'"     => "\\'",
+        "`"     => "\\`",
+        "$"     => "\\$"
       }
 
       JS_ESCAPE_MAP["\342\200\250".force_encoding(Encoding::UTF_8).encode!] = '&#x2028;'
@@ -24,7 +26,7 @@ module ActionView
       #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
       def escape_javascript(javascript)
         if javascript
-          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u) {|match| JS_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -33,6 +33,14 @@ class JavaScriptHelperTest < ActionView::TestCase
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end
 
+  def test_escape_backtick
+    assert_equal "\\`", escape_javascript("`")
+  end
+
+  def test_escape_dollar_sign
+    assert_equal "\\$", escape_javascript("$")
+  end
+
   def test_escape_javascript_with_safebuffer
     given = %('quoted' "double-quoted" new-line:\n </closed>)
     expect = %(\\'quoted\\' \\"double-quoted\\" new-line:\\n <\\/closed>)


### PR DESCRIPTION
Backport 033a738817abd6e446e1b320cb7d1a5c15224e9a to [4-2-stable](https://github.com/rails/rails/tree/4-2-stable).
