### PR TITLE
This is causing problems in master wrt backtraces

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -17,8 +17,6 @@ module Rails
       end
 
       if output_inline? && result.failure && (!result.skipped? || options[:verbose])
-        result.failures.each { |f| f.backtrace.clear } if result.error?
-
         io.puts
         io.puts
         io.puts color_output(result, by: result)


### PR DESCRIPTION
Before #39304 was merged, backtraces would look like this:

```
$ be ruby -I lib:test test/controller/request_forgery_protection_test.rb -n test_ignores_trailing_slash_during_generation
Run options: -n test_ignores_trailing_slash_during_generation --seed 22205

E

Error:
PerFormTokensControllerTest#test_ignores_trailing_slash_during_generation:
NoMethodError: undefined method `have_cookie_jar?' for #<Object:0x00007f9ce19b9620>
    /Users/aaron/git/rails/actionpack/lib/action_controller/test_case.rb:522:in `ensure in process'
    /Users/aaron/git/rails/actionpack/lib/action_controller/test_case.rb:542:in `process'
    /Users/aaron/git/rails/actionpack/lib/action_controller/test_case.rb:395:in `get'
    test/controller/request_forgery_protection_test.rb:1005:in `test_ignores_trailing_slash_during_generation'

rails test test/controller/request_forgery_protection_test.rb:1004

Finished in 0.213230s, 4.6898 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

After #39304 was merged they look like this:

```
$ be ruby -I lib:test test/controller/request_forgery_protection_test.rb -n test_ignores_trailing_slash_during_generation
Run options: -n test_ignores_trailing_slash_during_generation --seed 62892

E

Error:
PerFormTokensControllerTest#test_ignores_trailing_slash_during_generation:
NoMethodError: undefined method `have_cookie_jar?' for #<Object:0x00007fa6d60193c8>

rails test test/controller/request_forgery_protection_test.rb:1004

Finished in 0.211953s, 4.7180 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

This patch reverts the part of #39304 that removes the backtrace.

/cc @zenspider
