### PR TITLE
Update the Active Model error treated as hash deprecation warning

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -230,7 +230,8 @@ module ActiveModel
           parameter like this:
 
           person.errors.each do |error|
-            error.full_message
+            attribute = error.attribute
+            message = error.message
           end
 
           You are passing a block expecting two parameters,


### PR DESCRIPTION
### Summary

This message more clearly communicates how to access the attribute and message keys that you would expect to get when using the previous API.

before you might iterate over errors like,

```ruby
errors.each do |attribute, message|
  # My error code here
end
```

This message helps the user find the methods on error that match the previous API.