### PR TITLE
Add a link between config.cache_store in configuration.md and cache_store documentation

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -71,7 +71,7 @@ These configuration methods are to be called on a `Rails::Railtie` object, such 
 * `config.beginning_of_week` sets the default beginning of week for the
 application. Accepts a valid day of week as a symbol (e.g. `:monday`).
 
-* `config.cache_store` configures which cache store to use for Rails caching. Options include one of the symbols `:memory_store`, `:file_store`, `:mem_cache_store`, `:null_store`, `:redis_cache_store`, or an object that implements the cache API. Defaults to `:file_store`.
+* `config.cache_store` configures which cache store to use for Rails caching. Options include one of the symbols `:memory_store`, `:file_store`, `:mem_cache_store`, `:null_store`, `:redis_cache_store`, or an object that implements the cache API. Defaults to `:file_store`. See [Cache Stores](caching_with_rails.html#cache-stores) for per-store configuration options.
 
 * `config.colorize_logging` specifies whether or not to use ANSI color codes when logging information. Defaults to `true`.
 


### PR DESCRIPTION
### Summary

Add a link between `config.cache_store` in [Configuring Rails Applications](https://edgeguides.rubyonrails.org/configuring.html#rails-general-configuration) and Cache Store configuration options in [Caching with Rails: An Overview](https://edgeguides.rubyonrails.org/caching_with_rails.html#cache-stores)

### Other Information

It would be easier to navigate the documentation to find possible options for `config.cache_store`.

