### PR TITLE
Remove hashing from secure_compare and clarify documentation

### DIFF
--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -19,12 +19,14 @@ module ActiveSupport
     end
     module_function :fixed_length_secure_compare
 
-    # Constant time string comparison, for variable length strings.
+    # Secure string comparison for strings of variable length.
     #
-    # The values are first processed by SHA256, so that we don't leak length info
-    # via timing attacks.
+    # While a timing attack would not be able to discern the content of
+    # a secret compared via secure_compare, it is possible to determine
+    # the secret length. This should be considered when using secure_compare
+    # to compare weak, short secrets to user input.
     def secure_compare(a, b)
-      fixed_length_secure_compare(::Digest::SHA256.digest(a), ::Digest::SHA256.digest(b)) && a == b
+      a.length == b.length && fixed_length_secure_compare(a, b)
     end
     module_function :secure_compare
   end


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/commit/17e6f1507b7f2c2a883c180f4f9548445d6dfbda introduced the `variable_size_secure_compare` method (now called `secure_compare`) to allow for secure comparison of strings that are of differing lengths and prevent timing attacks. It did so by using a hash function to normalize the lengths of the strings and calling the fixed-length secure comparison function. 

This approach prevents timing attacks from being used to determine the string's contents, but does not prevent an attacker from being able to determine the length of the secret in question. This is because the SHA256 hash function (as with all hash functions) has a runtime proportional to its input length. For this reason, using SHA256 provides no additional security benefit to using a traditional length check. This PR replaces the current hash-based approach with a length check and call to the fixed-length secure comparison function.

In addition, we clarify the docs to mention that this function could potentially leak the length of secrets to an attacker observing the timing of requests.

### Other Information

Credit to @wrs for bringing this to our attention via the Rails bug bounty program.
