### PR TITLE
Support duration method chaining

### DIFF
--- a/activesupport/lib/active_support/core_ext/numeric/time.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/time.rb
@@ -47,6 +47,23 @@ class Numeric
   end
   alias :week :weeks
 
+  # Returns a Duration instance matching the number of months provided.
+  #
+  #   2.months # => 2 months
+  def months
+    ActiveSupport::Duration.months(self)
+  end
+  alias :month :months
+
+
+  # Returns a Duration instance matching the number of years provided.
+  #
+  #   2.years # => 2 years
+  def years
+    ActiveSupport::Duration.years(self)
+  end
+  alias :year :years
+
   # Returns a Duration instance matching the number of fortnights provided.
   #
   #   2.fortnights # => 4 weeks

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -212,7 +212,7 @@ module ActiveSupport
     PARTS.each do |part|
       define_method(part) do
         self.value /= PARTS_IN_SECONDS[part].to_f
-        self.value.round(2).public_send(part)
+        self.value.public_send(part)
       end
       alias_method part.to_s.singularize, part
     end
@@ -385,7 +385,7 @@ module ActiveSupport
 
       parts.
         sort_by { |unit,  _ | PARTS.index(unit) }.
-        map     { |unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}" }.
+        map     { |unit, val| "#{val.round} #{val == 1 ? unit.to_s.chop : unit.to_s}" }.
         to_sentence(locale: ::I18n.default_locale)
     end
 

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -209,6 +209,14 @@ module ActiveSupport
         end
     end
 
+    PARTS.each do |part|
+      define_method(part) do
+        self.value /= PARTS_IN_SECONDS[part].to_f
+        self.value.round(2).public_send(part)
+      end
+      alias_method part.to_s.singularize, part
+    end
+
     def initialize(value, parts) #:nodoc:
       @value, @parts = value, parts
       @parts.reject! { |k, v| v.zero? } unless value == 0

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -78,6 +78,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "3600 seconds",                    (1.day / 24).inspect
   end
 
+  def test_method_chaining
+    assert_equal 1.day.hours, 24.hours
+    assert_equal 1.year.days.months.year, 1.year
+  end
+
   def test_inspect_locale
     current_locale = I18n.default_locale
     I18n.default_locale = :de


### PR DESCRIPTION
Closes #37749
## Issue
```ruby
[15] pry(main)> 1.hours.minutes
=> 3600 minutes
[16] pry(main)> 1.hours.seconds
=> 3600 seconds
[17] pry(main)> 1.days.minutes
=> 86400 minutes
[18] pry(main)> 1.days.hours.minutes
=> 311040000 minutes
[19] pry(main)> 1.hours.minutes.parts
=> [[:minutes, 3600]]
[20] pry(main)> 1.hours.minutes.value
=> 216000 
```
### Summary
This pr solve the registered [issue](https://github.com/rails/rails/issues/37749). It's about the method chaining of duration as mention above(see Issue section). The problem currently exists due to passing seconds value to the next chained [method call](https://github.com/rails/rails/blob/cf1abb775ef3949ea89f50e7ac939eb8230c4379/activesupport/lib/active_support/duration.rb#L429) and the passed seconds value is treated as the value for [called method](https://github.com/rails/rails/blob/cf1abb775ef3949ea89f50e7ac939eb8230c4379/activesupport/lib/active_support/duration.rb#L149-L173).eg: `1.days.minutes`, at first '1.days' works normal but then when calling `.minutes` it passes value **86400** returned from `1.days`. so now `.minutes` returns **86400 minutes**. 
  
In this PR I defined all the duration's [parts](https://github.com/rails/rails/blob/cf1abb775ef3949ea89f50e7ac939eb8230c4379/activesupport/lib/active_support/duration.rb#L125) instance method on `ActiveSupport::Duration` class and those methods convert value according to the method.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
A similar solution is suggested in pr [38308](https://github.com/rails/rails/pull/38308).
 
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
***After change***
```ruby
[1] pry(main)> 1.hours.minutes
=> 60 minutes
[2] pry(main)> 1.hours.seconds
=> 3600 seconds
[3] pry(main)> 1.days.minutes
=> 1440 minutes
[4] pry(main)> 1.days.hours.minutes
=> 1440 minutes
[5] pry(main)> 1.hours.minutes.parts
=> {:minutes=>60.0}
[6] pry(main)> 1.hours.minutes.value
=> 3600.0
[7] pry(main)> 3.months.year
=> 0 years
[8] pry(main)> 3.months.year.parts
=> {:years=>0.25}
```