### PR TITLE
Allow the construction of a CTE from an Arel::Table

### DIFF
--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -4,6 +4,7 @@ module Arel # :nodoc: all
   class Table
     include Arel::Crud
     include Arel::FactoryMethods
+    include Arel::AliasPredication
 
     @engine = nil
     class << self; attr_accessor :engine; end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -192,12 +192,12 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_With(o, collector)
           collector << "WITH "
-          inject_join o.children, collector, ", "
+          collect_ctes(o.children, collector)
         end
 
         def visit_Arel_Nodes_WithRecursive(o, collector)
           collector << "WITH RECURSIVE "
-          inject_join o.children, collector, ", "
+          collect_ctes(o.children, collector)
         end
 
         def visit_Arel_Nodes_Union(o, collector)
@@ -873,6 +873,27 @@ module Arel # :nodoc: all
           collector = visit o.right, collector
           collector << " IS NULL)"
           collector << " THEN 0 ELSE 1 END"
+        end
+
+        def collect_ctes(children, collector)
+          children.each_with_index do |child, i|
+            collector << ", " unless i == 0
+
+            case child
+            when Arel::Nodes::As
+              name = child.left.name
+              relation = child.right
+            when Arel::Nodes::TableAlias
+              name = child.name
+              relation = child.relation
+            end
+
+            collector << quote_table_name(name)
+            collector << " AS "
+            visit relation, collector
+          end
+
+          collector
         end
     end
   end

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -708,6 +708,31 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::With" do
+        it "handles table aliases" do
+          manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr2"))
+          expr1 = Table.new(:bar).project(Arel.star).as("expr1")
+          expr2 = Table.new(:baz).project(Arel.star).as("expr2")
+          manager.with(expr1, expr2)
+
+          _(compile(manager.ast)).must_be_like %{
+            WITH expr1 AS (SELECT * FROM "bar"), expr2 AS (SELECT * FROM "baz") SELECT * FROM expr2
+          }
+        end
+      end
+
+      describe "Nodes::WithRecursive" do
+        it "handles table aliases" do
+          manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr1"))
+          expr1 = Table.new(:bar).project(Arel.star).as("expr1")
+          manager.with(:recursive, expr1)
+
+          _(compile(manager.ast)).must_be_like %{
+            WITH RECURSIVE expr1 AS (SELECT * FROM "bar") SELECT * FROM expr1
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Per the discussion [here](https://discuss.rubyonrails.org/t/what-has-happened-to-arel/74383/33?u=eric_hayes) this change makes it a little easier to construct a common table expression by removing the need to build an explicit `As` node.

**Typically**
CTE construction requires setting up an alias with `Arel::Nodes::As`

```ruby
my_table = Arel::Table.new(:my_cte)
my_query = Arel::Table.new(:users).project(Arel.star)

Arel::Table.new(:foo)
  .project(Arel.star)
  .from(my_table)
  .with(Arel::Nodes::As.new(my_table, my_query))
```
(This will still work after the change)

**After**
Now you can set up the alias the table with `as` (as with other uses of `as` the argument is the name)

```ruby
my_table = Arel::Table.new(:my_cte)
my_query = Arel::Table.new(:users).project(Arel.star).as('my_cte')

Arel::Table.new(:foo)
  .project(Arel.star)
  .from('my_cte')
  .with(my_query)
```

Each should construct SQL along the lines of:

```sql
WITH my_cte AS (SELECT * FROM users) SELECT * FROM my_cte
```

This also covers `WITH RECURSIVE`:
```ruby
expr1 = Table.new(:bar).project(Arel.star).as("expr1")

Table.new(:foo)
  .project(Arel.star)
  .from(Arel.sql("expr1"))
  .with(:recursive, expr1)
  .to_sql

# => WITH RECURSIVE expr1 AS (SELECT * FROM "bar") SELECT * FROM expr1
```