### PR TITLE
Deduplicate same clauses in `merge`

### DIFF
--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -24,7 +24,7 @@ module ActiveRecord
           predicates_unreferenced_by(other)
         end
 
-        WhereClause.new(predicates + other.predicates)
+        WhereClause.new(predicates | other.predicates)
       end
 
       def except(*columns)


### PR DESCRIPTION
Related to #39328, #39358.

For now, `merge` cannot override non-equality clauses, so non-equality
clauses will easily be duplicated by `merge`.

This deduplicates redundant same clauses in `merge`.
