### PR TITLE
Replacing plus with push in array

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -7,9 +7,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:counter_cache, :join_table, :index_errors]
-      valid += [:as, :foreign_type] if options[:as]
-      valid += [:through, :source, :source_type] if options[:through]
+      valid = super
+      valid.push(:counter_cache, :join_table, :index_errors)
+      valid.push(:as, :foreign_type) if options[:as]
+      valid.push(:through, :source, :source_type) if options[:through]
       valid
     end
 

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -7,8 +7,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super
-      valid.push(:counter_cache, :join_table, :index_errors)
+      valid = super + [:counter_cache, :join_table, :index_errors]
       valid.push(:as, :foreign_type) if options[:as]
       valid.push(:through, :source, :source_type) if options[:through]
       valid


### PR DESCRIPTION
### Summary
Every time an object is getting added using "+" and is being assigned to itself. The new object id is created. Instead, we should use a "push" in which a new object id is not created.
Sample code to explain this:
:001 > valid = [:counter_cache, :join_table, :index_errors]
 => [:counter_cache, :join_table, :index_errors]
002 > valid.object_id
 => 70353367984560
003 > valid += [:as, :foreign_type]
 => [:counter_cache, :join_table, :index_errors, :as, :foreign_type]
004 > valid.object_id
 => 70353359749500
005 > valid.push(:through, :source, :source_type)
 => [:counter_cache, :join_table, :index_errors, :as, :foreign_type, :through, :source, :source_type]
006 > valid.object_id
 => 70353359749500
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
