### PR TITLE
Add an example of the JSON element in ActiveRecord::Attribute

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -74,6 +74,7 @@ module ActiveRecord
       #   # db/schema.rb
       #   create_table :store_listings, force: true do |t|
       #     t.string :my_string, default: "original default"
+      #     t.string :changed_json
       #   end
       #
       #   StoreListing.new.my_string # => "original default"
@@ -81,9 +82,11 @@ module ActiveRecord
       #   # app/models/store_listing.rb
       #   class StoreListing < ActiveRecord::Base
       #     attribute :my_string, :string, default: "new default"
+      #     attribute :changed_json, :json, default: {}
       #   end
       #
       #   StoreListing.new.my_string # => "new default"
+      #   StoreListing.new.changed_json # => {}
       #
       #   class Product < ActiveRecord::Base
       #     attribute :my_default_proc, :datetime, default: -> { Time.now }


### PR DESCRIPTION
### Summary

I tried to use the ActiveRecord::Attribute with JSON element, but when I looked for rails/rails.
I couldn't find any examples.So I added an example of the JSON element in ActiveRecord::Attribute.

### Other Information
- there don't written in rails document.
https://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html
