### PR TITLE
Enables `cache_classes` for test environment by default

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Enable `cache_classes` in generated `config/environments/test.rb`
+
+    Not caching classes when running tests can cause trouble when editing files
+    due to class reloading. In particular, when using multi-db setups, editing files
+    while tests were running will raise errors due to models resetting their db connections.
+
+    This setting was originally disabled because Spring reloading code even when this
+    was true caused problems with Zeitwerk. File watchers with this setting enabled were
+    removed in #37216, so there are no incompatibilities now.
+
+    *Jorge Manrubia*
+
 *   Add `config.generators.after_generate` for processing to generated files.
 
     Register a callback that will get called right after generators has finished.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -8,13 +8,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  <%-# Spring executes the reloaders when files change. -%>
-  <%- if spring_install? -%>
-  config.cache_classes = false
-  config.action_view.cache_template_loading = true
-  <%- else -%>
   config.cache_classes = true
-  <%- end -%>
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -841,8 +841,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator
     assert_gem "spring"
     assert_file("config/environments/test.rb") do |contents|
-      assert_match("config.cache_classes = false", contents)
-      assert_match("config.action_view.cache_template_loading = true", contents)
+      assert_match("config.cache_classes = true", contents)
     end
   end
 
@@ -862,7 +861,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_spring_no_fork
     jruby_skip "spring doesn't run on JRuby"
-    assert_called_with(Process, :respond_to?, [[:fork], [:fork], [:fork], [:fork]], returns: false) do
+    assert_called_with(Process, :respond_to?, [[:fork], [:fork], [:fork]], returns: false) do
       run_generator
 
       assert_no_gem "spring"


### PR DESCRIPTION
### Summary

Enables `cache_classes` for test environment even when using Spring and removes setting for `cache_template_loading` since that will be now `true` implicitly.

### Other Information

- This [setting was disabled](https://github.com/jorgemanrubia/rails/commit/65344f254cde87950c7f176cb7aa09c002a6f882) due to Spring executing the reloaders when files changed even when this was true, eventually triggering [this error condition in Zeitwerk](https://github.com/rails/rails/blob/8237c4d33035bd131865f1e73577748892a75f0a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb#L13-L15), but [this commit](https://github.com/rails/rails/commit/f8cbd3d5bd88b550bb9d0db589ffa5849a4b2998)  by @jhawthorn removed the watchers and fixed the problem.

- When caching classes is disabled, modifying code while the suite is running can have unintended side effects. For example, when using a multi-db setup, `#connect_to` will make the suite fail when a class is reloaded (see [this example project that reproduces](https://github.com/jorgemanrubia/rails-error-when-editing-test-files) it). The reason is that transactional fixtures rely on keeping connections alive, while each class reload forces a reconnection and produces an error when trying to reacquire closed connections.

- This also removes `cache_template_loading` since that will be now [implicitly `true`](https://github.com/rails/rails/blob/88ee52f9d9cf2068bb400205e5a0c1d2e40169d1/actionview/lib/action_view/railtie.rb#L84-L88).

We've been using this setting set to true for a few days and we haven't got any issue. And it fixed the problem that provoked this investigation in the first place. 

cc @fxn 