### PR TITLE
Don't mark issues on a milestone as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,8 @@ exemptLabels:
   - attached PR
   - regression
   - release blocker
+# Issues on a milestone will never be considered stale
+exemptMilestones: true
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
https://github.com/probot/stale#usage

When an issue on a milestone goes stale, someone usually adds the pinned label to keep it open (https://github.com/rails/rails/pull/38577, https://github.com/rails/rails/pull/35489, https://github.com/rails/rails/issues/37183, https://github.com/rails/rails/issues/36963, https://github.com/rails/rails/pull/36886, https://github.com/rails/rails/issues/37069, etc.).

Once an issue has been assigned to a milestone, it shouldn't be closed unless we decide that the release can ship without it.