### PR TITLE
Fix setting instance variable for has_secure_password attribute setter method

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -93,10 +93,11 @@ module ActiveModel
         attr_reader attribute
 
         define_method("#{attribute}=") do |unencrypted_password|
+          instance_variable_set("@#{attribute}", unencrypted_password)
+
           if unencrypted_password.nil?
             self.send("#{attribute}_digest=", nil)
           elsif !unencrypted_password.empty?
-            instance_variable_set("@#{attribute}", unencrypted_password)
             cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
             self.send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_password, cost: cost))
           end

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -121,6 +121,7 @@ class SecurePasswordTest < ActiveModel::TestCase
     @existing_user.password = ""
     @existing_user.password_confirmation = ""
     assert @existing_user.valid?(:update), "user should be valid"
+    assert_equal "", @existing_user.password
   end
 
   test "updating an existing user with validation and a nil password" do
@@ -180,7 +181,10 @@ class SecurePasswordTest < ActiveModel::TestCase
   end
 
   test "setting a nil password should clear an existing password" do
+    @existing_user.password = "password"
+
     @existing_user.password = nil
+    assert_nil @existing_user.password
     assert_nil @existing_user.password_digest
   end
 


### PR DESCRIPTION
Problem:
```ruby
> u = User.new
> u.password = "secret"
=> "secret"
> u.password
=> "secret"
> u.password_digest
=> "$2a$12$zy2G155B8.EAO7.eoUTEWOJbonw09cAyv6UZ6wJZ8J5T4jm/4wJqC"
> u.password = nil
=> nil
> u.password
=> "secret" # <==== should also be nil
> u.password_digest
=> nil
```

Also, related to `has_secure_password` implementation, I find the following behavior incorrect and counterintuitive:
https://github.com/rails/rails/blob/57d926a78a6968b9268f4ec1acde608132a1c920/activemodel/test/cases/secure_password_test.rb#L177-L180

If I change `password`, `password_digest` should also be changed. If `password = ""` and validations are on, record should become invalid. But accordingly to current implementation, record will be valid and `password_digest` won't change. https://github.com/rails/rails/blob/57d926a78a6968b9268f4ec1acde608132a1c920/activemodel/lib/active_model/secure_password.rb#L82