### PR TITLE
Adds a rails test:all rake task

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -857,6 +857,7 @@ bin/rails test:system
 
 NOTE: By default, running `bin/rails test` won't run your system tests.
 Make sure to run `bin/rails test:system` to actually run them.
+You can also run `bin/rails test:all` to run all tests, including system tests.
 
 #### Creating Articles System Test
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Adds `rails test:all` for running all tests in the test directory.
+
+    This runs all test files in the test directory, including system tests.
+
+    *Niklas Häusele*
+
 *   Add `config.generators.after_generate` for processing to generated files.
 
     Register a callback that will get called right after generators has finished.

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -23,12 +23,6 @@ namespace :test do
     # If used with Active Record, this task runs before the database schema is synchronized.
   end
 
-  desc "Runs all tests, even system tests"
-  task all: "test:prepare" do
-    $: << "test"
-    Rails::TestUnit::Runner.rake_run(["test/**/*_test.rb"])
-  end
-
   task run: %w[test]
 
   desc "Run tests quickly, but also reset db"
@@ -39,6 +33,12 @@ namespace :test do
       $: << "test"
       Rails::TestUnit::Runner.rake_run(["test/#{name}"])
     end
+  end
+
+  desc "Runs all tests, including system tests"
+  task all: "test:prepare" do
+    $: << "test"
+    Rails::TestUnit::Runner.rake_run(["test/**/*_test.rb"])
   end
 
   task generators: "test:prepare" do

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -23,6 +23,12 @@ namespace :test do
     # If used with Active Record, this task runs before the database schema is synchronized.
   end
 
+  desc "Runs all tests, even system tests"
+  task all: "test:prepare" do
+    $: << "test"
+    Rails::TestUnit::Runner.rake_run(["test/**/*_test.rb"])
+  end
+
   task run: %w[test]
 
   desc "Run tests quickly, but also reset db"


### PR DESCRIPTION
This task runs all tests, including system tests.

### Summary

Following [this discussion](https://discuss.rubyonrails.org/t/rails-test-doesnt-run-system-tests/74729/3) I started to add this (new? https://github.com/rails/rails/commit/2a31ea5545dbbeeafaaabb622a3053e361018898) rake task.

### Other Information

I added a notice in the test guides for this new rake task, but maybe I should add why `bin/rails test` does not run all test per default. What do you think?
