### PR TITLE
Take a primay_key in count in the ActiveRecord::SignedId.find_signed

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -40,8 +40,10 @@ module ActiveRecord
       #   travel_back
       #   User.find_signed signed_id, purpose: :password_reset # => User.first
       def find_signed(signed_id, purpose: nil)
+        raise UnknownPrimaryKey.new(@klass) if primary_key.nil?
+
         if id = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose))
-          find_by id: id
+          find_by primary_key => id
         end
       end
 

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -3,18 +3,33 @@
 require "cases/helper"
 require "models/account"
 require "models/company"
+require "models/toy"
+require "models/matey"
 
 SIGNED_ID_VERIFIER_TEST_SECRET = "This is normally set by the railtie initializer when used with Rails!"
 
 ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
 
 class SignedIdTest < ActiveRecord::TestCase
-  fixtures :accounts
+  fixtures :accounts, :toys
 
-  setup { @account = Account.first }
+  setup do
+    @account = Account.first
+    @toy = Toy.first
+  end
 
   test "find signed record" do
     assert_equal @account, Account.find_signed(@account.signed_id)
+  end
+
+  test "find signed record with custom primary key" do
+    assert_equal @toy, Toy.find_signed(@toy.signed_id)
+  end
+
+  test "raise UnknownPrimaryKey when model have no primary key" do
+    assert_raises(ActiveRecord::UnknownPrimaryKey) do
+      Matey.find_signed("this will not be even verified")
+    end
   end
 
   test "find signed record with a bang" do


### PR DESCRIPTION
### Summary

Make a new `ActiveRecord::SignedId.find_signed` that @dhh added in a #39313, behave more like a `ActiveRecord::FinderMethods.find`, by taking the `primary_key` in count. Current variant of the `.find_signed` method will result in an error if a custom `primary_key` is used. It's because `#signed_id` uses the `ActiveRecord::AttributeMethods::PrimaryKey#id` resulting the `primary_key` is resolved, but the`.find_signed` uses a Symbol `:id` key.