### PR TITLE
Perf: Improve performance of where when using an array of values

### DIFF
--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -8,14 +8,21 @@ module ActiveModel
           cast(value)
         end
 
+        def serialize2(value)
+          cast(value)
+        end
+
         def cast(value)
-          value = \
+          value = if value <=> 0
+            value
+          else
             case value
             when true then 1
             when false then 0
-            when ::String then value.presence
-            else value
+            else value.presence
             end
+          end
+
           super(value)
         end
 

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -28,15 +28,24 @@ module ActiveModel
         ensure_in_range(super)
       end
 
+      def serializable?(value)
+        cast_value = cast(value)
+        in_range?(cast_value) && super
+      end
+
       private
         attr_reader :range
+
+        def in_range?(value)
+          !value || range.cover?(value)
+        end
 
         def cast_value(value)
           value.to_i rescue nil
         end
 
         def ensure_in_range(value)
-          if value && !range.cover?(value)
+          unless in_range?(value)
             raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
           end
           value

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -11,6 +11,10 @@ module ActiveModel
         @limit = limit
       end
 
+      def serializable?(_)
+        true
+      end
+
       def type # :nodoc:
       end
 
@@ -43,6 +47,10 @@ module ActiveModel
       # +String+, +Numeric+, +Date+, +Time+, +Symbol+, +true+, +false+, or
       # +nil+.
       def serialize(value)
+        value
+      end
+
+      def serialize2(value)
         value
       end
 

--- a/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb
+++ b/activerecord/lib/active_record/connection_adapters/determine_if_preparable_visitor.rb
@@ -24,6 +24,11 @@ module ActiveRecord
         @preparable = false
         super
       end
+
+      def visit_Arel_Nodes_HomogeneousIn(o, collector)
+        @preparable = false
+        super
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -139,12 +139,18 @@ module ActiveRecord
         mapping.key(subtype.deserialize(value))
       end
 
+      def serializable?(value)
+        (value.blank? || mapping.has_key?(value) || mapping.has_value?(value)) && super
+      end
+
       def serialize(value)
         mapping.fetch(value, value)
       end
 
+      alias :serialize2 :serialize
+
       def assert_valid_value(value)
-        unless value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
+        unless serializable?(value)
           raise ArgumentError, "'#{value}' is not a valid #{name}"
         end
       end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -16,6 +16,10 @@ module ActiveRecord
       register_handler(Set, ArrayHandler.new(self))
     end
 
+    def connection
+      @table.connection
+    end
+
     def build_from_hash(attributes)
       attributes = convert_dot_notation_to_hash(attributes)
       expand_from_hash(attributes)

--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -21,10 +21,22 @@ module ActiveRecord
           when 0 then NullPredicate
           when 1 then predicate_builder.build(attribute, values.first)
           else
-            values.map! do |v|
-              predicate_builder.build_bind_attribute(attribute.name, v)
+            if nils.empty? && ranges.empty?
+              predicate_builder.connection.in_clause_length
+              join_name = attribute.relation.table_alias || attribute.relation.name
+              quoted_column_name = "#{predicate_builder.connection.quote_table_name(join_name)}.#{predicate_builder.connection.quote_column_name(attribute.name)}"
+              type = attribute.type_caster
+
+              casted_values = values.map do |raw_value|
+                type.serialize2(raw_value) if type.serializable?(raw_value)
+              end
+
+              casted_values.compact!
+
+              return Arel::Nodes::HomogeneousIn.new(quoted_column_name, casted_values, attribute, :in)
+            else
+              build_in(values, predicate_builder, attribute)
             end
-            values.empty? ? NullPredicate : attribute.in(values)
           end
 
         unless nils.empty?
@@ -38,6 +50,12 @@ module ActiveRecord
 
       private
         attr_reader :predicate_builder
+
+        def build_in(values, predicate_builder, attribute)
+          attribute.in values.map { |v|
+            predicate_builder.build_bind_attribute(attribute.name, v)
+          }
+        end
 
         module NullPredicate # :nodoc:
           def self.or(other)

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -130,7 +130,7 @@ module ActiveRecord
         end
 
         def equality_node?(node)
-          node.respond_to?(:operator) && node.operator == :==
+          !node.is_a?(String) && node.equality?
         end
 
         def invert_predicate(node)

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -4,6 +4,8 @@ module ActiveRecord
   class TableMetadata # :nodoc:
     delegate :foreign_type, :foreign_key, :join_primary_key, :join_foreign_key, to: :association, prefix: true
 
