### PR TITLE
Only compute :only and :except callback conditions once …

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -69,7 +69,7 @@ module AbstractController
       end
 
       def _normalize_callback_option(options, from, to) # :nodoc:
-        if from = options[from]
+        if from = options.delete(from)
           _from = Array(from).map(&:to_s).to_set
           from = proc { |c| _from.include? c.action_name }
           options[to] = Array(options[to]).unshift(from)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/38323
Fix: https://github.com/rails/rails/issues/38679

Only compute :only and :except callback conditions once
    
 `_normalize_callback_options` mutates the options hash, but doesn't remove the `:only` and `:except` conditions.
    
 So if you call `before_action` & al with the same option hash you end up with multiple instance of identical `:if` / `:unless` procs.

Since `_normalize_callback_options` already mutates the `options` hash, I decided to continue down that route and mutate it further by deleting the `:only` and `:except` conditions.

An alternative fix would be to dup the `options` hash before mutating it. Given that this hash comes from a DSL, I think mutating it is fine, but I'm open to implementing the alternative fix. 

Props to @khustochka and @natematykiewicz for reporting and investigating the original issue, as well as providing failing test cases.

cc @rafaelfranca @Edouard-chin @etiennebarrie 
