### PR TITLE
[DatabaseSelector] Use monotonic time for duration calculations

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -83,7 +83,9 @@ module ActiveRecord
           end
 
           def time_since_last_write_ok?
-            Time.now - context.last_write_timestamp >= send_to_replica_delay
+            return true unless context.last_write_timestamp
+
+            Concurrent.monotonic_time - context.last_write_timestamp >= send_to_replica_delay
           end
       end
     end

--- a/activerecord/lib/active_record/middleware/database_selector/resolver/session.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver/session.rb
@@ -14,17 +14,6 @@ module ActiveRecord
             new(request.session)
           end
 
-          # Converts time to a timestamp that represents milliseconds since
-          # epoch.
-          def self.convert_time_to_timestamp(time)
-            time.to_i * 1000 + time.usec / 1000
-          end
-
-          # Converts milliseconds since epoch timestamp into a time object.
-          def self.convert_timestamp_to_time(timestamp)
-            timestamp ? Time.at(timestamp / 1000, (timestamp % 1000) * 1000) : Time.at(0)
-          end
-
           def initialize(session)
             @session = session
           end
@@ -32,11 +21,11 @@ module ActiveRecord
           attr_reader :session
 
           def last_write_timestamp
-            self.class.convert_timestamp_to_time(session[:last_write])
+            session[:last_write]
           end
 
           def update_last_write_timestamp
-            session[:last_write] = self.class.convert_time_to_timestamp(Time.now)
+            session[:last_write] = Concurrent.monotonic_time
           end
 
           def save(response)

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -16,7 +16,7 @@ module ActiveRecord
     end
 
     def test_empty_session
-      assert_equal Time.at(0), @session.last_write_timestamp
+      assert_nil @session.last_write_timestamp
     end
 
     def test_writing_the_session_timestamps
@@ -37,7 +37,7 @@ module ActiveRecord
     end
 
     def test_read_from_replicas
-      @session_store[:last_write] = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session.convert_time_to_timestamp(Time.now - 5.seconds)
+      @session_store[:last_write] = Concurrent.monotonic_time - 5.seconds
 
       resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver.new(@session)
 
@@ -51,7 +51,7 @@ module ActiveRecord
 
     unless in_memory_db?
       def test_can_write_while_reading_from_replicas_if_explicit
-        @session_store[:last_write] = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session.convert_time_to_timestamp(Time.now - 5.seconds)
+        @session_store[:last_write] = Concurrent.monotonic_time - 5.seconds
 
         resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver.new(@session)
 
@@ -77,7 +77,7 @@ module ActiveRecord
     end
 
     def test_read_from_primary
-      @session_store[:last_write] = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session.convert_time_to_timestamp(Time.now)
+      @session_store[:last_write] = Concurrent.monotonic_time
 
       resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver.new(@session)
 


### PR DESCRIPTION
### Summary

Move the use of `Time.now` to monotonic time to calculate duration.
Monotonic time is preferable because in some cases `Time.now` can be unstable[1].
It could be set manually by a system administrator or an NTP daemon program.

Since we are already using ConcurrentRuby library, use the [monotonic time from ConcurrentRuby].

The session‘s last_write_timestamp defaults to nil. We can use this
nil to know that we can write (because first time the value is not being set).
After first write, we use monotonic time minus last write to see if it‘s
bigger than the set send_to_replica_delay.

### Other Information

https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/

[monotonic time from ConcurrentRuby]: https://github.com/ruby-concurrency/concurrent-ruby/blob/aa9295ec46a97af67624a007b126971fd60b4d92/lib/concurrent-ruby/concurrent/utility/monotonic_time.rb