### PR TITLE
Support attribute aliases for `type_for_attribute`

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -381,6 +381,8 @@ module ActiveRecord
       # a string or a symbol.
       def type_for_attribute(attr_name, &block)
         attr_name = attr_name.to_s
+        attr_name = attribute_aliases[attr_name] || attr_name
+
         if block
           attribute_types.fetch(attr_name, &block)
         else

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -344,12 +344,11 @@ module ActiveRecord
 
     def compute_cache_version(timestamp_column) # :nodoc:
       timestamp_column = timestamp_column.to_s
-      timestamp_column = klass.attribute_aliases[timestamp_column] || timestamp_column
 
       if loaded? || distinct_value
         size = records.size
         if size > 0
-          timestamp = records.map { |record| record._read_attribute(timestamp_column) }.max
+          timestamp = records.map { |record| record.read_attribute(timestamp_column) }.max
         end
       else
         collection = eager_loading? ? apply_join_dependency : self

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -69,6 +69,8 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal :string, @first.column_for_attribute(:title).type
     assert_equal :string, @first.type_for_attribute("title").type
     assert_equal :string, @first.type_for_attribute(:title).type
+    assert_equal :string, @first.type_for_attribute("heading").type
+    assert_equal :string, @first.type_for_attribute(:heading).type
     assert_equal 250, @first.column_for_attribute("title").limit
   end
 


### PR DESCRIPTION
Similar with #39496.
