### PR TITLE
Backport a portion of #38684

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -168,6 +168,8 @@ module ActiveRecord
                                 spec_name = conn.pool.spec.name
                                 name = "#{spec_name}::SchemaMigration"
 
+                                return ActiveRecord::SchemaMigration if spec_name == "primary"
+
                                 Class.new(ActiveRecord::SchemaMigration) do
                                   define_singleton_method(:name) { name }
                                   define_singleton_method(:to_s) { name }

--- a/activerecord/test/cases/multi_db_migrator_test.rb
+++ b/activerecord/test/cases/multi_db_migrator_test.rb
@@ -67,6 +67,11 @@ class MultiDbMigratorTest < ActiveRecord::TestCase
     end
   end
 
+  def test_schema_migration_class_names
+    assert_equal "ActiveRecord::SchemaMigration", @schema_migration_a.name
+    assert_equal "ARUnit2Model::SchemaMigration", @schema_migration_b.name
+  end
+
   def test_finds_migrations
     @migrations_a_list.each_with_index do |pair, i|
       assert_equal @migrations_a[i].version, pair.first

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -133,12 +133,12 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord, "primary::SchemaMigration"].collect(&:to_s).sort
+    initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord].collect(&:to_s).sort
     assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort
     get "/load"
     assert_equal [Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort - initial
     get "/unload"
-    assert_equal ["ActiveRecord::InternalMetadata", "ActiveRecord::SchemaMigration", "primary::SchemaMigration"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
+    assert_equal ["ActiveRecord::InternalMetadata", "ActiveRecord::SchemaMigration"], ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
   end
 
   test "initialize cant be called twice" do

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -101,7 +101,7 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
   test "autoloaded? and overridden class names" do
     invalid_constant_name = Module.new do
       def self.name
-        "primary::SchemaMigration"
+        "MyModule::SchemaMigration"
       end
     end
     assert_not deps.autoloaded?(invalid_constant_name)


### PR DESCRIPTION
In Rails 6.0 the connection specification name for the
ActiveRecord::Base class is `primary`. In 6.1 we've changed it to be
`ActiveRecord::Base` to match how other classes behave.

Due to the way the schema migration table and connection to that table
are handled in Active Record we need to generate classes on the
connection so those connections are able to find the correct table.
Applications don't create the table, Rails does, and the default schema
migration class inherits directly from Active Record.

Since the default connection in 6.0 is named `primary` we end up with a
class name of `primary::SchemaMigration` which is not a valid constant
name and causes problems with Zeitwerk.

I realized however that I never backported #38684 to 6.0 which skips
the creation of the class for `ActiveRecord::Base` since it can use the
default. This should fix the issue for Zeitwrk since we're no longer
creating a `primary::SchemaMigration` class. The other databases in a
multi-db application won't have issues because they use their actual
class name, therefore causing no issues for Zeitwerk since it follows
the Active Model naming pattern.

Ref: #36757