### PR TITLE
Allow unique in addition to uniq in migration generator

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -6,8 +6,8 @@ require "active_support/deprecation"
 module Rails
   module Generators
     class GeneratedAttribute # :nodoc:
-      INDEX_OPTIONS = %w(index uniq)
-      UNIQ_INDEX_OPTIONS = %w(uniq)
+      INDEX_OPTIONS = %w(index uniq unique)
+      UNIQ_INDEX_OPTIONS = %w(uniq unique)
 
       attr_accessor :name, :type
       attr_reader   :attr_options

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -176,4 +176,14 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     att = Rails::Generators::GeneratedAttribute.parse("supplier:references:index")
     assert_not_predicate att, :required?
   end
+
+  def test_parse_attribute_with_uniq
+    att = Rails::Generators::GeneratedAttribute.parse("nickname:string:uniq")
+    assert_predicate att, :has_uniq_index?
+  end
+
+  def test_parse_attribute_with_unique
+    att = Rails::Generators::GeneratedAttribute.parse("nickname:string:unique")
+    assert_predicate att, :has_uniq_index?
+  end
 end


### PR DESCRIPTION
### Summary

Running the migration generator marking an attribute as `unique` was previously done using the `uniq` option, e.g. `username:string:uniq`. Wrongly using `unique` as the option skipped generating the index, which could lead to uniqueness validations not working.

References:
* [May of WTFs: validates_uniqueness_of doesn’t really guarantee uniqueness](https://discuss.rubyonrails.org/t/validates-uniqueness-of-doesnt-really-guarantee-uniqueness/74398)
* [Github Issue: Allow column_name:type:unique as an alias for column_name:type:uniq](https://github.com/rails/rails/issues/39025)

### Other Information

none
