### PR TITLE
rails new cool_app --interactive

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -294,6 +294,7 @@ module Rails
 
       class_option :minimal, type: :boolean,
                              desc: "Preconfigure a minimal rails app"
+
       class_option :interactive, type: :boolean, default: false, aliases: "-i",
                                  desc: "Interactive setup for your rails app"
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators/app_base"
+require_relative "interactive_options"
 
 module Rails
   module ActionMethods # :nodoc:
@@ -293,6 +294,8 @@ module Rails
 
       class_option :minimal, type: :boolean,
                              desc: "Preconfigure a minimal rails app"
+      class_option :interactive, type: :boolean, default: false, aliases: "-i",
+                                 desc: "Interactive setup for your rails app"
 
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false,
                                  desc: "Don't run bundle install"
@@ -337,6 +340,10 @@ module Rails
                 option[:skip_javascript] = false
               end
             end.freeze
+        end
+
+        if options[:interactive]
+          self.options = options.merge(interactive_options).freeze
         end
 
         @after_bundle_callbacks = []
@@ -596,6 +603,10 @@ module Rails
 
       def get_builder_class
         defined?(::AppBuilder) ? ::AppBuilder : Rails::AppBuilder
+      end
+
+      def interactive_options
+        InteractiveOptions.perform(options.dup)
       end
     end
 

--- a/railties/lib/rails/generators/rails/app/interactive_options.rb
+++ b/railties/lib/rails/generators/rails/app/interactive_options.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Rails
+  module Generators
+    class InteractiveOptions # :nodoc:
+      include Database
+      include Thor::Shell
+
+      attr_reader :options
+
+      def self.perform(initial_options)
+        new(initial_options).perform
+      end
+
+      def initialize(initial_options)
+        @options = initial_options
+      end
+
+      def perform
+        say "Rails CLI #{Rails.version}", :green
+
+        case inquire_rails_version
+        when "dev"    then options[:dev] = true
+        when "edge"   then options[:edge] = true
+        when "master" then options[:master] = true
+        end
+
+        options[:database]             = inquire_database
+        options[:skip_action_cable]    = inquire_action_cable
+        options[:skip_action_mailer]   = inquire_action_mailer
+        options[:skip_action_mailbox]  = inquire_action_mailbox
+        options[:skip_active_storage]  = inquire_active_storage
+        options[:skip_action_text]     = inquire_action_text
+        options[:skip_bootsnap]        = inquire_bootsnap
+        options[:skip_jbuilder]        = inquire_jbuilder
+        options[:skip_javascript]      = inquire_javascript
+        options[:skip_spring]          = inquire_spring
+        options[:skip_sprockets]       = inquire_sprockets
+        options[:skip_system_tests]    = inquire_system_tests
+        options[:skip_turbolinks]      = inquire_turbolinks
+        options[:skip_webpack_install] = inquire_webpack
+        options[:webpack]              = inquire_webpack_library unless options[:skip_webpack_install]
+
+        options
+      end
+
+      private
+        def inquire_rails_version
+          say <<~MESSAGE
+          Target different versions of rails for your application.
+          *dev* will target your checked out version of rails.
+          *edge* will target the latest commit on rails.
+          *master* will target the rails master branch.
+          *stable* will target the rails gem version you have installed.
+          MESSAGE
+          inquire_from_list("What is your preferred rails version?", %w(dev edge master stable), "stable")
+        end
+
+        def inquire_database
+          inquire_from_list("What is your preferred database?", DATABASES, options[:database])
+        end
+
+        def inquire_action_cable
+          say "Action cable integrates web sockets with your rails application: https://github.com/rails/rails/tree/master/actioncable"
+          inquire_boolean("Skip action cable?", options[:skip_action_cable])
+        end
+
+        def inquire_action_mailer
+          say "Action mailer is a framework for designing email services: https://github.com/rails/rails/tree/master/actionmailer"
+          inquire_boolean("Skip action mailer?", options[:skip_action_mailer])
+        end
+
+        def inquire_action_mailbox
+          say "Action Mailbox routes incoming emails to controller-like mailboxes for processing in Rails: https://github.com/rails/rails/tree/master/actionmailbox"
+          inquire_boolean("Skip action mailbox?", options[:skip_action_mailbox])
+        end
+
+        def inquire_active_storage
+          say "Active Storage makes it simple to upload and reference files in cloud services: https://github.com/rails/rails/tree/master/activestorage"
+          inquire_boolean("Skip active storage?", options[:skip_active_storage])
+        end
+
+        def inquire_action_text
+          say "Action Text brings rich text content and editing to Rails: https://github.com/rails/rails/tree/master/actiontext"
+          inquire_boolean("Skip action text?", options[:skip_action_text])
+        end
+
+        def inquire_bootsnap
+          say "Bootsnap boots rails apps, faster: https://github.com/Shopify/bootsnap"
+          inquire_boolean("Skip bootsnap?", options[:skip_bootsnap])
+        end
+
+        def inquire_jbuilder
+          say "Jbuilder generates JSON objects with a Builder-style DSL: https://github.com/rails/jbuilder"
+          inquire_boolean("Skip jbuilder?", options[:skip_jbuilder])
+        end
+
+        def inquire_javascript
+          say "Use yarn to handle your package dependency management."
+          inquire_boolean("Skip javascript?", options[:skip_javascript])
+        end
+
+        def inquire_spring
+          say "Rails application preloader, speeds up development by keeping your application running in the background: https://github.com/rails/spring"
+          inquire_boolean("Skip spring?", options[:skip_spring])
+        end
+
+        def inquire_sprockets
+          say "Sprockets is a Ruby library for compiling and serving web assets: https://github.com/rails/sprockets"
+          inquire_boolean("Skip sprocket?", options[:skip_sprockets])
+        end
+
+        def inquire_system_tests
+          say "System tests are useful for writing end-to-end tests with a tool like capybara."
+          inquire_boolean("Skip system tests?", options[:skip_system_tests])
+        end
+
+        def inquire_turbolinks
+          say "Turbolinks makes navigating your web application faster: https://github.com/turbolinks/turbolinks"
+          inquire_boolean("Skip turbolinks?", options[:skip_turbolinks])
+        end
+
+        def inquire_webpack
+          say "Webpacker manages your app-like JavaScript modules in Rails: https://github.com/rails/webpacker"
+          inquire_boolean("Skip webpack?", options[:skip_webpack_install])
+        end
+
+        def inquire_webpack_library
+          inquire_from_list("What is your preferred webpack library?", AppGenerator::WEBPACKS, options[:webpack])
+        end
+
+        # Ask a boolean question. Returns true for "y" and false for "n".
+        def inquire_boolean(question, default = true)
+          answer = inquire_from_list question, %w(y n), default ? "y" : "n"
+          answer == "y" ? true : false
+        end
+
+        # Ask a question from a preset list of answers. Returns one of the preset answers.
+        def inquire_from_list(question, possible_answers, default = nil)
+          ask question, limited_to: possible_answers, default: default
+        end
+    end
+  end
+end

