### PR TITLE
Add DidYouMean for HasManyThroughAssociationNotFoundError

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -51,12 +51,39 @@ module ActiveRecord
   end
 
   class HasManyThroughAssociationNotFoundError < ActiveRecordError #:nodoc:
-    def initialize(owner_class_name = nil, reflection = nil)
-      if owner_class_name && reflection
-        super("Could not find the association #{reflection.options[:through].inspect} in model #{owner_class_name}")
+    attr_reader :owner_class, :reflection
+    def initialize(owner_class = nil, reflection = nil)
+      if owner_class && reflection
+        @owner_class = owner_class
+        @reflection = reflection
+        super("Could not find the association #{reflection.options[:through].inspect} in model #{owner_class.name}")
       else
         super("Could not find the association.")
       end
+    end
+
+    class Correction
+      def initialize(error)
+        @error = error
+      end
+
+      def corrections
+        if @error.reflection && @error.owner_class
+          maybe_these = @error.owner_class.reflections.keys
+          maybe_these -= [@error.reflection.name.to_s] # remove failing reflection
+
+          maybe_these.sort_by { |n|
+            DidYouMean::Jaro.distance(@error.reflection.options[:through].to_s, n)
+          }.reverse.first(4)
+        else
+          []
+        end
+      end
+    end
+
+    # We may not have DYM, and DYM might not let us register error handlers
+    if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+      DidYouMean.correct_error(self, Correction)
     end
   end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -923,7 +923,7 @@ module ActiveRecord
 
       def check_validity!
         if through_reflection.nil?
-          raise HasManyThroughAssociationNotFoundError.new(active_record.name, self)
+          raise HasManyThroughAssociationNotFoundError.new(active_record, self)
         end
 
         if through_reflection.polymorphic?

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -341,6 +341,15 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     assert_raise(ActiveRecord::HasManyThroughAssociationNotFoundError) { authors(:david).nothings }
   end
 
+  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+    def test_exceptions_have_suggestions_for_fix
+      error = assert_raise(ActiveRecord::HasManyThroughAssociationNotFoundError) {
+        authors(:david).nothings
+      }
+      assert_match "Did you mean?", error.message
+    end
+  end
+
   def test_has_many_through_join_model_with_conditions
     assert_equal [], posts(:welcome).invalid_taggings
     assert_equal [], posts(:welcome).invalid_tags


### PR DESCRIPTION
### Summary

If a has_many :through association isn't found we can suggest similar associations:

```
class Author
  has_many :categorizations, -> { }
  has_many :categories, through: :categorizations
  has_many :categorized_posts, through: :categorizations, source: :post
  has_many :category_post_comments, through: :categories, source: :post_comments

  has_many :nothings, through: :kateggorisatons, class_name: "Category"
end

Author.first.nothings

Could not find the association :kateggorisatons in model Author
Did you mean?  categorizations
               categories
               categorized_posts
               category_post_comments
```