### PR TITLE
Deprecate passing a Hash Class to `uuid_from_hash` is deprecated in favour of String

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Passing a Hash Class to `uuid_from_hash` is deprecated in favour of String.
+    
+    Before:
+
+        Digest::UUID.uuid_from_hash(Digest::SHA1, Digest::UUID::OID_NAMESPACE, "1.2.3")
+        # => "42d5e23b-3a02-5135-85c6-52d1102f1f00"       
+
+    After:
+
+        Digest::UUID.uuid_from_hash("SHA1", Digest::UUID::OID_NAMESPACE, "1.2.3")
+        # => "42d5e23b-3a02-5135-85c6-52d1102f1f00"
+               
+    *Vipul A M*
+
 *   `require_dependency` has been documented to be _obsolete_ in `:zeitwerk`
     mode. The method is not deprecated as such (yet), but applications are
     encouraged to not use it.

--- a/activesupport/lib/active_support/core_ext/digest/uuid.rb
+++ b/activesupport/lib/active_support/core_ext/digest/uuid.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "securerandom"
+require "openssl"
 
 module Digest
   module UUID
@@ -11,20 +12,28 @@ module Digest
 
     # Generates a v5 non-random UUID (Universally Unique IDentifier).
     #
-    # Using Digest::MD5 generates version 3 UUIDs; Digest::SHA1 generates version 5 UUIDs.
+    # Using MD5 generates version 3 UUIDs; SHA1 generates version 5 UUIDs.
     # uuid_from_hash always generates the same UUID for a given name and namespace combination.
     #
     # See RFC 4122 for details of UUID at: https://www.ietf.org/rfc/rfc4122.txt
     def self.uuid_from_hash(hash_class, uuid_namespace, name)
-      if hash_class == Digest::MD5
-        version = 3
-      elsif hash_class == Digest::SHA1
-        version = 5
-      else
-        raise ArgumentError, "Expected Digest::SHA1 or Digest::MD5, got #{hash_class.name}."
+      unless hash_class.is_a?(String)
+        hash_class = hash_class.to_s.scan(/MD5|SHA1$/).first
+        ActiveSupport::Deprecation.warn(<<~EOM)
+          Passing a Hash Class to `uuid_from_hash` is deprecated and will be removed in Rails 6.2.
+          Please pass a string instead (SHA1 or MD5).
+        EOM
       end
 
-      hash = hash_class.new
+      if hash_class == "MD5"
+        version = 3
+      elsif hash_class == "SHA1"
+        version = 5
+      else
+        raise ArgumentError, "Expected SHA1 or MD5, got #{hash_class}."
+      end
+
+      hash = OpenSSL::Digest.new(hash_class)
       hash.update(uuid_namespace)
       hash.update(name)
 
@@ -37,12 +46,12 @@ module Digest
 
     # Convenience method for uuid_from_hash using Digest::MD5.
     def self.uuid_v3(uuid_namespace, name)
-      uuid_from_hash(Digest::MD5, uuid_namespace, name)
+      uuid_from_hash("MD5", uuid_namespace, name)
     end
 
     # Convenience method for uuid_from_hash using Digest::SHA1.
     def self.uuid_v5(uuid_namespace, name)
-      uuid_from_hash(Digest::SHA1, uuid_namespace, name)
+      uuid_from_hash("SHA1", uuid_namespace, name)
     end
 
     # Convenience method for SecureRandom.uuid.

--- a/activesupport/test/core_ext/digest/uuid_test.rb
+++ b/activesupport/test/core_ext/digest/uuid_test.rb
@@ -23,4 +23,10 @@ class DigestUUIDExt < ActiveSupport::TestCase
       Digest::UUID.uuid_from_hash(Digest::SHA2, Digest::UUID::OID_NAMESPACE, "1.2.3")
     end
   end
+
+  def test_hash_class_passing_deprecation
+    assert_deprecated(/Passing a Hash Class to `uuid_from_hash` is deprecated and will be removed in Rails 6/) do
+      Digest::UUID.uuid_from_hash(Digest::SHA1, Digest::UUID::OID_NAMESPACE, "1.2.3")
+    end
+  end
 end


### PR DESCRIPTION
Before:

    Digest::UUID.uuid_from_hash(Digest::SHA1, Digest::UUID::OID_NAMESPACE, "1.2.3")
    # => "42d5e23b-3a02-5135-85c6-52d1102f1f00"

After:

    Digest::UUID.uuid_from_hash("SHA1", Digest::UUID::OID_NAMESPACE, "1.2.3")
    # => "42d5e23b-3a02-5135-85c6-52d1102f1f00"

Related discussions:
https://github.com/ruby/openssl/pull/362
https://github.com/ruby/openssl/issues/304
https://github.com/rails/rails/pull/39410#issuecomment-636058108