### PR TITLE
[Proposal] Succinct version checks (e.g. Rails.v6_0?) when supporting multiple Rails versions

### DIFF
--- a/railties/test/version_test.rb
+++ b/railties/test/version_test.rb
@@ -11,4 +11,22 @@ class VersionTest < ActiveSupport::TestCase
     assert Rails.gem_version.is_a? Gem::Version
     assert_equal Rails.version, Rails.gem_version.to_s
   end
+
+  def test_version_predicates
+    assert_respond_to Rails, :v9?
+    assert_respond_to Rails, :v9_0?
+    assert_respond_to Rails, :v9_99?
+    assert_respond_to Rails, :v9_0_0?
+    assert_respond_to Rails, :v9_99_99?
+    assert_respond_to Rails, :v9_0_0_0?
+    assert_respond_to Rails, :v9_99_99_99?
+
+    assert Rails.send("v#{Rails::VERSION::MAJOR}?")
+    assert Rails.send("v#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}?")
+    assert Rails.send("v#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}_#{Rails::VERSION::TINY}?")
+
+    assert_not Rails.send("v#{Rails::VERSION::MAJOR - 1}?")
+    assert_not Rails.send("v#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR + 1}?")
+    assert_not Rails.send("v#{Rails::VERSION::MAJOR}_#{Rails::VERSION::MINOR}_#{Rails::VERSION::TINY - 1}?")
+  end
 end


### PR DESCRIPTION
When writing code to be compatible with multiple Rails versions, its handy to have a succinct way to check the version.

Say you're upgrading an app from Rails 5.2 to 6.0 and the app needs to be compatible with both versions, you might have some code that only runs `if Rails.v5_2?` or `if Rails.v6_0?`.

I've been using these `Rails.vX_Y?` checks on upgrades after learning about GitHub and Shopify's approach to upgrading their apps by running different Rails versions side-by-side.

Here's an example from a GitHub blog post on how they upgraded to 5.2 where methods like these could be useful:

```diff
-if GitHub.rails_3_2?
+if Rails.v3_2?
  ## 3.2 code (i.e. production a year and a half ago)
-elsif GitHub.rails_4_2?
+elsif Rails.v4_2?
```
https://github.blog/2018-09-28-upgrading-github-from-rails-3-2-to-5-2/

There are a few apps following this approach to upgrades with each writing their own variation of these `GitHub.rails_X_Y?` methods. It'd be nice to provide a common alternative.

Here's another possible use [taken from camaleon-cms](https://github.com/owen2345/camaleon-cms/blob/19369328a6d70859657c9bcae76747e9ca15ddfb/lib/camaleon_cms/engine.rb#L22-L30):

```diff
-require 'draper' if PluginRoutes.isRails4?
+require 'draper' if Rails.v4?
...
-app.config.active_record.belongs_to_required_by_default = false if PluginRoutes.isRails5? || PluginRoutes.isRails6?
+app.config.active_record.belongs_to_required_by_default = false if Rails.v5? || Rails.v6?
```

The code here is just a proposal and needs refining. I do wonder if it supports too fine-grained versions like `v5_2_0_1?` that might never be used. This could be dropped.

Feedback welcome, and thanks for taking a look :-)