### PR TITLE
Typo fix for rails guide 

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1298,7 +1298,7 @@ This loads all the articles and the associated category and comments for each ar
 Category.includes(articles: [{ comments: :guest }, :tags]).find(1)
 ```
 
-This will find the category with id 1 and eager load all of the associated articles, the associated articles' tags and comments, and every comment's guest association.
+This will find the category with id 1 and eager load all of the associated articles, the associated article's tags and comments, and every comment's guest association.
 
 ### Specifying Conditions on Eager Loaded Associations
 


### PR DESCRIPTION
### Summary
There was a misplaces single quote in the documentation. This fixes that by updating the associated markdown file.

### Other Information
I didn't find a section for typos in the contributors guide. Sorry if I am opening the PR in a wrong way
