### PR TITLE
Lock benchmark-ips version < 2.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ group :test do
     gem "byebug"
   end
 
-  gem "benchmark-ips"
+  gem "benchmark-ips", "< 2.8"
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,7 +547,7 @@ DEPENDENCIES
   azure-storage-blob
   backburner
   bcrypt (~> 3.1.11)
-  benchmark-ips
+  benchmark-ips (< 2.8)
   blade
   blade-sauce_labs_plugin
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
Looks like "File does not exist: benchmark/ips/stats/stats_metric" is
caused by benchmark-ips 2.8.0.

https://buildkite.com/rails/rails/builds/68586#d77847d6-b3f5-4fd9-af9e-45f465c9d801/940-965
https://buildkite.com/rails/rails/builds/68586#e2037c59-a695-41ff-9040-c8ee74fa7c16/940-965

