### PR TITLE
Update `supports_rename_index?` version for MariaDB

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -694,7 +694,11 @@ module ActiveRecord
         end
 
         def supports_rename_index?
-          mariadb? ? false : database_version >= "5.7.6"
+          if mariadb?
+            database_version >= "10.5.2"
+          else
+            database_version >= "5.7.6"
+          end
         end
 
         def configure_connection

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -93,6 +93,10 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
         end
 
         def test_rename_reference_column_of_child_table
+          if current_adapter?(:Mysql2Adapter) && !@connection.send(:supports_rename_index?)
+            skip "Cannot drop index, needed in a foreign key constraint"
+          end
+
           rocket = Rocket.create!(name: "myrocket")
           rocket.astronauts << Astronaut.create!
 


### PR DESCRIPTION
Looks like the CI failure is caused by rename index on a foreign key
constraint.

https://buildkite.com/rails/rails/builds/69099#1b008fd1-1d2f-4c87-934a-8cdfd6e42c67/1022-2096
