### PR TITLE
Should not substitute binds when `prepared_statements: true`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -185,12 +185,16 @@ module ActiveRecord
       private
         def type_casted_binds(binds)
           case binds.first
-          when ActiveModel::Attribute
-            binds.map { |attr| type_cast(attr.value_for_database) }
           when Array
             binds.map { |column, value| type_cast(value, column) }
           else
-            binds.map { |value| type_cast(value) }
+            binds.map do |value|
+              if ActiveModel::Attribute === value
+                type_cast(value.value_for_database)
+              else
+                type_cast(value)
+              end
+            end
           end
         end
 

--- a/activerecord/lib/active_record/explain.rb
+++ b/activerecord/lib/active_record/explain.rb
@@ -37,13 +37,18 @@ module ActiveRecord
 
     private
       def render_bind(attr)
-        value = if attr.type.binary? && attr.value
-          "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
+        if ActiveModel::Attribute === attr
+          value = if attr.type.binary? && attr.value
+            "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
+          else
+            connection.type_cast(attr.value_for_database)
+          end
         else
-          connection.type_cast(attr.value_for_database)
+          value = connection.type_cast(attr)
+          attr  = nil
         end
 
-        [attr.name, value]
+        [attr&.name, value]
       end
   end
 end

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -102,7 +102,7 @@ module ActiveRecord
         @bound_attributes = bound_attributes
 
         bound_attributes.each_with_index do |attr, i|
-          if Substitute === attr.value
+          if ActiveModel::Attribute === attr && Substitute === attr.value
             @indexes << i
           end
         end

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -50,8 +50,13 @@ module ActiveRecord
 
       def sql_for(binds, connection)
         val = @values.dup
-        casted_binds = binds.map(&:value_for_database)
-        @indexes.each { |i| val[i] = connection.quote(casted_binds.shift) }
+        @indexes.each do |i|
+          value = binds.shift
+          if ActiveModel::Attribute === value
+            value = value.value_for_database
+          end
+          val[i] = connection.quote(value)
+        end
         val.join
       end
     end
@@ -72,6 +77,15 @@ module ActiveRecord
       def add_bind(obj)
         @binds << obj
         @parts << Substitute.new
+        self
+      end
+
+      def add_binds(binds)
+        @binds.concat binds
+        binds.size.times do |i|
+          @parts << ", " unless i == 0
+          @parts << Substitute.new
+        end
         self
       end
 

--- a/activerecord/lib/arel/collectors/bind.rb
+++ b/activerecord/lib/arel/collectors/bind.rb
@@ -16,6 +16,11 @@ module Arel # :nodoc: all
         self
       end
 
+      def add_binds(binds)
+        @binds.concat binds
+        self
+      end
+
       def value
         @binds
       end

--- a/activerecord/lib/arel/collectors/composite.rb
+++ b/activerecord/lib/arel/collectors/composite.rb
@@ -22,6 +22,12 @@ module Arel # :nodoc: all
         self
       end
 
+      def add_binds(binds, &block)
+        left.add_binds(binds, &block)
+        right.add_binds(binds, &block)
+        self
+      end
+
       def value
         [left.value, right.value]
       end

--- a/activerecord/lib/arel/collectors/sql_string.rb
+++ b/activerecord/lib/arel/collectors/sql_string.rb
@@ -17,6 +17,11 @@ module Arel # :nodoc: all
         @bind_index += 1
         self
       end
+
+      def add_binds(binds, &block)
+        self << (@bind_index...@bind_index += binds.size).map(&block).join(", ")
+        self
+      end
     end
   end
 end

--- a/activerecord/lib/arel/collectors/substitute_binds.rb
+++ b/activerecord/lib/arel/collectors/substitute_binds.rb
@@ -20,6 +20,10 @@ module Arel # :nodoc: all
         self << quoter.quote(bind)
       end
 
+      def add_binds(binds)
+        self << binds.map { |bind| quoter.quote(bind) }.join(", ")
+      end
+
       def value
         delegate.value
       end

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -41,8 +41,8 @@ module Arel # :nodoc: all
           visit(o.expr, collector) << " )"
         end
 
-        def visit_Arel_Nodes_BindParam(o, collector)
-          collector.add_bind(o.value) { |i| "$#{i}" }
+        def visit_Arel_Nodes_BindParam(o, collector, value = o.value)
+          collector.add_bind(value) { |i| "$#{i}" }
         end
 
         def visit_Arel_Nodes_GroupingElement(o, collector)

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -41,10 +41,6 @@ module Arel # :nodoc: all
           visit(o.expr, collector) << " )"
         end
 
-        def visit_Arel_Nodes_BindParam(o, collector, value = o.value)
-          collector.add_bind(value) { |i| "$#{i}" }
-        end
-
         def visit_Arel_Nodes_GroupingElement(o, collector)
           collector << "( "
           visit(o.expr, collector) << " )"
@@ -91,6 +87,11 @@ module Arel # :nodoc: all
           visit o.expr, collector
           collector << " NULLS LAST"
         end
+
+        BIND_BLOCK = proc { |i| "$#{i}" }
+        private_constant :BIND_BLOCK
+
+        def bind_block; BIND_BLOCK; end
 
         # Used by Lateral visitor to enclose select queries in parentheses
         def grouping_parentheses(o, collector)

