### PR TITLE
Remove unmaintained gem from ActiveJob README [ci skip]

### DIFF
--- a/activejob/README.md
+++ b/activejob/README.md
@@ -95,9 +95,6 @@ their gem, or as a stand-alone gem. For discussion about this see the
 following PRs: [23311](https://github.com/rails/rails/issues/23311#issuecomment-176275718),
 [21406](https://github.com/rails/rails/pull/21406#issuecomment-138813484), and [#32285](https://github.com/rails/rails/pull/32285).
 
-## Auxiliary gems
-
-* [activejob-stats](https://github.com/seuros/activejob-stats)
 
 ## Download and installation
 
@@ -110,6 +107,7 @@ The latest version of Active Job can be installed with RubyGems:
 Source code can be downloaded as part of the Rails project on GitHub:
 
 * https://github.com/rails/rails/tree/master/activejob
+
 
 ## License
 


### PR DESCRIPTION
### Summary

I was very surprised to find a reference to a gem which last commit was on 2014 and I couldn't even find it in rubygems https://rubygems.org/gems/activejob-stats . This PR deletes that reference. 
