### PR TITLE
Fix incorrectly successful datetime precision tests

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/datetime_precision_quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/datetime_precision_quoting_test.rb
@@ -25,28 +25,25 @@ class Mysql2DatetimePrecisionQuotingTest < ActiveRecord::Mysql2TestCase
     end
   end
 
-  test "no microsecond precision for MariaDB lt 5.3.0" do
-    stub_version "5.2.9-MariaDB" do
-      assert_no_microsecond_precision
-    end
-  end
-
   private
     def assert_microsecond_precision
-      assert_match_quoted_microsecond_datetime(/\.000001\z/)
+      assert_match_quoted_microsecond_datetime(/\.123456\z/)
     end
 
     def assert_no_microsecond_precision
-      assert_match_quoted_microsecond_datetime(/\d\z/)
+      assert_match_quoted_microsecond_datetime(/:55\z/)
     end
 
     def assert_match_quoted_microsecond_datetime(match)
-      assert_match match, @connection.quoted_date(Time.now.change(usec: 1))
+      assert_match match, @connection.quoted_date(Time.now.change(sec: 55, usec: 123456))
     end
 
     def stub_version(full_version_string)
-      @connection.stub(:full_version, full_version_string) do
+      @connection.stub(:get_full_version, full_version_string) do
+        @connection.schema_cache.clear!
         yield
       end
+    ensure
+      @connection.schema_cache.clear!
     end
 end


### PR DESCRIPTION
### Summary

- datetime with precision was passing assert_no_microsecond_precision
unintentionally, because `/\d\z/` is match to both datetime with
precision and datetime without precision. Fixed that by changing
time and regex to make it easier to grasp with and without precision.

- Fix stub_version to consider schema_cache. ref: #35795

- Remove failing test for unsupported version of MariaDB. ref: fb6743a

