### PR TITLE
Update pg gem required version to 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -127,7 +127,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "sqlite3", "~> 1.4"
 
   group :db do
-    gem "pg", ">= 0.18.0"
+    gem "pg", "~> 1.1"
     gem "mysql2", "~> 0.5"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -569,7 +569,7 @@ DEPENDENCIES
   minitest-retry
   mysql2 (~> 0.5)
   nokogiri (>= 1.8.1)
-  pg (>= 0.18.0)
+  pg (~> 1.1)
   psych (~> 3.0)
   puma
   que

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "pg", ">= 0.18", "< 2.0"
+gem "pg", "~> 1.1"
 require "pg"
 require "thread"
 require "digest/sha1"

--- a/railties/lib/rails/generators/database.rb
+++ b/railties/lib/rails/generators/database.rb
@@ -14,7 +14,7 @@ module Rails
       def gem_for_database(database = options[:database])
         case database
         when "mysql"          then ["mysql2", ["~> 0.5"]]
-        when "postgresql"     then ["pg", [">= 0.18", "< 2.0"]]
+        when "postgresql"     then ["pg", ["~> 1.1"]]
         when "sqlite3"        then ["sqlite3", ["~> 1.4"]]
         when "oracle"         then ["activerecord-oracle_enhanced-adapter", nil]
         when "sqlserver"      then ["activerecord-sqlserver-adapter", nil]

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -547,7 +547,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     if defined?(JRUBY_VERSION)
       assert_gem "activerecord-jdbcpostgresql-adapter"
     else
-      assert_gem "pg", "'>= 0.18', '< 2.0'"
+      assert_gem "pg", "'~> 1.1'"
     end
   end
 

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -40,7 +40,7 @@ module Rails
 
             assert_file("Gemfile") do |content|
               assert_match "# Use pg as the database for Active Record", content
-              assert_match "gem 'pg', '>= 0.18', '< 2.0'", content
+              assert_match "gem 'pg', '~> 1.1'", content
             end
           end
 


### PR DESCRIPTION
This is required for #39063 to use `PG::TextDecoder::Numeric`.

Ref https://github.com/ged/ruby-pg/pull/25.

The pg gem 1.1.0 was released at August 24, 2018, so I think it is good
timing to bump the required version for improving and cleaning up the
code base.

https://rubygems.org/gems/pg/versions