### PR TITLE
Allow Erubi bufvar to be configured

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -14,10 +14,10 @@ module ActionView
             # Dup properties so that we don't modify argument
             properties = Hash[properties]
 
+            properties[:bufvar]     ||= "@output_buffer"
             properties[:preamble]   ||= ""
-            properties[:postamble]  ||= "@output_buffer.to_s"
+            properties[:postamble]  ||= "#{properties[:bufvar]}.to_s"
 
-            properties[:bufvar]     = "@output_buffer"
             properties[:escapefunc] = ""
 
             super
@@ -39,7 +39,7 @@ module ActionView
             if text == "\n"
               @newline_pending += 1
             else
-              src << "@output_buffer.safe_append='"
+              src << bufvar << ".safe_append='"
               src << "\n" * @newline_pending if @newline_pending > 0
               src << text.gsub(/['\\]/, '\\\\\&')
               src << "'.freeze;"
@@ -54,9 +54,9 @@ module ActionView
             flush_newline_if_pending(src)
 
             if (indicator == "==") || @escape
-              src << "@output_buffer.safe_expr_append="
+              src << bufvar << ".safe_expr_append="
             else
-              src << "@output_buffer.append="
+              src << bufvar << ".append="
             end
 
             if BLOCK_EXPR.match?(code)
@@ -78,7 +78,7 @@ module ActionView
 
           def flush_newline_if_pending(src)
             if @newline_pending > 0
-              src << "@output_buffer.safe_append='#{"\n" * @newline_pending}'.freeze;"
+              src << bufvar << ".safe_append='#{"\n" * @newline_pending}'.freeze;"
               @newline_pending = 0
             end
           end

--- a/actionview/test/template/erb/erbubi_test.rb
+++ b/actionview/test/template/erb/erbubi_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_view/template/handlers/erb/erubi"
+
+class ErubiTest < ActiveSupport::TestCase
+  test "can configure bufvar" do
+    template = <<~ERB
+      foo
+
+      <%= "foo".upcase %>
+
+      <%== "foo".length %>
+    ERB
+
+    baseline = ActionView::Template::Handlers::ERB::Erubi.new(template)
+    erubi = ActionView::Template::Handlers::ERB::Erubi.new(template, bufvar: "boofer")
+
+    assert_equal baseline.src.gsub("#{baseline.bufvar}.", "boofer."), erubi.src
+  end
+end


### PR DESCRIPTION
This allows `render_in` components that compile their own templates to use their view context's current output buffer while a `with_output_buffer` block is being evaluated.

Partially addresses #39377.
