### PR TITLE
Fix left joins order when merging multiple left joins from different associations

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -135,11 +135,16 @@ module ActiveRecord
           if other.klass == relation.klass
             relation.left_outer_joins!(*other.left_outer_joins_values)
           else
-            associations = other.left_outer_joins_values
+            associations, others = other.left_outer_joins_values.partition do |join|
+              case join
+              when Hash, Symbol, Array; true
+              end
+            end
+
             join_dependency = other.construct_join_dependency(
               associations, Arel::Nodes::OuterJoin
             )
-            relation.joins!(join_dependency)
+            relation.left_outer_joins!(join_dependency, *others)
           end
         end
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1151,12 +1151,14 @@ module ActiveRecord
         end
       end
 
-      def select_association_list(associations)
+      def select_association_list(associations, stashed_joins = nil)
         result = []
         associations.each do |association|
           case association
           when Hash, Symbol, Array
             result << association
+          when ActiveRecord::Associations::JoinDependency
+            stashed_joins&.<< association
           else
             yield if block_given?
           end
@@ -1164,15 +1166,15 @@ module ActiveRecord
         result
       end
 
-      def valid_association_list(associations)
-        select_association_list(associations) do
+      def valid_association_list(associations, stashed_joins)
+        select_association_list(associations, stashed_joins) do
           raise ArgumentError, "only Hash, Symbol and Array are allowed"
         end
       end
 
       def build_left_outer_joins(manager, outer_joins, aliases)
         buckets = Hash.new { |h, k| h[k] = [] }
-        buckets[:association_join] = valid_association_list(outer_joins)
+        buckets[:association_join] = valid_association_list(outer_joins, buckets[:stashed_join])
         build_join_query(manager, buckets, Arel::Nodes::OuterJoin, aliases)
       end
 
@@ -1180,12 +1182,13 @@ module ActiveRecord
         buckets = Hash.new { |h, k| h[k] = [] }
 
         unless left_outer_joins_values.empty?
-          left_joins = valid_association_list(left_outer_joins_values.flatten)
-          buckets[:stashed_join] << construct_join_dependency(left_joins, Arel::Nodes::OuterJoin)
+          stashed_left_joins = []
+          left_joins = valid_association_list(left_outer_joins_values.flatten, stashed_left_joins)
+          stashed_left_joins.unshift construct_join_dependency(left_joins, Arel::Nodes::OuterJoin)
         end
 
         if joins.last.is_a?(ActiveRecord::Associations::JoinDependency)
-          buckets[:stashed_join] << joins.pop if joins.last.base_klass == klass
+          stashed_eager_load = joins.pop if joins.last.base_klass == klass
         end
 
         joins.map! do |join|
@@ -1198,7 +1201,7 @@ module ActiveRecord
 
         while joins.first.is_a?(Arel::Nodes::Join)
           join_node = joins.shift
-          if join_node.is_a?(Arel::Nodes::StringJoin) && !buckets[:stashed_join].empty?
+          if join_node.is_a?(Arel::Nodes::StringJoin) && (stashed_eager_load || stashed_left_joins)
             buckets[:join_node] << join_node
           else
             buckets[:leading_join] << join_node
@@ -1217,6 +1220,9 @@ module ActiveRecord
             raise "unknown class: %s" % join.class.name
           end
         end
+
+        buckets[:stashed_join].concat stashed_left_joins if stashed_left_joins
+        buckets[:stashed_join] << stashed_eager_load if stashed_eager_load
 
         build_join_query(manager, buckets, Arel::Nodes::InnerJoin, aliases)
       end

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/post"
 require "models/comment"
+require "models/rating"
 require "models/author"
 require "models/essay"
 require "models/category"
@@ -10,7 +11,15 @@ require "models/categorization"
 require "models/person"
 
 class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
-  fixtures :authors, :author_addresses, :essays, :posts, :comments, :categorizations, :people
+  fixtures :authors, :author_addresses, :essays, :posts, :comments, :ratings, :categorizations, :people
+
+  def test_merging_multiple_left_joins_from_different_associations
+    count = Author.joins(:posts).merge(Post.left_joins(:comments).merge(Comment.left_joins(:ratings))).count
+    assert_equal 16, count
+
+    count = Author.left_joins(:posts).merge(Post.left_joins(:comments).merge(Comment.left_joins(:ratings))).count
+    assert_equal 16, count
+  end
 
   def test_construct_finder_sql_applies_aliases_tables_on_association_conditions
     result = Author.left_outer_joins(:thinking_posts, :welcome_posts).to_a


### PR DESCRIPTION
#38597 is caused by #35864.

To reproduce this issue, at least it is required four different models
and three left joins from different relations.

When merging a relation from different model, new stashed (left) joins
should be placed before existing stashed joins, but #35864 had broken
that expectation if left joins are stashed multiple times.

This fixes that stashed left joins order as expected.

Fixes #38597.