### PR TITLE
Ensure associations are inherited even after subclasses are defined

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -288,7 +288,7 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
 
   class PeopleList < ActiveRecord::Base
     has_and_belongs_to_many :has_and_belongs_to_many, before_add: :enlist
-    has_many :has_many, before_add: :enlist
+    has_many :has_many
     belongs_to :belongs_to
     has_one :has_one
   end
@@ -299,6 +299,18 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
     has_many :has_many, class_name: "DifferentPerson"
     belongs_to :belongs_to, class_name: "DifferentPerson"
     has_one :has_one, class_name: "DifferentPerson"
+  end
+
+  class DifferentPeopleList2 < PeopleList
+    has_one :has_one_2
+  end
+
+  class PeopleList < ActiveRecord::Base
+    silence_warnings do
+      # silence method redefined warnings
+      has_many :has_many, before_add: :enlist
+    end
+    has_one :has_one_2
   end
 
   def test_habtm_association_redefinition_callbacks_should_differ_and_not_inherited
@@ -318,30 +330,45 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_habtm_association_redefinition_reflections_should_differ_and_not_inherited
-    assert_not_equal(
+    assert_not_same(
       PeopleList.reflect_on_association(:has_and_belongs_to_many),
       DifferentPeopleList.reflect_on_association(:has_and_belongs_to_many)
     )
   end
 
   def test_has_many_association_redefinition_reflections_should_differ_and_not_inherited
-    assert_not_equal(
+    assert_not_same(
       PeopleList.reflect_on_association(:has_many),
       DifferentPeopleList.reflect_on_association(:has_many)
     )
   end
 
   def test_belongs_to_association_redefinition_reflections_should_differ_and_not_inherited
-    assert_not_equal(
+    assert_not_same(
       PeopleList.reflect_on_association(:belongs_to),
       DifferentPeopleList.reflect_on_association(:belongs_to)
     )
   end
 
   def test_has_one_association_redefinition_reflections_should_differ_and_not_inherited
-    assert_not_equal(
+    assert_not_same(
       PeopleList.reflect_on_association(:has_one),
       DifferentPeopleList.reflect_on_association(:has_one)
+    )
+  end
+
+  def test_parent_association_definition_after_subclass_is_defined_should_be_inherited
+    assert_same(
+      PeopleList.reflect_on_association(:has_many),
+      DifferentPeopleList2.reflect_on_association(:has_many)
+    )
+    assert_same(
+      PeopleList.reflect_on_association(:has_one_2),
+      DifferentPeopleList.reflect_on_association(:has_one_2)
+    )
+    assert_not_same(
+      PeopleList.reflect_on_association(:has_one_2),
+      DifferentPeopleList2.reflect_on_association(:has_one_2)
     )
   end
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -310,7 +310,7 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
       # silence method redefined warnings
       has_many :has_many, before_add: :enlist
     end
-    has_one :has_one_2
+    has_one :has_one_2 unless DifferentPeopleList.reflect_on_association(:has_one_2)
   end
 
   def test_habtm_association_redefinition_callbacks_should_differ_and_not_inherited

--- a/activesupport/lib/active_support/core_ext/class/attribute.rb
+++ b/activesupport/lib/active_support/core_ext/class/attribute.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/class/subclasses"
 require "active_support/core_ext/module/redefine_method"
 
 class Class
@@ -122,6 +123,10 @@ class Class
           methods << "silence_redefinition_of_method def #{name}?; !!self.#{name}; end"
         end
       end
+
+      if default.is_a?(Hash)
+        class_methods << inplace_updatable_class_attribute(name)
+      end
     end
 
     location = caller_locations(1, 1).first
@@ -129,4 +134,26 @@ class Class
 
     attrs.each { |name| public_send("#{name}=", default) }
   end
+
+  private
+    def inplace_updatable_class_attribute(name)
+      update_method = name.to_s.sub(/\A(_*)/, "\\1inplace_update_")
+
+      <<~RUBY
+        def #{update_method}(key, value)
+          prev_value = #{name}[key]
+          #{name}[key] = value
+
+          descendants.each do |subclass|
+            next if subclass.#{name}.equal?(#{name})
+
+            if !subclass.#{name}.key?(key) || prev_value&.equal?(subclass.#{name}[key])
+              subclass.#{name}[key] = value
+            end
+          end
+
+          #{name}
+        end
+      RUBY
+    end
 end


### PR DESCRIPTION
This is a common `class_attribute` implementation issue (e.g. #39467,
#39468, #38871).

For now, we should take care of the change propagation by themselves if
we want to ensure the propagation after the `class_attribute` are
accessed in subclasses.

Fixes #20678.
