### PR TITLE
Allow GCSService to understand custom upload options

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for `upload` options with `GCSService`
+
+    *Brendan Abbott*
+
 *   Add `config.active_storage.web_image_content_types` to allow applications
     to add content types (like `image/webp`) in which variants can be processed,
     instead of letting those images be converted to the fallback PNG format.

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,4 +1,15 @@
-*   Add support for `upload` options with `GCSService`
+*   Add support for `upload` options with `GCSService`.
+
+    For example, to add `Cache-Control` headers to uploaded files, modify
+    `config/storage.yml` with the `upload` key and corresponding Hash:
+
+    ```yml
+    google:
+      service: GCS
+      ...
+      upload:
+        cache_control: "public, max-age=60"
+    ```
 
     *Brendan Abbott*
 

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -114,6 +114,7 @@ module ActiveStorage
         file_for(key).public_url
       end
 
+
       attr_reader :config
 
       def file_for(key, skip_lookup: true)

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -88,7 +88,7 @@ module ActiveStorage
 
     def url_for_direct_upload(key, expires_in:, checksum:, **)
       instrument :url, key: key do |payload|
-        generated_url = bucket.signed_url key, method: "PUT", expires: expires_in, content_md5: checksum
+        generated_url = bucket.signed_url key, method: "PUT", expires: expires_in, content_md5: checksum, **upload_options
 
         payload[:url] = generated_url
 

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -7,10 +7,13 @@ module ActiveStorage
   # Wraps the Google Cloud Storage as an Active Storage service. See ActiveStorage::Service for the generic API
   # documentation that applies to all services.
   class Service::GCSService < Service
+    attr_reader :upload_options
+
     def initialize(public: false, upload: {}, **config)
       @config = config
       @public = public
       @upload_options = upload
+      @upload_options[:acl] = "public_read" if public?
     end
 
     def upload(key, io, checksum: nil, content_type: nil, disposition: nil, filename: nil)
@@ -111,7 +114,7 @@ module ActiveStorage
         file_for(key).public_url
       end
 
-      attr_reader :config, :upload_options
+      attr_reader :config
 
       def file_for(key, skip_lookup: true)
         bucket.file(key, skip_lookup: skip_lookup)

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -17,6 +17,26 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
       assert_includes @service.bucket.find_file(@key).acl.readers, "allUsers"
     end
 
+    test "direct upload file is accessible by all users" do
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      checksum = Digest::MD5.base64digest(data)
+      url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      request.add_field "Content-Type", ""
+      request.add_field "Content-MD5", checksum
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
+      end
+
+      assert_includes @service.bucket.find_file(key).acl.readers, "allUsers"
+    ensure
+      @service.delete key
+    end
+
     test "public URL generation" do
       url = @service.url(@key, filename: ActiveStorage::Filename.new("avatar.png"))
 

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -13,6 +13,10 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
       assert_equal "public_read", @service.upload_options[:acl]
     end
 
+    test "uploaded file is accessible by all users" do
+      assert_includes @service.bucket.find_file(@key).acl.readers, "allUsers"
+    end
+
     test "public URL generation" do
       url = @service.url(@key, filename: ActiveStorage::Filename.new("avatar.png"))
 

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -9,6 +9,10 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
 
     include ActiveStorage::Service::SharedServiceTests
 
+    test "public acl options" do
+      assert_equal "public_read", @service.upload_options[:acl]
+    end
+
     test "public URL generation" do
       url = @service.url(@key, filename: ActiveStorage::Filename.new("avatar.png"))
 

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -57,6 +57,33 @@ if SERVICE_CONFIGURATIONS[:gcs]
       @service.delete key
     end
 
+    test "direct upload with custom upload options" do
+      cache_control = "public, max-age=60"
+      service = build_service(upload: { cache_control: cache_control })
+
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      checksum = Digest::MD5.base64digest(data)
+      url      = service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      service.headers_for_direct_upload(key, checksum: checksum, filename: ActiveStorage::Filename.new("test.txt"), disposition: :attachment).each do |k, v|
+        request.add_field k, v
+      end
+      request.add_field "Content-Type", ""
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
+      end
+
+      url = service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal(cache_control, response["Cache-Control"])
+    ensure
+      service.delete key
+    end
+
     test "upload with content_type and content_disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -211,15 +211,10 @@ google:
   upload:
     acl: "" # will be set to `public_read` on public buckets
     cache_control: ""
-    content_encoding: ""
-    content_language: ""
-    crc32c: ""
-    encryption_key: ""
-    kms_key: ""
-    metadata:
-      key: ""
     storage_class: ""
 ```
+
+The [Google Cloud Storage SDK docs](https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/Bucket.html#create_file-instance_method) detail other possible upload options.
 
 Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) gem to your `Gemfile`:
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -118,6 +118,7 @@ amazon:
   secret_access_key: ""
   region: ""
   bucket: ""
+  public: false
 ```
 
 Optionally provide a Hash of upload options:
@@ -129,7 +130,7 @@ amazon:
   secret_access_key: ""
   region: ""
   bucket: ""
-  upload: 
+  upload:
     server_side_encryption: "" # 'aws:kms' or 'AES256'
 ```
 
@@ -176,6 +177,7 @@ google:
   credentials: <%= Rails.root.join("path/to/keyfile.json") %>
   project: ""
   bucket: ""
+  public: false
 ```
 
 Optionally provide a Hash of credentials instead of a keyfile path:
@@ -196,6 +198,27 @@ google:
     client_x509_cert_url: ""
   project: ""
   bucket: ""
+```
+
+Optionally provide a Hash of upload options:
+
+```yaml
+google:
+  service: GCS
+  credentials: <%= Rails.root.join("path/to/keyfile.json") %>
+  project: ""
+  bucket: ""
+  upload:
+    acl: "" # will be set to `public_read` on public buckets
+    cache_control: ""
+    content_encoding: ""
+    content_language: ""
+    crc32c: ""
+    encryption_key: ""
+    kms_key: ""
+    metadata:
+      key: ""
+    storage_class: ""
 ```
 
 Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) gem to your `Gemfile`:


### PR DESCRIPTION
### Summary

This PR is an attempt to implement #32325 to make ActiveStorage's `GCSService` be able to accept metadata to pass to objects when they are being uploaded.
 
### Other Information

I modelled this off the `S3Service` implementation in that the value is provided by ActiveStorage's config (`storage.yml`), and the key is named consistently (`upload`).

The available keys that can be passed are what is available in the [Google Cloud Storage](https://github.com/googleapis/google-cloud-ruby/blob/516e9f339f1bbea60df16d65f33facf7a16a03e6/google-cloud-storage/lib/google/cloud/storage/bucket.rb#L1250-L1255) gem though it's worth noting that `md5`, `content_type` and `content_disposition` will all be overridden.