### PR TITLE
Reset ActiveSupport::CurrentAttributes even where executor doesn't wrap

### DIFF
--- a/activesupport/lib/active_support/current_attributes/test_helper.rb
+++ b/activesupport/lib/active_support/current_attributes/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveSupport::CurrentAttributes::TestHelper # :nodoc:
+  def before_setup
+    ActiveSupport::CurrentAttributes.reset_all
+    super
+  end
+
+  def before_teardown
+    ActiveSupport::CurrentAttributes.reset_all
+    super
+  end
+end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -22,6 +22,11 @@ module ActiveSupport
       app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
       app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
       app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
+
+      ActiveSupport.on_load(:active_support_test_case) do
+        require "active_support/current_attributes/test_helper"
+        include ActiveSupport::CurrentAttributes::TestHelper
+      end
     end
 
     initializer "active_support.deprecation_behavior" do |app|

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/current_attributes/test_helper"
 
 class CurrentAttributesTest < ActiveSupport::TestCase
+  # Automatically included in Rails apps via railtie but that dodn't run here.
+  include ActiveSupport::CurrentAttributes::TestHelper
+
   Person = Struct.new(:id, :name, :time_zone)
 
   class Current < ActiveSupport::CurrentAttributes
@@ -40,15 +44,13 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     attribute :current, :previous
   end
 
-  setup do
-    @original_time_zone = Time.zone
-    Current.reset
-    Session.reset
-  end
+  # Eagerly set-up `instance`s by reference.
+  [ Current.instance, Session.instance ]
 
-  teardown do
-    Time.zone = @original_time_zone
-  end
+  setup    { @original_time_zone = Time.zone }
+  teardown { Time.zone = @original_time_zone }
+
+  setup { assert_nil Session.previous, "Expected Session to not have leaked state" }
 
   test "read and write attribute" do
     Current.world = "world/1"
@@ -78,6 +80,7 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
     Current.reset
     assert_equal "UTC", Time.zone.name
+    assert_equal 42, Session.previous
     assert_nil Session.current
   end
 


### PR DESCRIPTION
Currently there's a problem with ActiveSupport::CurrentAttributes where
they don't reset unless there's a controller or a job executing.

This is because we correctly hook into the controller/job executor to
reset them.

However, we were missing plain tests, so this is that.