### PR TITLE
.annotate_template_file_names annotates HTML output with template names

### DIFF
--- a/actionmailbox/test/dummy/config/environments/development.rb
+++ b/actionmailbox/test/dummy/config/environments/development.rb
@@ -57,6 +57,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Render template filenames as comments in HTML
+  # config.action_view.annotate_template_file_names = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Render template filenames as comments in HTML
+  # config.action_view.annotate_template_file_names = true
 end

--- a/actiontext/test/dummy/config/environments/development.rb
+++ b/actiontext/test/dummy/config/environments/development.rb
@@ -57,6 +57,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Render template filenames as comments in HTML
+  # config.action_view.annotate_template_file_names = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Render template filenames as comments in HTML
+  # config.action_view.annotate_template_file_names = true
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionView::Base.annotate_template_file_names` annotates HTML output with template file names.
+
+    *Joel Hawksley*, *Aaron Patterson*
+
 *   `ActionView::Helpers::TranslationHelper#translate` returns nil when
     passed `default: nil` without a translation matching `I18n#translate`.
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -162,6 +162,9 @@ module ActionView #:nodoc:
     # Specify whether submit_tag should automatically disable on click
     cattr_accessor :automatically_disable_submit_tag, default: true
 
+    # Render template filenames as comments in HTML
+    cattr_accessor :annotate_template_file_names, default: false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -58,7 +58,8 @@ module ActionView
           self.class.erb_implementation.new(
             erb,
             escape: (self.class.escape_ignore_list.include? template.type),
-            trim: (self.class.erb_trim_mode == "-")
+            trim: (self.class.erb_trim_mode == "-"),
+            short_identifier: template.short_identifier
           ).src
         end
 

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -13,8 +13,15 @@ module ActionView
 
             # Dup properties so that we don't modify argument
             properties = Hash[properties]
-            properties[:preamble]   = ""
-            properties[:postamble]  = "@output_buffer.to_s"
+
+            if ActionView::Base.annotate_template_file_names
+              properties[:preamble]   = "@output_buffer.safe_append='<!-- BEGIN #{properties[:short_identifier]} -->\n';"
+              properties[:postamble]  = "@output_buffer.safe_append='<!-- END #{properties[:short_identifier]} -->\n';@output_buffer.to_s"
+            else
+              properties[:preamble]   = ""
+              properties[:postamble]  = "@output_buffer.to_s"
+            end
+
             properties[:bufvar]     = "@output_buffer"
             properties[:escapefunc] = ""
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1453,4 +1453,22 @@ class RenderTest < ActionController::TestCase
     get :render_call_to_partial_with_layout_in_main_layout_and_within_content_for_layout
     assert_equal "Before (Anthony)\nInside from partial (Anthony)\nAfter\nBefore (David)\nInside from partial (David)\nAfter\nBefore (Ramm)\nInside from partial (Ramm)\nAfter", @response.body
   end
+
+  def test_template_annotations
+    ActionView::Base.annotate_template_file_names = true
+
+    get :render_with_explicit_template_with_locals
+
+    lines = @response.body.split("\n")
+
+    assert_includes lines.first, "<!-- BEGIN"
+    assert_includes lines.first, "test/fixtures/actionpack/test/render_file_with_locals.erb -->"
+
+    assert_includes lines[1], "The secret is area51"
+
+    assert_includes lines.last, "<!-- END"
+    assert_includes lines.last, "test/fixtures/actionpack/test/render_file_with_locals.erb -->"
+  ensure
+    ActionView::Base.annotate_template_file_names = false
+  end
 end

--- a/activestorage/test/dummy/config/environments/development.rb
+++ b/activestorage/test/dummy/config/environments/development.rb
@@ -46,6 +46,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Render template filenames as comments in HTML
+  # config.action_view.annotate_template_file_names = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -35,4 +35,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Render template filenames as comments in HTML
+  # config.action_view.annotate_template_file_names = true
 end


### PR DESCRIPTION
# .annotate_template_file_names annotates HTML output with template file names

## Problem

As a developer, when looking at a page in my web browser, it's sometimes
difficult to figure out which template(s) are being used to render the page.

## Solution

`config.action_view.annotate_template_file_names` adds HTML comments to the
rendered output indicating where each template begins and ends, leveraging the lovely `ActionView::Template#short_identifier` introduced by @jhawthorn in https://github.com/rails/rails/pull/35407:

![Screen Shot 2020-03-30 at 2 41 39 PM](https://user-images.githubusercontent.com/1940294/77960048-dc999380-7294-11ea-8878-3f0c6dfadc4a.png)
(Note: Chrome moves any HTML comments outside the `html` tag to inside `body`, which is why `<!-- END app/views/layouts/application.html.erb -->` is shown as being inside `body`, despite falling after the closing `html` tag in the document)

Co-authored-by: Aaron Patterson <tenderlove@github.com>