### PR TITLE
Add option to skip ActiveJob generation

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -55,6 +55,9 @@ module Rails
         class_option :skip_active_storage, type: :boolean, default: false,
                                            desc: "Skip Active Storage files"
 
+        class_option :skip_active_job,     type: :boolean, default: false,
+                                           desc: "Skip Active Job files"
+
         class_option :skip_puma,           type: :boolean, aliases: "-P", default: false,
                                            desc: "Skip Puma related files"
 
@@ -204,7 +207,8 @@ module Rails
             :skip_action_mailer,
             :skip_test,
             :skip_sprockets,
-            :skip_action_cable
+            :skip_action_cable,
+            :skip_active_job
           ),
           skip_active_storage?,
           skip_action_mailbox?,

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -460,6 +460,12 @@ module Rails
         end
       end
 
+      def delete_active_job_files_skipping_active_job
+        if options[:skip_active_job]
+          remove_dir "app/jobs"
+        end
+      end
+
       def delete_non_api_initializers_if_api_option
         if options[:api]
           remove_file "config/initializers/cookies_serializer.rb"

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -6,7 +6,7 @@ require "rails/all"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
+<%= comment_if :skip_active_job %>require "active_job/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 <%= comment_if :skip_active_storage %>require "active_storage/engine"
 require "action_controller/railtie"

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -66,9 +66,11 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  <%- unless options[:skip_active_job] -%>
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "<%= app_name %>_production"
+  <%- end -%>
 
   <%- unless options.skip_action_mailer? -%>
   config.action_mailer.perform_caching = false

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -93,7 +93,7 @@ task default: :test
     end
 
     PASSTHROUGH_OPTIONS = [
-      :skip_active_record, :skip_active_storage, :skip_action_mailer, :skip_javascript, :skip_action_cable, :skip_sprockets, :database,
+      :skip_active_record, :skip_active_storage, :skip_action_mailer, :skip_javascript, :skip_action_cable, :skip_active_job, :skip_sprockets, :database,
       :api, :quiet, :pretend, :skip
     ]
 

--- a/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
@@ -17,7 +17,7 @@ require "rails/all"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
+<%= comment_if :skip_active_job %>require "active_job/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 <%= comment_if :skip_active_storage %>require "active_storage/engine"
 require "action_controller/railtie"

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/application.rb.tt
@@ -6,7 +6,7 @@ require "rails/all"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
+<%= comment_if :skip_active_job %>require "active_job/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 <%= comment_if :skip_active_storage %>require "active_storage/engine"
 require "action_controller/railtie"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -355,6 +355,19 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_app_update_does_not_generate_active_job_contents_when_skip_active_job_is_given
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root, "--skip-active-job"]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true, skip_active_job: true }, { destination_root: app_root, shell: @shell }
+      generator.send(:app_const)
+      quietly { generator.send(:update_config_files) }
+
+      assert_no_file "#{app_root}/app/jobs/application_job.rb"
+    end
+  end
+
   def test_app_update_does_not_generate_bootsnap_contents_when_skip_bootsnap_is_given
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-bootsnap"]

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -130,12 +130,12 @@ module SharedGeneratorTests
       "--skip-action-mailbox",
       "--skip-action-text",
       "--skip-action-cable",
+      "--skip-active-job",
       "--skip-sprockets"
     ]
 
     assert_file "#{application_path}/config/application.rb", /^require\s+["']rails["']/
     assert_file "#{application_path}/config/application.rb", /^require\s+["']active_model\/railtie["']/
-    assert_file "#{application_path}/config/application.rb", /^require\s+["']active_job\/railtie["']/
     assert_file "#{application_path}/config/application.rb", /^# require\s+["']active_record\/railtie["']/
     assert_file "#{application_path}/config/application.rb", /^# require\s+["']active_storage\/engine["']/
     assert_file "#{application_path}/config/application.rb", /^require\s+["']action_controller\/railtie["']/
@@ -313,6 +313,15 @@ module SharedGeneratorTests
     assert_no_directory "#{application_path}/app/channels"
     assert_file "Gemfile" do |content|
       assert_no_match(/redis/, content)
+    end
+  end
+
+  def test_generator_if_skip_active_job_is_given
+    run_generator [destination_root, "--skip-active-job"]
+    assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']active_job\/railtie["']/
+    assert_no_directory "#{application_path}/app/jobs"
+    assert_file "#{application_path}/config/environments/production.rb" do |content|
+      assert_no_match(/config\.active_job/, content)
     end
   end
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
TL;DR: allows `rails new --skip-active-job` to be used

This PR aims to add a new option to skip the generation of active job files and config when a new rails project is being created. This was already being done for every other major Rails module but it was missing for ActiveJob.