### PR TITLE
[Guides] line-height should be unitless

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -100,7 +100,7 @@ body {
   text-align: center;
   font-family: Helvetica, Arial, sans-serif;
   font-size: 87.5%;
-  line-height: 1.5em;
+  line-height: 1.5;
   background: #fff;
   color: #999;
 }
@@ -256,7 +256,7 @@ body {
   padding: 1em 1.5em 1em 1.25em;
   width: 20em;
   font-size: 0.9285em;
-  line-height: 1.3846em;
+  line-height: 1.3846;
   margin-right: 1em;
 }
 
@@ -469,14 +469,14 @@ a, a:link, a:visited {
 
 h1 {
   font-size: 2.5em;
-  line-height: 1em;
+  line-height: 1;
   margin: 0.6em 0 .2em;
   font-weight: bold;
 }
 
 h2 {
   font-size: 2.1428em;
-  line-height: 1em;
+  line-height: 1;
   margin: 0.7em 0 .2333em;
   font-weight: bold;
 }
@@ -489,7 +489,7 @@ h2 {
 
 h3 {
   font-size: 1.7142em;
-  line-height: 1.286em;
+  line-height: 1.286;
   margin: 0.875em 0 0.2916em;
   font-weight: bold;
 }
@@ -502,21 +502,21 @@ h3 {
 
 h4 {
   font-size: 1.2857em;
-  line-height: 1.2em;
+  line-height: 1.2;
   margin: 1.6667em 0 .3887em;
   font-weight: bold;
 }
 
 h5 {
   font-size: 1em;
-  line-height: 1.5em;
+  line-height: 1.5;
   margin: 1em 0 .5em;
   font-weight: bold;
 }
 
 h6 {
   font-size: 1em;
-  line-height: 1.5em;
+  line-height: 1.5;
   margin: 1em 0 .5em;
   font-weight: normal;
 }
@@ -692,7 +692,7 @@ div.code_container {
 
 #subCol .content {
   font-size: 0.7857em;
-  line-height: 1.5em;
+  line-height: 1.5;
 }
 
 #subCol .content li {

--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -100,7 +100,7 @@ body {
   text-align: center;
   font-family: Helvetica, Arial, sans-serif;
   font-size: 87.5%;
-  line-height: 1.5em;
+  line-height: 1.5;
   background: #fff;
   color: #999;
   direction: rtl;
@@ -257,7 +257,7 @@ body {
   padding: 1em 1.5em 1em 1.25em;
   width: 20em;
   font-size: 0.9285em;
-  line-height: 1.3846em;
+  line-height: 1.3846;
   margin-left: 1em;
 }
 
@@ -470,14 +470,14 @@ a, a:link, a:visited {
 
 h1 {
   font-size: 2.5em;
-  line-height: 1em;
+  line-height: 1;
   margin: 0.6em 0 .2em;
   font-weight: bold;
 }
 
 h2 {
   font-size: 2.1428em;
-  line-height: 1em;
+  line-height: 1;
   margin: 0.7em 0 .2333em;
   font-weight: bold;
 }
@@ -490,7 +490,7 @@ h2 {
 
 h3 {
   font-size: 1.7142em;
-  line-height: 1.286em;
+  line-height: 1.286;
   margin: 0.875em 0 0.2916em;
   font-weight: bold;
 }
@@ -503,21 +503,21 @@ h3 {
 
 h4 {
   font-size: 1.2857em;
-  line-height: 1.2em;
+  line-height: 1.2;
   margin: 1.6667em 0 .3887em;
   font-weight: bold;
 }
 
 h5 {
   font-size: 1em;
-  line-height: 1.5em;
+  line-height: 1.5;
   margin: 1em 0 .5em;
   font-weight: bold;
 }
 
 h6 {
   font-size: 1em;
-  line-height: 1.5em;
+  line-height: 1.5;
   margin: 1em 0 .5em;
   font-weight: normal;
 }
@@ -693,7 +693,7 @@ div.code_container {
 
 #subCol .content {
   font-size: 0.7857em;
-  line-height: 1.5em;
+  line-height: 1.5;
 }
 
 #subCol .content li {


### PR DESCRIPTION
### Summary

When line-height has unit, it will have unexpected results. Based on recommendations by MDN[1] and CSSTricks[2].

I went through local generated files and they look unchanged / slightly better in some cases after this change.

There is another occurrence of line-height that sets with unit. I removed that file in #38796.

### Other Information

[1] MDN https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#Prefer_unitless_numbers_for_line-height_values
[2] CSS Tricks https://css-tricks.com/almanac/properties/l/line-height/#article-header-id-0