### PR TITLE
Fix `ActiveSupport::CurrentAttributes` attributes to be thread local.

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -148,7 +148,8 @@ module ActiveSupport
         end
 
         def current_instances
-          Thread.current[:current_attributes_instances] ||= {}
+          Thread.current.thread_variable_get(:current_attributes_instances) ||
+            Thread.current.thread_variable_set(:current_attributes_instances, {})
         end
 
         def current_instances_key

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -50,6 +50,22 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     Time.zone = @original_time_zone
   end
 
+  test "attribute is local to the current thread" do
+    Current.world = "world/1"
+
+    Thread.new do
+      assert_nil Current.world
+    end.join
+  end
+
+  test "attribute is not local to current fibre" do
+    Current.world = "world/1"
+
+    Fibre.new do
+      assert_equal "world/1", Current.world
+    end.resume
+  end
+
   test "read and write attribute" do
     Current.world = "world/1"
     assert_equal "world/1", Current.world


### PR DESCRIPTION
### Summary

`Thread#[]` and `Thread#[]=` are getting or setting a fibre-local variable when we want a thread local variable in this case. Instead we need to use `Thread#thread_variable_get` or `Thread#thread_variable_set`.

From Ruby API doc:

>thr[sym] → obj or nilclick to toggle source
Attribute Reference—Returns the value of a fiber-local variable (current thread's root fiber if not explicitly inside a Fiber), using either a symbol or a string name. If the specified variable does not exist, returns nil.

> thr[sym] = obj → objclick to toggle source
Attribute Assignment—Sets or creates the value of a fiber-local variable, using either a symbol or a string.
> See also #[].
> For thread-local variables, please see thread_variable_set and thread_variable_get.