### PR TITLE
Use DidYouMean for associations not found for join

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -202,7 +202,7 @@ module ActiveRecord
 
         def find_reflection(klass, name)
           klass._reflect_on_association(name) ||
-            raise(ConfigurationError, "Can't join '#{klass.name}' to association named '#{name}'; perhaps you misspelled it?")
+            raise(AssociationForJoinNotFoundError.new(klass, name))
         end
 
         def build(associations, base_klass)


### PR DESCRIPTION
### Summary
If an association isn't found for a join we can suggest similar associations:

A new error (`AssociationForJoinNotFoundError`) is introduced to handle
the corrections because `ConfigurationError` is used in other places as well.

```
class Post
  has_many :comments
end

Post.includes(:nonexistent_relation).where(nonexistent_relation: { name: "Rochester" }).find(1)

Can't join 'Post' to association named 'nonexistent_relation'; perhaps you misspelled it?
Did you mean?  comments
```