### PR TITLE
Utilize Symbol#start_with? and #end_with?

### DIFF
--- a/actionview/lib/action_view/helpers/atom_feed_helper.rb
+++ b/actionview/lib/action_view/helpers/atom_feed_helper.rb
@@ -115,7 +115,7 @@ module ActionView
         end
 
         feed_opts = { "xml:lang" => options[:language] || "en-US", "xmlns" => "http://www.w3.org/2005/Atom" }
-        feed_opts.merge!(options).reject! { |k, v| !k.to_s.start_with?("xml") }
+        feed_opts.merge!(options).reject! { |k, v| !k.start_with?("xml") }
 
         xml.feed(feed_opts) do
           xml.id(options[:id] || "tag:#{request.host},#{options[:schema_date]}:#{request.fullpath.split(".")[0]}")

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1668,7 +1668,7 @@ module ActionView
 
         convert_to_legacy_options(@options)
 
-        if @object_name.to_s.end_with?("[]")
+        if @object_name&.end_with?("[]")
           if (object ||= @template.instance_variable_get("@#{@object_name.to_s.delete_suffix("[]")}")) && object.respond_to?(:to_param)
             @auto_index = object.to_param
           else

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -358,7 +358,7 @@ module Rails
         end
 
         def method_missing(method, *args)
-          if method.to_s.end_with?("=")
+          if method.end_with?("=")
             @configurations[method.to_s.delete_suffix("=").to_sym] = args.first
           else
             @configurations.fetch(method) {

--- a/railties/lib/rails/railtie/configuration.rb
+++ b/railties/lib/rails/railtie/configuration.rb
@@ -88,7 +88,7 @@ module Rails
 
     private
       def method_missing(name, *args, &blk)
-        if name.to_s.end_with?("=")
+        if name.end_with?("=")
           @@options[name.to_s.delete_suffix("=").to_sym] = args.first
         elsif @@options.key?(name)
           @@options[name]


### PR DESCRIPTION
Follow-up to #39155.

Thanks to `Symbol#start_with?` and `#end_with?`, these calls no longer need to be prefixed with `.to_s`.
