### PR TITLE
Fix typo [ci skip]

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -31,7 +31,7 @@ $ bin/rails generate
 
 NOTE: To create a rails application we use the `rails` global command, the rails gem installed via `gem install rails`. When inside the directory of your application, we use  the command `bin/rails` which uses the bundled rails inside this application.
 
-You will get a list of all generators that comes with Rails. If you need a detailed description of the helper generator, for example, you can simply do:
+You will get a list of all generators that come with Rails. If you need a detailed description of the helper generator, for example, you can simply do:
 
 ```bash
 $ bin/rails generate helper --help


### PR DESCRIPTION
"Generators" is plural but "comes" is singular.  This is an easy mistake to make as "comes" ends in an "s," so it is logical for someone to mistake it for plural.  However, "comes" is singular.  The plural for "comes" is "come."  Since this verb is being performed by multiple "generators," it should be plural.
