### PR TITLE
Fix Ruby 2.7 keyword arguments warning

### DIFF
--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -107,6 +107,7 @@ module ActionDispatch
         @_routes = nil
         super
       end
+      ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
       # Hook overridden in controller to add request information
       # with +default_url_options+. Application logic should not

--- a/actionpack/test/dispatch/prefix_generation_test.rb
+++ b/actionpack/test/dispatch/prefix_generation_test.rb
@@ -126,12 +126,19 @@ module TestGenerationPrefix
       end
     end
 
+    module KwObject
+      def initialize(kw:)
+      end
+    end
+
     class EngineObject
+      include KwObject
       include ActionDispatch::Routing::UrlFor
       include BlogEngine.routes.url_helpers
     end
 
     class AppObject
+      include KwObject
       include ActionDispatch::Routing::UrlFor
       include RailsApplication.routes.url_helpers
     end
@@ -144,8 +151,8 @@ module TestGenerationPrefix
 
     def setup
       RailsApplication.routes.default_url_options = {}
-      @engine_object = EngineObject.new
-      @app_object = AppObject.new
+      @engine_object = EngineObject.new(kw: 1)
+      @app_object = AppObject.new(kw: 2)
     end
 
     include BlogEngine.routes.mounted_helpers


### PR DESCRIPTION
Partially addresses #39227.
