### PR TITLE
Fix _decrypt method when using aes-256-ecb

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -188,7 +188,7 @@ module ActiveSupport
 
         cipher.decrypt
         cipher.key = @secret
-        cipher.iv  = iv
+        cipher.iv  = iv if iv.present?
         if aead_mode?
           cipher.auth_tag = auth_tag
           cipher.auth_data = ""

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -95,6 +95,12 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_aead_not_decrypted(encryptor, "eHdGeExnZEwvMSt3U3dKaFl1WFo0TjVvYzA0eGpjbm5WSkt5MXlsNzhpZ0ZnbWhBWFlQZTRwaXE1bVJCS2oxMDZhYVp2dVN3V0lNZUlWQ3c2eVhQbnhnVjFmeVVubmhRKzF3WnZyWHVNMDg9LS1HSisyakJVSFlPb05ISzRMaXRzcFdBPT0=--831a1d54a3cda8a0658dc668a03dedcbce13b5ca")
   end
 
+  def test_aes_256_ecb_mode_encryption
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-ecb")
+    message = encryptor.encrypt_and_sign(@data)
+    assert_equal @data, encryptor.decrypt_and_verify(message)
+  end
+
   def test_messing_with_aead_values_causes_failures
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
     text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")


### PR DESCRIPTION
When using `aes-256-ecb` cipher method to encrypt a message, the method `_decrypt` fails due to the initialization vector (`iv`) is `nil`. 

This happens since `ECB` method doesn't need this vector so we can avoid the assignation.

Error message:
<img width="851" alt="Screen Shot 2020-05-13 at 18 09 58" src="https://user-images.githubusercontent.com/42612638/81868071-17574280-9548-11ea-84d5-e15227d85d1d.png">
