### PR TITLE
Migrate all top level uses of ::Digest to OpenSSL::Digest.

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -3,7 +3,7 @@
 gem "pg", "~> 1.1"
 require "pg"
 require "thread"
-require "digest/sha1"
+require "openssl"
 
 module ActionCable
   module SubscriptionAdapter
@@ -58,7 +58,7 @@ module ActionCable
 
       private
         def channel_identifier(channel)
-          channel.size > 63 ? Digest::SHA1.hexdigest(channel) : channel
+          channel.size > 63 ? OpenSSL::Digest.hexdigest("SHA1", channel) : channel
         end
 
         def listener

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -116,7 +116,7 @@ module ActionMailbox
           end
 
           def expected_signature
-            OpenSSL::HMAC.hexdigest OpenSSL::Digest::SHA256.new, key, "#{timestamp}#{token}"
+            OpenSSL::HMAC.hexdigest OpenSSL::Digest.new("SHA256"), key, "#{timestamp}#{token}"
           end
       end
   end

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -75,7 +75,7 @@ module ActionMailbox
           end
 
           def expected_signature
-            Base64.strict_encode64 OpenSSL::HMAC.digest(OpenSSL::Digest::SHA1.new, key, message)
+            Base64.strict_encode64 OpenSSL::HMAC.digest(OpenSSL::Digest.new("SHA1"), key, message)
           end
 
           def message

--- a/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
@@ -14,7 +14,7 @@ module ActionMailbox::InboundEmail::MessageId
     # attachment called +raw_email+. Before the upload, extract the Message-ID from the +source+ and set
     # it as an attribute on the new +InboundEmail+.
     def create_and_extract_message_id!(source, **options)
-      message_checksum = Digest::SHA1.hexdigest(source)
+      message_checksum = OpenSSL::Digest.hexdigest("SHA1", source)
       message_id = extract_message_id(source) || generate_missing_message_id(message_checksum)
 
       create! options.merge(message_id: message_id, message_checksum: message_checksum) do |inbound_email|

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -228,12 +228,12 @@ module ActionController
       # of a plain-text password.
       def expected_response(http_method, uri, credentials, password, password_is_ha1 = true)
         ha1 = password_is_ha1 ? password : ha1(credentials, password)
-        ha2 = ::Digest::MD5.hexdigest([http_method.to_s.upcase, uri].join(":"))
-        ::Digest::MD5.hexdigest([ha1, credentials[:nonce], credentials[:nc], credentials[:cnonce], credentials[:qop], ha2].join(":"))
+        ha2 = OpenSSL::Digest.hexdigest("MD5", [http_method.to_s.upcase, uri].join(":"))
+        OpenSSL::Digest.hexdigest("MD5", [ha1, credentials[:nonce], credentials[:nc], credentials[:cnonce], credentials[:qop], ha2].join(":"))
       end
 
       def ha1(credentials, password)
-        ::Digest::MD5.hexdigest([credentials[:username], credentials[:realm], password].join(":"))
+        OpenSSL::Digest.hexdigest("MD5", [credentials[:username], credentials[:realm], password].join(":"))
       end
 
       def encode_credentials(http_method, credentials, password, password_is_ha1)
@@ -307,7 +307,7 @@ module ActionController
       def nonce(secret_key, time = Time.now)
         t = time.to_i
         hashed = [t, secret_key]
-        digest = ::Digest::MD5.hexdigest(hashed.join(":"))
+        digest = OpenSSL::Digest.hexdigest("MD5", hashed.join(":"))
         ::Base64.strict_encode64("#{t}:#{digest}")
       end
 
@@ -324,7 +324,7 @@ module ActionController
 
       # Opaque based on digest of secret key
       def opaque(secret_key)
-        ::Digest::MD5.hexdigest(secret_key)
+        OpenSSL::Digest.hexdigest("MD5", secret_key)
       end
     end
 

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -414,7 +414,7 @@ module ActionController #:nodoc:
 
       def csrf_token_hmac(session, identifier) # :doc:
         OpenSSL::HMAC.digest(
-          OpenSSL::Digest::SHA256.new,
+          OpenSSL::Digest.new("SHA256"),
           real_csrf_token(session),
           identifier
         )

