### PR TITLE
Implement AAD authentication for Azure Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,8 @@ end
 group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.11", require: false
-  gem "azure-storage-blob", require: false
+  gem "adal", require: false
+  gem "azure-storage-blob", "~> 2.0", require: false
 
   gem "image_processing", "~> 1.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,10 @@ GEM
     activerecord-jdbcsqlite3-adapter (60.1-java)
       activerecord-jdbc-adapter (= 60.1)
       jdbc-sqlite3 (~> 3.8, < 3.30)
+    adal (1.0.0)
+      jwt (~> 1.5)
+      nokogiri (~> 1.6)
+      uri_template (~> 0.7)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     amq-protocol (2.3.0)
@@ -290,7 +294,7 @@ GEM
     jmespath (1.4.0)
     json (2.3.0)
     json (2.3.0-java)
-    jwt (2.2.1)
+    jwt (1.5.6)
     kindlerb (1.2.0)
       mustache
       nokogiri
@@ -503,6 +507,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
+    uri_template (0.7.0)
     useragent (0.16.10)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -543,9 +548,10 @@ DEPENDENCIES
   activerecord-jdbcmysql-adapter (>= 1.3.0)
   activerecord-jdbcpostgresql-adapter (>= 1.3.0)
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)
+  adal
   aws-sdk-s3
   aws-sdk-sns
-  azure-storage-blob
+  azure-storage-blob (~> 2.0)
   backburner
   bcrypt (~> 3.1.11)
   benchmark-ips

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   The Azure service now permits authenticating through Azure Active Directory.
+
+    To enable Azure Active Directory authentication, configure the tenant ID,
+    client ID and client secret of the Azure Active Directory principal that
+    should be used for authentication:
+
+    ```yaml
+    azure:
+      service: AzureStorage
+      storage_account_name: mystorageaccount
+      container: mycontainer
+      tenant_id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+      client_id: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+      client_secret: <%= Rails.application.credentials.dig(:azure, :client_secret) %>
+    ```
+
+    Note that the Azure Active Directory principal used for authentication must
+    be granted at least the roles "Storage Blob Delegator" on the storage
+    account as well as "Storage Blob Data Contributor" on the container.
+    The former role is required for generating shared access signatures for
+    direct uploads and asset URLs and the latter role is required for
+    read/write/delete/list permissions on the contents of the container.
+
+    *Clemens Wolff*
+
 *   Files can now be served by proxying them from the underlying storage service
     instead of redirecting to a signed service URL. Use the
     `rails_storage_proxy_path` and `_url` helpers to proxy an attached file:

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -1,20 +1,75 @@
 # frozen_string_literal: true
 
-gem "azure-storage-blob", ">= 1.1"
+gem "azure-storage-blob", "~> 2.0"
 
 require "active_support/core_ext/numeric/bytes"
 require "azure/storage/blob"
+require "azure/storage/blob/default"
 require "azure/storage/common/core/auth/shared_access_signature"
 
 module ActiveStorage
   # Wraps the Microsoft Azure Storage Blob Service as an Active Storage service.
   # See ActiveStorage::Service for the generic API documentation that applies to all services.
   class Service::AzureStorageService < Service
-    attr_reader :client, :container, :signer
+    # Client that authenticates to Azure Storage via Azure Active Directory
+    # See https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad
+    class AzureActiveDirectoryClient
+      attr_reader :storage_account_name, :options, :auth_context, :client_credential
+      attr_accessor :user_delegation_key
 
-    def initialize(storage_account_name:, storage_access_key:, container:, public: false, **options)
-      @client = Azure::Storage::Blob::BlobService.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **options)
-      @signer = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
+      def initialize(storage_account_name, **options)
+        require "adal"
+        gem "adal", "~> 1.0"
+
+        tenant_id = options.delete(:tenant_id) || ""
+        client_id = options.delete(:client_id) || ""
+        client_secret = options.delete(:client_secret) || ""
+
+        if tenant_id.empty? || client_id.empty? || client_secret.empty?
+          raise ArgumentError, "all of tenant_id, client_id, and client_secret must be provided"
+        end
+
+        @storage_account_name = storage_account_name
+        @options = options
+        @auth_context = ADAL::AuthenticationContext.new("login.microsoftonline.com", tenant_id)
+        @client_credential = ADAL::ClientCredential.new(client_id, client_secret)
+        @user_delegation_key = nil
+      end
+
+      def blob_service
+        token = @auth_context.acquire_token_for_client("https://storage.azure.com/", @client_credential)
+        token_credential = Azure::Storage::Common::Core::TokenCredential.new token.access_token
+        token_signer = Azure::Storage::Common::Core::Auth::TokenSigner.new token_credential
+        client = Azure::Storage::Common::Client.create(storage_account_name: @storage_account_name, signer: token_signer)
+        Azure::Storage::Blob::BlobService.new(client: client, api_version: "2018-11-09", **@options)
+      end
+
+      def shared_access_signature
+        if @user_delegation_key.nil? || @user_delegation_key.signed_expiry.to_datetime <= DateTime.now
+          now = Time.now
+          @user_delegation_key = blob_service.get_user_delegation_key(now - 5.minutes, now + 6.days)
+        end
+        Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(@storage_account_name, "", @user_delegation_key)
+      end
+    end
+
+    # Client that authenticates to Azure Storage via account access keys
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+    class AccessKeyClient
+      attr_reader :blob_service, :shared_access_signature
+
+      def initialize(storage_account_name, storage_access_key, **options)
+        @blob_service = Azure::Storage::Blob::BlobService.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **options)
+        @shared_access_signature = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
+      end
+    end
+
+    attr_reader :clients, :container
+
+    def initialize(storage_account_name:, storage_access_key: nil, container:, public: false, **options)
+      @clients = storage_access_key.nil? || storage_access_key.empty? \
+        ? AzureActiveDirectoryClient.new(storage_account_name, **options) \
+        : AccessKeyClient.new(storage_account_name, storage_access_key, **options)
       @container = container
       @public = public
     end
