### PR TITLE
Support `ALGORITHM = INSTANT` DDL option for index operations on MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Support `ALGORITHM = INSTANT` DDL option for index operations on MySQL.
+
+    *Ryuta Kamizono*
+
 *   Fix index creation to preserve index comment in bulk change table on MySQL.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -142,7 +142,12 @@ module ActiveRecord
       end
 
       def index_algorithms
-        { default: +"ALGORITHM = DEFAULT", copy: +"ALGORITHM = COPY", inplace: +"ALGORITHM = INPLACE" }
+        {
+          default: "ALGORITHM = DEFAULT",
+          copy:    "ALGORITHM = COPY",
+          inplace: "ALGORITHM = INPLACE",
+          instant: "ALGORITHM = INSTANT",
+        }
       end
 
       # HELPER METHODS ===========================================

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -58,8 +58,10 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
     expected = "CREATE INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10))"
     assert_equal expected, add_index(:people, :last_name, length: 10, using: :btree)
 
-    expected = "CREATE INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10)) ALGORITHM = COPY"
-    assert_equal expected, add_index(:people, :last_name, length: 10, using: :btree, algorithm: :copy)
+    %i(default copy inplace instant).each do |algorithm|
+      expected = "CREATE INDEX `index_people_on_last_name` USING btree ON `people` (`last_name`(10)) ALGORITHM = #{algorithm.upcase}"
+      assert_equal expected, add_index(:people, :last_name, length: 10, using: :btree, algorithm: algorithm)
+    end
 
     with_real_execute do
       add_index(:people, :first_name)


### PR DESCRIPTION
Since MySQL 8.0.12, MySQL supports `ALGORITHM=INSTANT` DDL option.

https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-index-operations