### PR TITLE
Fix keyword arguments warnings in ActiveSupport::Cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -707,7 +707,7 @@ module ActiveSupport
           entry
         end
 
-        def get_entry_value(entry, name, options)
+        def get_entry_value(entry, name, **options)
           instrument(:fetch_hit, name, options) { }
           entry.value
         end


### PR DESCRIPTION
### Summary

Ruby 2.7 displays warning without separation of positional and keyword arguments. This PR intend to fix it for the method `get_entry_value`.

```
activesupport/lib/active_support/cache.rb:330: warning: Passing the keyword argument as the last hash parameter is deprecated
activesupport/lib/active_support/cache.rb:710: warning: The called method `get_entry_value`
```

