### PR TITLE
Remove redundant begin block from yarn template

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -1,10 +1,8 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarn", *ARGV
-  rescue Errno::ENOENT
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarn", *ARGV
+rescue Errno::ENOENT
+  $stderr.puts "Yarn executable was not detected in the system."
+  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end


### PR DESCRIPTION
### Summary

This will create bin/yarn without the begin block. This matches the rubocop configuration of Style/RedundantBegin and avoids rubocop complains on new projects.



