### PR TITLE
Handle paths with trailing slashes in rails test

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow relative paths with trailing slashes to be passed to `rails test`.
+
+    *Eugene Kenny*
+
 *   Add `rack-mini-profiler` gem to the default `Gemfile`.
 
     `rack-mini-profiler` displays performance information such as SQL time and flame graphs.

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -61,7 +61,7 @@ module Rails
         private
           def extract_filters(argv)
             # Extract absolute and relative paths but skip -n /.*/ regexp filters.
-            argv.select { |arg| %r%^/?\w+/%.match?(arg) && !arg.end_with?("/") }.map do |path|
+            argv.select { |arg| path_argument?(arg) && !regexp_filter?(arg) }.map do |path|
               case
               when /(:\d+)+$/.match?(path)
                 file, *lines = path.split(":")
@@ -74,6 +74,14 @@ module Rails
                 path
               end
             end
+          end
+
+          def regexp_filter?(arg)
+            arg.start_with?("/") && arg.end_with?("/")
+          end
+
+          def path_argument?(arg)
+            %r%^/?\w+/%.match?(arg)
           end
       end
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -310,6 +310,16 @@ module ApplicationTests
       end
     end
 
+    def test_run_relative_path_with_trailing_slash
+      create_test_file :models, "account"
+      create_test_file :controllers, "accounts_controller"
+
+      run_test_command("test/models/").tap do |output|
+        assert_match "AccountTest", output
+        assert_match "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
     def test_run_with_ruby_command
       app_file "test/models/post_test.rb", <<-RUBY
         require 'test_helper'


### PR DESCRIPTION
Followup to https://github.com/rails/rails/commit/07d84b7c8db5b85f7521cfc5d2028ed973d9a14b.

The `rails test` command scans its arguments for test paths to load before handing off option parsing to Minitest. To avoid incorrectly interpreting a `-n /regex/` pattern as an absolute path to a directory, it skips arguments that end with a slash. However a relative path ending in a slash is not ambiguous, so we can safely treat those as test paths.

This is especially useful in bash, where tab completing a directory leaves a trailing slash in place.