### PR TITLE
Type cast `pluck` values for table name unqalified column in joins tables

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -131,6 +131,10 @@ module ActiveRecord
         relation._select!(-> { aliases.columns })
       end
 
+      def each(&block)
+        join_root.each(&block)
+      end
+
       protected
         attr_reader :join_root, :join_type
 


### PR DESCRIPTION
Follow up to #39264, and fixes demonstrated case in #39290.

If the column has no type caster and the model don't know the attribute,
let's will attempt to lookup cast type from join dependency tree.

cc @eileencodes 