### PR TITLE
Update SchemaCacheTest#schema_dump_path

### DIFF
--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -269,7 +269,7 @@ module ActiveRecord
 
       private
         def schema_dump_path
-          "test/assets/schema_dump_5_1.yml"
+          "#{ASSETS_ROOT}/schema_dump_5_1.yml"
         end
     end
   end


### PR DESCRIPTION
### Summary

Use `ASSETS_ROOT` (defined in `activerecord/test/config.rb`) to guarantee a valid path to `schema_dump_5_1.yml`. This change makes it easier to run the test against other adapters.
