### PR TITLE
[Bugfix?] Fix db:prepare's behaviour (and bin/setup) right after rails new

### DIFF
--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -33,8 +33,6 @@ module ApplicationTests
         rails "db:system:change", "--to=postgresql"
         rails "db:drop", allow_failure: true
 
-        app_file "db/schema.rb", ""
-
         output = `bin/setup 2>&1`
 
         # Ignore line that's only output by Bundler < 1.14

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -738,18 +738,16 @@ module ApplicationTests
         use_postgresql
 
         Dir.chdir(app_path) do
-          begin
-            FileUtils.rm_rf("db/schema.rb")
-            rails "db:drop"
+          FileUtils.rm_rf("db/schema.rb")
+          rails "db:drop"
 
-            output = rails("db:prepare")
+          output = rails("db:prepare")
 
-            assert_equal 0, $?.exitstatus
-            assert_match(/Created database/, output)
-            assert File.exist?("db/schema.rb")
-          ensure
-            rails "db:drop" rescue nil
-          end
+          assert_equal 0, $?.exitstatus
+          assert_match(/Created database/, output)
+          assert File.exist?("db/schema.rb")
+        ensure
+          rails "db:drop" rescue nil
         end
       end
 

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -734,6 +734,25 @@ module ApplicationTests
         end
       end
 
+      test "db:prepare works when database and schema file do not exist" do
+        use_postgresql
+
+        Dir.chdir(app_path) do
+          begin
+            FileUtils.rm_rf("db/schema.rb")
+            rails "db:drop"
+
+            output = rails("db:prepare")
+
+            assert_equal 0, $?.exitstatus
+            assert_match(/Created database/, output)
+            assert File.exist?("db/schema.rb")
+          ensure
+            rails "db:drop" rescue nil
+          end
+        end
+      end
+
       test "db:prepare does not touch schema when dumping is disabled" do
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"


### PR DESCRIPTION
## Background

It looks like the `db:prepare` task is unable to handle the following scenario:

- The Rails app uses a PostgreSQL database. (I'm suspecting that applies to MySQL and some other databases too.)
- The development database does not exist.
- The `db/schema.rb` file does not exist.

This scenario is typical of a fresh new Rails application.

This impacts `bin/setup` and renders it unable to run right after creating a new Rails application.

## Reproducing the issue

Simply create a new Rails application preconfigured for a PostgreSQL database then run `bin/setup`.
(You'll need a PostgreSQL server installed and running.)

```sh
$ rails new -d postgresql testapp
$ cd testapp
$ bin/setup
```

Result (truncated):
```
== Preparing database ==
Created database 'testapp_development'
Created database 'testapp_test'
/Users/david-stosik/dev/testapp/db/schema.rb doesn't exist yet. Run `rails db:migrate` to create it, then try again. If you do not intend to use a database, you should instead alter /Users/david-stosik/dev/testapp/config/application.rb to limit the frameworks that will be loaded.

== Command ["bin/rails db:prepare"] failed ==
```

### Expected outcome

The script should not fail, the database should be created, and `db/schema.rb` initialized with an empty schema.

## The fix

I wasn't really sure how to fix the bug, and wanted, as much as possible, to use existing helpers. Unfortunately, `check_schema_file` aborts if the file does not exist, so I used `dump_filename` once more to recover the schema filename, then `File.exist?` to check if it exists prior to trying to load it.

Here is how I would summarize the process:
- if the database does not exist, then create the database
- if the schema file exists, then load it
- run migrations (which might be a no-op if the schema file exists and there are no new migrations)
- dump the schema (might be a no-op as well)
- if the database was created, then load seeds

cc @robertomiranda @guilleiguaran 