### PR TITLE
Added link to infosec.mozilla.org under the security guide.

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1214,5 +1214,5 @@ The security landscape shifts and it is important to keep up to date, because mi
 
 * Subscribe to the Rails security [mailing list](https://groups.google.com/forum/#!forum/rubyonrails-security).
 * [Brakeman - Rails Security Scanner](https://brakemanscanner.org/) - To perform static security analysis for Rails applications.
-* [Keep up to date on the other application layers](http://secunia.com/) (they have a weekly newsletter, too).
+* [Mozilla's Web Security Guidelines](https://infosec.mozilla.org/guidelines/web_security.html) - Recommendations on topics covering Content Security Policy, HTTP headers, Cookies, TLS configuration, etc.
 * A [good security blog](https://www.owasp.org) including the [Cross-Site scripting Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md).


### PR DESCRIPTION
### Summary

I think this guide merits to be widely known. It contains a condensed list of various HTTP flags, settings for cookie (I suppose `SameSite`, `httpOnly` and `secure` ought be mentioned under the cookie section as well, in addition to details to the fact that cookies are encrypted), and a link to their SSL/TLS configuration tool. 

### Other Information

These three sites are linked somehow from the above site.
https://observatory.mozilla.org
https://securityheaders.com
https://www.ssllabs.com/