### PR TITLE
Don't load app environment when running encrypted commands

### DIFF
--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -21,7 +21,7 @@ module Rails
       end
 
       def edit(file_path)
-        require_application_and_environment!
+        require_application!
         encrypted = Rails.application.encrypted(file_path, key_path: options[:key])
 
         ensure_editor_available(command: "bin/rails encrypted:edit") || (return)
@@ -38,7 +38,7 @@ module Rails
       end
 
       def show(file_path)
-        require_application_and_environment!
+        require_application!
         encrypted = Rails.application.encrypted(file_path, key_path: options[:key])
 
         say encrypted.read.presence || missing_encrypted_message(key: encrypted.key, key_path: options[:key], file_path: file_path)

--- a/railties/test/commands/encrypted_test.rb
+++ b/railties/test/commands/encrypted_test.rb
@@ -87,6 +87,16 @@ class Rails::Command::EncryptedCommandTest < ActiveSupport::TestCase
     assert_match(/access_key_id: 123/, run_show_command("config/tokens.yml.enc", key: "config/tokens.key"))
   end
 
+  test "show command does not raise when an initializer tries to access non-existent credentials" do
+    app_file "config/initializers/raise_when_loaded.rb", <<-RUBY
+      Rails.application.credentials.missing_key!
+    RUBY
+
+    run_edit_command("config/tokens.yml.enc", key: "config/tokens.key")
+
+    assert_match(/access_key_id: 123/, run_show_command("config/tokens.yml.enc", key: "config/tokens.key"))
+  end
+
   private
     def run_edit_command(file, key: nil, editor: "cat", **options)
       switch_env("EDITOR", editor) do


### PR DESCRIPTION
### Summary
This extends the fix made by a39aa99c814/https://github.com/rails/rails/pull/34789 to the EncryptedCommand class, which suffers from the exact same issue outlined in the referenced PR. 

It seems like EncryptedCommand & CredentialsCommand have a lot of duplicated/shared code, but I wasn't sure if there was historical desire to keep them separated, so I didn't embark on a larger refactor.