### PR TITLE
Make signed_id_verifier_secret lazily evaluated

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -266,7 +266,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
     initializer "active_record.set_signed_id_verifier_secret" do
       ActiveSupport.on_load(:active_record) do
-        self.signed_id_verifier_secret ||= Rails.application.key_generator.generate_key("active_record/signed_id")
+        self.signed_id_verifier_secret ||= -> { Rails.application.key_generator.generate_key("active_record/signed_id") }
       end
     end
   end

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -70,10 +70,13 @@ module ActiveRecord
       # Rails.application.key_generator. By default, it's SHA256 for the digest and JSON for the serialization.
       def signed_id_verifier
         @signed_id_verifier ||= begin
-          if signed_id_verifier_secret.nil?
+          secret = signed_id_verifier_secret
+          secret = secret.call if secret.respond_to?(:call)
+
+          if secret.nil?
             raise ArgumentError, "You must set ActiveRecord::Base.signed_id_verifier_secret to use signed ids"
           else
-            ActiveSupport::MessageVerifier.new signed_id_verifier_secret, digest: "SHA256", serializer: JSON
+            ActiveSupport::MessageVerifier.new secret, digest: "SHA256", serializer: JSON
           end
         end
       end

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -6,7 +6,7 @@ require "models/company"
 require "models/toy"
 require "models/matey"
 
-SIGNED_ID_VERIFIER_TEST_SECRET = "This is normally set by the railtie initializer when used with Rails!"
+SIGNED_ID_VERIFIER_TEST_SECRET = -> { "This is normally set by the railtie initializer when used with Rails!" }
 
 ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
 
@@ -83,6 +83,17 @@ class SignedIdTest < ActiveRecord::TestCase
 
   test "fail to work without a signed_id_verifier_secret" do
     ActiveRecord::Base.signed_id_verifier_secret = nil
+    Account.instance_variable_set :@signed_id_verifier, nil
+
+    assert_raises(ArgumentError) do
+      @account.signed_id
+    end
+  ensure
+    ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
+  end
+
+  test "fail to work without when signed_id_verifier_secret lambda is nil" do
+    ActiveRecord::Base.signed_id_verifier_secret = -> { nil }
     Account.instance_variable_set :@signed_id_verifier, nil
 
     assert_raises(ArgumentError) do


### PR DESCRIPTION
The signed id feature introduced in #39313 can cause loading issues since it may try to generate a key before the secret key base has been set. To prevent this wrap the secret initialization in a lambda.