### PR TITLE
update_columns accept anything that responds to to_h

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -672,6 +672,8 @@ module ActiveRecord
       raise ActiveRecordError, "cannot update a new record" if new_record?
       raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
 
+      attributes = attributes.to_h unless attributes.is_a?(Hash)
+
       attributes = attributes.transform_keys do |key|
         name = key.to_s
         self.class.attribute_aliases[name] || name

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -839,6 +839,15 @@ class PersistenceTest < ActiveRecord::TestCase
     assert developer.update_columns(name: "Will"), "did not update record due to default scope"
   end
 
+  def test_update_columns_with_objects_that_respond_to_to_h
+    topic = Topic.find(1)
+    object = Class.new { def to_h; { id: 123 }; end }.new
+    topic.update_columns(object)
+    assert_equal 123, topic.id
+    topic.reload
+    assert_equal 123, topic.id
+  end
+
   def test_update
     topic = Topic.find(1)
     assert_not_predicate topic, :approved?


### PR DESCRIPTION
### Summary

Resolves #39180 by calling `.to_h` unless the object is already a `Hash`