### PR TITLE
Filter sensitive parameters in `ActiveJob` logs by default

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add an option to filter sensitive values of job's arguments.
+
+    ```ruby
+      class SensitiveJob < ApplicationJob
+        self.filter_arguments = [:password]
+
+        def perform(my_sensitive_argument)
+        end
+      end
+    ```
+
+    By default, `filter_arguments` is set `Rails.application.config.filter_parameters`  by Railtie hook.
+
+    *Igor Springer*
+
 *   While using `perform_enqueued_jobs` test helper enqueued jobs must be stored for the later check with
     `assert_enqueued_with`.
 

--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -107,10 +107,26 @@ module ActiveJob
       def args_info(job)
         if job.class.log_arguments? && job.arguments.any?
           " with arguments: " +
-            job.arguments.map { |arg| format(arg).inspect }.join(", ")
+            job.arguments
+              .map { |arg| filter(job.class.filter_arguments, arg) }
+              .map { |arg| format(arg).inspect }
+              .join(", ")
         else
           ""
         end
+      end
+
+      def filter(filter_arguments, arg)
+        case arg
+        when Hash
+          parameter_filter(filter_arguments).filter(arg)
+        else
+          arg
+        end
+      end
+
+      def parameter_filter(filter_arguments)
+        @parameter_filter ||= ActiveSupport::ParameterFilter.new(filter_arguments)
       end
 
       def format(arg)

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -11,6 +11,7 @@ module ActiveJob
     included do
       cattr_accessor :logger, default: ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
       class_attribute :log_arguments, instance_accessor: false, default: true
+      class_attribute :filter_arguments, instance_accessor: false, default: []
 
       around_enqueue { |_, block| tag_logger(&block) }
       around_perform { |job, block| tag_logger(job.class.name, job.job_id, &block) }

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -36,6 +36,12 @@ module ActiveJob
       end
     end
 
+    initializer "active_job.set_filter_arguments" do
+      ActiveSupport.on_load(:active_job) do
+        self.filter_arguments += Rails.application.config.filter_parameters
+      end
+    end
+
     initializer "active_job.set_reloader_hook" do |app|
       ActiveSupport.on_load(:active_job) do
         ActiveJob::Callbacks.singleton_class.set_callback(:execute, :around, prepend: true) do |_, inner|

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -864,6 +864,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_job.log_arguments` controls if the arguments of a job are logged. Defaults to `true`.
 
+* `config.active_job.filter_arguemnts` controls which sensitive argument values should be filtered. Works when arguments are passed as `Hash`. Defaults to `Rails.application.config.filter_parameters` (set by Railtie hook).
+
 * `config.active_job.retry_jitter` controls the amount of "jitter" (random variation) applied to the delay time calculated when retrying failed jobs. Defaults to `0.15`.
 
 ### Configuring Action Cable

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2553,6 +2553,15 @@ module ApplicationTests
       assert_equal [ :password, :credit_card_number ], ActiveRecord::Base.filter_attributes
     end
 
+    test "ActiveJob::Base.filter_arguments should equal to filter_parameters" do
+      app_file "config/initializers/filter_parameters_logging.rb", <<-RUBY
+        Rails.application.config.filter_parameters += [ :password, :credit_card_number ]
+      RUBY
+      app "development"
+      assert_equal [ :password, :credit_card_number ], Rails.application.config.filter_parameters
+      assert_equal [ :password, :credit_card_number ], ActiveJob::Base.filter_arguments
+    end
+
     test "ActiveStorage.routes_prefix can be configured via config.active_storage.routes_prefix" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

`log_arguments` class boolean attribute introduced in https://github.com/rails/rails/pull/37660 allows disabling all the logs.

This commit implements an additional way to avoid leaking sensitive values by introducing another class attribute named `filter_arguments`. By default, it is set to `Rails.application.config.filter_parameters` which is commonly used to filter sensitive data.

There is one caveat though. My proposition works only with hashes as it is kinda hard to provide a bulletproof mechanism for all possible cases. On the other hand, based on my experience, hashes are commonly used as jobs' arguments.

This is my first contribution to Rails framework, so I am open to every suggestion. Thank you in advance.
