### PR TITLE
Unify the query values normalization for multiple values

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -137,7 +137,7 @@ module ActiveRecord
               end
 
               reflection.all_includes do
-                scope.includes! item.includes_values
+                scope.includes_values |= item.includes_values
               end
 
               scope.unscope!(*item.unscope_values)

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -90,7 +90,7 @@ module ActiveRecord
               end
 
               if values[:references] && !values[:references].empty?
-                scope.references!(values[:references])
+                scope.references_values |= values[:references]
               else
                 scope.references!(source_reflection.table_name)
               end

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -23,10 +23,10 @@ module ActiveRecord
 
     def self.references(attributes)
       attributes.map do |key, value|
+        key = key.to_s
         if value.is_a?(Hash)
           key
         else
-          key = key.to_s
           key.split(".").first if key.include?(".")
         end
       end.compact


### PR DESCRIPTION
Currently the query values normalization for multiple values is missing
some parts.

Some values are flatten, but others are not flatten.
Some values are compact, but others are not compact.
some values are compact_blank, but others are not compact_blank.

Originally all multiple values should be flatten and compact_blank
before `build_arel`, if it is not ensured which multiple values are
normalized or not, we need to normalize it again carefully and
conservatively in `build_arel`.

To unify the query values normalization for multiple values, ensure the
normalization in `check_if_method_has_arguments!` since all multiple
values should be checked by the method.