### PR TITLE
Improves ActiveRecord::Base.connection_handler.while_preventing_writes documentation [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1018,16 +1018,14 @@ module ActiveRecord
         Thread.current[:prevent_writes] = prevent_writes
       end
 
-      # Prevent most writing to the database regardless of role.
+      # Prevent writing to the database regardless of role.
       #
       # In some cases you may want to prevent writes to the database
       # even if you are on a database that can write. `while_preventing_writes`
-      # will prevent most writes to the database for the duration of the block.
+      # will prevent writes to the database for the duration of the block.
       #
-      # Note: `while_preventing_writes` does not necessarily catch all writes,
-      # it's meant as a safeguard against accidental writes. Writes as created
-      # by ActiveRecord will most likely be caught. Handcrafted write queries
-      # may still be possible though.
+      # Note: `while_preventing_writes` is not as safe as a separate readonly
+      # database user, it only provides a safeguard against accidental writes.
       def while_preventing_writes(enabled = true)
         original, self.prevent_writes = self.prevent_writes, enabled
         yield

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1018,11 +1018,16 @@ module ActiveRecord
         Thread.current[:prevent_writes] = prevent_writes
       end
 
-      # Prevent writing to the database regardless of role.
+      # Prevent regular writing to the database regardless of role.
       #
       # In some cases you may want to prevent writes to the database
       # even if you are on a database that can write. `while_preventing_writes`
-      # will prevent writes to the database for the duration of the block.
+      # will prevent most writes to the database for the duration of the block.
+      #
+      # Note: `while_preventing_writes` does not necessarily catch all writes,
+      # it's meant as a safeguard against accidental writes. Writes as created
+      # by ActiveRecord will most likely be caught. Handcrafted write queries
+      # may still be possible though.
       def while_preventing_writes(enabled = true)
         original, self.prevent_writes = self.prevent_writes, enabled
         yield

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1018,7 +1018,7 @@ module ActiveRecord
         Thread.current[:prevent_writes] = prevent_writes
       end
 
-      # Prevent regular writing to the database regardless of role.
+      # Prevent most writing to the database regardless of role.
       #
       # In some cases you may want to prevent writes to the database
       # even if you are on a database that can write. `while_preventing_writes`


### PR DESCRIPTION
Address #39132 "ActiveRecord::Base.connection_handler.while_preventing_writes does not prevent all writes"

Not all write queries which are wrapped in a `while_preventing_writes` block are
blocked. For example in Postgres these are valid queries which are actually
executed:

    ActiveRecord::Base.connection_handler.while_preventing_writes do
      ActiveRecord::Base.connection.execute "EXPLAIN ANALYZE DELETE FROM users WHERE id = 26"
      ActiveRecord::Base.connection.execute "/*/**/SELECT*/ UPDATE users SET role = 'admin' WHERE id = 10"
      ActiveRecord::Base.connection.execute "SELECT * INTO users_new FROM users"
    end

The documentation should mention, that this method is not supposed to catch all
writes, but rather the usual writes as they would be created by ActiveRecord.
