### PR TITLE
make expiring memcache writes more efficient

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -146,7 +146,7 @@ module ActiveSupport
           expires_in = options[:expires_in].to_i
           if expires_in > 0 && !options[:raw]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
-            expires_in += 5.minutes
+            expires_in += 5.minutes.to_i
           end
           rescue_error_with false do
             @data.with { |c| c.send(method, key, value, expires_in, **options) }


### PR DESCRIPTION
### Summary

integer-to-integer math is roughly twice as efficient as integer-to-duration or duration-to-duration math (see benchmarks below).  For a potentially high volume operation like this where one side of the equation is already being given the `to_i` treatment and the other side is a whole integer value, it seems strictly better to `to_i` the other side.

### Other Information

```
pry(main)> n = 5000000
pry(main)> Benchmark.bm do |x|
pry(main)*   x.report { for i in 1..n; a = 5.minutes.to_i + 5.minutes.to_i; end }
pry(main)*   x.report { for i in 1..n; a = 5.minutes.to_i + 5.minutes; end }
pry(main)*   x.report { for i in 1..n; a = 5.minutes + 5.minutes; end }
pry(main)* end
       user     system      total        real
   6.501673   0.017579   6.519252 (  6.535457)
  13.594478   0.033289  13.627767 ( 13.654871)
  12.253478   0.033972  12.287450 ( 12.317427)
```

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