@@ -105,6 +160,14 @@ module ActiveStorage
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
       { "Content-Type" => content_type, "Content-MD5" => checksum, "x-ms-blob-content-disposition" => content_disposition, "x-ms-blob-type" => "BlockBlob" }
+    end
+
+    def client
+      @clients.blob_service
+    end
+
+    def signer
+      @clients.shared_access_signature
     end
 
     private

--- a/activestorage/lib/active_storage/service/azure_storage_service/access_key_client.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service/access_key_client.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+gem "azure-storage-blob", "~> 2.0"
+
+require "azure/storage/blob"
+require "azure/storage/blob/default"
+require "azure/storage/common/core/auth/shared_access_signature"
+
+module ActiveStorage
+  # Client that authenticates to Azure Storage via account access keys
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+  class Service::AzureStorageService::AccessKeyClient
+    attr_reader :blob_service, :shared_access_signature
+
+    def initialize(storage_account_name, storage_access_key, **options)
+      @blob_service = Azure::Storage::Blob::BlobService.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **options)
+      @shared_access_signature = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
+    end
+  end
+end

--- a/activestorage/lib/active_storage/service/azure_storage_service/active_directory_client.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service/active_directory_client.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+gem "adal", "~> 1.0"
+gem "azure-storage-blob", "~> 2.0"
+
+require "adal"
+require "azure/storage/blob"
+require "azure/storage/blob/default"
+require "azure/storage/common/core/auth/shared_access_signature"
+
+module ActiveStorage
+  # Client that authenticates to Azure Storage via Azure Active Directory
+  # See https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad
+  class Service::AzureStorageService::ActiveDirectoryClient
+    attr_reader :storage_account_name, :options, :auth_context, :client_credential
+    attr_accessor :user_delegation_key
+
+    def initialize(storage_account_name, **options)
+      tenant_id = options.delete(:tenant_id) || ""
+      client_id = options.delete(:client_id) || ""
+      client_secret = options.delete(:client_secret) || ""
+
+      if tenant_id.empty? || client_id.empty? || client_secret.empty?
+        raise ArgumentError, "all of tenant_id, client_id, and client_secret must be provided"
+      end
+
+      @storage_account_name = storage_account_name
+      @options = options
+      @auth_context = ADAL::AuthenticationContext.new("login.microsoftonline.com", tenant_id)
+      @client_credential = ADAL::ClientCredential.new(client_id, client_secret)
+      @user_delegation_key = nil
+    end
+
+    def blob_service
+      token = @auth_context.acquire_token_for_client("https://storage.azure.com/", @client_credential)
+      token_credential = Azure::Storage::Common::Core::TokenCredential.new token.access_token
+      token_signer = Azure::Storage::Common::Core::Auth::TokenSigner.new token_credential
+      client = Azure::Storage::Common::Client.create(storage_account_name: @storage_account_name, signer: token_signer)
+      Azure::Storage::Blob::BlobService.new(client: client, api_version: "2018-11-09", **@options)
+    end
+
+    def shared_access_signature
+      if @user_delegation_key.nil? || @user_delegation_key.signed_expiry.to_datetime <= DateTime.now
+        now = Time.now
+        @user_delegation_key = blob_service.get_user_delegation_key(now - 5.minutes, now + 6.days)
+      end
+      Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(@storage_account_name, "", @user_delegation_key)
+    end
+  end
+end

