### PR TITLE
Fix rename column in bulk alter table for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1493,7 +1493,7 @@ module ActiveRecord
           schema_creation.accept(AddColumnDefinition.new(cd))
         end
 
-        def rename_column_for_alter(table_name, column_name, new_column_name)
+        def rename_column_sql(table_name, column_name, new_column_name)
           "RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -667,7 +667,7 @@ module ActiveRecord
         end
 
         def rename_column_for_alter(table_name, column_name, new_column_name)
-          return super if supports_rename_column?
+          return rename_column_sql(table_name, column_name, new_column_name) if supports_rename_column?
 
           column  = column_for(table_name, column_name)
           options = {

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -437,7 +437,7 @@ module ActiveRecord
         # Renames a column in a table.
         def rename_column(table_name, column_name, new_column_name) #:nodoc:
           clear_cache!
-          execute("ALTER TABLE #{quote_table_name(table_name)} #{rename_column_for_alter(table_name, column_name, new_column_name)}")
+          execute("ALTER TABLE #{quote_table_name(table_name)} #{rename_column_sql(table_name, column_name, new_column_name)}")
           rename_column_indexes(table_name, column_name, new_column_name)
         end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1056,6 +1056,23 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_equal "This is a comment", column(:birthdate).comment
     end
 
+    def test_rename_columns
+      with_bulk_change_table do |t|
+        t.string :qualification
+      end
+
+      assert column(:qualification)
+
+      with_bulk_change_table do |t|
+        t.rename :qualification, :experience
+        t.string :qualification_experience
+      end
+
+      assert_not column(:qualification)
+      assert column(:experience)
+      assert column(:qualification_experience)
+    end
+
     def test_removing_columns
       with_bulk_change_table do |t|
         t.string :qualification, :experience


### PR DESCRIPTION
PostgreSQL doesn't support rename column operation in bulk alter table.

Fixes #39322.
