### PR TITLE
`remove_foreign_key` doesn't care `:validate` option if database has no feature

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -105,8 +105,9 @@ module ActiveRecord
         !ActiveRecord::SchemaDumper.fk_ignore_pattern.match?(name) if name
       end
 
-      def defined_for?(to_table: nil, **options)
+      def defined_for?(to_table: nil, validate: nil, **options)
         (to_table.nil? || to_table.to_s == self.to_table) &&
+          (validate.nil? || validate == options.fetch(:validate, validate)) &&
           options.all? { |k, v| self.options[k].to_s == v.to_s }
       end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -61,7 +61,7 @@ module ActiveRecord
 
         def remove_foreign_key(from_table, to_table = nil, **options)
           to_table ||= options[:to_table]
-          options = options.except(:name, :to_table)
+          options = options.except(:name, :to_table, :validate)
           foreign_keys = foreign_keys(from_table)
 
           fkey = foreign_keys.detect do |fk|

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -32,7 +32,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         class CreateRocketsMigration < ActiveRecord::Migration::Current
-          def up
+          def change
             create_table :rockets do |t|
               t.string :name
             end
@@ -41,11 +41,6 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
               t.string :name
               t.references :rocket, foreign_key: true
             end
-          end
-
-          def down
-            drop_table :astronauts, if_exists: true
-            drop_table :rockets, if_exists: true
           end
         end
 
@@ -533,18 +528,13 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         class CreateSchoolsAndClassesMigration < ActiveRecord::Migration::Current
-          def up
+          def change
             create_table(:schools)
 
             create_table(:classes) do |t|
               t.references :school
             end
-            add_foreign_key :classes, :schools
-          end
-
-          def down
-            drop_table :classes, if_exists: true
-            drop_table :schools, if_exists: true
+            add_foreign_key :classes, :schools, validate: true
           end
         end
 

--- a/activerecord/test/cases/migration/references_foreign_key_test.rb
+++ b/activerecord/test/cases/migration/references_foreign_key_test.rb
@@ -170,17 +170,12 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         class CreateDogsMigration < ActiveRecord::Migration::Current
-          def up
+          def change
             create_table :dog_owners
 
             create_table :dogs do |t|
               t.references :dog_owner, foreign_key: true
             end
-          end
-
-          def down
-            drop_table :dogs, if_exists: true
-            drop_table :dog_owners, if_exists: true
           end
         end
 


### PR DESCRIPTION
Fixes #39170.

#39170 is a regression caused by 362348b to maintain kwargs flag to
address kwargs warnings.
