### PR TITLE
Address `InnerJoinAssociationTest#test_eager_load_with_string_joins` failure with mysql2

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -16,6 +16,10 @@ class DirtyTest < ActiveRecord::TestCase
     Person.create first_name: "foo"
   end
 
+  def teardown
+    Person.delete_by(first_name: "foo")
+  end
+
   def test_attribute_changes
     # New record - no changes.
     pirate = Pirate.new


### PR DESCRIPTION
### Summary

`ReadOnlyTest#test_field_named_field` performs implicit commit the transaction by `ReadOnlyTest#setup` because of the MySQL database behavior.

This commit addresses the failure at https://buildkite.com/rails/rails/builds/68962#68213887-1cef-4f76-9c95-aebc8799c806

Here are minimum steps to reproduce:

```ruby
% ARCONN=mysql2 bin/test test/cases/readonly_test.rb test/cases/dirty_test.rb test/cases/associations/inner_join_association_test.rb \
-n "/^(?:ReadOnlyTest#(?:test_has_many_with_through_is_not_implicitly_marked_readonly)|DirtyTest#(?:test_field_named_field)|InnerJoinAssociationTest#(?:test_eager_load_with_string_joins))$/" --seed 50855
Using mysql2
Run options: -n "/^(?:ReadOnlyTest#(?:test_has_many_with_through_is_not_implicitly_marked_readonly)|DirtyTest#(?:test_field_named_field)|InnerJoinAssociationTest#(?:test_eager_load_with_string_joins))$/" --seed 50855

..F

Failure:
InnerJoinAssociationTest#test_eager_load_with_string_joins [/Users/yahonda/src/github.com/rails/rails/activerecord/test/cases/associations/inner_join_association_test.rb:87]:
Expected: 3
  Actual: 4

bin/test test/cases/associations/inner_join_association_test.rb:82

Finished in 0.114674s, 26.1611 runs/s, 26.1611 assertions/s.
3 runs, 3 assertions, 1 failures, 0 errors, 0 skips
```

References:
- "13.3.3 Statements That Cause an Implicit Commit"
https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
