### PR TITLE
Alias direct_descendants as subclasses

### DIFF
--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -13,6 +13,7 @@ module ActiveSupport
         descendants = @@direct_descendants[klass]
         descendants ? descendants.to_a : []
       end
+      alias_method :subclasses, :direct_descendants
 
       def descendants(klass)
         arr = []
@@ -59,6 +60,7 @@ module ActiveSupport
     def direct_descendants
       DescendantsTracker.direct_descendants(self)
     end
+    alias_method :subclasses, :direct_descendants
 
     def descendants
       DescendantsTracker.descendants(self)

--- a/activesupport/test/descendants_tracker_test_cases.rb
+++ b/activesupport/test/descendants_tracker_test_cases.rb
@@ -42,6 +42,12 @@ module DescendantsTrackerTestCases
     assert_equal_sets [], Child2.direct_descendants
   end
 
+  def test_subclasses
+    [Parent, Child1, Child2].each do |klass|
+      assert_equal klass.direct_descendants, klass.subclasses
+    end
+  end
+
   def test_clear
     mark_as_autoloaded(*ALL) do
       ActiveSupport::DescendantsTracker.clear


### PR DESCRIPTION
This enables e.g. `klass.subclasses` and `klass.direct_descendants` both to work regardless of whether `klass` extends `DescendantsTracker`, and to get a performance boost when `klass` *does* extend `DescendantsTracker`.