### PR TITLE
Add support for default order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Add `#default_order` query method and association option which can be used to order records when no other order is specified.
+
+    This extends the functionality offered by `#implicit_order_column` to scopes and associations.
+
+    Usage:
+
+    ```ruby
+    class Post < ApplicationRecord
+      has_many :comments, default_order: :likes
+      # .. or ..
+      has_many :comments, -> { default_order(:likes) }
+    end
+
+    post = Post.first
+
+    post.comments # comments ordered by `likes`
+    post.comments.order(:created_at) # comments ordered by `created_at`
+    ```
+
+    *Dan Ungureanu*
+
 *   Raise `ActiveRecord::MultiparameterAssignmentErrors` instead of `NoMethodError`
     when assigning a malformed multiparameter attribute name.
 

--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -152,6 +152,7 @@ module ActiveRecord
               scope.unscope!(*item.table_name_qualified_unscope_values)
               scope.where_clause += item.where_clause
               scope.order_values = item.order_values | scope.order_values
+              scope.default_order_values = item.default_order_values | scope.default_order_values
             end
           end
 

--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:counter_cache, :join_table, :index_errors, :as, :through]
+      valid = super + [:counter_cache, :join_table, :index_errors, :default_order, :as, :through]
       valid += [:foreign_type] if options[:as]
       valid += [:source, :source_type, :disable_joins] if options[:through]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -298,6 +298,7 @@ module ActiveRecord
       def scope
         scope = super
         scope.none! if null_scope?
+        scope.default_order!(options[:default_order]) if options[:default_order].present?
         scope
       end
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       :create_or_find_by, :create_or_find_by!,
       :destroy, :destroy_all, :delete, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
-      :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
+      :select, :reselect, :order, :regroup, :in_order_of, :reorder, :default_order, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -52,8 +52,9 @@ module ActiveRecord
     end
 
     MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
-                            :order, :joins, :left_outer_joins, :references,
-                            :extending, :unscope, :optimizer_hints, :annotate,
+                            :order, :default_order, :joins, :left_outer_joins,
+                            :references, :extending, :unscope, :optimizer_hints,
+                            :annotate,
                             :with].freeze
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering, :strict_loading,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -640,6 +640,10 @@ module ActiveRecord
 
       def ordered_relation
         if order_values.empty?
+          if default_order_values.present?
+            return order(default_order_values)
+          end
+
           if !_order_columns.empty?
             return order(_order_columns.map { |column| table[column].asc })
           end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -791,6 +791,30 @@ module ActiveRecord
       self
     end
 
+    # Defines a default order used when no other order is specified.
+    #
+    #   User.default_order('email DESC') # generated SQL has 'ORDER BY email DESC'
+    #
+    # Subsequent calls to order on the same relation will replace default
+    # order. For example:
+    #
+    #   User.default_order('email DESC').order('id ASC').order('name ASC')
+    #
+    # generates a query with 'ORDER BY id ASC, name ASC'.
+    def default_order(*args)
+      check_if_method_has_arguments!(__callee__, args) do
+        sanitize_order_arguments(args)
+      end
+      spawn.default_order!(*args)
+    end
+
+    # Same as #default_order but operates on relation in-place instead of copying.
+    def default_order!(*args) # :nodoc:
+      preprocess_order_args(args)
+      self.default_order_values = args
+      self
+    end
+
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :left_outer_joins, :annotate,
                                      :includes, :eager_load, :preload, :from, :readonly,
@@ -2115,6 +2139,7 @@ module ActiveRecord
 
       def build_order(arel)
         orders = order_values.compact_blank
+        orders = default_order_values.compact_blank if orders.empty?
         arel.order(*orders) unless orders.empty?
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -656,6 +656,26 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.limited_clients.length, firm.limited_clients.count
   end
 
+  def test_default_order
+    post = posts(:welcome)
+
+    comments = post.comments
+    assert_equal [1, 2], comments.pluck(:id)
+    assert_equal 1, comments.first.id
+
+    comments = post.comments.order(:body)
+    assert_equal [2, 1], comments.pluck(:id)
+    assert_equal 2, comments.first.id
+
+    comments = post.ordered_comments
+    assert_equal [2, 1], comments.pluck(:id)
+    assert_equal 2, comments.first.id
+
+    comments = post.ordered_comments.order(:id)
+    assert_equal [1, 2], comments.pluck(:id)
+    assert_equal 1, comments.first.id
+  end
+
   def test_finding
     assert_equal 3, Firm.first.clients.length
   end
@@ -3203,7 +3223,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
       :anonymous_class, :primary_key, :foreign_key, :dependent, :validate, :inverse_of,
       :strict_loading, :query_constraints, :deprecated, :autosave, :class_name, :before_add,
       :after_add, :before_remove, :after_remove, :extend, :counter_cache, :join_table,
-      :index_errors, :as, :through
+      :index_errors, :default_order, :as, :through
     MESSAGE
   end
 

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -5,7 +5,7 @@ require "models/post"
 
 module ActiveRecord
   class RelationMutationTest < ActiveRecord::TestCase
-    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select, :with]).each do |method|
+    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :default_order, :unscope, :select, :with]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal [:foo], relation.public_send("#{method}_values")
@@ -34,6 +34,11 @@ module ActiveRecord
       obj = Object.new
       assert relation.order!(obj)
       assert_equal [obj], relation.order_values
+    end
+
+    test "#default_order!" do
+      assert relation.default_order!("name ASC").equal?(relation)
+      assert_equal ["name ASC"], relation.default_order_values
     end
 
     test "extending!" do

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2024,6 +2024,20 @@ class RelationTest < ActiveRecord::TestCase
     assert_nil relation.order_values.first
   end
 
+  def test_default_order
+    comments = posts(:welcome).comments
+    assert_equal [1, 2], comments.pluck(:id)
+    assert_equal 1, comments.first.id
+
+    comments = comments.default_order(:body)
+    assert_equal [2, 1], comments.pluck(:id)
+    assert_equal 2, comments.first.id
+
+    comments = comments.order(:id)
+    assert_equal [1, 2], comments.pluck(:id)
+    assert_equal 1, comments.first.id
+  end
+
   def test_reorder_with_first
     post = nil
 

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -91,6 +91,8 @@ class Post < ActiveRecord::Base
     end
   end
 
+  has_many :ordered_comments, class_name: "Comment", default_order: :body
+
   has_many :comments_with_extend, extend: NamedExtension, class_name: "Comment", foreign_key: "post_id" do
     def greeting
       "hello"


### PR DESCRIPTION
### Summary

Add `#default_order` and `default_order` relation option to define a default order which will be used if no other order is specified.

This extends the functionality offered by `#implicit_order_column` to scopes and relations.

Usage:

```ruby
    class Post < ApplicationRecord
      has_many :comments, default_order: :likes
      # .. or ..
      has_many :comments, -> { default_order(:likes) }
    end

    post = Post.first
    post.comments # comments ordered by `likes`
    post.comments.order(:created_at) # comments ordered by `created_at`
```

### Other Information

I started a discussion about this on Ruby on Rails forum:

https://discuss.rubyonrails.org/t/default-order-for-relations/75554