### PR TITLE
ActiveStorage enable variants for custom media types

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Rails 7.1.0.beta1 (September 13, 2023) ##
 
+*   Enable variants for custom media types.
+
+    Refer to the Active Storage Rails guide to register custom transformers.
+
+    *Sébastien Dubois*
+
 *   Disables the session in `ActiveStorage::Blobs::ProxyController`
     and `ActiveStorage::Representations::ProxyController`
     in order to allow caching by default in some CDNs as CloudFlare

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -39,10 +39,14 @@ module ActiveStorage::Blob::Representable
     end
   end
 
-  # Returns true if the variant processor can transform the blob (its content
-  # type is in +ActiveStorage.variable_content_types+).
+  # Returns true if the variant processor can transform the blob.
+  # By default, this will return true for images whose types are registered
+  # in config.active_storage.variable_content_types.
+  # To handle other image types, add them to variable_content_types.
+  # To handle other media types, register a custom variant transformer
+  # as described in the documentation.
   def variable?
-    ActiveStorage.variable_content_types.include?(content_type)
+    ActiveStorage.transformers.any? { |klass| klass.accept?(self) }
   end
 
 

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -6,8 +6,9 @@
 # These variants are used to create thumbnails, fixed-size avatars, or any other derivative image from the
 # original.
 #
-# Variants rely on {ImageProcessing}[https://github.com/janko/image_processing] gem for the actual transformations
-# of the file, so you must add <tt>gem "image_processing"</tt> to your Gemfile if you wish to use variants. By
+# Image variants can be used to create thumbnails, fixed-size avatars, or any other derivative image from the
+# original. These rely on {ImageProcessing}[https://github.com/janko/image_processing] gem for the actual transformations
+# of the file, so you must add <tt>gem "image_processing"</tt> to your Gemfile if you wish to use these. By
 # default, images will be processed with {ImageMagick}[http://imagemagick.org] using the
 # {MiniMagick}[https://github.com/minimagick/minimagick] gem, but you can also switch to the
 # {libvips}[http://libvips.github.io/libvips/] processor operated by the {ruby-vips}[https://github.com/libvips/ruby-vips]
@@ -18,6 +19,8 @@
 #
 #   Rails.application.config.active_storage.variant_processor = :vips
 #   # => :vips
+#
+# To transform additional media types, please refer to the documentation.
 #
 # Note that to create a variant it's necessary to download the entire blob file from the service. Because of this process,
 # you also want to be considerate about when the variant is actually processed. You shouldn't be processing variants inline
@@ -41,8 +44,8 @@
 # This will create and process a variant of the avatar blob that's constrained to a height and width of 100.
 # Then it'll upload said variant to the service according to a derivative key of the blob and the transformations.
 #
-# You can combine any number of ImageMagick/libvips operations into a variant, as well as any macros provided by the
-# ImageProcessing gem (such as +resize_to_limit+):
+# As far as image variants are concerned, you can combine any number of ImageMagick/libvips operations into a variant,
+# as well as any macros provided by the ImageProcessing gem (such as +resize_to_limit+):
 #
 #   avatar.variant(resize_to_limit: [800, 800], colourspace: "b-w", rotate: "-90")
 #
@@ -108,7 +111,7 @@ class ActiveStorage::Variant
 
     def process
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(blob, input) do |output|
           service.upload(key, output, content_type: content_type)
         end
       end

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -44,7 +44,7 @@ class ActiveStorage::VariantWithRecord
 
     def transform_blob
       blob.open do |input|
-        variation.transform(input) do |output|
+        variation.transform(blob, input) do |output|
           yield io: output, filename: "#{blob.filename.base}.#{variation.format.downcase}",
             content_type: variation.content_type, service_name: blob.service.name
         end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -51,6 +51,7 @@ module ActiveStorage
 
   mattr_accessor :queues, default: {}
 
+  mattr_accessor :transformers, default: []
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers,  default: []
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -26,6 +26,7 @@ module ActiveStorage
     isolate_namespace ActiveStorage
 
     config.active_storage = ActiveSupport::OrderedOptions.new
