### PR TITLE
Deprecate marshalling load from legacy attributes format

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate marshalling load from legacy attributes format.
+
+    *Ryuta Kamizono*
+
 *   `*_previously_changed?` accepts `:from` and `:to` keyword arguments like `*_changed?`.
 
         topic.update!(status: :archived)

--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -78,6 +78,9 @@ module ActiveModel
 
     def marshal_load(values)
       if values.is_a?(Hash)
+        ActiveSupport::Deprecation.warn(<<~MSG.squish)
+          Marshalling load from legacy attributes format is deprecated and will be removed in Rails 6.2.
+        MSG
         empty_hash = {}.freeze
         initialize(empty_hash, empty_hash, empty_hash, empty_hash, values)
         @materialized = true

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -224,12 +224,13 @@ module ActiveModel
       attributes.instance_variable_get(:@attributes).instance_eval do
         class << self
           def marshal_dump
-            materialize
+            materialize # legacy marshal format before Rails 5.1
           end
         end
       end
 
-      attributes = Marshal.load(Marshal.dump(attributes))
+      data = Marshal.dump(attributes)
+      attributes = assert_deprecated { Marshal.load(data) }
       assert_equal({ foo: "1" }, attributes.to_hash)
     end
 


### PR DESCRIPTION
Since #31827, marshalling attributes hash format is changed to improve
performance because materializing lazy attribute hash is too expensive.

In that time, we had kept an ability to load from legacy attributes
format, since that performance improvement is backported to 5-1-stable
and 5-0-stable.

Now all supported versions will dump attributes as new format, the
backward compatibity should no longer be needed.
