### PR TITLE
Ensure type cast is not evaluated at relation build time

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/array_handler.rb
@@ -22,15 +22,7 @@ module ActiveRecord
           when 1 then predicate_builder.build(attribute, values.first)
           else
             if nils.empty? && ranges.empty?
-              type = attribute.type_caster
-
-              casted_values = values.map do |raw_value|
-                type.unchecked_serialize(raw_value) if type.serializable?(raw_value)
-              end
-
-              casted_values.compact!
-
-              return Arel::Nodes::HomogeneousIn.new(casted_values, attribute, :in)
+              return Arel::Nodes::HomogeneousIn.new(values, attribute, :in)
             else
               attribute.in values.map { |v|
                 predicate_builder.build_bind_attribute(attribute.name, v)

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -40,6 +40,17 @@ module Arel # :nodoc: all
         attribute.name
       end
 
+      def casted_values
+        type = attribute.type_caster
+
+        casted_values = values.map do |raw_value|
+          type.unchecked_serialize(raw_value) if type.serializable?(raw_value)
+        end
+
+        casted_values.compact!
+        casted_values
+      end
+
       def fetch_attribute(&block)
         if attribute
           yield attribute

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -323,7 +323,6 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_HomogeneousIn(o, collector)
           collector.preparable = false
-          collector << "("
 
           collector << quote_table_name(o.table_name) << "." << quote_column_name(o.column_name)
 
@@ -333,7 +332,7 @@ module Arel # :nodoc: all
             collector << "NOT IN ("
           end
 
-          values = o.values.map { |v| @connection.quote v }
+          values = o.casted_values.map { |v| @connection.quote(v) }
 
           expr = if values.empty?
             @connection.quote(nil)
@@ -342,7 +341,7 @@ module Arel # :nodoc: all
           end
 
           collector << expr
-          collector << "))"
+          collector << ")"
           collector
         end
 

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -25,6 +25,20 @@ module ActiveRecord
       assert_equal [comment], Comment.joins(post: :author).where(authors: { id: "2-foo" })
     end
 
+    def test_type_cast_is_not_evaluated_at_relation_build_time
+      posts = nil
+
+      assert_not_called_on_instance_of(Type::Value, :cast) do
+        posts = Post.where(id: "1-foo")
+      end
+      assert_equal [posts(:welcome)], posts.to_a
+
+      assert_not_called_on_instance_of(Type::Value, :cast) do
+        posts = Post.where(id: ["1-foo", "bar"])
+      end
+      assert_equal [posts(:welcome)], posts.to_a
+    end
+
     def test_where_copies_bind_params
       author = authors(:david)
       posts  = author.posts.where("posts.id != 1")


### PR DESCRIPTION
Some apps would expect that type cast is not evaluated at relation build
time consistently.

Context:

https://github.com/kamipo/rails/commit/b571c4f3f2811b5d3dc8b005707cf8c353abdf03#r31015008
https://github.com/rails/rails/pull/34303

And also this removes extra grouping on IN clause behaved as before.

cc @eileencodes @tenderlove @rafaelfranca 