### PR TITLE
Make find_signed and find_signed! consistent

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -60,8 +60,10 @@ module ActiveRecord
       #   User.first.destroy
       #   User.find_signed! signed_id # => ActiveRecord::RecordNotFound
       def find_signed!(signed_id, purpose: nil)
+        raise UnknownPrimaryKey.new(self) if primary_key.nil?
+
         if id = signed_id_verifier.verify(signed_id, purpose: combine_signed_id_purposes(purpose))
-          find(id)
+          find_by! primary_key => id
         end
       end
 

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -26,9 +26,16 @@ class SignedIdTest < ActiveRecord::TestCase
     assert_equal @toy, Toy.find_signed(@toy.signed_id)
   end
 
-  test "raise UnknownPrimaryKey when model have no primary key" do
+  test "find_signed raise UnknownPrimaryKey when model has no primary key" do
     error = assert_raises(ActiveRecord::UnknownPrimaryKey) do
       Matey.find_signed("this will not be even verified")
+    end
+    assert_equal "Unknown primary key for table mateys in model Matey.", error.message
+  end
+
+  test "find_signed! raise UnknownPrimaryKey when model has no primary key" do
+    error = assert_raises(ActiveRecord::UnknownPrimaryKey) do
+      Matey.find_signed!("this will not be even verified")
     end
     assert_equal "Unknown primary key for table mateys in model Matey.", error.message
   end


### PR DESCRIPTION
### Summary

`find_signed` allows finding by a custom primary key, but `find_signed!` doesn't allow it. I think there should be consistency between them, so I added support for custom primary keys in `find_signed!`