### PR TITLE
Add config/initializers/time_formats.rb to make it easier to add / look up time formats

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/time_formats.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/time_formats.rb.tt
@@ -1,0 +1,23 @@
+# Rails ships with the following default date / time formats which are declared
+# in Time::DATE_FORMATS
+#
+# datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000
+#
+# datetime.to_formatted_s(:db)            # => "2007-12-04 00:00:00"
+# datetime.to_formatted_s(:number)        # => "20071204000000"
+# datetime.to_formatted_s(:usec)          # => "20071204000000000000"
+# datetime.to_formatted_s(:nsec)          # => "20071204000000000000000"
+# datetime.to_formatted_s(:time)          # => "00:00"
+# datetime.to_formatted_s(:short)         # => "04 Dec 00:00"
+# datetime.to_formatted_s(:long)          # => "December 04, 2007 00:00"
+# datetime.to_formatted_s(:long_ordinal)  # => "December 4th, 2007 00:00"
+# datetime.to_formatted_s(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
+# datetime.to_formatted_s(:iso8601)       # => "2007-12-04T00:00:00+00:00"
+#
+# You can add your own formats to the Time::DATE_FORMATS hash
+# Use the format name as the hash key and either a strftime string or
+# Proc instance that takes a time argument as the value.
+#
+# Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+# Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
+#

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/time_formats.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/time_formats.rb.tt
@@ -1,22 +1,13 @@
-# Rails ships with the following default date / time formats which are declared
-# in Time::DATE_FORMATS
-#
-# datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000
+# Common date / time formats in Time::DATE_FORMATS:
 #
 # datetime.to_formatted_s(:db)            # => "2007-12-04 00:00:00"
-# datetime.to_formatted_s(:number)        # => "20071204000000"
-# datetime.to_formatted_s(:usec)          # => "20071204000000000000"
-# datetime.to_formatted_s(:nsec)          # => "20071204000000000000000"
 # datetime.to_formatted_s(:time)          # => "00:00"
 # datetime.to_formatted_s(:short)         # => "04 Dec 00:00"
 # datetime.to_formatted_s(:long)          # => "December 04, 2007 00:00"
-# datetime.to_formatted_s(:long_ordinal)  # => "December 4th, 2007 00:00"
 # datetime.to_formatted_s(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
 # datetime.to_formatted_s(:iso8601)       # => "2007-12-04T00:00:00+00:00"
 #
-# You can add your own formats to the Time::DATE_FORMATS hash
-# Use the format name as the hash key and either a strftime string or
-# Proc instance that takes a time argument as the value.
+# Add your own formats:
 #
 # Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 # Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -59,6 +59,7 @@ DEFAULT_APP_FILES = %w(
   config/initializers/filter_parameter_logging.rb
   config/initializers/inflections.rb
   config/initializers/mime_types.rb
+  config/initializers/time_formats.rb
   config/initializers/wrap_parameters.rb
   config/locales
   config/locales/en.yml


### PR DESCRIPTION
Initiated from  [A May Of WTFs](https://discuss.rubyonrails.org/t/time-now-vs-time-current-vs-datetime-now/75183/25)

Looking up Rails default DateTime formats seems to be a very common pain point, to the point where somebody created https://railsdatetimeformats.com/. 

This PR expands on the documentation in [`to_formatted_s`](https://api.rubyonrails.org/classes/DateTime.html#method-i-to_formatted_s) by creating `config/initializers/time_formats.rb` by default in a new Rails app with instructions on how to add new DateTime formats and notes on default formats available. 




<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
