### PR TITLE
Add rubocop group to Gemfile for use in CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,8 +12,17 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Install RuboCop gems
+    - name: Cache gems
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-rubocop-
+    - name: Install gems
       run: |
-        gem install --no-document rubocop rubocop-performance rubocop-rails
+        bundle config path vendor/bundle
+        bundle config set without 'default doc job cable storage ujs test db'
+        bundle install --jobs 4 --retry 3
     - name: Run RuboCop
-      run: rubocop --parallel
+      run: bundle exec rubocop --parallel

--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,11 @@ gem "uglifier", ">= 1.3.0", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
-gem "rubocop", ">= 0.47", require: false
-gem "rubocop-performance", require: false
-gem "rubocop-rails", require: false
+group :rubocop do
+  gem "rubocop", ">= 0.47", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+end
 
 group :doc do
   gem "sdoc", "~> 1.1"


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/38834 we install the latest version of RuboCop in our GitHub Actions workflow for speed, but this sacrifices reproducibility; the results will change whenever RuboCop publishes a new version. Instead we can add a new group to our Gemfile that just contains the dependencies necessary to run RuboCop, and skip installing everything else in CI.

Unfortunately it's not possible to tell Bundler to only install gems from a single group, so we have to tell it not to install every other group instead.