### PR TITLE
Add tests for ModelSchema.derive_join_table_name

### DIFF
--- a/activerecord/test/cases/model_schema_test.rb
+++ b/activerecord/test/cases/model_schema_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class ActiveRecordModelSchemaTest < ActiveRecord::TestCase
+  def test_derive_join_table_name
+    first_table = "artists"
+    second_table = "records"
+
+    result = ActiveRecord::ModelSchema.derive_join_table_name(first_table, second_table)
+
+    assert_equal "artists_records", result
+  end
+
+  def test_derive_join_table_name_with_common_prefix_removed
+    first_table = "music_artists"
+    second_table = "music_records"
+
+    result = ActiveRecord::ModelSchema.derive_join_table_name(first_table, second_table)
+
+    assert_equal "music_artists_records", result
+  end
+end


### PR DESCRIPTION
### Summary

Add tests for `ActiveRecord::ModelSchema.derive_join_table_name`. https://github.com/rails/rails/blob/520d77414b7627e78fe7add981fc24f29986ccd1/activerecord/lib/active_record/model_schema.rb#L146-L148

This method is used in `ActiveRecord::Reflection` (`AssociationReflection`) and
`ActiveRecord::Migration` to figure out the join table name automatically.

### Other Information

N/A