### PR TITLE
Refactor railsrc file location to be xdg compliant

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,8 +1,8 @@
 *   Make railsrc file location xdg-specification compliant
 
-    Rails new will load the railsrc file from XDG_CONFIG_HOME/rails/railsrc
-    It will then fallback to .config if XDG_CONFIG_HOME not specified
-    It will then fallback to HOME/.railsrc
+    Rails new will load the `railsrc` file from `XDG_CONFIG_HOME/rails/railsrc`.
+    It will then fallback to `.config` if `XDG_CONFIG_HOME` not specified.
+    It will then fallback to `HOME/.railsrc`.
 
     The fallback behaviour means this does not cause any breaking changes.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,8 +1,9 @@
 *   Make railsrc file location xdg-specification compliant
 
-    Rails new will load the `railsrc` file from `XDG_CONFIG_HOME/rails/railsrc`.
-    It will then fallback to `.config` if `XDG_CONFIG_HOME` not specified.
-    It will then fallback to `HOME/.railsrc`.
+    `rails new` will now look for the default `railsrc` file at
+    `$XDG_CONFIG_HOME/rails/railsrc` (or `~/.config/rails/railsrc` if
+    `XDG_CONFIG_HOME` is not set).  If this file does not exist, `rails new`
+    will fall back to `~/.railsrc`.
 
     The fallback behaviour means this does not cause any breaking changes.
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Make railsrc file location xdg-specification compliant
+
+    Rails new will load the railsrc file from XDG_CONFIG_HOME/rails/railsrc
+    It will then fallback to .config if XDG_CONFIG_HOME not specified
+    It will then fallback to HOME/.railsrc
+
+    The fallback behaviour means this does not cause any breaking changes.
+
+    *Nick Wolf*
+
 *   Deprecate `config.active_support.use_sha1_digests`
 
     `config.active_support.use_sha1_digests` is deprecated. It is replaced with `config.active_support.hash_digest_class` which allows setting the desired Digest instead. The Rails version defaults have been updated to use this new method as well so the behavior there is unchanged.

--- a/railties/lib/rails/generators/rails/app/USAGE
+++ b/railties/lib/rails/generators/rails/app/USAGE
@@ -3,7 +3,8 @@ Description:
     directory structure and configuration at the path you specify.
 
     You can specify extra command-line arguments to be used every time
-    'rails new' runs in the .railsrc configuration file in your home directory.
+    'rails new' runs in the .railsrc configuration file in your home directory,
+    or in $XDG_CONFIG_HOME/rails/railsrc if XDG_CONFIG_HOME is set.
 
     Note that the arguments specified in the .railsrc file don't affect the
     defaults values shown above in this help message.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -606,7 +606,7 @@ module Rails
       end
 
       def self.default_rc_file
-        xdg_config_home = ENV["XDG_CONFIG_HOME"].presence || '~/.config'
+        xdg_config_home = ENV["XDG_CONFIG_HOME"].presence || "~/.config"
         xdg_railsrc = File.expand_path("rails/railsrc", xdg_config_home)
         if File.exist?(xdg_railsrc)
           xdg_railsrc

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -606,8 +606,9 @@ module Rails
       end
 
       def self.default_rc_file
-        xdg_railsrc = File.expand_path("rails/railsrc", ENV["XDG_CONFIG_HOME"]) if ENV["XDG_CONFIG_HOME"]
-        if xdg_railsrc && File.exist?(xdg_railsrc)
+        xdg_config_home = ENV["XDG_CONFIG_HOME"].presence || '~/.config'
+        xdg_railsrc = File.expand_path("rails/railsrc", xdg_config_home)
+        if File.exist?(xdg_railsrc)
           xdg_railsrc
         else
           File.expand_path("~/.railsrc")

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -606,15 +606,12 @@ module Rails
       end
 
       def self.default_rc_file
-        return File.expand_path("~/.railsrc") unless ENV["XDG_CONFIG_HOME"]
-
-        xdg_railsrc = ENV["XDG_CONFIG_HOME"] + "/rails/railsrc"
-        rc_file = if File.exist?(xdg_railsrc)
+        xdg_railsrc = File.expand_path("rails/railsrc", ENV["XDG_CONFIG_HOME"]) if ENV["XDG_CONFIG_HOME"]
+        if xdg_railsrc && File.exist?(xdg_railsrc)
           xdg_railsrc
         else
-          "~/.railsrc"
+          File.expand_path("~/.railsrc")
         end
-        File.expand_path(rc_file)
       end
 
       private

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -606,7 +606,15 @@ module Rails
       end
 
       def self.default_rc_file
