### PR TITLE
Database tasks can SKIP_TEST_DATABASE with environment variable

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `SKIP_TEST_DATABASE` environment variable to disable modifying the test database when `rails db:create` and `rails db:drop` are called.
+
+    *Jason Schweier*
+
 *   `connects_to` can only be called on `ActiveRecord::Base` or abstract classes.
 
     Ensure that `connects_to` can only be called from `ActiveRecord::Base` or abstract classes. This protects the application from opening duplicate or too many connections.

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -494,7 +494,7 @@ module ActiveRecord
 
         def each_current_configuration(environment, name = nil)
           environments = [environment]
-          environments << "test" if environment == "development" && !ENV["DATABASE_URL"]
+          environments << "test" if environment == "development" && !ENV["SKIP_TEST_DATABASE"] && !ENV["DATABASE_URL"]
 
           environments.each do |env|
             ActiveRecord::Base.configurations.configs_for(env_name: env).each do |db_config|

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -447,6 +447,29 @@ module ActiveRecord
       ENV["RAILS_ENV"] = old_env
     end
 
+    def test_creates_development_database_without_test_database_when_skip_test_database
+      old_env = ENV["RAILS_ENV"]
+      ENV["RAILS_ENV"] = "development"
+      ENV["SKIP_TEST_DATABASE"] = "true"
+
+      with_stubbed_configurations_establish_connection do
+        assert_called_with(
+          ActiveRecord::Tasks::DatabaseTasks,
+          :create,
+          [
+            [config_for("development", "primary")]
+          ],
+        ) do
+          ActiveRecord::Tasks::DatabaseTasks.create_current(
+            ActiveSupport::StringInquirer.new("development")
+          )
+        end
+      end
+    ensure
+      ENV["RAILS_ENV"] = old_env
+      ENV.delete("SKIP_TEST_DATABASE")
+    end
+
     def test_establishes_connection_for_the_given_environments
       ActiveRecord::Tasks::DatabaseTasks.stub(:create, nil) do
         assert_called_with(ActiveRecord::Base, :establish_connection, [:development]) do


### PR DESCRIPTION
### Summary

Small fix for https://github.com/rails/rails/issues/27299
Specifically, implements the comment here: https://github.com/rails/rails/issues/27299#issuecomment-617880652

Introduces environment variable `SKIP_TEST_DATABASE`, that when present, will not create/drop/etc. the test database.

Example:

```
➜ SKIP_TEST_DATABASE=true bundle exec rake db:create
Created database 'db/development.sqlite3'

➜ bundle exec rake db:create
Created database 'db/development.sqlite3'
Created database 'db/test.sqlite3'
```

### Other Information

I added a CHANGELOG entry for `activerecord` but think this should be documented somewhere.

I've searched the guides but have not found a "rake tasks" place where it would makes sense. I'm open to suggestions.