### PR TITLE
Don't show backtrace if a Rails command isn't found

### DIFF
--- a/railties/lib/rails/command/spellchecker.rb
+++ b/railties/lib/rails/command/spellchecker.rb
@@ -5,10 +5,14 @@ module Rails
     module Spellchecker # :nodoc:
       class << self
         def suggest(word, from:)
+          suggestions(word, from: from).first
+        end
+
+        def suggestions(word, from:)
           if defined?(DidYouMean::SpellChecker)
-            DidYouMean::SpellChecker.new(dictionary: from.map(&:to_s)).correct(word).first
+            DidYouMean::SpellChecker.new(dictionary: from.map(&:to_s)).correct(word)
           else
-            from.sort_by { |w| levenshtein_distance(word, w) }.first
+            from.sort_by { |w| levenshtein_distance(word, w) }
           end
         end
 

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -9,7 +9,12 @@ module Rails
 
       class << self
         def printing_commands
-          formatted_rake_tasks.map(&:first)
+          formatted_rake_tasks.map(&:name_with_args)
+        end
+
+        def performable_commands_and_options
+          rake_tasks.map(&:name_with_args) +
+            rake_option_arguments
         end
 
         def perform(task, args, config)
@@ -34,15 +39,20 @@ module Rails
             Rake::TaskManager.record_task_metadata = true
             Rake.application.instance_variable_set(:@name, "rails")
             load_tasks
-            @rake_tasks = Rake.application.tasks.select(&:comment)
+            @rake_tasks = Rake.application.tasks
           end
 
           def formatted_rake_tasks
-            rake_tasks.map { |t| [ t.name_with_args, t.comment ] }
+            rake_tasks.select(&:comment)
           end
 
           def require_rake
             require "rake" # Defer booting Rake until we know it's needed.
+          end
+
+          def rake_option_arguments
+            options = Rake.application.standard_rake_options.flat_map{ |opt| opt[0..-3] }
+            options.map { |opt| opt.split(/( |=)/).first }
           end
       end
     end


### PR DESCRIPTION
### Summary

If a Rake command isn't found, Rake would generate an error with a
backtrace. While this can be useful if you create your own Rake apps, it
makes no sense for the Rails command line which developers only consume.

![image](https://user-images.githubusercontent.com/28561/83614206-2fd5de00-a585-11ea-8e92-e411823da3ed.png)


Instead we can suggests commands, from the Rails and Rake namespaces,
and leave out the backtrace.

![image](https://user-images.githubusercontent.com/28561/83614092-0452f380-a585-11ea-85dc-94e60d69dcad.png)

This change also suggests commands from both the Rails and Rake namespaces:
![image](https://user-images.githubusercontent.com/28561/83614410-74617980-a585-11ea-86f9-8b0697a35e0a.png)

### Other Information

This change uses 'Maybe you meant?' instead of 'Did you mean?' to keep it consistent with the `generate` command.
