### PR TITLE
Fix merging NOT IN clause to behave the same as before

### DIFF
--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -21,7 +21,7 @@ module Arel # :nodoc: all
       alias :== :eql?
 
       def equality?
-        true
+        type == :in
       end
 
       def invert

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -88,6 +88,16 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
   end
 
+  def test_merge_not_in_clause
+    david, mary, bob = authors(:david, :mary, :bob)
+
+    non_mary_and_bob = Author.where.not(id: [mary, bob])
+
+    assert_equal [david], non_mary_and_bob
+    assert_equal [david], Author.where(id: david).merge(non_mary_and_bob)
+    assert_equal [], Author.where(id: mary).merge(non_mary_and_bob)
+  end
+
   def test_relation_merging
     devs = Developer.where("salary >= 80000").merge(Developer.limit(2)).merge(Developer.order("id ASC").where("id < 3"))
     assert_equal [developers(:david), developers(:jamis)], devs.to_a


### PR DESCRIPTION
`HomogeneousIn` has changed merging behavior for NOT IN clause from
before. This changes `equality?` to return true only if `type == :in` to
restore the original behavior.

cc @tenderlove @eileencodes 