### PR TITLE
Remove useless `eq_all`, `eq_any`, etc

### DIFF
--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -6,14 +6,6 @@ module Arel # :nodoc: all
       Nodes::NotEqual.new self, quoted_node(other)
     end
 
-    def not_eq_any(others)
-      grouping_any :not_eq, others
-    end
-
-    def not_eq_all(others)
-      grouping_all :not_eq, others
-    end
-
     def eq(other)
       Nodes::Equality.new self, quoted_node(other)
     end
@@ -24,14 +16,6 @@ module Arel # :nodoc: all
 
     def is_distinct_from(other)
       Nodes::IsDistinctFrom.new self, quoted_node(other)
-    end
-
-    def eq_any(others)
-      grouping_any :eq, others
-    end
-
-    def eq_all(others)
-      grouping_all :eq, quoted_array(others)
     end
 
     def between(other)
@@ -65,14 +49,6 @@ module Arel # :nodoc: all
       else
         Nodes::In.new self, quoted_node(other)
       end
-    end
-
-    def in_any(others)
-      grouping_any :in, others
-    end
-
-    def in_all(others)
-      grouping_all :in, others
     end
 
     def not_between(other)
@@ -110,28 +86,12 @@ module Arel # :nodoc: all
       end
     end
 
-    def not_in_any(others)
-      grouping_any :not_in, others
-    end
-
-    def not_in_all(others)
-      grouping_all :not_in, others
-    end
-
     def matches(other, escape = nil, case_sensitive = false)
       Nodes::Matches.new self, quoted_node(other), escape, case_sensitive
     end
 
     def matches_regexp(other, case_sensitive = true)
       Nodes::Regexp.new self, quoted_node(other), case_sensitive
-    end
-
-    def matches_any(others, escape = nil, case_sensitive = false)
-      grouping_any :matches, others, escape, case_sensitive
-    end
-
-    def matches_all(others, escape = nil, case_sensitive = false)
-      grouping_all :matches, others, escape, case_sensitive
     end
 
     def does_not_match(other, escape = nil, case_sensitive = false)
@@ -142,60 +102,20 @@ module Arel # :nodoc: all
       Nodes::NotRegexp.new self, quoted_node(other), case_sensitive
     end
 
-    def does_not_match_any(others, escape = nil)
-      grouping_any :does_not_match, others, escape
-    end
-
-    def does_not_match_all(others, escape = nil)
-      grouping_all :does_not_match, others, escape
-    end
-
     def gteq(right)
       Nodes::GreaterThanOrEqual.new self, quoted_node(right)
-    end
-
-    def gteq_any(others)
-      grouping_any :gteq, others
-    end
-
-    def gteq_all(others)
-      grouping_all :gteq, others
     end
 
     def gt(right)
       Nodes::GreaterThan.new self, quoted_node(right)
     end
 
-    def gt_any(others)
-      grouping_any :gt, others
-    end
-
-    def gt_all(others)
-      grouping_all :gt, others
-    end
-
     def lt(right)
       Nodes::LessThan.new self, quoted_node(right)
     end
 
-    def lt_any(others)
-      grouping_any :lt, others
-    end
-
-    def lt_all(others)
-      grouping_all :lt, others
-    end
-
     def lteq(right)
       Nodes::LessThanOrEqual.new self, quoted_node(right)
-    end
-
-    def lteq_any(others)
-      grouping_any :lteq, others
-    end
-
-    def lteq_all(others)
-      grouping_all :lteq, others
     end
 
     def when(right)
@@ -219,18 +139,6 @@ module Arel # :nodoc: all
     end
 
     private
-      def grouping_any(method_id, others, *extras)
-        nodes = others.map { |expr| send(method_id, expr, *extras) }
-        Nodes::Grouping.new nodes.inject { |memo, node|
-          Nodes::Or.new(memo, node)
-        }
-      end
-
-      def grouping_all(method_id, others, *extras)
-        nodes = others.map { |expr| send(method_id, expr, *extras) }
-        Nodes::Grouping.new Nodes::And.new(nodes)
-      end
-
       def quoted_node(other)
         Nodes.build_quoted(other, self)
       end

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -31,38 +31,6 @@ module Arel
         end
       end
 
