### PR TITLE
Fix `minimum` and `maximum` on time zone aware attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -62,10 +62,6 @@
 
     *Ryuta Kamizono*
 
-*   Fix aggregate functions to return numeric value consistently even on custom attribute type.
-
-    *Ryuta Kamizono*
-
 *   Support bulk insert/upsert on relation to preserve scope values.
 
     *Josef Šimánek*, *Ryuta Kamizono*

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -307,9 +307,7 @@ module ActiveRecord
         result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder) }
 
         type_cast_calculated_value(result.cast_values.first, operation) do |value|
-          if value.is_a?(String) &&
-              column = klass.columns_hash[column_name.to_s]
-            type = connection.lookup_cast_type_from_column(column)
+          if type = klass.attribute_types[column_name.to_s]
             type.deserialize(value)
           else
             value
@@ -379,9 +377,7 @@ module ActiveRecord
           key = key_records[key] if associated
 
           result[key] = type_cast_calculated_value(row[column_alias], operation) do |value|
-            if value.is_a?(String) &&
-                (type || column = klass.columns_hash[column_name.to_s])
-              type ||= connection.lookup_cast_type_from_column(column)
+            if type ||= klass.attribute_types[column_name.to_s]
               type.deserialize(value)
             else
               value


### PR DESCRIPTION
This is the opposite direction of #39039.

#39111 fixes `minimum` and `maximum` on date columns with type casting
by column type on the database. But column type has no information for
time zone aware attributes, it means that attribute type should always
be precedence over column type. I've realized that fact in the related
issue report #39248.

I've reverted the expectation of #39039, to make time zone aware
attributes works.