### PR TITLE
Updated Active Storage configuration guide for previewers default values [ci skip]

### DIFF
--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -3,8 +3,9 @@
 # Some non-image blobs can be previewed: that is, they can be presented as images. A video blob can be previewed by
 # extracting its first frame, and a PDF blob can be previewed by extracting its first page.
 #
-# A previewer extracts a preview image from a blob. Active Storage provides previewers for videos and PDFs:
-# ActiveStorage::Previewer::VideoPreviewer and ActiveStorage::Previewer::PDFPreviewer. Build custom previewers by
+# A previewer extracts a preview image from a blob. Active Storage provides previewers for videos and PDFs.
+# ActiveStorage::Previewer::VideoPreviewer is used for videos whereas ActiveStorage::Previewer::PopplerPDFPreviewer
+# and ActiveStorage::Previewer::MuPDFPreviewer are used for PDFs. Build custom previewers by
 # subclassing ActiveStorage::Previewer and implementing the requisite methods. Consult the ActiveStorage::Previewer
 # documentation for more details on what's required of previewers.
 #
@@ -13,11 +14,11 @@
 # by manipulating +Rails.application.config.active_storage.previewers+ in an initializer:
 #
 #   Rails.application.config.active_storage.previewers
-#   # => [ ActiveStorage::Previewer::PDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
+#   # => [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
 #
 #   # Add a custom previewer for Microsoft Office documents:
 #   Rails.application.config.active_storage.previewers << DOCXPreviewer
-#   # => [ ActiveStorage::Previewer::PDFPreviewer, ActiveStorage::Previewer::VideoPreviewer, DOCXPreviewer ]
+#   # => [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer, DOCXPreviewer ]
 #
 # Outside of a Rails application, modify +ActiveStorage.previewers+ instead.
 #

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -889,7 +889,7 @@ You can find more detailed configuration options in the
 
 * `config.active_storage.analyzers` accepts an array of classes indicating the analyzers available for Active Storage blobs. The default is `[ActiveStorage::Analyzer::ImageAnalyzer, ActiveStorage::Analyzer::VideoAnalyzer]`. The former can extract width and height of an image blob; the latter can extract width, height, duration, angle, and aspect ratio of a video blob.
 
-* `config.active_storage.previewers` accepts an array of classes indicating the image previewers available in Active Storage blobs. The default is `[ActiveStorage::Previewer::PDFPreviewer, ActiveStorage::Previewer::VideoPreviewer]`. The former can generate a thumbnail from the first page of a PDF blob; the latter from the relevant frame of a video blob.
+* `config.active_storage.previewers` accepts an array of classes indicating the image previewers available in Active Storage blobs. The default is `[ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer]`. `PopplerPDFPreviewer` and `MuPDFPreviewer` can generate a thumbnail from the first page of a PDF blob; `VideoPreviewer` from the relevant frame of a video blob.
 
 * `config.active_storage.paths` accepts a hash of options indicating the locations of previewer/analyzer commands. The default is `{}`, meaning the commands will be looked for in the default path. Can include any of these options:
     * `:ffprobe` - The location of the ffprobe executable.


### PR DESCRIPTION
I ran into the issue of rendering videos preview in Action Text some days back. That when I noticed that the default values in the configuration are wrong `config.active_storage.previewers`. 
The changes were made in this PR: https://github.com/rails/rails/commit/0b717c20458d12191f479fc693dd1ca1eb11c050

Current default can be found here: https://github.com/rails/rails/blob/master/activestorage/lib/active_storage/engine.rb#L26