### PR TITLE
Fix schema cache load and corresponding test

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -129,13 +129,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
       if config.active_record.delete(:use_schema_cache_dump)
         config.after_initialize do |app|
           ActiveSupport.on_load(:active_record) do
-            db_config = ActiveRecord::Base.configurations.configs_for(
-              env_name: Rails.env,
-              name: "primary",
-            )
+            db_config = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first
+
             filename = ActiveRecord::Tasks::DatabaseTasks.cache_dump_filename(
-              "primary",
-              schema_cache_path: db_config&.schema_cache_path,
+              db_config.name,
+              schema_cache_path: db_config&.schema_cache_path
             )
 
             cache = ActiveRecord::ConnectionAdapters::SchemaCache.load_from(filename)


### PR DESCRIPTION
This test was incorrect. `primary` was winning for the schema cache load
but when you boot an application it's actually the first configuration
that wins (in a multi db app).

The test didn't catch this because I forgot to add a migrations_paths to
the configuration.

We updated the schema cache loader railtie as well because any
application that didn't have a `primary` config would not be able to use
the schema cache. Originally we thought we'd enforce a `primary`
configuration but no longer feel that's correct. It's simpler to say
that the first wins in a 3-tier rather than implementing a solution to
require `primary` and / or allow aliases.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>
Co-authored-by: John Hawthorn <john@hawthorn.email>