### PR TITLE
Fix random CI fail due to non-deterministic order

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -169,14 +169,14 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_limit_should_apply_before_count
-    accounts = Account.limit(4)
+    accounts = Account.order(:id).limit(4)
 
     assert_equal 3, accounts.count(:firm_id)
     assert_equal 3, accounts.select(:firm_id).count
   end
 
   def test_limit_should_apply_before_count_arel_attribute
-    accounts = Account.limit(4)
+    accounts = Account.order(:id).limit(4)
 
     firm_id_attribute = Account.arel_table[:firm_id]
     assert_equal 3, accounts.count(firm_id_attribute)


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/68187#333e3624-ac0d-4b23-95b9-f068d9901093/1016-1028

These tests expect the 2nd `Account` fixture (with a NULL `firm_id`) to be in the first four rows of the result set, but that behavior is not guaranteed without an `order`.