--- a/railties/lib/rails/generators/rails/app/interactive_options.rb
+++ b/railties/lib/rails/generators/rails/app/interactive_options.rb
@@ -61,27 +61,27 @@ module Rails
         end
 
         def inquire_action_cable
-          say "Action cable integrates web sockets with your rails application: https://github.com/rails/rails/tree/master/actioncable"
+          say "Action cable integrates web sockets with your rails application: https://guides.rubyonrails.org/action_cable_overview.html"
           inquire_boolean("Skip action cable?", options[:skip_action_cable])
         end
 
         def inquire_action_mailer
-          say "Action mailer is a framework for designing email services: https://github.com/rails/rails/tree/main/actionmailer"
+          say "Action mailer is a framework for designing email services: https://guides.rubyonrails.org/action_mailer_basics.html"
           inquire_boolean("Skip action mailer?", options[:skip_action_mailer])
         end
 
         def inquire_action_mailbox
-          say "Action Mailbox routes incoming emails to controller-like mailboxes for processing in Rails: https://github.com/rails/rails/tree/main/actionmailbox"
+          say "Action Mailbox routes incoming emails to controller-like mailboxes for processing in Rails: https://guides.rubyonrails.org/action_mailbox_basics.html"
           inquire_boolean("Skip action mailbox?", options[:skip_action_mailbox])
         end
 
         def inquire_active_storage
