### PR TITLE
Fix random CI fail due to cross-second time delay

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -649,7 +649,10 @@ module ActiveJob
 
       def prepare_args_for_assertion(args)
         args.dup.tap do |arguments|
-          arguments[:at] = round_time_arguments(arguments[:at]) if arguments[:at]
+          if arguments[:at]
+            at_range = arguments[:at] - 1..arguments[:at] + 1
+            arguments[:at] = ->(at) { at_range.cover?(at) }
+          end
           arguments[:args] = round_time_arguments(arguments[:args]) if arguments[:args]
         end
       end
@@ -669,7 +672,7 @@ module ActiveJob
 
       def deserialize_args_for_assertion(job)
         job.dup.tap do |new_job|
-          new_job[:at] = round_time_arguments(Time.at(new_job[:at])) if new_job[:at]
+          new_job[:at] = Time.at(new_job[:at]) if new_job[:at]
           new_job[:args] = ActiveJob::Arguments.deserialize(new_job[:args]) if new_job[:args]
         end
       end


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/68010#749ce70d-1e01-4419-90e5-ee4531f66466/1057-1069

Support for testing jobs with a relative time delay was added in #36767.  It was implemented by truncating the `usec` portion of the `at` time in order to allow for sub-second time differences.  However, sub-second time differences can occur across seconds.  Thus, this commit changes `at` time matching to use an explicit time range.
