### PR TITLE
Added docs for client-side logger

### DIFF
--- a/actioncable/app/javascript/action_cable/logger.js
+++ b/actioncable/app/javascript/action_cable/logger.js
@@ -1,8 +1,15 @@
 import adapters from "./adapters"
 
-// The logger can be enabled with:
+// The logger is disabled by default. You can enable it with:
 //
 //   ActionCable.logger.enabled = true
+//
+//   Example:
+//
+//   import * as ActionCable from '@rails/actioncable'
+//
+//   ActionCable.logger.enabled = true
+//   ActionCable.logger.log('Connection Established.')
 //
 
 export default {

--- a/actioncable/app/javascript/action_cable/logger.js
+++ b/actioncable/app/javascript/action_cable/logger.js
@@ -1,5 +1,10 @@
 import adapters from "./adapters"
 
+// The logger can be enabled with:
+//
+//   ActionCable.logger.enabled = true
+//
+
 export default {
   log(...messages) {
     if (this.enabled) {

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -754,6 +754,17 @@ connections as you have workers. The default worker pool size is set to 4, so
 that means you have to make at least 4 database connections available.
  You can change that in `config/database.yml` through the `pool` attribute.
 
+### Client side logging
+
+Client side logging is disabled by default. You can enable this by setting the `ActionCable.logger.enabled` to true.
+
+```ruby
+import * as ActionCable from '@rails/actioncable'
+
+ActionCable.logger.enabled = true
+```
+
+
 ### Other Configurations
 
 The other common option to configure is the log tags applied to the
@@ -770,14 +781,6 @@ config.action_cable.log_tags = [
 
 For a full list of all configuration options, see the
 `ActionCable::Server::Configuration` class.
-
-Client-side logs can be enabled with the following:
-
-```ruby
-import * as ActionCable from '@rails/actioncable'
-
-ActionCable.logger.enabled = true
-```
 
 ## Running Standalone Cable Servers
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -771,6 +771,14 @@ config.action_cable.log_tags = [
 For a full list of all configuration options, see the
 `ActionCable::Server::Configuration` class.
 
+Client-side logs can be enabled with the following:
+
+```ruby
+import * as ActionCable from '@rails/actioncable'
+
+ActionCable.logger.enabled = true
+```
+
 ## Running Standalone Cable Servers
 
 ### In App


### PR DESCRIPTION
### Summary

There is no mention of client-side ActionCable logger in [Action Cable Overview](https://edgeguides.rubyonrails.org/action_cable_overview.html) guide.

### Other Information
I added the entry inside the [Other Configuration](https://edgeguides.rubyonrails.org/action_cable_overview.html#other-configurations) section because I could not come up with any better place. Also, that section talks about the server side logging.

[Client-Side Components](https://edgeguides.rubyonrails.org/action_cable_overview.html#client-side-components) was another good place to add it but it did not make sense to add the whole section for such a small text.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
