### PR TITLE
Add failing test for join + pluck returns uncasted values when symbol argument is passed for joined table

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -743,6 +743,16 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal expected, actual
   end
 
+  def test_pluck_with_join_is_type_cast_consistently
+    p Author.first.author_address_id.is_a?(Integer)
+    pluck_with_string = Author.joins(:books).pluck(:author_address_id, "books.last_read")
+    pluck_with_symbol = Author.joins(:books).pluck(:author_address_id, :last_read)
+
+    assert_equal [[1, "read"], [1, "reading"], [1, nil], [1, "unread"]], pluck_with_string
+    assert_equal [[1, "read"], [1, "reading"], [1, nil], [1, "unread"]], pluck_with_symbol
+    assert_equal pluck_with_string, pluck_with_symbol
+  end
+
   def test_pluck_with_type_cast_does_not_corrupt_the_query_cache
     topic = topics(:first)
     relation = Topic.where(id: topic.id)


### PR DESCRIPTION
@kamipo I thought you'd find this interesting. Thanks for the fix in #39264 - it led me to dig into the other cases of inconsistency that might be in Rails.

---

The PR #39264 fixed `pluck` so that when plucking on a join the string
columns correctly returned casted values rather than uncasted values.

This led me to dig into other patterns to ensure the changes were
correct. I discovered that 6.0 has been not-casting values for string
pluck, plucks with Arel.sql and symbol plucks.

While string and arel.sql plucks are fixed, symbol plucks still return
uncasted values when called on the joined table. Note the columns are
correctly casted for the Author table, but not for the books table.

I'm not entirely sure how to fix this since Rails quotes the column name
if it's a symbol so it has no type caster to cast on. This is a problem
for all non-string values like boolean, enum, etc.

---

Here's a script I used to test different types of joins and plucks to figure out which cases were still broken and compared them to the 6.0 behavior. The new behavior in 6.1 is correct but symbol columns are the incorrect behavior. This case is somewhat odd because technically it's an ambiguous column and it's better to be clear, but it doesn't fail and it does get the correct data from the database, it's just never casted because the symbol becomes `"`last_read`" and not an object with a type caster.

```ruby
require "active_record"
require "minitest/autorun"
require "logger"
​
ActiveRecord::Base.establish_connection(adapter: "mysql2", database: "activerecord_unittest", username: "rails")
ActiveRecord::Base.logger = Logger.new(STDOUT)
​
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :title
    t.boolean :active
  end
​
  create_table :comments, force: true do |t|
    t.integer :post_id
    t.boolean :deleted
  end
​
  create_table :categories, force: true do |t|
    t.string :name
    t.boolean :on
  end
​
  create_table :categorizations, force: true do |t|
    t.integer :post_id
    t.integer :category_id
  end
end
​
class Post < ActiveRecord::Base
  has_many :comments
  has_many :categorizations
  has_many :categories, through: :categorizations
end
​
class Comment < ActiveRecord::Base
  belongs_to :post
end
​
class Category < ActiveRecord::Base
  has_many :categorizations
  has_many :posts, through: :categorizations
end
​
class Categorization < ActiveRecord::Base
  belongs_to :category
  belongs_to :post
end
​
class BugTest < Minitest::Test
  def test_association_stuff
    post = Post.create!(title: ":(", active: true)
    post2 = Post.create!(title: ":(", active: false)
    Comment.create(post: post, deleted: true)
    Comment.create(post: post, deleted: false)
    Comment.create(post: post, deleted: true)
​
    cat = Category.create!(name: "fun", on: true)
    cat2 = Category.create!(name: "not fun", on: false)
​
    Categorization.create!(post: post, category: cat)
    Categorization.create!(post: post, category: cat2)
​
    # Correctly pass on both
    # all pass on 6.0 and 6.1
    assert_equal [true, false], Post.pluck(:active)
    assert_equal [true, false], Post.pluck("posts.active")
    assert_equal [true, false], Post.pluck(Arel.sql("posts.active"))
​
    # Correctly pass on both
    # all pass in 6.0 and 6.1
    assert_equal [true, false, true], Post.find(1).comments.pluck(:deleted)
    assert_equal [true, false, true], Post.find(1).comments.pluck("comments.deleted")
    assert_equal [true, false, true], Post.find(1).comments.pluck(Arel.sql("comments.deleted"))
​
    # Pluck with symbol still failing in 6.1, Pluck in 6.0 was incorrect
    # 6.0 => [1, 0], 6.1 => [1, 0]
    assert_equal [true, false], Post.where(id: [1, 2]).joins(:categories).pluck(:on)
    # 6.0 => [1, 0], 6.1 => [true, false]
    assert_equal [true, false], Post.where(id: [1, 2]).joins(:categories).pluck("categories.on")
    # 6.0 => [1, 0], 6.1 => [true, false]
    assert_equal [true, false], Post.where(id: [1, 2]).joins(:categories).pluck(Arel.sql("categories.on"))
​
    # Pluck with symbol still failing in 6.1, Pluck in 6.0 was incorrect
    # 6.0 => [1, 0, 1], 6.1 => [1, 0, 1]
    assert_equal [true, false, true],  Post.where(id: 1).joins(:comments).pluck(:deleted)
    # 6.0 => [1, 0, 1], 6.1 => [true, false, true]
    assert_equal [true, false, true],  Post.where(id: 1).joins(:comments).pluck("comments.deleted")
    # 6.0 => [1, 0, 1], 6.1 => [true, false, true]
    assert_equal [true, false, true],  Post.where(id: 1).joins(:comments).pluck(Arel.sql("comments.deleted"))
  end
end
```