### PR TITLE
Create update yarn task

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -9,10 +9,10 @@ module ActionText
       source_root File.expand_path("templates", __dir__)
 
       def install_javascript_dependencies
-        rails_command "app:update:bin", inline: true
+        rails_command "app:update:bin:yarn", inline: true
 
         say "Installing JavaScript dependencies", :green
-        run "yarn add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}",
+        run "bin/yarn add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}",
           abort_on_failure: true, capture: true
       end
 

--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -9,7 +9,7 @@ module ActionText
       source_root File.expand_path("templates", __dir__)
 
       def install_javascript_dependencies
-        rails_command "app:update:bin:yarn", inline: true
+        rails_command "app:binstub:yarn", inline: true
 
         say "Installing JavaScript dependencies", :green
         run "bin/yarn add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}",

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -100,6 +100,16 @@ module Rails
       end
     end
 
+    def yarn_when_updating
+      return if File.exist?("bin/yarn")
+
+      template "bin/yarn" do |content|
+        "#{shebang}\n" + content
+      end
+
+      chmod "bin", 0755 & ~File.umask, verbose: false
+    end
+
     def config
       empty_directory "config"
 
@@ -313,6 +323,11 @@ module Rails
         build(:bin_when_updating)
       end
       remove_task :update_bin_files
+
+      def update_bin_yarn
+        build(:yarn_when_updating)
+      end
+      remove_task :update_bin_yarn
 
       def update_active_storage
         unless skip_active_storage?

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -58,11 +58,11 @@ namespace :app do
     task :upgrade_guide_info do
       Rails::AppUpdater.invoke_from_app_generator :display_upgrade_guide_info
     end
+  end
 
-    namespace :bin do
-      task :yarn do
-        Rails::AppUpdater.invoke_from_app_generator :update_bin_yarn
-      end
+  namespace :binstub do
+    task :yarn do
+      Rails::AppUpdater.invoke_from_app_generator :update_bin_yarn
     end
   end
 end

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -58,5 +58,11 @@ namespace :app do
     task :upgrade_guide_info do
       Rails::AppUpdater.invoke_from_app_generator :display_upgrade_guide_info
     end
+
+    namespace :bin do
+      task :yarn do
+        Rails::AppUpdater.invoke_from_app_generator :update_bin_yarn
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary

Related discussions: [r422715537](https://github.com/rails/rails/pull/35085#discussion_r422715537), #39233

Create `bin/rails app:update:bin:yarn` to update the `bin/yarn` file. The motivation for having this file created is so that we can provide a more user-friendly message when running `bin/rails action_text:install` in a machine where yarn is not installed.

This PR does two things:
1. Create the task for generating `bin/yarn`
2. Use it in actiontext's install generator

This should prevent the other binstubs from being overridden which causes issues for existing spring binstubs.

Something that caught my attention is that the install generator was silently failing in my machine because the JS package for version `6.1.0-alpha` is not yet released. Not sure if that's because of yarn, but it would be nice to provide a message saying that the release does not exist.

cc/ @dhh, @abhaynikam, @kaspth 