### PR TITLE
Remove unused `limit` on `enum` and `set` columns in MySQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -558,17 +558,8 @@ module ActiveRecord
           m.alias_type %r(year)i,          "integer"
           m.alias_type %r(bit)i,           "binary"
 
-          m.register_type(%r(enum)i) do |sql_type|
-            limit = sql_type[/^enum\s*\((.+)\)/i, 1]
-              .split(",").map { |enum| enum.strip.length - 2 }.max
-            MysqlString.new(limit: limit)
-          end
-
-          m.register_type(%r(^set)i) do |sql_type|
-            limit = sql_type[/^set\s*\((.+)\)/i, 1]
-              .split(",").map { |set| set.strip.length - 1 }.sum - 1
-            MysqlString.new(limit: limit)
-          end
+          m.register_type %r(^enum)i, MysqlString.new
+          m.register_type %r(^set)i,  MysqlString.new
         end
 
         def register_integer_type(mapping, key, **options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -49,7 +49,7 @@ module ActiveRecord
           end
 
           def schema_limit(column)
-            super unless /\A(?:enum|set|(?:tiny|medium|long)?(?:text|blob))\b/.match?(column.sql_type)
+            super unless /\A(?:tiny|medium|long)?(?:text|blob)\b/.match?(column.sql_type)
           end
 
           def schema_precision(column)

--- a/activerecord/test/cases/adapters/mysql2/enum_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/enum_test.rb
@@ -15,11 +15,6 @@ class Mysql2EnumTest < ActiveRecord::Mysql2TestCase
     end
   end
 
-  def test_enum_limit
-    column = EnumTest.columns_hash["enum_column"]
-    assert_equal 8, column.limit
-  end
-
   def test_should_not_be_unsigned
     column = EnumTest.columns_hash["enum_column"]
     assert_not_predicate column, :unsigned?


### PR DESCRIPTION
Before #36604, `enum` and `set` columns were incorrectly dumped as a
`string` column.

If an `enum` column is defined as `foo enum('apple','orange')`, it was
dumped as `t.string :foo, limit: 6`, the `limit: 6` is seemed to
restrict invalid string longer than `'orange'`.

But now, `enum` and `set` columns are correctly dumped as `enum` and
`set` columns, the limit as longest element is no longer used.
