### PR TITLE
Consistently use named route parameters

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -232,6 +232,9 @@ module ActionDispatch
                 @arg_size.times { |i|
                   key = @required_parts[i]
                   value = args[i].to_param
+                  if key != :id
+                    value = args[i].try(key) || value
+                  end
                   yield key if value.nil? || value.empty?
                   params[key] = value
                 }

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -233,7 +233,7 @@ module ActionDispatch
                   key = @required_parts[i]
                   value = args[i].to_param
                   if key != :id
-                    value = args[i].try(key) || value
+                    value = args[i].try(key).try(:to_s) || value
                   end
                   yield key if value.nil? || value.empty?
                   params[key] = value


### PR DESCRIPTION
### Summary

Restful routes support using a [custom parameter](https://guides.rubyonrails.org/routing.html#overriding-named-route-parameters). For instance:

```ruby
resources :videos, param: :identifier
```

Unfortunately, this parameter is then *completely ignored* when using the associated route helper:

```ruby
v = Video.create(identifier: "foobar")
app.video_path(v) # This would return "/videos/1"
```

This patch makes it consistent:
```ruby
app.video_path(v) # This now returns "/videos/foobar"
```

### Rationale

The recommended way to achieve this is by implementing the `to_param` method. I think this is broken for several reasons:

* The routing (which I think is sort of a "control" problem from an MVC standpoint) is mixed into the model. I think this is not a good separation of concerns.
* When a named param is used we still need to implement `to_param` even though Rails could make a smart guess (that's actually the case even in the [doc's example](https://guides.rubyonrails.org/routing.html#overriding-named-route-parameters), where the `to_param` wouldn't be needed at all with this patch).
* Using `to_param` simply prevents more complex routing since you cannot use two different routing strategies for one given model (since there'll be only one `to_param` method). For example, it's currently not possible to use routes such as `/videos/:title` and  `/admin/videos/:id` to manipulate the same Video model.