### PR TITLE
Include the basic migration types [ci skip]

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -300,9 +300,7 @@ class CreateProducts < ActiveRecord::Migration[6.0]
 end
 ```
 
-You can append as many column name/type pairs as you want.
-
-The native migration types are: :primary_key, :string, :text, :integer, :bigint, :float, :decimal, :numeric, :datetime, :time, :date, :binary, :boolean.
+You can append as many column name/type pairs as you want. Common column types include: `bigint`, `binary`, `boolean`, `date`, `datetime`, `decimal`, `float`, `integer`, `numeric`, `primary_key`, `string`, `text`, and `time`.
 
 ### Passing Modifiers
 

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -302,6 +302,8 @@ end
 
 You can append as many column name/type pairs as you want.
 
+The native migration types are: :primary_key, :string, :text, :integer, :bigint, :float, :decimal, :numeric, :datetime, :time, :date, :binary, :boolean.
+
 ### Passing Modifiers
 
 Some commonly used [type modifiers](#column-modifiers) can be passed directly on


### PR DESCRIPTION
Include the basic migration types in the documentation. A new person starting with rails will need them right here.


