### PR TITLE
Don't run webpacker:install inline on rails new because it raise error

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -416,9 +416,9 @@ module Rails
 
       def run_webpack
         if webpack_install?
-          rails_command "webpacker:install", inline: true
+          rails_command "webpacker:install"
           if options[:webpack] && options[:webpack] != "webpack"
-            rails_command "webpacker:install:#{options[:webpack]}", inline: true
+            rails_command "webpacker:install:#{options[:webpack]}"
           end
         end
       end


### PR DESCRIPTION
### Summary

I'm trying to create a new Rails app using `master` branch via `/rails/railties/exe/rails new my_app --master`

Then I got an error

```
...
Bundle complete! 15 Gemfile dependencies, 69 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle binstubs bundler
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
       rails  webpacker:install
rails aborted!
Gem::LoadError: You have already activated tzinfo 1.2.7, but your Gemfile requires tzinfo 2.0.2. Prepending `bundle exec` to your command may solve this.
/Users/jasl/Workspaces/Ruby/my_app/config/boot.rb:3:in `<top (required)>'
```

I guess `inline` invoking command in `rails new` doesn't follow new app's `Gemfile.lock`, then it goes conflict.

By removing `inline: true` the problem solved.