### PR TITLE
Accept multiple arguments in Symbol#start_with? and Symbol#end_with?

### DIFF
--- a/activesupport/lib/active_support/core_ext/symbol/starts_ends_with.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/starts_ends_with.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Symbol
-  def start_with?(prefix)
-    to_s.start_with?(prefix)
+  def start_with?(*prefixes)
+    to_s.start_with?(*prefixes)
   end unless :a.respond_to?(:start_with?)
 
-  def end_with?(suffix)
-    to_s.end_with?(suffix)
+  def end_with?(*suffixes)
+    to_s.end_with?(*suffixes)
   end unless :a.respond_to?(:end_with?)
 
   alias :starts_with? :start_with?

--- a/activesupport/test/core_ext/symbol_ext_test.rb
+++ b/activesupport/test/core_ext/symbol_ext_test.rb
@@ -9,10 +9,14 @@ class SymbolStartsEndsWithTest < ActiveSupport::TestCase
     assert s.start_with?("h")
     assert s.start_with?("hel")
     assert_not s.start_with?("el")
+    assert s.start_with?("he", "lo")
+    assert_not s.start_with?("el", "lo")
 
     assert s.end_with?("o")
     assert s.end_with?("lo")
     assert_not s.end_with?("el")
+    assert s.end_with?("he", "lo")
+    assert_not s.end_with?("he", "ll")
   end
 
   def test_starts_ends_with_alias
@@ -20,9 +24,13 @@ class SymbolStartsEndsWithTest < ActiveSupport::TestCase
     assert s.starts_with?("h")
     assert s.starts_with?("hel")
     assert_not s.starts_with?("el")
+    assert s.starts_with?("he", "lo")
+    assert_not s.starts_with?("el", "lo")
 
     assert s.ends_with?("o")
     assert s.ends_with?("lo")
     assert_not s.ends_with?("el")
+    assert s.ends_with?("he", "lo")
+    assert_not s.ends_with?("he", "ll")
   end
 end


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/39155, for consistency with the upstream implementation.

https://ruby-doc.org/core-2.7.1/Symbol.html#method-i-start_with-3F
https://ruby-doc.org/core-2.7.1/Symbol.html#method-i-end_with-3F