### PR TITLE
Add override of unary plus for `ActiveSupport::Duration`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Add override of unary plus for `ActiveSupport::Duration`.
+
+    `+ 1.second` is now identical to `+1.second` to prevent errors
+    where a seemingly innocent change of formatting leads to a change in the code behavior.
+
+    Before:
+    ```ruby
+    +1.second.class
+    # => ActiveSupport::Duration
+    (+ 1.second).class
+    # => Integer
+    ```
+
+    After:
+    ```ruby
+    +1.second.class
+    # => ActiveSupport::Duration
+    (+ 1.second).class
+    # => ActiveSupport::Duration
+    ```
+
+    Fixes #39079.
+
+    *Roman Kushnir*
+
 *   Add subsec to `ActiveSupport::TimeWithZone#inspect`.
 
     Before:

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -295,6 +295,10 @@ module ActiveSupport
       Duration.new(-value, parts.transform_values(&:-@))
     end
 
+    def +@ #:nodoc:
+      self
+    end
+
     def is_a?(klass) #:nodoc:
       Duration == klass || value.is_a?(klass)
     end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -91,6 +91,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_nothing_raised { Date.today - Date.today }
   end
 
+  def test_unary_plus
+    assert_equal (+ 1.second), 1.second
+    assert_instance_of ActiveSupport::Duration, + 1.second
+  end
+
   def test_plus
     assert_equal 2.seconds, 1.second + 1.second
     assert_instance_of ActiveSupport::Duration, 1.second + 1.second


### PR DESCRIPTION
### Summary

Fixes #39079.

`+ 1.second` is now identical to `+1.second` to prevent errors where a seemingly innocent change of formatting leads to a change in the code behavior.

```ruby
(+ 1.second).class
=> ActiveSupport::Duration # was Integer
```
