### PR TITLE
Add explicit_columns_select ActiveRecord configuration option

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -135,6 +135,14 @@ module ActiveRecord
 
       class_attribute :default_pool_key, instance_writer: false
 
+      ##
+      # :singleton-method:
+      # Specifies whether select clause builder should use explicit column names instead of the star.
+      # This reduces the risk of PreparedStatementCacheExpired exception being raised from
+      # transactions happening during migration adding column(s) with PostgreSQL.
+      # Can be overriden in individual models.
+      class_attribute :explicit_columns_select, default: false, instance_accessor: false
+
       self.filter_attributes = []
 
       def self.connection_handler

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1232,7 +1232,7 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq))
-        elsif klass.ignored_columns.any?
+        elsif klass.ignored_columns.any? || klass.explicit_columns_select
           arel.project(*klass.column_names.map { |field| arel_attribute(field) })
         else
           arel.project(table[Arel.star])

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1509,9 +1509,13 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "explicit_columns_select flag modifies default behavior of select" do
+    tn = Bird.quoted_table_name
+    id, name, color, pirate_id =
+      *%w[id name color pirate_id].map { |column| Bird.connection.quote_column_name(column) }
+
     explicit_select_query =
-      %{select "birds"."id", "birds"."name", "birds"."color", "birds"."pirate_id" from "birds"}
-    star_query = %{select "birds".* from "birds"}
+      %{select #{tn}.#{id}, #{tn}.#{name}, #{tn}.#{color}, #{tn}.#{pirate_id} from #{tn}}
+    star_query = %{select #{tn}.* from #{tn}}
 
     ActiveRecord::Base.explicit_columns_select = true
     assert_equal explicit_select_query, Bird.all.to_sql.downcase
@@ -1524,7 +1528,8 @@ class BasicsTest < ActiveRecord::TestCase
 
     Bird.explicit_columns_select = true
     assert_equal explicit_select_query, Bird.all.to_sql.downcase
-
+  ensure
+    ActiveRecord::Base.explicit_columns_select = false
     Bird.explicit_columns_select = false
   end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1508,6 +1508,26 @@ class BasicsTest < ActiveRecord::TestCase
     assert query.include?("name")
   end
 
+  test "explicit_columns_select flag modifies default behavior of select" do
+    explicit_select_query =
+      %{select "birds"."id", "birds"."name", "birds"."color", "birds"."pirate_id" from "birds"}
+    star_query = %{select "birds".* from "birds"}
+
+    ActiveRecord::Base.explicit_columns_select = true
+    assert_equal explicit_select_query, Bird.all.to_sql.downcase
+
+    Bird.explicit_columns_select = false
+    assert_equal star_query, Bird.all.to_sql.downcase
+
+    ActiveRecord::Base.explicit_columns_select = false
+    assert_equal star_query, Bird.all.to_sql.downcase
+
+    Bird.explicit_columns_select = true
+    assert_equal explicit_select_query, Bird.all.to_sql.downcase
+
+    Bird.explicit_columns_select = false
+  end
+
   test "column names are quoted when using #from clause and model has ignored columns" do
     assert_not_empty Developer.ignored_columns
     query = Developer.from("developers").to_sql


### PR DESCRIPTION
### Summary

Column-adding migrations have the potential to fail transactions that are happening alongside, when queries are cached as prepared statements in PostgreSQL.
This is caused by result type of prepared statement being changed mid-transaction, PostgreSQL signals error which gets wrapped in the `ActiveRecord::PreparedStatementCacheExpired` exception.

This PR introduces a new (disabled by default) setting for ActiveRecord `explicit_columns_select`, it can be used both globally and on the individual models' level. 

When enabled, AR queries use explicit colum names in selects and not `*`. 
Such queries remain unaffected by migrations adding new columns.

If this solution is acceptable and makes sense to be included in Rails, I'll add the changelog entry.

### Other Information

#### Non-function considerations:
- Performance of both types of queries is understood to be the same
- Listing all column names in the select clause adds noticeable overhead to pathological cases of models with large number of columns

#### Currently existing workarounds:
- Disabling prepared statements altogether - this has a significant negative impact on the database load
- Setting `self.ignored_columns = %w[nonexistent_column]` - triggers the same code path as this patch, but as every hack, requires comment in each place it's applied, also needs to be set individually on each affected model


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
