### PR TITLE
Test Attached::Many in Attached::Many test

### DIFF
--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -325,12 +325,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching an existing blob from a signed ID to a new record" do
     User.new(name: "Jason").tap do |user|
-      user.avatar.attach create_blob(filename: "funky.jpg").signed_id
+      user.highlights.attach create_blob(filename: "funky.jpg").signed_id
       assert user.new_record?
-      assert_equal "funky.jpg", user.avatar.filename.to_s
+      assert_equal "funky.jpg", user.highlights.first.filename.to_s
 
       user.save!
-      assert_equal "funky.jpg", user.reload.avatar.filename.to_s
+      assert_equal "funky.jpg", user.reload.highlights.first.filename.to_s
     end
   end
 


### PR DESCRIPTION
This exact test [exists in `one_test.rb`](https://github.com/rails/rails/blob/b1f6d8c8d8ad3e2e5b96e95b455c70f2c895ce14/activestorage/test/models/attached/one_test.rb#L341-L350).  It was probably overlooked after being copied and pasted.
