### PR TITLE
Adding a route for Mandrill's url check.

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update Mandrill inbound email route to respond appropriately to HEAD requests for URL health checks from Mandrill.
+
+    *Bill Cromie*
+
 *   Add way to deliver emails via source instead of filling out a form through the conductor interface.
 
     *DHH*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -15,7 +15,7 @@ module ActionMailbox
   # - <tt>500 Server Error</tt> if the Mandrill API key is missing, or one of the Active Record database,
   #   the Active Storage service, or the Active Job backend is misconfigured or unavailable
   class Ingresses::Mandrill::InboundEmailsController < ActionMailbox::BaseController
-    before_action :authenticate
+    before_action :authenticate, except: :health_check
 
     def create
       raw_emails.each { |raw_email| ActionMailbox::InboundEmail.create_and_extract_message_id! raw_email }
@@ -23,6 +23,10 @@ module ActionMailbox
     rescue JSON::ParserError => error
       logger.error error.message
       head :unprocessable_entity
+    end
+
+    def health_check
+      head :ok
     end
 
     private

--- a/actionmailbox/config/routes.rb
+++ b/actionmailbox/config/routes.rb
@@ -2,10 +2,13 @@
 
 Rails.application.routes.draw do
   scope "/rails/action_mailbox", module: "action_mailbox/ingresses" do
-    post "/mandrill/inbound_emails" => "mandrill/inbound_emails#create", as: :rails_mandrill_inbound_emails
     post "/postmark/inbound_emails" => "postmark/inbound_emails#create", as: :rails_postmark_inbound_emails
     post "/relay/inbound_emails"    => "relay/inbound_emails#create",    as: :rails_relay_inbound_emails
     post "/sendgrid/inbound_emails" => "sendgrid/inbound_emails#create", as: :rails_sendgrid_inbound_emails
+
+    # Mandrill checks for the existence of a URL with a HEAD request before it will create the webhook.
+    get "/mandrill/inbound_emails"  => "mandrill/inbound_emails#health_check", as: :rails_mandrill_inbound_health_check
+    post "/mandrill/inbound_emails" => "mandrill/inbound_emails#create",       as: :rails_mandrill_inbound_emails
 
     # Mailgun requires that a webhook's URL end in 'mime' for it to receive the raw contents of emails.
     post "/mailgun/inbound_emails/mime" => "mailgun/inbound_emails#create", as: :rails_mailgun_inbound_emails

--- a/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
@@ -10,6 +10,12 @@ class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDi
     @events = JSON.generate([{ event: "inbound", msg: { raw_msg: file_fixture("../files/welcome.eml").read } }])
   end
 
+  test "verifying existence of Mandrill inbound route" do
+    # Mandrill uses a HEAD request to verify if a URL exists before creating the ingress webhook
+    head rails_mandrill_inbound_health_check_url
+    assert_response :ok
+  end
+
   test "receiving an inbound email from Mandrill" do
     assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
       post rails_mandrill_inbound_emails_url,

--- a/railties/test/application/rake/routes_test.rb
+++ b/railties/test/application/rake/routes_test.rb
@@ -20,10 +20,11 @@ module ApplicationTests
         assert_equal <<~MESSAGE, run_rake_routes
                                          Prefix Verb   URI Pattern                                                                              Controller#Action
                                            cart GET    /cart(.:format)                                                                          cart#show
-                  rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
                   rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
                      rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
                   rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                  action_mailbox/ingresses/sendgrid/inbound_emails#create
+            rails_mandrill_inbound_health_check GET    /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#health_check
+                  rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
                    rails_mailgun_inbound_emails POST   /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)                              action_mailbox/ingresses/mailgun/inbound_emails#create
                  rails_conductor_inbound_emails GET    /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#index
                                                 POST   /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#create

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -62,10 +62,10 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
     assert_equal <<~MESSAGE, run_routes_command([ "-g", "POST" ])
                                      Prefix Verb URI Pattern                                                         Controller#Action
                                             POST /cart(.:format)                                                     cart#create
-              rails_mandrill_inbound_emails POST /rails/action_mailbox/mandrill/inbound_emails(.:format)             action_mailbox/ingresses/mandrill/inbound_emails#create
               rails_postmark_inbound_emails POST /rails/action_mailbox/postmark/inbound_emails(.:format)             action_mailbox/ingresses/postmark/inbound_emails#create
                  rails_relay_inbound_emails POST /rails/action_mailbox/relay/inbound_emails(.:format)                action_mailbox/ingresses/relay/inbound_emails#create
               rails_sendgrid_inbound_emails POST /rails/action_mailbox/sendgrid/inbound_emails(.:format)             action_mailbox/ingresses/sendgrid/inbound_emails#create
+              rails_mandrill_inbound_emails POST /rails/action_mailbox/mandrill/inbound_emails(.:format)             action_mailbox/ingresses/mandrill/inbound_emails#create
                rails_mailgun_inbound_emails POST /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)         action_mailbox/ingresses/mailgun/inbound_emails#create
                                             POST /rails/conductor/action_mailbox/inbound_emails(.:format)            rails/conductor/action_mailbox/inbound_emails#create
       rails_conductor_inbound_email_sources POST /rails/conductor/action_mailbox/inbound_emails/sources(.:format)    rails/conductor/action_mailbox/inbound_emails/sources#create
@@ -166,10 +166,11 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
 
     assert_equal <<~MESSAGE, run_routes_command
                                      Prefix Verb   URI Pattern                                                                              Controller#Action
