### PR TITLE
Reduce calls to get path info when finding routes

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -106,8 +106,9 @@ module ActionDispatch
         end
 
         def find_routes(req)
-          routes = filter_routes(req.path_info).concat custom_routes.find_all { |r|
-            r.path.match?(req.path_info)
+          path_info = req.path_info
+          routes = filter_routes(path_info).concat custom_routes.find_all { |r|
+            r.path.match?(path_info)
           }
 
           if req.head?
@@ -119,7 +120,7 @@ module ActionDispatch
           routes.sort_by!(&:precedence)
 
           routes.map! { |r|
-            match_data = r.path.match(req.path_info)
+            match_data = r.path.match(path_info)
             path_parameters = {}
             match_data.names.each_with_index { |name, i|
               val = match_data[i + 1]


### PR DESCRIPTION
### Summary

👋 I work for Shopify. Recently, I was doing some profiling of production requests in order to get a better understanding of where time goes for a subset of cache hits to our main application. These typically take 40-50ms. In particular, I was interested in what happens in our middleware stack and all the things we do on every request prior to doing the actual "work".

That led me to this (from a profile viewed in [Speedscope](https://github.com/jlfwong/speedscope)): 

<img width="662" alt="Screen Shot 2020-04-10 at 12 28 02 AM" src="https://user-images.githubusercontent.com/7451862/78962483-3b93af80-7ac2-11ea-9b50-3258682ce8a6.png">

<img width="714" alt="Screen Shot 2020-04-10 at 12 28 18 AM" src="https://user-images.githubusercontent.com/7451862/78962491-3e8ea000-7ac2-11ea-8287-ddaa5edfae65.png">

The calls to `Rack::Request::Helpers#path_info` were somewhat surprising. Taking a look at the code, that same function is called repeatedly for no good reason. So, I changed the code to simply keep it in a local variable and reuse the value.

I didn't write a benchmark because this change is pretty simple and straightforward. I also suspect it should have basically no performance effect on applications which have a small number of routes (it will save some allocations, however). I suspect this is noticeable at Shopify scale because of the sheer number of routes that need to be iterated over.