### PR TITLE
Skip interpolated strings in AV::Digestor

### DIFF
--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -41,8 +41,9 @@ module ActionView
       # Create a dependency tree for template named +name+.
       def tree(name, finder, partial = false, seen = {})
         logical_name = name.gsub(%r|/_|, "/")
+        interpolated = name.include?("#")
 
-        if template = find_template(finder, logical_name, [], partial, [])
+        if !interpolated && (template = find_template(finder, logical_name, [], partial, []))
           if node = seen[template.identifier] # handle cycles in the tree
             node
           else
@@ -55,7 +56,7 @@ module ActionView
             node
           end
         else
-          unless name.include?("#") # Dynamic template partial names can never be tracked
+          unless interpolated # Dynamic template partial names can never be tracked
             logger.error "  Couldn't find template for digesting: #{name}"
           end
 


### PR DESCRIPTION
Attempting to fix the same warning as #39068

I wasn't actually able to reproduce the warning, but I know this is in the stacktrace, and this will also avoid the warning in case there is another registered `DependencyTracker` with the same issue as `ERBTracker`. Also we were already specially handing strings which include `#` here as interpolated, so it actually does seem like the a good place to handle it.

cc @georgeclaghorn @kaspth