### PR TITLE
Fix through association to respect source scope for `includes`/`preload`

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -132,7 +132,9 @@ module ActiveRecord
           end
 
           def reflection_scope
-            @reflection_scope ||= reflection.scope ? reflection.scope_for(klass.unscoped) : klass.unscoped
+            @reflection_scope ||= begin
+              reflection.join_scopes(klass.arel_table, klass.predicate_builder).inject(klass.unscoped, &:merge!)
+            end
           end
 
           def build_scope
@@ -142,7 +144,7 @@ module ActiveRecord
               scope.where!(reflection.type => model.polymorphic_name)
             end
 
-            scope.merge!(reflection_scope) if reflection.scope
+            scope.merge!(reflection_scope) unless reflection_scope.empty_scope?
 
             if preload_scope && !preload_scope.empty_scope?
               scope.merge!(preload_scope)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1055,6 +1055,12 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_through_with_source_scope
+    expected = [readers(:michael_welcome).becomes(LazyReader)]
+    assert_equal expected, Author.preload(:lazy_readers_skimmers_or_not).first.lazy_readers_skimmers_or_not
+    assert_equal expected, Author.eager_load(:lazy_readers_skimmers_or_not).first.lazy_readers_skimmers_or_not
+  end
+
   def test_has_many_through_polymorphic_with_rewhere
     post = TaggedPost.create!(title: "Tagged", body: "Post")
     tag = post.tags.create!(name: "Tag")

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -517,7 +517,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   def test_nested_has_many_through_with_conditions_on_through_associations_preload
     assert_empty Author.where("tags.id" => 100).joins(:misc_post_first_blue_tags)
 
-    author = assert_queries(3) { Author.includes(:misc_post_first_blue_tags).third }
+    author = assert_queries(2) { Author.includes(:misc_post_first_blue_tags).third }
     blue = tags(:blue)
 
     assert_no_queries do
@@ -538,7 +538,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_nested_has_many_through_with_conditions_on_source_associations_preload
-    author = assert_queries(4) { Author.includes(:misc_post_first_blue_tags_2).third }
+    author = assert_queries(2) { Author.includes(:misc_post_first_blue_tags_2).third }
     blue = tags(:blue)
 
     assert_no_queries do

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -176,6 +176,8 @@ class Author < ActiveRecord::Base
 
   has_many :topics, primary_key: "name", foreign_key: "author_name"
 
+  has_many :lazy_readers_skimmers_or_not, through: :posts
+
   attr_accessor :post_log
   after_initialize :set_post_log
 


### PR DESCRIPTION
`reflection.scope` is not aware of all source scopes if the association
is through association.

It should use `reflection.join_scopes` for that.

Fixes #39376.