### PR TITLE
Avoid `synchronize {}` call for ThreadPool::Queue#any_waiting? for MRI

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -111,9 +111,7 @@ module ActiveRecord
 
         # Test if any threads are currently waiting on the queue.
         def any_waiting?
-          synchronize do
-            @num_waiting > 0
-          end
+          num_waiting > 0
         end
 
         if RUBY_ENGINE == "ruby"


### PR DESCRIPTION
`#num_waiting` is already synchronized, if needed.

@kamipo 