### PR TITLE
Skip calling concat() when exception.annotated_source_code returns ni…

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -143,7 +143,7 @@ module ActionDispatch
           message = []
           message << "  "
           message << "#{exception.class} (#{exception.message}):"
-          message.concat(exception.annotated_source_code) if exception.respond_to?(:annotated_source_code)
+          message.concat(exception.annotated_source_code) if exception.respond_to?(:annotated_source_code) && !exception.annotated_source_code.nil?
           message << "  "
           message.concat(trace)
 


### PR DESCRIPTION
### Summary
This fix is to address an identical problem described in #36719.

I can confirm the more general issue of some exceptions not being logged in the console on development still exists. I've had a couple of issues crop up in the past weeks around `sassc` compilation errors and today with an `ActionView::Template::Error (Multiple files with the same output path cannot be linked)` error, with the exceptions never being displayed in the console, leaving me completely stumped as to why my Rails app was returning HTTP 500 / error pages.

In my situation, I was able to step down to https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L146 and determine that `concat()` is throwing a new exception, causing the logging to be completely silenced when `exception.annotated_source_code` returns `nil`.

I've self-tested this fix and it now logs the exceptions as one would expect. Hopefully this saves people a lot of time that I've spent tracking down silent errors.

### Other Information

I was able to trigger this silent exception issue when a `ActionView::Template::Error (Multiple files with the same output path cannot be linked...)` exception was thrown. The easiest way I know to do this is make a **copy** of an existing coffeescript file with another preprocessor extension such as having both files exist: `/app/assets/javascripts/file.coffee` and `/app/assets/javascripts/file.coffee.erb` then try loading a page in your browser.
