### PR TITLE
Reduce allocations in action_view cache expiry

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -42,8 +42,7 @@ module ActionView
 
     private
       def dirs_to_watch
-        fs_paths = all_view_paths.grep(FileSystemResolver)
-        fs_paths.map(&:path).sort.uniq
+        all_view_paths.grep(FileSystemResolver).map!(&:path).tap(&:uniq!).sort!
       end
 
       def all_view_paths


### PR DESCRIPTION
### Summary

Reduce a few allocations in cache expiry `dirs_to_watch`. There's a minimal IPS improvement too.

Basically, switch to use the mutating version of the array methods. Also, flipped the order of `sort!` and `uniq!`. Removing duplicates first may speed up sorting slightly.

#### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory"
  gem "listen"
end

module ActionView
  class CacheExpiry
    def fast_dirs_to_watch
      fs_paths = ActionView::ViewPaths
        .all_view_paths
        .flat_map(&:paths)
        .grep(FileSystemResolver)
        .map!(&:path)

      fs_paths.uniq!
      fs_paths.sort!
    end
  end
end

path_set = ActionView::PathSet.new((0..100_000).map { |i| "foo_#{i}" }).freeze
ActionView::ViewPaths.set_view_paths(self, path_set)
executor = ActionView::CacheExpiry.new(watcher: ActiveSupport::EventedFileUpdateChecker)

puts "IPS"
Benchmark.ips do |x|
  x.report("dirs_to_watch")      { executor.send(:dirs_to_watch) }
  x.report("fast_dirs_to_watch") { executor.send(:fast_dirs_to_watch) }
  x.compare!
end

puts "MEMORY"
Benchmark.memory do |x|
  x.report("dirs_to_watch")      { executor.send(:dirs_to_watch) }
  x.report("fast_dirs_to_watch") { executor.send(:fast_dirs_to_watch) }
  x.compare!
end
```
#### Results
```
IPS
Warming up --------------------------------------
       dirs_to_watch     1.000  i/100ms
  fast_dirs_to_watch     1.000  i/100ms
Calculating -------------------------------------
       dirs_to_watch      8.016  (±12.5%) i/s -     39.000  in   5.038087s
  fast_dirs_to_watch      8.236  (±12.1%) i/s -     40.000  in   5.034429s

Comparison:
  fast_dirs_to_watch:        8.2 i/s
       dirs_to_watch:        8.0 i/s - same-ish: difference falls within error

MEMORY
Calculating -------------------------------------
       dirs_to_watch     4.222M memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
  fast_dirs_to_watch     1.822M memsize (     0.000  retained)
                         5.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
  fast_dirs_to_watch:    1821888 allocated
       dirs_to_watch:    4222032 allocated - 2.32x more
```