### PR TITLE
Test extract_options! extracts ordered options

### DIFF
--- a/activesupport/test/core_ext/array/extract_options_test.rb
+++ b/activesupport/test/core_ext/array/extract_options_test.rb
@@ -3,6 +3,7 @@
 require_relative "../../abstract_unit"
 require "active_support/core_ext/array"
 require "active_support/core_ext/hash"
+require "active_support/ordered_options"
 
 class ExtractOptionsTest < ActiveSupport::TestCase
   class HashSubclass < Hash
@@ -43,5 +44,14 @@ class ExtractOptionsTest < ActiveSupport::TestCase
     array = [{ foo: 1 }.with_indifferent_access]
     options = array.extract_options!
     assert_equal(1, options[:foo])
+  end
+
+  def test_extract_options_extracts_ordered_options
+    hash = ActiveSupport::OrderedOptions.new
+    hash.foo = 1
+    array = [hash]
+    options = array.extract_options!
+    assert_equal({ foo: 1 }, options)
+    assert_equal([], array)
   end
 end


### PR DESCRIPTION
### Summary

I was looking into the source code of the ActiveSupport::OrderedOptions` and noticed this method
https://github.com/rails/rails/blob/0cffb053a6b1b23b74243b829df768db97ccd004/activesupport/lib/active_support/ordered_options.rb#L60-L62

I didn’t know what it is about so I went to search for it 
and via the `git-blame` I came to this commit https://github.com/rails/rails/commit/974ce9c3339441617da4c58a056087034fa25fc0

Then I’ve found the `ExtractOptionsTest`
https://github.com/rails/rails/blob/0cffb053a6b1b23b74243b829df768db97ccd004/activesupport/test/core_ext/array/extract_options_test.rb#L7
and noticed that besides `Hash` it tests the `ActiveSupport::HashWithIndifferentAccess` 
though a bit of "indirectly" via `with_indifferent_access`
https://github.com/rails/rails/blob/0cffb053a6b1b23b74243b829df768db97ccd004/activesupport/test/core_ext/array/extract_options_test.rb#L42-L46
via
https://github.com/rails/rails/blob/0cffb053a6b1b23b74243b829df768db97ccd004/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb#L9-L11

And I thought that it is missing the testing of the `ActiveSupport::OrderedOptions`.

This PR adds the "missing" test. 
```
› bundle exec ruby -w -Itest activesupport/test/core_ext/array/extract_options_test.rb
Run options: --seed 53831

# Running:

.....

Finished in 0.208386s, 23.9939 runs/s, 52.7867 assertions/s.
5 runs, 11 assertions, 0 failures, 0 errors, 0 skips
```

Though I'm not sure if it's a good place for the test. 
Maybe I should add it to the https://github.com/rails/rails/blob/0cffb053a6b1b23b74243b829df768db97ccd004/activesupport/test/ordered_options_test.rb#L6

Or maybe it does not worth adding at all 😄
