### PR TITLE
Ensure cache fragment keys (i.e. dependency tree digests) include all relevant templates

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Ensure cache fragment digests include all relevant template dependencies when
+    fragments are contained in a block passed to the render helper. Remove the
+    virtual_path keyword arguments found in CacheHelper as they no longer possess
+    any function following 1581cab.
+
+    Fixes #38984
+
+    *Aaron Lipman*
+
 *   Deprecate `config.action_view.raise_on_missing_translations` in favor of
     `config.i18n.raise_on_missing_translations`.
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -269,9 +269,9 @@ module ActionView #:nodoc:
       _prepare_context
     end
 
-    def _run(method, template, locals, buffer, &block)
+    def _run(method, template, locals, buffer, add_to_stack: true, &block)
       _old_output_buffer, _old_virtual_path, _old_template = @output_buffer, @virtual_path, @current_template
-      @current_template = template
+      @current_template = template if add_to_stack
       @output_buffer = buffer
       send(method, locals, buffer, &block)
     ensure

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -270,12 +270,12 @@ module ActionView #:nodoc:
     end
 
     def _run(method, template, locals, buffer, add_to_stack: true, &block)
-      _old_output_buffer, _old_virtual_path, _old_template = @output_buffer, @virtual_path, @current_template
+      _old_output_buffer, _old_template = @output_buffer, @current_template
       @current_template = template if add_to_stack
       @output_buffer = buffer
       send(method, locals, buffer, &block)
     ensure
-      @output_buffer, @virtual_path, @current_template = _old_output_buffer, _old_virtual_path, _old_template
+      @output_buffer, @current_template = _old_output_buffer, _old_template
     end
 
     def compiled_method_container

--- a/actionview/lib/action_view/context.rb
+++ b/actionview/lib/action_view/context.rb
@@ -18,7 +18,6 @@ module ActionView
     def _prepare_context
       @view_flow     = OutputFlow.new
       @output_buffer = nil
-      @virtual_path  = nil
     end
 
     # Encapsulates the interaction with the view flow so it

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -124,10 +124,10 @@ module ActionView
         def scope_key_by_partial(key)
           stringified_key = key.to_s
           if stringified_key.start_with?(".")
-            if @virtual_path
+            if @current_template&.virtual_path
               @_scope_key_by_partial_cache ||= {}
-              @_scope_key_by_partial_cache[@virtual_path] ||= @virtual_path.gsub(%r{/_?}, ".")
-              "#{@_scope_key_by_partial_cache[@virtual_path]}#{stringified_key}"
+              @_scope_key_by_partial_cache[@current_template.virtual_path] ||= @current_template.virtual_path.gsub(%r{/_?}, ".")
+              "#{@_scope_key_by_partial_cache[@current_template.virtual_path]}#{stringified_key}"
             else
               raise "Cannot use t(#{key.inspect}) shortcut because path is not available"
             end

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -282,7 +282,7 @@ module ActionView
           identifier: template.identifier,
           layout: layout && layout.virtual_path
         ) do |payload|
-          content = template.render(view, locals) do |*name|
+          content = template.render(view, locals, add_to_stack: !block) do |*name|
             view._layout_for(*name, &block)
           end
 

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -68,7 +68,7 @@ module ActionView
       end
 
       def expanded_cache_key(key, view, template, digest_path)
-        key = view.combined_fragment_cache_key(view.cache_fragment_name(key, virtual_path: template.virtual_path, digest_path: digest_path))
+        key = view.combined_fragment_cache_key(view.cache_fragment_name(key, digest_path: digest_path))
         key.frozen? ? key.dup : key # #read_multi & #write may require mutability, Dalli 2.6.0.
       end
 

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -176,10 +176,10 @@ module ActionView
     # This method is instrumented as "!render_template.action_view". Notice that
     # we use a bang in this instrumentation because you don't want to
     # consume this in production. This is only slow if it's being listened to.
-    def render(view, locals, buffer = ActionView::OutputBuffer.new, &block)
+    def render(view, locals, buffer = ActionView::OutputBuffer.new, add_to_stack: true, &block)
       instrument_render_template do
         compile!(view)
-        view._run(method_name, self, locals, buffer, &block)
+        view._run(method_name, self, locals, buffer, add_to_stack: add_to_stack, &block)
       end
     rescue => e
       handle_render_error(view, e)

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -59,8 +59,6 @@ module RenderERBUtils
   end
 
   def render_erb(string)
