### PR TITLE
allow for only no-store in cache-control header

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Added support for exclusive no-store Cache-Control header.
+
+    If `no-store` is set on Cache-Control header it is exclusive (all other cache directives are dropped).
+
+    *Chris Kruger*
+
 *   Catch invalid UTF-8 parameters for POST requests and respond with BadRequest.
 
     Additionally, perform `#set_binary_encoding` in `ActionDispatch::Http::Request#GET` and

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -125,7 +125,7 @@ module ActionDispatch
       private
         DATE          = "Date"
         LAST_MODIFIED = "Last-Modified"
-        SPECIAL_KEYS  = Set.new(%w[extras no-cache max-age public private must-revalidate])
+        SPECIAL_KEYS  = Set.new(%w[extras no-store no-cache max-age public private must-revalidate])
 
         def generate_weak_etag(validators)
           "W/#{generate_strong_etag(validators)}"
@@ -166,6 +166,7 @@ module ActionDispatch
         end
 
         DEFAULT_CACHE_CONTROL = "max-age=0, private, must-revalidate"
+        NO_STORE              = "no-store"
         NO_CACHE              = "no-cache"
         PUBLIC                = "public"
         PRIVATE               = "private"
@@ -194,7 +195,9 @@ module ActionDispatch
 
           control.merge! cache_control
 
-          if control[:no_cache]
+          if control[:no_store]
+            self._cache_control = NO_STORE
+          elsif control[:no_cache]
             options = []
             options << PUBLIC if control[:public]
             options << NO_CACHE

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -62,6 +62,12 @@ module ActionController
         assert_equal "public", @response.headers["Cache-Control"]
       end
 
+      def test_cache_control_no_store_is_respected
+        @response.set_header("Cache-Control", "private, no-store")
+        @response.stream.write "omg"
+        assert_equal "no-store", @response.headers["Cache-Control"]
+      end
+
       def test_content_length_is_removed
         @response.headers["Content-Length"] = "1234"
         @response.stream.write "omg"

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -295,6 +295,17 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal("application/xml; charset=utf-16", resp.headers["Content-Type"])
   end
 
+  test "respect no-store cache-control" do
+    resp = ActionDispatch::Response.new.tap { |response|
+      response.cache_control[:public] = true
+      response.cache_control[:no_store] = true
+      response.body = "Hello"
+    }
+    resp.to_a
+
+    assert_equal("no-store", resp.headers["Cache-Control"])
+  end
+
   test "read content type with default charset utf-8" do
     resp = ActionDispatch::Response.new(200, "Content-Type" => "text/xml")
     assert_equal("utf-8", resp.charset)


### PR DESCRIPTION
### Summary
In the case where it is desirable to set the rails application to default to absolutely no caching, i.e. for compliance reasons like PCI DSS it would nice to be able to simply do so. 

What appears to be the most immediate way of doing so is to modify the configuration in `config/application.rb` like so: 

```
config.action_dispatch.default_headers.merge!('Cache-Control' => 'no-store', 'Pragma' => 'no-cache')
```
However this is stymied somewhat by the result appearing as `Cache-Control: private, no-store`

The `private` keyword in this use case is at best superfluous when offered with `no-store` and in the worst case scenario dangerous (if the browser is in any way confused about this).

I used [this reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) to reach this conclusion.

This PR allows one to set the default Cache-Control header to reflect the simple `no-store` directive without it also including `private`
