### PR TITLE
Ignore interpolated strings in DependencyTracker

### DIFF
--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -130,8 +130,9 @@ module ActionView
 
         def add_dependencies(render_dependencies, arguments, pattern)
           arguments.scan(pattern) do
-            add_dynamic_dependency(render_dependencies, Regexp.last_match[:dynamic])
-            add_static_dependency(render_dependencies, Regexp.last_match[:static])
+            match = Regexp.last_match
+            add_dynamic_dependency(render_dependencies, match[:dynamic])
+            add_static_dependency(render_dependencies, match[:static], match[:quote])
           end
         end
 
@@ -141,7 +142,12 @@ module ActionView
           end
         end
 
-        def add_static_dependency(dependencies, dependency)
+        def add_static_dependency(dependencies, dependency, quote_type)
+          if quote_type == '"'
+            # Ignore if there is interpolation
+            return if dependency.include?('#{')
+          end
+
           if dependency
             if dependency.include?("/")
               dependencies << dependency

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -192,4 +192,14 @@ class ERBTrackerTest < Minitest::Test
       "comments/comment"
     ], tracker.dependencies
   end
+
+  def test_dependencies_with_interpolation
+    template = FakeTemplate.new(%q{
+      <%# render "double/#{quote}" %>
+      <%# render 'single/#{quote}' %>
+    }, :erb)
+    tracker = make_tracker("interpolation/_string", template)
+
+    assert_equal ["single/\#{quote}"], tracker.dependencies
+  end
 end


### PR DESCRIPTION
`ActionView::DependencyTracker` looks through ERB templates using a regex to find render calls. Previously this would incorrectly pick up interpolated strings, like `render "foo/#{bar}"`.

This does not attempt to completely correct `DependencyTracker`, we can't parse Ruby accurately with a regex (I really want to rewrite it using a real parser 😅), but should avoid a relatively common case that previously was generating warnings in #38858.

cc @kaspth 