--- a/actionpack/test/controller/http_digest_authentication_test.rb
+++ b/actionpack/test/controller/http_digest_authentication_test.rb
@@ -9,7 +9,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
     before_action :authenticate_with_request, only: :display
 
     USERS = { "lifo" => "world", "pretty" => "please",
-              "dhh" => ::Digest::MD5.hexdigest(["dhh", "SuperSecret", "secret"].join(":")) }
+              "dhh" => OpenSSL::Digest.hexdigest("MD5", ["dhh", "SuperSecret", "secret"].join(":")) }
 
     def index
       render plain: "Hello Secret"
@@ -185,7 +185,7 @@ class HttpDigestAuthenticationTest < ActionController::TestCase
   test "authentication request with password stored as ha1 digest hash" do
     @request.env["HTTP_AUTHORIZATION"] = encode_credentials(
       username: "dhh",
-      password: ::Digest::MD5.hexdigest(["dhh", "SuperSecret", "secret"].join(":")),
+      password: OpenSSL::Digest.hexdigest("MD5", ["dhh", "SuperSecret", "secret"].join(":")),
       password_is_ha1: true)
     get :display
 

--- a/actiontext/lib/action_text/attachments/caching.rb
+++ b/actiontext/lib/action_text/attachments/caching.rb
@@ -9,7 +9,7 @@ module ActionText
 
       private
         def cache_digest
-          Digest::SHA256.hexdigest(node.to_s)
+          OpenSSL::Digest.hexdigest("SHA256", node.to_s)
         end
     end
   end

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -31,7 +31,7 @@ module SneakersJobsManager
     @pid = fork do
       queues = %w(integration_tests)
       workers = queues.map do |q|
-        worker_klass = "ActiveJobWorker" + Digest::MD5.hexdigest(q)
+        worker_klass = "ActiveJobWorker" + OpenSSL::Digest.hexdigest("MD5", q)
         Sneakers.const_set(worker_klass, Class.new(ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper) do
           from_queue q
         end)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/string/access"
-require "digest/sha2"
+require "openssl"
 
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
@@ -1481,7 +1481,7 @@ module ActiveRecord
         def foreign_key_name(table_name, options)
           options.fetch(:name) do
             identifier = "#{table_name}_#{options.fetch(:column)}_fk"
-            hashed_identifier = Digest::SHA256.hexdigest(identifier).first(10)
+            hashed_identifier = OpenSSL::Digest.hexdigest("SHA256", identifier).first(10)
 
             "fk_rails_#{hashed_identifier}"
           end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -523,7 +523,7 @@ module ActiveRecord
         end
 
         def schema_sha1(file)
-          Digest::SHA1.hexdigest(File.read(file))
+          OpenSSL::Digest.hexdigest("SHA1", File.read(file))
         end
     end
   end

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -281,7 +281,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
 
   private
     def compute_checksum_in_chunks(io)
-      Digest::MD5.new.tap do |checksum|
+      OpenSSL::Digest.new("MD5").tap do |checksum|
         while chunk = io.read(5.megabytes)
           checksum << chunk
         end

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -69,7 +69,7 @@ class ActiveStorage::Variant
 
   # Returns a combination key of the blob and the variation that together identifies a specific variant.
   def key
-    "variants/#{blob.key}/#{Digest::SHA256.hexdigest(variation.key)}"
+    "variants/#{blob.key}/#{OpenSSL::Digest.hexdigest("SHA256", variation.key)}"
   end
 
   # Returns the URL of the blob variant on the service. See {ActiveStorage::Blob#url} for details.

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -59,7 +59,7 @@ class ActiveStorage::Variation
   end
 
   def digest
-    Digest::SHA1.base64digest Marshal.dump(transformations)
+    OpenSSL::Digest.base64digest("SHA1", Marshal.dump(transformations))
   end
 
   private

--- a/activestorage/lib/active_storage/downloader.rb
+++ b/activestorage/lib/active_storage/downloader.rb
@@ -35,7 +35,7 @@ module ActiveStorage
       end
 
       def verify_integrity_of(file, checksum:)
-        unless Digest::MD5.file(file).base64digest == checksum
+        unless OpenSSL::Digest.new("MD5").file(file).base64digest == checksum
           raise ActiveStorage::IntegrityError
         end
       end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -2,7 +2,7 @@
 
 require "fileutils"
 require "pathname"
