### PR TITLE
Fix #39205 ReadOnlyError when on writing connection

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -190,7 +190,7 @@ module ActiveRecord
       # need to share a connection pool so that the reading connection
       # can see data in the open transaction on the writing connection.
       def setup_shared_connection_pool
-        writing_handler = ActiveRecord::Base.connection_handler
+        writing_handler = ActiveRecord::Base.connection_handlers[ActiveRecord::Base.writing_role]
 
         ActiveRecord::Base.connection_handlers.values.each do |handler|
           if handler != writing_handler

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1418,3 +1418,52 @@ class MultipleDatabaseFixturesTest < ActiveRecord::TestCase
       end
     end
 end
+
+class UsesWritingConnectionForFixtures < ActiveRecord::TestCase
+  include ActiveRecord::TestFixtures
+  self.use_transactional_tests = true
+
+  fixtures :dogs
+
+  def setup
+    @old_handler = ActiveRecord::Base.connection_handler
+    @old_handlers = ActiveRecord::Base.connection_handlers
+    @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+    db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(ENV["RAILS_ENV"], "readonly", readonly_config)
+
+    handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+    handler.establish_connection(db_config)
+    ActiveRecord::Base.connection_handlers = {}
+    ActiveRecord::Base.connection_handler = handler
+    ActiveRecord::Base.connects_to(database: { writing: :default, reading: :readonly })
+  end
+
+  def teardown
+    ActiveRecord::Base.configurations = @prev_configs
+    ActiveRecord::Base.connection_handler = @old_handler
+    ActiveRecord::Base.connection_handlers = @old_handlers
+  end
+
+  def test_uses_writing_connection_for_fixtures
+    ActiveRecord::Base.connected_to(role: :reading) do
+      Dog.first
+
+      assert_nothing_raised do
+        ActiveRecord::Base.connected_to(role: :writing) { Dog.create! alias: "Doggo" }
+      end
+    end
+  end
+
+  private
+    def config
+      { "default" => default_config, "readonly" => readonly_config }
+    end
+
+    def default_config
+      { "adapter" => "sqlite3", "database" => "test/fixtures/fixture_database.sqlite3" }
+    end
+
+    def readonly_config
+      default_config.merge("replica" => true)
+    end
+end


### PR DESCRIPTION
### Summary

Resolves https://github.com/rails/rails/issues/39205

I tried to solve the issue by making sure that the variable `writing_handler` was actually getting set with a writing connection handler (and not a reading one by mistake).

Notes:
1. I added a test but it looks a bit complex, I couldn't make it be simpler.
2. I broke the test `enlist_fixture_connections ensures multiple databases share a connection pool` and couldn't make it work yet. I would appreciate help here.

cc @sinsoku @eileencodes 