### PR TITLE
Add DidYouMean for ParameterMissing

### DIFF
--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -22,6 +22,20 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     end
   end
 
+  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+    test "exceptions have suggestions for fix" do
+      error = assert_raise ActionController::ParameterMissing do
+        post :create, params: { magazine: { name: "Mjallo!" } }
+      end
+      assert_match "Did you mean?", error.message
+
+      error = assert_raise ActionController::ParameterMissing do
+        post :create, params: { book: { title: "Mjallo!" } }
+      end
+      assert_match "Did you mean?", error.message
+    end
+  end
+
   test "required parameters that are present will not raise" do
     post :create, params: { book: { name: "Mjallo!" } }
     assert_response :ok


### PR DESCRIPTION
### Summary

If a parameter isn't found we can suggest similar params:

```
class BooksController < ActionController::Base
  def create
    params.require(:book).require(:name)
    head :ok
  end
end

post :create, params: { magazine: { name: "Mjallo!" } }

param is missing or the value is empty: book
Did you mean?  controller
               action
               magazine

post :create, params: { book: { title: "Mjallo!" } }

param is missing or the value is empty: name
Did you mean?  title

```

Unlike #39240 the suggestions aren't formatted for multiline:
![image](https://user-images.githubusercontent.com/28561/82303051-b5209680-99ba-11ea-9c09-1e868a662404.png)

