### PR TITLE
Remove useless type cast on aggregated value

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -565,10 +565,6 @@ module ActiveRecord
         pool.checkin self
       end
 
-      def column_name_for_operation(operation, node) # :nodoc:
-        visitor.compile(node)
-      end
-
       def default_index_type?(index) # :nodoc:
         index.using.nil?
       end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -427,16 +427,6 @@ module ActiveRecord
         @use_insert_returning
       end
 
-      def column_name_for_operation(operation, node) # :nodoc:
-        OPERATION_ALIASES.fetch(operation) { operation.downcase }
-      end
-
-      OPERATION_ALIASES = { # :nodoc:
-        "maximum" => "max",
-        "minimum" => "min",
-        "average" => "avg",
-      }
-
       # Returns the version of the connected PostgreSQL server.
       def get_database_version # :nodoc:
         @connection.server_version
@@ -904,6 +894,7 @@ module ActiveRecord
             "oid" => PG::TextDecoder::Integer,
             "float4" => PG::TextDecoder::Float,
             "float8" => PG::TextDecoder::Float,
+            "numeric" => PG::TextDecoder::Numeric,
             "bool" => PG::TextDecoder::Boolean,
           }
 


### PR DESCRIPTION
Related #39039.

Currently PostgreSQL adapter is the only adapter that rely on type
casting by `result.column_types`, now the adapter can return numeric
value without type casting by Active Record side.
So we can remove that useless type cast on aggregated value.