### PR TITLE
Ensure public S3 direct uploads have correct ACL

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -80,7 +80,7 @@ module ActiveStorage
     def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
       instrument :url, key: key do |payload|
         generated_url = object_for(key).presigned_url :put, expires_in: expires_in.to_i,
-          content_type: content_type, content_length: content_length, content_md5: checksum
+          content_type: content_type, content_length: content_length, content_md5: checksum, **upload_options
 
         payload[:url] = generated_url
 

--- a/activestorage/test/service/azure_storage_public_service_test.rb
+++ b/activestorage/test/service/azure_storage_public_service_test.rb
@@ -17,6 +17,30 @@ if SERVICE_CONFIGURATIONS[:azure_public]
       response = Net::HTTP.get_response(URI(url))
       assert_equal "200", response.code
     end
+
+    test "direct upload" do
+      key          = SecureRandom.base58(24)
+      data         = "Something else entirely!"
+      checksum     = Digest::MD5.base64digest(data)
+      content_type = "text/xml"
+      url          = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: content_type, content_length: data.size, checksum: checksum)
+
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      @service.headers_for_direct_upload(key, checksum: checksum, content_type: content_type, filename: ActiveStorage::Filename.new("test.txt")).each do |k, v|
+        request.add_field k, v
+      end
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
+      end
+
+      response = Net::HTTP.get_response(URI(@service.url(key)))
+      assert_equal "200", response.code
+      assert_equal data, response.body
+    ensure
+      @service.delete key
+    end
   end
 else
   puts "Skipping Azure Storage Public Service tests because no Azure configuration was supplied"

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -17,6 +17,28 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
       response = Net::HTTP.get_response(URI(url))
       assert_equal "200", response.code
     end
+
+    test "direct upload" do
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      checksum = Digest::MD5.base64digest(data)
+      url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      request.add_field "Content-Type", ""
+      request.add_field "Content-MD5", checksum
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
+      end
+
+      response = Net::HTTP.get_response(URI(@service.url(key)))
+      assert_equal "200", response.code
+      assert_equal data, response.body
+    ensure
+      @service.delete key
+    end
   end
 else
   puts "Skipping GCS Public Service tests because no GCS configuration was supplied"


### PR DESCRIPTION
### Summary

Direct uploads to public S3 buckets weren't being given public ACL permissions, resulting in uploaded files not having public-read access. Passing upload options when generating the direct upload URL resolves this.

Google and Azure storage weren't affected.

Also added tests to cover public direct uploads for all cloud storage services.

Resolves #39006

### Other Information

N/A