-      describe "#not_eq_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].not_eq_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].not_eq_any([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" != 1 OR "users"."id" != 2)
-          }
-        end
-      end
-
-      describe "#not_eq_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].not_eq_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].not_eq_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" != 1 AND "users"."id" != 2)
-          }
-        end
-      end
-
       describe "#gt" do
         it "should create a GreaterThan node" do
           relation = Table.new(:users)
@@ -101,38 +69,6 @@ module Arel
         end
       end
 
-      describe "#gt_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].gt_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].gt_any([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" > 1 OR "users"."id" > 2)
-          }
-        end
-      end
-
-      describe "#gt_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].gt_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].gt_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" > 1 AND "users"."id" > 2)
-          }
-        end
-      end
-
       describe "#gteq" do
         it "should create a GreaterThanOrEqual node" do
           relation = Table.new(:users)
@@ -157,38 +93,6 @@ module Arel
           current_time = ::Time.now
           mgr.where relation[:created_at].gteq(current_time)
           _(mgr.to_sql).must_match %{"users"."created_at" >= '#{current_time}'}
-        end
-      end
-
-      describe "#gteq_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].gteq_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].gteq_any([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" >= 1 OR "users"."id" >= 2)
-          }
-        end
-      end
-
-      describe "#gteq_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].gteq_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].gteq_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" >= 1 AND "users"."id" >= 2)
-          }
         end
       end
 
@@ -219,38 +123,6 @@ module Arel
         end
       end
 
-      describe "#lt_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].lt_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].lt_any([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" < 1 OR "users"."id" < 2)
-          }
-        end
-      end
-
-      describe "#lt_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].lt_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].lt_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" < 1 AND "users"."id" < 2)
-          }
-        end
-      end
-
       describe "#lteq" do
         it "should create a LessThanOrEqual node" do
           relation = Table.new(:users)
@@ -275,38 +147,6 @@ module Arel
           current_time = ::Time.now
           mgr.where relation[:created_at].lteq(current_time)
           _(mgr.to_sql).must_match %{"users"."created_at" <= '#{current_time}'}
-        end
-      end
-
-      describe "#lteq_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].lteq_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].lteq_any([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" <= 1 OR "users"."id" <= 2)
-          }
-        end
-      end
-
-      describe "#lteq_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].lteq_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].lteq_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" <= 1 AND "users"."id" <= 2)
-          }
         end
       end
 
@@ -416,54 +256,6 @@ module Arel
         end
       end
 
-      describe "#eq_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].eq_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].eq_any([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 OR "users"."id" = 2)
-          }
-        end
-
-        it "should not eat input" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          values = [1, 2]
-          mgr.where relation[:id].eq_any(values)
-          _(values).must_equal [1, 2]
-        end
-      end
-
-      describe "#eq_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].eq_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].eq_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 AND "users"."id" = 2)
-          }
-        end
-
-        it "should not eat input" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          values = [1, 2]
-          mgr.where relation[:id].eq_all(values)
-          _(values).must_equal [1, 2]
-        end
-      end
-
       describe "#matches" do
         it "should create a Matches node" do
           relation = Table.new(:users)
@@ -480,38 +272,6 @@ module Arel
         end
       end
 
-      describe "#matches_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:name].matches_any(["%chunky%", "%bacon%"])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:name].matches_any(["%chunky%", "%bacon%"])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%chunky%' OR "users"."name" LIKE '%bacon%')
-          }
-        end
-      end
-
-      describe "#matches_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:name].matches_all(["%chunky%", "%bacon%"])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:name].matches_all(["%chunky%", "%bacon%"])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."name" LIKE '%chunky%' AND "users"."name" LIKE '%bacon%')
-          }
-        end
-      end
-
       describe "#does_not_match" do
         it "should create a DoesNotMatch node" do
           relation = Table.new(:users)
@@ -524,38 +284,6 @@ module Arel
           mgr.where relation[:name].does_not_match("%bacon%")
           _(mgr.to_sql).must_be_like %{
             SELECT "users"."id" FROM "users" WHERE "users"."name" NOT LIKE '%bacon%'
-          }
-        end
-      end
-
-      describe "#does_not_match_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:name].does_not_match_any(["%chunky%", "%bacon%"])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:name].does_not_match_any(["%chunky%", "%bacon%"])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."name" NOT LIKE '%chunky%' OR "users"."name" NOT LIKE '%bacon%')
-          }
-        end
-      end
-
-      describe "#does_not_match_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:name].does_not_match_all(["%chunky%", "%bacon%"])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."name" NOT LIKE '%chunky%' AND "users"."name" NOT LIKE '%bacon%')
           }
         end
       end
