### PR TITLE
Add retry_jitter to 6.1 new framework defaults

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -159,10 +159,6 @@ module Rails
         when "6.1"
           load_defaults "6.0"
 
-          if respond_to?(:active_job)
-            active_job.retry_jitter = 0.15
-          end
-
           if respond_to?(:active_record)
             active_record.has_many_inversing = true
           end
@@ -172,6 +168,7 @@ module Rails
           end
 
           if respond_to?(:active_job)
+            active_job.retry_jitter = 0.15
             active_job.skip_after_callbacks_if_terminated = true
           end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -12,6 +12,9 @@
 # Track Active Storage variants in the database.
 # Rails.application.config.active_storage.track_variants = true
 
+# Apply random variation to the delay when retrying failed jobs.
+# Rails.application.config.active_job.retry_jitter = 0.15
+
 # Stop executing `after_enqueue`/`after_perform` callbacks if
 # `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
 # Rails.application.config.active_job.skip_after_callbacks_if_terminated = true


### PR DESCRIPTION
This was added to the defaults for new applications in https://github.com/rails/rails/pull/37923, but we also need an entry in the new framework defaults initializer for upgrading applications.