### PR TITLE
Adds :inline option to Action Mailbox generator rails_command

### DIFF
--- a/actionmailbox/lib/generators/action_mailbox/install/install_generator.rb
+++ b/actionmailbox/lib/generators/action_mailbox/install/install_generator.rb
@@ -21,7 +21,7 @@ module ActionMailbox
       end
 
       def create_migrations
-        rails_command "railties:install:migrations FROM=active_storage,action_mailbox"
+        rails_command "railties:install:migrations FROM=active_storage,action_mailbox", inline: true
       end
     end
   end


### PR DESCRIPTION
This PR just adds `inline` option to the `rails_command` which was missing after changes in commit: f6f5163 and PR: #37516 

Tested it on local. Works fine now.

cc/ @jonathanhefner 