### PR TITLE
Where with block

### DIFF
--- a/activerecord/lib/active_record/relation/query_composer.rb
+++ b/activerecord/lib/active_record/relation/query_composer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class QueryComposer
+    delegate :[], to: :arel_table
+
+    def initialize(model)
+      @model = model
+      @arel_table = model.arel_table
+      @reflections = model._reflections
+    end
+
+    def method_missing(name, *_args)
+      if reflections.key?(name.to_s)
+        self.class.new(reflections[name.to_s].klass)
+      else
+        super
+      end
+    end
+
+    private
+      attr_reader :model, :arel_table, :reflections
+  end
+end

--- a/activerecord/lib/active_record/relation/query_composer.rb
+++ b/activerecord/lib/active_record/relation/query_composer.rb
@@ -8,6 +8,7 @@ module ActiveRecord
       @model = model
       @arel_table = model.arel_table
       @reflections = model._reflections
+      define_attribute_accessors
     end
 
     def method_missing(name, *_args)
@@ -20,5 +21,13 @@ module ActiveRecord
 
     private
       attr_reader :model, :arel_table, :reflections
+
+      def define_attribute_accessors
+        model.attribute_names.each do |attr|
+          define_singleton_method attr do
+            arel_table[attr]
+          end
+        end
+      end
   end
 end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -663,7 +663,7 @@ module ActiveRecord
     #
     # If the condition is any blank-ish object, then #where is a no-op and returns
     # the current relation.
-    def where(opts = :chain, *rest)
+    def where(opts = :chain, *rest, &block)
       new_scope = if :chain == opts && block_given?
         self
       elsif :chain == opts
@@ -676,7 +676,7 @@ module ActiveRecord
 
       if block_given?
         composer = QueryComposer.new(model)
-        constraints = yield composer
+        constraints = composer.instance_exec(composer, &block)
         new_scope.where!(constraints)
       else
         new_scope

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -78,6 +78,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, posts.to_a.size
   end
 
+  def test_block_instance_method_where
+    posts = Post.where { author_id.eq(1).and(id.eq(1)) }
+    assert_equal 1, posts.to_a.size
+  end
+
   def test_scoped
     topics = Topic.all
     assert_kind_of ActiveRecord::Relation, topics
@@ -527,6 +532,12 @@ class RelationTest < ActiveRecord::TestCase
 
   def tests_finding_with_block_and_methods_on_joined_table
     firms = DependentFirm.joins(:account).where { |firm| firm.name.eq("RailsCore").and(firm.accounts.credit_limit.eq(55..60)) }.to_a
+    assert_equal 1, firms.size
+    assert_equal companies(:rails_core), firms.first
+  end
+
+  def tests_finding_with_block_and_instance_methods_on_joined_table
+    firms = DependentFirm.joins(:account).where { name.eq("RailsCore").and(accounts.credit_limit.eq(55..60)) }.to_a
     assert_equal 1, firms.size
     assert_equal companies(:rails_core), firms.first
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -63,6 +63,16 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, posts.to_a.size
   end
 
+  def test_block_where
+    posts = Post.where { |post| post[:author_id].eq(1).and(post[:id].eq(1)) }
+    assert_equal 1, posts.to_a.size
+  end
+
+  def test_block_where_can_chain
+    posts = Post.where { |post| post[:author_id].eq(1) }.where { |post| post[:id].eq(1) }
+    assert_equal 1, posts.to_a.size
+  end
+
   def test_scoped
     topics = Topic.all
     assert_kind_of ActiveRecord::Relation, topics
@@ -500,6 +510,12 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_finding_with_hash_conditions_on_joined_table
     firms = DependentFirm.joins(:account).where(name: "RailsCore", accounts: { credit_limit: 55..60 }).to_a
+    assert_equal 1, firms.size
+    assert_equal companies(:rails_core), firms.first
+  end
+
+  def tests_finding_with_block_on_joined_table
+    firms = DependentFirm.joins(:account).where { |firm| firm[:name].eq("RailsCore").and(firm.accounts[:credit_limit].eq(55..60)) }.to_a
     assert_equal 1, firms.size
     assert_equal companies(:rails_core), firms.first
   end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -73,6 +73,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, posts.to_a.size
   end
 
+  def test_block_method_where
+    posts = Post.where { |post| post.author_id.eq(1).and(post.id.eq(1)) }
+    assert_equal 1, posts.to_a.size
+  end
+
   def test_scoped
     topics = Topic.all
     assert_kind_of ActiveRecord::Relation, topics
@@ -516,6 +521,12 @@ class RelationTest < ActiveRecord::TestCase
 
   def tests_finding_with_block_on_joined_table
     firms = DependentFirm.joins(:account).where { |firm| firm[:name].eq("RailsCore").and(firm.accounts[:credit_limit].eq(55..60)) }.to_a
+    assert_equal 1, firms.size
+    assert_equal companies(:rails_core), firms.first
+  end
+
+  def tests_finding_with_block_and_methods_on_joined_table
+    firms = DependentFirm.joins(:account).where { |firm| firm.name.eq("RailsCore").and(firm.accounts.credit_limit.eq(55..60)) }.to_a
     assert_equal 1, firms.size
     assert_equal companies(:rails_core), firms.first
   end

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -367,10 +367,10 @@ class NestedRelationScopingTest < ActiveRecord::TestCase
     Developer.where("name = 'Jamis'").scoping do
       assert_equal "Jamis", Developer.first.name
 
