### PR TITLE
add additional instrumentation block for ActionView layout rendering

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Instrument layout rendering in `TemplateRenderer#render_with_layout` as `render_layout.action_view`, and include (when necessary) the layout's virtual path in notification payloads for collection and partial renders.
+
+    *Zach Kemp*
+
 *   `ActionView::Base.annotate_template_file_names` annotates HTML output with template file names.
 
     *Joel Hawksley*, *Aaron Patterson*

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -144,6 +144,7 @@ module ActionView
         ActiveSupport::Notifications.instrument(
           "render_collection.action_view",
           identifier: identifier,
+          layout: layout && layout.virtual_path,
           count: collection.size
         ) do |payload|
           spacer = if @options.key?(:spacer_template)

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -279,7 +279,8 @@ module ActionView
       def render_partial_template(view, locals, template, layout, block)
         ActiveSupport::Notifications.instrument(
           "render_partial.action_view",
-          identifier: template.identifier
+          identifier: template.identifier,
+          layout: layout && layout.virtual_path
         ) do |payload|
           content = template.render(view, locals) do |*name|
             view._layout_for(*name, &block)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -64,13 +64,14 @@ module ActionView
 
       def render_with_layout(view, template, path, locals)
         layout  = path && find_layout(path, locals.keys, [formats.first])
-        content = yield(layout)
 
         body = if layout
-          view.view_flow.set(:layout, content)
-          layout.render(view, locals) { |*name| view._layout_for(*name) }
+          ActiveSupport::Notifications.instrument("render_layout.action_view", identifier: layout.identifier) do
+            view.view_flow.set(:layout, yield(layout))
+            layout.render(view, locals) { |*name| view._layout_for(*name) }
+          end
         else
-          content
+          yield
         end
         build_rendered_template(body, template)
       end

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -63,6 +63,21 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     end
   end
 
+  def test_render_template_with_layout
+    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      @view.render(template: "test/hello_world", layout: "layouts/yield")
+      wait
+
+      assert_equal 2, @logger.logged(:debug).size
+      assert_equal 2, @logger.logged(:info).size
+
+      assert_match(/Rendering layout layouts\/yield\.erb/, @logger.logged(:debug).first)
+      assert_match(/Rendering test\/hello_world\.erb within layouts\/yield/, @logger.logged(:debug).last)
+      assert_match(/Rendered test\/hello_world\.erb within layouts\/yield/, @logger.logged(:info).first)
+      assert_match(/Rendered layout layouts\/yield\.erb/, @logger.logged(:info).last)
+    end
+  end
+
   def test_render_file_template
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
       @view.render(file: "#{FIXTURE_LOAD_PATH}/test/hello_world.erb")
@@ -137,6 +152,30 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     end
   end
 
+  def test_render_partial_as_layout
+    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      set_view_cache_dependencies
+      set_cache_controller
+
+      @view.render(layout: "layouts/yield_only") { "hello" }
+
+      assert_equal 1, @logger.logged(:debug).size
+      assert_match(/Rendered layouts\/_yield_only\.erb/, @logger.logged(:debug).first)
+    end
+  end
+
+  def test_render_partial_with_layout
+    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      set_view_cache_dependencies
+      set_cache_controller
+
+      @view.render(partial: "partial", layout: "layouts/yield_only")
+
+      assert_equal 1, @logger.logged(:debug).size
+      assert_match(/Rendered test\/_partial\.html\.erb within layouts\/_yield_only/, @logger.logged(:debug).first)
+    end
+  end
+
   def test_render_uncached_outer_partial_with_inner_cached_partial_wont_mix_cache_hits_or_misses
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
       set_view_cache_dependencies
@@ -207,6 +246,19 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
       assert_match(/Rendered collection of test\/_customer.erb \[2 times\]/, @logger.logged(:debug).last)
     end
   end
+
+  def test_render_collection_template_with_layout
+    Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do
+      set_cache_controller
+
+      @view.render(partial: "test/customer", layout: "layouts/yield_only", collection: [ Customer.new("david"), Customer.new("mary") ])
+      wait
+
+      assert_equal 1, @logger.logged(:debug).size
+      assert_match(/Rendered collection of test\/_customer.erb within layouts\/_yield_only \[2 times\]/, @logger.logged(:debug).last)
+    end
+  end
+
 
   def test_render_collection_with_implicit_path
     Rails.stub(:root, File.expand_path(FIXTURE_LOAD_PATH)) do


### PR DESCRIPTION
### Summary

For templates rendered with a layout, instrument the layout render in a block around the template render.

### Other Information

This change is upstreamed/adapted from https://github.com/skylightio/skylight-ruby/blob/master/lib/skylight/probes/action_view.rb#L25, in which we have always treated the layout render as a 'parent' span of the template render (and under this change, that is actually the correct order of operations; prior to this change, the `content = yield(layout)` line's position meant that the template and its layout were rendered sequentially).

This instrumentation applies to the common general case of rendering a template into an implicit or explicit global layout, and is fired under the key `render_layout.action_view`.

Additionally, in cases where we wouldn't want to instrument a 'layout' wrapper separately (e.g., in a collection or partial render), the additional event is not fired, but the layout information is added to the existing render event payload.