### PR TITLE
Style fix for CachingKeyGenerator

### DIFF
--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -35,7 +35,7 @@ module ActiveSupport
 
     # Returns a derived key suitable for use.
     def generate_key(*args)
-      @cache_keys[args.join('|')] ||= @key_generator.generate_key(*args)
+      @cache_keys[args.join("|")] ||= @key_generator.generate_key(*args)
     end
   end
 end


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/39143 used single quotes instead of double quotes. This corrects that error.