### PR TITLE
Fix EagerLoadPolyAssocsTest setup

### DIFF
--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -20,8 +20,17 @@ module Remembered
   end
 
   module ClassMethods
-    def remembered; @@remembered ||= []; end
-    def sample; @@remembered.sample; end
+    def remembered
+      collection_name = "@@#{name.demodulize.underscore}_remembered"
+
+      if class_variable_defined?(collection_name)
+        class_variable_get(collection_name)
+      else
+        class_variable_set(collection_name, [])
+      end
+    end
+
+    def sample; remembered.sample; end
   end
 end
 

--- a/activerecord/test/cases/associations/eager_load_nested_include_test.rb
+++ b/activerecord/test/cases/associations/eager_load_nested_include_test.rb
@@ -20,16 +20,7 @@ module Remembered
   end
 
   module ClassMethods
-    def remembered
-      collection_name = "@@#{name.demodulize.underscore}_remembered"
-
-      if class_variable_defined?(collection_name)
-        class_variable_get(collection_name)
-      else
-        class_variable_set(collection_name, [])
-      end
-    end
-
+    def remembered; @remembered ||= []; end
     def sample; remembered.sample; end
   end
 end


### PR DESCRIPTION
### Summary

`EagerLoadPolyAssocsTest` includes a `Remembered` module in multiple test ActiveRecord classes. The module is supposed to keep track of records created for each of the included classes individually, but it collects all records for every class. This happens because `@@remembered` is defined on the `Remembered` module and shared between the ActiveRecord classes.

We can see this with a test like

```ruby
assert_equal NUM_SIMPLE_OBJS, Circle.remembered.length
```

`Circle.remembered.length` should only be 50 (`NUM_SIMPLE_OBJS`), but it's 350 because there are `NUM_SIMPLE_OBJS` being created for 7 AR classes.

This only becomes an issue for databases (like CockroachDB) that use [random primary keys instead of sequential ones by default](https://www.cockroachlabs.com/docs/v19.2/serial.html#modes-of-operation).

To fix the bug, we can make the remembered collection name unique per ActiveRecord class.

### Other Information

I'm not sure this is the best way to fix the test, but it was the path of least resistance. I'm open to suggestions! 😄


