### PR TITLE
Expose Arel attributes through ActiveRecord::Table module and `t` method

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -76,6 +76,7 @@ module ActiveRecord
   autoload :Validations
   autoload :SecureToken
   autoload :DatabaseSelector, "active_record/middleware/database_selector"
+  autoload :Table
 
   eager_autoload do
     autoload :ConnectionAdapters

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -162,9 +162,16 @@ module ActiveRecord
         @find_by_statement_cache = { true => Concurrent::Map.new, false => Concurrent::Map.new }
       end
 
+      def define_table_constant(child_class)
+        # We have a connection at this point, which we need for this to work
+        Table.base = child_class
+        child_class.const_set(:Table, Table)
+      end
+
       def inherited(child_class) # :nodoc:
         # initialize cache at class definition for thread safety
         child_class.initialize_find_by_cache
+        child_class.define_table_constant(child_class)
         super
       end
 
@@ -295,6 +302,14 @@ module ActiveRecord
 
       def _internal? # :nodoc:
         false
+      end
+
+      # Makes methods from ::Table available through a <tt>t</tt> method
+      #
+      # Developer.t.id.class #=> Arel::Attributes::Attribute
+      #
+      def t
+        self::Table
       end
 
       private

--- a/activerecord/lib/active_record/table.rb
+++ b/activerecord/lib/active_record/table.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Table
+    mattr_accessor :base
+
+    extend self
+
+    ##
+    # Contains class methods corresponding to a table's columns, lazily evaluated
+    # at call time. Returns instances of <tt>Arel::Attributes::Attribute</tt>.
+    #
+    # Available through a Model::Table interface:
+    #
+    # Developer::Table.id.class #=> Arel::Attributes::Attribute
+
+    def method_missing(method_name, *args, &block)
+      send(:define_method, method_name) do
+        base.arel_attribute(method_name)
+      end
+      send(method_name)
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      columns.find { |c| c.name == method_name.to_s } || super
+    end
+
+    def columns
+      base.connection.columns(base.table_name)
+    end
+  end
+end

--- a/activerecord/test/cases/table_test.rb
+++ b/activerecord/test/cases/table_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+
+class TableTest < ActiveRecord::TestCase
+  def test_t_responds_to_column_names
+    Developer.column_names.each do |name|
+      assert_respond_to Developer.t, name
+    end
+  end
+
+  def test_table_responds_to_column_names
+    Developer.column_names.each do |name|
+      assert_respond_to Developer::Table, name
+    end
+  end
+
+  def test_table_is_arel_attribute
+    assert_kind_of Arel::Attributes::Attribute, Developer::Table.id
+  end
+end


### PR DESCRIPTION
### Summary

This implements a `Table` module and `t` class method for ActiveRecord models. 
The goal is to expose a table's Arel attributes without directly typing "Arel". This started with the `[]` method here: https://github.com/rails/rails/pull/39198

The module is installed after a db connection is available, and the methods are defined at call time:

Examples:

```ruby
Developer::Table.id.eq(42)

Developer.t.salary.gt(9000)
```

References:
- https://github.com/rails/rails/pull/39198
- https://discuss.rubyonrails.org/t/what-has-happened-to-arel/74383/36