### PR TITLE
Remove dup from Request#set_cotent_type

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -448,7 +448,7 @@ module ActionDispatch # :nodoc:
     end
 
     def set_content_type(content_type, charset)
-      type = (content_type || "").dup
+      type = +(content_type || "")
       type << "; charset=#{charset.to_s.downcase}" if charset
       set_header CONTENT_TYPE, type
     end


### PR DESCRIPTION
### Summary

Use `+` to mutate the type string instead of dupping in `set_content_type`.

Based on my investigations, this looks safe to mutate. Please, let me know if that's not the case.

#### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "benchmark-ips"
end

module ActionDispatch
  class Response
    def fast_set_content_type(content_type, charset)
      type = +(content_type || "")
      type << "; charset=#{charset.to_s.downcase}" if charset
      set_header CONTENT_TYPE, type
    end
  end
end

response = ActionDispatch::Response.new

SCENARIOS = {
  "WITH CONTENT-TYPE" => "application/xml",
  "WITHOUT CONTENT-TYPE" => nil
}

SCENARIOS.each_pair do |name, value|
  puts "*" * 80
  puts name
  puts "*" * 80

  Benchmark.ips do |x|
    x.report("set_content_type")      { response.send(:set_content_type, value, "charset=utf-8") }
    x.report("fast_set_content_type") { response.send(:fast_set_content_type, value, "charset=utf-8") }
    x.compare!
  end
end
```
#### Results
```
********************************************************************************
WITH CONTENT-TYPE
********************************************************************************
Warming up --------------------------------------
    set_content_type    81.142k i/100ms
fast_set_content_type
                        80.276k i/100ms
Calculating -------------------------------------
    set_content_type    851.480k (± 5.4%) i/s -      4.301M in   5.066131s
fast_set_content_type
                        950.261k (± 6.2%) i/s -      4.817M in   5.086873s

Comparison:
fast_set_content_type:   950261.1 i/s
    set_content_type:   851480.4 i/s - same-ish: difference falls within error

********************************************************************************
WITHOUT CONTENT-TYPE
********************************************************************************
Warming up --------------------------------------
    set_content_type   109.191k i/100ms
fast_set_content_type
                       120.634k i/100ms
Calculating -------------------------------------
    set_content_type      1.057M (± 7.5%) i/s -      5.350M in   5.093055s
fast_set_content_type
                          1.227M (± 2.6%) i/s -      6.152M in   5.018501s

Comparison:
fast_set_content_type:  1226719.1 i/s
    set_content_type:  1057400.1 i/s - 1.16x  (± 0.00) slower
```