### PR TITLE
Set retry_jitter to 0.0 for upgraded applications

### DIFF
--- a/activejob/lib/active_job/exceptions.rb
+++ b/activejob/lib/active_job/exceptions.rb
@@ -8,7 +8,7 @@ module ActiveJob
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :retry_jitter, instance_accessor: false, instance_predicate: false, default: 0.15
+      class_attribute :retry_jitter, instance_accessor: false, instance_predicate: false, default: 0.0
     end
 
     module ClassMethods

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -865,7 +865,7 @@ There are a few configuration options available in Active Support:
 
 * `config.active_job.log_arguments` controls if the arguments of a job are logged. Defaults to `true`.
 
-* `config.active_job.retry_jitter` controls the amount of "jitter" (random variation) applied to the delay time calculated when retrying failed jobs. Defaults to `0.15`.
+* `config.active_job.retry_jitter` controls the amount of "jitter" (random variation) applied to the delay time calculated when retrying failed jobs. Defaults to `0.0`.
 
 ### Configuring Action Cable
 
@@ -971,6 +971,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 - `config.active_record.has_many_inversing`: `true`
 - `config.active_storage.track_variants`: `true`
+- `config.active_job.retry_jitter`: `0.15`
 
 #### For '6.0', new defaults from previous versions below and:
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2257,10 +2257,17 @@ module ApplicationTests
       end
     end
 
-    test "ActiveJob::Base.retry_jitter is 0.15 by default" do
+    test "ActiveJob::Base.retry_jitter is 0.15 by default for new apps" do
       app "development"
 
       assert_equal 0.15, ActiveJob::Base.retry_jitter
+    end
+
+    test "ActiveJob::Base.retry_jitter is 0.0 by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      app "development"
+
+      assert_equal 0.0, ActiveJob::Base.retry_jitter
     end
 
     test "ActiveJob::Base.retry_jitter can be set by config" do


### PR DESCRIPTION
Followup to @kamipo's comment here: https://github.com/rails/rails/pull/37923#discussion_r356383531

The point of new framework defaults is that they're opt-in for upgraded applications, but the default for this option applied the new behaviour.