### PR TITLE
Allow using thread variables for CurrentAttributes instances

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -117,6 +117,10 @@ module ActiveSupport
   def self.utc_to_local_returns_utc_offset_times=(value)
     DateAndTime::Compatibility.utc_to_local_returns_utc_offset_times = value
   end
+
+  def self.current_attributes_use_thread_variables=(value)
+    CurrentAttributes._use_thread_variables = value
+  end
 end
 
 autoload :I18n, "active_support/i18n"

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -143,13 +143,23 @@ module ActiveSupport
         current_instances.clear
       end
 
+      def _use_thread_variables=(value) # :nodoc:
+        @@use_thread_variables = value
+      end
+      @@use_thread_variables = false
+
       private
         def generated_attribute_methods
           @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
         end
 
         def current_instances
-          Thread.current[:current_attributes_instances] ||= {}
+          if @@use_thread_variables
+            Thread.current.thread_variable_get(:current_attributes_instances) ||
+              Thread.current.thread_variable_set(:current_attributes_instances, {})
+          else
+            Thread.current[:current_attributes_instances] ||= {}
+          end
         end
 
         def current_instances_key

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -174,4 +174,23 @@ class CurrentAttributesTest < ActiveSupport::TestCase
   test "respond_to? for methods that have not been called" do
     assert_equal true, Current.respond_to?("respond_to_test")
   end
+
+  test "CurrentAttributes use fiber-local variables" do
+    Session.current = 42
+    enumerator = Enumerator.new do |yielder|
+      yielder.yield Session.current
+    end
+    assert_nil enumerator.next
+  end
+
+  test "CurrentAttributes can use thread-local variables" do
+    ActiveSupport::CurrentAttributes._use_thread_variables = true
+    Session.current = 42
+    enumerator = Enumerator.new do |yielder|
+      yielder.yield Session.current
+    end
+    assert_equal 42, enumerator.next
+  ensure
+    ActiveSupport::CurrentAttributes._use_thread_variables = false
+  end
 end


### PR DESCRIPTION
### Summary

`ActiveSupport::CurrentAttributes` objects are stored in fiber-local variables.
There was already a proposal to make them stored in thread-local variables in #38905, which was closed because we don't want to encourage the use of thread variables given Fibers can be used as the thread of execution for some servers, namely Falcon.

The problem is that Ruby using Fibers internally for Enumerators make fiber variables not work in some situations. When code using CurrentAttributes is called from inside an Enumerator, and the calling code is getting the object yielded by calling Enumerator#next, the current fiber is the internal one, which results in the CurrentAttributes being unset.

To be clear, this is clearly a Ruby problem, not really a Rails issue, but it prevents us from using CurrentAttributes out of the box, and we have a monkey-patch for this reason. You can see a reduced reproduction script here: https://gist.github.com/etiennebarrie/a46be637a925d07aea64c8efcc5fabcc.

This PR adds a configuration option which allows to store CurrentAttributes instances in thread-local variables.

You can see an example app here: https://github.com/etiennebarrie/rails-app/tree/current-attributes-fiber-vs-thread

Run it with `rails s` and you get a `nil` CurrentAttribute attribute when using #next.

Run it with `thread_current_attributes=1 rails s` and CurrentAttributes work in all the cases.


### Other Information

Regarding the patch, I used:

* `Rails.application.config.active_support.current_attributes_use_thread_variables=` for the configuration value
* `ActiveSupport::CurrentAttributes._use_thread_variables=` for the setter
* `@@use_thread_variables` for the class variable

I used a class variable since the store is at the top-level of the hierarchy in `ActiveSupport::CurrentAttributes`, it makes sense to have only one value for this. But the setter is public for the configuration to be passed to it, which means one can do `Current._use_thread_variables = false` (with `Current < ActiveSupport::CurrentAttributes`) and still impact the global configuration.

Not sure what's the best arrangement we could have here, but we could also make the setter private and have the configuration value use `send`, or remove the setter and use `class_variable_set` directly, or inverting the dependency and call `ActiveSupport.current_attributes_use_thread_variables`. Let me know if there's a preferred solution.

Last point, I didn't add a changelog entry because I'm not sure it's a feature that makes a lot of sense to publicize, my guess is that people getting bitten by this could find this issue and learn about the feature that way (most probably in development/test, not in production, so that's not so bad as it sounds).

~~Edit: removed the class variable in favor of `class_attribute`.~~
Edit: brought back the class variable since per-subclass config can't work, you can see it not being reset at https://github.com/etiennebarrie/rails-app/tree/current-attributes-fiber-vs-thread%5E