### PR TITLE
Add inflection rule for coterie

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -66,6 +66,7 @@ module ActiveSupport
     inflect.irregular("sex", "sexes")
     inflect.irregular("move", "moves")
     inflect.irregular("zombie", "zombies")
+    inflect.irregular("coterie", "coteries")
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))
   end

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -367,13 +367,14 @@ module InflectorTestCases
   }
 
   Irregularities = {
-    "person" => "people",
-    "man"    => "men",
-    "child"  => "children",
-    "sex"    => "sexes",
-    "move"   => "moves",
-    "cow"    => "kine", # Test inflections with different starting letters
-    "zombie" => "zombies",
-    "genus"  => "genera"
+    "person"  => "people",
+    "man"     => "men",
+    "child"   => "children",
+    "sex"     => "sexes",
+    "move"    => "moves",
+    "cow"     => "kine", # Test inflections with different starting letters
+    "zombie"  => "zombies",
+    "genus"   => "genera",
+    "coterie" => "coteries"
   }
 end


### PR DESCRIPTION
### Summary

This patch fixes an issue where the word `coteries` is wrongly singularized to `cotery` instead of `coterie` , which leads to issues when used in database table names.

[Coterie](https://en.wiktionary.org/wiki/coterie) is a word oftenly used in tabletop RPG games.