### PR TITLE
Fix `assert_called_with` an array as expected argument

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -20,7 +20,7 @@ module ActiveSupport
         def assert_called_with(object, method_name, args, returns: nil)
           mock = Minitest::Mock.new
 
-          if args.all? { |arg| arg.is_a?(Array) }
+          if args.size > 1 && args.all? { |arg| arg.is_a?(Array) }
             args.each { |arg| mock.expect(:call, returns, arg) }
           else
             mock.expect(:call, returns, args)

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -7,6 +7,7 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     def increment; 1; end
     def decrement; end
     def <<(arg); end
+    def push(args); end
   end
 
   setup do
@@ -66,6 +67,12 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_assert_called_with_an_array_as_expected_argument
+    assert_called_with(@object, :<<, [ [ 2 ] ]) do
+      @object << [ 2 ]
+    end
+  end
+
   def test_assert_called_with_arguments_and_returns
     assert_called_with(@object, :<<, [ 2 ], returns: 10) do
       assert_equal(10, @object << 2)
@@ -86,6 +93,17 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
     assert_called_with(@object, :<<, [ [ 1 ], [ 2 ] ]) do
       @object << 1
       @object << 2
+    end
+
+    assert_called_with(@object, :<<, [ [ [ 1 ] ], [ [ 2 ] ] ]) do
+      @object << [ 1 ]
+      @object << [ 2 ]
+    end
+  end
+
+  def test_assert_called_with_expected_arguments_as_array_and_one_non_array_object
+    assert_called_with(@object, :push, [ [ 1 ], { number: 42 } ]) do
+      @object.push([ 1 ], { number: 42 })
     end
   end
 


### PR DESCRIPTION
Despite `assert_called_with` is a private api in Rails
I decided to suggest this change for consideration.
Feel free to close this if it does not make sense.

See test cases in the git-diff and this issue for context:
https://github.com/bogdanvlviv/minitest-mock_expectations/issues/4

```ruby
# Before:
assert_called_with(@object, :<<, [ [ [2] ] ]) do
  @object << [2]
end

# After:
assert_called_with(@object, :<<, [ [2] ]) do
  @object << [2]
end
```