### PR TITLE
Add `update_heritable_value_of`

### DIFF
--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -14,7 +14,7 @@ module ActionMailer
       cattr_accessor :perform_deliveries, default: true
       cattr_accessor :deliver_later_queue_name, default: :mailers
 
-      class_attribute :delivery_methods, default: {}.freeze
+      class_attribute :delivery_methods, default: {}
       class_attribute :delivery_method, default: :smtp
 
       add_delivery_method :smtp, Mail::SMTP,
@@ -50,7 +50,7 @@ module ActionMailer
       def add_delivery_method(symbol, klass, default_options = {})
         class_attribute(:"#{symbol}_settings") unless respond_to?(:"#{symbol}_settings")
         public_send(:"#{symbol}_settings=", default_options)
-        self.delivery_methods = delivery_methods.merge(symbol.to_sym => klass).freeze
+        update_heritable_value_of(:delivery_methods, symbol.to_sym, klass)
       end
 
       def wrap_delivery_behavior(mail, method = nil, options = nil) # :nodoc:

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -207,7 +207,7 @@ module ActiveModel
       #   person.name_short?     # => true
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
-        self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
+        update_heritable_value_of(:attribute_aliases, new_name.to_s, old_name.to_s)
         ActiveSupport::CodeGenerator.batch(self, __FILE__, __LINE__) do |code_generator|
           attribute_method_patterns.each do |pattern|
             method_name = pattern.method_name(new_name).to_s

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -228,8 +228,7 @@ module ActiveRecord
           end
         end
 
-        self.attributes_to_define_after_schema_loads =
-          attributes_to_define_after_schema_loads.merge(name => [cast_type, default])
+        update_heritable_value_of(:attributes_to_define_after_schema_loads, name, [cast_type, default])
       end
 
       # This is the low level API which sits beneath +attribute+. It only

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -7,8 +7,15 @@ module ActiveRecord
   module Reflection # :nodoc:
     extend ActiveSupport::Concern
 
+    class LiloHash < Hash
+      def []=(key, value)
+        delete(key)
+        super
+      end
+    end
+
     included do
-      class_attribute :_reflections, instance_writer: false, default: {}
+      class_attribute :_reflections, instance_writer: false, default: LiloHash.new
       class_attribute :aggregate_reflections, instance_writer: false, default: {}
       class_attribute :automatic_scope_inversing, instance_writer: false, default: false
     end
@@ -21,12 +28,11 @@ module ActiveRecord
 
       def add_reflection(ar, name, reflection)
         ar.clear_reflections_cache
-        name = -name.to_s
-        ar._reflections = ar._reflections.except(name).merge!(name => reflection)
+        ar.update_heritable_value_of(:_reflections, -name.to_s, reflection)
       end
 
       def add_aggregate_reflection(ar, name, reflection)
-        ar.aggregate_reflections = ar.aggregate_reflections.merge(-name.to_s => reflection)
+        ar.update_heritable_value_of(:aggregate_reflections, -name.to_s, reflection)
       end
 
       private
@@ -126,6 +132,7 @@ module ActiveRecord
       end
 
       def clear_reflections_cache # :nodoc:
+        direct_descendants.each(&:clear_reflections_cache)
         @__reflections = nil
       end
     end

--- a/activestorage/lib/active_storage/reflection.rb
+++ b/activestorage/lib/active_storage/reflection.rb
@@ -30,7 +30,7 @@ module ActiveStorage
 
     module ReflectionExtension # :nodoc:
       def add_attachment_reflection(model, name, reflection)
-        model.attachment_reflections = model.attachment_reflections.merge(name.to_s => reflection)
+        model.update_heritable_value_of(:attachment_reflections, name.to_s, reflection)
       end
 
       private

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -950,11 +950,7 @@ module ActiveSupport
           end
 
           def set_callbacks(name, callbacks) # :nodoc:
-            unless singleton_class.method_defined?(:__callbacks, false)
-              self.__callbacks = __callbacks.dup
-            end
-            self.__callbacks[name.to_sym] = callbacks
-            self.__callbacks
+            update_heritable_value_of(:__callbacks, name.to_sym, callbacks)
           end
       end
   end

