### PR TITLE
May Of WTFs: Change action_on_unpermitted_parameters to :raise by default

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -31,7 +31,7 @@ module ActionController
             app.config.action_controller.delete(:always_permitted_parameters)
         end
         ActionController::Parameters.action_on_unpermitted_parameters = options.delete(:action_on_unpermitted_parameters) do
-          (Rails.env.test? || Rails.env.development?) ? :log : false
+          (Rails.env.test? || Rails.env.development?) ? :raise : false
         end
       end
     end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -499,7 +499,7 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.
 
-* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
+* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:raise` in development and test environments, and `false` in all other environments.
 
 * `config.action_controller.always_permitted_parameters` sets a list of permitted parameters that are permitted by default. The default values are `['controller', 'action']`.
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1421,22 +1421,22 @@ module ApplicationTests
       assert_equal 200, last_response.status
     end
 
-    test "config.action_controller.action_on_unpermitted_parameters is :log by default in development" do
+    test "config.action_controller.action_on_unpermitted_parameters is :raise by default in development" do
       app "development"
 
       require "action_controller/base"
       require "action_controller/api"
 
-      assert_equal :log, ActionController::Parameters.action_on_unpermitted_parameters
+      assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
-    test "config.action_controller.action_on_unpermitted_parameters is :log by default in test" do
+    test "config.action_controller.action_on_unpermitted_parameters is :raise by default in test" do
       app "test"
 
       require "action_controller/base"
       require "action_controller/api"
 
-      assert_equal :log, ActionController::Parameters.action_on_unpermitted_parameters
+      assert_equal :raise, ActionController::Parameters.action_on_unpermitted_parameters
     end
 
     test "config.action_controller.action_on_unpermitted_parameters is false by default in production" do


### PR DESCRIPTION
### Summary

This PR aims to change the default `action_on_unpermitted_parameters` to `raise`, to avoid silently errors that cause a big waste of Rails developer time. 

This is a breaking change, but maybe a welcoming one? Quoting some good points that @ansonhoyt made on a Rails discourse thread:

> I see no concerns for old apps for two reasons:
> 
> - If raising in development (and test) breaks existing apps, it has served its purpose of exposing an unnoticed problem. I don’t recommend :raise in production.
> - When old apps upgrade Rails, they’d have an opportunity to reject this change after applying rails app:update. They also have the opportunity to keep config.load_defaults = 6.0 and apply new configs as they’re ready via config/intializers/new_framework_defaults.rb. See Configuring Rails Applications and Upgrading Ruby on Rails. This is a great mechanism for easing into new configs, and it is already there.
> 

I'm setting this to `draft` for now since it will possibly break lots of existing apps. Looking forward to hear where the core team stand on this. 

On discourse: https://discuss.rubyonrails.org/t/unpermitted-strong-parameter-lost-in-logs/75026/7