### PR TITLE
Fix `rewhere` to truly overwrite collided where clause by new where clause

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Fix `rewhere` to truly overwrite collided where clause by new where clause.
+
+    ```ruby
+    steve = Person.find_by(name: "Steve")
+    david = Author.find_by(name: "David")
+
+    relation = Essay.where(writer: steve)
+
+    # Before
+    relation.rewhere(writer: david).to_a # => []
+
+    # After
+    relation.rewhere(writer: david).to_a # => [david]
+    ```
+
+    *Ryuta Kamizono*
+
 *   Inspect time attributes with subsec.
 
     ```ruby

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -92,6 +92,12 @@ module ActiveRecord
         end
       end
 
+      def each_attribute(&block)
+        predicates.each do |node|
+          Arel.fetch_attribute(node, &block)
+        end
+      end
+
       protected
         attr_reader :predicates
 
@@ -141,7 +147,15 @@ module ActiveRecord
 
         def except_predicates(columns)
           predicates.reject do |node|
-            Arel.fetch_attribute(node) { |attr| columns.include?(attr.name.to_s) }
+            Arel.fetch_attribute(node) do |attr|
+              columns.any? do |column|
+                if column.is_a?(Arel::Attributes::Attribute)
+                  attr == column
+                else
+                  attr.name.to_s == column.to_s
+                end
+              end
+            end
           end
         end
 

--- a/activerecord/test/fixtures/essays.yml
+++ b/activerecord/test/fixtures/essays.yml
@@ -9,3 +9,8 @@ mary_stay_home:
   name: Stay Home
   writer_type: Author
   writer_id: Mary
+
+steve_connecting_the_dots:
+  name: Connecting The Dots
+  writer_type: Man
+  writer_id: Steve

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -23,6 +23,8 @@ class Post < ActiveRecord::Base
     end
   end
 
+  alias_attribute :text, :body
+
   scope :containing_the_letter_a, -> { where("body LIKE '%a%'") }
   scope :titled_with_an_apostrophe, -> { where("title LIKE '%''%'") }
   scope :ranked_by_comments, -> { order(arel_attribute(:comments_count).desc) }


### PR DESCRIPTION
```ruby
steve = Person.find_by(name: "Steve")
david = Author.find_by(name: "David")

relation = Essay.where(writer: steve)

# Before
relation.rewhere(writer: david).to_a # => []

# After
relation.rewhere(writer: david).to_a # => [david]
```

For now `rewhere` only works for truly column names, doesn't work for
alias attributes, nested conditions, associations.

To fix that, need to build new where clause first, and then get
attribute names from new where clause.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
