### PR TITLE
Explicitly require frameworks in application.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt
@@ -1,8 +1,5 @@
 require_relative "boot"
 
-<% if include_all_railties? -%>
-require "rails/all"
-<% else -%>
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
@@ -17,7 +14,6 @@ require "action_view/railtie"
 <%= comment_if :skip_action_cable %>require "action_cable/engine"
 <%= comment_if :skip_sprockets %>require "sprockets/railtie"
 <%= comment_if :skip_test %>require "rails/test_unit/railtie"
-<% end -%>
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
When a new framework is added to Rails (e.g. Active Storage), existing apps generated with `require "rails/all"` will load the framework without having properly installed it.  This can cause issues when running `rails app:update` because `--skip-*` options are [prepopulated based on loaded constants](https://github.com/rails/rails/blob/23b4aa505d04731c7890e19e8f8996869526f5b3/railties/lib/rails/app_updater.rb#L25-L32) (e.g. `defined?(ActiveStorage::Engine)`).  For example, update migrations may be generated for tables which do not exist (#35620, #38379).

By explicitly requiring frameworks, we ensure `rails app:update` will skip inappropriate updates.

---

I wanted to get some reactions on this before proceeding further.

An alternative solution would be an auto-generated app-specific `.railsrc` file as proposed in #22790.  However, #22790 was closed in favor of #29645, which introduced prepopulating `--skip-*` options based on loaded constants.
