### PR TITLE
Deprecate use of non-existent enum in query for Mysql2

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate use of non-existent enum in query.
+
+    *Atul Kanswal*
+
 *   Build predicate conditions with objects that delegate `#id` and primary key:
 
     ```ruby

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -144,6 +144,12 @@ module ActiveRecord
       end
 
       def serialize(value)
+        unless serializable?(value)
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            '#{value}' is not a valid #{name}. Passing a non-existent enum
+            value in a query is deprecated and will raise an error in Rails 6.2.
+          MSG
+        end
         mapping.fetch(value, value)
       end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -69,6 +69,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
     assert_equal books(:ddd), Book.where(last_read: :forgotten).first
+    assert_deprecated { Book.where(status: :not_defined).first } if ActiveRecord::Base.connection.adapter_name == "Mysql2"
   end
 
   test "find via where with strings" do
@@ -79,6 +80,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where.not(status: "published").first
     assert_equal @book, Book.where.not(status: "written").first
     assert_equal books(:ddd), Book.where(last_read: "forgotten").first
+    assert_deprecated { Book.where(status: "not_defined").first } if ActiveRecord::Base.connection.adapter_name == "Mysql2"
   end
 
   test "build from scope" do


### PR DESCRIPTION
### Summary
In Mysql2 non-existent enum in query gives invalid result

Suddenly raising error for using non-existent enum in query could cause a bad user experience. We need to deprecate this behaviour first. 
Only for Mysql2
### Other Information
Deprecating use of non-existent enum , will raise Argument Error in next Rails versions
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
