### PR TITLE
Ensure array passed to preloader has no duplicate records by object_id

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       class Association #:nodoc:
         def initialize(klass, owners, reflection, preload_scope)
           @klass         = klass
-          @owners        = owners
+          @owners        = owners.uniq(&:__id__)
           @reflection    = reflection
           @preload_scope = preload_scope
           @model         = owners.first && owners.first.class

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -41,7 +41,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
            :owners, :pets, :toys, :jobs, :references, :companies, :members, :author_addresses,
            :subscribers, :books, :subscriptions, :developers, :categorizations, :essays,
-           :categories_posts, :clubs, :memberships, :organizations
+           :categories_posts, :clubs, :memberships, :organizations, :author_favorites
 
   # Dummies to force column loads so query counts are clean.
   def setup
@@ -67,11 +67,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_preload_with_nested_association
-    posts = Post.preload(:author, :author_favorites_with_scope).to_a
+    posts = Post.where(id: [authors(:david).id, authors(:mary).id]).
+      preload(:author, :author_favorites_with_scope).order(:id).to_a
 
     assert_no_queries do
       posts.each(&:author)
       posts.each(&:author_favorites_with_scope)
+      assert_equal 1, posts[0].author_favorites_with_scope.length
     end
   end
 


### PR DESCRIPTION
Fixes #39073, #39035

### Summary

Duplicate records by `id` are possible for preloader because of `joins`. However, if duplicate objects equal by `object_id` are passed, the best fix would be to just remove duplicates.

### Other Information

Even though the issue #39073  is only happening for `though` association, it is better to implement the fix inside `AssociationPreloader` because in this way it is going to affect direct usage of `Preloader` class which are no officially documented but very popular anyway.


cc @inkstak @kamipo @alipman88 