### PR TITLE
Adds Many monad to Active Support and Active Record relations

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,36 @@
+*   Adds `Enumerable#with_many` which creates Many monad from a collection.
+
+    Mapping over a collection and traverse the association or property
+    of a collection using `flat_map` or `map` adds chaining. Addition of monad
+    eases the chaining in a better way.
+
+    Example:
+    ```ruby
+        class Blog < ApplicationRecord
+            has_many :categories
+        end
+
+        class Category < ApplicationRecord
+            has_many :posts
+        end
+
+        class Post < ApplicationRecord
+            has_many :comments
+        end
+    ```
+
+    Let say, we want to fetch all the comments for blogs added by DHH user. The query would be as follows:
+    ```ruby
+        # Before
+        blogs = Blog.where(author: { name: "DHH" })
+        blogs.flat_map(:categories).flat_map(:posts).flat_map(:comments)
+
+        # After this addition
+        blogs.with_many.categories.posts.comments
+    ```
+
+    *Abhay Nikam*
+
 *   Add Date and Time `#yesterday?` and `#tomorrow?` alongside `#today?`.
 
     Aliased to `#prev_day?` and `#next_day?` to match the existing `#prev/next_day` methods.

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/monads/many"
+
 module Enumerable
   INDEX_WITH_DEFAULT = Object.new
   private_constant :INDEX_WITH_DEFAULT
@@ -189,6 +191,22 @@ module Enumerable
   #    #=> { b: 1, f: true }
   def compact_blank
     reject(&:blank?)
+  end
+
+  # Converts an enumerable to +Many+ monad.
+  # +with_many+ eases the mapping over the collection and traversing
+  # the association or the property of the object.
+  #
+  #   [{ name: "David" }, { name: "Rafael" }].with_many
+  #   # => #<Monads::Many @values=[{:name=>"David"}, {:name=>"Rafael"}]>
+  #
+  # +with_many+ when called on a ActiveRecord::Relation collection
+  # returns a monad with values.
+  #
+  #   blogs.with_many.categories.posts.comments
+  #   # => #<Monads::Many: @values=[#<Comment id: 1, body: "This is awesome new feature">]>
+  def with_many
+    Monads::Many.new(self)
   end
 end
 

--- a/activesupport/lib/active_support/monads/many.rb
+++ b/activesupport/lib/active_support/monads/many.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Monads # :nodoc:
+  class Many # :nodoc:
+    attr_reader :values
+
+    def initialize(values)
+      @values = values
+    end
+
+    def try(&block)
+      Many.new(values.map(&block).flat_map(&:values))
+    end
+
+    def method_missing(*args, &block)
+      try do |value|
+        Many.new(value.public_send(*args, &block))
+      end
+    end
+  end
+end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -284,4 +284,13 @@ class EnumerableTests < ActiveSupport::TestCase
     values.compact_blank!
     assert_equal({ b: 1, f: true }, values)
   end
+
+  def test_with_many
+    empty_array = []
+    assert_equal empty_array, empty_array.with_many.values
+
+    payments = [ Payment.new(5), Payment.new(15) ]
+    assert_equal 20, payments.with_many.price.values.sum
+    assert_equal 40, payments.with_many.price.values.sum { |p| p * 2 }
+  end
 end

--- a/activesupport/test/monads/many_test.rb
+++ b/activesupport/test/monads/many_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/monads/many"
+
+class Monads::ManyTest < ActiveSupport::TestCase
+  Post = Struct.new(:title, :comments)
+  Comment = Struct.new(:body)
+
+  def test_many_monad_values
+    assert_equal posts, many_monad(posts).values
+  end
+
+  def test_try
+    expected = ["REMOTE WORK", "WELCOME TO THE WEBLOG"]
+    actual = []
+    many_monad(posts).try do |post|
+      actual << post.title.upcase
+      Monads::Many.new(post)
+    end
+
+    assert_equal expected, actual
+  end
+
+  def test_try_with_empty_collection_doesnt_raise_on_block
+    assert_empty many_monad([]).try { |value| values * 2 }.values
+  end
+
+  def test_many_monad_returns_flattened_collection
+    expected = ["Nice post", "Awesome", "Thank you"]
+    assert_equal expected, many_monad(posts).comments.body.values
+  end
+
+  def test_many_monad_raises_error_if_method_is_not_defined_on_value
+    assert_raises do
+      many_monad(posts).comments.created_at
+    end
+  end
+
+  private
+    def many_monad(values)
+      Monads::Many.new(values)
+    end
+
+    def posts
+      @_posts ||= [
+        Post.new("Remote Work", [Comment.new("Nice post"), Comment.new("Awesome")]),
+        Post.new("Welcome to the weblog", [Comment.new("Thank you")])
+      ]
+    end
+end


### PR DESCRIPTION
fixes #37875

This PR introduces the Many monads in Active Support. To use Many monads with Active Record we have introduced `Enumerable#with_many` which converts the enumerable to Many monads.

@kddeisz  I hope my work does not overlap with your work done in PR: #37938. 

cc/ @dhh 

**NOTE:** I want to write test cases for `with_many` for Active Record relations but could not find a proper place where enumerable tests are written. If those are needed and somebody has any idea, please do point me in that direction. Thanks