### PR TITLE
Add description to db:rollback command for multiple databases [ci skip]

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -245,6 +245,7 @@ db_namespace = namespace :db do
 
   namespace :rollback do
     ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Rollback #{name} database for current environment (specify steps w/ STEP=n)."
       task name => :load_config do
         step = ENV["STEP"] ? ENV["STEP"].to_i : 1
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: name)

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -149,6 +149,9 @@ rails db:migrate:primary                 # Migrate primary database for current 
 rails db:migrate:status                  # Display status of migrations
 rails db:migrate:status:animals          # Display status of migrations for animals database
 rails db:migrate:status:primary          # Display status of migrations for primary database
+rails db:rollback                        # Rolls the schema back to the previous version (specify steps w/ STEP=n)
+rails db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
+rails db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
 rails db:schema:dump                     # Creates a db/schema.rb file that is portable against any DB supported  ...
 rails db:schema:dump:animals             # Creates a db/schema.rb file that is portable against any DB supported  ...
 rails db:schema:dump:primary             # Creates a db/schema.rb file that is portable against any DB supported  ...


### PR DESCRIPTION
`rails -T` command omits rake tasks that do not have a task description, so I added a description to `db:rollback` command for multiple databases and updated the documentation accordingly.