-              rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
               rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
                  rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
               rails_sendgrid_inbound_emails POST   /rails/action_mailbox/sendgrid/inbound_emails(.:format)                                  action_mailbox/ingresses/sendgrid/inbound_emails#create
+        rails_mandrill_inbound_health_check GET    /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#health_check
+              rails_mandrill_inbound_emails POST   /rails/action_mailbox/mandrill/inbound_emails(.:format)                                  action_mailbox/ingresses/mandrill/inbound_emails#create
                rails_mailgun_inbound_emails POST   /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)                              action_mailbox/ingresses/mailgun/inbound_emails#create
              rails_conductor_inbound_emails GET    /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#index
                                             POST   /rails/conductor/action_mailbox/inbound_emails(.:format)                                 rails/conductor/action_mailbox/inbound_emails#create
@@ -209,106 +210,111 @@ class Rails::Command::RoutesTest < ActiveSupport::TestCase
       URI               | /cart(.:format)
       Controller#Action | cart#show
       --[ Route 2 ]--------------
-      Prefix            | rails_mandrill_inbound_emails
-      Verb              | POST
-      URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
-      Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
-      --[ Route 3 ]--------------
       Prefix            | rails_postmark_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/postmark/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/postmark/inbound_emails#create
-      --[ Route 4 ]--------------
+      --[ Route 3 ]--------------
       Prefix            | rails_relay_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/relay/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/relay/inbound_emails#create
-      --[ Route 5 ]--------------
+      --[ Route 4 ]--------------
       Prefix            | rails_sendgrid_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/sendgrid/inbound_emails(.:format)
       Controller#Action | action_mailbox/ingresses/sendgrid/inbound_emails#create
+      --[ Route 5 ]--------------
+      Prefix            | rails_mandrill_inbound_health_check
+      Verb              | GET
+      URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
+      Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#health_check
       --[ Route 6 ]--------------
+      Prefix            | rails_mandrill_inbound_emails
+      Verb              | POST
+      URI               | /rails/action_mailbox/mandrill/inbound_emails(.:format)
+      Controller#Action | action_mailbox/ingresses/mandrill/inbound_emails#create
+      --[ Route 7 ]--------------
       Prefix            | rails_mailgun_inbound_emails
       Verb              | POST
       URI               | /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)
       Controller#Action | action_mailbox/ingresses/mailgun/inbound_emails#create
-      --[ Route 7 ]--------------
+      --[ Route 8 ]--------------
       Prefix            | rails_conductor_inbound_emails
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#index
-      --[ Route 8 ]--------------
+      --[ Route 9 ]--------------
       Prefix            | 
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#create
-      --[ Route 9 ]--------------
+      --[ Route 10 ]-------------
       Prefix            | new_rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#new
-      --[ Route 10 ]-------------
+      --[ Route 11 ]-------------
       Prefix            | edit_rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id/edit(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#edit
-      --[ Route 11 ]-------------
+      --[ Route 12 ]-------------
       Prefix            | rails_conductor_inbound_email
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#show
-      --[ Route 12 ]-------------
+      --[ Route 13 ]-------------
       Prefix            | 
       Verb              | PATCH
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#update
-      --[ Route 13 ]-------------
+      --[ Route 14 ]-------------
       Prefix            | 
       Verb              | PUT
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#update
-      --[ Route 14 ]-------------
+      --[ Route 15 ]-------------
       Prefix            | 
       Verb              | DELETE
       URI               | /rails/conductor/action_mailbox/inbound_emails/:id(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails#destroy
-      --[ Route 15 ]-------------
+      --[ Route 16 ]-------------
       Prefix            | new_rails_conductor_inbound_email_source
       Verb              | GET
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources/new(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#new
-      --[ Route 16 ]-------------
+      --[ Route 17 ]-------------
       Prefix            | rails_conductor_inbound_email_sources
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/inbound_emails/sources(.:format)
       Controller#Action | rails/conductor/action_mailbox/inbound_emails/sources#create
-      --[ Route 17 ]-------------
+      --[ Route 18 ]-------------
       Prefix            | rails_conductor_inbound_email_reroute
       Verb              | POST
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
       Controller#Action | rails/conductor/action_mailbox/reroutes#create
-      --[ Route 18 ]-------------
+      --[ Route 19 ]-------------
       Prefix            | rails_service_blob
       Verb              | GET
       URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs#show
-      --[ Route 19 ]-------------
+      --[ Route 20 ]-------------
       Prefix            | rails_blob_representation
       Verb              | GET
       URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations#show
-      --[ Route 20 ]-------------
+      --[ Route 21 ]-------------
       Prefix            | rails_disk_service
       Verb              | GET
       URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
       Controller#Action | active_storage/disk#show
-      --[ Route 21 ]-------------
+      --[ Route 22 ]-------------
       Prefix            | update_rails_disk_service
       Verb              | PUT
       URI               | /rails/active_storage/disk/:encoded_token(.:format)
       Controller#Action | active_storage/disk#update
-      --[ Route 22 ]-------------
+      --[ Route 23 ]-------------
       Prefix            | rails_direct_uploads
       Verb              | POST
       URI               | /rails/active_storage/direct_uploads(.:format)


### PR DESCRIPTION
### Summary

Mandrill's Inbound API checks to see if a URL exists before it creates the web hook. It sends a HEAD request to  "/mandrill/inbound_emails", which rails converts into a GET request. This simply returns 200, and the word 'OK'.

Now we can generate inbound API calls with ease on Mandrill, without having to shuffle around tokens.

Fixes #37609
### Other Information

CHANGELOG
Simplifies the creation of Mandrill Inbound API urls, no longer have to set a temporary "test-webhook" token.