### PR TITLE
Bugfix for Mime::Type::MimeTypeInvalid handling in ActionDispatch::DebugExceptions

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -61,7 +61,7 @@ module ActionDispatch
           begin
             content_type = request.formats.first
           rescue Mime::Type::InvalidMimeType
-            render_for_api_request(Mime[:text], wrapper)
+            content_type = Mime[:text]
           end
 
           if api_request?(content_type)


### PR DESCRIPTION
Explained thoroughly in #38977

The fix is easy, the work was in tracking it down!

### Summary

Errors that fire inside the ActionDispatch exception handling code can get swallowed easily since the code is attempting to fail safely. This patch fixes one such subtle failure when an API-only application attempts to rescue an InvalidMimeType exception.