### PR TITLE
Add path information to fixture loading error

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -644,15 +644,15 @@ module ActiveRecord
           all_loaded_fixtures.update(fixtures_map)
         end
 
-      def find_precise_fixture_error(table_rows_for_connection, conn, fixture_sets)
-        # reproduce the error to find it
-        table_rows_for_connection.each do |key, values|
-          conn.insert_fixtures_set({ key => values }, [key])
-        rescue => e
-          problematic_fixture = fixture_sets.find { |fs| fs.name == key }
-          return Fixture::FixtureError.new("[#{problematic_fixture.path}] #{e.message}")
+        def find_precise_fixture_error(table_rows_for_connection, conn, fixture_sets)
+          # reproduce the error to find it
+          table_rows_for_connection.each do |key, values|
+            conn.insert_fixtures_set({ key => values }, [key])
+          rescue => e
+            problematic_fixture = fixture_sets.find { |fs| fs.name == key }
+            return Fixture::FixtureError.new("[#{problematic_fixture.path}] #{e.message}")
+          end
         end
-      end
     end
 
     attr_reader :table_name, :name, :fixtures, :model_class, :ignored_fixtures, :config, :path

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -631,11 +631,10 @@ module ActiveRecord
               conn.insert_fixtures_set(table_rows_for_connection, table_rows_for_connection.keys)
             rescue
               # find and show error
-              table_rows_for_connection.each do |key,values|
-                begin
-                  conn.insert_fixtures_set({key => values}, [key])
+              table_rows_for_connection.each do |key, values|
+                  conn.insert_fixtures_set({ key => values }, [key])
                 rescue => e
-                  problematic_fixture = fixture_sets.find {|fs|fs.name == key}
+                  problematic_fixture = fixture_sets.find { |fs| fs.name == key }
                   fixture_error = Fixture::FixtureError.new("Error: #{problematic_fixture.path}: #{e.message}")
                   fixture_error.set_backtrace(e.backtrace)
                   raise fixture_error

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -632,13 +632,12 @@ module ActiveRecord
             rescue
               # find and show error
               table_rows_for_connection.each do |key, values|
-                  conn.insert_fixtures_set({ key => values }, [key])
-                rescue => e
-                  problematic_fixture = fixture_sets.find { |fs| fs.name == key }
-                  fixture_error = Fixture::FixtureError.new("Error: #{problematic_fixture.path}: #{e.message}")
-                  fixture_error.set_backtrace(e.backtrace)
-                  raise fixture_error
-                end
+                conn.insert_fixtures_set({ key => values }, [key])
+              rescue => e
+                problematic_fixture = fixture_sets.find { |fs| fs.name == key }
+                fixture_error = Fixture::FixtureError.new("Error: #{problematic_fixture.path}: #{e.message}")
+                fixture_error.set_backtrace(e.backtrace)
+                raise fixture_error
               end
             end
 


### PR DESCRIPTION
### Summary

When fixture cannot be loaded, there's no information on which file broke. Finding the file from the DB error can be daunting or impossible if dealing with many files

### Other Information

This relates to issue #38342
