### PR TITLE
Lazily build path regex in PathParser

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -36,10 +36,6 @@ module ActionView
     end
 
     class PathParser # :nodoc:
-      def initialize
-        @regex = build_path_regex
-      end
-
       def build_path_regex
         handlers = Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
         formats = Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
@@ -60,6 +56,7 @@ module ActionView
       end
 
       def parse(path)
+        @regex ||= build_path_regex
         match = @regex.match(path)
         {
           prefix: match[:prefix] || "",

--- a/railties/test/application/rendering_test.rb
+++ b/railties/test/application/rendering_test.rb
@@ -77,7 +77,9 @@ module ApplicationTests
             source
           end
         end
-        ActionView::Template.register_template_handler(:rubby, RubbyHandler)
+        ActiveSupport.on_load :action_view do
+          ActionView::Template.register_template_handler(:rubby, RubbyHandler)
+        end
       RUBY
 
       get "/"


### PR DESCRIPTION
Eagerly building the path regex can exclude handlers which are added on Action View load.

Fixes #39492.

---

/cc @jhawthorn Since you are familiar with the parts involved here.  Is there a more proper solution?
