### PR TITLE
require, require_relative, load by double quotes

### DIFF
--- a/actionmailbox/test/dummy/Rakefile
+++ b/actionmailbox/test/dummy/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/actionmailbox/test/dummy/bin/rails
+++ b/actionmailbox/test/dummy/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require_relative "../config/boot"
+require "rails/commands"

--- a/actionmailbox/test/dummy/bin/rake
+++ b/actionmailbox/test/dummy/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/actionmailbox/test/dummy/bin/setup
+++ b/actionmailbox/test/dummy/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.

--- a/actionmailbox/test/dummy/bin/update
+++ b/actionmailbox/test/dummy/bin/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.

--- a/actionmailbox/test/dummy/config.ru
+++ b/actionmailbox/test/dummy/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/actionmailbox/test/dummy/config/application.rb
+++ b/actionmailbox/test/dummy/config/application.rb
@@ -1,6 +1,6 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 
 Bundler.require(*Rails.groups)
 

--- a/actionmailbox/test/dummy/config/boot.rb
+++ b/actionmailbox/test/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/actionmailbox/test/dummy/config/boot.rb
+++ b/actionmailbox/test/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/actionmailbox/test/dummy/config/environment.rb
+++ b/actionmailbox/test/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -80,7 +80,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -136,7 +136,7 @@ module ActionController
     #
     # === Simple \Digest example
     #
-    #   require 'digest/md5'
+    #   require "digest/md5"
     #   class PostsController < ApplicationController
     #     REALM = "SuperSecret"
     #     USERS = {"dhh" => "secret", #plain text password

--- a/actionpack/lib/action_dispatch/journey/parser.rb
+++ b/actionpack/lib/action_dispatch/journey/parser.rb
@@ -4,7 +4,7 @@
 # from Racc grammar file "".
 #
 
-require 'racc/parser.rb'
+require "racc/parser.rb"
 
 # :stopdoc:
 

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -27,7 +27,7 @@ module ActionDispatch
   #
   # Here is an example system test:
   #
-  #   require 'application_system_test_case'
+  #   require "application_system_test_case"
   #
   #   class Users::CreateTest < ApplicationSystemTestCase
   #     test "adding a new user" do

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -513,7 +513,7 @@ module ActionDispatch
   #
   # A simple integration test that exercises multiple controllers:
   #
-  #   require 'test_helper'
+  #   require "test_helper"
   #
   #   class UserFlowsTest < ActionDispatch::IntegrationTest
   #     test "login and browse site" do
@@ -542,7 +542,7 @@ module ActionDispatch
   #
   # Here's an example of multiple sessions and custom DSL in an integration test
   #
-  #   require 'test_helper'
+  #   require "test_helper"
   #
   #   class UserFlowsTest < ActionDispatch::IntegrationTest
   #     test "login and browse site" do

--- a/actiontext/test/dummy/Rakefile
+++ b/actiontext/test/dummy/Rakefile
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/actiontext/test/dummy/bin/rails
+++ b/actiontext/test/dummy/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require_relative "../config/boot"
+require "rails/commands"

--- a/actiontext/test/dummy/bin/rake
+++ b/actiontext/test/dummy/bin/rake
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/actiontext/test/dummy/bin/setup
+++ b/actiontext/test/dummy/bin/setup
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.

--- a/actiontext/test/dummy/bin/update
+++ b/actiontext/test/dummy/bin/update
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.

--- a/actiontext/test/dummy/config.ru
+++ b/actiontext/test/dummy/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/actiontext/test/dummy/config/application.rb
+++ b/actiontext/test/dummy/config/application.rb
@@ -1,6 +1,6 @@
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails/all'
+require "rails/all"
 
 Bundler.require(*Rails.groups)
 require "action_text"

--- a/actiontext/test/dummy/config/boot.rb
+++ b/actiontext/test/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/actiontext/test/dummy/config/boot.rb
+++ b/actiontext/test/dummy/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/actiontext/test/dummy/config/environment.rb
+++ b/actiontext/test/dummy/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -59,7 +59,7 @@ module ActiveRecord
   # Since fixtures are a testing construct, we use them in our unit and functional tests. There
   # are two ways to use the fixtures, but first let's take a look at a sample unit test:
   #
-  #   require 'test_helper'
+  #   require "test_helper"
   #
   #   class WebSiteTest < ActiveSupport::TestCase
   #     test "web_site_count" do

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -691,7 +691,7 @@ module ActiveRecord
     # Or equivalently, if +TenderloveMigration+ is defined as in the
     # documentation for Migration:
     #
-    #   require_relative '20121212123456_tenderlove_migration'
+    #   require_relative "20121212123456_tenderlove_migration"
     #
     #   class FixupTLMigration < ActiveRecord::Migration[6.0]
     #     def change

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -19,7 +19,7 @@ module ActiveSupport
   # By using <tt>ActiveSupport::Concern</tt> the above module could instead be
   # written as:
   #
