### PR TITLE
Remove assumption that a primary config exists

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -563,7 +563,7 @@ db_namespace = namespace :db do
       end
     ensure
       if should_reconnect
-        ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: "primary"))
+        ActiveRecord::Base.establish_connection(ActiveRecord::Tasks::DatabaseTasks.env.to_sym)
       end
     end
 

--- a/railties/lib/rails/info.rb
+++ b/railties/lib/rails/info.rb
@@ -95,7 +95,7 @@ module Rails
 
     # The name of the database adapter for the current environment.
     property "Database adapter" do
-      ActiveRecord::Base.configurations.configs_for(env_name: Rails.env, name: "primary").adapter
+      ActiveRecord::Base.connection.pool.db_config.adapter
     end
 
     property "Database schema version" do


### PR DESCRIPTION
Applications may not have a primary configuration so we should not
assume there is one. In both these cases we can get the right connection
without that.

For the databases.rake file we want to re-establish a connection for the
environment we're in. The first config defined under an environment for
a multi-db app will win. This is already the case on application boot so
we should be consistent.

For the info.rb file we already have a connection so we can lookup the
adapter from the connection's db_config. If a primary hadn't existed
this would have thrown an exception.

Followup to https://github.com/rails/rails/pull/39535 which removed the
assumption there was a primary config from the schema cache load
railtie.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>