### PR TITLE
Copy options before delegating in with_options

### DIFF
--- a/activesupport/lib/active_support/option_merger.rb
+++ b/activesupport/lib/active_support/option_merger.rb
@@ -38,7 +38,7 @@ module ActiveSupport
         end
       else
         def invoke_method(method, arguments, options, &block)
-          arguments << options if options
+          arguments << options.dup if options
           @context.__send__(method, *arguments, &block)
         end
       end

--- a/activesupport/test/option_merger_test.rb
+++ b/activesupport/test/option_merger_test.rb
@@ -37,6 +37,12 @@ class OptionMergerTest < ActiveSupport::TestCase
     end
   end
 
+  def test_method_with_options_copies_options_when_options_are_missing
+    with_options(@options) do |o|
+      assert_not_same @options, o.method_with_options
+    end
+  end
+
   def test_method_with_options_allows_to_overwrite_options
     local_options = { hello: "moon" }
     assert_equal @options.keys, local_options.keys


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/39343.

cd31e113c0663dabcdc293d9e7dc3b6e1392db5d switched to passing options as keyword arguments, which always creates a new hash.

9e4ff29f748b05c3a949f0d75167950039b6cda8 removed a now-unnecessary call to `dup`, since the options could no longer be accidentally mutated.

a55620f3fa89d957817349e5170f686d505eeee4 switched back to passing options as a positional argument for Ruby < 2.7, but didn't restore the call to `dup`, which meant that the same options hash was now passed with every method call and mutations leaked from one call to another.