### PR TITLE
Avoid excess DB calls if record is missing in VariantWithRecord

### DIFF
--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -56,6 +56,7 @@ class ActiveStorage::VariantWithRecord
     end
 
     def record
-      @record ||= blob.variant_records.find_by(variation_digest: variation.digest)
+      return @record if instance_variable_defined?(:@record)
+      @record = blob.variant_records.find_by(variation_digest: variation.digest)
     end
 end


### PR DESCRIPTION
### Summary

Just a tiny perf improvement.

Before:

```ruby
variant = blob.variant(resize: "100x100")

variant.image
#=> SELECT * FROM active_storage_variant_records WHERE blob_id = ? ...

variant.url
#=> SELECT * FROM active_storage_variant_records WHERE blob_id = ? ...
```

After:

```ruby
variant = blob.variant(resize: "100x100")

variant.image
#=> SELECT * FROM active_storage_variant_records WHERE blob_id = ? ...

variant.url
#=> nothing
```

**NOTE:** We could even add a test for this change, if `assert_queries` were not a ActiveRecord testing internal feature 🤷🏻‍♂️

```ruby
test "loads variant record from DB only once" do
  blob = create_file_blob(filename: "racecar.jpg", service_name: "local_public")
  variant = blob.variant(resize: "100x100")

  assert_queries(1) do
    refute variant.processed?
    assert_nil variant.image
  end
end
```

