### PR TITLE
Test failing on Windows because binary file being read inconsistently

### DIFF
--- a/activerecord/lib/active_record/fixture_set/render_context.rb
+++ b/activerecord/lib/active_record/fixture_set/render_context.rb
@@ -10,7 +10,7 @@ class ActiveRecord::FixtureSet::RenderContext # :nodoc:
       end
 
       def binary(path)
-        %(!!binary "#{Base64.strict_encode64(File.read(path))}")
+        %(!!binary "#{Base64.strict_encode64(File.read(path, mode: 'rb'))}")
       end
     end
   end


### PR DESCRIPTION
### Summary

The `FixturesTest#test_binary_in_fixtures` test fails on Windows as the binary file is being read in a mix of binary and text modes. 

The image is being read in binary mode at the start of the test https://github.com/rails/rails/blob/0dc3f5146da5d9f661ad4eb216d337b9525dfc7c/activerecord/test/cases/fixtures_test.rb#L532

But the fixture data is read in text mode https://github.com/rails/rails/blob/0dc3f5146da5d9f661ad4eb216d337b9525dfc7c/activerecord/lib/active_record/fixture_set/render_context.rb#L13.

This doesn't seem to be a problem for *nix environments but is for Windows. The issue was introduced in https://github.com/rails/rails/pull/30073/

**Windows**
```
> require "base64"
=> true
> Base64.strict_encode64(File.read('activerecord/test/assets/flowers.jpg')).length
=> 84
> Base64.strict_encode64(File.read('activerecord/test/assets/flowers.jpg', mode: 'rb')).length
=> 7780
```

**Unix-like**
```
> require "base64"
=> true
> Base64.strict_encode64(File.read('activerecord/test/assets/flowers.jpg')).length
=> 7780
> Base64.strict_encode64(File.read('activerecord/test/assets/flowers.jpg', mode: 'rb')).length
=> 7780
```

References: 
- https://ci.appveyor.com/project/rails-sqlserver/activerecord-sqlserver-adapter/builds/32723100/job/kx53snywsw4ja4id
- https://www.rubytapas.com/2016/12/14/ruby-code-on-windows/