### PR TITLE
Look up RequestEncoder.parser on every #parsed_body call

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_response.rb
+++ b/actionpack/lib/action_dispatch/testing/test_response.rb
@@ -14,11 +14,6 @@ module ActionDispatch
       new response.status, response.headers, response.body
     end
 
-    def initialize(*) # :nodoc:
-      super
-      @response_parser = RequestEncoder.parser(content_type)
-    end
-
     # Was the response successful?
     def success?
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
@@ -47,7 +42,7 @@ module ActionDispatch
     end
 
     def parsed_body
-      @parsed_body ||= @response_parser.call(body)
+      @parsed_body ||= RequestEncoder.parser(content_type).call(body)
     end
   end
 end


### PR DESCRIPTION
### Summary

A followup to https://github.com/rails/rails/pull/23597

At time of initialization for unit tests, the content_type will always be nil, causing the IdentityEncoder to always be returned and used. By looking up the appropriate parser every time, we guarantee the correct parser is used (especially if a unit test uses `as: :foobar` and deviates from normal flow).

This should not have any memory performance impacts because .parser accesses a class instance variable.

With this commit you're now able to successfully run below, where before it would fail with #parsed_body being a string:

```ruby
# would fail without this PR:
RSpec.describe Api::MyApi, type: :controller do
  controller do
    def create
      render json: { foo: 'bar' }
    end
  end

  it do
    # trying to do all forms of informing the testing framework that we're a JSON request
    @request.headers['Accept'] = 'application/json'
    @request.headers['Content-Type'] = 'application/json'
    post :create, as: :json, format: :json
    expect(response.parsed_body).to eq( 'foo' => 'bar' )
  end
end
```
### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
