### PR TITLE
Automatically infer inverse_of regardless of whether an association has an explicit foreign_key option

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -100,7 +100,10 @@ module ActiveRecord
         end
 
         def find_target?
-          !loaded? && foreign_key_present? && klass
+          return unless foreign_key_present? && klass
+          return true unless loaded?
+
+          target && owner._read_attribute(reflection.foreign_key) != target._read_attribute(primary_key(klass))
         end
 
         def require_counter_update?

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -639,9 +639,9 @@ module ActiveRecord
         # Anything with a scope can additionally ruin our attempt at finding an
         # inverse, so we exclude reflections with scopes.
         def can_find_inverse_of_automatically?(reflection)
+          reflection.active_record.name &&
           reflection.options[:inverse_of] != false &&
             !reflection.options[:through] &&
-            !reflection.options[:foreign_key] &&
             !reflection.scope
         end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -22,6 +22,7 @@ require "models/project"
 require "models/author"
 require "models/user"
 require "models/room"
+require "models/bird"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars
@@ -197,7 +198,7 @@ class InverseAssociationTests < ActiveRecord::TestCase
     has_many_without_inverse_ref = Club.reflect_on_association(:memberships)
     assert_not_predicate has_many_without_inverse_ref, :has_inverse?
 
-    belongs_to_without_inverse_ref = Sponsor.reflect_on_association(:sponsor_club)
+    belongs_to_without_inverse_ref = Sponsor.reflect_on_association(:sponsorable_with_conditions)
     assert_not_predicate belongs_to_without_inverse_ref, :has_inverse?
   end
 
@@ -219,7 +220,7 @@ class InverseAssociationTests < ActiveRecord::TestCase
     has_many_ref = Club.reflect_on_association(:memberships)
     assert_nil has_many_ref.inverse_of
 
-    belongs_to_ref = Sponsor.reflect_on_association(:sponsor_club)
+    belongs_to_ref = Sponsor.reflect_on_association(:sponsorable_with_conditions)
     assert_nil belongs_to_ref.inverse_of
   end
 
@@ -904,6 +905,22 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_nothing_raised { Face.first.polymorphic_human = Human.first }
     # fails because Interest does have the correct inverse_of
     assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.polymorphic_human = Interest.first }
+  end
+
+  def test_automatic_inverse_of_for_has_many_with_foreign_key_option
+    post = Post.create!(title: "My Post", body: "Empty")
+    post.categorizations.create!
+    categorization = post.reload.categorizations.first
+    assert categorization.association(:post).loaded?
+    assert_equal post, categorization.post
+  end
+
+  def test_automatic_inverse_of_for_has_one_with_foreign_key_option
+    person = Person.create!(first_name: "Donald")
+    person.create_bird!(name: "Raven")
+    bird = person.reload.bird
+    assert bird.association(:person).loaded?
+    assert_equal person, bird.person
   end
 end
 

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -135,7 +135,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_many_through_has_one_through_with_has_one_source_reflection_preload
-    member = assert_queries(4) { Member.includes(:nested_sponsors).first }
+    member = assert_queries(3) { Member.includes(:nested_sponsors).first }
     mustache = sponsors(:moustache_club_sponsor_for_groucho)
     assert_no_queries do
       assert_equal [mustache], member.nested_sponsors

--- a/activerecord/test/models/bird.rb
+++ b/activerecord/test/models/bird.rb
@@ -2,6 +2,7 @@
 
 class Bird < ActiveRecord::Base
   belongs_to :pirate
+  belongs_to :person, foreign_key: :pirate_id
   validates_presence_of :name
 
   accepts_nested_attributes_for :pirate

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -4,6 +4,7 @@ class Person < ActiveRecord::Base
   has_many :readers
   has_many :secure_readers
   has_one  :reader
+  has_one :bird, foreign_key: :pirate_id
 
   has_many :posts, through: :readers
   has_many :secure_posts, through: :secure_readers


### PR DESCRIPTION
### Summary

Since 26d19b4661f3d89a075b5f05d926c578ff0c730f first introduced automatic inference
of inverse_of, associations with an explicit foreign_key have been excluded.
Intuitively, foreign key column names don't seem to have any impact of inverse
associations and I did not find any hints in commit messages or pull requests
(neither for rails nor for https://github.com/rubocop-hq/rubocop-rails/blob/master/lib/rubocop/cop/rails/inverse_of.rb)
as to why it would be more difficult to infer the inverse_of when a foreign_key
option is set.  (See https://github.com/rails/rails/pull/9522#issuecomment-14481624, which mentions, but doesn't explain, excluding foreign_key.)

### Other Information

FYI @koic @wata727 @bdewater @rrosenblum:  This will allow simplification of https://github.com/rubocop-hq/rubocop-rails/blob/master/lib/rubocop/cop/rails/inverse_of.rb