### PR TITLE
Send disconnect message during remote disconnect

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -9,6 +9,10 @@
 
     *Daniel Spinosa*
 
+*  `ActionCable.server.remote_connections.where(...).disconnect` now sends `disconnect` message
+   before closing the connection with the reconnection strategy specified (defaults to `true`).
+
+   *Vladimir Dementyev*
 
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -121,7 +121,8 @@
     disconnect_reasons: {
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
-      server_restart: "server_restart"
+      server_restart: "server_restart",
+      remote: "remote"
     },
     default_mount_path: "/cable",
     protocols: [ "actioncable-v1-json", "actioncable-unsupported" ]

--- a/actioncable/app/javascript/action_cable/internal.js
+++ b/actioncable/app/javascript/action_cable/internal.js
@@ -9,7 +9,8 @@ export default {
   "disconnect_reasons": {
     "unauthorized": "unauthorized",
     "invalid_request": "invalid_request",
-    "server_restart": "server_restart"
+    "server_restart": "server_restart",
+    "remote": "remote"
   },
   "default_mount_path": "/cable",
   "protocols": [

--- a/actioncable/lib/action_cable.rb
+++ b/actioncable/lib/action_cable.rb
@@ -41,7 +41,8 @@ module ActionCable
     disconnect_reasons: {
       unauthorized: "unauthorized",
       invalid_request: "invalid_request",
-      server_restart: "server_restart"
+      server_restart: "server_restart",
+      remote: "remote"
     },
     default_mount_path: "/cable",
     protocols: ["actioncable-v1-json", "actioncable-unsupported"].freeze

--- a/actioncable/lib/action_cable/connection/internal_channel.rb
+++ b/actioncable/lib/action_cable/connection/internal_channel.rb
@@ -32,7 +32,7 @@ module ActionCable
           case message["type"]
           when "disconnect"
             logger.info "Removing connection (#{connection_identifier})"
-            websocket.close
+            close(reason: ActionCable::INTERNAL[:disconnect_reasons][:remote], reconnect: message.fetch("reconnect", true))
           end
         rescue Exception => e
           logger.error "There was an exception - #{e.class}(#{e.message})"

--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -19,6 +19,11 @@ module ActionCable
   # This will disconnect all the connections established for
   # <tt>User.find(1)</tt>, across all servers running on all machines, because
   # it uses the internal channel that all of these servers are subscribed to.
+  #
+  # By default, server sends a "disconnect" message with "reconnect" flag set to true.
+  # You can override it by specifying the `reconnect` option:
+  #
+  #   ActionCable.server.remote_connections.where(current_user: User.find(1)).disconnect(reconnect: false)
   class RemoteConnections
     attr_reader :server
 
@@ -44,8 +49,8 @@ module ActionCable
         end
 
         # Uses the internal channel to disconnect the connection.
-        def disconnect
-          server.broadcast internal_channel, { type: "disconnect" }
+        def disconnect(reconnect: true)
+          server.broadcast internal_channel, { type: "disconnect", reconnect: reconnect }
         end
 
         # Returns all the identifiers that were applied to this connection.


### PR DESCRIPTION
### Summary

Send `{type: :disconnect, reason: :remote}` message to a client before closing the connection when initiated by `ActionCable.server.remote_connections.where(...).disconnect`.

NOTE: The default value for `reconnect` is true to be backward-compatible with the current behavior.

### Other Information

Follow-up for #34194
