### PR TITLE
Fix aliases for stylesheet_engine option in Generators:

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -39,7 +39,7 @@ module Rails
         resource_controller: "-c",
         scaffold_controller: "-c",
         stylesheets: "-y",
-        stylesheet_engine: "-se",
+        stylesheet_engine: "--se",
         scaffold_stylesheet: "-ss",
         template_engine: "-e",
         test_framework: "-t"

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -425,6 +425,18 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/assets/stylesheets/posts.css"
   end
 
+  def test_scaffold_generator_alias_css_stylesheets_engine
+    run_generator [ "posts", "--se=css" ]
+    assert_file "app/assets/stylesheets/posts.css"
+    assert_no_file "app/assets/stylesheets/posts.scss"
+  end
+
+  def test_scaffold_generator_alias_nocss_stylesheets_engine
+    output = run_generator [ "posts", "--se=NOCSS" ]
+    assert_no_file "app/assets/stylesheets/posts.css"
+    assert_match(/NOCSS \[not found\]/, output)
+  end
+
   def test_scaffold_generator_outputs_error_message_on_missing_attribute_type
     run_generator ["post", "title", "body:text", "author"]
 


### PR DESCRIPTION
If using one-dash the alias for stylesheet_engine wont work.

This patch change the `se` alias to two dash makes work for this option alias.