### PR TITLE
`merge(..., rewhere: true)` should have the ability to overwrite non-attribute nodes

### DIFF
--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -130,21 +130,23 @@ class RelationMergingTest < ActiveRecord::TestCase
   end
 
   def test_relation_merging_with_arel_equalities_keeps_last_equality
-    devs = Developer.where(Developer.arel_table[:salary].eq(80000)).merge(
-      Developer.where(Developer.arel_table[:salary].eq(9000))
-    )
+    salary_attr = Developer.arel_table[:salary]
+
+    devs = Developer.where(salary_attr.eq(80000)).merge(Developer.where(salary_attr.eq(9000)))
+    assert_equal [developers(:poor_jamis)], devs.to_a
+
+    devs = Developer.where(salary_attr.eq(80000)).merge(Developer.where(salary_attr.eq(9000)), rewhere: true)
     assert_equal [developers(:poor_jamis)], devs.to_a
   end
 
   def test_relation_merging_with_arel_equalities_keeps_last_equality_with_non_attribute_left_hand
     salary_attr = Developer.arel_table[:salary]
-    devs = Developer.where(
-      Arel::Nodes::NamedFunction.new("abs", [salary_attr]).eq(80000)
-    ).merge(
-      Developer.where(
-        Arel::Nodes::NamedFunction.new("abs", [salary_attr]).eq(9000)
-      )
-    )
+    abs_salary = Arel::Nodes::NamedFunction.new("abs", [salary_attr])
+
+    devs = Developer.where(abs_salary.eq(80000)).merge(Developer.where(abs_salary.eq(9000)))
+    assert_equal [developers(:poor_jamis)], devs.to_a
+
+    devs = Developer.where(abs_salary.eq(80000)).merge(Developer.where(abs_salary.eq(9000)), rewhere: true)
     assert_equal [developers(:poor_jamis)], devs.to_a
   end
 


### PR DESCRIPTION
Related to #7380 and #7392.

`merge` allows to overwrite non-attribute nodes by #7392, so
`merge(..., rewhere: true)` should also have the same ability, to
migrate from the half-baked current behavior to entirely consistent new
behavior.
