### PR TITLE
Add test for HTML format fallback from JS template

### DIFF
--- a/actionview/test/fixtures/test/_js_html_fallback.html.erb
+++ b/actionview/test/fixtures/test/_js_html_fallback.html.erb
@@ -1,0 +1,1 @@
+<b>Hello from a HTML partial!</b>

--- a/actionview/test/fixtures/test/js_html_fallback.js.erb
+++ b/actionview/test/fixtures/test/js_html_fallback.js.erb
@@ -1,0 +1,1 @@
+document.write("<%= j render(partial: "js_html_fallback").chomp.html_safe %>")

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -58,6 +58,11 @@ module RenderTestCases
     ] }, rendered_templates)
   end
 
+  def test_explicit_js_format_adds_html_fallback
+    rendered_templates = @controller_view.render(template: "test/js_html_fallback", formats: :js)
+    assert_equal(%Q(document.write("<b>Hello from a HTML partial!<\\/b>")\n), rendered_templates)
+  end
+
   def test_render_without_options
     e = assert_raises(ArgumentError) { @view.render() }
     assert_match(/You invoked render but did not give any of (.+) option\./, e.message)


### PR DESCRIPTION
When rendering a template with an explicit JS format, typically via `respond_to :js`, we want to be able to render HTML partials without having to specify their format, to make SJR more ergonomic.

This blog post demonstrates how this behaviour is useful:
https://signalvnoise.com/posts/3697-server-generated-javascript-responses

```erb
<%# renders messages/_message.html.erb %>
$('#messages').prepend('<%=j render @message %>');
$('#<%= dom_id @message %>').highlight();
```

There was no existing test coverage for this functionality, and I misguidedly suggested removing the code that enables it in https://github.com/rails/rails/pull/39476#discussion_r432685411. Wups!

This pattern arguably creates a similar problem to https://github.com/rails/rails/issues/39475, but in this case the mixing of formats is under the programmer's control.