### PR TITLE
Make host authorization display consistent host message in debug view

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -57,6 +57,9 @@ module ActionDispatch
       request = Request.new(env)
 
       format = request.xhr? ? "text/plain" : "text/html"
+      # SERVER_NAME is not used for authorization
+      # so display it in debug view may be misleading
+      request.set_header("SERVER_NAME", nil)
       template = DebugView.new(host: request.host)
       body = template.render(template: "rescues/blocked_host", layout: "rescues/layout")
 

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -135,6 +135,18 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_match "Blocked host: localhost", response.body
   end
 
+  test "doesn't display SERVER_NAME in debug message" do
+    @app = ActionDispatch::HostAuthorization.new(App, "localhost")
+
+    get "/", env: {
+      "SERVER_NAME" => "www.example.com",
+      "HOST" => ""
+    }
+
+    assert_response :forbidden
+    assert_match "<h1>Blocked host: </h1>", response.body
+  end
+
   test "forwarded hosts should be permitted" do
     @app = ActionDispatch::HostAuthorization.new(App, "domain.com")
 


### PR DESCRIPTION
Rails doesn't use the SERVER_NAME header in host authorization.
But when displaying the host in debug view, it uses `ActionDispatch::Request#host`, which can get the host from `HTTP_HOST`, `HTTP_X_FORWARDED_HOST` and `SERVER_NAME` headers. And this makes it return confusing debugging messages when `HTTP_HOST` is empty but `SERVER_NAME` is present.

