### PR TITLE
Add delegation constants to Module

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -11,6 +11,14 @@ class Module
        return self super then true undef unless until when while yield)
   ).freeze
 
+  DELEGATION_RESERVED_KEYWORDS = Set.new(
+    %w(_ arg args block)
+  )
+
+  DELEGATION_RESERVED_METHOD_NAMES = Set.new(
+    RUBY_RESERVED_WORDS + DELEGATION_RESERVED_KEYWORDS
+  ).freeze
+
   # Provides a +delegate+ class method to easily expose contained objects'
   # public methods as your own.
   #


### PR DESCRIPTION
### Summary

Adds the `DELEGATION_RESERVED_METHOD_NAMES ` referenced in b395acf4673045c03fc7845b5103b801f0a5950d. Also adds `DELEGATION_RESERVED_KEYWORDS`.

I pulled these from the [latest](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/module/delegation.rb) ActiveSupport module delegation code.


