### PR TITLE
Clarify versioning strategy in maintenance policy

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -5,7 +5,7 @@ Maintenance Policy for Ruby on Rails
 
 Support of the Rails framework is divided into four groups: New features, bug
 fixes, security issues, and severe security issues. They are handled as
-follows, all versions in `X.Y.Z` format.
+follows, all versions, except for security releases, in `X.Y.Z`, format.
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Summary

Not all releases are using `X.Y.Z`. In fact there are many releases using the `X.Y.Z.N` version schema, which seems to be reserved for [security fixes](https://github.com/rails/rails/pull/38403) (which can have consequences for actually getting these fixes if they occur in npm packages, see https://github.com/rails/rails/issues/39351)
