### PR TITLE
Make import @rails/actioncable safe for SSR

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -2,10 +2,11 @@
   typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define([ "exports" ], factory) : factory(global.ActionCable = {});
 })(this, function(exports) {
   "use strict";
-  var adapters = {
-    logger: self.console,
-    WebSocket: self.WebSocket
-  };
+  var adapters = {};
+  if (typeof self !== "undefined") {
+    adapters.WebSocket = self.WebSocket;
+    adapters.logger = self.console;
+  }
   var logger = {
     log: function log() {
       if (this.enabled) {

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -4,8 +4,8 @@
   "use strict";
   var adapters = {};
   if (typeof self !== "undefined") {
-    adapters.WebSocket = self.WebSocket;
     adapters.logger = self.console;
+    adapters.WebSocket = self.WebSocket;
   }
   var logger = {
     log: function log() {

--- a/actioncable/app/javascript/action_cable/adapters.js
+++ b/actioncable/app/javascript/action_cable/adapters.js
@@ -1,4 +1,8 @@
-export default {
-  logger: self.console,
-  WebSocket: self.WebSocket
+const adapters = {}
+
+if (typeof self !== "undefined") {
+  adapters.logger = self.console
+  adapters.WebSocket = self.WebSocket
 }
+
+export default adapters


### PR DESCRIPTION
### Summary

Make it safe to import from `@rails/actioncable` if you're running with server-side rendering. My use-case is a React app with SSR, working with a Rails API backend.

With 6.0.3, I get the following error during a server-side render:
```
ReferenceError: self is not defined
     at /app/node_modules/@rails/actioncable/app/assets/javascripts/action_cable.js:6:13
     at /app/node_modules/@rails/actioncable/app/assets/javascripts/action_cable.js:2:66
     at Object.<anonymous> (/app/node_modules/@rails/actioncable/app/assets/javascripts/action_cable.js:3:3)
```

This PR has changes to type-check `self` before referencing it in the code that is run on import. I don't expect ActionCable to run outside of a browser environment, but I would at least expect it to import safely in a node environment for ease-of-use if you're using SSR. This allows me to conditionally use ActionCable later dependent on running in the browser.

This fixes a stale issue #36601 - this issue refers to `window` being undefined, since it dates back to before references to `window` were changed to `self` to support WebWorkers