### PR TITLE
Load selenium/webdriver only if needed

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -4,7 +4,6 @@ gem "capybara", ">= 3.26"
 
 require "capybara/dsl"
 require "capybara/minitest"
-require "selenium/webdriver"
 require "action_controller"
 require "action_dispatch/system_testing/driver"
 require "action_dispatch/system_testing/browser"

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -10,7 +10,10 @@ module ActionDispatch
         @options = options[:options] || {}
         @capabilities = capabilities
 
-        @browser.preload unless name == :rack_test
+        if name == :selenium
+          require "selenium/webdriver"
+          @browser.preload
+        end
       end
 
       def use

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -148,9 +148,13 @@ class DriverTest < ActiveSupport::TestCase
     ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
   end
 
-  test "does not preload if :rack_test is set" do
+  test "does not preload if used driver is not :selenium" do
     assert_not_called_on_instance_of(ActionDispatch::SystemTesting::Browser, :preload) do
       ActionDispatch::SystemTesting::Driver.new(:rack_test, using: :chrome)
+    end
+
+    assert_not_called_on_instance_of(ActionDispatch::SystemTesting::Browser, :preload) do
+      ActionDispatch::SystemTesting::Driver.new(:poltergeist)
     end
   end
 end


### PR DESCRIPTION
### Summary

Currently, 'selenium-webdriver' gem is required to use system tests even if a non-selenium driver is used (such as Poltergeist, [Cuprite](https://github.com/rubycdp/cuprite), etc.).

Even more: calling `driven_by :not_seleinium` would call `@browser.preload`, and thus, try to preinitialize Selenium internals.

This PR moves `require` to `Driver#initialize` to load it only if `:selenium` is used. Also, makes calling `@browser.preload` Selenium-only as well (because it's Selenium-specific).

### Other Information

I think, in 7.0 we should move this require statement to generator (and default `application_system_test_case.rb`). If we add it in 6.1 that would be a breaking change.
