### PR TITLE
Avoid confliting Kernel-named scopes on Relation

### DIFF
--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -199,7 +199,7 @@ module ActiveRecord
 
         private
           def singleton_method_added(name)
-            generate_relation_method(name) if Kernel.respond_to?(name)
+            generate_relation_method(name) if Kernel.respond_to?(name) && !ActiveRecord::Relation.method_defined?(name)
           end
 
           def valid_scope_name?(name)

--- a/activerecord/test/models/reply.rb
+++ b/activerecord/test/models/reply.rb
@@ -10,9 +10,14 @@ class Reply < Topic
 
   scope :ordered, -> { Reply.order(:id) }
 
+  # Method on Kernel
   def self.open
     approved
   end
+
+  # Methods both on Kernel and Relation
+  def self.load(data:); end
+  def self.select(data:); end
 end
 
 class SillyReply < Topic


### PR DESCRIPTION
A previous change https://github.com/rails/rails/pull/39210 made singleton methods eagerly define their relation methods if it shared a name with a method on Kernel. This caused issues if defining singleton methods with a name which was also defined both on Kernel and on `AcitveRecord::Relation`, like `load` and `select`.

This commit avoids defining the method if it exists on `AR::Relation`.

cc @kamipo @eileencodes @HParker @kytrinyx 