### PR TITLE
Fix eager load with Arel joins to maintain the original joins order

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -52,7 +52,7 @@ module ActiveRecord
         attr_reader :value_transformation
 
         def join(table, constraint)
-          table.create_join(table, table.create_on(constraint))
+          table.create_join(table, table.create_on(constraint), Arel::Nodes::LeadingJoin)
         end
 
         def last_chain_scope(scope, reflection, owner)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1178,6 +1178,9 @@ module ActiveRecord
         build_join_query(manager, buckets, Arel::Nodes::OuterJoin, aliases)
       end
 
+      class ::Arel::Nodes::LeadingJoin < Arel::Nodes::InnerJoin # :nodoc:
+      end
+
       def build_joins(manager, joins, aliases)
         buckets = Hash.new { |h, k| h[k] = [] }
 
@@ -1201,7 +1204,7 @@ module ActiveRecord
 
         while joins.first.is_a?(Arel::Nodes::Join)
           join_node = joins.shift
-          if join_node.is_a?(Arel::Nodes::StringJoin) && (stashed_eager_load || stashed_left_joins)
+          if !join_node.is_a?(Arel::Nodes::LeadingJoin) && (stashed_eager_load || stashed_left_joins)
             buckets[:join_node] << join_node
           else
             buckets[:leading_join] << join_node

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -87,6 +87,15 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_equal 3, Person.eager_load(:agents).joins(string_join).count
   end
 
+  def test_eager_load_with_arel_joins
+    agents = Person.arel_table.alias("agents_people")
+    agents_2 = Person.arel_table.alias("agents_people_2")
+    constraint = agents[:primary_contact_id].eq(agents_2[:id]).and(agents[:id].gt(agents_2[:id]))
+    arel_join = agents.create_join(agents, agents.create_on(constraint), Arel::Nodes::OuterJoin)
+
+    assert_equal 3, Person.eager_load(:agents).joins(arel_join).count
+  end
+
   def test_construct_finder_sql_ignores_empty_joins_hash
     sql = Author.joins({}).to_sql
     assert_no_match(/JOIN/i, sql)

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -83,6 +83,15 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
     assert_equal 16, Author.left_outer_joins(:posts).joins("LEFT OUTER JOIN comments ON comments.post_id = posts.id").count
   end
 
+  def test_left_outer_joins_with_arel_join
+    comments = Comment.arel_table
+    posts = Post.arel_table
+    constraint = comments[:post_id].eq(posts[:id])
+    arel_join = comments.create_join(comments, comments.create_on(constraint), Arel::Nodes::OuterJoin)
+
+    assert_equal 16, Author.left_outer_joins(:posts).joins(arel_join).count
+  end
+
   def test_join_conditions_added_to_join_clause
     queries = capture_sql { Author.left_outer_joins(:essays).to_a }
     assert queries.any? { |sql| /writer_type.*?=.*?(Author|\?|\$1|\:a1)/i.match?(sql) }


### PR DESCRIPTION
#38354 is caused by #36304, to fix invalid joins order for through
associations.

Actually passing Arel joins to `joins` is not officially supported
unlike string joins, and also Arel joins could be easily converted to
string joins by `to_sql`. But I'd not intend to break existing apps
without deprecation cycle, so I've changed to mark only implicit joins
as leading joins, to maintain the original joins order for user supplied
Arel joins.

Fixes #38354.
