### PR TITLE
Use size == 1 instead of one? to check hashes count in HashWithIndifferentAccess#update

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -125,7 +125,7 @@ module ActiveSupport
     #   hash_2['key'] = 12
     #   hash_1.update(hash_2) { |key, old, new| old + new } # => {"key"=>22}
     def update(*other_hashes, &block)
-      if other_hashes.one?
+      if other_hashes.size == 1
         update_with_single_argument(other_hashes.first, block)
       else
         other_hashes.each do |other_hash|


### PR DESCRIPTION
### Summary

[`one?`](https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-one-3F) checks is there is only one true element in the enumerable. Since we need to check the number of elements in `other_hashes` we need to check if `size == 1`.