### PR TITLE
Refactor uncastable through reflection test to detect join key overrides

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -771,15 +771,7 @@ module ActiveRecord
 
       def klass
         @klass ||= delegate_reflection.compute_class(class_name).tap do |klass|
-          if !parent_reflection.is_a?(HasAndBelongsToManyReflection) &&
-             !(klass.reflections.key?(options[:through].to_s) ||
-               klass.reflections.key?(options[:through].to_s.pluralize)) &&
-             active_record.type_for_attribute(active_record.primary_key).type != :integer
-            raise NotImplementedError, <<~MSG.squish
-              In order to correctly type cast #{active_record}.#{active_record.primary_key},
-              #{klass} needs to define a :#{options[:through]} association.
-            MSG
-          end
+          check_reflection_validity!(klass)
         end
       end
 
@@ -1001,6 +993,26 @@ module ActiveRecord
         def derive_class_name
           # get the class_name of the belongs_to association of the through reflection
           options[:source_type] || source_reflection.class_name
+        end
+
+        def custom_join_key_type?
+          source_reflection.active_record.attributes_to_define_after_schema_loads.key?(
+            delegate_reflection.foreign_key
+          )
+        end
+
+        def check_reflection_validity!(klass)
+          return unless custom_join_key_type?
+
+          through_reflection = options[:through].to_s
+
+          unless klass.reflections.key?(through_reflection) ||
+                 klass.reflections.key?(through_reflection.pluralize)
+            raise NotImplementedError, <<~MSG.squish
+              In order to correctly type cast #{active_record}.#{active_record.primary_key},
+              #{klass} needs to define a :#{through_reflection} association.
+            MSG
+          end
         end
 
         delegate_methods = AssociationReflection.public_instance_methods -

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -517,17 +517,33 @@ class ReflectionTest < ActiveRecord::TestCase
     end
 end
 
-class UncastableReflectionTest < ActiveRecord::TestCase
+class UncastableOverriddenAttributeReflectionTest < ActiveRecord::TestCase
+  class NickType < ActiveRecord::Type::Binary
+    def serialize(value)
+      super("nickname-#{value}")
+    end
+
+    def deserialize(value)
+      super(value).to_s.delete_prefix("nickname-")
+    end
+
+    def cast_value(value)
+      value.to_s
+    end
+  end
+
   class Book < ActiveRecord::Base
   end
 
   class Subscription < ActiveRecord::Base
     belongs_to :subscriber
     belongs_to :book
+    attribute :subscriber_id, NickType.new
   end
 
   class Subscriber < ActiveRecord::Base
     self.primary_key = "nick"
+    attribute :nick, NickType.new
     has_many :subscriptions
     has_one :subscription
     has_many :books, through: :subscriptions
@@ -550,17 +566,16 @@ class UncastableReflectionTest < ActiveRecord::TestCase
   test "uncastable has_many through: reflection" do
     error = assert_raises(NotImplementedError) { @subscriber.books }
     assert_equal <<~MSG.squish, error.message
-      In order to correctly type cast UncastableReflectionTest::Subscriber.nick,
-      UncastableReflectionTest::Book needs to define a :subscriptions association.
+      In order to correctly type cast #{self.class}::Subscriber.nick,
+      #{self.class}::Book needs to define a :subscriptions association.
     MSG
   end
 
   test "uncastable has_one through: reflection" do
     error = assert_raises(NotImplementedError) { @subscriber.book }
-
     assert_equal <<~MSG.squish, error.message
-      In order to correctly type cast UncastableReflectionTest::Subscriber.nick,
-      UncastableReflectionTest::Book needs to define a :subscription association.
+      In order to correctly type cast #{self.class}::Subscriber.nick,
+      #{self.class}::Book needs to define a :subscription association.
     MSG
   end
 


### PR DESCRIPTION
To fix https://github.com/rails/rails/issues/35839, I added https://github.com/rails/rails/pull/36847 to detect when a non-integer primary key was being used so we could ensure the foreign key type on the join table [was able to be casted](https://github.com/rails/rails/blob/a8aca0235092c33527aedea6ce8bf82766f8cec1/activerecord/lib/active_record/table_metadata.rb#L48) using the type info on the model. This fix falls short when realizing that the type can be [inferred from table metadata](https://github.com/rails/rails/blob/dd2acd5ec6d747ee4be00d9125e93c1a1a6dd8a7/activerecord/lib/active_record/relation/predicate_builder.rb#L60), and that we only really care when the foreign key on the join table has been overridden with `attribute`. 

This means we can check `attributes_to_define_after_schema_loads` on the join model to see if its foreign key type has been overridden. So, I've refactored the uncastable through reflection check to look for attribute overrides.

Closes https://github.com/rails/rails/issues/38340
Closes https://github.com/rails/rails/issues/38724
Closes https://github.com/rails/rails/pull/39200