### PR TITLE
Set timezone on a Job initialization to make it conform more with perform_later when doing JobClass.perform_now

### DIFF
--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -85,6 +85,7 @@ module ActiveJob
       @priority   = self.class.priority
       @executions = 0
       @exception_executions = {}
+      @timezone   = Time.zone&.name
     end
     ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
@@ -101,7 +102,7 @@ module ActiveJob
         "executions" => executions,
         "exception_executions" => exception_executions,
         "locale"     => I18n.locale.to_s,
-        "timezone"   => Time.zone&.name,
+        "timezone"   => timezone,
         "enqueued_at" => Time.now.utc.iso8601
       }
     end

--- a/activejob/test/cases/timezones_test.rb
+++ b/activejob/test/cases/timezones_test.rb
@@ -21,4 +21,16 @@ class TimezonesTest < ActiveSupport::TestCase
 
     assert_equal "Just 5 hours to go", JobBuffer.last_value
   end
+
+  test "perform_now passes down current timezone to the job" do
+    Time.zone = "America/New_York"
+
+    Time.use_zone("London") do
+      job = TimezoneDependentJob.new("2018-01-01T00:00:00Z")
+      assert_equal "London", job.timezone
+      job.perform_now
+    end
+
+    assert_equal "Happy New Year!", JobBuffer.last_value
+  end
 end


### PR DESCRIPTION
Fixes #39529