-  #   require 'active_support/concern'
+  #   require "active_support/concern"
   #
   #   module M
   #     extend ActiveSupport::Concern
@@ -76,7 +76,7 @@ module ActiveSupport
   # is the +Bar+ module, not the +Host+ class. With <tt>ActiveSupport::Concern</tt>,
   # module dependencies are properly resolved:
   #
-  #   require 'active_support/concern'
+  #   require "active_support/concern"
   #
   #   module Foo
   #     extend ActiveSupport::Concern

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -126,7 +126,7 @@ module ActiveSupport
 
     # Reads and writes attributes from a configuration <tt>OrderedHash</tt>.
     #
-    #   require 'active_support/configurable'
+    #   require "active_support/configurable"
     #
     #   class User
     #     include ActiveSupport::Configurable

--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -64,8 +64,8 @@ Replace the code beneath the comment in `script/rails` with the following conten
 ENGINE_ROOT = File.expand_path('../..', __FILE__)
 ENGINE_PATH = File.expand_path('../../lib/your_engine_name/engine', __FILE__)
 
-require 'rails/all'
-require 'rails/engine/commands'
+require "rails/all"
+require "rails/engine/commands"
 ```
 
 Creating a Rails 3.2 application

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -799,7 +799,7 @@ basic setup is as follows:
 
 ```ruby
 # cable/config.ru
-require_relative '../config/environment'
+require_relative "../config/environment"
 Rails.application.eager_load!
 
 run ActionCable.server

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -425,7 +425,7 @@ the Active Model API.
 * `test/models/person_test.rb`
 
     ```ruby
-    require 'test_helper'
+    require "test_helper"
 
     class PersonTest < ActiveSupport::TestCase
       include ActiveModel::Lint::Tests

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -672,7 +672,7 @@ can't be done.
 You can use Active Record's ability to rollback migrations using the `revert` method:
 
 ```ruby
-require_relative '20121212123456_example_migration'
+require_relative "20121212123456_example_migration"
 
 class FixupExampleMigration < ActiveRecord::Migration[6.0]
   def change

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -26,7 +26,7 @@ In order to have a near-zero default footprint, Active Support does not load any
 Thus, after a simple require like:
 
 ```ruby
-require 'active_support'
+require "active_support"
 ```
 
 objects do not even respond to `blank?`. Let's see how to load its definition.
@@ -42,8 +42,8 @@ NOTE: Defined in `active_support/core_ext/object/blank.rb`.
 That means that you can require it like this:
 
 ```ruby
-require 'active_support'
-require 'active_support/core_ext/object/blank'
+require "active_support"
+require "active_support/core_ext/object/blank"
 ```
 
 Active Support has been carefully revised so that cherry-picking a file loads only strictly needed dependencies, if any.
@@ -55,8 +55,8 @@ The next level is to simply load all extensions to `Object`. As a rule of thumb,
 Thus, to load all extensions to `Object` (including `blank?`):
 
 ```ruby
-require 'active_support'
-require 'active_support/core_ext/object'
+require "active_support"
+require "active_support/core_ext/object"
 ```
 
 #### Loading All Core Extensions
@@ -64,8 +64,8 @@ require 'active_support/core_ext/object'
 You may prefer just to load all core extensions, there is a file for that:
 
 ```ruby
-require 'active_support'
-require 'active_support/core_ext'
+require "active_support"
+require "active_support/core_ext"
 ```
 
 #### Loading All Active Support
@@ -73,7 +73,7 @@ require 'active_support/core_ext'
 And finally, if you want to have all Active Support available just issue:
 
 ```ruby
-require 'active_support/all'
+require "active_support/all"
 ```
 
 That does not even put the entire Active Support in memory upfront indeed, some stuff is configured via `autoload`, so it is only loaded if used.

--- a/guides/source/autoloading_and_reloading_constants_classic_mode.md
+++ b/guides/source/autoloading_and_reloading_constants_classic_mode.md
@@ -27,8 +27,8 @@ Ruby on Rails allows applications to be written as if their code was preloaded.
 In a normal Ruby program classes need to load their dependencies:
 
 ```ruby
-require 'application_controller'
-require 'post'
+require "application_controller"
+require "post"
 
 class PostsController < ApplicationController
   def index
@@ -440,7 +440,7 @@ autoload_paths and eager_load_paths
 As you probably know, when `require` gets a relative file name:
 
 ```ruby
-require 'erb'
+require "erb"
 ```
 
 Ruby looks for the file in the directories listed in `$LOAD_PATH`. That is, Ruby
@@ -1030,7 +1030,7 @@ have to know all its descendants.
 Files defining constants to be autoloaded should never be `require`d:
 
 ```ruby
-require 'user' # DO NOT DO THIS
+require "user" # DO NOT DO THIS
 
 class UsersController < ApplicationController
   ...

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -25,7 +25,7 @@ Rails offers four standard spots to place initialization code:
 Running Code Before Rails
 -------------------------
 
