### PR TITLE
Use html for DidYouMean suggestions on error pages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb
@@ -1,0 +1,18 @@
+<% if exception.respond_to?(:original_message) && exception.respond_to?(:corrections) %>
+  <h2><%= h exception.original_message %></h2>
+  <%
+    # The 'did_you_mean' gem can raise exceptions when calling #corrections on
+    # the exception. If it does there are no corrections to show.
+    corrections = exception.corrections rescue []
+  %>
+  <% if corrections.any? %>
+    <b>Did you mean?</b>
+    <ul>
+    <% corrections.each do |correction| %>
+      <li style="list-style-type: none"><%= h correction %></li>
+    <% end %>
+    </ul>
+  <% end %>
+<% else %>
+  <h2><%= h exception.message %></h2>
+<% end %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -8,11 +8,8 @@
 </header>
 
 <div id="container">
-  <h2>
-    <%= h @exception.message %>
-
-    <%= render "rescues/actions", exception: @exception, request: @request %>
-  </h2>
+  <%= render "rescues/message_and_suggestions", exception: @exception %>
+  <%= render "rescues/actions", exception: @exception, request: @request %>
 
   <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx, error_index: 0 %>
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show, error_index: 0 %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
@@ -2,5 +2,5 @@
   <h1>Unknown action</h1>
 </header>
 <div id="container">
-  <h2><%= h @exception.message %></h2>
+  <%= render "rescues/message_and_suggestions", exception: @exception %>
 </div>

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -17,6 +17,12 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  class SimpleController < ActionController::Base
+    def hello
+      self.response_body = "hello"
+    end
+  end
+
   class Boomer
     attr_accessor :closed
 
@@ -67,7 +73,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       when "/pass"
         [404, { "X-Cascade" => "pass" }, self]
       when "/not_found"
-        raise AbstractController::ActionNotFound
+        controller = SimpleController.new
+        raise AbstractController::ActionNotFound.new(nil, controller, :not_found)
       when "/runtime_error"
         raise RuntimeError
       when "/method_not_allowed"
@@ -101,7 +108,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       when "/missing_keys"
         raise ActionController::UrlGenerationError, "No route matches"
       when "/parameter_missing"
-        raise ActionController::ParameterMissing, :missing_param_key
+        raise ActionController::ParameterMissing.new(:missing_param_key, %w(valid_param_key))
       when "/original_syntax_error"
         eval "broke_syntax =" # `eval` need for raise native SyntaxError at runtime
       when "/syntax_error_into_view"
@@ -307,6 +314,22 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_no_match(/<body>/, body)
     assert_equal "application/json", response.media_type
     assert_match(/ActionController::ParameterMissing/, body)
+  end
+
+  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+    test "rescue with suggestions" do
+      @app = DevelopmentApp
+
+      get "/not_found", headers: { "action_dispatch.show_exceptions" => true }
+      assert_response 404
+      assert_select("b", /Did you mean\?/)
+      assert_select("li", "hello")
+
+      get "/parameter_missing", headers: { "action_dispatch.show_exceptions" => true }
+      assert_response 400
+      assert_select("b", /Did you mean\?/)
+      assert_select("li", "valid_param_key")
+    end
   end
 
   test "rescue with HTML format for HTML API request" do


### PR DESCRIPTION
### Summary

The current suggestions are shown on a single line.
Instead we can use some prettier formatting.

### Before
![image](https://user-images.githubusercontent.com/28561/82420959-af8d8400-9a80-11ea-90cb-410cc5cf1eee.png)
![image](https://user-images.githubusercontent.com/28561/82421026-c03dfa00-9a80-11ea-909b-b8314c1dde73.png)

### After
![image](https://user-images.githubusercontent.com/28561/82420894-9d134a80-9a80-11ea-958e-503ab4b1df3d.png)
![image](https://user-images.githubusercontent.com/28561/82421073-cfbd4300-9a80-11ea-85f8-2e6a058f249a.png)
