### PR TITLE
Add `config.generators.after_generate` for processing to generated files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `config.generators.after_generate` for processing to generated files.
+
+    Register a callback that will get called right after generators has finished.
+
+    *Yuji Yaginuma*
+
 *   Make test file patterns configurable via Environment variables
 
     This makes test file patterns configurable via two environment variables:

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -108,7 +108,7 @@ module Rails
 
     class Generators #:nodoc:
       attr_accessor :aliases, :options, :templates, :fallbacks, :colorize_logging, :api_only
-      attr_reader :hidden_namespaces
+      attr_reader :hidden_namespaces, :after_generate_callbacks
 
       def initialize
         @aliases = Hash.new { |h, k| h[k] = {} }
@@ -118,6 +118,7 @@ module Rails
         @colorize_logging = true
         @api_only = false
         @hidden_namespaces = []
+        @after_generate_callbacks = []
       end
 
       def initialize_copy(source)
@@ -129,6 +130,10 @@ module Rails
 
       def hide_namespace(namespace)
         @hidden_namespaces << namespace
+      end
+
+      def after_generate(&block)
+        @after_generate_callbacks << block
       end
 
       def method_missing(method, *args)

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -80,6 +80,7 @@ module Rails
         templates_path.concat config.templates
         templates_path.uniq!
         hide_namespaces(*config.hidden_namespaces)
+        after_generate_callbacks.replace config.after_generate_callbacks
       end
 
       def templates_path #:nodoc:
@@ -92,6 +93,10 @@ module Rails
 
       def options #:nodoc:
         @options ||= DEFAULT_OPTIONS.dup
+      end
+
+      def after_generate_callbacks # :nodoc:
+        @after_generate_callbacks ||= []
       end
 
       # Hold configured generators fallbacks. If a plugin developer wants a
@@ -269,6 +274,7 @@ module Rails
         if klass = find_by_namespace(names.pop, names.any? && names.join(":"))
           args << "--help" if args.empty? && klass.arguments.any?(&:required?)
           klass.start(args, config)
+          run_after_generate_callback if config[:behavior] == :invoke
         else
           options     = sorted_groups.flat_map(&:last)
           suggestion  = Rails::Command::Spellchecker.suggest(namespace.to_s, from: options)
@@ -279,6 +285,11 @@ module Rails
             Run `bin/rails generate --help` for more options.
           MSG
         end
+      end
+
+      def add_generated_file(file) # :nodoc:
+        (@@generated_files ||= []) << file
+        file
       end
 
       private
@@ -313,6 +324,15 @@ module Rails
 
         def file_lookup_paths # :doc:
           @file_lookup_paths ||= [ "{#{lookup_paths.join(',')}}", "**", "*_generator.rb" ]
+        end
+
+        def run_after_generate_callback
+          if defined?(@@generated_files) && !@@generated_files.empty?
+            @after_generate_callbacks.each do |callback|
+              callback.call(@@generated_files)
+            end
+            @@generated_files = []
+          end
         end
     end
   end

--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -19,6 +19,11 @@ module Rails
           exists? && File.binread(existing_migration) == render
         end
 
+        def invoke!
+          invoked_file = super
+          File.exist?(@destination) ? invoked_file : relative_existing_migration
+        end
+
         def revoke!
           say_destination = exists? ? relative_existing_migration : relative_destination
           say_status :remove, :red, say_destination

--- a/railties/lib/rails/generators/migration.rb
+++ b/railties/lib/rails/generators/migration.rb
@@ -62,13 +62,14 @@ module Rails
         dir, base = File.split(destination)
         numbered_destination = File.join(dir, ["%migration_number%", base].join("_"))
 
-        create_migration numbered_destination, nil, config do
+        file = create_migration numbered_destination, nil, config do
           if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
             ERB.new(::File.binread(source), trim_mode: "-", eoutvar: "@output_buffer").result(context)
           else
             ERB.new(::File.binread(source), nil, "-", "@output_buffer").result(context)
           end
         end
+        Rails::Generators.add_generated_file(file)
       end
     end
   end

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -22,7 +22,7 @@ module Rails
       no_tasks do
         def template(source, *args, &block)
           inside_template do
-            super
+            Rails::Generators.add_generated_file(super)
           end
         end
 

--- a/railties/test/generators/create_migration_test.rb
+++ b/railties/test/generators/create_migration_test.rb
@@ -73,6 +73,15 @@ class CreateMigrationTest < Rails::Generators::TestCase
     assert_predicate @migration, :identical?
   end
 
+  def test_invoke_return_existing_file_when_exists_identical
+    migration_exists!
+    create_migration
+
+    invoked_file = nil
+    quietly { invoked_file = @migration.invoke! }
+    assert_equal @existing_migration.relative_existing_migration, invoked_file
+  end
+
   def test_invoke_when_exists_not_identical
     migration_exists!
     create_migration { "different content" }


### PR DESCRIPTION
This is useful if users want to process generated files.
For example, can execute an autocorrect of RuboCop for generated files as like following.

```ruby
config.generators.after_generate do |files|
  system("bundle exec rubocop --auto-correct " + files.join(" "), exception: true)
end
```