### PR TITLE
Replace 'Stubs out' with 'Generates' in generator USAGE's [ci skip]

### DIFF
--- a/actioncable/lib/rails/generators/channel/USAGE
+++ b/actioncable/lib/rails/generators/channel/USAGE
@@ -1,6 +1,6 @@
 Description:
 ============
-    Stubs out a new cable channel for the server (in Ruby) and client (in JavaScript).
+    Generates a new cable channel for the server (in Ruby) and client (in JavaScript).
     Pass the channel name, either CamelCased or under_scored, and an optional list of channel actions as arguments.
 
 Example:

--- a/actionmailbox/lib/rails/generators/mailbox/USAGE
+++ b/actionmailbox/lib/rails/generators/mailbox/USAGE
@@ -1,6 +1,6 @@
 Description:
 ============
-    Stubs out a new mailbox class in app/mailboxes and invokes your template
+    Generates a new mailbox class in app/mailboxes and invokes your template
     engine and test framework generators.
 
 Example:

--- a/actionmailer/lib/rails/generators/mailer/USAGE
+++ b/actionmailer/lib/rails/generators/mailer/USAGE
@@ -1,6 +1,6 @@
 Description:
 ============
-    Stubs out a new mailer and its views. Passes the mailer name, either
+    Generates a new mailer and its views. Passes the mailer name, either
     CamelCased or under_scored, and an optional list of emails as arguments.
 
     This generates a mailer class in app/mailers and invokes your template

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -267,7 +267,7 @@ ActiveRecord options:
 ...
 
 Description:
-    Stubs out a new model. Pass the model name, either CamelCased or
+    Generates a new model. Pass the model name, either CamelCased or
     under_scored, and an optional list of attribute pairs as arguments.
 
 ...

--- a/railties/lib/rails/generators/rails/assets/USAGE
+++ b/railties/lib/rails/generators/rails/assets/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out new asset placeholders. Pass the asset name, either CamelCased
+    Generates new asset placeholders. Pass the asset name, either CamelCased
     or under_scored.
 
     To create an asset within a folder, specify the asset's name as a

--- a/railties/lib/rails/generators/rails/controller/USAGE
+++ b/railties/lib/rails/generators/rails/controller/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new controller and its views. Pass the controller name, either
+    Generates a new controller and its views. Pass the controller name, either
     CamelCased or under_scored, and a list of views as arguments.
 
     To create a controller within a module, specify the controller name as a

--- a/railties/lib/rails/generators/rails/generator/USAGE
+++ b/railties/lib/rails/generators/rails/generator/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new generator at lib/generators. Pass the generator name as an argument,
+    Generates a new generator at lib/generators. Pass the generator name as an argument,
     either CamelCased or snake_cased.
 
 Example:

--- a/railties/lib/rails/generators/rails/helper/USAGE
+++ b/railties/lib/rails/generators/rails/helper/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new helper. Pass the helper name, either CamelCased
+    Generates a new helper. Pass the helper name, either CamelCased
     or under_scored.
 
     To create a helper within a module, specify the helper name as a

--- a/railties/lib/rails/generators/rails/integration_test/USAGE
+++ b/railties/lib/rails/generators/rails/integration_test/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new integration test. Pass the name of the test, either
+    Generates a new integration test. Pass the name of the test, either
     CamelCased or under_scored, as an argument.
 
     This generator invokes the current integration tool, which defaults to

--- a/railties/lib/rails/generators/rails/migration/USAGE
+++ b/railties/lib/rails/generators/rails/migration/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new database migration. Pass the migration name, either
+    Generates a new database migration. Pass the migration name, either
     CamelCased or under_scored, and an optional list of attribute pairs as arguments.
 
     A migration class is generated in db/migrate prefixed by a timestamp of the current date and time.

--- a/railties/lib/rails/generators/rails/model/USAGE
+++ b/railties/lib/rails/generators/rails/model/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new model. Pass the model name, either CamelCased or
+    Generates a new model. Pass the model name, either CamelCased or
     under_scored, and an optional list of attribute pairs as arguments.
 
     Attribute pairs are field:type arguments specifying the

--- a/railties/lib/rails/generators/rails/resource/USAGE
+++ b/railties/lib/rails/generators/rails/resource/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new resource including an empty model and controller suitable
+    Generates a new resource including an empty model and controller suitable
     for a RESTful, resource-oriented application. Pass the singular model name,
     either CamelCased or under_scored, as the first argument, and an optional
     list of attribute pairs.

--- a/railties/lib/rails/generators/rails/scaffold_controller/USAGE
+++ b/railties/lib/rails/generators/rails/scaffold_controller/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a scaffolded controller, its seven RESTful actions and related
+    Generates a scaffolded controller, its seven RESTful actions and related
     views. Pass the model name, either CamelCased or under_scored. The
     controller name is retrieved as a pluralized version of the model name.
 

--- a/railties/lib/rails/generators/rails/system_test/USAGE
+++ b/railties/lib/rails/generators/rails/system_test/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new system test. Pass the name of the test, either
+    Generates a new system test. Pass the name of the test, either
     CamelCased or under_scored, as an argument.
 
     This generator invokes the current system tool, which defaults to

--- a/railties/lib/rails/generators/rails/task/USAGE
+++ b/railties/lib/rails/generators/rails/task/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Stubs out a new Rake task. Pass the namespace name, and a list of tasks as arguments.
+    Generates a new Rake task. Pass the namespace name, and a list of tasks as arguments.
 
     This generates a task file in lib/tasks.
 


### PR DESCRIPTION
### Summary

Generators generate things, but what is meant by 'Stubbing out' might
confuse beginners and non-native English speakers.
While generated tests are stubs that should have an implementation, a
generated model is a valid model that doesn't require any changes.

