### PR TITLE
Build Journey::Path::Pattern ast in a single loop

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -41,14 +41,14 @@ module ActionDispatch
         end
 
         def ast
-          @spec.find_all(&:symbol?).each do |node|
-            re = @requirements[node.to_sym]
-            node.regexp = re if re
-          end
-
-          @spec.find_all(&:star?).each do |node|
-            node = node.left
-            node.regexp = @requirements[node.to_sym] || /(.+)/
+          @spec.each do |node|
+            if node.symbol?
+              re = @requirements[node.to_sym]
+              node.regexp = re if re
+            elsif node.star?
+              node = node.left
+              node.regexp = @requirements[node.to_sym] || /(.+)/
+            end
           end
 
           @spec


### PR DESCRIPTION
### Summary

This PR makes a small performance enhancement by building Journey::Path::Pattern ast using a single `each` loop.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

require "action_dispatch/journey/path/pattern"

module ActionDispatch
  module Journey
    module Path
      class Pattern
        def fast_ast
          @spec.each do |node|
            if node.symbol?
              re = @requirements[node.to_sym]
              node.regexp = re if re
            elsif node.star?
              node = node.left
              node.regexp = @requirements[node.to_sym] || /(.+)/
            end
          end

          @spec
        end
      end
    end
  end
end

path = ActionDispatch::Journey::Path::Pattern.from_string "/page/:id(/:action)(.:format)"

puts "IPS"

Benchmark.ips do |x|
  x.report("ast")      { path.ast }
  x.report("fast_ast") { path.fast_ast }
  x.compare!
end

puts "MEMORY"

Benchmark.memory do |x|
  x.report("ast")      { path.ast }
  x.report("fast_ast") { path.fast_ast }
  x.compare!
end
```
### Results
```
IPS
Warming up --------------------------------------
                 ast     7.572k i/100ms
            fast_ast    16.195k i/100ms
Calculating -------------------------------------
                 ast     78.133k (± 2.1%) i/s -    393.744k in   5.041539s
            fast_ast    165.113k (± 2.5%) i/s -    825.945k in   5.005666s

Comparison:
            fast_ast:   165112.9 i/s
                 ast:    78132.7 i/s - 2.11x  slower

MEMORY
Calculating -------------------------------------
                 ast   240.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
            fast_ast    80.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
            fast_ast:         80 allocated
                 ast:        240 allocated - 3.00x more
```