### PR TITLE
Improve clarity of callback update warning [ci skip]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -117,7 +117,7 @@ Here is a list with all the available Active Record callbacks, listed in the sam
 
 WARNING. `after_save` runs both on create and update, but always _after_ the more specific callbacks `after_create` and `after_update`, no matter the order in which the macro calls were executed.
 
-WARNING. Care should be taken in callbacks to avoid updating attributes. For example, avoid running `update(attribute: "value")` and similar code during callbacks. This can alter the state of the model and may result in unexpected side effects during commit. Instead, you should try to assign values in the `before_create` or earlier callbacks.
+WARNING. Avoid updating or saving attributes in callbacks. For example, don't call `update(attribute: "value")` within a callback. This can alter the state of the model and may result in unexpected side effects during commit. Instead, you can safely assign values directly (for example, `self.attribute = "value"`) in `before_create` / `before_update` or earlier callbacks.
 
 NOTE: `before_destroy` callbacks should be placed before `dependent: :destroy`
 associations (or use the `prepend: true` option), to ensure they execute before


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/38166 added a warning to the [ActiveRecord Callbacks docs](https://guides.rubyonrails.org/active_record_callbacks.html#available-callbacks). 

Closes https://github.com/rails/rails/issues/39418, an issue which discussed how the current writing might be vague.

### Other Information

Feedback requested from @jules2689 who helped me understand the meaning