### PR TITLE
Ensure attributes are always inherited

### DIFF
--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -222,6 +222,20 @@ module ActiveRecord
       end
     end
 
+    test "attributes added after subclass attributes added are inherited" do
+      parent = Class.new(ActiveRecord::Base) do
+        self.table_name = "topics"
+      end
+
+      child = Class.new(parent) do
+        attribute :qux, Type::Value.new
+      end
+
+      parent.attribute(:foo, Type::Value.new)
+
+      assert_equal(:bar, child.new(foo: :bar).foo)
+    end
+
     test "attributes added after subclasses load are inherited" do
       parent = Class.new(ActiveRecord::Base) do
         self.table_name = "topics"


### PR DESCRIPTION
Prior to this commit, attributes were not inherited by a subclass if they were added to the parent class after the subclass had added its own attributes.  This was due to the way attribute definitions were stored in an append-only `class_attribute`.  This commit changes the way attribute definitions are stored to ensure they are always inherited.

---

Splitting this off from #38871.