### PR TITLE
Support kwargs for named scopes

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -195,6 +195,7 @@ module ActiveRecord
               scope
             end
           end
+          singleton_class.send(:ruby2_keywords, name) if respond_to?(:ruby2_keywords, true)
 
           generate_relation_method(name)
         end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -127,6 +127,18 @@ class NamedScopingTest < ActiveRecord::TestCase
     assert objects.all?(&:approved?), "all objects should be approved"
   end
 
+  def test_scope_with_kwargs
+    # Explicit true
+    topics = Topic.with_kwargs(approved: true)
+    assert_operator topics.length, :>, 0
+    assert topics.all?(&:approved?), "all objects should be approved"
+
+    # No arguments
+    topics = Topic.with_kwargs()
+    assert_operator topics.length, :>, 0
+    assert topics.none?(&:approved?), "all objects should not be approved"
+  end
+
   def test_has_many_associations_have_access_to_scopes
     assert_not_equal Post.containing_the_letter_a, authors(:david).posts
     assert_not_empty Post.containing_the_letter_a

--- a/activerecord/test/models/topic.rb
+++ b/activerecord/test/models/topic.rb
@@ -32,6 +32,8 @@ class Topic < ActiveRecord::Base
     end
   }.new(self)
 
+  scope :with_kwargs, ->(approved: false) { where(approved: approved) }
+
   module NamedExtension
     def two
       2


### PR DESCRIPTION
We fixed `generate_relation_method` to address kwargs warnings at
#38038, but I missed generated named scopes also need the same fix.

Test case has picked from #39196.

See the CI result show no kwargs related warnings.

cc @jhawthorn