### PR TITLE
Satisfy Rubocop

### DIFF
--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -490,7 +490,7 @@ module ActionDispatch
       private
         def _generate(route_name, options, recall)
           if recall
-            options = options.merge(:_recall => recall)
+            options = options.merge(_recall: recall)
           end
           path = @route_set.path_for(options, route_name)
           uri = URI.parse path


### PR DESCRIPTION
Fixes offense:

```
actionpack/test/journey/router_test.rb:493:37: C: Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
            options = options.merge(:_recall => recall)
                                    ^^^^^^^^^^^
```
