### PR TITLE
Reject hexadecimal numbers with signs while validating numericality

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -13,6 +13,8 @@ module ActiveModel
 
       INTEGER_REGEX = /\A[+-]?\d+\z/
 
+      HEXADECIMAL_REGEX = /\A[+-]?0[xX]/
+
       def check_validity!
         keys = CHECKS.keys - [:odd, :even]
         options.slice(*keys).each do |option, value|
@@ -106,7 +108,7 @@ module ActiveModel
       end
 
       def is_hexadecimal_literal?(raw_value)
-        /\A0[xX]/.match?(raw_value.to_s)
+        HEXADECIMAL_REGEX.match?(raw_value.to_s)
       end
 
       def filtered_options(value)

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -21,7 +21,7 @@ class NumericalityValidationTest < ActiveModel::TestCase
   FLOATS = [0.0, 10.0, 10.5, -10.5, -0.0001] + FLOAT_STRINGS
   INTEGERS = [0, 10, -10] + INTEGER_STRINGS
   BIGDECIMAL = BIGDECIMAL_STRINGS.collect! { |bd| BigDecimal(bd) }
-  JUNK = ["not a number", "42 not a number", "0xdeadbeef", "0xinvalidhex", "0Xdeadbeef", "00-1", "--3", "+-3", "+3-1", "-+019.0", "12.12.13.12", "123\nnot a number"]
+  JUNK = ["not a number", "42 not a number", "0xdeadbeef", "-0xdeadbeef", "+0xdeadbeef", "0xinvalidhex", "0Xdeadbeef", "00-1", "--3", "+-3", "+3-1", "-+019.0", "12.12.13.12", "123\nnot a number"]
   INFINITY = [1.0 / 0.0]
 
   def test_default_validates_numericality_of


### PR DESCRIPTION
Given the following class definition

```ruby
class User < ApplicationRecord
  validates :email, presence: true
  validates :age, numericality: true
end
```

Currently '0x11' is validated as not a number. But '0x11' and '-0x11' pass the validation but parsed value is 0 and -0 respectively.

```ruby
irb(main):004:0> User
=> User(id: integer, email: text, age: decimal, created_at: datetime, updated_at: datetime)

irb(main):008:0> u = User.new(email: 'abc', age: '0x11')
=> #<User id: nil, email: "abc", age: 0.0, created_at: nil, updated_at: nil>
irb(main):009:0> u.valid?
=> false
irb(main):010:0> u.errors.full_messages
=> ["Age is not a number"]

irb(main):011:0> u = User.new(email: 'abc', age: '+0x11')
=> #<User id: nil, email: "abc", age: 0.0, created_at: nil, updated_at: nil>
irb(main):012:0> u.valid?
=> true


irb(main):013:0> u = User.new(email: 'abc', age: '-0x11')
=> #<User id: nil, email: "abc", age: -0.0, created_at: nil, updated_at: nil>
irb(main):014:0> u.valid?
=> true
```
