### PR TITLE
Remove unused `operand1`/`operand2` aliases

### DIFF
--- a/activerecord/lib/arel/nodes/equality.rb
+++ b/activerecord/lib/arel/nodes/equality.rb
@@ -4,8 +4,6 @@ module Arel # :nodoc: all
   module Nodes
     class Equality < Arel::Nodes::Binary
       def operator; :== end
-      alias :operand1 :left
-      alias :operand2 :right
 
       def invert
         Arel::Nodes::NotEqual.new(left, right)

--- a/activerecord/test/cases/arel/nodes/equality_test.rb
+++ b/activerecord/test/cases/arel/nodes/equality_test.rb
@@ -15,22 +15,6 @@ module Arel
           end
         end
 
-        describe "operand1" do
-          it "should equal left" do
-            attr = Table.new(:users)[:id]
-            left = attr.eq(10)
-            _(left.left).must_equal left.operand1
-          end
-        end
-
-        describe "operand2" do
-          it "should equal right" do
-            attr = Table.new(:users)[:id]
-            left = attr.eq(10)
-            _(left.right).must_equal left.operand2
-          end
-        end
-
         describe "to_sql" do
           it "takes an engine" do
             engine = FakeRecord::Base.new


### PR DESCRIPTION
There is no worth to keep those unused aliases and tests which are
private API.