### PR TITLE
Add web_image_content_types config option for ActiveStorage

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `config.active_storage.web_image_content_types` to allow applications
+    to add content types (like `image/webp`) in which variants can be processed,
+    instead of letting those images be converted to the fallback PNG format.
+
+    *Jeroen van Haperen*
+
 *   Add support for creating variants of `WebP` images out of the box.
 
     *Dino Maric*

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -53,8 +53,6 @@ require "ostruct"
 # * {ImageProcessing::Vips}[https://github.com/janko-m/image_processing/blob/master/doc/vips.md#methods]
 # * {ruby-vips reference}[http://www.rubydoc.info/gems/ruby-vips/Vips/Image]
 class ActiveStorage::Variant
-  WEB_IMAGE_CONTENT_TYPES = %w[ image/png image/jpeg image/jpg image/gif ]
-
   attr_reader :blob, :variation
   delegate :service, to: :blob
 
@@ -106,7 +104,7 @@ class ActiveStorage::Variant
 
     def specification
       @specification ||=
-        if WEB_IMAGE_CONTENT_TYPES.include?(blob.content_type)
+        if ActiveStorage.web_image_content_types.include?(blob.content_type)
           Specification.new \
             filename: blob.filename,
             content_type: blob.content_type,

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ActiveStorage::VariantWithRecord
-  WEB_IMAGE_CONTENT_TYPES = %w[ image/png image/jpeg image/jpg image/gif ]
-
   attr_reader :blob, :variation
 
   def initialize(blob, variation)
@@ -36,7 +34,7 @@ class ActiveStorage::VariantWithRecord
   private
     def transform_blob
       blob.open do |input|
-        if blob.content_type.in?(WEB_IMAGE_CONTENT_TYPES)
+        if blob.content_type.in?(ActiveStorage.web_image_content_types)
           variation.transform(input) do |output|
             yield io: output, filename: blob.filename, content_type: blob.content_type, service_name: blob.service.name
           end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -53,6 +53,7 @@ module ActiveStorage
   mattr_accessor :paths, default: {}
 
   mattr_accessor :variable_content_types,           default: []
+  mattr_accessor :web_image_content_types,          default: []
   mattr_accessor :binary_content_type,              default: "application/octet-stream"
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :content_types_allowed_inline,     default: []

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -41,6 +41,13 @@ module ActiveStorage
       image/webp
     )
 
+    config.active_storage.web_image_content_types = %w(
+      image/png
+      image/jpeg
+      image/jpg
+      image/gif
+    )
+
     config.active_storage.content_types_to_serve_as_binary = %w(
       text/html
       text/javascript
@@ -79,6 +86,7 @@ module ActiveStorage
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []
+        ActiveStorage.web_image_content_types = app.config.active_storage.web_image_content_types || []
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []
         ActiveStorage.service_urls_expire_in = app.config.active_storage.service_urls_expire_in || 5.minutes
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -902,6 +902,8 @@ You can find more detailed configuration options in the
 
 * `config.active_storage.variable_content_types` accepts an array of strings indicating the content types that Active Storage can transform through ImageMagick. The default is `%w(image/png image/gif image/jpg image/jpeg image/pjpeg image/tiff image/bmp image/vnd.adobe.photoshop image/vnd.microsoft.icon image/webp)`.
 
+* `config.active_storage.web_image_content_types` accepts an array of strings regarded as web image content types in which variants can be processed without being converted to the fallback PNG format. If you want to use `WebP` variants in your application you can add `image/webp` to this array. The default is `%w(image/png image/jpeg image/jpg image/gif)`.
+
 * `config.active_storage.content_types_to_serve_as_binary` accepts an array of strings indicating the content types that Active Storage will always serve as an attachment, rather than inline. The default is `%w(text/html
 text/javascript image/svg+xml application/postscript application/x-shockwave-flash text/xml application/xml application/xhtml+xml application/mathml+xml text/cache-manifest)`.
 


### PR DESCRIPTION
Add `config.active_storage.web_image_content_types` to allow applications
to add content types (like `image/webp`) in which variants can be processed,
instead of letting those images be converted to the fallback PNG format.

### Summary

The default options that are regarded as web image content types are `image/png image/jpeg image/jpg image/gif`. With this configuration addition the application can add new image formats like `image/webp` in which variants can be processed.

### Other Information

Idea to have the web image content types configurable is from @georgeclaghorn in comments on PR https://github.com/rails/rails/pull/38918
