### PR TITLE
MailDeliveryJob should be the new default

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -457,7 +457,7 @@ module ActionMailer
 
     helper ActionMailer::MailHelper
 
-    class_attribute :delivery_job, default: ::ActionMailer::DeliveryJob
+    class_attribute :delivery_job, default: ::ActionMailer::MailDeliveryJob
     class_attribute :default_params, default: {
       mime_version: "1.0",
       charset:      "UTF-8",


### PR DESCRIPTION
### Summary

A deprecation warning was introduced in https://github.com/rails/rails/pull/34591
But for those of us who never customized the delivery method, it can be quite puzzling.
I think the default should simply be updated.

