### PR TITLE
Add perform_all_later to AJ

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -23,6 +23,21 @@ module ActiveJob
       end
       ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
 
+      # Push many jobs onto the queue at once. The parameter +args+ is an array of arrays.
+      # Each entry is an array arguments for a single job. For example, the following arguments
+      # would enqueue two jobs.
+      #
+      # +args+: [[1, "String arg", <#SomeModel ...>], [2, "String arg", <#SomeModel ...>]]
+      # First job enqueued with [1, "String arg", <#SomeModel ...>]
+      # Second job enqueued with [2, "String arg", <#SomeModel ...>]
+      def perform_all_later(args)
+        jobs = args.flat_map do |single_job_arguments|
+          job_or_instantiate(*single_job_arguments)
+        end
+
+        queue_adapter.enqueue_all(jobs)
+      end
+
       private
         def job_or_instantiate(*args) # :doc:
           args.first.is_a?(self) ? args.first : new(*args)

--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -35,6 +35,14 @@ module ActiveJob
           "at"      => timestamp
       end
 
+      def enqueue_all(jobs)
+        Sidekiq::Client.push_bulk \
+          "class"   => JobWrapper,
+          "wrapped" => jobs.first.class,
+          "queue"   => jobs.first.queue_name,
+          "args"    => jobs.map { |j| [j.serialize] }
+      end
+
       class JobWrapper #:nodoc:
         include Sidekiq::Worker
 


### PR DESCRIPTION
### Summary

This is an exploration to add support for pushing jobs in bulk. The idea is to iterate on it to understand if it's viable/desired or not.

This partial implementation does work (I tested on an application), but has some challenges and open questions:
1. The `push_bulk` call returns an array of JIDs in the same order as the arguments passed. One could think that we could simply loop through them and assign a `job_provider_id` to each job instance. However, in the case of Sidekiq, if any set of arguments failed to be pre-processed they are ignored and the JIDs array is compacted. Thus, there's no way of accurately being able to set the `job_provider_id` for all jobs (it would only work for when all arguments are properly processed). [Sidekiq reference](https://github.com/mperham/sidekiq/blob/cb7c3a753082604bb2540e9e96031432d0bd8fc0/lib/sidekiq/client.rb#L107).
2. Pushing big batches of jobs is [not recommended](https://github.com/mperham/sidekiq/blob/cb7c3a753082604bb2540e9e96031432d0bd8fc0/lib/sidekiq/client.rb#L81). Should this abstraction worry about this? Maybe log a warning if trying to enqueue too many jobs?

I also made a quick attempt to just expose the `JobWrapper` class to use it via Sidekiq's API straight away like this:
```ruby
Sidekiq::Client.push_bulk(
  "class" => JobWrapper,
  "args" => [...]
)
```

However, this bypasses serialization and ends up not working properly.