### PR TITLE
Allow logs to be tagged without a block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Calling `ActiveSupport::TaggedLogging#tagged` without a block now returns a tagged logger.
+
+    ```ruby
+    logger.tagged("BCX").info("Funky time!") # => [BCX] Funky time!
+    ```
+
+    *Eugene Kenny*
+
 *   Align `Range#cover?` extension behavior with Ruby behavior for backwards ranges.
 
     `(1..10).cover?(5..3)` now returns `false`, as it does in plain Ruby.

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -129,3 +129,80 @@ class TaggedLoggingTest < ActiveSupport::TestCase
     assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
   end
 end
+
+class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase
+  setup do
+    @output = StringIO.new
+    @logger = ActiveSupport::TaggedLogging.new(Logger.new(@output))
+  end
+
+  test "tagged once" do
+    @logger.tagged("BCX").info "Funky time"
+    assert_equal "[BCX] Funky time\n", @output.string
+  end
+
+  test "tagged twice" do
+    @logger.tagged("BCX").tagged("Jason").info "Funky time"
+    assert_equal "[BCX] [Jason] Funky time\n", @output.string
+  end
+
+  test "tagged thrice at once" do
+    @logger.tagged("BCX", "Jason", "New").info "Funky time"
+    assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string
+  end
+
+  test "tagged are flattened" do
+    @logger.tagged("BCX", %w(Jason New)).info "Funky time"
+    assert_equal "[BCX] [Jason] [New] Funky time\n", @output.string
+  end
+
+  test "tagged once with blank and nil" do
+    @logger.tagged(nil, "", "New").info "Funky time"
+    assert_equal "[New] Funky time\n", @output.string
+  end
+
+  test "shares tags across threads" do
+    logger = @logger.tagged("BCX")
+
+    Thread.new do
+      logger.info "Dull story"
+      logger.tagged("OMG").info "Cool story"
+    end.join
+
+    logger.info "Funky time"
+
+    assert_equal "[BCX] Dull story\n[BCX] [OMG] Cool story\n[BCX] Funky time\n", @output.string
+  end
+
+  test "keeps each tag in their own instance" do
+    other_output = StringIO.new
+    other_logger = ActiveSupport::TaggedLogging.new(Logger.new(other_output))
+
+    tagged_logger = @logger.tagged("OMG")
+    other_tagged_logger = other_logger.tagged("BCX")
+    tagged_logger.info "Cool story"
+    other_tagged_logger.info "Funky time"
+
+    assert_equal "[OMG] Cool story\n", @output.string
+    assert_equal "[BCX] Funky time\n", other_output.string
+  end
+
+  test "does not share the same formatter instance of the original logger" do
+    other_logger = ActiveSupport::TaggedLogging.new(@logger)
+
+    tagged_logger = @logger.tagged("OMG")
+    other_tagged_logger = other_logger.tagged("BCX")
+    tagged_logger.info "Cool story"
+    other_tagged_logger.info "Funky time"
+
+    assert_equal "[OMG] Cool story\n[BCX] Funky time\n", @output.string
+  end
+
+  test "mixed levels of tagging" do
+    logger = @logger.tagged("BCX")
+    logger.tagged("Jason").info "Funky time"
+    logger.info "Junky time!"
+
+    assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
+  end
+end


### PR DESCRIPTION
Calling `ActiveSupport::TaggedLogger#tagged` without a block now returns a new logger with the tags applied. This is useful for when you want to tag an individual log line, rather than an entire request.

Our application has code that looks like this in several places:

```ruby
class NotificationWorker
  LOG_PREFIX = "[Notifications]"

  def perform
    log("Started delivering notifications")

    Notification.pending.find_each do |notification|
      notification.deliver!
      log("Successfully delivered notification #{notification.id}")
    rescue
      log("Failed to deliver notification #{notification.id}, #{e.class}: #{e.message}", level: :error)
    end

    log("Finished delivering notifications")
  end

  def log(msg, level: :info)
    Rails.logger.send(level, "#{LOG_PREFIX} #{msg}")
  end
end
```

The brackets in `LOG_PREFIX` imitate tagged logging, so that we can search for those lines in the same way that we search for all of the logs from a particular request or job. We want to be able to find the lines summarising the outcome of the job, without any other lines logged by `deliver!`.

With this change, we'll be able to write that code in a way that's closer to normal logger usage:

```ruby
class NotificationWorker
  def perform
    logger.info("Started delivering notifications")

    Notification.pending.find_each do |notification|
      notification.deliver!
      logger.info("Successfully delivered notification #{notification.id}")
    rescue
      logger.error("Failed to deliver notification #{notification.id}, #{e.class}: #{e.message}")
    end

    logger.info("Finished delivering notifications")
  end

  def logger
    Rails.logger.tagged("Notifications")
  end
end
```