### PR TITLE
Fix flakey destroyed_by_association tests

### DIFF
--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -21,7 +21,7 @@ require "models/membership"
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
-           :ships, :pirates, :authors, :author_addresses, :memberships, :clubs
+           :ships, :pirates, :authors, :author_addresses, :books, :memberships, :clubs
 
   def setup
     Account.destroyed_account_ids.clear


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/68661#84f8790a-fc9e-42ef-a7fb-5bd15a489de8/1002-1012

The failing `destroyed_by_association` tests create an author (a `DestroyByParentAuthor`) and a book (a `DestroyByParentBook`) that belongs to that author.  If the database already contains books that refer to that author's ID from previous tests (i.e. tests that disabled `use_transactional_tests`), then one of those books will be loaded and destroyed instead of the intended `DestroyByParentBook` book.

By loading the `:books` fixtures, we ensure the database does not contain such unexpected books.