-In the rare event that your application needs to run some code before Rails itself is loaded, put it above the call to `require 'rails/all'` in `config/application.rb`.
+In the rare event that your application needs to run some code before Rails itself is loaded, put it above the call to `require "rails/all"` in `config/application.rb`.
 
 Configuring Rails Components
 ----------------------------

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1417,8 +1417,8 @@ required, you should require them before the engine's initialization. For
 example:
 
 ```ruby
-require 'other_engine/engine'
-require 'yet_another_engine/engine'
+require "other_engine/engine"
+require "yet_another_engine/engine"
 
 module MyEngine
   class Engine < ::Rails::Engine

--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -75,8 +75,8 @@ This file is as follows:
 ```ruby
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require_relative "../config/boot"
+require "rails/commands"
 ```
 
 The `APP_PATH` constant will be used later in `rails/commands`. The `config/boot` file referenced here is the `config/boot.rb` file in our application which is responsible for loading Bundler and setting it up.
@@ -88,7 +88,7 @@ The `APP_PATH` constant will be used later in `rails/commands`. The `config/boot
 ```ruby
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.
 ```
 
 In a standard Rails application, there's a `Gemfile` which declares all
@@ -410,7 +410,7 @@ module Rack
 
       if options[:debug]
         $DEBUG = true
-        require 'pp'
+        require "pp"
         p options[:server]
         pp wrapped_app
         pp app
@@ -490,7 +490,7 @@ The `options[:config]` value defaults to `config.ru` which contains this:
 ```ruby
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application
 ```
@@ -522,7 +522,7 @@ This is where the majority of the initialization process of Rails happens.
 The `require` line for `config/environment.rb` in `config.ru` is the first to run:
 
 ```ruby
-require_relative 'config/environment'
+require_relative "config/environment"
 ```
 
 ### `config/environment.rb`
@@ -532,7 +532,7 @@ This file is the common file required by `config.ru` (`rails server`) and Passen
 This file begins with requiring `config/application.rb`:
 
 ```ruby
-require_relative 'application'
+require_relative "application"
 ```
 
 ### `config/application.rb`
@@ -540,7 +540,7 @@ require_relative 'application'
 This file requires `config/boot.rb`:
 
 ```ruby
-require_relative 'boot'
+require_relative "boot"
 ```
 
 But only if it hasn't been required before, which would be the case in `rails server`
@@ -554,7 +554,7 @@ Loading Rails
 The next line in `config/application.rb` is:
 
 ```ruby
-require 'rails/all'
+require "rails/all"
 ```
 
 ### `railties/lib/rails/all.rb`

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -64,7 +64,7 @@ To use `rackup` instead of Rails' `rails server`, you can put the following insi
 
 ```ruby
 # Rails.root/config.ru
-require_relative 'config/environment'
+require_relative "config/environment"
 run Rails.application
 ```
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -81,7 +81,7 @@ create  test/fixtures/articles.yml
 The default test stub in `test/models/article_test.rb` looks like this:
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class ArticleTest < ActiveSupport::TestCase
   # test "the truth" do
@@ -93,7 +93,7 @@ end
 A line by line examination of this file will help get you oriented to Rails testing code and terminology.
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 ```
 
 By requiring this file, `test_helper.rb` the default configuration to run our tests is loaded. We will include this with all the tests we write, so any methods added to this file are available to all our tests.
@@ -943,7 +943,7 @@ $ bin/rails generate integration_test user_flows
 Here's what a freshly generated integration test looks like:
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class UserFlowsTest < ActionDispatch::IntegrationTest
   # test "the truth" do
@@ -985,7 +985,7 @@ previous command we should see:
 Now let's open that file and write our first assertion:
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class BlogFlowTest < ActionDispatch::IntegrationTest
   test "can see the welcome page" do
@@ -1348,7 +1348,7 @@ Notice we're starting to see some duplication in these three tests, they both ac
 Our test should now look something as what follows. Disregard the other tests for now, we're leaving them out for brevity.
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class ArticlesControllerTest < ActionDispatch::IntegrationTest
   # called before every single test
@@ -1409,7 +1409,7 @@ end
 ```
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class ProfileControllerTest < ActionDispatch::IntegrationTest
 
@@ -1440,8 +1440,8 @@ end
 These helpers can then be explicitly required as needed and included as needed
 
 ```ruby
-require 'test_helper'
-require 'test_helpers/multiple_assertions'
+require "test_helper"
+require "test_helpers/multiple_assertions"
 
 class NumberTest < ActiveSupport::TestCase
   include MultipleAssertions
@@ -1456,7 +1456,7 @@ or they can continue to be included directly into the relevant parent classes
 
 ```ruby
 # test/test_helper.rb
-require 'test_helpers/sign_in_helper'
+require "test_helpers/sign_in_helper"
 
 class ActionDispatch::IntegrationTest
   include SignInHelper
@@ -1616,7 +1616,7 @@ If you generated your mailer, the generator does not create stub fixtures for th
 Here's a unit test to test a mailer named `UserMailer` whose action `invite` is used to send an invitation to a friend. It is an adapted version of the base test created by the generator for an `invite` action.
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class UserMailerTest < ActionMailer::TestCase
   test "invite" do
