### PR TITLE
Revert use of argument-forwarding keyword `...` in active_record/relation/delegate.rb

### DIFF
--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -60,10 +60,9 @@ module ActiveRecord
           return if method_defined?(method)
 
           if /\A[a-zA-Z_]\w*[!?]?\z/.match?(method)
-            definition = RUBY_VERSION >= "2.7" ? "..." : "*args, &block"
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{method}(#{definition})
-                scoping { klass.#{method}(#{definition}) }
+              def #{method}(*args, &block)
+                scoping { klass.#{method}(*args, &block) }
               end
             RUBY
           else


### PR DESCRIPTION
Reverts a change from 57ace94c42a2006b5efc0fba0539a5cc72d9a5db

`generate_method` sometimes creates methods which are reserved Ruby keywords. Using `...` in combination with a Ruby keyword seems to generate a syntax error which does not occur with `*args, &block`. It seems this language feature isn't ready for prime-time, at least where dynamically generated code is involved.

To test this error yourself, try in a Ruby console:

```ruby
class Works
  def true(*args)
    puts(*args)
  end
end

Works.new.true 1, 2, 3
# => 1, 2, 3

class WontWork
  def true(...)
    puts(...)
  end
end

# => freezes
```

In the context of ActiveRecord:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :enum
  end
end

class Post < ActiveRecord::Base
  enum :shown => [ :true, :false ]
end

class BugTest < Minitest::Test
  def test_delegation_syntax
    post = Post.create!
    refute_nil post
  end
end
```