### PR TITLE
Restore the `lookup_store` compatibility to accept config as a single object

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -59,6 +59,8 @@ module ActiveSupport
         when Symbol
           options = parameters.extract_options!
           retrieve_store_class(store).new(*parameters, **options)
+        when Array
+          lookup_store(*store)
         when nil
           ActiveSupport::Cache::MemoryStore.new
         else

--- a/activesupport/test/cache/cache_store_setting_test.rb
+++ b/activesupport/test/cache/cache_store_setting_test.rb
@@ -66,6 +66,14 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
     assert_equal "/path/to/cache/directory", store.cache_path
   end
 
+  def test_redis_cache_store_with_single_array_object
+    cache_store = [:redis_cache_store, namespace: "foo"]
+
+    store = ActiveSupport::Cache.lookup_store(cache_store)
+    assert_kind_of ActiveSupport::Cache::RedisCacheStore, store
+    assert_equal "foo", store.options[:namespace]
+  end
+
   def test_redis_cache_store_with_ordered_options
     options = ActiveSupport::OrderedOptions.new
     options.update namespace: "foo"


### PR DESCRIPTION
fa986ae broke the `lookup_store` compatibility. It's public API so
deprecation cycle is required if we want to make a breaking change.

cc @jeremy 