### PR TITLE
Remove HTML fallback for JS requests

### DIFF
--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -86,7 +86,7 @@ class MimeControllerLayoutsTest < ActionController::TestCase
     assert_equal '<html><div id="super_iphone">Super iPhone</div></html>', @response.body
   end
 
-  def test_non_navigational_format_with_no_template_raises
+  def test_js_format_with_no_template_does_not_fall_back_to_html_template
     assert_raise ActionController::UnknownFormat do
       get :index, format: :js
     end

--- a/actionpack/test/controller/mime/accept_format_test.rb
+++ b/actionpack/test/controller/mime/accept_format_test.rb
@@ -86,8 +86,9 @@ class MimeControllerLayoutsTest < ActionController::TestCase
     assert_equal '<html><div id="super_iphone">Super iPhone</div></html>', @response.body
   end
 
-  def test_non_navigational_format_with_no_template_fallbacks_to_html_template_with_no_layout
-    get :index, format: :js
-    assert_equal "Hello Firefox", @response.body
+  def test_non_navigational_format_with_no_template_raises
+    assert_raise ActionController::UnknownFormat do
+      get :index, format: :js
+    end
   end
 end

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -294,7 +294,7 @@ module ActionView #:nodoc:
       old_view_renderer  = @view_renderer
       old_lookup_context = @lookup_context
 
-      if !lookup_context.html_fallback_for_js && options[:formats]
+      if options[:formats]
         formats = Array(options[:formats])
         if formats == [:js]
           formats << :html

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -123,7 +123,7 @@ module ActionView
 
     # Helpers related to template lookup using the lookup context information.
     module ViewPaths
-      attr_reader :view_paths, :html_fallback_for_js
+      attr_reader :view_paths
 
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         @view_paths.find(*args_for_lookup(name, prefixes, partial, keys, options))
@@ -285,11 +285,6 @@ module ActionView
         invalid_values = (values - Template::Types.symbols)
         unless invalid_values.empty?
           raise ArgumentError, "Invalid formats: #{invalid_values.map(&:inspect).join(", ")}"
-        end
-
-        if values == [:js]
-          values << :html
-          @html_fallback_for_js = true
         end
       end
       super(values)

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -172,7 +172,7 @@ module ActionView
 
       def prepend_formats(formats) # :doc:
         formats = Array(formats)
-        return if formats.empty? || @lookup_context.html_fallback_for_js
+        return if formats.empty?
 
         @lookup_context.formats = formats | @lookup_context.formats
       end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -72,7 +72,7 @@ class LookupContextTest < ActiveSupport::TestCase
 
   test "adds :html fallback to :js formats" do
     @lookup_context.formats = [:js]
-    assert_equal [:js, :html], @lookup_context.formats
+    assert_equal [:js], @lookup_context.formats
   end
 
   test "raises on invalid format assignment" do


### PR DESCRIPTION
We shouldn't fall back to HTML for JS requests because caching proxies
might cache secrets that are embedded in the HTML (like CSRF tokens).

See #39475

I *think* this removes everything related to the HTML fallback, but I'm not 100% sure.