### PR TITLE
Make custom inspect methods more consistent

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -855,7 +855,7 @@ module ActionController
     end
 
     def inspect
-      "<#{self.class} #{@parameters} permitted: #{@permitted}>"
+      "#<#{self.class} #{@parameters} permitted: #{@permitted}>"
     end
 
     def self.hook_into_yaml_loading # :nodoc:

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -369,7 +369,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "inspect shows both class name, parameters and permitted flag" do
     assert_equal(
-      '<ActionController::Parameters {"person"=>{"age"=>"32", '\
+      '#<ActionController::Parameters {"person"=>{"age"=>"32", '\
         '"name"=>{"first"=>"David", "last"=>"Heinemeier Hansson"}, ' \
         '"addresses"=>[{"city"=>"Chicago", "state"=>"Illinois"}]}} permitted: false>',
       @params.inspect

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -169,7 +169,7 @@ module ActiveModel
     end
 
     def inspect # :nodoc:
-      "<##{self.class.name} attribute=#{@attribute}, type=#{@type}, options=#{@options.inspect}>"
+      "#<#{self.class.name} attribute=#{@attribute}, type=#{@type}, options=#{@options.inspect}>"
     end
 
     protected

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -104,7 +104,7 @@ module ActiveSupport
       end
 
       def inspect # :nodoc:
-        "<##{self.class.name} entries=#{@data.size}, size=#{@cache_size}, options=#{@options.inspect}>"
+        "#<#{self.class.name} entries=#{@data.size}, size=#{@cache_size}, options=#{@options.inspect}>"
       end
 
       # Synchronize calls to the cache. This should be called wherever the underlying cache implementation

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -195,7 +195,7 @@ module ActiveSupport
 
       def inspect
         instance = @redis || @redis_options
-        "<##{self.class} options=#{options.inspect} redis=#{instance.inspect}>"
+        "#<#{self.class} options=#{options.inspect} redis=#{instance.inspect}>"
       end
 
       # Cache Store API implementation.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1319,7 +1319,7 @@ module ApplicationTests
       app "development"
 
       post "/posts.json", '{ "title": "foo", "name": "bar" }', "CONTENT_TYPE" => "application/json"
-      assert_equal '<ActionController::Parameters {"title"=>"foo"} permitted: false>', last_response.body
+      assert_equal '#<ActionController::Parameters {"title"=>"foo"} permitted: false>', last_response.body
     end
 
     test "config.action_controller.permit_all_parameters = true" do


### PR DESCRIPTION
### Summary

Calling `Object#inspect` returns a string starting with a pound sign (#):
```Object.new.inspect
=> "#<Object:0x00007fb4b115b428>"
```

Some custom `inspect` implementations did not:
```
ActionController::Parameters.new({}).inspect
=> "<ActionController::Parameters {} permitted: false>"
```
This change make everything more consistent by always starting with the pound sign.


