### PR TITLE
Add .yardoc to generated plugin .gitignore

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/gitignore.tt
@@ -1,4 +1,5 @@
 /.bundle/
+/.yardoc
 /doc/
 /log/*.log
 /pkg/


### PR DESCRIPTION
Although Rails uses RDoc, Yard is also a popular choice.  If the Yard gem is installed, the `yard doc` command will generate documentation for a plugin without the need for a Rake task or other configuration.  Doing so generates `doc/` and `.yardoc/` directories.  The former is already in the generated `.gitignore` file.  This commit adds the latter.
