### PR TITLE
Avoid allocating extra hash and arrays when as_json is called without options

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -121,17 +121,17 @@ module ActiveModel
     #   user.serializable_hash(include: { notes: { only: 'title' }})
     #   # => {"name" => "Napoleon", "notes" => [{"title"=>"Battle of Austerlitz"}]}
     def serializable_hash(options = nil)
-      options ||= {}
-
       attribute_names = attributes.keys
+
+      return serializable_attributes(attribute_names) unless options
+
       if only = options[:only]
         attribute_names &= Array(only).map(&:to_s)
       elsif except = options[:except]
         attribute_names -= Array(except).map(&:to_s)
       end
 
-      hash = {}
-      attribute_names.each { |n| hash[n] = read_attribute_for_serialization(n) }
+      hash = serializable_attributes(attribute_names)
 
       Array(options[:methods]).each { |m| hash[m.to_s] = send(m) }
 
@@ -164,6 +164,10 @@ module ActiveModel
       #     end
       #   end
       alias :read_attribute_for_serialization :send
+
+      def serializable_attributes(attribute_names)
+        attribute_names.index_with { |n| read_attribute_for_serialization(n) }
+      end
 
       # Add associations specified via the <tt>:include</tt> option.
       #

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -11,10 +11,12 @@ module ActiveRecord #:nodoc:
     end
 
     def serializable_hash(options = nil)
-      options = options ? options.dup : {}
+      if self.class.has_attribute?(self.class.inheritance_column)
+        options = options ? options.dup : {}
 
-      options[:except] = Array(options[:except]).map(&:to_s)
-      options[:except] |= Array(self.class.inheritance_column)
+        options[:except] = Array(options[:except]).map(&:to_s)
+        options[:except] |= Array(self.class.inheritance_column)
+      end
 
       super(options)
     end


### PR DESCRIPTION
Even if `options` will be passed as nil, in called `serializable_hash` method it will be `||=` to Hash.  