### PR TITLE
rails new cool_app --minimal

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Create a new rails app using a minimal stack.
+
+      `rails new cool_app --minimal`
+
+    All the following are excluded from your minimal stack:
+
+    - action_cable
+    - action_mailbox
+    - action_mailer
+    - action_text
+    - active_job
+    - active_storage
+    - bootsnap
+    - jbuilder
+    - spring
+    - system_tests
+    - turbolinks
+    - webpack
+
+    *Haroon Ahmed*, *DHH*
+
 *   Add default ENV variable option with BACKTRACE to turn off backtrace cleaning when debugging framework code in the
     generated config/initializers/backtrace_silencers.rb.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -52,6 +52,9 @@ module Rails
         class_option :skip_active_record,  type: :boolean, aliases: "-O", default: false,
                                            desc: "Skip Active Record files"
 
+        class_option :skip_active_job,     type: :boolean, default: false,
+                                           desc: "Skip Active Job"
+
         class_option :skip_active_storage, type: :boolean, default: false,
                                            desc: "Skip Active Storage files"
 
@@ -75,6 +78,9 @@ module Rails
 
         class_option :skip_turbolinks,     type: :boolean, default: false,
                                            desc: "Skip turbolinks gem"
+
+        class_option :skip_jbuilder,       type: :boolean, default: false,
+                                           desc: "Skip jbuilder gem"
 
         class_option :skip_test,           type: :boolean, aliases: "-T", default: false,
                                            desc: "Skip test files"
@@ -204,7 +210,8 @@ module Rails
             :skip_action_mailer,
             :skip_test,
             :skip_sprockets,
-            :skip_action_cable
+            :skip_action_cable,
+            :skip_active_job
           ),
           skip_active_storage?,
           skip_action_mailbox?,
@@ -243,6 +250,10 @@ module Rails
 
       def skip_action_text? # :doc:
         options[:skip_action_text] || skip_active_storage?
+      end
+
+      def skip_dev_gems? # :doc:
+        options[:skip_dev_gems]
       end
 
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)
@@ -327,6 +338,7 @@ module Rails
       end
 
       def jbuilder_gemfile_entry
+        return [] if options[:skip_jbuilder]
         comment = "Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder"
         GemfileEntry.new "jbuilder", "~> 2.7", comment, {}, options[:api]
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -44,7 +44,7 @@ end
 
 <% end -%>
 group :development do
-<%- unless options.api? -%>
+<%- unless options.api? || options.skip_dev_gems? -%>
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   <%- if options.dev? || options.edge? || options.master? -%>
   gem 'web-console', github: 'rails/web-console'

--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -6,7 +6,7 @@ require "rails/all"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
+<%= comment_if :skip_active_job %>require "active_job/railtie"
 <%= comment_if :skip_active_record %>require "active_record/railtie"
 <%= comment_if :skip_active_storage %>require "active_storage/engine"
 require "action_controller/railtie"

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -66,9 +66,11 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  <%- unless options[:skip_active_job] -%>
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "<%= app_name %>_production"
+  <%- end -%>
 
   <%- unless options.skip_action_mailer? -%>
   config.action_mailer.perform_caching = false


### PR DESCRIPTION
### Summary

discussion: https://discuss.rubyonrails.org/t/interactive-rails-new/74355/50

`rails new cool_app --minimal`

A minimal rails stack to get you started, everything that is excluded:

- [x] skip_action_cable
- [x] skip_action_mailbox
- [x] skip_action_mailer
- [x] skip_action_text
- [x] skip_active_job
- [x] skip_active_storage
- [x] skip_bootsnap
- [x] skip_jbuilder 
- [x] skip_spring
- [x] skip_system_tests
- [x] skip_turbolinks
- [x] skip_webpack
- [x] Sprockets should have JavaScript folders by default
- [x] `rails new --minimal webpack=react` works

Rails app I created using the minimal flag:
- https://github.com/hahmed/cool_app_minimal `rails new cool_app_minimal --minimal`
- https://github.com/hahmed/cool_app_minimal_react `rails new cool_app_minimal_react --minimal --webpack=react`

Want to help test out this PR? here is how:

- Pull down this branch
- Uninstall your local rails copy using `gem uninstall rails`
- Move into the root directory where you pulled down the rails code, then install: `rake install`
- Run `rails --version` which should be `Rails 6.1.0.alpha`
- In another directory create your rails app `rails new cool_app --minimal`