### PR TITLE
Improve ActiveStorage migrations

### DIFF
--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -10,4 +10,8 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
       change_column :active_storage_blobs, :service_name, :string, null: false
     end
   end
+
+  def down
+    remove_column :active_storage_blobs, :service_name
+  end
 end

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,5 +1,5 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
-  def up
+  def change
     create_table :active_storage_variant_records do |t|
       t.belongs_to :blob, null: false, index: false
       t.string :variation_digest, null: false


### PR DESCRIPTION
### Summary

Makes ActiveStorage migrations when upgrading to Rails 6 rollbackable