### PR TITLE
Add did you mean ssupport to UrlGeneration errors

### DIFF
--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -39,12 +39,16 @@ module ActionController
       end
 
       def corrections
-        maybe_these = @error.routes.named_routes.helper_names.grep(/#{@error.route_name}/)
-        maybe_these -= [@error.method_name.to_s] # remove exact match
+        if @error.method_name
+          maybe_these = @error.routes.named_routes.helper_names.grep(/#{@error.route_name}/)
+          maybe_these -= [@error.method_name.to_s] # remove exact match
 
-        maybe_these.sort_by { |n|
-          DidYouMean::Jaro.distance(@error.route_name, n)
-        }.reverse.first(4)
+          maybe_these.sort_by { |n|
+            DidYouMean::Jaro.distance(@error.route_name, n)
+          }.reverse.first(4)
+        else
+          []
+        end
       end
     end
 

--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -48,7 +48,10 @@ module ActionController
       end
     end
 
-    DidYouMean.correct_error(self, Correction)
+    # We may not have DYM, and DYM might not let us register error handlers
+    if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+      DidYouMean.correct_error(self, Correction)
+    end
   end
 
   class MethodNotAllowed < ActionControllerError #:nodoc:

--- a/actionpack/lib/action_controller/metal/exceptions.rb
+++ b/actionpack/lib/action_controller/metal/exceptions.rb
@@ -23,6 +23,29 @@ module ActionController
   end
 
   class UrlGenerationError < ActionControllerError #:nodoc:
+    attr_reader :routes, :route_name, :constraints, :missing_keys, :unmatched_keys
+
+    def initialize(message, routes = nil, route_name = nil, constraints = nil, missing_keys = nil, unmatched_keys = nil)
+      @routes     = routes
+      @route_name     = route_name
+      @constraints    = constraints
+      @missing_keys   = missing_keys
+      @unmatched_keys = unmatched_keys
+
+      super(message)
+    end
+
+    class Correction
+      def initialize error
+        @error = error
+      end
+
+      def corrections
+        @error.routes.named_routes.helper_names.grep(/#{@error.route_name}/).sort
+      end
+    end
+
+    DidYouMean.correct_error(self, Correction)
   end
 
   class MethodNotAllowed < ActionControllerError #:nodoc:

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -54,7 +54,7 @@ module ActionDispatch
         message << ", missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
         message << ", possible unmatched constraints: #{unmatched_keys.sort.inspect}" if unmatched_keys && !unmatched_keys.empty?
 
-        raise ActionController::UrlGenerationError, message
+        raise ActionController::UrlGenerationError.new(message, routes, name, constraints, missing_keys, unmatched_keys)
       end
 
       def clear

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -15,7 +15,7 @@ module ActionDispatch
         @cache  = nil
       end
 
-      def generate(name, options, path_parameters)
+      def generate(name, options, path_parameters, method_name = nil)
         constraints = path_parameters.merge(options)
         missing_keys = nil
 
@@ -54,7 +54,7 @@ module ActionDispatch
         message << ", missing required keys: #{missing_keys.sort.inspect}" if missing_keys && !missing_keys.empty?
         message << ", possible unmatched constraints: #{unmatched_keys.sort.inspect}" if unmatched_keys && !unmatched_keys.empty?
 
-        raise ActionController::UrlGenerationError.new(message, routes, name, constraints, missing_keys, unmatched_keys)
+        raise ActionController::UrlGenerationError.new(message, routes, name, method_name)
       end
 
       def clear

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -194,7 +194,7 @@ module ActionDispatch
               @arg_size       = @required_parts.size
             end
 
-            def call(t, args, inner_options, url_strategy)
+            def call(t, method_name, args, inner_options, url_strategy)
               if args.size == arg_size && !inner_options && optimize_routes_generation?(t)
                 options = t.url_options.merge @options
                 options[:path] = optimized_helper(args)
@@ -258,7 +258,7 @@ module ActionDispatch
             @route_name   = route_name
           end
 
-          def call(t, args, inner_options, url_strategy)
+          def call(t, method_name, args, inner_options, url_strategy)
             controller_options = t.url_options
             options = controller_options.merge @options
             hash = handle_positional_args(controller_options,
@@ -267,7 +267,7 @@ module ActionDispatch
                                           options,
                                           @segment_keys)
 
-            t._routes.url_for(hash, route_name, url_strategy)
+            t._routes.url_for(hash, route_name, url_strategy, method_name)
           end
 
           def handle_positional_args(controller_options, inner_options, args, result, path_params)
@@ -323,7 +323,7 @@ module ActionDispatch
                 when ActionController::Parameters
                   args.pop.to_h
                 end
-              helper.call(self, args, options, url_strategy)
+              helper.call(self, name, args, options, url_strategy)
             end
           end
       end
@@ -735,8 +735,8 @@ module ActionDispatch
 
         # Generates a path from routes, returns [path, params].
         # If no route is generated the formatter will raise ActionController::UrlGenerationError
-        def generate
-          @set.formatter.generate(named_route, options, recall)
+        def generate(method_name)
+          @set.formatter.generate(named_route, options, recall, method_name)
         end
 
         def different_controller?
@@ -766,8 +766,8 @@ module ActionDispatch
         return path, params.keys
       end
 
-      def generate(route_key, options, recall = {})
-        Generator.new(route_key, options, recall, self).generate
+      def generate(route_key, options, recall = {}, method_name = nil)
+        Generator.new(route_key, options, recall, self).generate(method_name)
       end
       private :generate
 
@@ -792,7 +792,7 @@ module ActionDispatch
       end
 
       # The +options+ argument must be a hash whose keys are *symbols*.
-      def url_for(options, route_name = nil, url_strategy = UNKNOWN)
+      def url_for(options, route_name = nil, url_strategy = UNKNOWN, method_name = nil)
         options = default_url_options.merge options
 
         user = password = nil
@@ -814,7 +814,7 @@ module ActionDispatch
         path_options = options.dup
         RESERVED_OPTIONS.each { |ro| path_options.delete ro }
 
-        path, params = generate(route_name, path_options, recall)
+        path, params = generate(route_name, path_options, recall, method_name)
 
         if options.key? :params
           params.merge! options[:params]

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4883,6 +4883,23 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
     error = assert_raises(ActionController::UrlGenerationError, message) { product_path(id: nil, "id" => "url-tested") }
     assert_match message, error.message
   end
+
+  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+    test "exceptions have suggestions for fix" do
+      error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
+      assert_match "Did you mean?", error.message
+    end
+  end
+
+  # FIXME: we should fix all locations that raise this exception to provide
+  # the info DidYouMean needs and then delete this test.  Just adding the
+  # test for now because some parameters to the constructor are optional, and
+  # we don't want to break other code.
+  test "correct for empty UrlGenerationError" do
+    err = ActionController::UrlGenerationError.new("oh no!")
+    correction = ActionController::UrlGenerationError::Correction.new(err)
+    assert_equal [], correction.corrections
+  end
 end
 
 class TestDefaultUrlOptions < ActionDispatch::IntegrationTest

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4868,7 +4868,7 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
     message = "No route matches #{url.inspect}, possible unmatched constraints: #{missing.inspect}"
 
     error = assert_raises(ActionController::UrlGenerationError, message) { product_path(id: nil) }
-    assert_equal message, error.message
+    assert_match message, error.message
   end
 
   test "URL helpers raise message with mixed parameters when generation fails" do
@@ -4877,11 +4877,11 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
 
     # Optimized URL helper
     error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
-    assert_equal message, error.message
+    assert_match message, error.message
 
     # Non-optimized URL helper
     error = assert_raises(ActionController::UrlGenerationError, message) { product_path(id: nil, "id" => "url-tested") }
-    assert_equal message, error.message
+    assert_match message, error.message
   end
 end
 


### PR DESCRIPTION
This commit is a PoC for adding did you mean support to Url Generation
errors.  I think we can do much better than this, but I wanted to try
something out as a first pass.

This is driven from feedback [here](https://discuss.rubyonrails.org/t/provide-a-hint-when-unable-to-pluralize-a-route/74781).

Here is what the dev experience looks like:

<img width="1338" alt="Action Controller: Exception caught 2020-05-11 12-31-09" src="https://user-images.githubusercontent.com/3124/81603521-54260c80-9383-11ea-9041-83b363d6534a.png">

<img width="1131" alt="try-with-dym — bin:rails :Users:aaron:git:try-with-dym — fsevent_watch ◂ localhost:3000)  try-with-dym  XPC_FLAGS=0x0 XPC_SERVI… 2020-05-11 12-31-48" src="https://user-images.githubusercontent.com/3124/81603572-6a33cd00-9383-11ea-966f-a2d65ae92776.png">
