### PR TITLE
Add Arel support for PostgreSQL contains and overlaps operators

### DIFF
--- a/activerecord/lib/arel/nodes/infix_operation.rb
+++ b/activerecord/lib/arel/nodes/infix_operation.rb
@@ -47,6 +47,18 @@ module Arel # :nodoc: all
       end
     end
 
+    class Contains < InfixOperation
+      def initialize(left, right)
+        super("@>", left, right)
+      end
+    end
+
+    class Overlaps < InfixOperation
+      def initialize(left, right)
+        super("&&", left, right)
+      end
+    end
+
     class BitwiseAnd < InfixOperation
       def initialize(left, right)
         super(:&, left, right)

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -206,6 +206,14 @@ module Arel # :nodoc: all
       Nodes::Concat.new self, other
     end
 
+    def contains(other)
+      Arel::Nodes::Contains.new(self, other)
+    end
+
+    def overlaps(other)
+      Arel::Nodes::Overlaps.new(self, other)
+    end
+
     private
       def grouping_any(method_id, others, *extras)
         nodes = others.map { |expr| send(method_id, expr, *extras) }

--- a/activerecord/lib/arel/visitors/postgresql.rb
+++ b/activerecord/lib/arel/visitors/postgresql.rb
@@ -92,6 +92,9 @@ module Arel # :nodoc: all
           collector << " NULLS LAST"
         end
 
+        alias :visit_Arel_Nodes_Contains :visit_Arel_Nodes_InfixOperation
+        alias :visit_Arel_Nodes_Overlaps :visit_Arel_Nodes_InfixOperation
+
         # Used by Lateral visitor to enclose select queries in parentheses
         def grouping_parentheses(o, collector)
           if o.expr.is_a? Nodes::SelectStatement

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -1043,6 +1043,38 @@ module Arel
         end
       end
 
+      describe "#contains" do
+        it "should create a Contains node" do
+          relation = Table.new(:products)
+          query = Nodes.build_quoted("{foo,bar}")
+          _(relation[:tags].contains(query)).must_be_kind_of Nodes::Contains
+        end
+
+        it "should generate @> in sql" do
+          relation = Table.new(:products)
+          mgr = relation.project relation[:id]
+          query = Nodes.build_quoted("{foo,bar}")
+          mgr.where relation[:tags].contains(query)
+          _(mgr.to_sql).must_be_like %{ SELECT "products"."id" FROM "products" WHERE "products"."tags" @> '{foo,bar}' }
+        end
+      end
+
+      describe "#overlaps" do
+        it "should create an Overlaps node" do
+          relation = Table.new(:products)
+          query = Nodes.build_quoted("{foo,bar}")
+          _(relation[:tags].overlaps(query)).must_be_kind_of Nodes::Overlaps
+        end
+
+        it "should generate && in sql" do
+          relation = Table.new(:products)
+          mgr = relation.project relation[:id]
+          query = Nodes.build_quoted("{foo,bar}")
+          mgr.where relation[:tags].overlaps(query)
+          _(mgr.to_sql).must_be_like %{ SELECT "products"."id" FROM "products" WHERE "products"."tags" && '{foo,bar}' }
+        end
+      end
+
       describe "equality" do
         describe "#to_sql" do
           it "should produce sql" do

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -331,6 +331,22 @@ module Arel
           }
         end
       end
+
+      describe "Nodes::InfixOperation" do
+        it "should handle Contains" do
+          inner = Nodes.build_quoted('{"foo":"bar"}')
+          outer = Table.new(:products)[:metadata]
+          sql = compile Nodes::Contains.new(outer, inner)
+          _(sql).must_be_like %{ "products"."metadata" @> '{"foo":"bar"}' }
+        end
+
+        it "should handle Overlaps" do
+          column = Table.new(:products)[:tags]
+          search = Nodes.build_quoted("{foo,bar,baz}")
+          sql = compile Nodes::Overlaps.new(column, search)
+          _(sql).must_be_like %{ "products"."tags" && '{foo,bar,baz}' }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Per [this discussion][arel-discussion] on the discourse forum, this is an addition to Arel for supporting `@>` (contains) and `&&` (overlaps) operators in PostgreSQL. They are useful for GIN-indexed data such as `jsonb` or array columns.

### Other Information

PostgreSQL also supports an _is contained by_ operator, `<@`. This feels low-value to me, since you could just invert the order of the parameters.

There are additional operators for checking for keys by name:
- `?` _Does the key/element string exist within the JSON value?_
  - example: `'{"a":1, "b":2}'::jsonb ? 'b'`
- '?|` _Do any of these key/element strings exist?_
  - example: `'{"a":1, "b":2, "c":3}'::jsonb ?| array['b', 'c']`
- `?&` _Do all of these key/element strings exist?_
 - example: `'["a", "b"]'::jsonb ?& array['a', 'b']`

I've left them out of this because I am uncertain how in-demand they might be. The two I did implement are scratching a personal itch, but I have had far less use for the rest. If you'd prefer to see a more comprehensive approach then I am happy to add them.

attn: @tenderlove 

  [arel-discussion]: https://discuss.rubyonrails.org/t/what-has-happened-to-arel/74383/51