### PR TITLE
Silence Rake task backtraces

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -19,6 +19,9 @@ module Rails
             load "rails/tasks.rb"
             rake.init("rails", [task, *args])
             rake.load_rakefile
+            if Rails.respond_to?(:root)
+              rake.options.suppress_backtrace_pattern = /\A(?!#{Regexp.quote(Rails.root.to_s)})/
+            end
             rake.standard_exception_handling { rake.top_level }
           end
         end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -25,6 +25,22 @@ module ApplicationTests
       assert $task_loaded
     end
 
+    test "task backtrace is silenced" do
+      add_to_config <<-RUBY
+        rake_tasks do
+          task :boom do
+            raise "boom"
+          end
+        end
+      RUBY
+
+      backtrace = rails("boom", allow_failure: true).lines.grep(/:\d+:in /)
+      app_lines, framework_lines = backtrace.partition { |line| line.start_with?(app_path) }
+
+      assert_not_empty app_lines
+      assert_empty framework_lines
+    end
+
     test "task is protected when previous migration was production" do
       with_rails_env "production" do
         rails "generate", "model", "product", "name:string"


### PR DESCRIPTION
Silence Rake task backtraces, similar to `Rails::BacktraceCleaner`.  Application lines are preserved, but all other lines are hidden.

This also affects unrecognized tasks, causing the backtrace to be hidden entirely.  Closes #39524.
