### PR TITLE
Build GTG::Simulator memos in a single loop

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/simulator.rb
@@ -14,6 +14,8 @@ module ActionDispatch
       end
 
       class Simulator # :nodoc:
+        INITIAL_STATE = [0].freeze
+
         attr_reader :tt
 
         def initialize(transition_table)
@@ -22,18 +24,17 @@ module ActionDispatch
 
         def memos(string)
           input = StringScanner.new(string)
-          state = [0]
+          state = INITIAL_STATE
+
           while sym = input.scan(%r([/.?]|[^/.?]+))
             state = tt.move(state, sym)
           end
 
-          acceptance_states = state.find_all { |s|
-            tt.accepting? s
-          }
+          acceptance_states = state.each_with_object([]) do |s, memos|
+            memos.concat(tt.memo(s)) if tt.accepting?(s)
+          end
 
-          return yield if acceptance_states.empty?
-
-          acceptance_states.flat_map { |x| tt.memo(x) }.compact
+          acceptance_states.empty? ? yield : acceptance_states
         end
       end
     end


### PR DESCRIPTION
### Summary

This PR is a suggestion for making GTG::Simulator a little faster and to save a few allocations. Basically, it just builds the acceptance_states in a single loop. Additionally, the re-used regex and initial state were moved into constants.

If this suggestion is accepted/desired, I will put together another PR for the NFA::Simulator, which contains the exact same logic for its own memos.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActionDispatch
  module Journey
    module GTG
      class Simulator
        INITIAL_STATE = [0]
        MEMO_PATTERN = %r([/.?]|[^/.?]+).freeze

        def fast_memos(string)
          input = StringScanner.new(string)
          state = INITIAL_STATE

          while sym = input.scan(MEMO_PATTERN)
            state = tt.move(state, sym)
          end

          acceptance_states = state.each_with_object([]) do |s, memos|
            next unless tt.accepting? s
            memo = tt.memo(s)

            if memo.is_a?(Array)
              memos.concat(memo)
            elsif memo.present?
              memos << memo
            end
          end

          acceptance_states.empty? ? yield : acceptance_states
        end
      end
    end
  end
end

parser = ActionDispatch::Journey::Parser.new
ast = ActionDispatch::Journey::Nodes::Or.new %w{/articles(.:format)
         /articles/new(.:format)
         /articles/:id/edit(.:format)
         /articles/:id(.:format)}.map { |x|
  ast = parser.parse x
  ast.each { |n| n.memo = ast }
  ast
}

gtg = ActionDispatch::Journey::GTG::Builder.new(ast).transition_table
simulator = ActionDispatch::Journey::GTG::Simulator.new(gtg)

SCENARIOS = {
  "NOMATCH" => "/doesnt_match",
  "MATCH" => "/articles"
}

SCENARIOS.each_pair do |name, value|
  puts "*" * 80
  puts name
  puts "*" * 80

  puts "IPS"
  Benchmark.ips do |x|
    x.report("memos")      { simulator.memos(value) { [] } }
    x.report("fast_memos") { simulator.fast_memos(value) { [] } }
    x.compare!
  end

  puts "MEMORY"
  Benchmark.memory do |x|
    x.report("memos")      { simulator.memos(value) { [] } }
    x.report("fast_memos") { simulator.fast_memos(value) { [] } }
    x.compare!
  end
end
```
### Results
```
********************************************************************************
NOMATCH
********************************************************************************
IPS
Warming up --------------------------------------
               memos    41.382k i/100ms
          fast_memos    42.694k i/100ms
Calculating -------------------------------------
               memos    456.984k (± 6.5%) i/s -      2.276M in   5.003134s
          fast_memos    473.658k (± 4.6%) i/s -      2.391M in   5.058374s

Comparison:
          fast_memos:   473657.8 i/s
               memos:   456983.5 i/s - same-ish: difference falls within error

MEMORY
Calculating -------------------------------------
               memos   536.000  memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
          fast_memos   496.000  memsize (     0.000  retained)
                         9.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Comparison:
          fast_memos:        496 allocated
               memos:        536 allocated - 1.08x more
********************************************************************************
MATCH
********************************************************************************
IPS
Warming up --------------------------------------
               memos    35.068k i/100ms
          fast_memos    38.690k i/100ms
Calculating -------------------------------------
               memos    379.421k (± 5.8%) i/s -      1.894M in   5.010507s
          fast_memos    431.525k (± 5.9%) i/s -      2.167M in   5.039697s

Comparison:
          fast_memos:   431524.9 i/s
               memos:   379421.0 i/s - 1.14x  slower

MEMORY
Calculating -------------------------------------
               memos   576.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
          fast_memos   456.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Comparison:
          fast_memos:        456 allocated
               memos:        576 allocated - 1.26x more
```