### PR TITLE
Include ActionText helpers after ActionView has loaded

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -40,6 +40,11 @@ module ActionText
       ActiveSupport.on_load(:action_controller_base) do
         helper ActionText::Engine.helpers
       end
+
+      ActiveSupport.on_load(:action_view) do
+        include ActionText::ContentHelper
+        include ActionText::TagHelper
+      end
     end
 
     initializer "action_text.renderer" do |app|


### PR DESCRIPTION
### Summary

The ActionText helpers need to wait for ActionView to have loaded.
Otherwise the methods won't be available to ActionView resulting in
errors like:
```
undefined method `rich_text_area_tag'
```

Fixes #37672

### Other Information

No tests are included as I'm not sure how to test this..