-    @virtual_path = nil
-
     template = ActionView::Template.new(
       string.strip,
       "test template",

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -10,7 +10,6 @@ class RelationCacheTest < ActionView::TestCase
     view_paths     = ActionController::Base.view_paths
     lookup_context = ActionView::LookupContext.new(view_paths, {}, ["test"])
     @view_renderer = ActionView::Renderer.new(lookup_context)
-    @virtual_path  = "path"
     @current_template = lookup_context.find "test/hello_world"
 
     controller.cache_store = ActiveSupport::Cache::MemoryStore.new

--- a/actionview/test/fixtures/test/cache_fragment_inside_render_layout_block_1.html.erb
+++ b/actionview/test/fixtures/test/cache_fragment_inside_render_layout_block_1.html.erb
@@ -1,0 +1,1 @@
+<%= render layout: "layouts/yield_only" do %><%= cache "foo" do %>CAT<% end %><% end %>

--- a/actionview/test/fixtures/test/cache_fragment_inside_render_layout_block_2.html.erb
+++ b/actionview/test/fixtures/test/cache_fragment_inside_render_layout_block_2.html.erb
@@ -1,0 +1,1 @@
+<%= render layout: "layouts/yield_only" do %><%= cache "foo" do %>DOG<% end %><% end %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -22,6 +22,7 @@ module RenderTestCases
 
     controller = TestController.new
     controller.perform_caching = true
+    controller.cache_store = :memory_store
     @view.controller = controller
 
     @controller_view = controller.view_context_class.with_empty_template_cache.new(
@@ -704,6 +705,13 @@ class CachedViewRenderTest < ActiveSupport::TestCase
     view_paths = ActionController::Base.view_paths
     assert_equal ActionView::OptimizedFileSystemResolver, view_paths.first.class
     setup_view(view_paths)
+  end
+
+  def test_cache_fragments_inside_render_layout_call_with_block
+    cat = @view.render(template: "test/cache_fragment_inside_render_layout_block_1")
+    dog = @view.render(template: "test/cache_fragment_inside_render_layout_block_2")
+
+    assert_not_equal cat, dog
   end
 end
 

--- a/actionview/test/template/template_test.rb
+++ b/actionview/test/template/template_test.rb
@@ -22,7 +22,6 @@ class TestERBTemplate < ActiveSupport::TestCase
     def initialize(*)
       super
       @output_buffer = "original"
-      @virtual_path = nil
     end
 
     def hello
@@ -35,7 +34,7 @@ class TestERBTemplate < ActiveSupport::TestCase
 
     def partial
       ActionView::Template.new(
-        "<%= @virtual_path %>",
+        "<%= @current_template.virtual_path %>",
         "partial",
         ERBHandler,
         virtual_path: "partial",
@@ -115,9 +114,9 @@ class TestERBTemplate < ActiveSupport::TestCase
   end
 
   def test_virtual_path
-    @template = new_template("<%= @virtual_path %>" \
+    @template = new_template("<%= @current_template.virtual_path %>" \
                              "<%= partial.render(self, {}) %>" \
-                             "<%= @virtual_path %>")
+                             "<%= @current_template.virtual_path %>")
     assert_equal "hellopartialhello", render
   end
 


### PR DESCRIPTION
### Summary

A Rails view may rely on several templates (e.g. layouts and partials) in addition to the template for the action being rendered (e.g. "show.html.erb"). To track which view file is currently being rendered for the purpose of generating template tree digests used in cache fragment keys, Action View uses a stack, the top item of which is accessed via the `@current_template` variable (introduced in 1581cab).

Consider the following template:

    <!-- home.html.erb -->
    <%= render layout: "wrapper" do %>
      <%= cache "foo" %>
        HOME
      <%= end %>
    <%= end %>

Inside the block passed to the render helper, `@current_template` corresponds to the wrapper.html.erb template instead of home.html.erb. As wrapper.html.erb is then used as the root node for generating the template tree digest used in the cache fragment key, the cache fragment fails to expire upon changes to home.html.erb. Additionally, should a second template use the wrapper.html.erb layout and contain a cache fragment with the same key, the cache fragment keys for both templates will be identical - causing cached content to "leak" from one view to another (as described in #38984).

This PR skips adding templates to the stack when rendered as a layout with a block via the render helper. This results in `@current_template` corresponding to the view file currently being rendered, ensuring correctly-expiring and unique cache fragment digests. Additionally, the `virtual_path` keyword arguments found in CacheHelper are removed as they no longer possess any function. (Following the introduction of `@current_template`, virtual path is accessed via `@current_template.virtual_path` rather than as a standalone variable.) Lastly, the `@virtual_path` instance variable is removed from the codebase entirely, and all references to it are replaced with `@current_template.virtual_path.`

### Other Changes

The controller cache store used in actionview/test/template/render_test.rb is now set to `:memory_store` (was previously nil). This was necessary to provide a failing test fixed by this PR.

### Other Information

This PR is split into two separate commits. The first commit contains the minimum changes necessary to fix the bug described in #38984 while passing all tests. The second commit provides a refactor removing the redundant `@virtual_path` variable from the codebase entirely, and replacing it with `@current_template.virtual_path`. I've left them as separate commits to make it easier for reviewers to follow what changes fix #38984 and what's part of a tangential refactor, but happy to rebase into a single commit prior to merging.