### PR TITLE
Add render_in support to capture helper

### DIFF
--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -40,9 +40,16 @@ module ActionView
       #
       #   @greeting # => "Welcome to my shiny new web page! The date and time is 2018-09-06 11:09:16 -0500"
       #
-      def capture(*args)
+      def capture(*args, &block)
         value = nil
-        buffer = with_output_buffer { value = yield(*args) }
+        block_context = block.binding.receiver
+
+        buffer = if block_context.respond_to?(:render_in) && block_context.respond_to?(:with_output_buffer)
+          block_context.with_output_buffer { value = yield(*args) }
+        else
+          with_output_buffer { value = yield(*args) }
+        end
+
         if (string = buffer.presence || value) && string.is_a?(String)
           ERB::Util.html_escape string
         end

--- a/actionview/test/lib/test_form_components.rb
+++ b/actionview/test/lib/test_form_components.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class FormLabelComponent < ActionView::Base
+  def initialize(form:)
+    @form = form
+  end
+
+  # Returns ActionView::OutputBuffer.
+  def render_in(view_context, &block)
+    @view_context = view_context
+    @output_buffer = ActionView::OutputBuffer.new
+
+    template = ActionView::Template::Handlers::ERB.erb_implementation.new(<<~'erb', trim: true).src
+      <%= @form.label :title do %>
+        Test
+      <% end %>
+    erb
+
+    eval(template)
+  end
+end
+
+class FieldsForComponent < ActionView::Base
+  def initialize(form:, comment:)
+    @form = form
+    @comment = comment
+  end
+
+  # Returns ActionView::OutputBuffer.
+  def render_in(view_context, &block)
+    @view_context = view_context
+    @output_buffer = ActionView::OutputBuffer.new
+
+    template = ActionView::Template::Handlers::ERB.erb_implementation.new(<<~'erb', trim: true).src
+      <%= @form.fields_for "comment[]", @comment do |c| %>
+        <%= c.text_field(:name) %>
+      <% end %>
+    erb
+
+    eval(template)
+  end
+end
+
+class FieldsComponent < ActionView::Base
+  def initialize(form:)
+    @form = form
+  end
+
+  # Returns ActionView::OutputBuffer.
+  def render_in(view_context, &block)
+    @view_context = view_context
+    @output_buffer = ActionView::OutputBuffer.new
+
+    template = ActionView::Template::Handlers::ERB.erb_implementation.new(<<~'erb', trim: true).src
+      <%= @form.fields :comment do |c| %>
+        <%= c.text_field(:dont_exist_on_model ) %>
+      <% end %>
+    erb
+
+    eval(template)
+  end
+end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "controller/fake_models"
+require "test_form_components"
 
 class FormWithTest < ActionView::TestCase
   include RenderERBUtils
@@ -1076,6 +1077,18 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: :patch) do
       '<input type="text" name="post[comment][dont_exist_on_model]" id="post_comment_dont_exist_on_model" >'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_fields_render_in
+    form_with(model: @post) do |f|
+      concat view.render(FieldsComponent.new(form: f))
+    end
+
+    expected = whole_form("/posts/123", method: :patch) do
+      %Q(\n  <input type="text" name="post[comment][dont_exist_on_model]" id="post_comment_dont_exist_on_model">\n)
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
### Summary

Currently when using some form helpers along with `render_in` the output
is rendered out of order due to the use of `capture`. This happens
because the `capture` helper calls `with_output_buffer` on `self` when
the passed in block might be called in a different rendering context
with its own `@output_buffer`. Since the block is being evaluated in
that different rendering context setting `@output_buffer` via
`with_output_buffer` doesn't actually capture the content, but instead
renders the content directly into the block's rendering context's
`output_buffer`.

For example, if we have the following template:

```erb
<%= form_for @person do |f| %>
  <%= render InputComponent.new(form: f) %>
<% end %>
```

and this very simplified component template:

```erb
<%# InputComponent template %>
<%= form.label do %>
  Name
  <%= form.text_field :name %>
<% end %>
```

We will get rendered HTML that looks something like:

```html
<form>
  Name
  <input type="text" name="name">
  <label for="name"><label>
</form>
```

When we would expect:

```html
<form>
  <label for="name">
    Name
    <input type="text" name="name">
  <label>
</form>
```

This happens because the `form_for` builder keeps a reference to the
template object it was instantiated which is the object that label calls
`capture` on.

To resolve this issue, each time `capture` is called we retrieve the
`block`s rendering context and check if it responds to `render_in` and
`with_output_buffer`. This lets us override the correct `@output_buffer`
so we can capture the content and render it in the correct part of the
template.