### PR TITLE
Do not expose association relation in the API doc [ci skip]

### DIFF
--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  class AssociationRelation < Relation
+  class AssociationRelation < Relation # :nodoc:
     def initialize(klass, association, **)
       super(klass)
       @association = association

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -920,7 +920,7 @@ module ActiveRecord
         !!@association.include?(record)
       end
 
-      def proxy_association
+      def proxy_association # :nodoc:
         @association
       end
 


### PR DESCRIPTION
`Association` and `AssociationRelation` are implementation details, I do
not want to expose those internals in the API doc, and people basically
should not rely on those internals.

https://github.com/rails/rails/blob/8544c9c23687964ab754c06a7745215a5369a4e0/activerecord/lib/active_record/associations/association.rb
https://github.com/rails/rails/blob/8544c9c23687964ab754c06a7745215a5369a4e0/activerecord/lib/active_record/association_relation.rb

As a side note, `record.association(:name)` is also private API.

https://github.com/rails/rails/blob/8544c9c23687964ab754c06a7745215a5369a4e0/activerecord/lib/active_record/associations.rb#L228-L240
