### PR TITLE
Fixed BacktraceCleaner to never return an empty backtrace.

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -503,7 +503,9 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     output = StringIO.new
     backtrace_cleaner = ActiveSupport::BacktraceCleaner.new
-    backtrace_cleaner.add_silencer { true }
+    def backtrace_cleaner.clean(bt, _)
+      []
+    end
 
     env = { "action_dispatch.show_exceptions"   => true,
             "action_dispatch.logger"            => Logger.new(output),

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -104,28 +104,29 @@ module ActiveSupport
         add_silencer { |line| line.start_with?(RbConfig::CONFIG["rubylibdir"]) }
       end
 
+      # Process +ary+ via +filters+ using +method+, ensuring
+      # _something_ gets returned.
+      def process_collection(ary, filters, method)
+        filters.reduce(ary) { |bt, f| bt.send(method) { |line| f.call(line) } }
+      end
+
+      # Use @filters to transform the backtrace via map
       def filter_backtrace(backtrace)
-        @filters.each do |f|
-          backtrace = backtrace.map { |line| f.call(line) }
-        end
-
-        backtrace
+        process_collection backtrace, @filters, :map
       end
 
+      # Use @silencers to reject parts of the backtrace. Guarantee
+      # something non-empty is returned.
       def silence(backtrace)
-        @silencers.each do |s|
-          backtrace = backtrace.reject { |line| s.call(line) }
-        end
-
-        backtrace
+        result = process_collection backtrace, @silencers, :reject
+        result.first ? result : backtrace.dup
       end
 
+      # Use @silencers to select parts of the backtrace. Guarantee
+      # something non-empty is returned.
       def noise(backtrace)
-        backtrace.select do |line|
-          @silencers.any? do |s|
-            s.call(line)
-          end
-        end
+        result = backtrace.select { |line| @silencers.any? { |s| s.call(line) } }
+        result.first ? result : backtrace.dup
       end
   end
 end

--- a/activesupport/test/clean_backtrace_test.rb
+++ b/activesupport/test/clean_backtrace_test.rb
@@ -42,6 +42,17 @@ class BacktraceCleanerSilencerTest < ActiveSupport::TestCase
   end
 end
 
+class BacktraceCleanerShouldNeverReturnEmpty < ActiveSupport::TestCase
+  test "backtrace should return a backtrace no matter what" do
+    @bc = ActiveSupport::BacktraceCleaner.new
+    @bc.add_silencer { |line| true }
+
+    bt = %w[ first second third ]
+
+    assert_equal bt, @bc.clean(bt.dup)
+  end
+end
+
 class BacktraceCleanerMultipleSilencersTest < ActiveSupport::TestCase
   def setup
     @bc = ActiveSupport::BacktraceCleaner.new
@@ -103,14 +114,14 @@ class BacktraceCleanerDefaultFilterAndSilencerTest < ActiveSupport::TestCase
   end
 
   test "should silence gems from the backtrace" do
-    backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb" ]
+    backtrace = [ "#{Gem.path[0]}/gems/nosuchgem-1.2.3/lib/foo.rb", "other/file.rb" ]
     result = @bc.clean(backtrace)
-    assert_empty result
+    assert_equal %w[other/file.rb], result
   end
 
   test "should silence stdlib" do
-    backtrace = ["#{RbConfig::CONFIG["rubylibdir"]}/lib/foo.rb"]
+    backtrace = ["#{RbConfig::CONFIG["rubylibdir"]}/lib/foo.rb", "other/file.rb"]
     result = @bc.clean(backtrace)
-    assert_empty result
+    assert_equal %w[other/file.rb], result
   end
 end

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -17,6 +17,8 @@ module Rails
       end
 
       if output_inline? && result.failure && (!result.skipped? || options[:verbose])
+        result.failures.each { |f| f.backtrace.clear } if result.error?
+
         io.puts
         io.puts
         io.puts color_output(result, by: result)


### PR DESCRIPTION
### Summary

Empty backtraces means you didn't run any code, which isn't the case,
and goes against the contract that Minitest.backtrace_cleaner expects.
This fixes a bug I've seen in a number of reports.

It would be nice if this got backported to whatever versions are
active, as this keeps coming back on minitest issues.