### PR TITLE
Fix `AR::Relation#where_values_hash` with `HomogeousIn`:

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -119,10 +119,9 @@ module ActiveRecord
           equalities = []
 
           predicates.each do |node|
-            case node
-            when Arel::Nodes::Equality
+            if equality_node?(node)
               equalities << node
-            when Arel::Nodes::And
+            elsif node.is_a?(Arel::Nodes::And)
               equalities.concat equalities(node.children)
             end
           end

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -32,6 +32,10 @@ module Arel # :nodoc: all
         attribute
       end
 
+      def right
+        attribute.quoted_array(values)
+      end
+
       def table_name
         attribute.relation.table_alias || attribute.relation.name
       end

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -214,6 +214,10 @@ module Arel # :nodoc: all
       Arel::Nodes::Overlaps.new(self, other)
     end
 
+    def quoted_array(others)
+      others.map { |v| quoted_node(v) }
+    end
+
     private
       def grouping_any(method_id, others, *extras)
         nodes = others.map { |expr| send(method_id, expr, *extras) }
@@ -229,10 +233,6 @@ module Arel # :nodoc: all
 
       def quoted_node(other)
         Nodes.build_quoted(other, self)
-      end
-
-      def quoted_array(others)
-        others.map { |v| quoted_node(v) }
       end
 
       def infinity?(value)

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -52,6 +52,13 @@ module ActiveRecord
       assert_equal({}, relation.where_values_hash)
     end
 
+    def test_where_values_hash_with_in_clause
+      relation = Relation.new(Post)
+      relation.where!(title: ["foo", "bar", "hello"])
+
+      assert_equal({ "title" => ["foo", "bar", "hello"] }, relation.where_values_hash)
+    end
+
     def test_has_values
       relation = Relation.new(Post)
       relation.where!(id: 10)


### PR DESCRIPTION
Fix `AR::Relation#where_values_hash` with `HomogeousIn`:

- Calling `Blog.where(title: ['foo', 'bar']).where_values_hash` now
  returns an empty hash.
  This is a regression since 72fd0bae59 .

  `Arel::Node::HomogeousIn` isn't a `EqualityNode`, the `WhereClause`
  didn't had a case for this.

  I decide to not make `HomogeousIn` inherit from `EqualityNode`,
  because there is a comment questioning it for `In` https://github.com/rails/rails/blob/57d926a78a6968b9268f4ec1acde608132a1c920/activerecord/lib/arel/nodes.rb#L31
  Intead I just modified the `WhereClause` case and implemented
  `right` on the node which is needed by `where_value_hash` https://github.com/rails/rails/blob/57d926a78a6968b9268f4ec1acde608132a1c920/activerecord/lib/active_record/relation/where_clause.rb#L59

cc/ @tenderlove @rafaelfranca @paracycle @casperisfine @etiennebarrie 
