### PR TITLE
Update minimum Rack version to 2.0.9

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "rack",      "~> 2.0", ">= 2.0.8"
+  s.add_dependency "rack",      "~> 2.0", ">= 2.0.9"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/37974, if the `same_site:` option is set to `:none` when creating a cookie, it will be passed through to Rack. Support for `:none` was added in Rack 2.0.9, so we should bump the minimum required version to ensure it's available.