### PR TITLE
Also batch attribute readers and writers

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -42,17 +42,14 @@ module ActiveModel
       end
 
       private
-        def define_method_attribute=(name)
+        def define_method_attribute=(name, owner:)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-            generated_attribute_methods, name, writer: true,
+            owner, name, writer: true,
           ) do |temp_method_name, attr_name_expr|
-            generated_attribute_methods.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-              # frozen_string_literal: true
-              def #{temp_method_name}(value)
-                name = #{attr_name_expr}
-                write_attribute(name, value)
-              end
-            RUBY
+            owner <<
+              "def #{temp_method_name}(value)" <<
+              "  write_attribute(#{attr_name_expr}, value)" <<
+              "end"
           end
         end
 

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -7,17 +7,14 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-          def define_method_attribute(name)
+          def define_method_attribute(name, owner:)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-              generated_attribute_methods, name
+              owner, name
             ) do |temp_method_name, attr_name_expr|
-              generated_attribute_methods.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-                # frozen_string_literal: true
-                def #{temp_method_name}
-                  name = #{attr_name_expr}
-                  _read_attribute(name) { |n| missing_attribute(n, caller) }
-                end
-              RUBY
+              owner <<
+                "def #{temp_method_name}" <<
+                "  _read_attribute(#{attr_name_expr}) { |n| missing_attribute(n, caller) }" <<
+                "end"
             end
           end
       end

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -11,17 +11,14 @@ module ActiveRecord
 
       module ClassMethods # :nodoc:
         private
-          def define_method_attribute=(name)
+          def define_method_attribute=(name, owner:)
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
-              generated_attribute_methods, name, writer: true,
+              owner, name, writer: true,
             ) do |temp_method_name, attr_name_expr|
-              generated_attribute_methods.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-                # frozen_string_literal: true
-                def #{temp_method_name}(value)
-                  name = #{attr_name_expr}
-                  _write_attribute(name, value)
-                end
-              RUBY
+              owner <<
+                "def #{temp_method_name}(value)" <<
+                "  _write_attribute(#{attr_name_expr}, value)" <<
+                "end"
             end
           end
       end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/39094

In that previous PR I missed that the reader and setters where generated in two dedicated methods.

After #39094 I can see them in profiles:

```
==================================
  Mode: wall(1000)
  Samples: 106134 (6.07% miss rate)
  GC: 31635 (29.81%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     24136  (22.7%)       24136  (22.7%)     (marking)
...
      1493   (1.4%)        1493   (1.4%)     ActiveModel::AttributeMethods::ClassMethods::CodeGenerator#execute
...
      1048   (1.0%)         995   (0.9%)     ActiveModel::AttributeMethods::ClassMethods#define_proxy_call
...
       688   (0.6%)         664   (0.6%)     ActiveRecord::AttributeMethods::Read::ClassMethods#define_method_attribute
...
       448   (0.4%)         403   (0.4%)     ActiveRecord::AttributeMethods::Write::ClassMethods#define_method_attribute=


==================================
  Mode: cpu(1000)
  Samples: 107866 (5.30% miss rate)
  GC: 34064 (31.58%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     26907  (24.9%)       26907  (24.9%)     (marking)
...
      1483   (1.4%)        1483   (1.4%)     ActiveModel::AttributeMethods::ClassMethods::CodeGenerator#execute
...
      1068   (1.0%)        1024   (0.9%)     ActiveModel::AttributeMethods::ClassMethods#define_proxy_call
...
       737   (0.7%)         694   (0.6%)     ActiveRecord::AttributeMethods::Read::ClassMethods#define_method_attribute
...
       403   (0.4%)         364   (0.3%)     ActiveRecord::AttributeMethods::Write::ClassMethods#define_method_attribute=
```

So this PR goes a bit farther and also batch these two method generation with the others.

Since the code is split differently then before, to better visualize the improvements it's preferable to look at the time spent in `ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods` and it's callees.

Before #39094

```
ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods (/tmp/bundle/ruby/2.7.0/bundler/gems/rails-ff1b6a43c92e/activemodel/lib/active_model/attribute_methods.rb:251)
  samples:     8 self (0.0%)  /   13627 total (11.6%)
  callers:
    13627  (  100.0%)  ActiveRecord::AttributeMethods::ClassMethods#define_attribute_methods
    13620  (   99.9%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods
  callees (13619 total):
    13620  (  100.0%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods
    13619  (  100.0%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_method
 
```

After #39094

```
ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods (/tmp/bundle/ruby/2.7.0/bundler/gems/rails-21a451bb2c16/activemodel/lib/active_model/attribute_methods.rb:253)
  samples:     2 self (0.0%)  /   5987 total (6.0%)
  callers:
    5987  (  100.0%)  ActiveRecord::AttributeMethods::ClassMethods#define_attribute_methods
    4905  (   81.9%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods
  callees (5985 total):
    4905  (   82.0%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_method
    4905  (   82.0%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods
    1078  (   18.0%)  ActiveModel::AttributeMethods::ClassMethods::CodeGenerationBatcher#execute
       2  (    0.0%)  ActiveModel::AttributeMethods::ClassMethods#generated_attribute_methods
```

With this PR:

```
ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods (/tmp/bundle/ruby/2.7.0/bundler/gems/rails-078885a32ed8/activemodel/lib/active_model/attribute_methods.rb:253)
  samples:     2 self (0.0%)  /   4738 total (5.3%)
  callers:
    4738  (  100.0%)  ActiveRecord::AttributeMethods::ClassMethods#define_attribute_methods
    3505  (   74.0%)  ActiveModel::AttributeMethods::ClassMethods::CodeGenerator.batch
    3503  (   73.9%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods
  callees (4736 total):
    4738  (  100.0%)  ActiveModel::AttributeMethods::ClassMethods::CodeGenerator.batch
    3503  (   74.0%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_method
    3503  (   74.0%)  ActiveModel::AttributeMethods::ClassMethods#define_attribute_methods
  code:
```

So based on these CPU profiles, this additional PR makes `define_attribute_methods` another 10% faster.

cc @rafaelfranca @matthewd @etiennebarrie @Edouard-chin 