### PR TITLE
Ensure sqlite3_mem transaction tests run in memory

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -10,7 +10,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
   end
 
   test "shared_cached? is false when cache-mode is disabled" do
-    flags =::SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE
+    flags = ::SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE
 
     with_connection(flags: flags) do |conn|
       assert_not_predicate(conn, :shared_cache?)
@@ -102,15 +102,19 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
     end
 
     def shared_cache_flags
-      ::SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE | ::SQLite3::Constants::Open::SHAREDCACHE | ::SQLite3::Constants::Open::URI
+      ::SQLite3::Constants::Open::READWRITE | SQLite3::Constants::Open::CREATE | ::SQLite3::Constants::Open::SHAREDCACHE
     end
 
     def with_connection(options = {})
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-      conn_options = options.reverse_merge(
-        database: in_memory_db? ? "test/db/file::memory:" : db_config.database
-      )
-      conn = ActiveRecord::Base.sqlite3_connection(conn_options)
+      options = options.dup
+      if in_memory_db?
+        options[:database] ||= "file::memory:"
+        options[:flags] = options[:flags].to_i | ::SQLite3::Constants::Open::URI | ::SQLite3::Constants::Open::READWRITE
+      else
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        options[:database] ||= db_config.database
+      end
+      conn = ActiveRecord::Base.sqlite3_connection(options)
 
       yield(conn)
     ensure


### PR DESCRIPTION
SQLite3 does not recognize paths as file URIs unless the `SQLite3::Constants::Open::URI` flag is set.  Therefore, without this flag, a path like `"file::memory:"` is interpreted as a filename, causing a `"file::memory:"` file to be created and used as the database.  Most tests in `SQLite3TransactionTest` picked up this flag from `shared_cache_flags`, but a few did not.  Because those tests were creating a file, the path was changed in #38620 such that it no longer pointed to an in-memory database.

This commit restores the database path as `"file::memory:"` and ensures the URI flag is set whenever `in_memory_db?` is true.

---

I discovered this issue when I ran:

```bash
ARCONN=sqlite3_mem bin/test test/cases/adapters/sqlite3/transaction_test.rb
```

more than once, and received the following error:

```
Error:
SQLite3TransactionTest#test_opens_a_`read_uncommitted`_transaction:
ActiveRecord::StatementInvalid: SQLite3::SQLException: table "zines" already exists
```

After some digging, I found this discussion: https://github.com/rails/rails/pull/38620#discussion_r386428273

This PR resolves that discussion, though there may be a larger discussion to be had about enabling this flag by default.
