### PR TITLE
Remove dup from post body for forcing encoding

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -334,7 +334,7 @@ module ActionDispatch
     # variable is already set, wrap it in a StringIO.
     def body
       if raw_post = get_header("RAW_POST_DATA")
-        raw_post = raw_post.dup.force_encoding(Encoding::BINARY)
+        (+raw_post).force_encoding(Encoding::BINARY)
         StringIO.new(raw_post)
       else
         body_stream

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -334,7 +334,7 @@ module ActionDispatch
     # variable is already set, wrap it in a StringIO.
     def body
       if raw_post = get_header("RAW_POST_DATA")
-        (+raw_post).force_encoding(Encoding::BINARY)
+        raw_post = (+raw_post).force_encoding(Encoding::BINARY)
         StringIO.new(raw_post)
       else
         body_stream


### PR DESCRIPTION
### Summary

Very similar to #39437.

Instead of dupping the body to force the encoding, simply unfreeze the string.

#### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", path: "../rails", require: "rails/all"
  gem "benchmark-ips"
end

module ActionDispatch
  class Request
    def fast_body
      if raw_post = get_header("RAW_POST_DATA")
        (+raw_post).force_encoding(Encoding::BINARY)
        StringIO.new(raw_post)
      else
        body_stream
      end
    end
  end
end

post_body = {
  article: {
    title: "My article",
    content: (0..1000).map { "Blah!" }.join(" "),
    author: "Vini",
    published_at: "2020-05-01",
    created_at: "2020-04-20",
    updated_at: "2020-05-01",
    tags: %w[
      development
      web
      ruby
      rails
      software
    ]
  }
}.to_json

request = ActionDispatch::Request.new("RAW_POST_DATA" => post_body)

Benchmark.ips do |x|
  x.report("body")      { request.body }
  x.report("fast_body") { request.fast_body }
  x.compare!
end
```
#### Results
```
Warming up --------------------------------------
                body   130.235k i/100ms
           fast_body   192.171k i/100ms
Calculating -------------------------------------
                body      1.413M (± 9.2%) i/s -      7.033M in   5.020448s
           fast_body      1.743M (± 7.2%) i/s -      8.840M in   5.101291s

Comparison:
           fast_body:  1742855.9 i/s
                body:  1413440.7 i/s - 1.23x  (± 0.00) slower
```