### PR TITLE
Allow utc_to_local_returns_utc_offset_times to be set in new_framework_defaults_6_1.rb

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -18,7 +18,7 @@
 
     This changes the output of `ActiveSupport::TimeZone.utc_to_local`, but
     can be controlled with the
-    `Rails.application.config.active_support.utc_to_local_returns_utc_offset_times` config.
+    `ActiveSupport.utc_to_local_returns_utc_offset_times` config.
 
     New Rails 6.1 apps have it enabled by default, existing apps can upgrade
     via the config in config/initializers/new_framework_defaults_6_1.rb

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -179,9 +179,7 @@ module Rails
             action_dispatch.cookies_same_site_protection = :lax
           end
 
-          if respond_to?(:active_support)
-            active_support.utc_to_local_returns_utc_offset_times = true
-          end
+          ActiveSupport.utc_to_local_returns_utc_offset_times = true
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -24,4 +24,4 @@
 
 # Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
 # UTC offset or a UTC time.
-# Rails.application.config.active_support.utc_to_local_returns_utc_offset_times = true
+# ActiveSupport.utc_to_local_returns_utc_offset_times = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2295,13 +2295,35 @@ module ApplicationTests
       assert_equal :lax, Rails.application.config.action_dispatch.cookies_same_site_protection
     end
 
-    test "enables utc_to_local_returns_utc_offset_times by default" do
+    test "ActiveSupport.utc_to_local_returns_utc_offset_times is true in 6.1 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "6.1"'
 
       app "development"
 
-      assert_equal true, Rails.application.config.active_support.utc_to_local_returns_utc_offset_times
+      assert_equal true, ActiveSupport.utc_to_local_returns_utc_offset_times
+    end
+
+    test "ActiveSupport.utc_to_local_returns_utc_offset_times is false in 6.0 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "6.0"'
+
+      app "development"
+
+      assert_equal false, ActiveSupport.utc_to_local_returns_utc_offset_times
+    end
+
+    test "ActiveSupport.utc_to_local_returns_utc_offset_times can be configured in an initializer" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "6.0"'
+
+      app_file "config/initializers/new_framework_defaults_6_1.rb", <<-RUBY
+        ActiveSupport.utc_to_local_returns_utc_offset_times = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveSupport.utc_to_local_returns_utc_offset_times
     end
 
     test "ActiveStorage.queues[:analysis] is :active_storage_analysis by default" do


### PR DESCRIPTION
Followup to https://github.com/rails/rails/commit/bf34c808f9936ecb160914cace45c655ec0924c7.

Enabling this option in new_framework_defaults_6_1.rb didn't work before, as railtie initializers run before application initializers.

We could add special handling to the Active Support railtie so that this option is applied later than the others, but I'd prefer to just set it directly, as we did with `to_time_preserves_timezone` in 5.0:

https://github.com/rails/rails/blob/2efddadd6cba4e2129acedf1d402d11abcc03996/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults.rb.tt#L21