### PR TITLE
Avoid specifying ruby version twice

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby <%= "'#{RUBY_VERSION}'" -%>
+ruby File.read(File.join(__dir__, '.ruby-version'))
 
 <% unless gemfile_entries.first&.comment -%>
 


### PR DESCRIPTION
### Summary

On a new Rails project, the ruby version is specified twice: `.ruby-version` file and `Gemfile`. 
This is clearly a duplication and is not necessary since the Gemfile can read it from the `.ruby-version` file. When updating the ruby version you will now need to only update it in one place.
This change loads the version from the `.ruby-version` file.

I don't think any CHANGELOG entry is necessary but I can add it if you believe differently.