### PR TITLE
use number instead of string in application.rb in Rails guide

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -263,7 +263,7 @@ The default configuration for Rails 6
 ```ruby
 # config/application.rb
 
-config.load_defaults "6.0"
+config.load_defaults 6.0
 ```
 
 enables `zeitwerk` autoloading mode on CRuby. In that mode, autoloading, reloading, and eager loading are managed by [Zeitwerk](https://github.com/fxn/zeitwerk).


### PR DESCRIPTION
Creating a new Rails 6.0.2.2 application, `config/application.rb` shows the following:

```ruby
    # Initialize configuration defaults for originally generated Rails version.
    config.load_defaults 6.0
```

However, the documentation instead used a string:

```ruby
    # Initialize configuration defaults for originally generated Rails version.
    config.load_defaults "6.0"
```

This PR changes the documentation to reflect the current default `application.rb` in a new Rails 6.0 application.