+    config.active_storage.transformers = [ ActiveStorage::Transformers::ImageProcessingTransformer ]
     config.active_storage.previewers = [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
     config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
     config.active_storage.paths = ActiveSupport::OrderedOptions.new
@@ -85,6 +86,7 @@ module ActiveStorage
       config.after_initialize do |app|
         ActiveStorage.logger            = app.config.active_storage.logger || Rails.logger
         ActiveStorage.variant_processor = app.config.active_storage.variant_processor || :mini_magick
+        ActiveStorage.transformers      = app.config.active_storage.transformers || []
         ActiveStorage.previewers        = app.config.active_storage.previewers || []
         ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
         ActiveStorage.paths             = app.config.active_storage.paths || {}

--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -12,6 +12,10 @@ end
 module ActiveStorage
   module Transformers
     class ImageProcessingTransformer < Transformer
+      def self.accept?(blob)
+        ActiveStorage.variable_content_types.include?(blob.content_type)
+      end
+
       private
         class UnsupportedImageProcessingMethod < StandardError; end
         class UnsupportedImageProcessingArgument < StandardError; end

--- a/activestorage/lib/active_storage/transformers/transformer.rb
+++ b/activestorage/lib/active_storage/transformers/transformer.rb
@@ -4,21 +4,41 @@ module ActiveStorage
   module Transformers
     # = Active Storage \Transformers \Transformer
     #
-    # A Transformer applies a set of transformations to an image.
+    # A Transformer applies a set of transformations to a file.
     #
     # The following concrete subclasses are included in Active Storage:
     #
     # * ActiveStorage::Transformers::ImageProcessingTransformer:
     #   backed by ImageProcessing, a common interface for MiniMagick and ruby-vips
+    #
+    # To choose the transformer for a blob, Active Storage calls +accept?+ on each registered
+    # transformer in order. It uses the first transformer for which +accept?+ returns true when
+    # given the blob. In a Rails application, add or remove transformers by manipulating
+    # +Rails.application.config.active_storage.transformers+ in an initializer:
+    #
+    #   Rails.application.config.active_storage.transformers
+    #   # => [ ActiveStorage::Transformer::ImageProcessingTransformer ]
+    #
+    #   # Add a custom transformer for audios and videos:
+    #   Rails.application.config.active_storage.transformers << FfmpegTransformer
+    #   # => [ ActiveStorage::Transformer::ImageProcessingTransformer, FfmpegTransformer ]
+    #
+    # Outside of a Rails application, modify +ActiveStorage.transformers+ instead.
     class Transformer
       attr_reader :transformations
+
+      # Implement this method in a concrete subclass. Have it return true when given a blob from which
+      # the transformer can generate a variant.
+      def self.accept?(blob)
+        false
+      end
 
       def initialize(transformations)
         @transformations = transformations
       end
 
-      # Applies the transformations to the source image in +file+, producing a target image in the
-      # specified +format+. Yields an open Tempfile containing the target image. Closes and unlinks
+      # Applies the transformations to the source +file+, producing a target in the
+      # specified +format+. Yields an open Tempfile containing the target. Closes and unlinks
       # the output tempfile after yielding to the given block. Returns the result of the block.
       def transform(file, format:)
         output = process(file, format: format)
@@ -31,7 +51,15 @@ module ActiveStorage
       end
 
       private
-        # Returns an open Tempfile containing a transformed image in the given +format+.
+        def create_tempfile(ext: "")
+          ext = ".#{ext}" unless ext.blank? || ext.start_with?(".")
+          tempfile = Tempfile.new(["transformer_", ext], binmode: true)
+          yield tempfile
+        ensure
+          tempfile&.close!
+        end
+
+        # Returns an open Tempfile containing a transformed file in the given +format+.
         # All subclasses implement this method.
         def process(file, format:) # :doc:
           raise NotImplementedError

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -189,4 +189,19 @@ class Group < ActiveRecord::Base
   accepts_nested_attributes_for :users
 end
 
+class FfmpegTransformer < ActiveStorage::Transformers::Transformer
+  def self.accept?(blob)
+    blob.video? || blob.audio?
+  end
+
+  def transform(input, format:)
+    format ||= File.extname(input.path)
+    options = transformations[:ffmpeg_opts]
+    create_tempfile(ext: format) do |output|
+      system "ffmpeg -y -i #{input.path} #{options} #{output.path}"
+      yield output
+    end
+  end
+end
+
 require_relative "../../tools/test_common"


### PR DESCRIPTION
### Summary

Enables ActiveStorage variants for other file types than images, such as audio or video files, through an API for registering custom transformers similar to previewers. An example `ffmpeg` transformation is provided.

### Other Information

It was [suggested](https://discuss.rubyonrails.org/t/activestorage-only-supports-image-variants/74808) to submit this PR to get feedback (from @georgeclaghorn?). NB: As `ActiveStorage::Transformers::Transformer` and `ActiveStorage::Previewer` do not differ much, we could consider merging them in another PR to allow using them interchangeably.

To consider before merging:
- [ ] [rename variables](https://github.com/rails/rails/pull/39283#issuecomment-629232147) to reflect their new meaning