### PR TITLE
PERF: Improve performance of where when using an array of values

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -85,7 +85,7 @@ module ActiveRecord
         predicates.any? do |x|
           case x
           when Arel::Nodes::In
-            Array === x.right && x.right.empty?
+            Arel::Nodes::CastedArray === x.right && x.right.value.empty?
           when Arel::Nodes::Equality
             x.right.respond_to?(:unboundable?) && x.right.unboundable?
           end

--- a/activerecord/lib/arel/nodes/casted.rb
+++ b/activerecord/lib/arel/nodes/casted.rb
@@ -34,6 +34,16 @@ module Arel # :nodoc: all
       alias :== :eql?
     end
 
+    class CastedArray < Casted # :nodoc:
+      def value_for_database
+        if attribute.able_to_type_cast?
+          value.map { |v| attribute.type_cast_for_database(v) }
+        else
+          value
+        end
+      end
+    end
+
     class Quoted < Arel::Nodes::Unary # :nodoc:
       alias :value_for_database :value
       alias :value_before_type_cast :value

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -31,7 +31,7 @@ module Arel # :nodoc: all
     end
 
     def eq_all(others)
-      grouping_all :eq, quoted_array(others)
+      grouping_all :eq, others
     end
 
     def between(other)
@@ -238,7 +238,7 @@ Passing a range to `#not_in` is deprecated. Call `#not_between`, instead.
       end
 
       def quoted_array(others)
-        others.map { |v| quoted_node(v) }
+        Nodes::CastedArray.new(others, self)
       end
 
       def infinity?(value)

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -98,6 +98,7 @@ module Arel # :nodoc: all
 
     def type_cast_for_database(attribute_name, value)
       type_caster.type_cast_for_database(attribute_name, value)
+    rescue ::RangeError
     end
 
     def able_to_type_cast?

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -618,14 +618,14 @@ module Arel
           attribute = Attribute.new nil, nil
           node = attribute.between(-::Float::INFINITY..::Float::INFINITY)
 
-          _(node).must_equal Nodes::NotIn.new(attribute, [])
+          _(node).must_equal attribute.not_in([])
         end
 
         it "can be constructed with a quoted infinite range" do
           attribute = Attribute.new nil, nil
           node = attribute.between(quoted_range(-::Float::INFINITY, ::Float::INFINITY, false))
 
-          _(node).must_equal Nodes::NotIn.new(attribute, [])
+          _(node).must_equal attribute.not_in([])
         end
 
         it "can be constructed with a range ending at Infinity" do
@@ -707,11 +707,7 @@ module Arel
 
           _(node).must_equal Nodes::In.new(
             attribute,
-            [
-              Nodes::Casted.new(1, attribute),
-              Nodes::Casted.new(2, attribute),
-              Nodes::Casted.new(3, attribute),
-            ]
+            Nodes::CastedArray.new([1, 2, 3], attribute)
           )
         end
 
@@ -831,14 +827,14 @@ module Arel
           attribute = Attribute.new nil, nil
           node = attribute.not_between(-::Float::INFINITY..::Float::INFINITY)
 
-          _(node).must_equal Nodes::In.new(attribute, [])
+          _(node).must_equal attribute.in([])
         end
 
         it "can be constructed with a quoted infinite range" do
           attribute = Attribute.new nil, nil
           node = attribute.not_between(quoted_range(-::Float::INFINITY, ::Float::INFINITY, false))
 
-          _(node).must_equal Nodes::In.new(attribute, [])
+          _(node).must_equal attribute.in([])
         end
 
         it "can be constructed with a range ending at Infinity" do
@@ -934,11 +930,7 @@ module Arel
 
           _(node).must_equal Nodes::NotIn.new(
             attribute,
-            [
-              Nodes::Casted.new(1, attribute),
-              Nodes::Casted.new(2, attribute),
-              Nodes::Casted.new(3, attribute),
-            ]
+            Nodes::CastedArray.new([1, 2, 3], attribute)
           )
         end
 


### PR DESCRIPTION
This is a smaller alternative of performance improvement, without
refactoring type casting mechanism #39009.

This is relatively a smaller change (but about 40% faster than before),
so I think this could be easier reviewed without discuss about
refactoring type casting mechanism.

This just makes `attribute.in(values)` less allocation from an array of
casted nodes to one casted array node.

```ruby
ids = (1..1000).each.map do |n|
  Post.create!.id
end

Benchmark.ips do |x|
  x.report("where with ids") do
    Post.where(id: ids).to_a
  end

  x.report("where with sanitize") do
    Post.where(ActiveRecord::Base.sanitize_sql(["id IN (?)", ids])).to_a
  end

  x.compare!
end
```

Before:

```
Warming up --------------------------------------
      where with ids     7.000  i/100ms
 where with sanitize    13.000  i/100ms

Calculating -------------------------------------
      where with ids     70.661  (± 5.7%) i/s -    357.000  in   5.072771s
 where with sanitize    130.993  (± 7.6%) i/s -    663.000  in   5.096085s

Comparison:
 where with sanitize:      131.0 i/s
      where with ids:       70.7 i/s - 1.85x  slower
```

After:

```
Warming up --------------------------------------
      where with ids    10.000  i/100ms
 where with sanitize    13.000  i/100ms

Calculating -------------------------------------
      where with ids     98.174  (± 7.1%) i/s -    490.000  in   5.012851s
 where with sanitize    132.289  (± 8.3%) i/s -    663.000  in   5.052728s

Comparison:
 where with sanitize:      132.3 i/s
      where with ids:       98.2 i/s - 1.35x  slower
```

cc @eileencodes @tenderlove @rafaelfranca