### PR TITLE
Changed partial example to be more rails common

### DIFF
--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -595,6 +595,7 @@ end
 # in app/controllers/admin/products_controller
 class Admin::ProductsController < AdminController
   def index
+    @products = []
   end
 end
 ```

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -609,7 +609,7 @@ This makes `app/views/application/` a great place for your shared partials, whic
 
 ```erb
 <%# app/views/admin/products/index.html.erb %>
-<%= render @products || "empty_list" %>
+<%= render(@products) || render("empty_list") %>
 
 <%# app/views/application/_empty_list.html.erb %>
 There are no items in this list <em>yet</em>.


### PR DESCRIPTION
### Summary

If you create an action, you have some instance variable which are defined like in this example should be `@products`. If it is empty, then products is an empty array: `@products = []` or an empty list. The example before worked only if `@products = nil` which is a rare case for
such code.

Also the description of partial `empty_list.html.erb` tells: "There are no items in this list". For me this is `@products = []` and not `@products = nil`. That's why I've changed the example to this.

Another suggestion would be to change the whole example to something: "instance variable only defined for special condition".
