### PR TITLE
Casting aggregated value takes attribute type precedence over database type

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -416,8 +416,10 @@ module ActiveRecord
 
       def type_cast_calculated_value(value, operation)
         case operation
-        when "count", "sum"
-          value || 0
+        when "count"
+          value.to_i
+        when "sum"
+          yield value || 0
         when "average"
           value&.respond_to?(:to_d) ? value.to_d : value
         else # "minimum", "maximum"


### PR DESCRIPTION
Follow up to #39255, #39039.

One of the purpose of #39039 was to unify the behavior between the
databases.

Original code was:

```ruby
    type   = result.column_types.fetch(column_alias) do
      type_for(column_name)
    end
```

The code will attempt looking up type from `column_types`, then fallback
to attribute types, so I supposed the code was originally intended to
cast a value by the database types.

But now, most modern clients will already return casted values, and no
longer use `column_types`, except Postgres.
As a result, now most adapter accidentally fallback to attribute types.
Since casted by attribute types sometimes doesn't return numeric values,
I've unified the behavior to use database types consistently in #39039.

But later, I've learned that attribute types have important settings
like time zone aware attributes (#39255), and some existing code relying
on attribute types over database types (#39271).

I've changed all aggregated values are casted by attribute types.

Fixes #39271.

cc @eileencodes 