### PR TITLE
define enum setter methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add writer methods for all enum values.
+
+    Example:
+
+        class Post < ActiveRecord::Base
+          enum status: %i[ drafted active trashed ]
+        end
+
+        p.status # => "draft"
+        p.set_active # => 1
+        p.status # => "active"
+        p.reload.status # => "draft"
+
+    *Ritikesh*
+
 *   Prevent `build_association` from `touching` a parent record if the record isn't persisted for `has_one` associations.
 
     Fixes #38219

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -20,6 +20,12 @@ module ActiveRecord
   #   conversation.archived? # => true
   #   conversation.status    # => "archived"
   #
+  #   conversation.status    # => "archived"
+  #   conversation.set_active    # => 0
+  #   conversation.status    # => "active"
+  #   conversation.reload
+  #   conversation.status    # => "archived"
+  #
   #   # conversation.status = 1
   #   conversation.status = "archived"
   #
@@ -202,6 +208,10 @@ module ActiveRecord
             # def active!() update!(status: 0) end
             klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
             define_method("#{value_method_name}!") { update!(attr => value) }
+
+            # def set_active() write_attribute(:status, 0) end
+            klass.send(:detect_enum_conflict!, name, "set_#{value_method_name}")
+            define_method("set_#{value_method_name}") { write_attribute(attr, value) }
 
             # scope :active, -> { where(status: 0) }
             # scope :not_active, -> { where.not(status: 0) }

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -133,7 +133,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.set_spanish
+    @book.set_in_spanish
     assert_equal old_status, @book.changed_attributes[:status]
     assert_equal old_language, @book.changed_attributes[:language]
   end
@@ -152,7 +152,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.set_spanish
+    @book.set_in_spanish
     assert_equal [old_status, "proposed"], @book.changes[:status]
     assert_equal [old_language, "spanish"], @book.changes[:language]
   end
@@ -161,21 +161,21 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :published
-    @book.set_spanish
+    @book.set_in_spanish
     assert_equal old_status, @book.attribute_was(:status)
     assert_equal old_language, @book.attribute_was(:language)
   end
 
   test "enum attribute changed" do
     @book.status = :proposed
-    @book.set_french
+    @book.set_in_french
     assert @book.attribute_changed?(:status)
     assert @book.attribute_changed?(:language)
   end
 
   test "enum attribute changed to" do
     @book.status = :proposed
-    @book.set_french
+    @book.set_in_french
     assert @book.attribute_changed?(:status, to: "proposed")
     assert @book.attribute_changed?(:language, to: "french")
   end
@@ -184,7 +184,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.set_french
+    @book.set_in_french
     assert @book.attribute_changed?(:status, from: old_status)
     assert @book.attribute_changed?(:language, from: old_language)
   end
@@ -193,7 +193,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.set_french
+    @book.set_in_french
     assert @book.attribute_changed?(:status, from: old_status, to: "proposed")
     assert @book.attribute_changed?(:language, from: old_language, to: "french")
   end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -124,11 +124,16 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate @book, :written?
   end
 
+  test "method assignment" do
+    @book.set_written
+    assert_predicate @book, :written?
+  end
+
   test "enum changed attributes" do
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.language = :spanish
+    @book.set_spanish
     assert_equal old_status, @book.changed_attributes[:status]
     assert_equal old_language, @book.changed_attributes[:language]
   end
@@ -147,7 +152,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.language = :spanish
+    @book.set_spanish
     assert_equal [old_status, "proposed"], @book.changes[:status]
     assert_equal [old_language, "spanish"], @book.changes[:language]
   end
@@ -156,21 +161,21 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :published
-    @book.language = :spanish
+    @book.set_spanish
     assert_equal old_status, @book.attribute_was(:status)
     assert_equal old_language, @book.attribute_was(:language)
   end
 
   test "enum attribute changed" do
     @book.status = :proposed
-    @book.language = :french
+    @book.set_french
     assert @book.attribute_changed?(:status)
     assert @book.attribute_changed?(:language)
   end
 
   test "enum attribute changed to" do
     @book.status = :proposed
-    @book.language = :french
+    @book.set_french
     assert @book.attribute_changed?(:status, to: "proposed")
     assert @book.attribute_changed?(:language, to: "french")
   end
@@ -179,7 +184,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.language = :french
+    @book.set_french
     assert @book.attribute_changed?(:status, from: old_status)
     assert @book.attribute_changed?(:language, from: old_language)
   end
@@ -188,7 +193,7 @@ class EnumTest < ActiveRecord::TestCase
     old_status = @book.status
     old_language = @book.language
     @book.status = :proposed
-    @book.language = :french
+    @book.set_french
     assert @book.attribute_changed?(:status, from: old_status, to: "proposed")
     assert @book.attribute_changed?(:language, from: old_language, to: "french")
   end
@@ -202,7 +207,7 @@ class EnumTest < ActiveRecord::TestCase
   test "persist changes that are dirty" do
     @book.status = :proposed
     assert @book.attribute_changed?(:status)
-    @book.status = :written
+    @book.set_written
     assert @book.attribute_changed?(:status)
   end
 


### PR DESCRIPTION
```ruby
class Post < ActiveRecord::Base
  enum status: %i[ drafted active trashed ]
end

post.status # => "drafted"
post.set_active  # => 1
post.status # => "active"
post.reload.status # => "drafted"
```
Useful when you want to update multiple attributes along with the enum attribute. Helps in not sprinkling explicit enum symbols/strings in your controllers/modules. 
```ruby
class PostsController < ApplicationController
  ....
  def save_draft
    @post.body = params[:body]
    @post.set_drafted
    # @post.save
  end
  
  def publish
    @post.active!
  end
  
  def mark_spam
    @post.spam = true
    @post.set_trashed
    # @post.save
  end
  ...
end
```