### PR TITLE
Reference updated errors attribute names method in deprecation warning

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -271,7 +271,7 @@ module ActiveModel
     #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
     #   person.errors.keys     # => [:name]
     def keys
-      deprecation_removal_warning(:keys, "errors.map { |error| error.attribute }")
+      deprecation_removal_warning(:keys, "errors.attribute_names")
       keys = @errors.map(&:attribute)
       keys.uniq!
       keys.freeze


### PR DESCRIPTION
### Summary

Update the deprecation warning to reference the new `attribute_names` method

### Other Information

This PR makes it really clear that `keys` has an easy replacement, but `values` does not. Do we want to provide a direct replacement method for `values` as well?
