### PR TITLE
Small improvements to format_paragraph to allocate less memory

### DIFF
--- a/actionmailer/lib/action_mailer/mail_helper.rb
+++ b/actionmailer/lib/action_mailer/mail_helper.rb
@@ -54,19 +54,19 @@ module ActionMailer
     #   # => "    Here is a sample text with\n    more than 40 characters"
     def format_paragraph(text, len = 72, indent = 2)
       sentences = [[]]
+      space = " "
+      new_line = "\n"
+      indentation = " " * indent
 
       text.split.each do |word|
-        if sentences.first.present? && (sentences.last + [word]).join(" ").length > len
+        if sentences.first.any? && (sentences.last + [word]).join(space).length > len
           sentences << [word]
         else
           sentences.last << word
         end
       end
 
-      indentation = " " * indent
-      sentences.map! { |sentence|
-        "#{indentation}#{sentence.join(' ')}"
-      }.join "\n"
+      sentences.map! { |sentence| "#{indentation}#{sentence.join(space)}" }.join(new_line)
     end
   end
 end


### PR DESCRIPTION
### Summary

Small improvements to format_paragraph method to make the code slightly faster and allocate less memory.

```
require 'benchmark/ips'
require 'benchmark-memory'

text = "But soft! What light through yonder window breaks? It is the east, " \
        "and Juliet is the sun. Arise, fair sun, and kill the envious moon, " \
        "which is sick and pale with grief that thou, her maid, art far more " \
        "fair than she. Be not her maid, for she is envious! Her vestal " \
        "livery is but sick and green, and none but fools do wear it. Cast " \
        "it off!"

# current code
def format_paragraph(text, len = 72, indent = 2)
  sentences = [[]]

  text.split.each do |word|
    if sentences.first.any? && (sentences.last + [word]).join(" ").length > len
      sentences << [word]
    else
      sentences.last << word
    end
  end

  indentation = " " * indent
  sentences.map! { |sentence|
    "#{indentation}#{sentence.join(' ')}"
  }.join "\n"
end

# updated code
def format_paragraph2(text, len = 72, indent = 2)
  sentences = [[]]
  space = " "
  new_line = "\n"
  indentation = " " * indent

  text.split.each do |word|
    if sentences.first.any? && (sentences.last + [word]).join(space).length > len
      sentences << [word]
    else
      sentences.last << word
    end
  end

  sentences.map! { |sentence| "#{indentation}#{sentence.join(space)}" }.join(new_line)
end

Benchmark.ips do |x|
  x.report("format_paragraph2") { format_paragraph2(text) }
  x.report("format_paragraph") { format_paragraph(text) }
  x.compare!
end

puts "MEMORY"
Benchmark.memory do |x|
  x.report("format_paragraph")      { format_paragraph(text) }
  x.report("format_paragraph2") { format_paragraph2(text) }
  x.compare!
end
```

Result:

```
Warming up --------------------------------------
   format_paragraph2   970.000  i/100ms
    format_paragraph   924.000  i/100ms
Calculating -------------------------------------
   format_paragraph2      9.667k (± 1.1%) i/s -     48.500k in   5.017865s
    format_paragraph      9.361k (± 2.4%) i/s -     47.124k in   5.037172s

Comparison:
   format_paragraph2:     9666.8 i/s
    format_paragraph:     9360.7 i/s - same-ish: difference falls within error

MEMORY
Calculating -------------------------------------
    format_paragraph    30.558k memsize (     0.000  retained)
                       362.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
   format_paragraph2    27.718k memsize (    40.000  retained)
                       291.000  objects (     1.000  retained)
                        50.000  strings (     1.000  retained)

Comparison:
   format_paragraph2:      27718 allocated
    format_paragraph:      30558 allocated - 1.10x more
```
