### PR TITLE
Don't attempt to add a string to a lambda

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -402,7 +402,11 @@ module ActiveRecord
         if value.is_a?(String) && value.length > 50
           "#{value[0, 50]}...".inspect
         elsif value.is_a?(Time)
-          %("#{value.strftime(Time::DATE_FORMATS[:db] + '.%9N')}")
+          if Time::DATE_FORMATS[:db].respond_to?(:call)
+            Time::DATE_FORMATS[:db].call(value)
+          else
+            %("#{value.strftime(Time::DATE_FORMATS[:db] + '.%9N')}")
+          end
         elsif value.is_a?(Date)
           %("#{value.to_s(:db)}")
         else

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -21,6 +21,17 @@ class CoreTest < ActiveRecord::TestCase
     assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_s(:db)}.#{topic.written_on.strftime('%9N')}", bonus_time: "#{topic.bonus_time.to_s(:db)}.#{topic.bonus_time.strftime('%9N')}", last_read: "#{topic.last_read.to_s(:db)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_s(:db)}.#{topic.created_at.strftime('%9N')}", updated_at: "#{topic.updated_at.to_s(:db)}.#{topic.updated_at.strftime('%9N')}">), topic.inspect
   end
 
+  def test_inspect_instance_with_lambda_date_formatter
+    before = Time::DATE_FORMATS[:db]
+    Time::DATE_FORMATS[:db] = ->(date) { "my_format" }
+    topic = topics(:first)
+
+    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: my_format, bonus_time: my_format, last_read: "2004-04-15", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: my_format, updated_at: my_format>), topic.inspect
+
+  ensure
+    Time::DATE_FORMATS[:db] = before
+  end
+
   def test_inspect_new_instance
     assert_match(/Topic id: nil/, Topic.new.inspect)
   end


### PR DESCRIPTION
DATE_FORMATS can be either a format string or a lambda we don't want to attempt to concat them with a string if we are in the lambda case

In my code `DATE_FORMATS[:db]` is a proc with custom behavior this causes the error `NoMethodError:undefined method '+' for #<Proc:0x00007f7fcf938248>`