### PR TITLE
Add support for eager loading all rich text associations at once

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `with_all_rich_text` method to eager load all rich text associations on a model at once
+
+    *Matt Swanson*, *DHH*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Declare `ActionText::FixtureSet.attachment` to generate an

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -45,6 +45,16 @@ module ActionText
         scope :"with_rich_text_#{name}", -> { includes("rich_text_#{name}") }
         scope :"with_rich_text_#{name}_and_embeds", -> { includes("rich_text_#{name}": { embeds_attachments: :blob }) }
       end
+
+      # Eager load all dependent RichText models in bulk.
+      def with_all_rich_text
+        eager_load(rich_text_association_names)
+      end
+
+      private
+        def rich_text_association_names
+          reflect_on_all_associations(:has_one).select { |r| r.name =~ /^rich_text_/ }.collect(&:name)
+        end
     end
   end
 end

--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -53,7 +53,7 @@ module ActionText
 
       private
         def rich_text_association_names
-          reflect_on_all_associations(:has_one).select { |r| r.name =~ /^rich_text_/ }.collect(&:name)
+          reflect_on_all_associations(:has_one).collect(&:name).select { |n| n.start_with?("rich_text_") }
         end
     end
   end

--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -22,6 +22,27 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
 end
 
 class ActiveSupport::TestCase
+  def assert_queries(num)
+    ActiveRecord::Base.connection.materialize_transactions
+    count = 0
+    queries = []
+
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      unless ["SCHEMA", "TRANSACTION"].include? payload[:name]
+        count += 1
+        queries << payload[:sql]
+      end
+    end
+
+    result = yield
+    assert_equal num, count, "#{count} instead of #{num} queries were executed. #{queries.inspect}"
+    result
+  end
+
+  def assert_no_queries(&block)
+    assert_queries(0, &block)
+  end
+
   private
     def create_file_blob(filename:, content_type:, metadata: nil)
       ActiveStorage::Blob.create_and_upload! io: file_fixture(filename).open, filename: filename, content_type: content_type, metadata: metadata

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -86,4 +86,23 @@ class ActionText::ModelTest < ActiveSupport::TestCase
       assert_kind_of ActionText::RichText, message.content
     end
   end
+
+  test "eager loading" do
+    Message.create!(subject: "Subject", content: "<h1>Content</h1>")
+
+    message = assert_queries(2) { Message.with_rich_text_content.last }
+    assert_no_queries do
+      assert_equal "Content", message.content.to_plain_text
+    end
+  end
+
+  test "eager loading all rich text" do
+    Message.create!(subject: "Subject", content: "<h1>Content</h1>", body: "<h2>Body</h2>")
+
+    message = assert_queries(1) { Message.with_all_rich_text.last }
+    assert_no_queries do
+      assert_equal "Content", message.content.to_plain_text
+      assert_equal "Body", message.body.to_plain_text
+    end
+  end
 end


### PR DESCRIPTION
### Summary

ActionText provides `with_rich_text_#{name}` helpers to make it easy to preload rich text associations. This works great for single rich text fields on a model, but if you have multiple rich text fields, it will cause multiple queries to the ActionText table to load each one.

Consider the case of a model with lots of dynamic, user-generated content

```ruby
class Page < ApplicationRecord
  has_rich_text :header
  has_rich_text :sub_header
  has_rich_text :content
  has_rich_text :aside
  has_rich_text :footer
  ...
end
```

When trying to display all of the content for a `Page` using eager loading:

```ruby
Page
  .with_rich_text_header
  .with_rich_text_sub_header
  .with_rich_text_content
  .with_rich_text_aside
  .with_rich_text_footer
  .find(params[:id])
```

Rails will run a total of 6 queries (one to load `Page`, six individual `ActionText` loads).

This PR adds a `with_all_rich_text` that uses `eager_load` and reflects on `has_rich_text` associations to bulk load all rich text associations.

```ruby
Page.with_all_rich_text.find(params[:id])
```

### Other Information

Per #37976, ActionText internals are [currently in-flux](https://github.com/rails/rails/pull/37976#issuecomment-605503076) but wanted to see if there was interest in adding this feature in a future release, or if it fits better as an application-specific helper.