### PR TITLE
Use ActiveRecord's signed id methods in ActiveStorage

### DIFF
--- a/activestorage/app/controllers/concerns/active_storage/set_blob.rb
+++ b/activestorage/app/controllers/concerns/active_storage/set_blob.rb
@@ -9,7 +9,7 @@ module ActiveStorage::SetBlob #:nodoc:
 
   private
     def set_blob
-      @blob = ActiveStorage::Blob.find_signed(params[:signed_blob_id] || params[:signed_id])
+      @blob = ActiveStorage::Blob.find_signed!(params[:signed_blob_id] || params[:signed_id])
     rescue ActiveSupport::MessageVerifier::InvalidSignature
       head :not_found
     end

--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -68,7 +68,7 @@ module ActiveStorage
             )
           )
         when String
-          ActiveStorage::Blob.find_signed(attachable, record: record)
+          ActiveStorage::Blob.find_signed!(attachable, record: record)
         else
           raise ArgumentError, "Could not find or build blob: expected attachable, got #{attachable.inspect}"
         end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -21,7 +21,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
 
       response.parsed_body.tap do |details|
-        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed(details["signed_id"])
+        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
@@ -56,7 +56,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
 
       @response.parsed_body.tap do |details|
-        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed(details["signed_id"])
+        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
@@ -90,7 +90,7 @@ if SERVICE_CONFIGURATIONS[:azure]
         filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
 
       @response.parsed_body.tap do |details|
-        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed(details["signed_id"])
+        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
         assert_equal "hello.txt", details["filename"]
         assert_equal 6, details["byte_size"]
         assert_equal checksum, details["checksum"]
@@ -112,7 +112,7 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
       filename: "hello.txt", byte_size: 6, checksum: checksum, content_type: "text/plain" } }
 
     @response.parsed_body.tap do |details|
-      assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed(details["signed_id"])
+      assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"])
       assert_equal "hello.txt", details["filename"]
       assert_equal 6, details["byte_size"]
       assert_equal checksum, details["checksum"]

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -32,7 +32,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   test "attaching an existing blob from a signed ID passes record" do
     blob = create_blob(filename: "funky.jpg")
     arguments = [blob.signed_id, record: @user]
-    assert_called_with(ActiveStorage::Blob, :find_signed, arguments, returns: blob) do
+    assert_called_with(ActiveStorage::Blob, :find_signed!, arguments, returns: blob) do
       @user.avatar.attach blob.signed_id
     end
   end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -55,6 +55,14 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     @user.avatar.attach(blob)
 
     signed_id = @user.avatar.signed_id
-    assert_equal blob, ActiveStorage::Blob.find_signed(signed_id)
+    assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id)
+  end
+
+  test "signed blob ID backwards compatibility" do
+    blob = create_blob
+    @user.avatar.attach(blob)
+
+    signed_id_generated_old_way = ActiveStorage.verifier.generate(@user.avatar.id, purpose: :blob_id)
+    assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id_generated_old_way)
   end
 end


### PR DESCRIPTION
### Summary

ActiveRecord's signed id was merged recently. It'd be great to use it instead of having a similar implementation in ActiveStorage.

### Other information

~First commit keeps the methods in `ActiveStorage::Blob` and it calls `super`.~
~Second commit removes the additional level of indirection by just calling ActiveRecord's method.~

One concern is that ActiveRecord's purpose automatically combines it with the name of the model. So I guess this would break existing `signed_id`s when upgrading. Can you confirm?
```ruby
      def combine_signed_id_purposes(purpose)
        [ name.underscore, purpose.to_s ].compact_blank.join("/")
      end
```

Another concern is this commit `7fd006de0ba` which added an unused key argument `record` to "make sharding easier". Not sure how it works..