### PR TITLE
Add webpacker install instruction to guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -225,6 +225,29 @@ Hello, Rails!
 To begin with, let's get some text up on screen quickly. To do this, you need to
 get your Rails application server running.
 
+### Packaging frontend JS assets
+
+Before your server will run; you'll need a webpacker.yml to use the generated 
+source for your new project. This is to allow frontend assets to be built for 
+your rails application and support modern frontend tooling.
+
+By this point NodeJS and YARN should be setup. If they are not, please refer to
+the [#Installing Node.js and Yarn](#installing-node-js-and-yarn) section of this
+document.
+
+```bash
+$ bin/rails webpacker:install
+```
+
+If you have a specific frontend framework you'd like to work with, and Rails 
+has built-in support for those technologies, then you may find a more specific
+and helpful command for React, Angular, or other webpacker tooling by looking at
+all available webpacker commands.
+
+```bash
+$ bin/rails -T webpacker
+```
+
 ### Starting up the Web Server
 
 You actually have a functional Rails application already. To see it, you need to


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Adds section for webpacker install to guides, with signposting to explore further webpacker tasks.

Fixes #38954

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

I have been told #38954 is duplicate. I'd agree if it were not for the still missing commands. This has been an issue for at least 10 months [reddit post](https://www.reddit.com/r/rails/comments/by5b24/error_while_starting_rails_server_v600/)

I've personally never run into this before a recent error making a new rails app. It may be because team-mates had already helped me by performing this step, or that I was not making new rails applications often enough to remember.

Thank you for all the hard work making the framework.