### PR TITLE
`ActionView::Base.annotate_template_file_names` only annotates HTML

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -59,6 +59,7 @@ module ActionView
             erb,
             escape: (self.class.escape_ignore_list.include? template.type),
             trim: (self.class.erb_trim_mode == "-"),
+            format: template.format,
             short_identifier: template.short_identifier
           ).src
         end

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -14,7 +14,8 @@ module ActionView
             # Dup properties so that we don't modify argument
             properties = Hash[properties]
 
-            if ActionView::Base.annotate_template_file_names
+            # Annotate output with template file names, if we're rendering HTML
+            if ActionView::Base.annotate_template_file_names && properties[:format] == :html
               properties[:preamble]   = "@output_buffer.safe_append='<!-- BEGIN #{properties[:short_identifier]} -->\n';"
               properties[:postamble]  = "@output_buffer.safe_append='<!-- END #{properties[:short_identifier]} -->\n';@output_buffer.to_s"
             else

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1457,17 +1457,28 @@ class RenderTest < ActionController::TestCase
   def test_template_annotations
     ActionView::Base.annotate_template_file_names = true
 
-    get :render_with_explicit_template_with_locals
+    get :greeting
 
     lines = @response.body.split("\n")
 
     assert_includes lines.first, "<!-- BEGIN"
-    assert_includes lines.first, "test/fixtures/actionpack/test/render_file_with_locals.erb -->"
+    assert_includes lines.first, "test/fixtures/actionpack/test/greeting.html.erb -->"
 
-    assert_includes lines[1], "The secret is area51"
+    assert_includes lines[1], "This is grand!"
 
     assert_includes lines.last, "<!-- END"
-    assert_includes lines.last, "test/fixtures/actionpack/test/render_file_with_locals.erb -->"
+    assert_includes lines.last, "test/fixtures/actionpack/test/greeting.html.erb -->"
+  ensure
+    ActionView::Base.annotate_template_file_names = false
+  end
+
+  def test_template_annotations_do_not_render_for_non_html_format
+    ActionView::Base.annotate_template_file_names = true
+
+    get :render_with_explicit_template_with_locals
+
+    assert_not_includes @response.body, "BEGIN"
+    assert_equal @response.body.split("\n").length, 1
   ensure
     ActionView::Base.annotate_template_file_names = false
   end


### PR DESCRIPTION
In testing https://github.com/rails/rails/pull/38848 in the
GitHub monolith, we realized that we probably should only
be annotating HTML output with these comments, at least
in their current format. 

By passing `format` to `erb_implementation`, we set ourselves up to eventually
support annotations for other formats as well.

cc @tenderlove @eileencodes 