### PR TITLE
Support reentrant calls to RakeCommand.perform

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -15,12 +15,11 @@ module Rails
         def perform(task, args, config)
           require_rake
 
-          ARGV.replace([task, *args]) # set up ARGV for Rake
-
-          Rake.application.standard_exception_handling do
-            Rake.application.init("rails")
-            Rake.application.load_rakefile
-            Rake.application.top_level
+          Rake.with_application do |rake|
+            load "rails/tasks.rb"
+            rake.init("rails", [task, *args])
+            rake.load_rakefile
+            rake.standard_exception_handling { rake.top_level }
           end
         end
 

--- a/railties/lib/rails/tasks/statistics.rake
+++ b/railties/lib/rails/tasks/statistics.rake
@@ -3,7 +3,7 @@
 # While global constants are bad, many 3rd party tools depend on this one (e.g
 # rspec-rails & cucumber-rails). So a deprecation warning is needed if we want
 # to remove it.
-STATS_DIRECTORIES = [
+STATS_DIRECTORIES ||= [
   %w(Controllers        app/controllers),
   %w(Helpers            app/helpers),
   %w(Jobs               app/jobs),


### PR DESCRIPTION
Rake stores the current top-level task and arguments in global state.  Invoking another top-level task within the same process requires overwriting this state.  Doing so indiscriminately can cause incorrect behavior, such as infinitely repeating the original task.  In particular, this is a problem when running one task from another via `rails_command "...", inline: true`.

The solution is to save and restore the global state in each call to `RakeCommand.perform` using the `Rake.with_application` method.

Fixes #39128.
