### PR TITLE
Support native RENAME COLUMN syntax for MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1493,6 +1493,10 @@ module ActiveRecord
           schema_creation.accept(AddColumnDefinition.new(cd))
         end
 
+        def rename_column_for_alter(table_name, column_name, new_column_name)
+          "RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
+        end
+
         def remove_column_for_alter(table_name, column_name, type = nil, **options)
           "DROP COLUMN #{quote_column_name(column_name)}"
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -667,6 +667,8 @@ module ActiveRecord
         end
 
         def rename_column_for_alter(table_name, column_name, new_column_name)
+          return super if supports_rename_column?
+
           column  = column_for(table_name, column_name)
           options = {
             default: column.default,
@@ -698,6 +700,14 @@ module ActiveRecord
             database_version >= "10.5.2"
           else
             database_version >= "5.7.6"
+          end
+        end
+
+        def supports_rename_column?
+          if mariadb?
+            database_version >= "10.5.2"
+          else
+            database_version >= "8.0.3"
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -437,7 +437,7 @@ module ActiveRecord
         # Renames a column in a table.
         def rename_column(table_name, column_name, new_column_name) #:nodoc:
           clear_cache!
-          execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
+          execute("ALTER TABLE #{quote_table_name(table_name)} #{rename_column_for_alter(table_name, column_name, new_column_name)}")
           rename_column_indexes(table_name, column_name, new_column_name)
         end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -170,7 +170,11 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     @connection.execute "CREATE TABLE `bar_baz` (`foo` varchar(255))"
     @subscriber.logged.clear
     @connection.send(:rename_column_for_alter, "bar_baz", "foo", "foo2")
-    assert_equal "SCHEMA", @subscriber.logged[0][1]
+    if @connection.send(:supports_rename_column?)
+      assert_empty @subscriber.logged
+    else
+      assert_equal "SCHEMA", @subscriber.logged[0][1]
+    end
   ensure
     @connection.execute "DROP TABLE `bar_baz`"
   end


### PR DESCRIPTION
MySQL 8.0.3 (and MariaDB 10.5.2) now supports native RENAME COLUMN
syntax.

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-3.html#mysqld-8-0-3-sql-syntax
https://mariadb.com/kb/en/alter-table/#rename-column