### PR TITLE
Return enumerator from ActionController::Parameters' each_pair and each_value methods

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Calling `each_pair` or `each_value` on an `ActionController::Parameters`
+    without passing a block now returns an enumerator.
+
+    *Eugene Kenny*
+
 *   `fixture_file_upload` now uses path relative to `file_fixture_path`
 
     Previously the path had to be relative to `fixture_path`.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -360,6 +360,7 @@ module ActionController
     # Convert all hashes in values into parameters, then yield each pair in
     # the same way as <tt>Hash#each_pair</tt>.
     def each_pair(&block)
+      return to_enum(__callee__) unless block_given?
       @parameters.each_pair do |key, value|
         yield [key, convert_hashes_to_parameters(key, value)]
       end
@@ -369,6 +370,7 @@ module ActionController
     # Convert all hashes in values into parameters, then yield each value in
     # the same way as <tt>Hash#each_value</tt>.
     def each_value(&block)
+      return to_enum(:each_value) unless block_given?
       @parameters.each_pair do |key, value|
         yield convert_hashes_to_parameters(key, value)
       end

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -58,6 +58,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     end
   end
 
+  test "each without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.each
+    assert_equal @params, @params.each.to_h
+  end
+
   test "each_pair carries permitted status" do
     @params.permit!
     @params.each_pair { |key, value| assert(value.permitted?) if key == "person" }
@@ -75,6 +80,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     end
   end
 
+  test "each_pair without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.each_pair
+    assert_equal @params, @params.each_pair.to_h
+  end
+
   test "each_value carries permitted status" do
     @params.permit!
     @params.each_value do |value|
@@ -88,6 +98,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     end
   end
 
+  test "each_value without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.each_value
+    assert_equal @params.values, @params.each_value.to_a
+  end
+
   test "each_key converts to hash for permitted" do
     @params.permit!
     @params.each_key { |key| assert_kind_of(String, key) if key == "person" }
@@ -95,6 +110,11 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each_key converts to hash for unpermitted" do
     @params.each_key { |key| assert_kind_of(String, key) if key == "person" }
+  end
+
+  test "each_key without a block returns an enumerator" do
+    assert_kind_of Enumerator, @params.each_key
+    assert_equal @params.keys, @params.each_key.to_a
   end
 
   test "empty? returns true when params contains no key/value pairs" do


### PR DESCRIPTION
This matches Hash's behaviour:

```
irb(main):001:0> Hash.new.each_pair
=> #<Enumerator: {}:each_pair>
irb(main):002:0> Hash.new.each_value
=> #<Enumerator: {}:each_value>
```

### Before

```
irb(main):001:0> ActionController::Parameters.new(foo: "bar").each_pair
Traceback (most recent call last):
        5: from tools/console:11:in `<main>'
        4: from (irb):1
        3: from /Users/eugene/lib/rails/actionpack/lib/action_controller/metal/strong_parameters.rb:363:in `each_pair'
        2: from /Users/eugene/lib/rails/actionpack/lib/action_controller/metal/strong_parameters.rb:363:in `each_pair'
        1: from /Users/eugene/lib/rails/actionpack/lib/action_controller/metal/strong_parameters.rb:364:in `block in each_pair'
LocalJumpError (no block given (yield))
irb(main):002:0> ActionController::Parameters.new(foo: "bar").each_value
Traceback (most recent call last):
        6: from tools/console:11:in `<main>'
        5: from (irb):1
        4: from (irb):2:in `rescue in irb_binding'
        3: from /Users/eugene/lib/rails/actionpack/lib/action_controller/metal/strong_parameters.rb:372:in `each_value'
        2: from /Users/eugene/lib/rails/actionpack/lib/action_controller/metal/strong_parameters.rb:372:in `each_pair'
        1: from /Users/eugene/lib/rails/actionpack/lib/action_controller/metal/strong_parameters.rb:373:in `block in each_value'
LocalJumpError (no block given (yield))
```

### After

```
irb(main):001:0> ActionController::Parameters.new(foo: "bar").each_pair
=> #<Enumerator: <ActionController::Parameters {"foo"=>"bar"} permitted: false>:each_pair>
irb(main):002:0> ActionController::Parameters.new(foo: "bar").each_value
=> #<Enumerator: <ActionController::Parameters {"foo"=>"bar"} permitted: false>:each_value>
```