### PR TITLE
Introduce Resolver::PathParser 

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -67,4 +67,5 @@ autoload :Mime, "action_dispatch/http/mime_type"
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime::SET.symbols
   ActionView::Template::Types.delegate_to Mime
+  ActionView::LookupContext::DetailsKey.clear
 end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -116,4 +116,5 @@ autoload :Mime, "action_dispatch/http/mime_type"
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime::SET.symbols
   ActionView::Template::Types.delegate_to Mime
+  ActionView::LookupContext::DetailsKey.clear
 end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -35,7 +35,7 @@ module ActionView
       alias :to_s :to_str
     end
 
-    class PathParser
+    class PathParser # :nodoc:
       def initialize
         @regex = build_path_regex
       end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -35,6 +35,44 @@ module ActionView
       alias :to_s :to_str
     end
 
+    class PathParser
+      def initialize
+        @regex = build_path_regex
+      end
+
+      def build_path_regex
+        handlers = Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
+        formats = Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
+        locales = "[a-z]{2}(?:-[A-Z]{2})?"
+        variants = "[^.]*"
+
+        %r{
+          \A
+          (?:(?<prefix>.*)/)?
+          (?<partial>_)?
+          (?<action>.*?)
+          (?:\.(?<locale>#{locales}))??
+          (?:\.(?<format>#{formats}))??
+          (?:\+(?<variant>#{variants}))??
+          (?:\.(?<handler>#{handlers}))?
+          \z
+        }x
+      end
+
+      def parse(path)
+        match = @regex.match(path)
+        {
+          prefix: match[:prefix] || "",
+          action: match[:action],
+          partial: !!match[:partial],
+          locale: match[:locale]&.to_sym,
+          handler: match[:handler]&.to_sym,
+          format: match[:format]&.to_sym,
+          variant: match[:variant]
+        }
+      end
+    end
+
     # Threadsafe template cache
     class Cache #:nodoc:
       class SmallCache < Concurrent::Map
@@ -172,11 +210,13 @@ module ActionView
         @pattern = DEFAULT_PATTERN
       end
       @unbound_templates = Concurrent::Map.new
+      @path_parser = PathParser.new
       super()
     end
 
     def clear_cache
       @unbound_templates.clear
+      @path_parser = PathParser.new
       super()
     end
 
@@ -278,18 +318,11 @@ module ActionView
       # from the path, or the handler, we should return the array of formats given
       # to the resolver.
       def extract_handler_and_format_and_variant(path)
-        pieces = File.basename(path).split(".")
-        pieces.shift
+        details = @path_parser.parse(path)
 
-        extension = pieces.pop
-
-        handler = Template.handler_for_extension(extension)
-        format, variant = pieces.last.split(EXTENSIONS[:variants], 2) if pieces.last
-        format = if format
-          Template::Types[format]&.ref
-        elsif handler.respond_to?(:default_format) # default_format can return nil
-          handler.default_format
-        end
+        handler = Template.handler_for_extension(details[:handler])
+        format = details[:format] || handler.try(:default_format)
+        variant = details[:variant]
 
         # Template::Types[format] and handler.default_format can return nil
         [handler, format, variant]

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -18,9 +18,13 @@ end
 module TemplateHandlerHelper
   def with_template_handler(*extensions, handler)
     ActionView::Template.register_template_handler(*extensions, handler)
+    ActionController::Base.view_paths.paths.each(&:clear_cache)
+    ActionView::LookupContext::DetailsKey.clear
     yield
   ensure
     ActionView::Template.unregister_template_handler(*extensions)
+    ActionController::Base.view_paths.paths.each(&:clear_cache)
+    ActionView::LookupContext::DetailsKey.clear
   end
 end
 

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -148,22 +148,28 @@ module ResolverSharedTests
 
   def test_templates_sort_by_formats_json_first
     with_file "test/hello_world.html.erb", "Hello HTML!"
-    with_file "test/hello_world.json.jbuilder", "Hello JSON!"
+    with_file "test/hello_world.json.builder", "Hello JSON!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:json, :html], variants: :any, handlers: [:erb, :jbuilder])
+    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:json, :html], variants: :any, handlers: [:erb, :builder])
 
     assert_equal 2, templates.size
     assert_equal "Hello JSON!", templates[0].source
+    assert_equal :json, templates[0].format
+    assert_equal "Hello HTML!", templates[1].source
+    assert_equal :html, templates[1].format
   end
 
   def test_templates_sort_by_formats_html_first
     with_file "test/hello_world.html.erb", "Hello HTML!"
-    with_file "test/hello_world.json.jbuilder", "Hello JSON!"
+    with_file "test/hello_world.json.builder", "Hello JSON!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :jbuilder])
+    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
 
     assert_equal 2, templates.size
     assert_equal "Hello HTML!", templates[0].source
+    assert_equal :html, templates[0].format
+    assert_equal "Hello JSON!", templates[1].source
+    assert_equal :json, templates[1].format
   end
 
   def test_virtual_path_is_preserved_with_dot

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -204,8 +204,6 @@ module ResolverSharedTests
   end
 
   def test_templates_no_format_with_variant
-    return skip
-
     with_file "test/hello_world+mobile.erb", "Hello HTML!"
 
     templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
@@ -218,8 +216,6 @@ module ResolverSharedTests
   end
 
   def test_templates_no_format_or_handler_with_variant
-    return skip
-
     with_file "test/hello_world+mobile", "Hello HTML!"
 
     templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -172,6 +172,65 @@ module ResolverSharedTests
     assert_equal :json, templates[1].format
   end
 
+  def test_templates_with_variant
+    with_file "test/hello_world.html+mobile.erb", "Hello HTML!"
+
+    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+
+    assert_equal 1, templates.size
+    assert_equal "Hello HTML!", templates[0].source
+    assert_kind_of ActionView::Template::Handlers::ERB, templates[0].handler
+    assert_equal :html, templates[0].format
+    assert_equal "mobile", templates[0].variant
+  end
+
+  def test_finds_variants_in_order
+    with_file "test/hello_world.html+tricorder.erb", "Hello Spock!"
+    with_file "test/hello_world.html+lcars.erb", "Hello Geordi!"
+
+    tricorder = context.find("hello_world", "test", false, [], { variants: [:tricorder] })
+    lcars = context.find("hello_world", "test", false, [], { variants: [:lcars] })
+
+    assert_equal "Hello Spock!", tricorder.source
+    assert_equal "tricorder", tricorder.variant
+    assert_equal "Hello Geordi!", lcars.source
+    assert_equal "lcars", lcars.variant
+
+    templates = context.find_all("hello_world", "test", false, [], { variants: [:tricorder, :lcars] })
+    assert_equal [tricorder, lcars], templates
+
+    templates = context.find_all("hello_world", "test", false, [], { variants: [:lcars, :tricorder] })
+    assert_equal [lcars, tricorder], templates
+  end
+
+  def test_templates_no_format_with_variant
+    return skip
+
+    with_file "test/hello_world+mobile.erb", "Hello HTML!"
+
+    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+
+    assert_equal 1, templates.size
+    assert_equal "Hello HTML!", templates[0].source
+    assert_kind_of ActionView::Template::Handlers::ERB, templates[0].handler
+    assert_nil templates[0].format
+    assert_equal "mobile", templates[0].variant
+  end
+
+  def test_templates_no_format_or_handler_with_variant
+    return skip
+
+    with_file "test/hello_world+mobile", "Hello HTML!"
+
+    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+
+    assert_equal 1, templates.size
+    assert_equal "Hello HTML!", templates[0].source
+    assert_kind_of ActionView::Template::Handlers::Raw, templates[0].handler
+    assert_nil templates[0].format
+    assert_equal "mobile", templates[0].variant
+  end
+
   def test_virtual_path_is_preserved_with_dot
     with_file "test/hello_world.html.erb", "Hello html!"
 

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -62,7 +62,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
   end
 
   test "template digests are cleared before a request" do
-    assert_called(ActionView::LookupContext::DetailsKey, :clear) do
+    assert_called(ActionView::LookupContext::DetailsKey, :clear, times: 3) do
       get "/customers"
       assert_equal 200, last_response.status
     end

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -42,5 +42,47 @@ module ApplicationTests
       get "/pages/foo.bar"
       assert_equal 200, last_response.status
     end
+
+    test "New formats and handlers are detected from initializers" do
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          root to: 'pages#show'
+        end
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+        class PagesController < ApplicationController
+          layout false
+
+          def show
+            render :show, formats: [:awesome], handlers: [:rubby]
+          end
+        end
+      RUBY
+
+      app_file "app/views/pages/show.awesome.rubby", <<-RUBY
+        {
+          format: @current_template.format,
+          handler: @current_template.handler
+        }.inspect
+      RUBY
+
+      app_file "config/initializers/mime_types.rb", <<-RUBY
+        Mime::Type.register "text/awesome", :awesome
+      RUBY
+
+      app_file "config/initializers/template_handlers.rb", <<-RUBY
+        module RubbyHandler
+          def self.call(_, source)
+            source
+          end
+        end
+        ActionView::Template.register_template_handler(:rubby, RubbyHandler)
+      RUBY
+
+      get "/"
+      assert_equal 200, last_response.status
+      assert_equal "{:format=>:awesome, :handler=>RubbyHandler}", last_response.body
+    end
   end
 end


### PR DESCRIPTION
The template resolver is supposed to determine the handler, format, and variant from the path in extract_handler_and_format_and_variant.

Previously this behaviour was close but didn't exactly match the behaviour of finding templates, and in some cases (particularly with handlers or formats missing) would return incorrect results. I've added previously failing test for where the variant was misdetected.

This commit introduces Resolver::PathParser, a class which should be able to accurately from any path inside a view directory be able to tell us exactly the prefix, partial, variant, locale, format, variant, and handler of that template.

This works by building a building a regexp from the known handlers and file types. This requires that any resolvers have their cache cleared when new handlers or types are registered (this was already somewhat the requirement, since resolver lookups are cached, but this makes it necessary in more situations).

---

Keen readers will note that there's now two different regexes being made in this file 😓. One for finding files and this new one. In a follow up PR #39362 I intend to replace the find logic to instead use this regex, which will require some extra filtering. This will be possible because we have deprecated `.`s from being part of the action name, making the template names unambiguously refer to these properties.

This could also allow us in the future to offer `did_you_mean` style suggestions on missing templates (I really love these changes we've been seeing), or even parsing the entire `app/views` directory at boot (or on the first `render` call) and warning the user about any template's extensions we don't understand.

Thanks for reading ❤️