### PR TITLE
Raise error if generating attribute with unknown type

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -8,6 +8,25 @@ module Rails
     class GeneratedAttribute # :nodoc:
       INDEX_OPTIONS = %w(index uniq)
       UNIQ_INDEX_OPTIONS = %w(uniq)
+      DEFAULT_TYPES = %w(
+        attachment
+        attachments
+        belongs_to
+        boolean
+        date
+        datetime
+        decimal
+        digest
+        float
+        integer
+        references
+        rich_text
+        string
+        text
+        time
+        timestamp
+        token
+      )
 
       attr_accessor :name, :type
       attr_reader   :attr_options
@@ -25,6 +44,10 @@ module Rails
           type, attr_options = *parse_type_and_options(type)
           type = type.to_sym if type
 
+          if type && !valid_type?(type)
+            raise Thor::Error, "Unknown type '#{type}' for attribute '#{name}'."
+          end
+
           if type && reference?(type)
             if UNIQ_INDEX_OPTIONS.include?(has_index)
               attr_options[:index] = { unique: true }
@@ -32,6 +55,11 @@ module Rails
           end
 
           new(name, type, has_index, attr_options)
+        end
+
+        def valid_type?(type)
+          DEFAULT_TYPES.include?(type.to_s) ||
+            ActiveRecord::Base.connection.valid_type?(type)
         end
 
         def reference?(type)


### PR DESCRIPTION
Generators can create invalid migrations when passing an invalid attribute type.
For example, when mixing up the name and type:

    bin/rails g model post string:title

This will generate an attribute with a column named `string` of the type `title`,
instead of a column named `title` of the type `string`. Running the migration will result
in an error as the type `title` is not known to the database.

Instead of generating invalid files, the generator should raise an error if the type is
invalid. We can validate the type by checking if it's a default migration types. If the type
isn't a default type, we can ask the database connection if the type is valid. This uses
the `valid_type?` method defined on each database adapter, which returns true if the
adapter supports the column type.