@@ -1675,7 +1675,7 @@ Unit testing allows us to test the attributes of the email while functional and 
 
 ```ruby
 # Integration Test
-require 'test_helper'
+require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   test "invite friend" do
@@ -1689,7 +1689,7 @@ end
 
 ```ruby
 # System Test
-require 'test_helper'
+require "test_helper"
 
 class UsersTest < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome
@@ -1719,7 +1719,7 @@ By default, when you generate a job, an associated test will be generated as wel
 under the `test/jobs` directory. Here's an example test with a billing job:
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class BillingJobTest < ActiveJob::TestCase
   test 'that account is charged' do
@@ -1747,7 +1747,7 @@ the custom assertions provided by Active Job are pretty useful. For instance,
 within a model:
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class ProductTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -1765,7 +1765,7 @@ end
 When serializing job arguments, `Time`, `DateTime`, and `ActiveSupport::TimeWithZone` lose microsecond precision. This means comparing deserialized time with actual time doesn't always work. To compensate for the loss of precision, `assert_enqueued_with` and `assert_performed_with` will remove microseconds from time objects in argument assertions.
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class ProductTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
@@ -1874,7 +1874,7 @@ the custom assertions provided by Action Cable are pretty useful. For instance,
 within a model:
 
 ```ruby
-require 'test_helper'
+require "test_helper"
 
 class ProductTest < ActionCable::TestCase
   test "broadcast status after charge" do
@@ -1897,7 +1897,7 @@ class ChatRelayJob < ApplicationJob
 end
 
 # test/jobs/chat_relay_job_test.rb
-require 'test_helper'
+require "test_helper"
 
 class ChatRelayJobTest < ActiveJob::TestCase
   include ActionCable::TestHelper

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1234,7 +1234,7 @@ secrets, you need to:
 
 If your test helper contains a call to
 `ActiveRecord::Migration.check_pending!` this can be removed. The check
-is now done automatically when you `require 'rails/test_help'`, although
+is now done automatically when you `require "rails/test_help"`, although
 leaving this line in your helper is not harmful in any way.
 
 ### Cookies serializer

--- a/railties/lib/rails/generators/rails/app/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Rakefile.tt
@@ -1,6 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
@@ -1,3 +1,3 @@
 APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+require_relative "../config/boot"
+require "rails/commands"

--- a/railties/lib/rails/generators/rails/app/templates/bin/rake.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rake.tt
@@ -1,3 +1,3 @@
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -1,4 +1,4 @@
-require 'fileutils'
+require "fileutils"
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)

--- a/railties/lib/rails/generators/rails/app/templates/config.ru.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru.tt
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -1,7 +1,7 @@
-require_relative 'boot'
+require_relative "boot"
 
 <% if include_all_railties? -%>
-require 'rails/all'
+require "rails/all"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,6 +1,6 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.
 <%- end -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/environment.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environment.rb.tt
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -93,7 +93,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
+  # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -1,6 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
-require 'rails/test_help'
+require_relative "../config/environment"
+require "rails/test_help"
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -401,7 +401,7 @@ task default: :test
 
       def rakefile_test_tasks
         <<-RUBY
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'

--- a/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Rakefile.tt
@@ -1,5 +1,5 @@
-require 'bundler/setup'
-require 'rdoc/task'
+require "bundler/setup"
+require "rdoc/task"
 
 RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
@@ -11,13 +11,13 @@ end
 <% if engine? && !options[:skip_active_record] && with_dummy_app? -%>
 
 APP_RAKEFILE = File.expand_path("<%= dummy_path -%>/Rakefile", __dir__)
-load 'rails/tasks/engine.rake'
+load "rails/tasks/engine.rake"
 <% end -%>
 <% if engine? -%>
 
-load 'rails/tasks/statistics.rake'
+load "rails/tasks/statistics.rake"
 <% end -%>
 <% unless options[:skip_gemspec] -%>
 
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 <% end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -9,7 +9,7 @@ APP_PATH = File.expand_path('../<%= dummy_path -%>/config/application', __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
 <% if include_all_railties? -%>
 require "rails/all"

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -9,10 +9,10 @@ APP_PATH = File.expand_path('../<%= dummy_path -%>/config/application', __dir__)
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
 
 <% if include_all_railties? -%>
-require 'rails/all'
+require "rails/all"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:
@@ -27,4 +27,4 @@ require "action_view/railtie"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
 <%= comment_if :skip_test %>require "rails/test_unit/railtie"
 <% end -%>
-require 'rails/engine/commands'
+require "rails/engine/commands"

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
@@ -1,7 +1,7 @@
-require_relative 'boot'
+require_relative "boot"
 
 <% if include_all_railties? -%>
-require 'rails/all'
+require "rails/all"
 <% else -%>
 require "rails"
 # Pick the frameworks you want:

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb.tt
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/boot.rb.tt
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 
-require "bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE"])
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 $LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)

--- a/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class <%= camelized_modules %>::Test < ActiveSupport::TestCase
   test "truth" do

--- a/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/integration/navigation_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class NavigationTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/controller/templates/functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>ControllerTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb.tt
@@ -1,5 +1,5 @@
-require 'test_helper'
-require '<%= generator_path %>'
+require "test_helper"
+require "<%= generator_path %>"
 
 <% module_namespacing do -%>
 class <%= class_name %>GeneratorTest < Rails::Generators::TestCase

--- a/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/integration/templates/integration_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>Test < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/job/templates/unit_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/job/templates/unit_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>JobTest < ActiveJob::TestCase

--- a/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/mailer/templates/functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>MailerTest < ActionMailer::TestCase

--- a/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/model/templates/unit_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>Test < ActiveSupport::TestCase

--- a/railties/lib/rails/generators/test_unit/plugin/templates/%file_name%_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/plugin/templates/%file_name%_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class <%= class_name %>Test < ActiveSupport::TestCase
   # test "the truth" do

--- a/railties/lib/rails/generators/test_unit/plugin/templates/test_helper.rb
+++ b/railties/lib/rails/generators/test_unit/plugin/templates/test_helper.rb
@@ -1,2 +1,2 @@
-require 'active_support/testing/autorun'
-require 'active_support'
+require "active_support/testing/autorun"
+require "active_support"

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/api_functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/functional_test.rb.tt
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionDispatch::IntegrationTest

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -42,7 +42,7 @@ module Rails
   #   end
   #
   #   # lib/my_gem.rb
-  #   require 'my_gem/railtie' if defined?(Rails::Railtie)
+  #   require "my_gem/railtie" if defined?(Rails::Railtie)
   #
   # == Initializers
   #
@@ -91,7 +91,7 @@ module Rails
   #
   #   class MyRailtie < Rails::Railtie
   #     rake_tasks do
-  #       load 'path/to/my_railtie.tasks'
+  #       load "path/to/my_railtie.tasks"
   #     end
   #   end
   #
@@ -101,7 +101,7 @@ module Rails
   #
   #   class MyRailtie < Rails::Railtie
   #     generators do
-  #       require 'path/to/my_railtie_generator'
+  #       require "path/to/my_railtie_generator"
   #     end
   #   end
   #

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -116,7 +116,7 @@ module ApplicationTests
         end
       RUBY
       add_to_top_of_config <<-RUBY
-        require 'my_logger'
+        require "my_logger"
         config.logger = MyLogger.new STDOUT
       RUBY
 

--- a/railties/test/application/integration_test_case_test.rb
+++ b/railties/test/application/integration_test_case_test.rb
@@ -19,7 +19,7 @@ module ApplicationTests
       rails "generate", "mailer", "BaseMailer", "welcome"
 
       app_file "test/integration/mailer_integration_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class MailerIntegrationTest < ActionDispatch::IntegrationTest
           setup do
@@ -59,7 +59,7 @@ module ApplicationTests
 
     test "app method of integration tests returns test_app by default" do
       app_file "test/integration/default_app_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class DefaultAppIntegrationTest < ActionDispatch::IntegrationTest
           def test_app_returns_action_dispatch_test_app_by_default

--- a/railties/test/application/rake/notes_test.rb
+++ b/railties/test/application/rake/notes_test.rb
@@ -108,7 +108,7 @@ module ApplicationTests
         app_file "test/some_test.rb", 1000.times.map { "" }.join("\n") << "# TODO: note in test directory"
 
         app_file "lib/tasks/notes_custom.rake", <<-EOS
-          require 'rails/source_annotation_extractor'
+          require "rails/source_annotation_extractor"
           task :notes_custom do
             tags = 'TODO|FIXME'
             opts = { dirs: %w(lib test), tag: true }

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
 
       File.open("#{app_path}/config/boot.rb", "w") do |f|
         f.puts "ENV['BUNDLE_GEMFILE'] = '#{Bundler.default_gemfile}'"
-        f.puts "require 'bundler/setup'"
+        f.puts "require "bundler/setup""
       end
 
       primary, replica = PTY.open

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
 
       File.open("#{app_path}/config/boot.rb", "w") do |f|
         f.puts "ENV['BUNDLE_GEMFILE'] = '#{Bundler.default_gemfile}'"
-        f.puts "require "bundler/setup""
+        f.puts 'require "bundler/setup"'
       end
 
       primary, replica = PTY.open

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -54,7 +54,7 @@ module ApplicationTests
 
     def test_run_file_with_syntax_error
       app_file "test/models/error_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
         def; end
       RUBY
 
@@ -188,7 +188,7 @@ module ApplicationTests
 
     def test_run_named_test
       app_file "test/unit/chu_2_koi_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class Chu2KoiTest < ActiveSupport::TestCase
           def test_rikka
@@ -209,7 +209,7 @@ module ApplicationTests
 
     def test_run_matched_test
       app_file "test/unit/chu_2_koi_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class Chu2KoiTest < ActiveSupport::TestCase
           def test_rikka
@@ -251,7 +251,7 @@ module ApplicationTests
     def test_run_different_environment_using_env_var
       skip "no longer possible. Running tests in a different environment should be explicit"
       app_file "test/unit/env_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class EnvTest < ActiveSupport::TestCase
           def test_env
@@ -322,7 +322,7 @@ module ApplicationTests
 
     def test_run_with_ruby_command
       app_file "test/models/post_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostTest < ActiveSupport::TestCase
           test 'declarative syntax works' do
@@ -343,7 +343,7 @@ module ApplicationTests
     def test_mix_files_and_line_filters
       create_test_file :models, "account"
       app_file "test/models/post_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostTest < ActiveSupport::TestCase
           def test_post
@@ -366,7 +366,7 @@ module ApplicationTests
 
     def test_more_than_one_line_filter
       app_file "test/models/post_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostTest < ActiveSupport::TestCase
           test "first filter" do
@@ -394,7 +394,7 @@ module ApplicationTests
 
     def test_more_than_one_line_filter_with_multiple_files
       app_file "test/models/account_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class AccountTest < ActiveSupport::TestCase
           test "first filter" do
@@ -414,7 +414,7 @@ module ApplicationTests
       RUBY
 
       app_file "test/models/post_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostTest < ActiveSupport::TestCase
           test "first filter" do
@@ -454,7 +454,7 @@ module ApplicationTests
 
     def test_line_filters_trigger_only_one_runnable
       app_file "test/models/post_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostTest < ActiveSupport::TestCase
           test 'truth' do
@@ -478,7 +478,7 @@ module ApplicationTests
 
     def test_line_filter_with_minitest_string_filter
       app_file "test/models/post_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostTest < ActiveSupport::TestCase
           test 'by line' do
@@ -527,7 +527,7 @@ module ApplicationTests
       app_file "config/boot.rb", <<-RUBY
         ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-        require 'bundler/setup' # Set up gems listed in the Gemfile.
+        require "bundler/setup" # Set up gems listed in the Gemfile.
       RUBY
 
       assert_match "0 runs, 0 assertions", run_test_command("")
@@ -578,7 +578,7 @@ module ApplicationTests
       exercise_parallelization_regardless_of_machine_core_count(with: :processes)
 
       file_name = app_file("test/models/parallel_test.rb", <<-RUBY)
-        require 'test_helper'
+        require "test_helper"
 
         class ParallelTest < ActiveSupport::TestCase
           def test_crash
@@ -758,7 +758,7 @@ module ApplicationTests
 
     def test_warnings_option
       app_file "test/models/warnings_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
         def test_warnings
           a = 1
         end
@@ -920,7 +920,7 @@ module ApplicationTests
 
       def create_fixture_test(path = :unit, name = "test")
         app_file "test/#{path}/#{name}_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
 
           class #{name.camelize}Test < ActiveSupport::TestCase
             def test_fixture
@@ -932,7 +932,7 @@ module ApplicationTests
 
       def create_backtrace_test
         app_file "test/unit/backtrace_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
 
           class BacktraceTest < ActiveSupport::TestCase
             def test_backtrace
@@ -948,7 +948,7 @@ module ApplicationTests
 
       def create_test_for_env(env)
         app_file "test/models/environment_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
           class JSONReporter < Minitest::AbstractReporter
             def record(result)
               puts JSON.dump(klass: result.class.name,
@@ -972,7 +972,7 @@ module ApplicationTests
           # Minitest won't require the Rails minitest plugin when we run
           # these integration tests.  So we have to manually require the
           # Minitest plugin here.
-          require 'minitest/rails_plugin'
+          require "minitest/rails_plugin"
 
           class EnvironmentTest < ActiveSupport::TestCase
             def test_environment
@@ -987,7 +987,7 @@ module ApplicationTests
 
       def create_test_file(path = :unit, name = "test", pass: true, print: true)
         app_file "test/#{path}/#{name}_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
 
           class #{name.camelize}Test < ActiveSupport::TestCase
             def test_truth
@@ -1000,7 +1000,7 @@ module ApplicationTests
 
       def create_parallel_processes_test_file
         app_file "test/models/parallel_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
 
           class ParallelTest < ActiveSupport::TestCase
             RD1, WR1 = IO.pipe
@@ -1029,7 +1029,7 @@ module ApplicationTests
 
       def create_parallel_threads_test_file
         app_file "test/models/parallel_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
 
           class ParallelTest < ActiveSupport::TestCase
             Q1 = Queue.new
@@ -1059,7 +1059,7 @@ module ApplicationTests
 
       def create_env_test
         app_file "test/unit/env_test.rb", <<-RUBY
-          require 'test_helper'
+          require "test_helper"
 
           class EnvTest < ActiveSupport::TestCase
             def test_env

--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -21,7 +21,7 @@ module ApplicationTests
 
     test "simple successful test" do
       app_file "test/unit/foo_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class FooTest < ActiveSupport::TestCase
           def test_truth
@@ -35,7 +35,7 @@ module ApplicationTests
 
     test "after_run" do
       app_file "test/unit/foo_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         Minitest.after_run { puts "WORLD" }
         Minitest.after_run { puts "HELLO" }
@@ -53,7 +53,7 @@ module ApplicationTests
 
     test "simple failed test" do
       app_file "test/unit/foo_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class FooTest < ActiveSupport::TestCase
           def test_truth
@@ -76,7 +76,7 @@ module ApplicationTests
       HTML
 
       app_file "test/integration/posts_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class PostsTest < ActionDispatch::IntegrationTest
           def test_index
@@ -92,7 +92,7 @@ module ApplicationTests
 
     test "enable full backtraces on test failures" do
       app_file "test/unit/failing_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class FailingTest < ActiveSupport::TestCase
           def test_failure
@@ -111,7 +111,7 @@ module ApplicationTests
       version = output.match(/(\d+)_create_users\.rb/)[1]
 
       app_file "test/models/user_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class UserTest < ActiveSupport::TestCase
           test "user" do
@@ -148,7 +148,7 @@ module ApplicationTests
       version = output.match(/(\d+)_create_users\.rb/)[1]
 
       app_file "test/models/user_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class UserTest < ActiveSupport::TestCase
           test "user" do
@@ -187,7 +187,7 @@ module ApplicationTests
       version_1 = output_1.match(/(\d+)_create_users\.rb/)[1]
 
       app_file "test/models/user_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
         class UserTest < ActiveSupport::TestCase
           test "user" do
             User.create! name: "Jon"
@@ -212,7 +212,7 @@ module ApplicationTests
       version_2 = output_2.match(/(\d+)_add_email_to_users\.rb/)[1]
 
       app_file "test/models/user_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class UserTest < ActiveSupport::TestCase
           test "user" do
@@ -237,7 +237,7 @@ module ApplicationTests
       version = output.match(/(\d+)_create_users\.rb/)[1]
 
       app_file "test/models/user_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
 
         class UserTest < ActiveSupport::TestCase
           test "user" do
@@ -291,7 +291,7 @@ Expected: ["id", "name"]
         end
       RUBY
       app_file "test/models/user_test.rb", <<-RUBY
-        require 'test_helper'
+        require "test_helper"
         class UserTest < ActiveSupport::TestCase
           test "user" do
             User.create! name: "Jon"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -365,7 +365,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       quietly { generator.send(:update_config_files) }
 
       assert_file "#{app_root}/config/boot.rb" do |content|
-        assert_no_match(/require 'bootsnap\/setup'/, content)
+        assert_no_match(/require "bootsnap\/setup"/, content)
       end
     end
   end
@@ -968,12 +968,12 @@ class AppGeneratorTest < Rails::Generators::TestCase
     unless defined?(JRUBY_VERSION)
       assert_gem "bootsnap"
       assert_file "config/boot.rb" do |content|
-        assert_match(/require 'bootsnap\/setup'/, content)
+        assert_match(/require "bootsnap\/setup"/, content)
       end
     else
       assert_no_gem "bootsnap"
       assert_file "config/boot.rb" do |content|
-        assert_no_match(/require 'bootsnap\/setup'/, content)
+        assert_no_match(/require "bootsnap\/setup"/, content)
       end
     end
   end
@@ -983,7 +983,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_gem "bootsnap"
     assert_file "config/boot.rb" do |content|
-      assert_no_match(/require 'bootsnap\/setup'/, content)
+      assert_no_match(/require "bootsnap\/setup"/, content)
     end
   end
 
@@ -992,7 +992,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_gem "bootsnap"
     assert_file "config/boot.rb" do |content|
-      assert_no_match(/require 'bootsnap\/setup'/, content)
+      assert_no_match(/require "bootsnap\/setup"/, content)
     end
   end
 

--- a/railties/test/generators/generator_generator_test.rb
+++ b/railties/test/generators/generator_generator_test.rb
@@ -20,7 +20,7 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/awesome_generator_test.rb",
                /class AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/awesome\/awesome_generator'/
+               /require "generators\/awesome\/awesome_generator"/
   end
 
   def test_namespaced_generator_skeleton
@@ -36,7 +36,7 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class Rails::AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/rails/awesome_generator_test.rb",
                /class Rails::AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/rails\/awesome\/awesome_generator'/
+               /require "generators\/rails\/awesome\/awesome_generator"/
   end
 
   def test_generator_skeleton_is_created_without_file_name_namespace
@@ -52,7 +52,7 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/awesome_generator_test.rb",
                /class AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/awesome_generator'/
+               /require "generators\/awesome_generator"/
   end
 
   def test_namespaced_generator_skeleton_without_file_name_namespace
@@ -68,6 +68,6 @@ class GeneratorGeneratorTest < Rails::Generators::TestCase
                 /class Rails::AwesomeGenerator < Rails::Generators::NamedBase/
     assert_file "test/lib/generators/rails/awesome_generator_test.rb",
                /class Rails::AwesomeGeneratorTest < Rails::Generators::TestCase/,
-               /require 'generators\/rails\/awesome_generator'/
+               /require "generators\/rails\/awesome_generator"/
   end
 end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -414,8 +414,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "bin/rails", /ENGINE_PATH = File\.expand_path\('\.\.\/lib\/bukkits\/engine', __dir__\)/
     assert_file "bin/rails", /ENGINE_ROOT = File\.expand_path\('\.\.', __dir__\)/
     assert_file "bin/rails", %r|APP_PATH = File\.expand_path\('\.\./test/dummy/config/application', __dir__\)|
-    assert_file "bin/rails", /require 'rails\/all'/
-    assert_file "bin/rails", /require 'rails\/engine\/commands'/
+    assert_file "bin/rails", /require "rails\/all"/
+    assert_file "bin/rails", /require "rails\/engine\/commands"/
   end
 
   def test_shebang

--- a/railties/test/generators/plugin_test_helper.rb
+++ b/railties/test/generators/plugin_test_helper.rb
@@ -6,7 +6,7 @@ require "tmpdir"
 module PluginTestHelper
   def create_test_file(name, pass: true)
     plugin_file "test/#{name}_test.rb", <<-RUBY
-      require 'test_helper'
+      require "test_helper"
 
       class #{name.camelize}Test < ActiveSupport::TestCase
         def test_truth

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -30,7 +30,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
   def test_mix_files_and_line_filters
     create_test_file "account"
     plugin_file "test/post_test.rb", <<-RUBY
-      require 'test_helper'
+      require "test_helper"
 
       class PostTest < ActiveSupport::TestCase
         def test_post
@@ -96,7 +96,7 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
 
   def test_warnings_option
     plugin_file "test/models/warnings_test.rb", <<-RUBY
-      require 'test_helper'
+      require "test_helper"
       def test_warnings
         a = 1
       end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -513,7 +513,7 @@ Module.new do
 
   sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc --skip-webpack-install --quiet"
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
-    f.puts "require 'rails/all'"
+    f.puts "require "rails/all""
   end
 
   unless File.exist?("#{RAILS_FRAMEWORK_ROOT}/actionview/lib/assets/compiled/rails-ujs.js")

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -513,7 +513,7 @@ Module.new do
 
   sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc --skip-webpack-install --quiet"
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
-    f.puts "require "rails/all""
+    f.puts 'require "rails/all"'
   end
 
   unless File.exist?("#{RAILS_FRAMEWORK_ROOT}/actionview/lib/assets/compiled/rails-ujs.js")

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1555,8 +1555,8 @@ en:
 
     # Restrict frameworks to load in order to avoid engine frameworks affect tests.
     def restrict_frameworks
-      remove_from_config("require "rails/all"")
-      remove_from_config("require_relative "boot"")
+      remove_from_config('require "rails/all"')
+      remove_from_config('require_relative "boot"')
       remove_from_env_config("development", "config.active_storage.*")
       frameworks = <<~RUBY
         require "rails"

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -52,7 +52,7 @@ module RailtiesTest
 
       @plugin.write "Rakefile", <<-RUBY
         APP_RAKEFILE = '#{app_path}/Rakefile'
-        load 'rails/tasks/engine.rake'
+        load "rails/tasks/engine.rake"
         task :foo => :environment do
           puts "Task ran"
         end
@@ -200,7 +200,7 @@ module RailtiesTest
 
       @plugin.write "Rakefile", <<-RUBY
         APP_RAKEFILE = '#{app_path}/Rakefile'
-        load 'rails/tasks/engine.rake'
+        load "rails/tasks/engine.rake"
       RUBY
 
       add_to_config "ActiveRecord::Base.timestamped_migrations = false"
@@ -1532,7 +1532,7 @@ en:
     test "active_storage:install task works within engine" do
       @plugin.write "Rakefile", <<-RUBY
         APP_RAKEFILE = '#{app_path}/Rakefile'
-        load 'rails/tasks/engine.rake'
+        load "rails/tasks/engine.rake"
       RUBY
 
       Dir.chdir(@plugin.path) do
@@ -1555,8 +1555,8 @@ en:
 
     # Restrict frameworks to load in order to avoid engine frameworks affect tests.
     def restrict_frameworks
-      remove_from_config("require 'rails/all'")
-      remove_from_config("require_relative 'boot'")
+      remove_from_config("require "rails/all"")
+      remove_from_config("require_relative "boot"")
       remove_from_env_config("development", "config.active_storage.*")
       frameworks = <<~RUBY
         require "rails"


### PR DESCRIPTION
We should replace all single quote usage with double quotes, as per our style guide, but you gotta start somewhere. The generators generating single quote require lines have been bugging me personally, so this is a remedy for that (with a dash of cleaner campsite along with it).