### PR TITLE
Fix belongs_to through reflection casting check

### DIFF
--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define do
     t.column :difficulty, :integer, **default_zero
     t.column :cover, :string, default: "hard"
     t.string :isbn, **case_sensitive_options
+    t.string :publisher_id
     t.datetime :published_on
     t.boolean :boolean_status
     t.index [:author_id, :name], unique: true
@@ -888,6 +889,10 @@ ActiveRecord::Schema.define do
     t.string :name
     t.integer :lock_version, null: false, default: 0
     t.index :id, unique: true
+  end
+
+  create_table :publishers, id: false, force: true do |t|
+    t.string :code, null: false
   end
 
   create_table :subscribers, id: false, force: true do |t|


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/38724

Fixes a bug where belongs_to through relations with non-integer primary
keys were incorrectly raising an implementation error even through a
reflection association was present.