### PR TITLE
Backport #35096 to Rails 5.2

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -10,8 +10,8 @@ module ActiveStorage
   class Service::AzureStorageService < Service
     attr_reader :client, :blobs, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key:, container:)
-      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key)
+    def initialize(storage_account_name:, storage_access_key:, container:, **extra_client_options)
+      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **extra_client_options)
       @signer = Azure::Storage::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
       @blobs = client.blob_client
       @container = container


### PR DESCRIPTION
This backport is important to keep the development environment useful in Rails 5.2 without monkey patching.

Also, the original commit was intended to be applied in rails v5.2 first, not v6.