+    attr_reader :klass
+
     def initialize(klass, arel_table, association = nil, types = klass)
       @klass = klass
       @types = types
@@ -39,6 +41,10 @@ module ActiveRecord
 
     def associated_with?(association_name)
       klass && klass._reflect_on_association(association_name)
+    end
+
+    def connection
+      klass ? klass.connection : @types.connection
     end
 
     def associated_table(table_name)
@@ -85,6 +91,6 @@ module ActiveRecord
       end
 
     private
-      attr_reader :klass, :types, :arel_table, :association
+      attr_reader :types, :arel_table, :association
   end
 end

--- a/activerecord/lib/active_record/type_caster/connection.rb
+++ b/activerecord/lib/active_record/type_caster/connection.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         type || Type.default_value
       end
 
-      delegate :connection, to: :@klass, private: true
+      delegate :connection, to: :@klass
 
       private
         attr_reader :table_name

--- a/activerecord/lib/active_record/type_caster/map.rb
+++ b/activerecord/lib/active_record/type_caster/map.rb
@@ -9,8 +9,12 @@ module ActiveRecord
 
       def type_cast_for_database(attr_name, value)
         return value if value.is_a?(Arel::Nodes::BindParam)
-        type = types.type_for_attribute(attr_name)
+        type = type_for_attribute(attr_name)
         type.serialize(value)
+      end
+
+      def type_for_attribute(name)
+        types.type_for_attribute(name)
       end
 
       private

--- a/activerecord/lib/arel/attributes/attribute.rb
+++ b/activerecord/lib/arel/attributes/attribute.rb
@@ -9,6 +9,10 @@ module Arel # :nodoc: all
       include Arel::OrderPredications
       include Arel::Math
 
+      def type_caster
+        relation.type_for_attribute(name)
+      end
+
       ###
       # Create a node for lowering this attribute
       def lower

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -18,6 +18,7 @@ require "arel/nodes/false"
 # unary
 require "arel/nodes/unary"
 require "arel/nodes/grouping"
+require "arel/nodes/homogeneous_in"
 require "arel/nodes/ordering"
 require "arel/nodes/ascending"
 require "arel/nodes/descending"

--- a/activerecord/lib/arel/nodes/equality.rb
+++ b/activerecord/lib/arel/nodes/equality.rb
@@ -7,6 +7,8 @@ module Arel # :nodoc: all
       alias :operand1 :left
       alias :operand2 :right
 
+      def equality?; true; end
+
       def invert
         Arel::Nodes::NotEqual.new(left, right)
       end

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class HomogeneousIn < Node
+      attr_reader :attribute, :quoted_column_name, :values, :type
+
+      def initialize(quoted_column_name, values, attribute, type)
+        @quoted_column_name = quoted_column_name
+        @values = values
+        @attribute = attribute
+        @type = type
+      end
+
+      def hash
+        ivars.hash
+      end
+
+      def eql?(other)
+        super || (self.class == other.class && self.ivars == other.ivars)
+      end
+      alias :== :eql?
+
+      def equality?
+        true
+      end
+
+      def invert
+        Arel::Nodes::HomogeneousIn.new(quoted_column_name, values, attribute, type == :in ? :notin : :in)
+      end
+
+      def left
+        attribute
+      end
+
+      def fetch_attribute(&block)
+        if attribute
+          yield attribute
+        else
+          expr.fetch_attribute(&block)
+        end
+      end
+
+      protected
+        def ivars
+          [@attribute, @quoted_column_name, @values, @type]
+        end
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/node.rb
+++ b/activerecord/lib/arel/nodes/node.rb
@@ -44,6 +44,8 @@ module Arel # :nodoc: all
 
       def fetch_attribute
       end
+
+      def equality?; false; end
     end
   end
 end

--- a/activerecord/lib/arel/nodes/table_alias.rb
+++ b/activerecord/lib/arel/nodes/table_alias.rb
@@ -19,6 +19,10 @@ module Arel # :nodoc: all
         relation.type_cast_for_database(*args)
       end
 
