### PR TITLE
Support kwargs for named scopes

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -407,9 +407,16 @@ module ActiveRecord
       already_in_scope? ? yield : _scoping(self) { yield }
     end
 
-    def _exec_scope(name, *args, &block) # :nodoc:
+    def _exec_scope(name, *args, **kwargs, &block) # :nodoc:
       @delegate_to_klass = true
-      _scoping(_deprecated_spawn(name)) { instance_exec(*args, &block) || self }
+      _scoping(_deprecated_spawn(name)) do
+        if kwargs.empty?
+          # Ruby <= 2.6 compatibility
+          instance_exec(*args, &block) || self
+        else
+          instance_exec(*args, **kwargs, &block) || self
+        end
+      end
     ensure
       @delegate_to_klass = false
     end

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -183,14 +183,14 @@ module ActiveRecord
           extension = Module.new(&block) if block
 
           if body.respond_to?(:to_proc)
-            singleton_class.define_method(name) do |*args|
-              scope = all._exec_scope(name, *args, &body)
+            singleton_class.define_method(name) do |*args, **kwargs|
+              scope = all._exec_scope(name, *args, **kwargs, &body)
               scope = scope.extending(extension) if extension
               scope
             end
           else
-            singleton_class.define_method(name) do |*args|
-              scope = body.call(*args) || all
+            singleton_class.define_method(name) do |*args, **kwargs|
+              scope = body.call(*args, **kwargs) || all
               scope = scope.extending(extension) if extension
               scope
             end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -113,6 +113,30 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert objects.all?(&:approved?), "all objects should be approved"
   end
 
+  def test_scope_with_kwargs
+    # Explicit true
+    topics = Topic.with_kwargs(approved: true)
+    assert_operator topics.length, :>, 0
+    assert topics.all?(&:approved?), "all objects should be approved"
+
+    # No arguments
+    topics = Topic.with_kwargs()
+    assert_operator topics.length, :>, 0
+    assert topics.none?(&:approved?), "all objects should be approved"
+
+    unless RUBY_VERSION >= "2.7"
+      # Empty hash: should be valid in 2.6, warning in 2.7
+      topics = Topic.with_kwargs({})
+      assert_operator topics.length, :>, 0
+      assert topics.none?(&:approved?), "all objects should be approved"
+
+      # Hash for kwargs: valid in 2.6 warning in 2.7
+      topics = Topic.with_kwargs({approved: true})
+      assert_operator topics.length, :>, 0
+      assert topics.all?(&:approved?), "all objects should be approved"
+    end
+  end
+
   def test_has_many_associations_have_access_to_scopes
     assert_not_equal Post.containing_the_letter_a, authors(:david).posts
     assert_not_empty Post.containing_the_letter_a

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -28,6 +28,8 @@ class Topic < ActiveRecord::Base
     end
   }.new(self)
 
+  scope :with_kwargs, ->(approved: false) { where(approved: approved) }
+
   module NamedExtension
     def two
       2


### PR DESCRIPTION
Previously Ruby 2.7 would generate a warning when trying to define a named scope which took keyword arguments.

``` ruby
class Books
  scope :with_attributes, -> (author: nil, title: nil) {
    # ...
  }
end
```

This should allow those scopes to be defined and run without warnings.

cc @eileencodes @kytrinyx @HParker 