### PR TITLE
Allow to call update_columns with strong params

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -7,6 +7,8 @@ module ActiveRecord
   module Persistence
     extend ActiveSupport::Concern
 
+    include ActiveModel::ForbiddenAttributesProtection
+
     module ClassMethods
       # Creates an object (or multiple objects) and saves it to the database, if validations pass.
       # The resulting object is returned whether the object was saved successfully to the database or not.
@@ -671,6 +673,8 @@ module ActiveRecord
     def update_columns(attributes)
       raise ActiveRecordError, "cannot update a new record" if new_record?
       raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
+
+      attributes = sanitize_forbidden_attributes(attributes)
 
       attributes = attributes.transform_keys do |key|
         name = key.to_s

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -19,6 +19,7 @@ require "models/person"
 require "models/ship"
 require "models/admin"
 require "models/admin/user"
+require "support/stubs/strong_parameters"
 
 class PersistenceTest < ActiveRecord::TestCase
   fixtures :topics, :companies, :developers, :accounts, :minimalistics, :authors, :author_addresses, :posts, :minivans
@@ -837,6 +838,15 @@ class PersistenceTest < ActiveRecord::TestCase
     developer.save!
 
     assert developer.update_columns(name: "Will"), "did not update record due to default scope"
+  end
+
+  def test_update_columns_with_strong_params
+    topic = Topic.find(1)
+    params = ProtectedParams.new(id: 123).permit!
+    topic.update_columns(params)
+    assert_equal 123, topic.id
+    topic.reload
+    assert_equal 123, topic.id
   end
 
   def test_update


### PR DESCRIPTION
### Summary

Resolves #39180 

Benchmark changes:
old = without the patch
new = with the patch
```
Warming up --------------------------------------
                 old   922.000  i/100ms
Calculating -------------------------------------
                 old      9.002k (± 4.2%) i/s -     45.178k in   5.027960s
Warming up --------------------------------------
                 new   933.000  i/100ms
Calculating -------------------------------------
                 new      9.160k (± 2.9%) i/s -     46.650k in   5.096912s

Comparison:
                 new:     9160.4 i/s
                 old:     9002.2 i/s - same-ish: difference falls within error
```

Script for benchmark:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  #gem "rails", github: "santib/rails", branch: "fix_39180_update_columns_2"
  gem "rails", github: "rails/rails"
  gem "benchmark-ips", "< 2.8"
  gem "byebug"
  gem "sqlite3"
end

require "active_record"
require "active_model"

ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
@connection = ActiveRecord::Base.connection
@connection.create_table :posts, force: true do |t|
  t.string :title
end

class Post < ActiveRecord::Base
end

post = Post.create
i = 0

Benchmark.ips do |x|
  x.report("old") { post.update_columns(title: (i = i+1)) }

  x.report("new") { post.update_columns(title: (i = i+1)) }

  x.hold! 'temp_results'
  x.compare!
end
```