-require "digest/md5"
+require "openssl"
 require "active_support/core_ext/numeric/bytes"
 
 module ActiveStorage
@@ -154,7 +154,7 @@ module ActiveStorage
       end
 
       def ensure_integrity_of(key, checksum)
-        unless Digest::MD5.file(path_for(key)).base64digest == checksum
+        unless OpenSSL::Digest.new("MD5").file(path_for(key)).base64digest == checksum
           delete key
           raise ActiveStorage::IntegrityError
         end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -15,7 +15,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
     end
 
     test "creating new direct upload" do
-      checksum = Digest::MD5.base64digest("Hello")
+      checksum = OpenSSL::Digest.base64digest("MD5", "Hello")
 
       post rails_direct_uploads_url, params: { blob: {
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
@@ -50,7 +50,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     end
 
     test "creating new direct upload" do
-      checksum = Digest::MD5.base64digest("Hello")
+      checksum = OpenSSL::Digest.base64digest("MD5", "Hello")
 
       post rails_direct_uploads_url, params: { blob: {
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
@@ -84,7 +84,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     end
 
     test "creating new direct upload" do
-      checksum = Digest::MD5.base64digest("Hello")
+      checksum = OpenSSL::Digest.base64digest("MD5", "Hello")
 
       post rails_direct_uploads_url, params: { blob: {
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
@@ -106,7 +106,7 @@ end
 
 class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::IntegrationTest
   test "creating new direct upload" do
-    checksum = Digest::MD5.base64digest("Hello")
+    checksum = OpenSSL::Digest.base64digest("MD5", "Hello")
 
     post rails_direct_uploads_url, params: { blob: {
       filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
@@ -123,7 +123,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
   end
 
   test "creating new direct upload does not include root in json" do
-    checksum = Digest::MD5.base64digest("Hello")
+    checksum = OpenSSL::Digest.base64digest("MD5", "Hello")
 
     set_include_root_in_json(true) do
       post rails_direct_uploads_url, params: { blob: {

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -67,7 +67,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob with integrity" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: OpenSSL::Digest.base64digest("MD5", data)
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain" }
     assert_response :no_content
@@ -76,7 +76,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob without integrity" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest("bad data")
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: OpenSSL::Digest.base64digest("MD5", "bad data")
 
     put blob.service_url_for_direct_upload, params: data
     assert_response :unprocessable_entity
@@ -85,7 +85,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob with mismatched content type" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size, checksum: Digest::MD5.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size, checksum: OpenSSL::Digest.base64digest("MD5", data)
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/octet-stream" }
     assert_response :unprocessable_entity
@@ -95,7 +95,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
   test "directly uploading blob with different but equivalent content type" do
     data = "Something else entirely!"
     blob = create_blob_before_direct_upload(
-      byte_size: data.size, checksum: Digest::MD5.base64digest(data), content_type: "application/x-gzip")
+      byte_size: data.size, checksum: OpenSSL::Digest.base64digest("MD5", data), content_type: "application/x-gzip")
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "application/x-gzip" }
     assert_response :no_content
@@ -104,7 +104,7 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "directly uploading blob with mismatched content length" do
     data = "Something else entirely!"
-    blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: Digest::MD5.base64digest(data)
+    blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: OpenSSL::Digest.base64digest("MD5", data)
 
     put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain" }
     assert_response :unprocessable_entity

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -57,7 +57,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
     assert_equal data, blob.download
     assert_equal data.length, blob.byte_size
-    assert_equal Digest::MD5.base64digest(data), blob.checksum
+    assert_equal OpenSSL::Digest.base64digest("MD5", data), blob.checksum
   end
 
   test "create_and_upload extracts content type from data" do
@@ -148,7 +148,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   test "open without integrity" do
     create_blob(data: "Hello, world!").tap do |blob|
-      blob.update! checksum: Digest::MD5.base64digest("Goodbye, world!")
+      blob.update! checksum: OpenSSL::Digest.base64digest("MD5", "Goodbye, world!")
 
       assert_raises ActiveStorage::IntegrityError do
         blob.open { |file| flunk "Expected integrity check to fail" }

--- a/activestorage/test/service/azure_storage_public_service_test.rb
+++ b/activestorage/test/service/azure_storage_public_service_test.rb
@@ -21,7 +21,7 @@ if SERVICE_CONFIGURATIONS[:azure_public]
     test "direct upload" do
       key          = SecureRandom.base58(24)
       data         = "Something else entirely!"
-      checksum     = Digest::MD5.base64digest(data)
+      checksum     = OpenSSL::Digest.base64digest("MD5", data)
       content_type = "text/xml"
       url          = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: content_type, content_length: data.size, checksum: checksum)
 

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -12,7 +12,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     test "direct upload with content type" do
       key          = SecureRandom.base58(24)
       data         = "Something else entirely!"
-      checksum     = Digest::MD5.base64digest(data)
+      checksum     = OpenSSL::Digest.base64digest("MD5", data)
       content_type = "text/xml"
       url          = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: content_type, content_length: data.size, checksum: checksum)
 
@@ -34,7 +34,7 @@ if SERVICE_CONFIGURATIONS[:azure]
     test "direct upload with content disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = Digest::MD5.base64digest(data)
+      checksum = OpenSSL::Digest.base64digest("MD5", data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -56,7 +56,7 @@ if SERVICE_CONFIGURATIONS[:azure]
       key      = SecureRandom.base58(24)
       data     = "Foobar"
 
-      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest.base64digest("MD5", data), filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: nil, filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))
@@ -70,7 +70,7 @@ if SERVICE_CONFIGURATIONS[:azure]
       key  = SecureRandom.base58(24)
       data = "Foobar"
 
-      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest.base64digest("MD5", data), filename: ActiveStorage::Filename.new("test.txt"), disposition: :inline)
 
       assert_equal("inline; filename=\"test.txt\"; filename*=UTF-8''test.txt", @service.client.get_blob_properties(@service.container, key).properties[:content_disposition])
 

--- a/activestorage/test/service/gcs_public_service_test.rb
+++ b/activestorage/test/service/gcs_public_service_test.rb
@@ -21,7 +21,7 @@ if SERVICE_CONFIGURATIONS[:gcs_public]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = Digest::MD5.base64digest(data)
+      checksum = OpenSSL::Digest.base64digest("MD5", data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -16,7 +16,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = Digest::MD5.base64digest(data)
+      checksum = OpenSSL::Digest.base64digest("MD5", data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -36,7 +36,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "direct upload with content disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = Digest::MD5.base64digest(data)
+      checksum = OpenSSL::Digest.base64digest("MD5", data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url
@@ -61,7 +61,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
 
-      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest.base64digest("MD5", data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))
@@ -75,7 +75,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
 
-      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain")
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest.base64digest("MD5", data), content_type: "text/plain")
 
       url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
       response = Net::HTTP.get_response(URI(url))
@@ -88,7 +88,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     test "update metadata" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      @service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html")
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest.base64digest("MD5", data), disposition: :attachment, filename: ActiveStorage::Filename.new("test.html"), content_type: "text/html")
 
       @service.update_metadata(key, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain")
       url = @service.url(key, expires_in: 2.minutes, disposition: :attachment, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -25,7 +25,7 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
     io       = StringIO.new(data)
-    checksum = Digest::MD5.base64digest(data)
+    checksum = OpenSSL::Digest.base64digest("MD5", data)
 
     @service.upload key, io.tap(&:read), checksum: checksum
     assert_predicate io, :eof?
@@ -41,7 +41,7 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
   test "downloading from primary service" do
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
-    checksum = Digest::MD5.base64digest(data)
+    checksum = OpenSSL::Digest.base64digest("MD5", data)
 
     @service.primary.upload key, StringIO.new(data), checksum: checksum
 
@@ -60,7 +60,7 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
   test "mirroring a file from the primary service to secondary services where it doesn't exist" do
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"
-    checksum = Digest::MD5.base64digest(data)
+    checksum = OpenSSL::Digest.base64digest("MD5", data)
 
     @service.primary.upload key, StringIO.new(data), checksum: checksum
     @service.mirrors.third.upload key, StringIO.new("Surprise!")

--- a/activestorage/test/service/s3_public_service_test.rb
+++ b/activestorage/test/service/s3_public_service_test.rb
@@ -26,7 +26,7 @@ if SERVICE_CONFIGURATIONS[:s3_public]
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
-      checksum = Digest::MD5.base64digest(data)
+      checksum = OpenSSL::Digest.base64digest("MD5", data)
       url      = @service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
 
       uri = URI.parse url

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -80,7 +80,7 @@ class ActiveSupport::TestCase
     def directly_upload_file_blob(filename: "racecar.jpg", content_type: "image/jpeg", record: nil)
       file = file_fixture(filename)
       byte_size = file.size
-      checksum = Digest::MD5.file(file).base64digest
+      checksum = OpenSSL::Digest.new("MD5").file(file).base64digest
 
       create_blob_before_direct_upload(filename: filename, byte_size: byte_size, checksum: checksum, content_type: content_type, record: record).tap do |blob|
         service = ActiveStorage::Blob.service.try(:primary) || ActiveStorage::Blob.service

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -15,7 +15,7 @@ begin
 rescue LoadError
 end
 
-require "digest/sha2"
+require "openssl"
 require "active_support/core_ext/marshal"
 
 module ActiveSupport
@@ -443,7 +443,7 @@ module ActiveSupport
 
         def truncate_key(key)
           if key && key.bytesize > max_key_bytesize
-            suffix = ":sha2:#{::Digest::SHA2.hexdigest(key)}"
+            suffix = ":sha2:#{OpenSSL::Digest.hexdigest("SHA256", key)}"
             truncate_at = max_key_bytesize - suffix.bytesize
             "#{key.byteslice(0, truncate_at)}#{suffix}"
           else

--- a/activesupport/lib/active_support/core_ext/digest/uuid.rb
+++ b/activesupport/lib/active_support/core_ext/digest/uuid.rb
@@ -16,12 +16,12 @@ module Digest
     #
     # See RFC 4122 for details of UUID at: https://www.ietf.org/rfc/rfc4122.txt
     def self.uuid_from_hash(hash_class, uuid_namespace, name)
-      if hash_class == Digest::MD5
+      if hash_class == OpenSSL::Digest::MD5
         version = 3
-      elsif hash_class == Digest::SHA1
+      elsif hash_class == OpenSSL::Digest::SHA1
         version = 5
       else
-        raise ArgumentError, "Expected Digest::SHA1 or Digest::MD5, got #{hash_class.name}."
+        raise ArgumentError, "Expected OpenSSL::Digest::SHA1 or OpenSSL::Digest::MD5, got #{hash_class.name}."
       end
 
       hash = hash_class.new
@@ -37,12 +37,12 @@ module Digest
 
     # Convenience method for uuid_from_hash using Digest::MD5.
     def self.uuid_v3(uuid_namespace, name)
-      uuid_from_hash(Digest::MD5, uuid_namespace, name)
+      uuid_from_hash(OpenSSL::Digest::MD5, uuid_namespace, name)
     end
 
     # Convenience method for uuid_from_hash using Digest::SHA1.
     def self.uuid_v5(uuid_namespace, name)
-      uuid_from_hash(Digest::SHA1, uuid_namespace, name)
+      uuid_from_hash(OpenSSL::Digest::SHA1, uuid_namespace, name)
     end
 
     # Convenience method for SecureRandom.uuid.

--- a/activesupport/lib/active_support/digest.rb
+++ b/activesupport/lib/active_support/digest.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
+require "openssl/digest"
 module ActiveSupport
   class Digest #:nodoc:
     class <<self
       def hash_digest_class
-        @hash_digest_class ||= ::Digest::MD5
+        @hash_digest_class ||= OpenSSL::Digest::MD5
       end
 
       def hash_digest_class=(klass)

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -85,7 +85,7 @@ module ActiveSupport
     initializer "active_support.set_hash_digest_class" do |app|
       config.after_initialize do
         if app.config.active_support.use_sha1_digests
-          ActiveSupport::Digest.hash_digest_class = ::Digest::SHA1
+          ActiveSupport::Digest.hash_digest_class = OpenSSL::Digest::SHA1
         end
       end
     end

--- a/activesupport/test/core_ext/digest/uuid_test.rb
+++ b/activesupport/test/core_ext/digest/uuid_test.rb
@@ -20,7 +20,7 @@ class DigestUUIDExt < ActiveSupport::TestCase
 
   def test_invalid_hash_class
     assert_raise ArgumentError do
-      Digest::UUID.uuid_from_hash(Digest::SHA2, Digest::UUID::OID_NAMESPACE, "1.2.3")
+      Digest::UUID.uuid_from_hash(OpenSSL::Digest::SHA256, Digest::UUID::OID_NAMESPACE, "1.2.3")
     end
   end
 end

--- a/activesupport/test/digest_test.rb
+++ b/activesupport/test/digest_test.rb
@@ -6,7 +6,7 @@ require "openssl"
 class DigestTest < ActiveSupport::TestCase
   class InvalidDigest; end
   def test_with_default_hash_digest_class
-    assert_equal ::Digest::MD5.hexdigest("hello friend"), ActiveSupport::Digest.hexdigest("hello friend")
+    assert_equal OpenSSL::Digest.hexdigest("MD5", "hello friend"), ActiveSupport::Digest.hexdigest("hello friend")
   end
 
   def test_with_custom_hash_digest_class
@@ -16,7 +16,7 @@ class DigestTest < ActiveSupport::TestCase
     digest = ActiveSupport::Digest.hexdigest("hello friend")
 
     assert_equal 32, digest.length
-    assert_equal ::Digest::SHA1.hexdigest("hello friend")[0...32], digest
+    assert_equal OpenSSL::Digest.hexdigest("SHA1", "hello friend")[0...32], digest
   ensure
     ActiveSupport::Digest.hash_digest_class = original_hash_digest_class
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2172,18 +2172,18 @@ module ApplicationTests
       assert_equal true, ActiveSupport::MessageEncryptor.use_authenticated_message_encryption
     end
 
-    test "ActiveSupport::Digest.hash_digest_class is Digest::SHA1 by default for new apps" do
+    test "ActiveSupport::Digest.hash_digest_class is OpenSSL::Digest::SHA1 by default for new apps" do
       app "development"
 
-      assert_equal Digest::SHA1, ActiveSupport::Digest.hash_digest_class
+      assert_equal OpenSSL::Digest::SHA1, ActiveSupport::Digest.hash_digest_class
     end
 
-    test "ActiveSupport::Digest.hash_digest_class is Digest::MD5 by default for upgraded apps" do
+    test "ActiveSupport::Digest.hash_digest_class is OpenSSL::Digest::MD5 by default for upgraded apps" do
       remove_from_config '.*config\.load_defaults.*\n'
 
       app "development"
 
-      assert_equal Digest::MD5, ActiveSupport::Digest.hash_digest_class
+      assert_equal OpenSSL::Digest::MD5, ActiveSupport::Digest.hash_digest_class
     end
 
     test "ActiveSupport::Digest.hash_digest_class can be configured via config.active_support.use_sha1_digests" do
@@ -2195,7 +2195,7 @@ module ApplicationTests
 
       app "development"
 
-      assert_equal Digest::SHA1, ActiveSupport::Digest.hash_digest_class
+      assert_equal OpenSSL::Digest::SHA1, ActiveSupport::Digest.hash_digest_class
     end
 
     test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do


### PR DESCRIPTION
### Summary

Migrate all top level uses of `::Digest` to `OpenSSL::Digest`.

Fixes https://github.com/rails/rails/issues/38791

More information here:
https://bugs.ruby-lang.org/issues/13681
https://github.com/openssl/openssl/commit/65300dcfb04bae643ea7b8f42ff8c8f1b1210a9e

From OpenSSL Changelog which is hard to link:

https://github.com/openssl/openssl/blob/ccb8f0c87eb28d55a6607504f2fbf1be94836c49/CHANGES.md#L5106

> Experimental multi-implementation support for FIPS capable OpenSSL. When in FIPS mode the approved implementations are used as normal, when not in FIPS mode the internal unapproved versions are used instead. This means that the FIPS capable OpenSSL isn't forced to use the (often lower performance) FIPS implementations outside FIPS mode.
> Steve Henson

So the issue is on Ruby's internal version we don't have a gradual fallback. But using the openssl version > 1.0.1l and 1.0.2, openssl uses internal implementation to maintain FIPS compat

One concern to move to OpenSSL::Digest could be that top level ::Digest is ruby implementation and not OpenSLL, but given we use the OpenSSL versions all over, I think its save to move to use OpenSSL versions at remaining places
