### PR TITLE
Add Action Mailer :sender_host option

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -930,7 +930,7 @@ module ActionMailer
 
         headers_with_defaults = headers.reverse_merge(default_values)
         headers_with_defaults[:subject] ||= default_i18n_subject
-        headers_with_defaults
+        apply_sender_host(headers_with_defaults)
       end
 
       def compute_default(value)
@@ -941,6 +941,18 @@ module ActionMailer
         else
           instance_exec(&value)
         end
+      end
+
+      def apply_sender_host(headers)
+        sender_host = headers.delete(:sender_host)
+
+        [:from, :reply_to].each do |key|
+          if sender_host && headers[key].present? && !headers[key].include?("@")
+            headers[key] += "@#{sender_host}"
+          end
+        end
+
+        headers
       end
 
       def assign_headers_to_message(message, headers)

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -28,6 +28,10 @@ module ActionMailer
         options.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/test/mailers/previews" : nil
       end
 
+      default_url_host = options.dig(:default_url_options, :host) || app.default_url_options[:host]
+      options.default_options ||= {}
+      options.default_options[:sender_host] ||= default_url_host if default_url_host
+
       # make sure readers methods get compiled
       options.asset_host          ||= app.config.asset_host
       options.relative_url_root   ||= app.config.relative_url_root


### PR DESCRIPTION
When `sender_host` is set, it will be appended to `from` and `reply_to` values that do not include an `"@"`.  Additionally, `sender_host` will default to `default_url_options[:host]` if it is defined.

For example:

```ruby
# in config/application.rb
config.action_mailer.default_url_options = { host: "example.com" }

# in alert_mailer.rb
class AlertMailer < ActionMailer::Base
  def alert_email
    mail(from: "no-reply", to: "...")
  end
end
```

...will use a final `from` value of `"no-reply@example.com"`.

This DRYs up configuration a bit, and it provides a way for third-party code (e.g. Devise mailers) to specify reasonable default `from` values.

---

This is an idea that I wanted to get feedback on.  I chose the name `sender_host` to mirror `default_url_options[:host]`, but there may be better names (e.g. `sender_domain`, or possibly simply `domain` to mirror `smtp_settings[:domain]`).

**TODO:**
- [ ] tests
- [ ] docs
- [ ] changelog?
