### PR TITLE
Raise an exception when a date or time is used in an inclusion validator

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -12,6 +12,14 @@ module ActiveModel
         unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.respond_to?(:to_sym)
           raise ArgumentError, ERROR_MESSAGE
         end
+
+        return if delimiter.respond_to?(:call)
+
+        members = delimiter.respond_to?(:to_sym) ? record.send(delimiter) : delimiter
+        if members.is_a?(Range) && (members.first.is_a?(Time) || members.first.is_a?(DateTime) || members.first.is_a?(Date))
+          raise ArgumentError, "You should not use a #{members.first.class} as range parameter in your :in clause, because they are evaluated only once and might lead to unexpected behaviours.
+              Please use a proc or a lambda instead. in: ->(_) { start...end }"
+        end
       end
 
     private


### PR DESCRIPTION
### Summary

Writing the following validator:

```
validates :in_switzerland_since, inclusion: { in: 100.years.ago..Time.zone.today }
```

breaks after few days, if a person just arrived in Switzerland.

This is because the values `100.years.ago` and `Time.zone.today` are evaluated only when the class is loaded (boot time).

This problem, in the past, was affecting in a similar way also scopes. That's why now we use always proc or lambdas in scopes. 

The usage of a proc or lambda should be forced also in this case and the validation above should be rewritten as 

```
validates :in_switzerland_since, inclusion: { in: ->(_) { 100.years.ago..Time.zone.today } }
```

I deliberately didn't touch the tests to show that they will fail, and I am also aware that this would be a breaking change, and therefore you might probably want to go with a simpler warning message instead of an error.

If you agree that this is an issue and we should tackle it, just tell me if you want:
* **a breaking change** and I'll add regression tests and all that stuff.
* a warning message (maybe a deprecation warning?)

## Additional information

The above wouldn't be solved simply with the lambda, since the lambda would make the range always shift and after 100 years, the user would not be valid anymore. 
A better validation would do:

```
validates :in_switzerland_since, inclusion: { in: ->(_) { 100.years.ago..Time.zone.today } }, if: :in_switzerland_since_changed?
```