-      Developer.unscoped.where("name = 'David'") do
+      Developer.unscoped.where("name = 'David'").scoping do
         assert_equal "David", Developer.first.name
 
-        Developer.unscoped.where("name = 'Maiha'") do
+        Developer.unscoped.where("name = 'Maiha'").scoping do
           assert_nil Developer.first
         end
 


### PR DESCRIPTION
### Summary

Motivated by @tenderlove's PR about [exposing `arel_table`](https://github.com/rails/rails/pull/39198) I implemented a way to query using blocks and which I think provides great power without sacrificing readability.

The PR comes in three flavors which are divided into corresponding commits, each one building on the last and adding functionalities. Each commit is backward compatible and comes with tests as documentation of the syntax, I'm happy to do add more tests to cover all paths. 

The first commit is the vanilla version which sends the block an object that allows using the same syntax as `arel` and adds methods for associations. For a `Post` with many `Comment`s and each `Comment` with an `User` an example would be:

```ruby
# simple query
Post.where { |post| post[:updated_at].gt(1.day.ago) }

# deeply nested
Post.joins(comments: :user).where { |post| post.comments.user[:first_name].eq("John") }
```

The second commit defines a method for each attribute, which I think adds better readability. Redoing the examples with methods it'd be:

```ruby
# simple query
Post.where { |post| post.updated_at.gt(1.day.ago) }

# deeply nested
Post.joins(comments: :user).where { |post| post.comments.user.first_name.eq("John") }
```

The last commit executes the block in the instance of the `QueryComposer` (open to other names) which allows call methods directly without the need to use the parameter from the block, which is still passed so both syntaxes are allowed. Once again an example with the same domain:

```ruby
# simple query
Post.where { updated_at.gt(1.day.ago) }

# deeply nested
Post.joins(comments: :user).where { comments.user.first_name.eq("John") }
```

Any comments and feedback are welcome, I'm happy to add any requested changes @kamipo @rafaelfranca @flanger001. The only issue I found while running the tests was that `Model.unscoped.where(...) { }` associated the block to `unscoped` and so I had to change the tests to use `scoping` after the `where` call. I think having the block not associating to the last call is also a bit confusing IMHO and so I'd rather have this functionality than the ability to do that.

Domain for reference:

```ruby
class Post < ApplicationRecord
  has_many :comments
end

class Comments < ApplicationRecord
  belongs_to :user
end

class User < ApplicationRecord
end
```

### Other Information

Again, I'm looking for feedback on the syntaxes but I'm happy to provide benchmarks or anything else that might be interesting. I'm also aware that there are changes that may improve performance, like defining the attributes method lazily and not creating a new object every time an association is queried, and I'd be more than willing to test alternatives to the current implementation.

I did a benchmark just to check this does not slow down query creation too much and it turns out it's actually faster this way. Though I wouldn't call it a noticeable improvement.

```

Warming up --------------------------------------
           with_hash   771.000  i/100ms
Calculating -------------------------------------
           with_hash      7.716k (± 4.2%) i/s -     38.550k in   5.004979s

Warming up --------------------------------------
          with_block     1.376k i/100ms
Calculating -------------------------------------
          with_block     15.276k (±17.2%) i/s -     74.304k in   5.081121s

Pausing here -- run Ruby again to measure the next benchmark...

Comparison:
          with_block:    15276.3 i/s
           with_hash:     7716.1 i/s - 1.98x  slower
```

Here's the benchmark script:

```ruby
# frozen_string_literal: true

require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem 'rails', github: 'brunvez/rails', branch: 'where-with-block'
  gem 'benchmark-ips', '< 2.8'
  gem 'byebug'
  gem 'sqlite3'
end

require 'active_record'
require 'active_model'

ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
@connection = ActiveRecord::Base.connection
@connection.create_table :posts, force: true do |t|
  t.string :title
end
@connection.create_table :users, force: true do |t|
  t.string :name
end
@connection.create_table :comments, force: true do |t|
  t.string :content
  t.belongs_to :post
  t.belongs_to :user
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
  belongs_to :author, class_name: 'User', foreign_key: :user_id
end

class User < ActiveRecord::Base
  has_many :comments
end

Benchmark.ips do |x|
  x.report('with_hash') do
    Post.joins(comments: :author)
      .where(title: 'Something',
             comments: { content: 'Cool' },
             users: { name: 'John', id: 10 }
      )
  end

  x.report('with_block') do
    Post.joins(comments: :author).where do |post|
      post.title.eq('Something')
        .and(post.comments.content.eq('Cool'))
        .and(post.comments.author.name.eq('John'))
        .and(post.comments.author.id.eq(10))
    end
  end

  x.report('with_multiple_hashes') do
    Post.joins(comments: :author)
      .where(title: 'Something')
      .where(comments: { content: 'Cool' })
      .where(users: { name: 'John', id: 10 })
  end

  x.report('with_multiple_blocks') do
    Post.joins(comments: :author)
      .where { |post| post.title.eq('Something') }
      .where { |post| post.comments.content.eq('Cool') }
      .where { |post| post.comments.author.name.eq('John').and(post.comments.author.id.eq(10)) }
  end

  x.hold! 'temp_results'
  x.compare!
end
```