### PR TITLE
Simplify GitHub Action RuboCop by using globally installed gems

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,20 +12,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Install required package
+    - name: Install RuboCop gems
       run: |
-        sudo apt-get update
-        sudo apt-get -y install libmysqlclient-dev libpq-dev libsqlite3-dev libncurses5-dev
-    - name: Cache gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        gem install --no-document rubocop rubocop-performance rubocop-rails
     - name: Run RuboCop
-      run: bundle exec rubocop --parallel
+      run: rubocop --parallel


### PR DESCRIPTION
### Summary

Install and run `rubocop` as a global gem to speed up and simplify the linting workflow.

### Other Information

| Attempt | Time |
| --- | --- |
| Before |  1min 54s |
| With this PR | 1min 19s |
