### PR TITLE
S3 download's upper bound should not exceed content_length

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -137,7 +137,9 @@ module ActiveStorage
 
         raise ActiveStorage::FileNotFoundError unless object.exists?
 
-        while offset < object.content_length
+        content_length = object.content_length
+        while offset < content_length
+          chunk_size = [chunk_size, content_length - offset].min
           yield object.get(range: "bytes=#{offset}-#{offset + chunk_size - 1}").body.string.force_encoding(Encoding::BINARY)
           offset += chunk_size
         end


### PR DESCRIPTION
(big value give errors with some other S3 providers).

### Summary

Some S3 provider give error on ActiveStorage Preview operation.

It appears because ActiveStorage::Service::S3Service try download big chunks (5 megabytes):

I append checks and fix upper bound.