### PR TITLE
Use __id__ to dedup records for transactional callbacks

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -101,7 +101,7 @@ module ActiveRecord
 
       def rollback_records
         return unless records
-        ite = records.uniq(&:object_id)
+        ite = records.uniq(&:__id__)
         already_run_callbacks = {}
         while record = ite.shift
           trigger_callbacks = record.trigger_transactional_callbacks?
@@ -121,7 +121,7 @@ module ActiveRecord
 
       def commit_records
         return unless records
-        ite = records.uniq(&:object_id)
+        ite = records.uniq(&:__id__)
         already_run_callbacks = {}
         while record = ite.shift
           if @run_commit_callbacks


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/38257.

While not a particularly good idea, it's possible to use `object_id` as an attribute name, typically by defining a polymorphic association named `object`. Since https://github.com/rails/rails/pull/36190, transactional callbacks deduplicate records by their `object_id`, but this causes incorrect behaviour when the record has an attribute with that name.

Using `__id__` instead makes a naming collision much less likely.