### PR TITLE
Clarify docs about strict loading and add a test case for `strict_loading!`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -500,10 +500,17 @@ module ActiveRecord
       @readonly
     end
 
+    # Returns +true+ if the record is in strict_loading mode.
     def strict_loading?
       @strict_loading
     end
 
+    # Sets the record to strict_loading mode. This will raise an error
+    # if the record tries to lazily load an association.
+    #
+    #   user = User.first.strict_loading!
+    #   user.comments.to_a
+    #   => ActiveRecord::StrictLoadingViolationError
     def strict_loading!
       @strict_loading = true
     end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -752,7 +752,7 @@ module ActiveRecord
       ActiveRecord::Associations::AliasTracker.create(connection, table.name, joins, aliases)
     end
 
-    class StrictLoadingScope
+    class StrictLoadingScope # :nodoc:
       def self.empty_scope?
         true
       end

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -12,6 +12,18 @@ class StrictLoadingTest < ActiveRecord::TestCase
   fixtures :projects
   fixtures :ships
 
+  def test_strict_loading!
+    developer = Developer.first
+    assert_not_predicate developer, :strict_loading?
+
+    developer.strict_loading!
+    assert_predicate developer, :strict_loading?
+
+    assert_raises ActiveRecord::StrictLoadingViolationError do
+      developer.audit_logs.to_a
+    end
+  end
+
   def test_strict_loading
     Developer.all.each { |d| assert_not d.strict_loading? }
     Developer.strict_loading.each { |d| assert d.strict_loading? }


### PR DESCRIPTION
This PR does the following:
  - Hides `StrictLoadingScope` on API doc(https://edgeapi.rubyonrails.org/)
  - Documents `ActiveRecord::Base#strict_loading?` and `ActiveRecord::Base#strict_loading!`
    methods.
  - Adds the test case for `ActiveRecord::Base#strict_loading!` since it is
    a public API.