### PR TITLE
Inspect time attributes with subsec

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Inspect time attributes with subsec.
+
+    ```ruby
+    p Knot.create
+    => #<Knot id: 1, created_at: "2016-05-05 01:29:47.116928000">
+    ```
+
+    *akinomaeni*
+
 *   Deprecate passing a column to `type_cast`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -401,7 +401,9 @@ module ActiveRecord
       def format_for_inspect(value)
         if value.is_a?(String) && value.length > 50
           "#{value[0, 50]}...".inspect
-        elsif value.is_a?(Date) || value.is_a?(Time)
+        elsif value.is_a?(Time)
+          %("#{value.strftime(Time::DATE_FORMATS[:db] + '.%9N')}")
+        elsif value.is_a?(Date)
           %("#{value.to_s(:db)}")
         else
           value.inspect

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -39,7 +39,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "attribute_for_inspect with a date" do
     t = topics(:first)
 
-    assert_equal %("#{t.written_on.to_s(:db)}"), t.attribute_for_inspect(:written_on)
+    assert_equal %("#{t.written_on.to_s(:db)}.#{t.written_on.strftime('%9N')}"), t.attribute_for_inspect(:written_on)
   end
 
   test "attribute_for_inspect with an array" do

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -18,7 +18,7 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_inspect_instance
     topic = topics(:first)
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_s(:db)}", bonus_time: "#{topic.bonus_time.to_s(:db)}", last_read: "#{topic.last_read.to_s(:db)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_s(:db)}", updated_at: "#{topic.updated_at.to_s(:db)}">), topic.inspect
+    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_s(:db)}.#{topic.written_on.strftime('%9N')}", bonus_time: "#{topic.bonus_time.to_s(:db)}.#{topic.bonus_time.strftime('%9N')}", last_read: "#{topic.last_read.to_s(:db)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_s(:db)}.#{topic.created_at.strftime('%9N')}", updated_at: "#{topic.updated_at.to_s(:db)}.#{topic.updated_at.strftime('%9N')}">), topic.inspect
   end
 
   def test_inspect_new_instance


### PR DESCRIPTION
### Summary

before
```
p Knot.create
=> #<Knot id: 1, created_at: "2016-05-05 01:29:47">
```

after
```
p Knot.create
=> #<Knot id: 1, created_at: "2016-05-05 01:29:47.116928000">
```
