### PR TITLE
Return and cache correct size for compressed cache entries

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -766,7 +766,7 @@ module ActiveSupport
         @created_at = Time.now.to_f
         @expires_in = expires_in && expires_in.to_f
 
-        compress!(compress_threshold) if compress
+        calculate_size_and_possibly_compress!(compress, compress_threshold)
       end
 
       def value
@@ -795,17 +795,10 @@ module ActiveSupport
         end
       end
 
-      # Returns the size of the cached value. This could be less than
+      # Returns the size of the cached value. This is less than
       # <tt>value.size</tt> if the data is compressed.
       def size
-        case value
-        when NilClass
-          0
-        when String
-          @value.bytesize
-        else
-          @s ||= Marshal.dump(@value).bytesize
-        end
+        @value_size
       end
 
       # Duplicates the value in a class. This is used by cache implementations that don't natively
@@ -821,23 +814,22 @@ module ActiveSupport
       end
 
       private
-        def compress!(compress_threshold)
+        def calculate_size_and_possibly_compress!(compress, compress_threshold)
           case @value
-          when nil, true, false, Numeric
-            uncompressed_size = 0
           when String
-            uncompressed_size = @value.bytesize
+            @value_size = @value.bytesize
           else
             serialized = Marshal.dump(@value)
-            uncompressed_size = serialized.bytesize
+            @value_size = serialized.bytesize
           end
 
-          if uncompressed_size >= compress_threshold
+          if compress && @value_size >= compress_threshold
             serialized ||= Marshal.dump(@value)
             compressed = Zlib::Deflate.deflate(serialized)
 
-            if compressed.bytesize < uncompressed_size
+            if compressed.bytesize < @value_size
               @value = compressed
+              @value_size = compressed.bytesize
               @compressed = true
             end
           end


### PR DESCRIPTION
### Summary

👋 I was looking at a production profile in Speedscope (https://github.com/jlfwong/speedscope) and noticed this call sequence:

<img width="350" alt="Screen Shot 2020-04-21 at 5 25 13 PM" src="https://user-images.githubusercontent.com/7451862/79915535-1f164200-83f5-11ea-8ec0-d54ce21ad075.png">

I thought it odd that computing the size of a cache entry (here: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/memory_store.rb#L119-L121) would require uncompressing the value. It also seems wrong -- wouldn't we want to know the compressed size of the cache entry?

I changed the code to precompute the size when the entry is created. If the entry is compressed, it is the size of the entry after compression is applied. This way, the size of the entry (which was already available, just not being stored) will only have to be calculated once. 

### Other Information

I'm not sure why there were special cases for `NilClass` and `nil`, `true` and `false` in the two modified functions. I took them out for now but will dig at the history a bit more to see why they were there.