### PR TITLE
Fix random CI fail due to auto-updating timestamp

### DIFF
--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -22,6 +22,9 @@ class JobSerializationTest < ActiveSupport::TestCase
   end
 
   test "serialize and deserialize are symmetric" do
+    # Ensure `enqueued_at` does not change between serializations
+    freeze_time
+
     # Round trip a job in memory only
     h1 = HelloJob.new("Rafael")
     h2 = HelloJob.deserialize(h1.serialize)


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/68074#0fe7ca54-fcce-4a47-85db-a784275c8f51/1115-1125

Each time a job is serialized, [`enqueued_at` is updated](https://github.com/rails/rails/blob/834f5414c3b879a3a50c5cac128c9d9b007fa569/activejob/lib/active_job/core.rb#L105).  Thus, separate serializations of the same job can have different `enqueued_at` timestamps if the serializations do not occur within the same second.
