### PR TITLE
Skip test cases for upsert_all on relation for sqlite adapter for duplicate record

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -373,6 +373,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_on_relation
+    skip unless supports_insert_on_duplicate_update?
+
     author = Author.create!(name: "Jimmy")
 
     assert_difference "author.books.count", +1 do
@@ -381,6 +383,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_on_relation_precedence
+    skip unless supports_insert_on_duplicate_update?
+
     author = Author.create!(name: "Jimmy")
     second_author = Author.create!(name: "Bob")
 
@@ -390,6 +394,8 @@ class InsertAllTest < ActiveRecord::TestCase
   end
 
   def test_upsert_all_create_with
+    skip unless supports_insert_on_duplicate_update?
+
     assert_difference "Book.where(format: 'X').count", +2 do
       Book.create_with(format: "X").upsert_all([ { name: "A" }, { name: "B" } ])
     end


### PR DESCRIPTION
PR #38899 added `upsert_all` on relation with test cases but `insert_all` and `upsert_all` for sqlite adapter doesn't support duplicate record updates. First time they worked because upsert performed `insert` instead of `upsert`. 

They failed on my other PR so I debugged it and raised a PR to fix it. 