### PR TITLE
Update `fixture_file_upload` documentation to reflect recent changes.

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -6,14 +6,16 @@ require "action_dispatch/middleware/flash"
 module ActionDispatch
   module TestProcess
     module FixtureFile
-      # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.fixture_path, path), type)</tt>:
+      # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.file_fixture_path, path), type)</tt>:
       #
-      #   post :change_avatar, params: { avatar: fixture_file_upload('files/spongebob.png', 'image/png') }
+      #   post :change_avatar, params: { avatar: fixture_file_upload('spongebob.png', 'image/png') }
+      #
+      # Default fixture files location is <tt>test/fixtures/files</tt>.
       #
       # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
       # This will not affect other platforms:
       #
-      #   post :change_avatar, params: { avatar: fixture_file_upload('files/spongebob.png', 'image/png', :binary) }
+      #   post :change_avatar, params: { avatar: fixture_file_upload('spongebob.png', 'image/png', :binary) }
       def fixture_file_upload(path, mime_type = nil, binary = false)
         if self.class.respond_to?(:fixture_path) && self.class.fixture_path &&
             !File.exist?(path)

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -35,7 +35,7 @@ module ActionDispatch
               In Rails 6.2, the path needs to be relative to `file_fixture_path`.
 
               Please modify the call from
-              `fixture_file_upload(#{original_path})` to `fixture_file_upload(#{non_deprecated_path})`.
+              `fixture_file_upload("#{original_path}")` to `fixture_file_upload("#{non_deprecated_path}")`.
             EOM
           else
             path = file_fixture(original_path)

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -874,7 +874,7 @@ XML
 
   def test_fixture_path_is_accessed_from_self_instead_of_active_support_test_case
     TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
-      expected = "`fixture_file_upload(multipart/ruby_on_rails.jpg)` to `fixture_file_upload(ruby_on_rails.jpg)`"
+      expected = "`fixture_file_upload(\"multipart/ruby_on_rails.jpg\")` to `fixture_file_upload(\"ruby_on_rails.jpg\")`"
 
       assert_deprecated(expected) do
         uploaded_file = fixture_file_upload("multipart/ruby_on_rails.jpg", "image/png")
@@ -940,7 +940,7 @@ XML
 
   def test_fixture_file_upload_relative_to_fixture_path
     TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
-      expected = "`fixture_file_upload(multipart/ruby_on_rails.jpg)` to `fixture_file_upload(ruby_on_rails.jpg)`"
+      expected = "`fixture_file_upload(\"multipart/ruby_on_rails.jpg\")` to `fixture_file_upload(\"ruby_on_rails.jpg\")`"
 
       assert_deprecated(expected) do
         uploaded_file = fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpg")


### PR DESCRIPTION
### Summary

#39086 changed the default behaviour of `fixture_file_upload` method. Now file path passed to this method should be relative to `file_fixture_path`, not `fixture_path`. This PR modifies the method documentation to reflect the change.

### Other Information

Also the deprecation message was slightly changed. Quote signs were added around the file name in the suggested changes, so that the developer can just copy and paste them.

Before:
````
Please modify the call from
`fixture_file_upload(files/spongebob.jpg)` to `fixture_file_upload(spongebob.jpg)`.
````

After::
````
Please modify the call from
`fixture_file_upload("files/spongebob.jpg")` to `fixture_file_upload("spongebob.jpg")`.
````

