### PR TITLE
Add ability to delete signed/encrypted cookies

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -487,6 +487,12 @@ module ActionDispatch
         @parent_jar[name] = options
       end
 
+      def delete(name, options = {})
+        if data = @parent_jar.delete(name.to_s, options)
+          parse(name, data, purpose: "cookie.#{name}") || parse(name, data)
+        end
+      end
+
       protected
         def request; @parent_jar.request; end
 


### PR DESCRIPTION
### Summary

More than once, I have had the feeling like that the `delete` method was missing for signed/encrypted cookies. As an example, I was able to do
```ruby
  bar = cookies.delete(:foo)
```

but I couldn't do
```ruby
  bar = cookies.signed.delete(:foo)
```

instead, I needed to do
```ruby
  bar = cookies.signed[:foo]
  cookies.delete(:foo)
```

I see this PR as a small addition to the cookies API, but I'm ok if you decide to accept it or not 👌 