### PR TITLE
Improve performance for loaded association's `first`

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1103,6 +1103,10 @@ module ActiveRecord
       delegate(*delegate_methods, to: :scope)
 
       private
+        def check_reorder_deprecation
+          super unless loaded?
+        end
+
         def find_nth_with_limit(index, limit)
           load_target if find_from_target?
           super


### PR DESCRIPTION
Delegate to scope values (e.g. `offset_value`, `order_values`) is slow.

We can avoid that if records are already loaded.

```ruby
class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
  has_many :likes
end

class Like < ActiveRecord::Base
  belongs_to :post
end

10.times { Post.create! }
30.times { |i| Comment.create!(post_id: 1 + i % 10) }
150.times { |i |Like.create!(comment_id: 1 + i % 30) }

post = Post.includes(comments: :likes).last

result = Benchmark.measure do
  100.times { post.comments.each { |c| c.likes.first.id } }
end

puts
puts result
```

Before:

```
  0.013542   0.000582   0.014124 (  0.014125)
```

After:

```
  0.000938   0.000017   0.000955 (  0.000952)
```

Fixes #38252.