### PR TITLE
Add DATE_FORMATS[:inspect]

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -401,14 +401,8 @@ module ActiveRecord
       def format_for_inspect(value)
         if value.is_a?(String) && value.length > 50
           "#{value[0, 50]}...".inspect
-        elsif value.is_a?(Time)
-          if Time::DATE_FORMATS[:db].respond_to?(:call)
-            Time::DATE_FORMATS[:db].call(value)
-          else
-            %("#{value.strftime(Time::DATE_FORMATS[:db] + '.%9N')}")
-          end
-        elsif value.is_a?(Date)
-          %("#{value.to_s(:db)}")
+        elsif value.is_a?(Date) || value.is_a?(Time)
+          %("#{value.to_s(:inspect)}")
         else
           value.inspect
         end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -39,7 +39,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "attribute_for_inspect with a date" do
     t = topics(:first)
 
-    assert_equal %("#{t.written_on.to_s(:db)}.#{t.written_on.strftime('%9N')}"), t.attribute_for_inspect(:written_on)
+    assert_equal %("#{t.written_on.to_s(:inspect)}"), t.attribute_for_inspect(:written_on)
   end
 
   test "attribute_for_inspect with an array" do

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -18,18 +18,18 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_inspect_instance
     topic = topics(:first)
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_s(:db)}.#{topic.written_on.strftime('%9N')}", bonus_time: "#{topic.bonus_time.to_s(:db)}.#{topic.bonus_time.strftime('%9N')}", last_read: "#{topic.last_read.to_s(:db)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_s(:db)}.#{topic.created_at.strftime('%9N')}", updated_at: "#{topic.updated_at.to_s(:db)}.#{topic.updated_at.strftime('%9N')}">), topic.inspect
+    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_s(:inspect)}", bonus_time: "#{topic.bonus_time.to_s(:inspect)}", last_read: "#{topic.last_read.to_s(:inspect)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_s(:inspect)}", updated_at: "#{topic.updated_at.to_s(:inspect)}">), topic.inspect
   end
 
   def test_inspect_instance_with_lambda_date_formatter
-    before = Time::DATE_FORMATS[:db]
-    Time::DATE_FORMATS[:db] = ->(date) { "my_format" }
+    before = Time::DATE_FORMATS[:inspect]
+    Time::DATE_FORMATS[:inspect] = ->(date) { "my_format" }
     topic = topics(:first)
 
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: my_format, bonus_time: my_format, last_read: "2004-04-15", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: my_format, updated_at: my_format>), topic.inspect
+    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "my_format", bonus_time: "my_format", last_read: "2004-04-15", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "my_format", updated_at: "my_format">), topic.inspect
 
   ensure
-    Time::DATE_FORMATS[:db] = before
+    Time::DATE_FORMATS[:inspect] = before
   end
 
   def test_inspect_new_instance

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -10,6 +10,7 @@ class Date
     short: "%d %b",
     long: "%B %d, %Y",
     db: "%Y-%m-%d",
+    inspect: "%Y-%m-%d",
     number: "%Y%m%d",
     long_ordinal: lambda { |date|
       day_format = ActiveSupport::Inflector.ordinalize(date.day)

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -6,6 +6,7 @@ require "active_support/values/time_zone"
 class Time
   DATE_FORMATS = {
     db: "%Y-%m-%d %H:%M:%S",
+    inspect: "%Y-%m-%d %H:%M:%S.%9N %z",
     number: "%Y%m%d%H%M%S",
     nsec: "%Y%m%d%H%M%S%9N",
     usec: "%Y%m%d%H%M%S%6N",


### PR DESCRIPTION
Follow-up to #39147 and #39168.

By adding a new purpose-specific format, we avoid potential pitfalls from concatenating format strings.  We also save a String allocation per Time attribute per inspect.

The new format also includes a time zone offset for more introspective inspection.
