### PR TITLE
Freeze many read only ModelSchema properties

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -109,7 +109,7 @@ module ActiveRecord
       # value is the column object.
       def columns_hash(table_name)
         @columns_hash.fetch(table_name) do
-          @columns_hash[deep_deduplicate(table_name)] = columns(table_name).index_by(&:name)
+          @columns_hash[deep_deduplicate(table_name)] = columns(table_name).index_by(&:name).freeze
         end
       end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -289,7 +289,7 @@ module ActiveRecord
       # accessors defined, and won't be referenced in SQL queries.
       def ignored_columns=(columns)
         reload_schema_from_cache
-        @ignored_columns = columns.map(&:to_s)
+        @ignored_columns = columns.map(&:to_s).freeze
       end
 
       def sequence_name
@@ -356,7 +356,7 @@ module ActiveRecord
 
       def columns
         load_schema
-        @columns ||= columns_hash.values
+        @columns ||= columns_hash.values.freeze
       end
 
       def attribute_types # :nodoc:
@@ -392,7 +392,7 @@ module ActiveRecord
       # default values when instantiating the Active Record object for this table.
       def column_defaults
         load_schema
-        @column_defaults ||= _default_attributes.deep_dup.to_hash
+        @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
       end
 
       def _default_attributes # :nodoc:
@@ -402,7 +402,7 @@ module ActiveRecord
 
       # Returns an array of column names as strings.
       def column_names
-        @column_names ||= columns.map(&:name)
+        @column_names ||= columns.map(&:name).freeze
       end
 
       def symbol_column_to_string(name_symbol) # :nodoc:
@@ -417,7 +417,7 @@ module ActiveRecord
           c.name == primary_key ||
           c.name == inheritance_column ||
           c.name.end_with?("_id", "_count")
-        end
+        end.freeze
       end
 
       # Resets all the cached information about columns, which will cause them
@@ -488,7 +488,10 @@ module ActiveRecord
           unless table_name
             raise ActiveRecord::TableNotSpecified, "#{self} has no table configured. Set one with #{self}.table_name="
           end
-          @columns_hash = connection.schema_cache.columns_hash(table_name).except(*ignored_columns)
+
+          columns_hash = connection.schema_cache.columns_hash(table_name)
+          columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
+          @columns_hash = columns_hash.freeze
           @columns_hash.each do |name, column|
             define_attribute(
               name,


### PR DESCRIPTION
I just read about that issue here: https://discuss.rubyonrails.org/t/potpourri-of-head-scratchers/75459/3

> Model.column_names returns a reference not a copy. I created an issue by pushing or deleting items from this without realizing it was not a clone or a dup. This is super minor except for one key thing. Error caused by this appear very far away from the code where this happens, usually when creating records while importing (as is my case). Consider adding a ! bang to the end? Or at least improving the present documentation to make it clear it returns the actual property and not a copy of it.

That's indeed a nasty footgun. There's two way to go about it, either `.dup` on access or `.freeze` them on creation.

IMO `.freeze` is better as it clearly communicates that it is read only information if you try to mutate it, and it avoid useless allocations.

cc @rafaelfranca @tenderlove @etiennebarrie @Edouard-chin 