### PR TITLE
Allow `unscope` to be aware of table name qualified values

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Allow `unscope` to be aware of table name qualified values.
+
+    It is possible to unscope only the column in the specified table.
+
+    ```ruby
+    posts = Post.joins(:comments).group(:"posts.hidden")
+    posts = posts.where("posts.hidden": false, "comments.hidden": false)
+
+    posts.count
+    # => { false => 10 }
+
+    # unscope both hidden columns
+    posts.unscope(where: :hidden).count
+    # => { false => 11, true => 1 }
+
+    # unscope only comments.hidden column
+    posts.unscope(where: :"comments.hidden").count
+    # => { false => 11 }
+    ```
+
+    *Ryuta Kamizono*, *Slava Korolev*
+
 *   Fix `rewhere` to truly overwrite collided where clause by new where clause.
 
     ```ruby

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -62,6 +62,10 @@ module ActiveRecord
       Arel::Nodes::BindParam.new(attr)
     end
 
+    def resolve_arel_attribute(table_name, column_name)
+      table.associated_table(table_name).arel_attribute(column_name)
+    end
+
     protected
       def expand_from_hash(attributes)
         return ["1=0"] if attributes.empty?


### PR DESCRIPTION
It is possible to unscope only the column in the specified table.

```ruby
posts = Post.joins(:comments).group(:"posts.hidden")
posts = posts.where("posts.hidden": false, "comments.hidden": false)

posts.count
# => { false => 10 }

# unscope both hidden columns
posts.unscope(where: :hidden).count
# => { false => 11, true => 1 }

# unscope only comments.hidden column
posts.unscope(where: :"comments.hidden").count
# => { false => 11 }
```
