### PR TITLE
Resolve conflict between counter cache and optimistic locking

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Resolve conflict between counter cache and optimistic locking.
+
+    Bump an Active Record instance's lock version after updating its counter
+    cache. This avoids raising an unnecessary `ActiveRecord::StaleObjectError`
+    upon subsequent transactions by maintaining parity with the corresponding
+    database record's `lock_version` column.
+
+    Fixes #16449.
+
+    *Aaron Lipman*
+
 *   Support merging option `:rewhere` to allow mergee side condition to be replaced exactly.
 
     ```ruby

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -60,6 +60,15 @@ module ActiveRecord
         self.class.locking_enabled?
       end
 
+      def increment!(*, **) #:nodoc:
+        super.tap do
+          if locking_enabled?
+            self[self.class.locking_column] += 1
+            clear_attribute_change(self.class.locking_column)
+          end
+        end
+      end
+
       private
         def _create_record(attribute_names = self.attribute_names)
           if locking_enabled?

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -509,6 +509,12 @@ class OptimisticLockingTest < ActiveRecord::TestCase
     assert_equal 3, car.lock_version
     assert_operator previously_updated_at, :<, car.updated_at
     assert_operator previously_wheels_owned_at, :<, car.wheels_owned_at
+
+    car.wheels << Wheel.create!
+    assert_equal 1, car.wheels_count
+    assert_equal 4, car.lock_version
+    assert_not car.lock_version_changed?
+    assert_nothing_raised { car.update(name: "herbie") }
   end
 
   def test_polymorphic_destroy_with_dependencies_and_lock_version


### PR DESCRIPTION
### Summary

Bump an ActiveRecord instance's lock version after updating its counter cache. This avoids raising an unnecessary `ActiveRecord::StaleObjectError` upon subsequent transactions by maintaining parity with the corresponding database record's `lock_version` column. Fixes #16449.