### PR TITLE
Wrap redo migration into DDL transaction

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -266,6 +266,10 @@ module ActiveRecord
         ENV["VERSION"].to_i if ENV["VERSION"] && !ENV["VERSION"].empty?
       end
 
+      def step
+        ENV["STEP"] ? ENV["STEP"].to_i : 1
+      end
+
       def charset_current(env_name = env, db_name = name)
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: env_name, name: db_name)
         charset(db_config)


### PR DESCRIPTION
Wrap `db:migrate:redo` task into DDL transaction. That makes the task idempotent. In other words, if `up` step fails the next run of `db:migrate:redo` will start over on the current migration with `down`. So that it the task can run safely as many times as needed.

The process of a migration writing might take many runs to get it right. Having `db:migrate:redo` idempotent saves development time significantly, because there is no need to think if the previous run was failed, on which step, should `db:migrate` or `db:rollback` used after the previous `db:migrate:redo` fail. It eliminates that annoying cases when `db:migrate:redo` starts rolling back the previous migration because of failed `up` step on the current migration.

The implementation is based on this [discussion](https://discuss.rubyonrails.org/t/ddl-transaction-for-dbredo-task/74193/2).

Note, it wraps the "redo" task into transaction only when it runs for 1 step. There are different reasons of that:
- it's the most probable scenario where this feature is needed
- tech constraints - if redo runs on empty DB it runs all migrations up. It's implemented like that from the beginning so it's better not to change that due to backward compatibility. Wrapping all these "up" migrations into transaction seems not useful for that scenario