### PR TITLE
Require time core extensions in all environments

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -1,3 +1,5 @@
+require "active_support/core_ext/integer/time"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,3 +1,5 @@
+require "active_support/core_ext/integer/time"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -1,9 +1,9 @@
+require "active_support/core_ext/integer/time"
+
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped
 # and recreated between test runs. Don't rely on the data there!
-
-require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
These have been required in the generated test environment config since 1c7207a22faca3f07ee9aee1dc00a5b01286de2f, but the generated development config also uses them (albeit inside a conditional):

https://github.com/rails/rails/blob/a5469f0239ed210104fdea33d8e5ba87dbad4f5b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt#L25

...and the generated production config contains a comment which uses them:

https://github.com/rails/rails/blob/a5469f0239ed210104fdea33d8e5ba87dbad4f5b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L127

More generally, we shouldn't require core extensions in one environment and not others, since applications with `config.active_support.bare` enabled could rely on them implicitly and exhibit inconsistent behaviour across environments.

Somewhat incidentally closes https://github.com/rails/rails/issues/37391.