-        File.expand_path("~/.railsrc")
+        return File.expand_path("~/.railsrc") unless ENV["XDG_CONFIG_HOME"]
+
+        xdg_railsrc = ENV["XDG_CONFIG_HOME"] + "/rails/railsrc"
+        rc_file = if File.exist?(xdg_railsrc)
+          xdg_railsrc
+        else
+          "~/.railsrc"
+        end
+        File.expand_path(rc_file)
       end
 
       private

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -4,7 +4,7 @@ require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/generators/rails/app/app_generator"
 require "tempfile"
-require 'fileutils'
+require "fileutils"
 
 module Rails
   module Generators

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -13,6 +13,7 @@ module Rails
       # Future people who read this... These tests are just to surround the
       # current behavior of the ARGVScrubber, they do not mean that the class
       # *must* act this way, I just want to prevent regressions.
+
       include EnvHelpers
 
       def test_version

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -69,6 +69,7 @@ module Rails
 
         scrubber = Class.new(ARGVScrubber)
         assert_equal scrubber.default_rc_file, railrc_path
+        File.delete(railrc_path) if File.exist?(railrc_path)
       end
 
       def test_new_homedir_rc

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -4,6 +4,7 @@ require "active_support/test_case"
 require "active_support/testing/autorun"
 require "rails/generators/rails/app/app_generator"
 require "tempfile"
+require 'fileutils'
 
 module Rails
   module Generators
@@ -54,6 +55,20 @@ module Rails
         }.new ["new"]
         args = scrubber.prepare!
         assert_equal [], args
+      end
+
+      def test_xdg_config_no_custom_rc
+        xdg = Dir.tmpdir
+        ENV["XDG_CONFIG_HOME"] = xdg
+        rails_xdg_path = File.join(xdg, "rails")
+        Dir.mkdir(rails_xdg_path, 0700) unless Dir.exist?(rails_xdg_path)
+        Dir.new(rails_xdg_path)
+        railrc_path = File.join(rails_xdg_path, "railsrc")
+        railsrc = File.new(railrc_path, "w")
+        railsrc.close
+
+        scrubber = Class.new(ARGVScrubber)
+        assert_equal scrubber.default_rc_file, railrc_path
       end
 
       def test_new_homedir_rc

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -5,6 +5,7 @@ require "active_support/testing/autorun"
 require "rails/generators/rails/app/app_generator"
 require "tempfile"
 require "fileutils"
+require "env_helpers"
 
 module Rails
   module Generators
@@ -12,6 +13,7 @@ module Rails
       # Future people who read this... These tests are just to surround the
       # current behavior of the ARGVScrubber, they do not mean that the class
       # *must* act this way, I just want to prevent regressions.
+      include EnvHelpers
 
       def test_version
         ["-v", "--version"].each do |str|
@@ -57,19 +59,15 @@ module Rails
         assert_equal [], args
       end
 
-      def test_xdg_config_no_custom_rc
-        xdg = Dir.tmpdir
-        ENV["XDG_CONFIG_HOME"] = xdg
-        rails_xdg_path = File.join(xdg, "rails")
-        Dir.mkdir(rails_xdg_path, 0700) unless Dir.exist?(rails_xdg_path)
-        Dir.new(rails_xdg_path)
-        railrc_path = File.join(rails_xdg_path, "railsrc")
-        railsrc = File.new(railrc_path, "w")
-        railsrc.close
-
-        scrubber = Class.new(ARGVScrubber)
-        assert_equal scrubber.default_rc_file, railrc_path
-        File.delete(railrc_path) if File.exist?(railrc_path)
+      def test_default_rc_file_with_xdg_config_home
+        Dir.mktmpdir do |dir|
+          rc_file = File.join(dir, "rails/railsrc")
+          FileUtils.mkdir_p(File.dirname(rc_file))
+          FileUtils.touch(rc_file)
+          switch_env("XDG_CONFIG_HOME", dir) do
+            assert_equal rc_file, ARGVScrubber.default_rc_file
+          end
+        end
       end
 
       def test_new_homedir_rc


### PR DESCRIPTION
### Summary

The XDG Base Directory Specification (which is currently used by
FOSS projects such as Git, Tmux, Pry, Rspec) provides a default
location for various file formats, including config/rc files.

This comment refactors app_generator.rb to load railsrc from
XDG_CONFIG_HOME if both XDG_CONFIG_HOME is set and rails/railrc
exists within the XDG_CONFIG_HOME location.

To maintain backwards compatibility it defaults back to ~/.railsrc
if either XDG_CONFIG_HOME is not set or there is no rails/railsrc.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
