### PR TITLE
Use join in metal#render_to_string

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -39,13 +39,7 @@ module ActionController
     # Overwrite render_to_string because body can now be set to a Rack body.
     def render_to_string(*)
       result = super
-      if result.respond_to?(:each)
-        string = +""
-        result.each { |r| string << r }
-        string
-      else
-        result
-      end
+      result.is_a?(Array) ? result.join : result
     end
 
     def render_to_body(options = {})


### PR DESCRIPTION
### Summary

This PR simply changes manually looping and concatenating an Array into a string for a `join`.

In Metal#render_to_string, we are looping through Array results and concatenating it manually to the final response. I couldn't find any specific reason of why that would be. Using `<<` will fail for objects that don't have an implicit conversion to String, so I believe switching to join is safe.

Also, based on the tests, `result` is either a String/Buffer or an Array, so I switched from `respond_to?` to `is_a?`.

Let me know if these assumptions are valid.

#### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActionController
  module Rendering
    def fast_render_to_string(*)
      result = super
      result.is_a?(Array) ? result.join : result
    end
  end
end

class Parent
  RESPONSE = (0..50).map { |i| "some_response_part_#{i}" }

  def fast_render_to_string(*)
    RESPONSE
  end

  def render_to_string(*)
    RESPONSE
  end
end

class Child < Parent
  include ActionController::Rendering
end

child = Child.new

Benchmark.ips do |x|
  x.report("render_to_string")      { child.render_to_string }
  x.report("fast_render_to_string") { child.fast_render_to_string }
  x.compare!
end

Benchmark.memory do |x|
  x.report("render_to_string")      { child.render_to_string }
  x.report("fast_render_to_string") { child.fast_render_to_string }
  x.compare!
end
```
#### Results
```
IPS
Warming up --------------------------------------
    render_to_string    12.722k i/100ms
fast_render_to_string
                        27.850k i/100ms
Calculating -------------------------------------
    render_to_string    181.494k (±16.3%) i/s -    852.374k in   5.000940s
fast_render_to_string
                        388.692k (±21.6%) i/s -      1.755M in   5.003886s

Comparison:
fast_render_to_string:   388691.9 i/s
    render_to_string:   181493.8 i/s - 2.14x  slower

MEMORY
Calculating -------------------------------------
    render_to_string     1.656k memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
fast_render_to_string
                         1.183k memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
fast_render_to_string:       1183 allocated
    render_to_string:       1656 allocated - 1.40x more
```