### PR TITLE
Don't recommend disabling CSRF protection [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -32,29 +32,21 @@ module ActionController #:nodoc:
   # response may be extracted. To prevent this, only XmlHttpRequest (known as XHR or
   # Ajax) requests are allowed to make requests for JavaScript responses.
   #
-  # It's important to remember that XML or JSON requests are also checked by default. If
-  # you're building an API or an SPA you could change forgery protection method in
-  # <tt>ApplicationController</tt> (by default: <tt>:exception</tt>):
+  # Subclasses of <tt>ActionController::Base</tt> are protected by default with the
+  # <tt>:exception</tt> strategy, which raises an
+  # <tt>ActionController::InvalidAuthenticityToken</tt> error on unverified requests.
+  #
+  # APIs may want to disable this behavior since they are typically designed to be
+  # state-less: that is, the request API client handles the session instead of Rails.
+  # One way to achieve this is to use the <tt>:null_session</tt> strategy instead,
+  # which allows unverified requests to be handled, but with an empty session:
   #
   #   class ApplicationController < ActionController::Base
-  #     protect_from_forgery unless: -> { request.format.json? }
+  #     protect_from_forgery with: :null_session
   #   end
   #
-  # It is generally safe to exclude XHR requests from CSRF protection
-  # (like the code snippet above does), because XHR requests can only be made from
-  # the same origin. Note however that any cross-origin third party domain
-  # allowed via {CORS}[https://en.wikipedia.org/wiki/Cross-origin_resource_sharing]
-  # will also be able to create XHR requests. Be sure to check your
-  # CORS configuration before disabling forgery protection for XHR.
-  #
-  # CSRF protection is turned on with the <tt>protect_from_forgery</tt> method.
-  # By default <tt>protect_from_forgery</tt> protects your session with
-  # <tt>:null_session</tt> method, which provides an empty session
-  # during request.
-  #
-  # We may want to disable CSRF protection for APIs since they are typically
-  # designed to be state-less. That is, the request API client will handle
-  # the session for you instead of Rails.
+  # Note that API only applications don't include this module or a session middleware
+  # by default, and so don't require CSRF protection to be configured.
   #
   # The token parameter is named <tt>authenticity_token</tt> by default. The name and
   # value of this token must be added to every layout that renders forms by including


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/38388.

The previous example disables CSRF protection for JSON format requests, which allows any request to bypass it by adding the right Accept header.

Accept is one of the few headers that doesn't trigger a CORS preflight:
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Examples_of_access_control_scenarios

Instead of disabling it entirely, the simple case where authentication is handled without a session (e.g. when using API keys) can be solved by switching to the `:null_session` strategy.

For more complex cases (e.g. an API that uses session authentication), I don't think a copy-and-paste-able example is appropriate; the user needs to understand CSRF protection in order to make an informed choice.