### PR TITLE
Fix case when a requiring a file leads to constants defined not included in autoloaded_constants

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -297,7 +297,15 @@ module ActiveSupport #:nodoc:
         if Dependencies.load? && Dependencies.constant_watch_stack.watching?
           descs = Dependencies.constant_watch_stack.watching.flatten.uniq
 
-          Dependencies.new_constants_in(*descs) { yield }
+          new_constants = Dependencies.new_constants_in(*descs) { yield }
+          new_constants.each do |constant|
+            path_suffix = constant.underscore
+            if Dependencies.search_for_file(path_suffix) || Dependencies.autoloadable_module?(path_suffix)
+              Dependencies.autoloaded_constants << constant
+            end
+          end
+
+          Dependencies.autoloaded_constants.uniq!
         else
           yield
         end

--- a/activesupport/test/autoloading_fixtures/parent_child_conflict.rb
+++ b/activesupport/test/autoloading_fixtures/parent_child_conflict.rb
@@ -1,0 +1,4 @@
+require 'dependencies/parent_child_conflict/child_constant'
+
+class ParentChildConflict
+end

--- a/activesupport/test/autoloading_fixtures/parent_child_conflict.rb
+++ b/activesupport/test/autoloading_fixtures/parent_child_conflict.rb
@@ -1,4 +1,6 @@
-require 'dependencies/parent_child_conflict/child_constant'
+# frozen_string_literal: true
+
+require "dependencies/parent_child_conflict/child_constant"
 
 class ParentChildConflict
 end

--- a/activesupport/test/dependencies/parent_child_conflict/child_constant.rb
+++ b/activesupport/test/dependencies/parent_child_conflict/child_constant.rb
@@ -1,0 +1,4 @@
+class ParentChildConflict
+  module ChildConstant
+  end
+end

--- a/activesupport/test/dependencies/parent_child_conflict/child_constant.rb
+++ b/activesupport/test/dependencies/parent_child_conflict/child_constant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ParentChildConflict
   module ChildConstant
   end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -310,6 +310,18 @@ class DependenciesTest < ActiveSupport::TestCase
     remove_constants(:ConstFromLib)
   end
 
+  def test_module_with_required_class_defining_parent_class
+    with_autoloading_fixtures do
+      _ = ParentChildConflict
+
+      assert defined?(ParentChildConflict::ChildConstant)
+      assert ActiveSupport::Dependencies.autoloaded_constants.include?("ParentChildConflict")
+      assert_not ActiveSupport::Dependencies.autoloaded_constants.include?("ParentChildConflict::ChildConstant")
+    end
+  ensure
+    remove_constants(:ParentChildConflict)
+  end
+
   def test_directories_may_manifest_as_nested_classes
     with_autoloading_fixtures do
       assert_kind_of Class, ClassFolder


### PR DESCRIPTION
### Summary

There seems to be a bug where if a parent file which is being autoloaded `require`s a child file which defines the same constant the parent file, the result is that the conflicting constant is never put into `autoloaded_constants`. You can see my test case for more details.

My fix is to check in `load_dependency` which will get called when the parent file `require`s the child file, to check for any new constants defined in the child file and if it is a constant that exists in `autoload_paths`, put that in the `autoloaded_constants` array. 

I'm not sure if this is the correct fix, opening this for discussion! 

### Other Information

I made a [test app](https://github.com/aivenaivenaiven/test_app) to illustrate this issue.

Behavior: 
```
be rails runner 'User; p ActiveSupport::Dependencies.autoloaded_constants'
=> []
```
Expected:
```
be rails runner 'User; p ActiveSupport::Dependencies.autoloaded_constants'
=> ["User"]
```
