### PR TITLE
Fix group by count with eager loading + order + limit/offset

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -136,7 +136,7 @@ module ActiveRecord
             relation.select_values = [ klass.primary_key || table[Arel.star] ]
           end
           # PostgreSQL: ORDER BY expressions must appear in SELECT list when using DISTINCT
-          relation.order_values = []
+          relation.order_values = [] if group_values.empty?
         end
 
         relation.calculate(operation, column_name)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -851,20 +851,20 @@ class CalculationsTest < ActiveRecord::TestCase
   end if current_adapter?(:PostgreSQLAdapter)
 
   def test_group_by_with_limit
-    expected = { "Post" => 8, "SpecialPost" => 1 }
-    actual = Post.includes(:comments).group(:type).order(:type).limit(2).count("comments.id")
+    expected = { "StiPost" => 2, "SpecialPost" => 1 }
+    actual = Post.includes(:comments).group(:type).order(type: :desc).limit(2).count("comments.id")
     assert_equal expected, actual
   end
 
   def test_group_by_with_offset
-    expected = { "SpecialPost" => 1, "StiPost" => 2 }
-    actual = Post.includes(:comments).group(:type).order(:type).offset(1).count("comments.id")
+    expected = { "SpecialPost" => 1, "Post" => 8 }
+    actual = Post.includes(:comments).group(:type).order(type: :desc).offset(1).count("comments.id")
     assert_equal expected, actual
   end
 
   def test_group_by_with_limit_and_offset
     expected = { "SpecialPost" => 1 }
-    actual = Post.includes(:comments).group(:type).order(:type).offset(1).limit(1).count("comments.id")
+    actual = Post.includes(:comments).group(:type).order(type: :desc).offset(1).limit(1).count("comments.id")
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
`count` is too complex feature in Active Record, it is heavily mangling
select values, so it easily hit the ORDER BY with SELECT DISTINCT
limitation.

https://github.com/rails/rails/blob/35bf86fe838d310833adb283712ce4913447eea7/activerecord/lib/active_record/relation/calculations.rb#L133-L140
https://github.com/rails/rails/blob/35bf86fe838d310833adb283712ce4913447eea7/activerecord/lib/active_record/relation/calculations.rb#L253-L264

But at least in the case of group by, select values are always to be
aggregated value and group values, so meaningful order values are
originally limited. So in that case, remaining order values should
be safe as long as meaningful order values are set by people.

Fixes #38936.