### PR TITLE
Make inverse_of dynamic for the polymorphic belongs_to associations

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -529,11 +529,20 @@ module ActiveRecord
 
       def polymorphic_inverse_of(associated_class)
         if has_inverse?
-          if inverse_relationship = associated_class._reflect_on_association(options[:inverse_of])
+          inverse_of_name = polymorphic_inverse_of_name(associated_class)
+          if inverse_relationship = associated_class._reflect_on_association(inverse_of_name)
             inverse_relationship
           else
             raise InverseOfAssociationNotFoundError.new(self, associated_class)
           end
+        end
+      end
+
+      def polymorphic_inverse_of_name(associated_class)
+        if options[:inverse_of].is_a?(Proc)
+          options[:inverse_of].call(associated_class)
+        else
+          options[:inverse_of]
         end
       end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -21,6 +21,7 @@ require "models/company"
 require "models/project"
 require "models/author"
 require "models/post"
+require "models/member"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
@@ -779,6 +780,14 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_nothing_raised { Face.first.polymorphic_man = Man.first }
     # fails because Interest does have the correct inverse_of
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.polymorphic_man = Interest.first }
+  end
+
+  def test_set_inverse_for_polymorphic_association_dynamically
+    member = Member.create(face: Face.create)
+    man = Man.create(polymorphic_face: Face.create)
+    men = Face.all.map(&:polymorphic_man)
+    assert_includes men, member
+    assert_includes men, man
   end
 end
 

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -3,7 +3,7 @@
 class Face < ActiveRecord::Base
   belongs_to :man, inverse_of: :face
   belongs_to :human, polymorphic: true
-  belongs_to :polymorphic_man, polymorphic: true, inverse_of: :polymorphic_face
+  belongs_to :polymorphic_man, polymorphic: true, inverse_of: -> klass { klass == Member ? :face : :polymorphic_face }
   # Oracle identifier length is limited to 30 bytes or less, `polymorphic` renamed `poly`
   belongs_to :poly_man_without_inverse, polymorphic: true
   # These are "broken" inverse_of associations for the purposes of testing

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -37,6 +37,8 @@ class Member < ActiveRecord::Base
 
   belongs_to :admittable, polymorphic: true
   has_one :premium_club, through: :admittable
+
+  has_one :face, as: :polymorphic_man, inverse_of: :polymorphic_man
 end
 
 class SelfMember < ActiveRecord::Base


### PR DESCRIPTION
### Summary

When you have a few models which you would like to connect to the polymorphic model via `has_one` association and this associations named differently you have no option to tell `belongs_to` in the polymorphic model association how would you like to `inverse_of` for each specific polymorphic association.

Use case, while I worked on the project we have `PhoneNumber` model which associates via `belongs_to` polymorphic association with different objects. Some of them have `has_one :phone_number`, and some of them have for example non-standard `has_one :requests_phone_number`. In case if I would like to list all the phone numbers and get belongs_to association with possibility of inversion, it throws an exception with `InverseOfAssociationNotFoundError`.

This code solves this issue with possibility to set `inverse_of` with proc, where you can detect which class is currently associated with a polymorphic model.

Currently it works via Proc:

```ruby
belongs_to :user,
           polymorphic: true, 
           inverse_of: -> klass { klass.is_a?(User) ? :phone_number : :mobile_number }
```

One of the other solutions without using `Proc` might be to set `inverse_of` with `Hash` where first is a class_name of the associated model and the second is a association to the polymorphic model:

```ruby
belongs_to :user, 
           polymorphic: true, 
           inverse_of: {User: :phone_number, AdminUser: :mobile_number}
```

Please give me your feedback.

- [x] Write tests
- [x] Implement
- [ ] Add description to the changelog