### PR TITLE
Load XML Builder if it is not available

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -73,7 +73,7 @@ class Hash
   # configure your own builder with the <tt>:builder</tt> option. The method also accepts
   # options like <tt>:dasherize</tt> and friends, they are forwarded to the builder.
   def to_xml(options = {})
-    require "active_support/builder" unless defined?(Builder)
+    require "active_support/builder" unless defined?(Builder) && defined?(Builder::XmlMarkup)
 
     options = options.dup
     options[:indent]  ||= 2


### PR DESCRIPTION
### Summary

Loads Builder::XmlMarkup if it is not loaded.

### Other Information

Resolves issue #38937

Mitigation: In our rails application.rb, we load active_support/builder.