### PR TITLE
Align `Range#cover?` extension behavior with plain Ruby behavior for "backwards" ranges

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Align `Range#cover?` extension behavior with Ruby behavior for backwards ranges.
+
+    `(1..10).cover?(5..3)` now returns `false`, as it does in plain Ruby.
+    
+    Also update `#include?` and `#===` behavior to match.
+
+    *Michael Groeneman*  
+
 *   Update to TZInfo v2.0.0.
 
     This changes the output of `ActiveSupport::TimeZone.utc_to_local`, but

--- a/activesupport/lib/active_support/core_ext/range/compare_range.rb
+++ b/activesupport/lib/active_support/core_ext/range/compare_range.rb
@@ -15,6 +15,8 @@ module ActiveSupport
     # The given range must be fully bounded, with both start and end.
     def ===(value)
       if value.is_a?(::Range)
+        is_backwards_op = value.exclude_end? ? :>= : :>
+        return false if value.begin && value.end && value.begin.send(is_backwards_op, value.end)
         # 1...10 includes 1..9 but it does not include 1..10.
         # 1..10 includes 1...11 but it does not include 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
@@ -38,6 +40,8 @@ module ActiveSupport
     # The given range must be fully bounded, with both start and end.
     def include?(value)
       if value.is_a?(::Range)
+        is_backwards_op = value.exclude_end? ? :>= : :>
+        return false if value.begin && value.end && value.begin.send(is_backwards_op, value.end)
         # 1...10 includes 1..9 but it does not include 1..10.
         # 1..10 includes 1...11 but it does not include 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=
@@ -61,6 +65,8 @@ module ActiveSupport
     # The given range must be fully bounded, with both start and end.
     def cover?(value)
       if value.is_a?(::Range)
+        is_backwards_op = value.exclude_end? ? :>= : :>
+        return false if value.begin && value.end && value.begin.send(is_backwards_op, value.end)
         # 1...10 covers 1..9 but it does not cover 1..10.
         # 1..10 covers 1...11 but it does not cover 1...12.
         operator = exclude_end? && !value.exclude_end? ? :< : :<=

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -60,6 +60,15 @@ class RangeTest < ActiveSupport::TestCase
     assert((1..10).include?(1...11))
   end
 
+  def test_include_returns_false_for_backwards
+    assert_not((1..10).include?(5..3))
+  end
+
+  # Match quirky plain-Ruby behavior
+  def test_include_returns_false_for_empty_exclusive_end
+    assert_not((1..5).include?(3...3))
+  end
+
   if RUBY_VERSION >= "2.6"
     def test_include_with_endless_range
       assert(eval("1..").include?(2))
@@ -98,6 +107,15 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_compare_other_with_exclusive_end
     assert((1..10) === (1...11))
+  end
+
+  def test_compare_returns_false_for_backwards
+    assert_not((1..10) === (5..3))
+  end
+
+  # Match quirky plain-Ruby behavior
+  def test_compare_returns_false_for_empty_exclusive_end
+    assert_not((1..5) === (3...3))
   end
 
   if RUBY_VERSION >= "2.6"
@@ -143,6 +161,15 @@ class RangeTest < ActiveSupport::TestCase
 
   def test_should_cover_other_with_exclusive_end
     assert((1..10).cover?(1...11))
+  end
+
+  def test_cover_returns_false_for_backwards
+    assert_not((1..10).cover?(5..3))
+  end
+
+  # Match quirky plain-Ruby behavior
+  def test_cover_returns_false_for_empty_exclusive_end
+    assert_not((1..5).cover?(3...3))
   end
 
   if RUBY_VERSION >= "2.6"


### PR DESCRIPTION
### Summary

Previously:

In `irb`:

```ruby
irb(main):002:0> RUBY_VERSION
=> "2.6.5"
irb(main):004:0> (1..10).cover?(6..3)
=> false
```

In rails (HEAD) console

```ruby
irb(main):001:0> RUBY_VERSION
=> "2.6.5"
irb(main):003:0> (1..10).cover?(6..3)
=> true
```

Updated the `Range#cover?` core extension so that `(1..10).cover?(5..3)` now returns `false`, as it does in plain Ruby.

Also updated `#include?` and `#===` behavior to match, though in this case there is no plain-Ruby equivalent.