### PR TITLE
Add the configuration option for annotating templates with file names to the generated app

### DIFF
--- a/actionmailbox/test/dummy/config/environments/development.rb
+++ b/actionmailbox/test/dummy/config/environments/development.rb
@@ -57,8 +57,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Render template filenames as comments in HTML
-  # config.action_view.annotate_template_file_names = true
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -44,6 +44,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Render template filenames as comments in HTML
-  # config.action_view.annotate_template_file_names = true
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/actiontext/test/dummy/config/environments/development.rb
+++ b/actiontext/test/dummy/config/environments/development.rb
@@ -57,8 +57,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Render template filenames as comments in HTML
-  # config.action_view.annotate_template_file_names = true
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -44,6 +44,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Render template filenames as comments in HTML
-  # config.action_view.annotate_template_file_names = true
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -2,7 +2,7 @@
 
     *Zach Kemp*
 
-*   `ActionView::Base.annotate_template_file_names` annotates HTML output with template file names.
+*   `ActionView::Base.annotate_rendered_view_with_filenames` annotates HTML output with template file names.
 
     *Joel Hawksley*, *Aaron Patterson*
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -162,8 +162,8 @@ module ActionView #:nodoc:
     # Specify whether submit_tag should automatically disable on click
     cattr_accessor :automatically_disable_submit_tag, default: true
 
-    # Render template filenames as comments in HTML
-    cattr_accessor :annotate_template_file_names, default: false
+    # Annotate rendered view with file names
+    cattr_accessor :annotate_rendered_view_with_filenames, default: false
 
     class_attribute :_routes
     class_attribute :logger

--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -79,7 +79,7 @@ module ActionView
 
       private
         def annotate?(template)
-          ActionView::Base.annotate_template_file_names && template.format == :html
+          ActionView::Base.annotate_rendered_view_with_filenames && template.format == :html
         end
 
         def valid_encoding(string, encoding)

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1455,7 +1455,7 @@ class RenderTest < ActionController::TestCase
   end
 
   def test_template_annotations
-    ActionView::Base.annotate_template_file_names = true
+    ActionView::Base.annotate_rendered_view_with_filenames = true
 
     get :greeting
 
@@ -1469,22 +1469,22 @@ class RenderTest < ActionController::TestCase
     assert_includes lines.last, "<!-- END"
     assert_includes lines.last, "test/fixtures/actionpack/test/greeting.html.erb -->"
   ensure
-    ActionView::Base.annotate_template_file_names = false
+    ActionView::Base.annotate_rendered_view_with_filenames = false
   end
 
   def test_template_annotations_do_not_render_for_non_html_format
-    ActionView::Base.annotate_template_file_names = true
+    ActionView::Base.annotate_rendered_view_with_filenames = true
 
     get :render_with_explicit_template_with_locals
 
     assert_not_includes @response.body, "BEGIN"
     assert_equal @response.body.split("\n").length, 1
   ensure
-    ActionView::Base.annotate_template_file_names = false
+    ActionView::Base.annotate_rendered_view_with_filenames = false
   end
 
   def test_line_offset_with_annotations_enabled
-    ActionView::Base.annotate_template_file_names = true
+    ActionView::Base.annotate_rendered_view_with_filenames = true
 
     exc = assert_raises ActionView::Template::Error do
       get :render_line_offset
@@ -1494,6 +1494,6 @@ class RenderTest < ActionController::TestCase
     assert_equal "1", $1,
       "The line offset is wrong, perhaps the wrong exception has been raised, exception was: #{exc.inspect}"
   ensure
-    ActionView::Base.annotate_template_file_names = false
+    ActionView::Base.annotate_rendered_view_with_filenames = false
   end
 end

--- a/activestorage/test/dummy/config/environments/development.rb
+++ b/activestorage/test/dummy/config/environments/development.rb
@@ -46,8 +46,8 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Render template filenames as comments in HTML
-  # config.action_view.annotate_template_file_names = true
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -36,6 +36,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Render template filenames as comments in HTML
-  # config.action_view.annotate_template_file_names = true
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -668,6 +668,7 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.default_enforce_utf8` determines whether forms are generated with a hidden tag that forces older versions of Internet Explorer to submit forms encoded in UTF-8. This defaults to `false`.
 
+* `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
 ### Configuring Action Mailbox
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -74,6 +74,9 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   <%= '# ' unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -63,4 +63,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Annotate rendered view with file names
+  # config.action_view.annotate_rendered_view_with_filenames = true
 end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

The `annotate_template_file_names` option was introduced in https://github.com/rails/rails/pull/38848 but it is not part of generated Rails application. So added it in `development.rb` and `test.rb` as commented lines. Users can enable it by uncommenting it.
Also added a note about this option to the `configuring` guide.
