### PR TITLE
Update rescue_from documentation

### DIFF
--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -47,7 +47,7 @@ module ActiveSupport
       #       end
       #   end
       #
-      # Exceptions raised inside exception handlers are not propagated up.
+      # Exceptions raised inside exception handlers are not propagated to the handlers above it.
       def rescue_from(*klasses, with: nil, &block)
         unless with
           if block_given?


### PR DESCRIPTION
Documentation should clarify what `up` means here. It can be confused as call stack which would imply that exceptions are ignored if raised inside exception handler.