### PR TITLE
Fix references in the form builders guide [ci skip]

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -247,9 +247,9 @@ There are a few things to note here:
 
 * `@article` is the actual object being edited.
 * There is a single hash of options. HTML options (except `id` and `class`) are passed in the `:html` hash. Also you can provide a `:namespace` option for your form to ensure uniqueness of id attributes on form elements. The scope attribute will be prefixed with underscore on the generated HTML id.
-* The `form_with` method yields a **form builder** object (the `f` variable).
+* The `form_with` method yields a **form builder** object (the `form` variable).
 * If you wish to direct your form request to a particular URL, you would use `form_with url: my_nifty_url_path` instead. To see more in depth options on what `form_with` accepts be sure to [check out the API documentation](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with).
-* Methods to create form controls are called **on** the form builder object `f`.
+* Methods to create form controls are called **on** the form builder object `form`.
 
 The resulting HTML is:
 
@@ -726,7 +726,7 @@ The following two forms both upload a file.
 <% end %>
 ```
 
-Rails provides the usual pair of helpers: the barebones `file_field_tag` and the model oriented `file_field`. As you would expect in the first case the uploaded file is in `params[:picture]` and in the second case in `params[:person][:picture]`.
+Rails provides the usual pair of helpers: the barebones `file_field_tag` and the model oriented `file_field`. As you would expect in the first case the uploaded file is in `params[:person][:picture]` and in the second case in `params[:picture]`.
 
 ### What Gets Uploaded
 


### PR DESCRIPTION
### Summary

I caught two references that seemed inconsistent:

1. In section 2.2 Binding a Form to an Object, the code snippet variable was called `form`, but in the bullet points below, it was referenced as `f`.
2. In section 6 Uploading Files, the references to the params hash returned by two different forms was incorrect.

