### PR TITLE
Allow protocol to be overridden in route helpers

### DIFF
--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -228,7 +228,7 @@ module ActionView
       #   asset_url "application.js", host: "http://cdn.example.com" # => http://cdn.example.com/assets/application.js
       #
       def asset_url(source, options = {})
-        path_to_asset(source, options.merge(protocol: :request))
+        path_to_asset(source, { protocol: :request }.merge!(options))
       end
       alias_method :url_to_asset, :asset_url # aliased to avoid conflicts with an asset_url named route
 


### PR DESCRIPTION
### Summary

This fixes url helpers that are used outside of a web request. I am facing this issue while rendering images in an email view. The email is rendered in a background job where no request is present.

I'd like to use `image_url('logo.png', protocol: :https)`. Instead I have to use `asset_path('logo.png', type: :image, protocol: :https)`. In both cases, I've configured `Rails.application.config.action_controller.asset_host`.

### Other Information
 
I've discovered that adding the protocol to the configured asset_host also achieves the functionality that I want and allows me to use `image_url('logo.png')` directly but it doesn't seem quite correct to include the protocol in the host value.