### PR TITLE
Preserve column comment on renaming column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Preserve column comment value on changing column name on MySQL.
+
+    *Islam Taha*
+
 *   Add support for `if_exists` option for removing an index.
 
     The `remove_index` method can take an `if_exists` option. If this is set to true an error won't be raised if the index doesn't exist.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -665,7 +665,8 @@ module ActiveRecord
           options = {
             default: column.default,
             null: column.null,
-            auto_increment: column.auto_increment?
+            auto_increment: column.auto_increment?,
+            comment: column.comment
           }
 
           current_type = exec_query("SHOW COLUMNS FROM #{quote_table_name(table_name)} LIKE #{quote(column_name)}", "SCHEMA").first["Type"]

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -114,6 +114,17 @@ if ActiveRecord::Base.connection.supports_comments?
       assert_nil column.comment
     end
 
+    def test_rename_column_preserves_comment
+      @connection.add_column    :commenteds, :rating, :string, comment: "I am running out of imagination"
+      @connection.rename_column :commenteds, :rating, :new_rating
+
+      Commented.reset_column_information
+      column = Commented.columns_hash["new_rating"]
+
+      assert_equal :string, column.type
+      assert_equal column.comment, "I am running out of imagination"
+    end
+
     def test_schema_dump_with_comments
       # Do all the stuff from other tests
       @connection.add_column    :commenteds, :rating, :integer, comment: "I am running out of imagination"


### PR DESCRIPTION
Currently when you call the `rename_column` method it will remove column comment, this pull request is intended to retain comment value for column after renaming.