### PR TITLE
Remove semi colons from JS template

### DIFF
--- a/actioncable/lib/rails/generators/channel/templates/javascript/channel.js.tt
+++ b/actioncable/lib/rails/generators/channel/templates/javascript/channel.js.tt
@@ -14,7 +14,7 @@ consumer.subscriptions.create("<%= class_name %>Channel", {
   }<%= actions.any? ? ",\n" : '' %>
 <% actions.each do |action| -%>
   <%=action %>: function() {
-    return this.perform('<%= action %>');
+    return this.perform('<%= action %>')
   }<%= action == actions[-1] ? '' : ",\n" %>
 <% end -%>
-});
+})


### PR DESCRIPTION
### Summary

Remove semi colons from channel JS template.
