### PR TITLE
Upgrade-safe URL-safe CSRF tokens

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -98,6 +98,10 @@ module ActionController #:nodoc:
       config_accessor :default_protect_from_forgery
       self.default_protect_from_forgery = false
 
+      # Controls whether URL-safe CSRF tokens are generated.
+      config_accessor :urlsafe_csrf_tokens, instance_writer: false
+      self.urlsafe_csrf_tokens = false
+
       helper_method :form_authenticity_token
       helper_method :protect_against_forgery?
     end
@@ -472,15 +476,27 @@ module ActionController #:nodoc:
       end
 
       def generate_csrf_token # :nodoc:
-        SecureRandom.urlsafe_base64(AUTHENTICITY_TOKEN_LENGTH, padding: false)
+        if urlsafe_csrf_tokens
+          SecureRandom.urlsafe_base64(AUTHENTICITY_TOKEN_LENGTH, padding: false)
+        else
+          SecureRandom.base64(AUTHENTICITY_TOKEN_LENGTH)
+        end
       end
 
       def encode_csrf_token(csrf_token) # :nodoc:
-        Base64.urlsafe_encode64(csrf_token, padding: false)
+        if urlsafe_csrf_tokens
+          Base64.urlsafe_encode64(csrf_token, padding: false)
+        else
+          Base64.strict_encode64(csrf_token)
+        end
       end
 
       def decode_csrf_token(encoded_csrf_token) # :nodoc:
-        Base64.urlsafe_decode64(encoded_csrf_token)
+        if urlsafe_csrf_tokens
+          Base64.urlsafe_decode64(encoded_csrf_token)
+        else
+          Base64.strict_decode64(encoded_csrf_token)
+        end
       end
   end
 end

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -495,7 +495,11 @@ module ActionController #:nodoc:
         if urlsafe_csrf_tokens
           Base64.urlsafe_decode64(encoded_csrf_token)
         else
-          Base64.strict_decode64(encoded_csrf_token)
+          begin
+            Base64.strict_decode64(encoded_csrf_token)
+          rescue ArgumentError
+            Base64.urlsafe_decode64(encoded_csrf_token)
+          end
         end
       end
   end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -381,9 +381,11 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_allow_post_with_strict_encoded_token
-    session[:_csrf_token] = Base64.strict_encode64("railstestrailstestrailstestrails")
-    @controller.stub :form_authenticity_token, @token do
-      assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
+    token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
+    token_including_url_unsafe_chars = "+/".ljust(token_length, "A")
+    session[:_csrf_token] = token_including_url_unsafe_chars
+    @controller.stub :form_authenticity_token, token_including_url_unsafe_chars do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_unsafe_chars } }
     end
   end
 

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -175,12 +175,15 @@ end
 # common test methods
 module RequestForgeryProtectionTests
   def setup
+    @old_urlsafe_csrf_tokens = ActionController::Base.urlsafe_csrf_tokens
+    ActionController::Base.urlsafe_csrf_tokens = true
     @token = Base64.urlsafe_encode64("railstestrailstestrailstestrails")
     @old_request_forgery_protection_token = ActionController::Base.request_forgery_protection_token
     ActionController::Base.request_forgery_protection_token = :custom_authenticity_token
   end
 
   def teardown
+    ActionController::Base.urlsafe_csrf_tokens = @old_urlsafe_csrf_tokens
     ActionController::Base.request_forgery_protection_token = @old_request_forgery_protection_token
   end
 
@@ -382,6 +385,19 @@ module RequestForgeryProtectionTests
     @controller.stub :form_authenticity_token, @token do
       assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
     end
+  end
+
+  def test_should_allow_post_with_urlsafe_token_when_migrating
+    config_before = ActionController::Base.urlsafe_csrf_tokens
+    ActionController::Base.urlsafe_csrf_tokens = false
+    token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
+    token_including_url_safe_chars = "-_".ljust(token_length, "A")
+    session[:_csrf_token] = token_including_url_safe_chars
+    @controller.stub :form_authenticity_token, token_including_url_safe_chars do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_safe_chars } }
+    end
+  ensure
+    ActionController::Base.urlsafe_csrf_tokens = config_before
   end
 
   def test_should_allow_patch_with_token

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -970,6 +970,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 - `config.active_record.has_many_inversing`: `true`
 - `config.active_storage.track_variants`: `true`
+- `config.action_controller.urlsafe_csrf_tokens`: `true`
 
 #### For '6.0', new defaults from previous versions below and:
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -176,6 +176,10 @@ module Rails
             action_dispatch.cookies_same_site_protection = :lax
           end
 
+          if respond_to?(:action_controller)
+            action_controller.urlsafe_csrf_tokens = true
+          end
+
           ActiveSupport.utc_to_local_returns_utc_offset_times = true
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -25,6 +25,9 @@
 # It's best enabled when your entire app is migrated and stable on 6.1.
 # Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
 
+# Generate CSRF tokens that are encoded in URL-safe Base64.
+# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+
 # Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
 # UTC offset or a UTC time.
 # ActiveSupport.utc_to_local_returns_utc_offset_times = true


### PR DESCRIPTION
### Summary

As mentioned in https://github.com/rails/rails/pull/18496#issuecomment-613686495, the change from that PR is problematic if you have zero-downtime deployments, because URL-safe Base64-encoded CSRF tokens generated by the new version of the app need to be decoded by the old version of the app still running at the time.

This PR introduces an application config which changes default with Rails 6.1, ensuring new apps do use URL-safe tokens, while apps upgrading from 6.0 have control over the moment they decide to turn on that behavior.

That way, once application owners know they won't revert to 6.0, they can toggle the config (and eventually just use the 6.1 defaults) and get URL-safe tokens.

### Other Information

Here's a repro repo: https://github.com/etiennebarrie/rails-app/

```
$ git checkout urlsafe-csrf/6.0
$ bundle && rails s
```
Visit http://localhost:3000/ you get a Base64 strict token.

```
$ git checkout urlsafe-csrf/6.1.alpha
$ bundle && rails s
```

Without reloading, click the button, this succeeds and shows backward compatibility was working in that PR.
Make sure the new token you get has a `-` or `_` to trigger the failure, otherwise refresh until you get one.

```
$ git checkout urlsafe-csrf/6.0
$ bundle && rails s
```

Without reloading, click the button, you should get an exception backtrace in the server and an alert in the browser.

Now to see the fix working:

```
$ git checkout urlsafe-csrf/fix
$ bundle && RAILS_DEFAULTS=6.1 rails s
```

Refresh until you get a token with a `-` or `_`, then

```
$ rails s
```

Without reloading, click the button, this time it succeeds.

---

I don't think this is a long-term option we want to offer, so once 6.1 ships, we should remove the code generating/decoding/encoding in strict Base64 encoding.