### PR TITLE
Convert CoffeeScript to ES6 syntax

### DIFF
--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -12,11 +12,11 @@ module ActionCable
       #   </head>
       #
       # This is then used by Action Cable to determine the URL of your WebSocket server.
-      # Your CoffeeScript can then connect to the server without needing to specify the
+      # Your JavaScript can then connect to the server without needing to specify the
       # URL directly:
       #
-      #   #= require cable
-      #   @App = {}
+      #   window.Cable = require("@rails/actioncable")
+      #   window.App = {}
       #   App.cable = Cable.createConsumer()
       #
       # Make sure to specify the correct server location in each of your environment


### PR DESCRIPTION
### Summary

Convert CoffeeScript to ES6 syntax for the example in the comments.