### PR TITLE
Fix cache_version to work when updated_at is aliased

### DIFF
--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -97,7 +97,7 @@ module ActiveRecord
     def cache_version
       return unless cache_versioning
 
-      if has_attribute?("updated_at")
+      if try(:updated_at)
         timestamp = updated_at_before_type_cast
         if can_use_fast_cache_version?(timestamp)
           raw_timestamp_to_cache_version(timestamp)

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -8,7 +8,7 @@ require "models/owner"
 require "models/pet"
 
 class IntegrationTest < ActiveRecord::TestCase
-  fixtures :companies, :developers, :owners, :pets
+  fixtures :companies, :developers, :legacy_developers, :owners, :pets
 
   def test_to_param_should_return_string
     assert_kind_of String, Client.first.to_param
@@ -139,6 +139,13 @@ class IntegrationTest < ActiveRecord::TestCase
     dev = Developer.first
     dev.updated_at = nil
     assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_s(:usec)}", dev.cache_key
+  end
+
+  def test_cache_key_for_aliased_updated_at
+    with_cache_versioning do
+      dev = LegacyDeveloper.first
+      assert_equal dev.updated_datetime.utc.to_s(:usec), dev.cache_version
+    end
   end
 
   def test_cache_key_for_newer_updated_at

--- a/activerecord/test/fixtures/legacy_developers.yml
+++ b/activerecord/test/fixtures/legacy_developers.yml
@@ -1,0 +1,4 @@
+homer:
+  id: 1
+  name: Homer
+  updated_datetime: '2020-02-02'

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -107,6 +107,11 @@ class SymbolIgnoredDeveloper < ActiveRecord::Base
   attribute :last_name
 end
 
+class LegacyDeveloper < ActiveRecord::Base
+  self.table_name = "legacy_developers"
+  alias_attribute :updated_at, :updated_datetime
+end
+
 class AuditLog < ActiveRecord::Base
   belongs_to :developer, validate: true
   belongs_to :unvalidated_developer, class_name: "Developer"

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -307,6 +307,11 @@ ActiveRecord::Schema.define do
     end
   end
 
+  create_table :legacy_developers, force: true do |t|
+    t.string   :name
+    t.datetime :updated_datetime
+  end
+
   create_table :developers_projects, force: true, id: false do |t|
     t.integer :developer_id, null: false
     t.integer :project_id, null: false


### PR DESCRIPTION
### Summary

There are some times where unfortunately we need to work with legacy tables where we have a column named in another way than `updated_at` or `updated_on` but that does just the same thing. In Rails 5 we just added `alias_attribute :updated_at, :[my custom column name]` and cache versions were working excellent. Now we want to upgrade to Rails 6 but we found out we'd need to monkey patch the `cache_version` method in order to keep using fragment caching for these legacy tables. 