### PR TITLE
Don't gitignore tmp/pids/.keep

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -19,6 +19,11 @@
 <% if keeps? -%>
 !/log/.keep
 !/tmp/.keep
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep
 <% end -%>
 
 <% unless skip_active_storage? -%>


### PR DESCRIPTION
Since 04cfbc807f0567af5a27e8ba45eab52f7b9e6618, a keepfile is generated in `tmp/pids/` to ensure that the directory always exists. However, the gitignore pattern for `/tmp/*` meant it wasn't tracked in git.

To override that pattern we have to allow the `tmp/pids/` directory, ignore everything inside it, then finally allow `tmp/pids/.keep` again.