### PR TITLE
Docs: bad default for `default_protect_from_forgery`

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -496,7 +496,7 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.per_form_csrf_tokens` configures whether CSRF tokens are only valid for the method/action they were generated for.
 
-* `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController::Base`. This is false by default.
+* `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController::Base`. This is true by default.
 
 * `config.action_controller.relative_url_root` can be used to tell Rails that you are [deploying to a subdirectory](configuring.html#deploy-to-a-subdirectory-relative-url-root). The default is `ENV['RAILS_RELATIVE_URL_ROOT']`.
 


### PR DESCRIPTION
On a new Rails 6 app this defaults to true.

It is a bit confusing though, in that [here](https://github.com/rails/rails/blob/v6.0.3.1/railties/lib/rails/application/configuration.rb#L117) it's `true` but [here](https://github.com/rails/rails/blob/v6.0.3.1/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L99) it's `false`. Should I update the code to be consistent also?