### PR TITLE
Fix merging IN clause to be AND as Boolean algebra

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Fix merging IN clause to be AND as Boolean algebra.
+
+    ```ruby
+    david_and_mary = Author.where(id: [david, mary])
+    david_and_bob  = Author.where(id: [david, bob])
+
+    # Before
+    david_and_mary.merge(david_and_bob) # => [david, bob]
+    david_and_bob.merge(david_and_mary) # => [david, mary]
+
+    # After
+    david_and_mary.merge(david_and_bob) # => [david]
+    david_and_bob.merge(david_and_mary) # => [david]
+    ```
+
+    Fixes #39232.
+
+    *Ryuta Kamizono*
+
 *   Support `ALGORITHM = INSTANT` DDL option for index operations on MySQL.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -20,10 +20,6 @@ module Arel # :nodoc: all
       end
       alias :== :eql?
 
-      def equality?
-        true
-      end
-
       def invert
         Arel::Nodes::HomogeneousIn.new(values, attribute, type == :in ? :notin : :in)
       end

--- a/activerecord/lib/arel/nodes/in.rb
+++ b/activerecord/lib/arel/nodes/in.rb
@@ -2,7 +2,9 @@
 
 module Arel # :nodoc: all
   module Nodes
-    class In < Equality
+    class In < Arel::Nodes::Binary
+      include FetchAttribute
+
       def invert
         Arel::Nodes::NotIn.new(left, right)
       end

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -12,6 +12,28 @@ require "models/rating"
 class RelationMergingTest < ActiveRecord::TestCase
   fixtures :developers, :comments, :authors, :author_addresses, :posts
 
+  def test_merge_in_clause
+    david, mary, bob = authors(:david, :mary, :bob)
+
+    david_and_mary = Author.where(id: [david, mary])
+    david_and_bob  = Author.where(id: [david, bob])
+
+    assert_equal [david, mary], david_and_mary.sort_by(&:id)
+    assert_equal [david, bob], david_and_bob.sort_by(&:id)
+    assert_equal [david], david_and_mary.merge(david_and_bob)
+  end
+
+  def test_merge_or_clause
+    david, mary, bob = authors(:david, :mary, :bob)
+
+    david_and_mary = Author.where(id: david).or(Author.where(id: mary))
+    david_and_bob  = Author.where(id: david).or(Author.where(id: bob))
+
+    assert_equal [david, mary], david_and_mary.sort_by(&:id)
+    assert_equal [david, bob], david_and_bob.sort_by(&:id)
+    assert_equal [david], david_and_mary.merge(david_and_bob)
+  end
+
   def test_relation_merging
     devs = Developer.where("salary >= 80000").merge(Developer.limit(2)).merge(Developer.order("id ASC").where("id < 3"))
     assert_equal [developers(:david), developers(:jamis)], devs.to_a


### PR DESCRIPTION
Merging relation in Active Record behaves to replace a condition if the
condition is an equality, because `col = A AND col = B` is always empty
in that case, it is quite inconvenient in Active Record.

But IN clause is not an equality, but a set obviously.
So `col IN (A, B, ...) AND col IN (A, C, ...)` is not always empty.

I think it is considered a bug, caused by 87b6856, returning operator as
`:==` accidentally affected to IN node since IN node was introduced as a
subclass of Equality node before (I suppose it was also accidentally).

This fix is just to make IN node to Binary node, not an Equality node.

As a result, Active Record will regard IN clause as a set, not an
equality.

```ruby
david_and_mary = Author.where(id: [david, mary])
david_and_bob  = Author.where(id: [david, bob])

# Before
david_and_mary.merge(david_and_bob) # => [david, bob]
david_and_bob.merge(david_and_mary) # => [david, mary]

# After
david_and_mary.merge(david_and_bob) # => [david]
david_and_bob.merge(david_and_mary) # => [david]
```

Fixes #39232.