### PR TITLE
[ActiveRecord] Add magic frozen_string_literal command to generator templates

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :<%= table_name %><%= primary_key_type %> do |t|

--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
 <%- if migration_action == 'add' -%>
   def change

--- a/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/model.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 class <%= class_name %> < <%= parent_class_name.classify %>
 <% attributes.select(&:reference?).each do |attribute| -%>

--- a/activerecord/lib/rails/generators/active_record/model/templates/module.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/module.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 <% module_namespacing do -%>
 module <%= class_path.map(&:camelize).join('::') %>
   def self.table_name_prefix


### PR DESCRIPTION
### Summary

When you generate models and migrations there is no magic `frozen_string_literal: true` comment at the top. This comment helps improve performance by reducing memory allocation when using strings. I added this comment only to the generators within `activerecord` as a starting point, but there are many other generators across the codebase that could also benefit from this
