### PR TITLE
Update aws-sdk-s3 dependency

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "aws-sdk-s3", "~> 1.14"
+gem "aws-sdk-s3", "~> 1.48"
 
 require "aws-sdk-s3"
 require "active_support/core_ext/numeric/bytes"


### PR DESCRIPTION
### Summary

After upgrading to `6.0.3.1` the direct upload functionality stopped working for us with `ArgumentError: unexpected value at params[:whitelist_headers]`.

The underlying reason was we used a bit dated version of `aws-sdk-s3`, `whitelist_headers` support was added in `1.48.0`:
https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-s3/CHANGELOG.md#1480-2019-08-30

### Other Information

Probably worth adding version requirement to `6.0.3.1` release notes as well, since the aws sdk dependency is optional, not sure it is tracked somewhere else.

Thank you!