### PR TITLE
Use FFmpeg scene detection for video previews

### DIFF
--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -28,7 +28,21 @@ module ActiveStorage
 
     private
       def draw_relevant_frame_from(file, &block)
-        draw self.class.ffmpeg_path, "-i", file.path, "-y", "-vframes", "1", "-f", "image2", "-", &block
+        ffmpeg_args = [
+          "-i", file.path,
+          "-vf",
+            # Select the first video frame, plus keyframes and frames
+            # that meet the scene change threshold.
+            'select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),' +
+            # Loop the first 1-2 selected frames in case we were only
+            # able to select 1 frame, then drop the first looped frame.
+            # This lets us use the first video frame as a fallback.
+            "loop=loop=-1:size=2,trim=start_frame=1",
+          "-frames:v", "1",
+          "-f", "image2", "-",
+        ]
+
+        draw self.class.ffmpeg_path, *ffmpeg_args, &block
       end
   end
 end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -551,7 +551,7 @@ the box, Active Storage supports previewing videos and PDF documents.
 </ul>
 ```
 
-WARNING: Extracting previews requires third-party applications, FFmpeg for
+WARNING: Extracting previews requires third-party applications, FFmpeg v3.4+ for
 video and muPDF for PDFs, and on macOS also XQuartz and Poppler.
 These libraries are not provided by Rails. You must install them yourself to
 use the built-in previewers. Before you install and use third-party software,


### PR DESCRIPTION
Generating a video preview by capturing only the first frame of a video is problematic for videos that begin with a fade in from black.  By using keyframe and scene detection that is built in to FFmpeg, we can generate a more representative preview.

---

To test this out, I downloaded a few problematic videos from YouTube:

* https://youtu.be/0ibOfpr2g5k -- black screen with white letters fading in
* https://youtu.be/rpuwCrplaC0 -- stationary daytime scene that immediately fades to black, then fades back in to a nighttime scene
* https://youtu.be/ur_dt7Zn2q4 -- fade in from black to fullscreen image
* https://youtu.be/XTVoeDJsWs0 -- fade in from black to tiny lettering then to quarter-screen image

Below are the results.  The left column is the first frame of the video, i.e. the preview generated by `master`.  The right column is the preview generated by this branch.

![ffmpeg_preview_comparison](https://user-images.githubusercontent.com/771968/80772790-75822f80-8b1d-11ea-8b1e-a337335a296d.png)

/cc @johansmitsnl since you raised the issue in #38705
/cc @georgeclaghorn since you mentioned leveraging FFmpeg in https://github.com/rails/rails/pull/38705#issuecomment-619975035
