### PR TITLE
Fix db object to not return deprecated variable

### DIFF
--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -25,18 +25,15 @@ module ActiveRecord
     #   database adapter, name, and other important information for database
     #   connections.
     class HashConfig < DatabaseConfig
-      def initialize(env_name, name, config)
+      attr_reader :configuration_hash
+      def initialize(env_name, name, configuration_hash)
         super(env_name, name)
-        @config = config.symbolize_keys
+        @configuration_hash = configuration_hash.symbolize_keys.freeze
       end
 
       def config
         ActiveSupport::Deprecation.warn("DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys")
         configuration_hash.stringify_keys
-      end
-
-      def configuration_hash
-        @config.freeze
       end
 
       # Determines whether a database configuration is for a replica / readonly
@@ -62,7 +59,7 @@ module ActiveRecord
       end
 
       def _database=(database) # :nodoc:
-        @config = configuration_hash.dup.merge(database: database).freeze
+        @configuration_hash = configuration_hash.merge(database: database).freeze
       end
 
       def pool

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -31,11 +31,11 @@ module ActiveRecord
     class UrlConfig < HashConfig
       attr_reader :url
 
-      def initialize(env_name, name, url, config = {})
-        super(env_name, name, config)
+      def initialize(env_name, name, url, configuration_hash = {})
+        super(env_name, name, configuration_hash)
 
         @url = url
-        @config.merge!(build_url_hash)
+        @configuration_hash = @configuration_hash.merge(build_url_hash).freeze
       end
 
       private


### PR DESCRIPTION
Calling `db_config.config` was deprecated in #37185 in favor of
`db_config.configuration_hash`. When returning the objects from
`configurations` we should ensure the object returns the non-deprecated
method.

Before:

```
<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007ff0f61696a0
@env_name="development", @name="primary", @config={:adapter=>"mysql2",
:database=>"recipes_development"}>
```

After:

```
<ActiveRecord::DatabaseConfigurations::HashConfig:0x00007ff0f61696a0
@env_name="development", @name="primary", @configuration_hash={:adapter=>"mysql2",
:database=>"recipes_development"}>
```

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>