+      def type_for_attribute(name)
+        relation.type_for_attribute(name)
+      end
+
       def able_to_type_cast?
         relation.respond_to?(:able_to_type_cast?) && relation.able_to_type_cast?
       end

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -100,6 +100,10 @@ module Arel # :nodoc: all
       type_caster.type_cast_for_database(attribute_name, value)
     end
 
+    def type_for_attribute(name)
+      type_caster.type_for_attribute(name)
+    end
+
     def able_to_type_cast?
       !type_caster.nil?
     end

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -218,7 +218,13 @@ module Arel # :nodoc: all
         alias :visit_Symbol :visit_String
         alias :visit_Arel_Nodes_SqlLiteral :visit_String
 
-        def visit_Arel_Nodes_BindParam(o); end
+        def visit_Arel_Nodes_BindParam(o)
+          edge("value") { visit o.value }
+        end
+
+        def visit_ActiveRecord_Relation_QueryAttribute(o)
+          edge("value_before_type_cast") { visit o.value_before_type_cast }
+        end
 
         def visit_Hash(o)
           o.each_with_index do |pair, i|

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -324,6 +324,30 @@ module Arel # :nodoc: all
           end
         end
 
+        def visit_Arel_Nodes_HomogeneousIn(o, collector)
+          collector << "("
+
+          collector << o.quoted_column_name
+
+          if o.type == :in
+            collector << "IN ("
+          else
+            collector << "NOT IN ("
+          end
+
+          values = o.values.map { |v| @connection.quote v }
+
+          expr = if values.empty?
+            @connection.quote(nil)
+          else
+            values.join(",")
+          end
+
+          collector << expr
+          collector << "))"
+          collector
+        end
+
         def visit_Arel_SelectManager(o, collector)
           collector << "("
           visit(o.ast, collector) << ")"

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -538,6 +538,10 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Topic.find("1-meowmeow"), Topic.find(1)
   end
 
+  def test_out_of_range_slugs
+    assert_equal [Topic.find(1)], Topic.where(id: ["1-meowmeow", "9223372036854775808-hello"])
+  end
+
   def test_find_by_slug_with_array
     assert_equal Topic.find([1, 2]), Topic.find(["1-meowmeow", "2-hello"])
     assert_equal "The Second Topic of the day", Topic.find(["2-hello", "1-meowmeow"]).first.title


### PR DESCRIPTION
A coworker at GitHub found a few months back that if we used
`santitize_sql` over `where` when we knew the values going into `where`
it was a lot faster than `where`.

This PR adds a new Arel node type called `HomogenousIn` that will be
used when Rails knows the values are all homogenous and can therefore
pick a faster codepath. This new codepath skips some of the required
processing by `where` to make `wheres` with homogenous arrays faster
without requiring the application author to know when to use which query
type.

Using our benchmark code:

```ruby
ids = (1..1000).each.map do |n|
  Post.create!.id
end

Benchmark.ips do |x|
  x.report("where with ids") do
    Post.where(id: ids).to_a
  end

  x.report("where with sanitize") do
    Post.where(ActiveRecord::Base.sanitize_sql(["id IN (?)", ids])).to_a
  end

  x.compare!
end
```

Before this PR comparing where with a list of IDs to sanitize sql:

```
Warming up --------------------------------------
      where with ids    11.000  i/100ms
 where with sanitize    17.000  i/100ms

Calculating -------------------------------------
      where with ids    115.733  (± 4.3%) i/s -    583.000  in   5.045828s
 where with sanitize    174.231  (± 4.0%) i/s -    884.000  in   5.081495s

Comparison:
 where with sanitize:      174.2 i/s
      where with ids:      115.7 i/s - 1.51x  slower
```

After this PR comparing where with a list of IDs to sanitize sql:

```
Warming up --------------------------------------
      where with ids    16.000  i/100ms
 where with sanitize    19.000  i/100ms

Calculating -------------------------------------
      where with ids    158.293  (± 6.3%) i/s -    800.000  in   5.072208s
 where with sanitize    169.141  (± 3.5%) i/s -    855.000  in   5.060878s

Comparison:
 where with sanitize:      169.1 i/s
      where with ids:      158.3 i/s - same-ish: difference falls within error
```

Notes:

1) `sanitize2` is a horrific name, obviously. We aren't sure what to
name it though. Thoughts?
2) `HomogenousIn` may not be the best name for our new node.

Co-authored-by: Aaron Patterson <aaron.patterson@gmail.com>

cc/ @tenderlove 