--- a/activestorage/test/service/azure_storage_aad_service_test.rb
+++ b/activestorage/test/service/azure_storage_aad_service_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "service/shared_service_tests"
+require "uri"
+
+if SERVICE_CONFIGURATIONS[:azure_aad]
+  class ActiveStorage::Service::AzureStorageAADServiceTest < ActiveSupport::TestCase
+    SERVICE = ActiveStorage::Service.configure(:azure_aad, SERVICE_CONFIGURATIONS)
+
+    include ActiveStorage::Service::SharedServiceTests
+
+    test "signed URL generation" do
+      url = @service.url(@key, expires_in: 5.minutes,
+                         disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+
+      assert_match(/(\S+)&rscd=inline%3B\+filename%3D%22avatar\.png%22%3B\+filename\*%3DUTF-8%27%27avatar\.png&rsct=image%2Fpng/, url)
+      assert_match SERVICE_CONFIGURATIONS[:azure_aad][:container], url
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "200", response.code
+    end
+  end
+else
+  puts "Skipping Azure Storage AAD Service tests because no Azure configuration was supplied"
+end

--- a/activestorage/test/service/configurations.example.yml
+++ b/activestorage/test/service/configurations.example.yml
@@ -27,3 +27,11 @@
 #   storage_account_name: ""
 #   storage_access_key: ""
 #   container: ""
+#
+# azure_aad:
+#   service: AzureStorage
+#   storage_account_name: ""
+#   container: ""
+#   tenant_id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+#   client_id: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+#   client_secret: cccccccc-cccc-cccc-cccc-cccccccccccc

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -180,6 +180,25 @@ Add the [`azure-storage-blob`](https://github.com/Azure/azure-storage-ruby) gem 
 gem "azure-storage-blob", require: false
 ```
 
+To leverage [Azure Active Directory authentication for Azure Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad)
+instead of access key authentication, add the [`adal`](https://github.com/AzureAD/azure-activedirectory-library-for-ruby) gem to your `Gemfile`:
+
+```ruby
+gem "adal", require: false
+```
+
+Now declare the Azure Storage service in `config/storage.yml`:
+
+```yaml
+azure:
+  service: AzureStorage
+  storage_account_name: ""
+  tenant_id: ""
+  client_id: ""
+  client_secret: ""
+  container: ""
+```
+
 ### Google Cloud Storage Service
 
 Declare a Google Cloud Storage service in `config/storage.yml`:


### PR DESCRIPTION
### Summary

Currently, the Azure implementation of ActiveStorage supports [shared key authentication](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key). This commit extends the functionality to also support authentication via [Azure Active Directory (AAD)](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-azure-active-directory).

### Other Information

Authenticating to Azure Storage via AAD enables using role-based access control (RBAC) to manage access to the storage resources. This enables multi-tenancy use-cases, such as for example having
multiple Rails applications use different containers in the same Azure Storage account while ensuring that each application can only access data in its own container.

To enable AAD RBAC authentication, configure the tenant ID, client ID and client secret of the AAD principal that should be used for authentication:

```yaml
azure:
  service: AzureStorage
  storage_account_name: mystorageaccount
  container: mycontainer
  tenant_id: aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
  client_id: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
  client_secret: <%= Rails.application.credentials.dig(:azure, :client_secret) %>
```

Note that the AAD principal used for authentication must be granted at least the roles "Storage Blob Delegator" on the storage account as well as "Storage Blob Data Contributor" on the container. The former role is required for generating shared access signatures for direct uploads and asset URLs and the latter role is required for read/write/delete/list permissions on the contents of the container.

Also note that the AAD authentication flow relies on [user delegation keys](https://docs.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key) which were introduced in Azure Storage API version 2018-11-09. This means that as of update 1811 the functionality will not yet work when targeting Azure Stack Hub Storage.

For testing purposes, all the required resources and permissions to exercise the AAD authentication flow can be set up with the following script (assuming the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [JQ](https://stedolan.github.io/jq/download/) are installed):

```bash
service_principal_name="rails-azure-aad-integration-tests"  # CHANGE ME
location="eastus"  # CHANGE ME
subscription="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"  # CHANGE ME
storage_account_name="railsazureaad"  # CHANGE ME
container_name="integrationtests"  # CHANGE ME

az login
az account set -s "${subscription}"
az group create -l "${location}" -n "${resource_group_name}"
az storage account create -l "${location}" -g "${resource_group_name}" -n "${storage_account_name}" --kind StorageV2
az storage container create -n "${container_name}" --connection-string "$(az storage account show-connection-string -n "${storage_account_name}")"

sp="$(az ad sp create-for-rbac --name "${service_principal_name}" --skip-assignment)"
sp_tenant="$(jq -r '.tenant' <<< "${sp}")"
sp_client="$(jq -r '.appId' <<< "${sp}")"
sp_secret="$(jq -r '.password' <<< "${sp}")"

while ! az role assignment create --role "Storage Blob Data Contributor" --assignee "${sp_client}" --scope "/subscriptions/${subscription}/resourceGroups/${resource_group_name}/providers/Microsoft.Storage/storageAccounts/${storage_account_name}/blobServices/default/containers/${container_name}"; do sleep 2s; done

while ! az role assignment create --role "Storage Blob Delegator" --assignee "${sp_client}" --scope "/subscriptions/${subscription}/resourceGroups/${resource_group_name}/providers/Microsoft.Storage/storageAccounts/${storage_account_name}"; do sleep 2s; done

cat >> activestorage/test/service/configurations.yml << EOF
azure_aad:
  service: AzureStorage
  storage_account_name: "${storage_account_name}"
  tenant_id: "${sp_tenant}"
  client_id: "${sp_client}"
  client_secret: "${sp_secret}"
  container: "${container_name}"
EOF
```

Validated by @michaelperel
CC @jrodbeta