### PR TITLE
Add compact and compact! to ActionController::Parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added `compact` and `compact!` to `ActionController::Parameters`.
+
+    *Eugene Kenny*
+
 *   Calling `each_pair` or `each_value` on an `ActionController::Parameters`
     without passing a block now returns an enumerator.
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -759,6 +759,16 @@ module ActionController
     end
     alias_method :delete_if, :reject!
 
+    # Returns a new instance of <tt>ActionController::Parameters</tt> with +nil+ values removed.
+    def compact
+      new_instance_with_inherited_permitted_status(@parameters.compact)
+    end
+
+    # Removes all +nil+ values in place and returns +self+, or +nil+ if no changes were made.
+    def compact!
+      self if @parameters.compact!
+    end
+
     # Returns a new instance of <tt>ActionController::Parameters</tt> without the blank values.
     # Uses Object#blank? for determining if a value is blank.
     def compact_blank

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -128,6 +128,30 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.deep_transform_keys! { |k| k }, :permitted?
   end
 
+  test "compact retains permitted status" do
+    @params.permit!
+    assert_predicate @params.compact, :permitted?
+  end
+
+  test "compact retains unpermitted status" do
+    assert_not_predicate @params.compact, :permitted?
+  end
+
+  test "compact! returns nil when no values are nil" do
+    assert_nil @params.compact!
+  end
+
+  test "compact! retains permitted status" do
+    @params[:person] = nil
+    @params.permit!
+    assert_predicate @params.compact!, :permitted?
+  end
+
+  test "compact! retains unpermitted status" do
+    @params[:person] = nil
+    assert_not_predicate @params.compact!, :permitted?
+  end
+
   test "compact_blank retains permitted status" do
     @params.permit!
     assert_predicate @params.compact_blank, :permitted?


### PR DESCRIPTION
Inspired by https://github.com/rails/rails/pull/39311, I tried to replace `reject`, `reject!`, and `delete_if` with `compact` and `compact!` where applicable in my own codebase, but it broke the code when the receiver was an `ActionController::Parameters`.

I'm aware that 100% interface compatibility with Hash isn't the goal, but I think these make sense.