### PR TITLE
Add missing backticks [ci skip]

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -303,6 +303,7 @@ class ApplicationRecord < ActiveRecord::Base
     shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
   }
 end
+```
 
 Then models can swap connections manually via the `connected_to` API:
 


### PR DESCRIPTION
Fixes the markdown by adding the missing backticks [ci skip].