### PR TITLE
Add a separator to the cache key for ActiveSupport::CachingKeyGenerator

### DIFF
--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -35,7 +35,7 @@ module ActiveSupport
 
     # Returns a derived key suitable for use.
     def generate_key(*args)
-      @cache_keys[args.join] ||= @key_generator.generate_key(*args)
+      @cache_keys[args.join('|')] ||= @key_generator.generate_key(*args)
     end
   end
 end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -71,6 +71,13 @@ else
 
       assert_not_equal derived_key, different_length_key
     end
+
+    test "Does not cache key for different salts and lengths that are different but are equal when concatenated" do
+      derived_key = @caching_generator.generate_key("13", 37)
+      different_length_key = @caching_generator.generate_key("1", 337)
+
+      assert_not_equal derived_key, different_length_key
+    end
   end
 
 end


### PR DESCRIPTION
### Summary

The [ActiveSupport::CachingKeyGenerator](https://api.rubyonrails.org/classes/ActiveSupport/CachingKeyGenerator.html) is a thin wrapper around [ActiveSupport::KeyGenerator](https://api.rubyonrails.org/classes/ActiveSupport/KeyGenerator.html) that uses a Hash to memoize the output. The Hash key is currently a simple concatenation of the salt and the key length. This means if `generate_key` is called like `@caching_generator.generate_key("133", 7)` and then `@caching_generator.generate_key("13", 37)`, the cache key will be the same (`1337`) and the output in the second case will be a 7-byte key, rather than a 37-byte key. Neither of these values should be user-controlled in normal usage of this class, so it is unlikely that a cache key collision here would be exploitable in practice.

We fix this issue by adding a separator (`|`) that delineates the key size from the salt.

### Other Information

This PR was a result of a report to the Rails bug bounty program by https://hackerone.com/mysterican.