### PR TITLE
Ensure attribute decorations are always inherited

### DIFF
--- a/activerecord/lib/active_record/attribute_decorators.rb
+++ b/activerecord/lib/active_record/attribute_decorators.rb
@@ -4,11 +4,11 @@ module ActiveRecord
   module AttributeDecorators # :nodoc:
     extend ActiveSupport::Concern
 
-    included do
-      class_attribute :attribute_type_decorations, instance_accessor: false, default: TypeDecorator.new # :internal:
-    end
-
     module ClassMethods # :nodoc:
+      def deferred_attribute_type_decorations
+        @deferred_attribute_type_decorations ||= {}
+      end
+
       # This method is an internal API used to create class macros such as
       # +serialize+, and features like time zone aware attributes.
       #
@@ -39,48 +39,20 @@ module ActiveRecord
       # used to ensure that class macros are idempotent.
       def decorate_matching_attribute_types(matcher, decorator_name, &block)
         reload_schema_from_cache
-        decorator_name = decorator_name.to_s
-
-        # Create new hashes so we don't modify parent classes
-        self.attribute_type_decorations = attribute_type_decorations.merge(decorator_name => [matcher, block])
+        deferred_attribute_type_decorations[decorator_name.to_s] = [matcher, block]
       end
 
       private
         def load_schema!
           super
+
+          deferred = ancestors.map { |klass| klass.try(:deferred_attribute_type_decorations) }.compact.reduce(&:reverse_merge)
+
           attribute_types.each do |name, type|
-            decorated_type = attribute_type_decorations.apply(name, type)
+            decorated_type = deferred.each_value.reduce(type) do |t, (matcher, block)|
+              matcher.call(name, type) ? block.call(t) : t
+            end
             define_attribute(name, decorated_type)
-          end
-        end
-    end
-
-    class TypeDecorator # :nodoc:
-      delegate :clear, to: :@decorations
-
-      def initialize(decorations = {})
-        @decorations = decorations
-      end
-
-      def merge(*args)
-        TypeDecorator.new(@decorations.merge(*args))
-      end
-
-      def apply(name, type)
-        decorations = decorators_for(name, type)
-        decorations.inject(type) do |new_type, block|
-          block.call(new_type)
-        end
-      end
-
-      private
-        def decorators_for(name, type)
-          matching(name, type).map(&:last)
-        end
-
-        def matching(name, type)
-          @decorations.values.select do |(matcher, _)|
-            matcher.call(name, type)
           end
         end
     end


### PR DESCRIPTION
Prior to this commit, attribute decorations were not inherited by a subclass if they were added to the parent class after the subclass had added its own attribute decorations.  This was due to the way attribute decorations were stored in an append-only `class_attribute`.  This commit changes the way attribute decorations are stored to ensure they are always inherited.

---

Splitting this off from #38871.
