### PR TITLE
Avoid ActionView rendering instrumentation indirection

### DIFF
--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -170,12 +170,6 @@ module ActionView
         details || NO_DETAILS
       end
 
-      def instrument(name, **options) # :doc:
-        ActiveSupport::Notifications.instrument("render_#{name}.action_view", options) do |payload|
-          yield payload
-        end
-      end
-
       def prepend_formats(formats) # :doc:
         formats = Array(formats)
         return if formats.empty? || @lookup_context.html_fallback_for_js

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -141,7 +141,11 @@ module ActionView
 
       def render_collection(collection, view, path, template, layout, block)
         identifier = (template && template.identifier) || path
-        instrument(:collection, identifier: identifier, count: collection.size) do |payload|
+        ActiveSupport::Notifications.instrument(
+          "render_collection.action_view",
+          identifier: identifier,
+          count: collection.size
+        ) do |payload|
           spacer = if @options.key?(:spacer_template)
             spacer_template = find_template(@options[:spacer_template], @locals.keys)
             build_rendered_template(spacer_template.render(view, @locals), spacer_template)

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -277,7 +277,10 @@ module ActionView
       end
 
       def render_partial_template(view, locals, template, layout, block)
-        instrument(:partial, identifier: template.identifier) do |payload|
+        ActiveSupport::Notifications.instrument(
+          "render_partial.action_view",
+          identifier: template.identifier
+        ) do |payload|
           content = template.render(view, locals) do |*name|
             view._layout_for(*name, &block)
           end

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -62,7 +62,11 @@ module ActionView
         output  = ActionView::StreamingBuffer.new(buffer)
         yielder = lambda { |*name| view._layout_for(*name) }
 
-        instrument(:template, identifier: template.identifier, layout: (layout && layout.virtual_path)) do
+        ActiveSupport::Notifications.instrument(
+          "render_template.action_view",
+          identifier: template.identifier,
+          layout: layout && layout.virtual_path
+        ) do
           outer_config = I18n.config
           fiber = Fiber.new do
             I18n.config = outer_config

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -52,7 +52,11 @@ module ActionView
       # supplied as well.
       def render_template(view, template, layout_name, locals)
         render_with_layout(view, template, layout_name, locals) do |layout|
-          instrument(:template, identifier: template.identifier, layout: (layout && layout.virtual_path)) do
+          ActiveSupport::Notifications.instrument(
+            "render_template.action_view",
+            identifier: template.identifier,
+            layout: layout && layout.virtual_path
+          ) do
             template.render(view, locals) { |*name| view._layout_for(*name) }
           end
         end


### PR DESCRIPTION
The instrument helper we had here would allocate a new string object for the key each time it was called and also added two stack frames. The interpolated strings are also _slightly_ slower to hash since they aren't fstrings.

Though this was shorter before, I think this is a little more preferable as a code style since the subscribed keys are now greppable. After this, there's still one other place this pattern is used (in ActiveSupport cache).