### PR TITLE
No need to extend ActionController::Caching by ActiveSupport::Autoload

### DIFF
--- a/actionpack/lib/action_controller/caching.rb
+++ b/actionpack/lib/action_controller/caching.rb
@@ -22,7 +22,6 @@ module ActionController
   #   config.action_controller.cache_store = :mem_cache_store, Memcached::Rails.new('localhost:11211')
   #   config.action_controller.cache_store = MyOwnStore.new('parameter')
   module Caching
-    extend ActiveSupport::Autoload
     extend ActiveSupport::Concern
 
     included do


### PR DESCRIPTION
It is not used.