### PR TITLE
Fix test database creation with DATABASE_URL

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -249,7 +249,7 @@ module ActiveRecord
           next config if config.is_a?(UrlConfig)
           next config unless valid_enviroment_configuration?(current_env, config)
 
-          env_to_config = config.env_name == 'test' ? 'test' : current_env
+          env_to_config = config.env_name == "test" ? "test" : current_env
           url_config = environment_url_config(env_to_config, config.name, config.configuration_hash)
           url_config || config
         end
@@ -306,7 +306,7 @@ module ActiveRecord
       end
 
       def building_test_config_in_development?(current_env, config)
-        config.env_name == 'test' && current_env == 'development'
+        config.env_name == "test" && current_env == "development"
       end
   end
 end

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -246,9 +246,11 @@ module ActiveRecord
 
       def merge_db_environment_variables(current_env, configs)
         configs.map do |config|
-          next config if config.is_a?(UrlConfig) || config.env_name != current_env
+          next config if config.is_a?(UrlConfig)
+          next config unless valid_enviroment_configuration?(current_env, config)
 
-          url_config = environment_url_config(current_env, config.name, config.configuration_hash)
+          env_to_config = config.env_name == 'test' ? 'test' : current_env
+          url_config = environment_url_config(env_to_config, config.name, config.configuration_hash)
           url_config || config
         end
       end
@@ -297,6 +299,14 @@ module ActiveRecord
 
       def throw_getter_deprecation(method)
         ActiveSupport::Deprecation.warn("`ActiveRecord::Base.configurations` no longer returns a hash. Methods that act on the hash like `#{method}` are deprecated and will be removed in Rails 6.1. Use the `configs_for` method to collect and iterate over the database configurations.")
+      end
+
+      def valid_enviroment_configuration?(current_env, config)
+        config.env_name == current_env || building_test_config_in_development?(current_env, config)
+      end
+
+      def building_test_config_in_development?(current_env, config)
+        config.env_name == 'test' && current_env == 'development'
       end
   end
 end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -437,7 +437,7 @@ module ActiveRecord
 
         config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
         actual = resolve_db_config(:production, config)
-        expected = { adapter: "postgresql", database: "foo", host: "localhost", username: 'user', password: 'pwd' }
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", username: "user", password: "pwd" }
 
         assert_equal expected, actual.configuration_hash
       end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -103,6 +103,17 @@ module ActiveRecord
         assert_equal expected, actual.configuration_hash
       end
 
+      def test_resolver_with_database_uri_when_test_config_is_resolved_on_development
+        ENV["DATABASE_URL"] = "postgres://localhost"
+        ENV["RAILS_ENV"] = "development"
+
+        config = { "development" => { "adapter" => "postgresql", "database" => "foo_development" }, "test" => { "adapter" => "postgresql", "database" => "foo_test" } }
+        actual = resolve_db_config(:test, config)
+        expected = { adapter: "postgresql", database: "foo_test", host: "localhost" }
+
+        assert_equal expected, actual.configuration_hash
+      end
+
       def test_resolver_with_database_uri_and_unknown_symbol_key
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
         config = { "not_production" => {  "adapter" => "not_postgres", "database" => "not_foo" } }
@@ -418,6 +429,17 @@ module ActiveRecord
           database: "foo",
           adapter: "postgresql",
         }, actual.configuration_hash)
+      end
+
+      def test_resolver_with_complete_database_uri
+        ENV["DATABASE_URL"] = "postgres://user:pwd@localhost/foo"
+        ENV["RAILS_ENV"] = "production"
+
+        config = { "production" => { "adapter" => "not_postgres", "database" => "not_foo", "host" => "localhost" } }
+        actual = resolve_db_config(:production, config)
+        expected = { adapter: "postgresql", database: "foo", host: "localhost", username: 'user', password: 'pwd' }
+
+        assert_equal expected, actual.configuration_hash
       end
     end
   end


### PR DESCRIPTION
### Summary

Reference: https://github.com/rails/rails/issues/39222

This PR aims to fix the creation of test databases when the `DATABASE_URL` is set. The fix is being added for the description of the `db:create` to be truth, which due to a bug right now is not if  `DATABASE_URL` is set.

> when RAILS_ENV   is development, it defaults to creating the development and test databases

```
# activerecord/lib/activerecord/railties/databases.rake

desc "Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or when RAILS_ENV   is development, it defaults to creating the development and test databases."

task create: [:load_config] do
  ActiveRecord::Tasks::DatabaseTasks.create_current
end
```