### PR TITLE
MySQL: Uniqueness validator now respects default database collation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   MySQL: Uniqueness validator now respects default database collation,
+    no longer enforce case sensitive comparison by default.
+
+    *Ryuta Kamizono*
+
 *   Remove deprecated methods from `ActiveRecord::ConnectionAdapters::DatabaseLimits`.
 
     `column_name_length`

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -520,7 +520,7 @@ module ActiveRecord
         @connection
       end
 
-      def default_uniqueness_comparison(attribute, value, klass) # :nodoc:
+      def default_uniqueness_comparison(attribute, value) # :nodoc:
         attribute.eq(value)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -452,21 +452,6 @@ module ActiveRecord
         SQL
       end
 
-      def default_uniqueness_comparison(attribute, value, klass) # :nodoc:
-        column = column_for_attribute(attribute)
-
-        if column.collation && !column.case_sensitive? && !value.nil?
-          ActiveSupport::Deprecation.warn(<<~MSG.squish)
-            Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1.
-            To continue case sensitive comparison on the :#{attribute.name} attribute in #{klass} model,
-            pass `case_sensitive: true` option explicitly to the uniqueness validator.
-          MSG
-          attribute.eq(Arel::Nodes::Bin.new(value))
-        else
-          super
-        end
-      end
-
       def case_sensitive_comparison(attribute, value) # :nodoc:
         column = column_for_attribute(attribute)
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -61,7 +61,7 @@ module ActiveRecord
           return relation.none! if bind.unboundable?
 
           if !options.key?(:case_sensitive) || bind.nil?
-            klass.connection.default_uniqueness_comparison(attr, bind, klass)
+            klass.connection.default_uniqueness_comparison(attr, bind)
           elsif options[:case_sensitive]
             klass.connection.case_sensitive_comparison(attr, bind)
           else

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -314,28 +314,7 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t3.save, "Should save t3 as unique"
   end
 
-  if current_adapter?(:Mysql2Adapter)
-    def test_deprecate_validate_uniqueness_mismatched_collation
-      Topic.validates_uniqueness_of(:author_email_address)
-
-      topic1 = Topic.new(author_email_address: "david@loudthinking.com")
-      topic2 = Topic.new(author_email_address: "David@loudthinking.com")
-
-      assert_equal 1, Topic.where(author_email_address: "david@loudthinking.com").count
-
-      assert_deprecated do
-        assert_not topic1.valid?
-        assert_not topic1.save
-        assert topic2.valid?
-        assert topic2.save
-      end
-
-      assert_equal 2, Topic.where(author_email_address: "david@loudthinking.com").count
-      assert_equal 2, Topic.where(author_email_address: "David@loudthinking.com").count
-    end
-  end
-
-  def test_validate_case_sensitive_uniqueness_by_default
+  def test_validate_uniqueness_by_default_database_collation
     Topic.validates_uniqueness_of(:author_email_address)
 
     topic1 = Topic.new(author_email_address: "david@loudthinking.com")
@@ -343,20 +322,21 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     assert_equal 1, Topic.where(author_email_address: "david@loudthinking.com").count
 
-    ActiveSupport::Deprecation.silence do
-      assert_not topic1.valid?
-      assert_not topic1.save
+    assert_not topic1.valid?
+    assert_not topic1.save
+
+    if current_adapter?(:Mysql2Adapter)
+      # Case insensitive collation (utf8mb4_0900_ai_ci) by default.
+      # Should not allow "David" if "david" exists.
+      assert_not topic2.valid?
+      assert_not topic2.save
+    else
       assert topic2.valid?
       assert topic2.save
     end
 
-    if current_adapter?(:Mysql2Adapter)
-      assert_equal 2, Topic.where(author_email_address: "david@loudthinking.com").count
-      assert_equal 2, Topic.where(author_email_address: "David@loudthinking.com").count
-    else
-      assert_equal 1, Topic.where(author_email_address: "david@loudthinking.com").count
-      assert_equal 1, Topic.where(author_email_address: "David@loudthinking.com").count
-    end
+    assert_equal 1, Topic.where(author_email_address: "david@loudthinking.com").count
+    assert_equal 1, Topic.where(author_email_address: "David@loudthinking.com").count
   end
 
   def test_validate_case_sensitive_uniqueness

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -8,13 +8,6 @@ ActiveRecord::Schema.define do
   #                                                                     #
   # ------------------------------------------------------------------- #
 
-  case_sensitive_options =
-    if current_adapter?(:Mysql2Adapter)
-      { collation: "utf8mb4_bin" }
-    else
-      {}
-    end
-
   create_table :accounts, force: true do |t|
     t.references :firm, index: false
     t.string  :firm_name
@@ -115,7 +108,7 @@ ActiveRecord::Schema.define do
     t.column :font_size, :integer, **default_zero
     t.column :difficulty, :integer, **default_zero
     t.column :cover, :string, default: "hard"
-    t.string :isbn, **case_sensitive_options
+    t.string :isbn
     t.datetime :published_on
     t.boolean :boolean_status
     t.index [:author_id, :name], unique: true
@@ -284,7 +277,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :dashboards, force: true, id: false do |t|
-    t.string :dashboard_id, **case_sensitive_options
+    t.string :dashboard_id
     t.string :name
   end
 
@@ -348,7 +341,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :essays, force: true do |t|
-    t.string :name, **case_sensitive_options
+    t.string :name
     t.string :writer_id
     t.string :writer_type
     t.string :category_id
@@ -356,7 +349,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :events, force: true do |t|
-    t.string :title, limit: 5, **case_sensitive_options
+    t.string :title, limit: 5
   end
 
   create_table :eyes, force: true do |t|
@@ -398,7 +391,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :guids, force: true do |t|
-    t.column :key, :string, **case_sensitive_options
+    t.column :key, :string
   end
 
   create_table :guitars, force: true do |t|
@@ -406,8 +399,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :inept_wizards, force: true do |t|
-    t.column :name, :string, null: false, **case_sensitive_options
-    t.column :city, :string, null: false, **case_sensitive_options
+    t.column :name, :string, null: false
+    t.column :city, :string, null: false
     t.column :type, :string
   end
 
@@ -924,8 +917,8 @@ ActiveRecord::Schema.define do
   end
 
   create_table :topics, force: true do |t|
-    t.string   :title, limit: 250, **case_sensitive_options
-    t.string   :author_name, **case_sensitive_options
+    t.string   :title, limit: 250
+    t.string   :author_name
     t.string   :author_email_address
     if supports_datetime_with_precision?
       t.datetime :written_on, precision: 6
@@ -937,10 +930,10 @@ ActiveRecord::Schema.define do
     # use VARCHAR2(4000) instead of CLOB datatype as CLOB data type has many limitations in
     # Oracle SELECT WHERE clause which causes many unit test failures
     if current_adapter?(:OracleAdapter)
-      t.string   :content, limit: 4000, **case_sensitive_options
+      t.string   :content, limit: 4000
       t.string   :important, limit: 4000
     else
-      t.text     :content, **case_sensitive_options
+      t.text     :content
       t.text     :important
     end
     t.boolean  :approved, default: true

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -152,6 +152,9 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 ### Removals
 
+*   MySQL: Uniqueness validator now respects default database collation,
+    no longer enforce case sensitive comparison by default.
+
 *   Remove deprecated methods from `ActiveRecord::ConnectionAdapters::DatabaseLimits`.
 
     `column_name_length`


### PR DESCRIPTION
No longer enforce case sensitive comparison by default.

cc @rafaelfranca 