### PR TITLE
Fix `file_fixture_upload_bug`:

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -35,6 +35,8 @@ module ActionDispatch
               Please modify the call from
               `fixture_file_upload(#{original_path})` to `fixture_file_upload(#{non_deprecated_path})`.
             EOM
+          else
+            path = file_fixture(original_path)
           end
         elsif self.class.file_fixture_path && !File.exist?(path)
           path = file_fixture(path)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -930,6 +930,14 @@ XML
     end
   end
 
+  def test_fixture_file_upload_does_not_output_deprecation_when_file_fixture_path_is_set
+    TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
+      assert_not_deprecated do
+        fixture_file_upload("ruby_on_rails.jpg", "image/jpg")
+      end
+    end
+  end
+
   def test_fixture_file_upload_relative_to_fixture_path
     TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
       expected = "`fixture_file_upload(multipart/ruby_on_rails.jpg)` to `fixture_file_upload(ruby_on_rails.jpg)`"


### PR DESCRIPTION
Fix `file_fixture_upload_bug`:

- In beb7fba , I forgot to add a branch in the case where an
  application uses AR (and thus it responds to `fixture_path`) to
  return a path relative to file_fixture_path.

  Fix #39278

