### PR TITLE
Fix scaffold generator displaying the right error message in the view

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -4,8 +4,8 @@
       <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>
 
       <ul>
-        <%% <%= singular_table_name %>.errors.each do |error| %>
-          <li><%%= error.full_message %></li>
+        <%% <%= singular_table_name %>.errors.full_messages.each do |message| %>
+          <li><%%= message %></li>
         <%% end %>
       </ul>
     </div>


### PR DESCRIPTION
### Summary

When scaffolding a new view, the existing code for displaying an error no longer works, errors.each no longer returns a hash see here for more detail: `activemodel/lib/active_model/errors.rb#each`
### Other Information

related https://github.com/rails/rails/pull/38902

