### PR TITLE
Make fields_for work with Array of models

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2163,11 +2163,15 @@ module ActionView
         case record_name
         when String, Symbol
           record_name = record_name.to_s
-          if nested_attributes_association?(record_name)
+          if nested_attributes_association?(record_name) || record_object.is_a?(Array)
             return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
           end
+        when Array
+          record_object = record_name
+          record_name   = model_name_from_record_or_class(record_object.last).param_key.pluralize
+          return fields_for_with_nested_attributes(record_name, record_object, fields_options, block)
         else
-          record_object = record_name.is_a?(Array) ? record_name.last : record_name
+          record_object = record_name
           record_name   = model_name_from_record_or_class(record_object).param_key
         end
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -3552,6 +3552,48 @@ class FormHelperTest < ActionView::TestCase
     assert_equal 1, initialization_count, "form builder instantiated more than once"
   end
 
+  def test_fields_for_with_non_associated_collection
+    comment_relevances = Array.new(2) { |id| CommentRelevance.new(id + 1) }
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      concat f.fields_for(:relevances, comment_relevances) { |crf|
+        concat crf.text_field(:value)
+      }
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
+      '<input id="post_relevances_attributes_0_value" name="post[relevances_attributes][0][value]" type="text" value="commentrelevance #1" />' \
+      '<input id="post_relevances_attributes_0_id" name="post[relevances_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_relevances_attributes_1_value" name="post[relevances_attributes][1][value]" type="text" value="commentrelevance #2" />' \
+      '<input id="post_relevances_attributes_1_id" name="post[relevances_attributes][1][id]" type="hidden" value="2" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_fields_for_with_explicit_array
+    comment_relevances = Array.new(2) { |id| CommentRelevance.new(id + 1) }
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      concat f.fields_for(comment_relevances) { |crf|
+        concat crf.text_field(:value)
+      }
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
+      '<input id="post_comment_relevances_attributes_0_value" name="post[comment_relevances_attributes][0][value]" type="text" value="commentrelevance #1" />' \
+      '<input id="post_comment_relevances_attributes_0_id" name="post[comment_relevances_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comment_relevances_attributes_1_value" name="post[comment_relevances_attributes][1][value]" type="text" value="commentrelevance #2" />' \
+      '<input id="post_comment_relevances_attributes_1_id" name="post[comment_relevances_attributes][1][id]" type="hidden" value="2" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   private
     def hidden_fields(options = {})
       method = options[:method]


### PR DESCRIPTION
### Summary

Why this change?
I'd say that this PR is actually changing two things:
1. It allows to use `fields_for` with non associated models. This comes particularly handy when working with complex forms or using the well known form object pattern.
2. The current behavior when passing arrays as the only argument is pretty weird (it's just ignoring the fact that it's a collection) and BTW there aren't tests for this case. Instead I think it would be more reasonable to render a collection of inputs.
