### PR TITLE
Add missing `#` in `wrap_parameters` RDoc

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -189,7 +189,7 @@ module ActionController
       #
       #   wrap_parameters Person
       #     # wraps parameters by determining the wrapper key from Person class
-      #     (+person+, in this case) and the list of attribute names
+      #     # (+person+, in this case) and the list of attribute names
       #
       #   wrap_parameters include: [:username, :title]
       #     # wraps only +:username+ and +:title+ attributes from parameters.


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/6376558/83316672-28b17780-a1f5-11ea-9ee4-2bfe1a94c440.png)

**After**

![image](https://user-images.githubusercontent.com/6376558/83316662-1cc5b580-a1f5-11ea-921e-b9afacfdfe03.png)

Thanks!

[ci skip]