### PR TITLE
Add reboot! to rails console

### DIFF
--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -2,6 +2,7 @@
 
 require "active_support/all"
 require "action_controller"
+require "irb"
 
 module Rails
   module ConsoleMethods
@@ -32,6 +33,16 @@ module Rails
     def reload!(print = true)
       puts "Reloading..." if print
       Rails.application.reloader.reload!
+      true
+    end
+
+    # reboot a brand new session and exit current context
+    def reboot!(print = true)
+      puts "Rebooting..." if print
+      existing_context = IRB.CurrentContext
+      Rails.application.reloader.reload!
+      IRB.start
+      existing_context.exit
       true
     end
   end

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -174,4 +174,15 @@ class FullStackConsoleTest < ActiveSupport::TestCase
     write_prompt "puts Rails.env", "puts Rails.env\r\ntest"
     @primary.puts "quit"
   end
+
+  def test_reboot
+    options = "-- --verbose"
+    options += " --singleline --nocolorize" if RUBY_VERSION >= "2.7"
+    spawn_console(options)
+
+    write_prompt "a = 1", "a = 1"
+    write_prompt "reboot!", "Rebooting..."
+    write_prompt "a", "undefined local variable or method `a' for main:Object"
+    @primary.puts "quit"
+  end
 end


### PR DESCRIPTION
### Summary

Add the ability to `reboot!` inside rails a console, which will clear all local/instance variables and run reload! too. This will run a new console session within the current session and also close the old IRB context.

https://discuss.rubyonrails.org/t/console-is-not-aware-of-code-changes/74782/14

Not sure if a changelog needs to be added?