### PR TITLE
[Action Cable] Stop logging filtered params

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -2,6 +2,7 @@
 
 require "set"
 require "active_support/rescuable"
+require "active_support/parameter_filter"
 
 module ActionCable
   module Channel
@@ -275,7 +276,8 @@ module ActionCable
 
         def action_signature(action, data)
           (+"#{self.class.name}##{action}").tap do |signature|
-            if (arguments = data.except("action")).any?
+            if (data.except("action")).any?
+              arguments = ActiveSupport::ParameterFilter.new(connection.server.config.filter_parameters).filter(data)
               signature << "(#{arguments.inspect})"
             end
           end

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -45,7 +45,7 @@ module ActionCable
     end
 
     class ConnectionStub
-      attr_reader :transmissions, :identifiers, :subscriptions, :logger
+      attr_reader :transmissions, :identifiers, :subscriptions, :logger, :server
 
       def initialize(identifiers = {})
         @transmissions = []
@@ -57,6 +57,7 @@ module ActionCable
         @subscriptions = ActionCable::Connection::Subscriptions.new(self)
         @identifiers = identifiers.keys
         @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
+        @server = TestServer.new
       end
 
       def transmit(cable_message)

--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -35,6 +35,7 @@ module ActionCable
 
         previous_connection_class = connection_class
         self.connection_class = -> { "ApplicationCable::Connection".safe_constantize || previous_connection_class.call }
+        self.filter_parameters << Rails.application.config.filter_parameters
 
         options.each { |k, v| send("#{k}=", v) }
       end

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -7,7 +7,7 @@ module ActionCable
     class Configuration
       attr_accessor :logger, :log_tags
       attr_accessor :connection_class, :worker_pool_size
-      attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host
+      attr_accessor :disable_request_forgery_protection, :allowed_request_origins, :allow_same_origin_as_host, :filter_parameters
       attr_accessor :cable, :url, :mount_path
 
       def initialize
@@ -18,6 +18,7 @@ module ActionCable
 
         @disable_request_forgery_protection = false
         @allow_same_origin_as_host = true
+        @filter_parameters = []
       end
 
       # Returns constant of subscription adapter specified in config/cable.yml.

--- a/actioncable/test/channel/base_test.rb
+++ b/actioncable/test/channel/base_test.rb
@@ -105,6 +105,15 @@ class ActionCable::Channel::BaseTest < ActionCable::TestCase
     assert_equal({ id: 1 }, @channel.params)
   end
 
+  test "does not log filtered parameters" do
+    @connection.server.config.filter_parameters << :password
+    data = { password: "password", foo: "foo" }
+
+    assert_logged(':password=>"[FILTERED]"') do
+      @channel.perform_action data
+    end
+  end
+
   test "unsubscribing from a channel" do
     @channel.subscribe_to_channel
 

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -11,7 +11,7 @@ class TestServer
   def initialize(subscription_adapter: SuccessAdapter)
     @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
 
-    @config = OpenStruct.new(log_tags: [], subscription_adapter: subscription_adapter)
+    @config = OpenStruct.new(log_tags: [], subscription_adapter: subscription_adapter, filter_parameters: [])
 
     @mutex = Monitor.new
   end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
Re-created https://github.com/rails/rails/pull/25090 as per the [comment](https://github.com/rails/rails/pull/25090#issuecomment-442641807)

This prevents filtered params from being logged.

Fixes #25088

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
