### PR TITLE
Update ActiveRecord::OrTest#test_or_when_grouping

### DIFF
--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -95,7 +95,7 @@ module ActiveRecord
     end
 
     def test_or_when_grouping
-      groups = Post.where("id < 10").group("body").select("body, COUNT(*) AS c")
+      groups = Post.where("id < 10").group("body").select("body, COUNT(*) AS c").order("body DESC")
       expected = groups.having("COUNT(*) > 1 OR body like 'Such%'").to_a.map { |o| [o.body, o.c] }
       assert_equal expected, groups.having("COUNT(*) > 1").or(groups.having("body like 'Such%'")).to_a.map { |o| [o.body, o.c] }
     end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -95,9 +95,9 @@ module ActiveRecord
     end
 
     def test_or_when_grouping
-      groups = Post.where("id < 10").group("body").select("body, COUNT(*) AS c").order("body DESC")
-      expected = groups.having("COUNT(*) > 1 OR body like 'Such%'").to_a.map { |o| [o.body, o.c] }
-      assert_equal expected, groups.having("COUNT(*) > 1").or(groups.having("body like 'Such%'")).to_a.map { |o| [o.body, o.c] }
+      groups = Post.where("id < 10").group("body")
+      expected = groups.having("COUNT(*) > 1 OR body like 'Such%'").count
+      assert_equal expected, groups.having("COUNT(*) > 1").or(groups.having("body like 'Such%'")).count
     end
 
     def test_or_with_named_scope


### PR DESCRIPTION
### Summary

Update `ActiveRecord::OrTest#test_or_when_grouping` to fix flaky test issue.

This test case depends on an implicit order, but `ORDER` is not guaranteed in aggregate functions unless explicitly specified in many databases, including PostgreSQL and MySQL. Therefore, the test will intermittently fail:

```
--- expected
+++ actual
@@ -1 +1 @@
-[["hello", 6], ["Such a lovely day", 1]]
+[["Such a lovely day", 1], ["hello", 6]]
```

Because this test cares about returning the correct groups, adding an `order` clause to the groups will stabilize the order and shift the focus to the groups themselves.