### PR TITLE
Make PendingMigrationError actionable from tests

### DIFF
--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -17,7 +17,14 @@ if defined?(ActiveRecord::Base)
     ActiveRecord::Migration.maintain_test_schema!
   rescue ActiveRecord::PendingMigrationError => e
     puts e.to_s.strip
-    exit 1
+    actions = ActiveSupport::ActionableError.actions(e)
+    actions.each do |action, _|
+      if Rails::Generators::Base.new.yes?("\n#{action}?")
+        ActiveSupport::ActionableError.dispatch(e.class, action)
+      else
+        exit 1
+      end
+    end
   end
 
   ActiveSupport.on_load(:active_support_test_case) do


### PR DESCRIPTION
### Summary

PendingMigrationErrors are actionable in the browser which is really great.
I think ActionableErrors can be useful on the commandline as well.
This change makes PendingMigrationErrors actionable when running tests.
Instead of exiting we can ask the user if they want to migrate, and if they do
execute the action:

![actionableerrors](https://user-images.githubusercontent.com/28561/81043189-17a16f00-8eb2-11ea-95e0-ea1be64a115c.gif)

Another use case for commandline ActionableErrors could be the Yarn integrity check, which can be confusing for beginners. See: https://twitter.com/avdi/status/1257124422068178945
(Although the Yarn integrity check has been removed in the latest Webpacker, I still think an ActionableError would be a nice solution)