### PR TITLE
Decoding JSON dates should respect newlines

### DIFF
--- a/activesupport/lib/active_support/json/decoding.rb
+++ b/activesupport/lib/active_support/json/decoding.rb
@@ -10,8 +10,8 @@ module ActiveSupport
 
   module JSON
     # matches YAML-formatted dates
-    DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
-    DATETIME_REGEX = /^(?:\d{4}-\d{2}-\d{2}|\d{4}-\d{1,2}-\d{1,2}[T \t]+\d{1,2}:\d{2}:\d{2}(\.[0-9]*)?(([ \t]*)Z|[-+]\d{2}?(:\d{2})?)?)$/
+    DATE_REGEX = /\A\d{4}-\d{2}-\d{2}\z/
+    DATETIME_REGEX = /\A(?:\d{4}-\d{2}-\d{2}|\d{4}-\d{1,2}-\d{1,2}[T \t]+\d{1,2}:\d{2}:\d{2}(\.[0-9]*)?(([ \t]*)Z|[-+]\d{2}?(:\d{2})?)?)\z/
 
     class << self
       # Parses a JSON string (JavaScript Object Notation) into a hash.

--- a/activesupport/test/json/decoding_test.rb
+++ b/activesupport/test/json/decoding_test.rb
@@ -40,6 +40,8 @@ class TestJSONDecoding < ActiveSupport::TestCase
     # needs to be *exact*
     %({"a": " 2007-01-01 01:12:34 Z "})          => { "a" => " 2007-01-01 01:12:34 Z " },
     %({"a": "2007-01-01 : it's your birthday"})  => { "a" => "2007-01-01 : it's your birthday" },
+    %({"a": "Today is:\\n2020-05-21"})           => { "a" => "Today is:\n2020-05-21" },
+    %({"a": "2007-01-01 01:12:34 Z\\nwas my birthday"}) => { "a" => "2007-01-01 01:12:34 Z\nwas my birthday" },
     %([])    => [],
     %({})    => {},
     %({"a":1}) => { "a" => 1 },


### PR DESCRIPTION
### Summary

The two regex' used for decoding dates within JSON objects were matching on beginning and end of line instead of string.

This pull-request updates the two regex' with `\A` and `\z` to accommodate newlines within strings and adds two new test cases for these as well. 

### Other Information

Fixes https://github.com/rails/rails/issues/39382