-          say "Active Storage makes it simple to upload and reference files in cloud services: https://github.com/rails/rails/tree/main/activestorage"
+          say "Active Storage makes it simple to upload and reference files in cloud services: https://guides.rubyonrails.org/active_storage_overview.html"
           inquire_boolean("Skip active storage?", options[:skip_active_storage])
         end
 
         def inquire_action_text
-          say "Action Text brings rich text content and editing to Rails: https://github.com/rails/rails/tree/main/actiontext"
+          say "Action Text brings rich text content and editing to Rails: https://guides.rubyonrails.org/action_text_overview.html"
           inquire_boolean("Skip action text?", options[:skip_action_text])
         end
 

--- a/railties/lib/rails/generators/rails/app/interactive_options.rb
+++ b/railties/lib/rails/generators/rails/app/interactive_options.rb
@@ -22,7 +22,7 @@ module Rails
         case inquire_rails_version
         when "dev"    then options[:dev] = true
         when "edge"   then options[:edge] = true
-        when "master" then options[:master] = true
+        when "main" then options[:main] = true
         end
 
         options[:database]             = inquire_database
@@ -50,10 +50,10 @@ module Rails
           Target different versions of rails for your application.
           *dev* will target your checked out version of rails.
           *edge* will target the latest commit on rails.
-          *master* will target the rails master branch.
+          *main* will target the rails main branch.
           *stable* will target the rails gem version you have installed.
           MESSAGE
-          inquire_from_list("What is your preferred rails version?", %w(dev edge master stable), "stable")
+          inquire_from_list("What is your preferred rails version?", %w(dev edge main stable), "stable")
         end
 
         def inquire_database
@@ -66,27 +66,27 @@ module Rails
         end
 
         def inquire_action_mailer
-          say "Action mailer is a framework for designing email services: https://github.com/rails/rails/tree/master/actionmailer"
+          say "Action mailer is a framework for designing email services: https://github.com/rails/rails/tree/main/actionmailer"
           inquire_boolean("Skip action mailer?", options[:skip_action_mailer])
         end
 
         def inquire_action_mailbox
-          say "Action Mailbox routes incoming emails to controller-like mailboxes for processing in Rails: https://github.com/rails/rails/tree/master/actionmailbox"
+          say "Action Mailbox routes incoming emails to controller-like mailboxes for processing in Rails: https://github.com/rails/rails/tree/main/actionmailbox"
           inquire_boolean("Skip action mailbox?", options[:skip_action_mailbox])
         end
 
         def inquire_active_storage
-          say "Active Storage makes it simple to upload and reference files in cloud services: https://github.com/rails/rails/tree/master/activestorage"
+          say "Active Storage makes it simple to upload and reference files in cloud services: https://github.com/rails/rails/tree/main/activestorage"
           inquire_boolean("Skip active storage?", options[:skip_active_storage])
         end
 
         def inquire_action_text
-          say "Action Text brings rich text content and editing to Rails: https://github.com/rails/rails/tree/master/actiontext"
+          say "Action Text brings rich text content and editing to Rails: https://github.com/rails/rails/tree/main/actiontext"
           inquire_boolean("Skip action text?", options[:skip_action_text])
         end
 
         def inquire_bootsnap
-          say "Bootsnap boots rails apps, faster: https://github.com/Shopify/bootsnap"
+          say "Bootsnap makes Rails application boot faster: https://github.com/Shopify/bootsnap"
           inquire_boolean("Skip bootsnap?", options[:skip_bootsnap])
         end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1238,6 +1238,40 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "web-console", app_root
   end
 
