### PR TITLE
Shorten inspect on AbstractController::Base and ActionDispatch::Request

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -204,6 +204,10 @@ module AbstractController
       true
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+    end
+
     private
       # Returns true if the name can be considered an action because
       # it has a method defined in the controller.

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -431,6 +431,10 @@ module ActionDispatch
       super || scheme == "wss"
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name} method=#{method.dump}, original_url=#{original_url.dump}, remote_ip=#{remote_ip.dump}, media_type=#{media_type.dump}>"
+    end
+
     private
       def check_method(name)
         HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS[0...-1].join(', ')}, and #{HTTP_METHODS[-1]}")

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -147,6 +147,10 @@ class ControllerInstanceTests < ActiveSupport::TestCase
   ensure
     ActionDispatch::Response.default_headers = original_default_headers
   end
+
+  def test_inspect
+    assert_match(/#<EmptyController:0x[0-9a-f]+>/, @empty.inspect)
+  end
 end
 
 class PerformActionTest < ActionController::TestCase

--- a/actionpack/test/controller/metal_test.rb
+++ b/actionpack/test/controller/metal_test.rb
@@ -29,4 +29,9 @@ class MetalControllerInstanceTests < ActiveSupport::TestCase
   ensure
     ActionDispatch::Response.default_headers = original_default_headers
   end
+
+  def test_inspect
+    controller = SimpleController.new
+    assert_match(/#<MetalControllerInstanceTests::SimpleController:0x[0-9a-f]+>/, controller.inspect)
+  end
 end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1290,3 +1290,21 @@ class EarlyHintsRequestTest < BaseRequestTest
     assert_equal expected_hints, early_hints
   end
 end
+
+class RequestInspectTest < BaseRequestTest
+  test "inspect" do
+    request = stub_request(
+      "REQUEST_METHOD" => "POST",
+      "REMOTE_ADDR" => "1.2.3.4",
+      "HTTP_X_FORWARDED_PROTO" => "https",
+      "HTTP_X_FORWARDED_HOST" => "glu.ttono.us:443",
+      "PATH_INFO" => "/path/of/some/uri",
+      "QUERY_STRING" => "mapped=1",
+      "CONTENT_TYPE" => "application/x-www-form-urlencoded; charset=utf-8",
+    )
+    assert_match %r(#<ActionDispatch::Request method="POST"), request.inspect
+    assert_match %r(original_url="https://glu.ttono.us/path/of/some/uri\?mapped=1"), request.inspect
+    assert_match %r(remote_ip="1.2.3.4"), request.inspect
+    assert_match %r(media_type="application/x-www-form-urlencoded">), request.inspect
+  end
+end


### PR DESCRIPTION
Calling controller in the debug console generates an endless stream of characters.
This shortens it to only the class name but we can probably add some useful information (action_methods?).

```
controller.inspect
# => "#<MyController:0x00000000005028>"
```

Inspect on ActionDispatch::Request is shortened to relevant attributes:
```
request.inspect
# => "#<ActionDispatch::Request request_method=POST, original_url=https://glu.ttono.us/path/of/some/uri?mapped=1, remote_ip=1.2.3.4, media_type=application/x-www-form-urlencoded>"
```