### PR TITLE
Add DidYouMean for InverseOfAssociationNotFoundError

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -299,6 +299,17 @@ class InverseHasOneTests < ActiveRecord::TestCase
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Human.first.dirty_face }
   end
+
+  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+    def test_trying_to_use_inverses_that_dont_exist_should_have_suggestions_for_fix
+      error = assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) {
+        Human.first.dirty_face
+      }
+
+      assert_match "Did you mean?", error.message
+      assert_equal "horrible_human", error.corrections.first
+    end
+  end
 end
 
 class InverseHasManyTests < ActiveRecord::TestCase
@@ -649,6 +660,17 @@ class InverseBelongsToTests < ActiveRecord::TestCase
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.horrible_human }
+  end
+
+  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+    def test_trying_to_use_inverses_that_dont_exist_should_have_suggestions_for_fix
+      error = assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) {
+        Face.first.horrible_human
+      }
+
+      assert_match "Did you mean?", error.message
+      assert_equal "polymorphic_face", error.corrections.first
+    end
   end
 
   def test_building_has_many_parent_association_inverses_one_record


### PR DESCRIPTION
### Summary

If an inverse association isn't found we can suggest similar associations:

```
class Man < ActiveRecord::Base
  has_one :dirty_face, class_name: "Face", inverse_of: :dirty_man
end

class Face < ActiveRecord::Base
  belongs_to :man, inverse_of: :face
  belongs_to :horrible_man, class_name: "Man", inverse_of: :horrible_face
end
Man.first.dirty_face

Could not find the inverse association for dirty_face (:dirty_man in Face)
Did you mean?  man
               horrible_man
              ....
```