### PR TITLE
Fix autosave for bidirectional accepts_nested_attributes_for

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -296,7 +296,7 @@ module ActiveRecord
         begin
           @_nested_records_changed_for_autosave_already_called = true
           self.class._reflections.values.any? do |reflection|
-            next if reflection.inverse_of == saving_from_reflection
+            next if saving_from_reflection && reflection.inverse_of == saving_from_reflection
 
             if reflection.options[:autosave]
               association = association_instance_get(reflection.name)


### PR DESCRIPTION
### Summary

If two models both have accepts_nested_attributes_for to each other, the autosave causes there to be a double save and data loss of which attributes changed. See  https://github.com/rails/rails/issues/35597

### Other Information

Reproduction
```
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: 'rails/rails'
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :name
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
    t.text :text
  end
end

class Post < ActiveRecord::Base
  has_many :comments
  accepts_nested_attributes_for :comments, allow_destroy: true
end

class Comment < ActiveRecord::Base
  belongs_to :post
  accepts_nested_attributes_for :post
end

class BugTest < Minitest::Test
  def test_association_stuff
    post = Post.create!(comments_attributes: [{ text: 'blah' }])
    expected_changes = {"id"=>[nil, 1]}
    assert_equal expected_changes, post.saved_changes
  end
end
```
