### PR TITLE
Make test file patterns configurable via env vars

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Make test file patterns configurable via Environment variables
+
+    This makes test file patterns configurable via two environment variables:
+     `DEFAULT_TEST`, to configure files to test, and `DEFAULT_TEST_EXCLUDE`,
+    to configure files to exclude from testing.
+
+    These values were hardcoded before, which made it difficult to add
+    new categories of tests that should not be executed by default (e.g:
+    smoke tests).
+
+    *Jorge Manrubia*
+
 *   No longer include `rake rdoc` task when generating plugins.
 
     To generate docs, use the `rdoc lib` command instead.

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -44,8 +44,9 @@ module Rails
         def load_tests(argv)
           patterns = extract_filters(argv)
 
-          tests = Rake::FileList[patterns.any? ? patterns : "test/**/*_test.rb"]
-          tests.exclude("test/system/**/*", "test/dummy/**/*") if patterns.empty?
+
+          tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]
+          tests.exclude(default_test_exclude_glob) if patterns.empty?
 
           tests.to_a.each { |path| require File.expand_path(path) }
         end
@@ -74,6 +75,14 @@ module Rails
                 path
               end
             end
+          end
+
+          def default_test_glob
+            ENV["DEFAULT_TEST"] || "test/**/*_test.rb"
+          end
+
+          def default_test_exclude_glob
+            ENV["DEFAULT_TEST_EXCLUDE"] || "test/{system,dummy}/**/*_test.rb"
           end
 
           def regexp_filter?(arg)

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -895,6 +895,23 @@ module ApplicationTests
       assert_match "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips", output
     end
 
+    def test_can_exclude_files_from_being_tested_via_default_rails_command_by_setting_DEFAULT_TEST_EXCLUDE_env_var
+      create_test_file "smoke", "smoke_foo"
+
+      output = Dir.chdir(app_path) { `DEFAULT_TEST_EXCLUDE="test/smoke/**/*_test.rb" bin/rails test` }
+      assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
+    end
+
+    def test_can_exclude_files_from_being_tested_via_rake_task_by_setting_DEFAULT_TEST_EXCLUDE_env_var
+      create_test_file "smoke", "smoke_foo"
+
+      switch_env("DEFAULT_TEST_EXCLUDE", "test/smoke/**/*_test.rb") do
+        run_test_command "" do |output|
+          assert_match "0 runs, 0 assertions, 0 failures, 0 errors, 0 skips", output
+        end
+      end
+    end
+
     private
       def run_test_command(arguments = "test/unit/test_test.rb", **opts)
         rails "t", *Shellwords.split(arguments), allow_failure: true, **opts


### PR DESCRIPTION
This makes test file patterns configurable via two environment variables: `DEFAULT_TEST`, to configure files to test, and `DEFAULT_TEST_EXCLUDE`, to configure files to exclude from testing.

These values were hardcoded before, which made it difficult to add new categories of tests that should not be executed by default (e.g: smoke tests).

It uses environment variables instead of regular Rails config options because Rails environment is not available when the Runner builds the list of files to test (unless using Spring). A nicer solution would be making sure that the Rails environment is always loaded when the runner starts. This is a first simple step to make these paths configurable for now.