### PR TITLE
Change the polymorphic associations: instead of the related_to_type be first, will be the related_to_id, because is more specific, until, more performatic for database

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -579,5 +579,8 @@
 
     *Michael Duchemin*
 
+*   Change order of index creation for polymorphic association on rails to improve performance on database queries. Exp: [:foo_id. :foo_type].
+
+    *Andre Leoni*
 
 Please check [6-0-stable](https://github.com/rails/rails/blob/6-0-stable/activerecord/CHANGELOG.md) for previous changes.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -184,7 +184,7 @@ module ActiveRecord
         end
 
         def column_names
-          columns.map(&:first)
+          columns.map(&:first).sort
         end
 
         def foreign_table_name

--- a/activerecord/test/cases/migration/references_index_test.rb
+++ b/activerecord/test/cases/migration/references_index_test.rb
@@ -57,7 +57,7 @@ module ActiveRecord
             t.references :foo, polymorphic: true, index: true
           end
 
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
+          assert connection.index_exists?(table_name, [:foo_id, :foo_type], name: :index_testings_on_and_foo_id_foo_type)
         end
       end
 
@@ -95,7 +95,7 @@ module ActiveRecord
             t.references :foo, polymorphic: true, index: true
           end
 
-          assert connection.index_exists?(table_name, [:foo_type, :foo_id], name: :index_testings_on_foo_type_and_foo_id)
+          assert connection.index_exists?(table_name, [:foo_id, :foo_type], name: :index_testings_on_foo_id_foo_type)
         end
       end
     end

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
       def test_creates_polymorphic_index
         add_reference table_name, :taggable, polymorphic: true, index: true
-        assert index_exists?(table_name, [:taggable_type, :taggable_id])
+        assert index_exists?(table_name, [:taggable_id, :taggable_type])
       end
 
       def test_creates_reference_type_column_with_default


### PR DESCRIPTION
### Summary

Talking with our DBA, she saw that ever that we create a polymorphic association, we have to init from the most specific data (_id) to the less specific data (_type). Unlike how rails is handling this.

This improves the performance of queries related to this data depending on the query.

### Example

If I have the test data:

```
type: bundle, id: 1
type: bundle, id: 2
type: bundle, id: 3
type: product, id: 1
type: product, id: 2
type: product, id: 3
```

As the rails is doing today, it will search for all type, and last for a specific ID.

With the suggested change, it will first search for the ID, so, It is faster because normally have more equal ids that types.


### About the tests

I tested locally, but with some difficulty. If someone more should test to me, I appreciate it.

### Workaround

Today, we are doing like as:

```
class CreateHubShipments < ActiveRecord::Migration[5.1]
  def change
    create_table :shipments do |t|
      t.references :shippable, polymorphic: true, null: false, index: false
      t.timestamps
    end

    add_index :hub_shipments,
              [:shippable_id, :shippable_type],
              name: :index_hub_shipments_on_shippable_id_and_shippable_type
  end
end
```

So, we follow our DBA's performance requirements.

### About the changes

If I sort an array, every same value with the sufix as `_id` will be first at the `_type`, so, to avoid many changes, I only added a `.sort` on the `column_fields`.

```
irb(main):006:0> test = ["test_type", "test_id"]
=> ["test_type", "test_id"]
irb(main):007:0> test.sort
=> ["test_id", "test_type"]
irb(main):008:0> 
```