### PR TITLE
Add `change_null` for `change_table`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -496,6 +496,7 @@ module ActiveRecord
     #     t.timestamps
     #     t.change
     #     t.change_default
+    #     t.change_null
     #     t.rename
     #     t.references
     #     t.belongs_to
@@ -613,6 +614,16 @@ module ActiveRecord
       # See {connection.change_column_default}[rdoc-ref:SchemaStatements#change_column_default]
       def change_default(column_name, default_or_changes)
         @base.change_column_default(name, column_name, default_or_changes)
+      end
+
+      # Sets or removes a NOT NULL constraint on a column.
+      #
+      #  t.change_null(:qualification, true)
+      #  t.change_null(:qualification, false, 0)
+      #
+      # See {connection.change_column_null}[rdoc-ref:SchemaStatements#change_column_null]
+      def change_null(column_name, null, default = nil)
+        @base.change_column_null(name, column_name, null, default)
       end
 
       # Removes the column(s) from the table definition.

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -281,6 +281,13 @@ module ActiveRecord
         end
       end
 
+      def test_change_null_changes_column
+        with_change_table do |t|
+          @connection.expect :change_column_null, nil, [:delete_me, :bar, true, nil]
+          t.change_null :bar, true
+        end
+      end
+
       def test_remove_drops_single_column
         with_change_table do |t|
           if RUBY_VERSION < "2.7"


### PR DESCRIPTION
This PR enables to set or remove a NOT NULL constraint with reversible methods.

When changing a NOT NULL constraint, we use `ActiveRecord::ConnectionAdapters::SchemaStatements#change` method that is not reversible, so `up` and `down` methods were required. Actually, we can use `change_column_null` method if only one constraint changed, but if we want to change multiple constarints with ALTER QUERY, `up` and `down` methods were required.

```ruby
# before
def up
  change_table :users, bulk: true do |t|
    t.change :some_code, :integer, null: true
    t.change :birth_on, :date, null: true
  end
end

def down
  change_table :users, bulk: true do |t|
    t.change :some_code, :integer, null: false
    t.change :birth_on, :date, null: false
  end
end

# after
def change
  change_table :users, bulk: true do |t|
    t.change_null :some_code, true
    t.change_null :birth_on, true
  end
end
```