### PR TITLE
Deprecate custom Action Mailer delivery job:

### DIFF
--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -142,13 +142,36 @@ module ActionMailer
         else
           job = @mailer_class.delivery_job
 
-          if job <= MailDeliveryJob
+          if use_new_args?(job)
             job.set(options).perform_later(
               @mailer_class.name, @action.to_s, delivery_method.to_s, args: @args)
+          elsif job <= DeliveryJob
+            job.set(options).perform_later(
+              @mailer_class.name, @action.to_s, delivery_method.to_s, *@args)
           else
+            ActiveSupport::Deprecation.warn(<<~EOM)
+              In Rails 6.2, Action Mailer will pass the mail arguments inside the `:args` keyword argument.
+              The `perform` method of the #{job} needs to change and forward the mail arguments
+              from the `args` keyword argument.
+
+              The `perform` method should now look like:
+
+              `def perform(mailer, mail_method, delivery, args:)`
+            EOM
+
             job.set(options).perform_later(
               @mailer_class.name, @action.to_s, delivery_method.to_s, *@args)
           end
+        end
+      end
+
+      def use_new_args?(job)
+        parameters = job.public_instance_method(:perform).parameters
+
+        parameters.find do |key, name|
+          return true if key == :keyreq && name == :args
+
+          key == :keyrest
         end
       end
   end


### PR DESCRIPTION
Deprecate custom Action Mailer delivery job:

- Action Mailer delivery job should modify their `perform` method
  signature in order to receive the new payload that Action Mailer
  sends.

  Before:

  ```ruby
    def perform(mailer, mail_method, delivery_method, *args)
    end
  ```

  After:

  ```ruby
    def perform(mailer, mail_method, delivery_method, args:)
    end
  ```

  This new behaviour was introduced couple years ago in a attempt to
  get rid of the necessity to have a different job for paramterized
  mailers. A deprecation was introduced for custom jobs inheriting
  from `ActionMailer::DeliveryJob` but for jobs that didn't it went
  unnoticed.
  The deprecated behaviour was supposed to be removed in Rails 6.1
  but we couldn't and it got reverted https://github.com/rails/rails/pull/39257

cc/ @casperisfine @etiennebarrie @rafaelfranca 