### PR TITLE
Fix index options for if_not_exists/if_exists

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -98,9 +98,13 @@ module ActiveRecord
       #   index_exists?(:suppliers, :company_id, name: "idx_company_id")
       #
       def index_exists?(table_name, column_name, options = {})
-        column_names = Array(column_name).map(&:to_s)
         checks = []
-        checks << lambda { |i| Array(i.columns) == column_names }
+
+        if column_name.present?
+          column_names = Array(column_name).map(&:to_s)
+          checks << lambda { |i| Array(i.columns) == column_names }
+        end
+
         checks << lambda { |i| i.unique } if options[:unique]
         checks << lambda { |i| i.name == options[:name].to_s } if options[:name]
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -365,10 +365,9 @@ module ActiveRecord
       end
 
       def add_index(table_name, column_name, options = {}) #:nodoc:
-        return if options[:if_not_exists] && index_exists?(table_name, column_name, options)
-
         index, algorithm, _ = add_index_options(table_name, column_name, **options)
 
+        return if options[:if_not_exists] && index_exists?(table_name, column_name, name: index.name)
         create_index = CreateIndexDefinition.new(index, algorithm)
         execute schema_creation.accept(create_index)
       end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -73,13 +73,25 @@ module ActiveRecord
       end
 
       def test_add_index_which_already_exists_does_not_raise_error_with_option
-        connection.add_index(table_name, "foo", if_not_exists: true)
+        connection.add_index(table_name, "foo")
 
         assert_nothing_raised do
           connection.add_index(table_name, "foo", if_not_exists: true)
         end
 
         assert connection.index_name_exists?(table_name, "index_testings_on_foo")
+      end
+
+      def test_add_index_with_if_not_exists_matches_exact_index
+        connection.add_index(table_name, [:foo, :bar], unique: false, name: "index_testings_on_foo_bar")
+
+        assert connection.index_name_exists?(table_name, "index_testings_on_foo_bar")
+
+        assert_nothing_raised do
+          connection.add_index(table_name, [:foo, :bar], unique: true, if_not_exists: true)
+        end
+
+        assert connection.index_name_exists?(table_name, "index_testings_on_foo_and_bar")
       end
 
       def test_remove_index_which_does_not_exist_doesnt_raise_with_option
@@ -94,6 +106,16 @@ module ActiveRecord
         assert_nothing_raised do
           connection.remove_index(table_name, "foo", if_exists: true)
         end
+      end
+
+      def test_remove_index_with_name_which_does_not_exist_doesnt_raise_with_option
+        connection.add_index(table_name, [:foo], name: "foo")
+
+        assert connection.index_exists?(table_name, :foo, name: "foo")
+
+        connection.remove_index(table_name, nil, name: "foo", if_exists: true)
+
+        assert_not connection.index_exists?(table_name, :foo, name: "foo")
       end
 
       def test_internal_index_with_name_matching_database_limit


### PR DESCRIPTION
The `index_exists?` method wasn't very specific so when we added the
`if_not_exists` to `add_index` and `if_exists` to `remove_index` there
were a few cases where behavior was unexpected.

For `add_index` if you added a named index and then added a second index
with the same columns, but a different name, that index would not get
added because `index_exists` was looking only at column named and not at
the exact index name. We fixed `add_index` by moving the `index_exists`
check below `add_index_options` and pass `name` directly to
`index_exists` if there is a `if_not_exists` option.

For `remove_index` if you added a named index and then tried to remove
it with a nil column and a explicit name the index would not get removed
because `index_exists` saw a nil column. We fixed this by only doing the
column check in `index_exists` if `column` is present.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>