### PR TITLE
Correct ruby-pg repo link in rdocs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -56,7 +56,7 @@ module ActiveRecord
   end
 
   module ConnectionAdapters
-    # The PostgreSQL adapter works with the native C (https://bitbucket.org/ged/ruby-pg) driver.
+    # The PostgreSQL adapter works with the native C (https://github.com/ged/ruby-pg) driver.
     #
     # Options:
     #


### PR DESCRIPTION
### Summary

Updated rdoc with the `ruby-pg` driver link.

From bitbucket (was not accessible) to Github.
`https://github.com/ged/ruby-pg`