### PR TITLE
Docs: incorrect `use_sha1_digests` default

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -788,7 +788,7 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.time_precision` sets the precision of JSON encoded time values. Defaults to `3`.
 
-* `config.active_support.use_sha1_digests` specifies whether to use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header. Defaults to false.
+* `config.active_support.use_sha1_digests` specifies whether to use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header. Defaults to true.
 
 * `config.active_support.use_authenticated_message_encryption` specifies whether to use AES-256-GCM authenticated encryption as the default cipher for encrypting messages instead of AES-256-CBC. This is false by default.
 


### PR DESCRIPTION
This defaults to `true` on new Rails apps. See https://github.com/rails/rails/blob/master/railties/lib/rails/application/configuration.rb#L117
