### PR TITLE
Add status the 103 Early Hints as Not content for action_dispatch

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -81,7 +81,7 @@ module ActionDispatch # :nodoc:
     CONTENT_TYPE = "Content-Type"
     SET_COOKIE   = "Set-Cookie"
     LOCATION     = "Location"
-    NO_CONTENT_CODES = [100, 101, 102, 204, 205, 304]
+    NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304]
 
     cattr_accessor :default_charset, default: "utf-8"
     cattr_accessor :default_headers

--- a/actionpack/test/controller/new_base/bare_metal_test.rb
+++ b/actionpack/test/controller/new_base/bare_metal_test.rb
@@ -81,6 +81,11 @@ module BareMetalTest
       head 102
     end
 
+    def early_hints
+      self.content_type = "text/html"
+      head 103
+    end
+
     def no_content
       self.content_type = "text/html"
       head 204
@@ -117,6 +122,12 @@ module BareMetalTest
 
     test "head :processing (102) does not return a content-type header" do
       headers = HeadController.action(:processing).call(Rack::MockRequest.env_for("/")).second
+      assert_nil headers["Content-Type"]
+      assert_nil headers["Content-Length"]
+    end
+
+    test "head :early_hints (103) does not return a content-type header" do
+      headers = HeadController.action(:early_hints).call(Rack::MockRequest.env_for("/")).second
       assert_nil headers["Content-Type"]
       assert_nil headers["Content-Length"]
     end

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -153,7 +153,7 @@ class ResponseTest < ActiveSupport::TestCase
   end
 
   test "content length" do
-    [100, 101, 102, 204].each do |c|
+    [100, 101, 102, 103, 204].each do |c|
       @response = ActionDispatch::Response.new
       @response.status = c.to_s
       @response.set_header "Content-Length", "0"
@@ -163,7 +163,7 @@ class ResponseTest < ActiveSupport::TestCase
   end
 
   test "does not contain a message-body" do
-    [100, 101, 102, 204, 304].each do |c|
+    [100, 101, 102, 103, 204, 304].each do |c|
       @response = ActionDispatch::Response.new
       @response.status = c.to_s
       @response.body = "Body must not be included"


### PR DESCRIPTION
The status is defined in RFC 8297 https://tools.ietf.org/html/rfc8297