### PR TITLE
Do not swallow unknown configuration options for ActiveJob

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -13,26 +13,21 @@ module ActiveJob
       ActiveSupport.on_load(:active_job) { self.logger = ::Rails.logger }
     end
 
-    initializer "active_job.custom_serializers" do |app|
-      config.after_initialize do
-        custom_serializers = app.config.active_job.delete(:custom_serializers)
+    initializer "active_job.set_configs" do
+      config.after_initialize do |app|
+        options = app.config.active_job
+        options.queue_adapter ||= :async
+
+        custom_serializers = options.delete(:custom_serializers)
         ActiveJob::Serializers.add_serializers custom_serializers
-      end
-    end
 
-    initializer "active_job.set_configs" do |app|
-      options = app.config.active_job
-      options.queue_adapter ||= :async
-
-      ActiveSupport.on_load(:active_job) do
-        options.each do  |k, v|
-          k = "#{k}="
-          send(k, v) if respond_to? k
+        ActiveSupport.on_load(:active_job) do
+          options.each { |k, v| send("#{k}=", v) }
         end
-      end
 
-      ActiveSupport.on_load(:action_dispatch_integration_test) do
-        include ActiveJob::TestHelper
+        ActiveSupport.on_load(:action_dispatch_integration_test) do
+          include ActiveJob::TestHelper
+        end
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2257,6 +2257,17 @@ module ApplicationTests
       end
     end
 
+    test "raises when unknown configuration option is set for ActiveJob" do
+      add_to_config <<-RUBY
+        config.active_job.unknown = "test"
+      RUBY
+
+      assert_raise(NoMethodError) do
+        app "development"
+        ActiveJob::Base # load active_job
+      end
+    end
+
     test "ActiveJob::Base.retry_jitter is 0.15 by default for new apps" do
       app "development"
 


### PR DESCRIPTION
**Problem**:

In `application.rb` I made a mistake
```ruby
config.active_job.queu_adapter = :sidekiq
```

And in console I'm seeing:
```ruby
> Rails.application.config.active_job
=> {:queu_adapter=>:sidekiq, :queue_adapter=>:async}
> ActiveJob::Base.queue_adapter_name
=> "async"
```

So instead of swallowing nonexistent configs like spelling mistakes and wondering why everything is broken 😄 , it should be helpful to raise an error.