### PR TITLE
Remove redundant random calls

### DIFF
--- a/activesupport/lib/active_support/core_ext/securerandom.rb
+++ b/activesupport/lib/active_support/core_ext/securerandom.rb
@@ -18,9 +18,7 @@ module SecureRandom
   #   p SecureRandom.base58(24) # => "77TMHrHJFvFDwodq8w7Ev2m7"
   def self.base58(n = 16)
     SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-      idx = byte % 64
-      idx = SecureRandom.random_number(58) if idx >= 58
-      BASE58_ALPHABET[idx]
+      BASE58_ALPHABET[byte % 58]
     end.join
   end
 
@@ -37,9 +35,7 @@ module SecureRandom
   #   p SecureRandom.base36(24) # => "77tmhrhjfvfdwodq8w7ev2m7"
   def self.base36(n = 16)
     SecureRandom.random_bytes(n).unpack("C*").map do |byte|
-      idx = byte % 64
-      idx = SecureRandom.random_number(36) if idx >= 36
-      BASE36_ALPHABET[idx]
+      BASE36_ALPHABET[byte % 36]
     end.join
   end
 end


### PR DESCRIPTION
### Summary

Remove redundant random calls when generating base58 or base36 random strings.

### Other Information

These methods have more than enough randomness to create random strings already without calling random again for every overflow on an (arbitrary?) boundary. The base36 one is particularly puzzling, it's more likely to call `random_number` than not.

There's not likely to be much actual impact beyond slightly cleaner code.