### PR TITLE
Fix typos [ci skip]

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -96,7 +96,7 @@
 </table>
 
 <script type='text/javascript'>
-  // support forEarch iterator on NodeList
+  // support forEach iterator on NodeList
   NodeList.prototype.forEach = Array.prototype.forEach;
 
   // Enables path search functionality

--- a/actionview/test/ujs/public/test/data-remote.js
+++ b/actionview/test/ujs/public/test/data-remote.js
@@ -37,7 +37,7 @@ module('data-remote', {
         href: '/echo',
         'data-remote': 'true',
         disabled: 'disabled',
-        text: 'Disabed link'
+        text: 'Disabled link'
       }))
       .find('form').append($('<input type="text" name="user_name" value="john">'))
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -70,7 +70,7 @@ module ActiveRecord
         @scope
       end
 
-      # Returns a new relation with left outer joins and where clause to idenitfy
+      # Returns a new relation with left outer joins and where clause to identify
       # missing relations.
       #
       # For example, posts that are missing a related author:

--- a/activestorage/lib/active_storage/analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer.rb
@@ -13,7 +13,7 @@ module ActiveStorage
     end
 
     # Implement this method in concrete subclasses. It will determine if blob analysis
-    # should be done in a job or performed inine. By default, analysis is enqueued in a job.
+    # should be done in a job or performed inline. By default, analysis is enqueued in a job.
     def self.analyze_later?
       true
     end

--- a/activesupport/test/core_ext/module_test.rb
+++ b/activesupport/test/core_ext/module_test.rb
@@ -278,7 +278,7 @@ class ModuleTest < ActiveSupport::TestCase
     assert_nil rails.name
   end
 
-  # Ensures with check for nil, not for a falseish target.
+  # Ensures with check for nil, not for a falsy target.
   def test_delegation_with_allow_nil_and_false_value
     project = Project.new(false, false)
     assert_raise(NoMethodError) { project.name }


### PR DESCRIPTION
I wrote this shell script to find words from the Rails repo, so I can paste them into https://www.horsepaste.com/ for the [codenames game](https://en.m.wikipedia.org/wiki/Codenames_(board_game)):

```bash
git grep -Il '' | \
  grep -v -E "CHANGELOG|Gemfile|gemspec|package\.json|yarn\.lock" | \
  xargs cat | \
  sed '/[^ ]\{10,\}/d' | \
  sed 's/\([A-Z]\)/ \1/g' | \
  tr 'A-Z' 'a-z' | \
  tr -c -s 'a-z' '\n' | \
  sed '/^.\{0,3\}$/d' | \
  sort | \
  uniq | \
  tr '\n' ',' | \
  pbcopy
```

You can see the result [here](https://www.horsepaste.com/rails-fixed). Click "Next game" to cycle the words.

Found some typos in the codebase from this 😂