--- a/activesupport/test/core_ext/class/update_heritable_value_of_test.rb
+++ b/activesupport/test/core_ext/class/update_heritable_value_of_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/class/attribute"
+
+class UpdateHeritableValueOfTest < ActiveSupport::TestCase
+  setup do
+    @base = Class.new do
+      class_attribute :settings, default: {}
+    end
+
+    @sub = Class.new(@base)
+    @subsub = Class.new(@sub)
+  end
+
+  test "sets value" do
+    @base.update_heritable_value_of(:settings, :foo, "base value")
+
+    assert_equal "base value", @base.settings[:foo]
+  end
+
+  test "propagates value to subclasses" do
+    @base.update_heritable_value_of(:settings, :foo, "base value")
+
+    assert_equal "base value", @sub.settings[:foo]
+    assert_equal "base value", @subsub.settings[:foo]
+  end
+
+  test "propagates value to subclasses after subclass has been updated" do
+    @sub.update_heritable_value_of(:settings, :bar, "sub value")
+    @base.update_heritable_value_of(:settings, :foo, "base value")
+
+    assert_equal "base value", @sub.settings[:foo]
+    assert_equal "base value", @subsub.settings[:foo]
+    assert_equal "sub value", @sub.settings[:bar]
+    assert_equal "sub value", @subsub.settings[:bar]
+  end
+
+  test "does not set value in superclass" do
+    @sub.update_heritable_value_of(:settings, :bar, "sub value")
+
+    assert_not_includes @base.settings, :bar
+  end
+
+  test "does not overwrite value set in subclass" do
+    @sub.update_heritable_value_of(:settings, :bar, "sub value")
+    @base.update_heritable_value_of(:settings, :bar, "base value")
+
+    assert_equal "base value", @base.settings[:bar]
+    assert_equal "sub value", @sub.settings[:bar]
+    assert_equal "sub value", @subsub.settings[:bar]
+  end
+
+  test "does not overwrite value set in subclass even when value was the same" do
+    @base.update_heritable_value_of(:settings, :foo, :same_value)
+    @sub.update_heritable_value_of(:settings, :foo, :same_value)
+    @base.update_heritable_value_of(:settings, :foo, :new_value)
+
+    assert_equal :new_value, @base.settings[:foo]
+    assert_equal :same_value, @sub.settings[:foo]
+    assert_equal :same_value, @subsub.settings[:foo]
+  end
+
+  test "avoids allocating a Hash when possible" do
+    original_hash = @base.settings
+    @base.update_heritable_value_of(:settings, :foo, "base value")
+
+    assert_same original_hash, @base.settings
+    assert_same original_hash, @sub.settings
+    assert_same original_hash, @subsub.settings
+  end
+
+  test "avoids allocating a bookkeeping object when possible" do
+    @sub.update_heritable_value_of(:settings, :bar, "sub value")
+
+    assert @sub.settings.instance_variable_defined?(:@_class_attribute_inherited_keys)
+    assert_nil @sub.settings.instance_variable_get(:@_class_attribute_inherited_keys)
+  end
+end


### PR DESCRIPTION
Using a `class_attribute` for inheritance of values in a Hash is tricky.  When storing a new value in a subclass's Hash, you must be careful to not modify the superclass's Hash.  On the flip side, when storing a new value in a superclass's Hash, you must ensure the subclass can access the value if and only if it has not already been overridden in the subclass's Hash.  (See #39467, #39468, and #39473 for examples of addressing the latter.)

`update_heritable_value_of` handles both of these requirements:

```ruby
A = Class.new
B = Class.new(A)
C = Class.new(B)

A.class_attribute :settings, default: {}

A.update_heritable_value_of(:settings, :foo, "A")
A.update_heritable_value_of(:settings, :bar, "A")
B.update_heritable_value_of(:settings, :bar, "B")
C.update_heritable_value_of(:settings, :qux, "C")
A.update_heritable_value_of(:settings, :qux, "A")

A.settings  # == {:foo=>"A", :bar=>"A", :qux=>"A"}
B.settings  # == {:foo=>"A", :bar=>"B", :qux=>"A"}
C.settings  # == {:foo=>"A", :bar=>"B", :qux=>"C"}
```

---

/cc @eugeneius
/cc @kamipo

This is an alternative approach to what was being discussed in https://github.com/rails/rails/pull/39467#discussion_r432333910 and https://github.com/rails/rails/pull/39467#discussion_r432562283.

