### PR TITLE
Deprecate `allowed_index_name_length` in `DatabaseLimits`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Deprecate `in_clause_length` in `DatabaseLimits`.
+*   Deprecate `in_clause_length` and `allowed_index_name_length` in `DatabaseLimits`.
 
     *Ryuta Kamizono*
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
@@ -32,6 +32,7 @@ module ActiveRecord
       def allowed_index_name_length
         index_name_length
       end
+      deprecate :allowed_index_name_length
 
       # Returns the maximum length of an index name.
       def index_name_length

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1441,10 +1441,8 @@ module ActiveRecord
         end
 
         def validate_index_length!(table_name, new_name, internal = false)
-          max_index_length = internal ? index_name_length : allowed_index_name_length
-
-          if new_name.length > max_index_length
-            raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{allowed_index_name_length} characters"
+          if new_name.length > index_name_length
+            raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
           end
         end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -411,6 +411,10 @@ module ActiveRecord
       assert_deprecated { @connection.joins_per_query }
     end
 
+    def test_allowed_index_name_length_is_deprecated
+      assert_deprecated { @connection.allowed_index_name_length }
+    end
+
     unless current_adapter?(:OracleAdapter)
       def test_in_clause_length_is_deprecated
         assert_deprecated { @connection.in_clause_length }

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -254,7 +254,7 @@ module ActiveRecord
 
       def test_change_column_with_long_index_name
         table_name_prefix = "test_models_"
-        long_index_name = table_name_prefix + ("x" * (connection.allowed_index_name_length - table_name_prefix.length))
+        long_index_name = table_name_prefix + ("x" * (connection.index_name_length - table_name_prefix.length))
         add_column "test_models", "category", :string
         add_index :test_models, :category, name: long_index_name
 

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -44,7 +44,7 @@ module ActiveRecord
         e = assert_raises(ArgumentError) {
           connection.rename_index(table_name, "old_idx", too_long_index_name)
         }
-        assert_match(/too long; the limit is #{connection.allowed_index_name_length} characters/, e.message)
+        assert_match(/too long; the limit is #{connection.index_name_length} characters/, e.message)
 
         assert connection.index_name_exists?(table_name, "old_idx")
       end
@@ -66,7 +66,7 @@ module ActiveRecord
         e = assert_raises(ArgumentError) {
           connection.add_index(table_name, "foo", name: too_long_index_name)
         }
-        assert_match(/too long; the limit is #{connection.allowed_index_name_length} characters/, e.message)
+        assert_match(/too long; the limit is #{connection.index_name_length} characters/, e.message)
 
         assert_not connection.index_name_exists?(table_name, too_long_index_name)
         connection.add_index(table_name, "foo", name: good_index_name)
@@ -229,7 +229,7 @@ module ActiveRecord
 
       private
         def good_index_name
-          "x" * connection.allowed_index_name_length
+          "x" * connection.index_name_length
         end
     end
   end


### PR DESCRIPTION
`allowed_index_name_length` was used for internal temporary operations
in SQLite3, since index name in SQLite3 must be globally unique and
SQLite3 doesn't have ALTER TABLE feature (so it is emulated by creating
temporary table with prefix).

`allowed_index_name_length` was to reserve the margin for the prefix,
but actually SQLite3 doesn't have a limitation for identifier name
length, so the margin has removed at 36901e6.

Now `allowed_index_name_length` is no longer relied on by any adapter,
so I'd like to remove the internal specific method which is no longer
used.