### PR TITLE
Add attribute_names method on errors

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -263,6 +263,14 @@ module ActiveModel
       keys.freeze
     end
 
+    # Returns all error attribute names
+    #
+    #   person.errors.messages        # => {:name=>["cannot be nil", "must be specified"]}
+    #   person.errors.attribute_names # => [:name]
+    def attribute_names
+      @errors.map(&:attribute).uniq.freeze
+    end
+
     # Returns an xml formatted representation of the Errors hash.
     #
     #   person.errors.add(:name, :blank, message: "can't be blank")

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -167,6 +167,30 @@ class ErrorsTest < ActiveModel::TestCase
     end
   end
 
+  test "attribute_names returns the error attributes" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:foo, "omg")
+    errors.add(:baz, "zomg")
+
+    assert_equal [:foo, :baz], errors.attribute_names
+  end
+
+  test "attribute_names only returns unique attribute names" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:foo, "omg")
+    errors.add(:foo, "zomg")
+
+    assert_equal [:foo], errors.attribute_names
+  end
+
+  test "attribute_names returns an empty array after try to get a message only" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.messages[:foo]
+    errors.messages[:baz]
+
+    assert_equal [], errors.attribute_names
+  end
+
   test "detecting whether there are errors with empty?, blank?, include?" do
     person = Person.new
     person.errors[:foo]


### PR DESCRIPTION
### Summary

This method replaces the `keys` method on `errors` as a way to get the error attribute names from the errors object without treating `errors` like a hash.

### Other Information

I believe `keys` is deprecated because `errors` are being treated more like an array than a hash going forward, so the main reason for deprecating it is to update that API. Being able to access all the attributes you have errors for is still a useful feature.