### PR TITLE
Recognize Windows-style paths in test runner

### DIFF
--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -62,6 +62,7 @@ module Rails
           def extract_filters(argv)
             # Extract absolute and relative paths but skip -n /.*/ regexp filters.
             argv.select { |arg| path_argument?(arg) && !regexp_filter?(arg) }.map do |path|
+              path = path.tr("\\", "/")
               case
               when /(:\d+)+$/.match?(path)
                 file, *lines = path.split(":")
@@ -81,7 +82,7 @@ module Rails
           end
 
           def path_argument?(arg)
-            %r%^/?\w+/%.match?(arg)
+            %r"^[/\\]?\w+[/\\]".match?(arg)
           end
       end
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -320,6 +320,17 @@ module ApplicationTests
       end
     end
 
+    def test_run_windows_style_path
+      create_test_file :models, "account"
+      create_test_file :controllers, "accounts_controller"
+
+      # double-escape backslash -- once for Ruby and again for shelling out
+      run_test_command("test\\\\models").tap do |output|
+        assert_match "AccountTest", output
+        assert_match "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips", output
+      end
+    end
+
     def test_run_with_ruby_command
       app_file "test/models/post_test.rb", <<-RUBY
         require "test_helper"


### PR DESCRIPTION
Previously, a test runner argument had to contain a forward slash to be recognized as a path.  Now, backslashes will also be considered, enabling the use of Windows-style paths.

Fixes #38243.