+  def test_interactive_rails_app
+    app_root = File.join(destination_root, "myapp")
+
+    Rails::Generators::AppGenerator.class_eval do
+      def interactive_options
+        {
+          skip_active_job: false,
+          skip_active_storage: true,
+          skip_action_mailer: true,
+          skip_action_mailbox: true,
+          skip_action_text: true,
+          skip_action_cable: true,
+          skip_bootnap: true
+        }
+      end
+    end
+
+    run_generator [app_root, "--interactive"]
+    assert_file "#{app_root}/config/environment.rb", /Rails\.application\.initialize!/
+
+    assert_file "#{app_root}/config/boot.rb" do |content|
+      assert_no_match(/require "bootsnap\/setup"/, content)
+    end
+
+    assert_file "#{app_root}/config/application.rb" do |content|
+      assert_match(/\s+require\s+["']active_job\/railtie["']/, content)
+      assert_match(/#\s+require\s+["']active_storage\/engine["']/, content)
+      assert_match(/#\s+require\s+["']action_mailer\/railtie["']/, content)
+      assert_match(/#\s+require\s+["']action_mailbox\/engine["']/, content)
+      assert_match(/#\s+require\s+["']action_text\/engine["']/, content)
+      assert_match(/#\s+require\s+["']action_cable\/engine["']/, content)
+    end
+  end
+
   private
     def stub_rails_application(root)
       Rails.application.config.root = root

--- a/railties/test/generators/interactive_options_test.rb
+++ b/railties/test/generators/interactive_options_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "active_support/test_case"
+require "active_support/testing/autorun"
+require "rails/generators/rails/app/app_generator"
+
+module Rails
+  module Generators
+    class InteractiveOptionsTest < ActiveSupport::TestCase # :nodoc:
+      def test_perform
+        interactive_options = InteractiveOptions.new({ skip_action_text: false })
+
+        def interactive_options.inquire_rails_version
+          "edge"
+        end
+
+        def interactive_options.inquire_database
+          "mysql"
+        end
+
+        def interactive_options.inquire_active_storage
+          false
+        end
+
+        def interactive_options.inquire_action_cable
+          true
+        end
+
+        def interactive_options.inquire_action_mailer
+          true
+        end
+
+        def interactive_options.inquire_action_mailbox
+          true
+        end
+
+        def interactive_options.inquire_action_text
+          true
+        end
+
+        def interactive_options.inquire_bootsnap
+          true
+        end
+
+        def interactive_options.inquire_jbuilder
+          true
+        end
+
+        def interactive_options.inquire_javascript
+          true
+        end
+
+        def interactive_options.inquire_spring
+          true
+        end
+
+        def interactive_options.inquire_sprockets
+          true
+        end
+
+        def interactive_options.inquire_system_tests
+          true
+        end
+
+        def interactive_options.inquire_turbolinks
+          true
+        end
+
+        def interactive_options.inquire_webpack
+          false
+        end
+
+        def interactive_options.inquire_webpack_library
+          "stimulus"
+        end
+
+        io = capture_io { interactive_options.perform }
+
+        assert_match "Rails CLI #{Rails.version}\n", io.join
+        assert_equal true,        interactive_options.options[:edge]
+        assert_equal "mysql",     interactive_options.options[:database]
+        assert_equal true,        interactive_options.options[:skip_action_cable]
+        assert_equal true,        interactive_options.options[:skip_action_mailer]
+        assert_equal true,        interactive_options.options[:skip_action_mailbox]
+        assert_equal false,       interactive_options.options[:skip_active_storage]
+        assert_equal true,        interactive_options.options[:skip_action_text]
+        assert_equal true,        interactive_options.options[:skip_bootsnap]
+        assert_equal true,        interactive_options.options[:skip_jbuilder]
+        assert_equal true,        interactive_options.options[:skip_javascript]
+        assert_equal true,        interactive_options.options[:skip_spring]
+        assert_equal true,        interactive_options.options[:skip_sprockets]
+        assert_equal true,        interactive_options.options[:skip_system_tests]
+        assert_equal true,        interactive_options.options[:skip_turbolinks]
+        assert_equal false,       interactive_options.options[:skip_webpack_install]
+        assert_equal "stimulus",  interactive_options.options[:webpack]
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

rails new cool_app --interactive

Adds the ability to interactively setup your rails application. All the questions we ask:

- database
- skip_action_cable
- skip_action_mailer
- skip_action_mailbox
- skip_active_storage
- skip_action_text
- skip_bootsnap
- skip_jbuilder
- skip_javascript
- skip_spring
- skip_sprockets
- skip_system_tests
- skip_turbolinks
- skip_webpack
- webpack (which library you want to use if skip_webpack = false)

related #39282

If you want to help test this out, please do:

1. Pull down this branch
2. cd into the rails source
3. `railties/exe/rails new ~/Desktop/testapps/your_interactive_app --interactive`