@@ -693,7 +421,7 @@ module Arel
         it "can be constructed with a subquery" do
           relation = Table.new(:users)
           mgr = relation.project relation[:id]
-          mgr.where relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
+          mgr.where relation[:name].does_not_match("%chunky%")
           attribute = Attribute.new nil, nil
 
           node = attribute.in(mgr)
@@ -732,38 +460,6 @@ module Arel
           mgr.where relation[:id].in([1, 2, 3])
           _(mgr.to_sql).must_be_like %{
             SELECT "users"."id" FROM "users" WHERE "users"."id" IN (1, 2, 3)
-          }
-        end
-      end
-
-      describe "#in_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].in_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].in_any([[1, 2], [3, 4]])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" IN (1, 2) OR "users"."id" IN (3, 4))
-          }
-        end
-      end
-
-      describe "#in_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].in_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].in_all([[1, 2], [3, 4]])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" IN (1, 2) AND "users"."id" IN (3, 4))
           }
         end
       end
@@ -908,7 +604,7 @@ module Arel
         it "can be constructed with a subquery" do
           relation = Table.new(:users)
           mgr = relation.project relation[:id]
-          mgr.where relation[:name].does_not_match_all(["%chunky%", "%bacon%"])
+          mgr.where relation[:name].does_not_match("%chunky%")
           attribute = Attribute.new nil, nil
 
           node = attribute.not_in(mgr)
@@ -959,54 +655,6 @@ module Arel
           mgr.where relation[:id].not_in([1, 2, 3])
           _(mgr.to_sql).must_be_like %{
             SELECT "users"."id" FROM "users" WHERE "users"."id" NOT IN (1, 2, 3)
-          }
-        end
-      end
-
-      describe "#not_in_any" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].not_in_any([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ORs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].not_in_any([[1, 2], [3, 4]])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" NOT IN (1, 2) OR "users"."id" NOT IN (3, 4))
-          }
-        end
-      end
-
-      describe "#not_in_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].not_in_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].not_in_all([[1, 2], [3, 4]])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" NOT IN (1, 2) AND "users"."id" NOT IN (3, 4))
-          }
-        end
-      end
-
-      describe "#eq_all" do
-        it "should create a Grouping node" do
-          relation = Table.new(:users)
-          _(relation[:id].eq_all([1, 2])).must_be_kind_of Nodes::Grouping
-        end
-
-        it "should generate ANDs in sql" do
-          relation = Table.new(:users)
-          mgr = relation.project relation[:id]
-          mgr.where relation[:id].eq_all([1, 2])
-          _(mgr.to_sql).must_be_like %{
-            SELECT "users"."id" FROM "users" WHERE ("users"."id" = 1 AND "users"."id" = 2)
           }
         end
       end

--- a/activerecord/test/cases/arel/nodes/sql_literal_test.rb
+++ b/activerecord/test/cases/arel/nodes/sql_literal_test.rb
@@ -50,20 +50,6 @@ module Arel
         end
       end
 
-      describe 'grouped "or" equality' do
-        it "makes a grouping node with an or node" do
-          node = SqlLiteral.new("foo").eq_any([1, 2])
-          _(compile(node)).must_be_like %{ (foo = 1 OR foo = 2) }
-        end
-      end
-
-      describe 'grouped "and" equality' do
-        it "makes a grouping node with an and node" do
-          node = SqlLiteral.new("foo").eq_all([1, 2])
-          _(compile(node)).must_be_like %{ (foo = 1 AND foo = 2) }
-        end
-      end
-
       describe "serialization" do
         it "serializes into YAML" do
           yaml_literal = SqlLiteral.new("foo").to_yaml


### PR DESCRIPTION
All `*_all` and `*_any` are quite useless (e.g. `attr.eq_all([1,2])` ->
always empty, `attr.eq_any([1,2])` -> use `attr.in([1,2])` instead), and
it is hard to find effective use case.

I'd not like to maintain that useless private API which are not used in
the code base.