### PR TITLE
Improve error message on validation when symbol resolves to nil

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -80,7 +80,9 @@ module ActiveModel
 
     private
       def parse_as_number(raw_value, precision, scale)
-        if raw_value.is_a?(Float)
+        if raw_value.nil?
+          raw_value
+        elsif raw_value.is_a?(Float)
           parse_float(raw_value, precision, scale)
         elsif raw_value.is_a?(Numeric)
           raw_value

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -302,6 +302,16 @@ class NumericalityValidationTest < ActiveModel::TestCase
     assert_raise(ArgumentError) { Topic.validates_numericality_of :approved, equal_to: "foo" }
   end
 
+  def test_validates_numericality_with_symbol_resolves_to_nil
+    error= assert_raises(ArgumentError) do
+      Topic.define_method(:max_approved) { nil }
+      Topic.validates_numericality_of :approved, less_than_or_equal_to: :max_approved
+      valid!([4])
+    end
+    assert_match "comparison of Integer with nil failed", error.message
+    Topic.remove_method :max_approved
+  end
+
   def test_validates_numericality_equality_for_float_and_big_decimal
     Topic.validates_numericality_of :approved, equal_to: BigDecimal("65.6")
 


### PR DESCRIPTION
### Summary

Improves the error message when comparing a field with another.
See discussion here: https://github.com/rails/rails/issues/27968.
At the moment this cases raises "TypeError: can't convert nil into Float" which makes it hard to understand what happened.

With this PR, the error will still be raised (as discussed in the above topic) but the error is "comparison of Integer with nil failed".

We could go one step forward and display a custom message as of 
"you tried to compare <field_name> with <other_field_name>, but <other_field_name> is `nil` and this is not possible." 

I'd be in for that, I personally ❤️ very detailed error messages which help you in solving the issues by pointing in the right direction, but I am not sure if it goes too far. 

Still, this PR brings already an improvement to the current behaviour.