--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -164,7 +164,57 @@ if ActiveRecord::Base.connection.prepared_statements
         end
       end
 
+      def test_bind_params_to_sql_with_prepared_statements
+        assert_bind_params_to_sql
+      end
+
+      def test_bind_params_to_sql_with_unprepared_statements
+        @connection.unprepared_statement do
+          assert_bind_params_to_sql
+        end
+      end
+
       private
+        def assert_bind_params_to_sql
+          table = Author.quoted_table_name
+          pk = "#{table}.#{Author.quoted_primary_key}"
+
+          # prepared_statements: true
+          #
+          #   SELECT `authors`.* FROM `authors` WHERE (`authors`.`id` IN (?, ?, ?) OR `authors`.`id` IS NULL)
+          #
+          # prepared_statements: false
+          #
+          #   SELECT `authors`.* FROM `authors` WHERE (`authors`.`id` IN (1, 2, 3) OR `authors`.`id` IS NULL)
+          #
+          sql = "SELECT #{table}.* FROM #{table} WHERE (#{pk} IN (#{bind_params(1..3)}) OR #{pk} IS NULL)"
+
+          authors = Author.where(id: [1, 2, 3, nil])
+          assert_equal sql, @connection.to_sql(authors.arel)
+          assert_sql(sql) { assert_equal 3, authors.length }
+
+          # prepared_statements: true
+          #
+          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (?, ?, ?)
+          #
+          # prepared_statements: false
+          #
+          #   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (1, 2, 3)
+          #
+          sql = "SELECT #{table}.* FROM #{table} WHERE #{pk} IN (#{bind_params(1..3)})"
+
+          authors = Author.where(id: [1, 2, 3, 9223372036854775808])
+          assert_equal sql, @connection.to_sql(authors.arel)
+          assert_sql(sql) { assert_equal 3, authors.length }
+        end
+
+        def bind_params(ids)
+          collector = @connection.send(:collector)
+          bind_params = ids.map { |i| Arel::Nodes::BindParam.new(i) }
+          sql, _ = @connection.visitor.compile(bind_params, collector)
+          sql
+        end
+
         def to_sql_key(arel)
           sql = @connection.to_sql(arel)
           @connection.respond_to?(:sql_key, true) ? @connection.send(:sql_key, sql) : sql


### PR DESCRIPTION
Before IN clause optimization 70ddb8a, Active Record had generated an
SQL with binds when `prepared_statements: true`:

```ruby
# prepared_statements: true
#
#   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (?, ?, ?)
#
# prepared_statements: false
#
#   SELECT `authors`.* FROM `authors` WHERE `authors`.`id` IN (1, 2, 3)
#
Author.where(id: [1, 2, 3]).to_a
```

But now, binds in IN clause is substituted regardless of whether
`prepared_statements: true` or not:

```ruby
# prepared_statements: true
#
#   SELECT `authors`.* FROM `authors` WHERE `authors`.`id`IN (1,2,3)
#
# prepared_statements: false
#
#   SELECT `authors`.* FROM `authors` WHERE `authors`.`id`IN (1,2,3)
#
Author.where(id: [1, 2, 3]).to_a
```

I suppose that is considered as a regression for the context:

> While I would prefer that we fix/avoid the too-many-parameters
problem, but I don't like the idea of globally ditching bind params for
this edge case... we're getting to the point where I'd almost consider
anything that doesn't use a bind to be a bug.

https://github.com/rails/rails/pull/33844#issuecomment-421000003

This makes binds consider whether `prepared_statements: true` or not
(i.e. restore the original behavior as before), but still gain that
optimization when need the substitute binds (`prepared_statements: false`,
`relation.to_sql`). Even when `prepared_statements: true`, it still
much faster than before by optimized (bind node less) binds generation.

```ruby
class Post < ActiveRecord::Base
end

ids = (1..1000).each.map do |n|
  Post.create!.id
end

puts "prepared_statements: #{Post.connection.prepared_statements.inspect}"

Benchmark.ips do |x|
  x.report("where with ids") do
    Post.where(id: ids).to_a
  end
end
```

* Before (200058b0113efc7158432484d71c1a4f1484a4a1)

`prepared_statements: true`:

```
Warming up --------------------------------------
      where with ids     6.000  i/100ms
Calculating -------------------------------------
      where with ids     63.806  (± 7.8%) i/s -    318.000  in   5.015903s
```

`prepared_statements: false`:

```
Warming up --------------------------------------
      where with ids     7.000  i/100ms
Calculating -------------------------------------
      where with ids     73.550  (± 8.2%) i/s -    371.000  in   5.085672s
```

* Now with this change

`prepared_statements: true`:

```
Warming up --------------------------------------
      where with ids     9.000  i/100ms
Calculating -------------------------------------
      where with ids     91.992  (± 7.6%) i/s -    459.000  in   5.020817s
```

`prepared_statements: false`:

```
Warming up --------------------------------------
      where with ids    10.000  i/100ms
Calculating -------------------------------------
      where with ids    104.335  (± 8.6%) i/s -    520.000  in   5.026425s
```

cc @tenderlove @eileencodes @matthewd 