### PR TITLE
Print non-primary connection names to debug logs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add connection names to the debug log when non-primary connection is used.
+
+    *Tomoki Sekiyama*
+
 *   Deprecate passing a column to `type_cast`.
 
     *Ryuta Kamizono*


### PR DESCRIPTION
To make it easier to debug in multiple database environments, this adds the connection name to the SQL debug log when the non-primary connection pool is used for a query.
This doesn't change the output when default primary connection is used.

e.g.

```ruby
ActiveRecord::Base.connected_to(shard: :shard_one) { User.first }
```
writes a log like:
```
  [primary_shard1] User Load (0.4ms)  SELECT `users`.* FROM `users` ORDER BY `users`.`id` ASC LIMIT 1
```
