### PR TITLE
Allow associations to be autosaved multiple times

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -365,9 +365,7 @@ module ActiveRecord
       # Is used as a before_save callback to check while saving a collection
       # association whether or not the parent was a new record before saving.
       def before_save_collection_association
-        unless defined?(@new_record_before_save)
-          @new_record_before_save = new_record?
-        end
+        @new_record_before_save ||= new_record?
       end
 
       def after_save_collection_association

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -739,6 +739,15 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_equal 2, firm.clients.length
     assert_includes firm.clients, Client.find_by_name("New Client")
   end
+
+  def test_replace_on_duplicated_object
+    firm = Firm.create!("name" => "New Firm").dup
+    firm.clients = [companies(:second_client), Client.new("name" => "New Client")]
+    assert firm.save
+    firm.reload
+    assert_equal 2, firm.clients.length
+    assert_includes firm.clients, Client.find_by_name("New Client")
+  end
 end
 
 class TestDefaultAutosaveAssociationOnNewRecord < ActiveRecord::TestCase

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -77,6 +77,20 @@ class TransactionTest < ActiveRecord::TestCase
     assert_equal topic.title, topic.reload.title
   end
 
+  def test_rollback_dirty_changes_then_retry_save_on_new_record_with_autosave_association
+    author = Author.new(name: "DHH")
+    book = Book.create!
+    author.books << book
+
+    author.transaction do
+      author.save!
+      raise ActiveRecord::Rollback
+    end
+
+    author.save!
+    assert_equal author, book.reload.author
+  end
+
   def test_persisted_in_a_model_with_custom_primary_key_after_failed_save
     movie = Movie.create
     assert_not_predicate movie, :persisted?


### PR DESCRIPTION
 Since https://github.com/rails/rails/pull/38166, associations can only be autosaved once: after a record has been saved, `@new_record_before_save` will always be false. This assumes that records only transition to being persisted once, but there are two cases where it can happen multiple times: when the transaction that saved the record is rolled back, and when the persisted record is later duplicated.

This caused a regression in our application from 6.0.2.2 to 6.0.3.rc1, so I'd like to backport this.