### PR TITLE
Stop creating too many test databases

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -76,13 +76,13 @@ module ActiveSupport
 
         def after_fork
           Parallelization.after_fork_hooks.each do |cb|
-            cb.call(@id)
+            cb.call(@number)
           end
         end
 
         def run_cleanup
           Parallelization.run_cleanup_hooks.each do |cb|
-            cb.call(@id)
+            cb.call(@number)
           end
         end
 


### PR DESCRIPTION
Addresses Issue #39291

In https://github.com/rails/rails/pull/38893, parallel test worker ids were changed to `SecureRandom.uuid` to keep track of inflight work across distributed instances, but negelected to change the worker callbacks to match.  This caused a new set of unique test databases are created with every test run.

This commit makes the appropriate change to worker callbacks so only one set of of parallel test databases are created.