### PR TITLE
Fix `modules_for_helpers` to will raise `MissingHelperError`

### DIFF
--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 $:.unshift File.expand_path("lib", __dir__)
-$:.unshift File.expand_path("fixtures/helpers", __dir__)
-$:.unshift File.expand_path("fixtures/alternate_helpers", __dir__)
 
 ENV["TMPDIR"] = File.expand_path("tmp", __dir__)
 
@@ -22,6 +20,19 @@ require "action_view"
 require "action_view/testing/resolvers"
 require "active_support/dependencies"
 require "active_model"
+
+module ActionViewTestSuiteUtils
+  def self.require_helpers(helpers_dirs)
+    Array(helpers_dirs).each do |helpers_dir|
+      Dir.glob("#{helpers_dir}/**/*_helper.rb") do |helper_file|
+        require helper_file
+      end
+    end
+  end
+end
+
+ActionViewTestSuiteUtils.require_helpers("#{__dir__}/fixtures/helpers")
+ActionViewTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers")
 
 ActiveSupport::Dependencies.hook!
 

--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -79,10 +79,10 @@ module AbstractController
       end
 
       def test_declare_missing_helper
-        e = assert_raise AbstractController::Helpers::MissingHelperError do
+        e = assert_raise NameError do
           AbstractHelpers.helper :missing
         end
-        assert_equal "helpers/missing_helper.rb", e.path
+        assert_equal "uninitialized constant MissingHelper", e.message
       end
 
       def test_helpers_with_module_through_block
@@ -109,19 +109,9 @@ module AbstractController
     end
 
     class InvalidHelpersTest < ActiveSupport::TestCase
-      def test_controller_raise_error_about_real_require_problem
-        e = assert_raise(LoadError) { AbstractInvalidHelpers.helper(:invalid_require) }
-        assert_equal "No such file to load -- very_invalid_file_name.rb", e.message
-      end
-
       def test_controller_raise_error_about_missing_helper
-        e = assert_raise(AbstractController::Helpers::MissingHelperError) { AbstractInvalidHelpers.helper(:missing) }
-        assert_equal "Missing helper file helpers/missing_helper.rb", e.message
-      end
-
-      def test_missing_helper_error_has_the_right_path
-        e = assert_raise(AbstractController::Helpers::MissingHelperError) { AbstractInvalidHelpers.helper(:missing) }
-        assert_equal "helpers/missing_helper.rb", e.path
+        e = assert_raise(NameError) { AbstractInvalidHelpers.helper(:missing) }
+        assert_equal "uninitialized constant MissingHelper", e.message
       end
     end
   end


### PR DESCRIPTION
5b28a0e removed raising `MissingHelperError` path, that has broken
actionview tests for missing helper.

I've changed `MissingHelperError`'s super class from `LoadError` to
`NameError`, since `modules_for_helpers` no longer mostly raise
`LoadError`, it is hard to perfectly maintain the behavior as before.

cc @fxn 