### PR TITLE
Ensure `serialize` never raises an error

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Change `serialize` so it does not raise.
+
+    `serialize` should be responsible for validation and serialization. We should check whether values are serializable before serializing them. Out-of-range integers will no longer raise a `RangeError` with this change. They will now return `nil` if the value is not serializable.
+
+    *Aaron Patterson*, *Eileen M. Uchitelle*
+
 *   Deprecate marshalling load from legacy attributes format.
 
     *Ryuta Kamizono*

--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Change `serialize` so it does not raise.
 
-    `serialize` should be responsible for validation and serialization. We should check whether values are serializable before serializing them. Out-of-range integers will no longer raise a `RangeError` with this change. They will now return `nil` if the value is not serializable.
+    `serialize` should not be responsible for validation and serialization. We should check whether values are serializable before serializing them. Out-of-range integers will no longer raise a `RangeError` with this change. They will now return `nil` if the value is not serializable.
 
     *Aaron Patterson*, *Eileen M. Uchitelle*
 

--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -43,6 +43,10 @@ module ActiveModel
       @value
     end
 
+    def serializable?
+      type.serializable?(value_before_type_cast)
+    end
+
     def original_value
       if assigned?
         original_attribute.original_value

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -25,7 +25,8 @@ module ActiveModel
 
       def serialize(value)
         return if value.is_a?(::String) && non_numeric_string?(value)
-        ensure_in_range(super)
+        return unless serializable?(value)
+        super
       end
 
       def serializable?(value)
@@ -42,13 +43,6 @@ module ActiveModel
 
         def cast_value(value)
           value.to_i rescue nil
-        end
-
-        def ensure_in_range(value)
-          unless in_range?(value)
-            raise ActiveModel::RangeError, "#{value} is out of range for #{self.class} with limit #{_limit} bytes"
-          end
-          value
         end
 
         def max_value

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -81,27 +81,19 @@ module ActiveModel
       end
 
       test "values below int min value are out of range" do
-        assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-2147483649)
-        end
+        assert_not Integer.new.serializable?(-2147483649)
       end
 
       test "values above int max value are out of range" do
-        assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(2147483648)
-        end
+        assert_not Integer.new.serializable?(2147483648)
       end
 
       test "very small numbers are out of range" do
-        assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(-9999999999999999999999999999999)
-        end
+        assert_not Integer.new.serializable?(-9999999999999999999999999999999)
       end
 
       test "very large numbers are out of range" do
-        assert_raises(ActiveModel::RangeError) do
-          Integer.new.serialize(9999999999999999999999999999999)
-        end
+        assert_not Integer.new.serializable?(9999999999999999999999999999999)
       end
 
       test "normal numbers are in range" do
@@ -124,12 +116,8 @@ module ActiveModel
 
         assert_equal(9223372036854775807, type.serialize(9223372036854775807))
         assert_equal(-9223372036854775808, type.serialize(-9223372036854775808))
-        assert_raises(ActiveModel::RangeError) do
-          type.serialize(-9999999999999999999999999999999)
-        end
-        assert_raises(ActiveModel::RangeError) do
-          type.serialize(9999999999999999999999999999999)
-        end
+        assert_not type.serializable?(-9999999999999999999999999999999)
+        assert_not type.serializable?(9999999999999999999999999999999)
       end
     end
   end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Change `serialize` so it does not raise.
+
+    `serialize` should be responsible for validation and serialization. We should check whether values are serializable before serializing them. Out-of-range integers will no longer raise a `RangeError` with this change. They will now return `nil` if the value is not serializable.
+
+    *Aaron Patterson*, *Eileen M. Uchitelle*
+
 *   Do not mark Postgresql MAC address and UUID attributes as changed when the assigned value only varies by case.
 
     *Peter Fry*

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,6 +1,6 @@
 *   Change `serialize` so it does not raise.
 
-    `serialize` should be responsible for validation and serialization. We should check whether values are serializable before serializing them. Out-of-range integers will no longer raise a `RangeError` with this change. They will now return `nil` if the value is not serializable.
+    `serialize` should not be responsible for validation and serialization. We should check whether values are serializable before serializing them. Out-of-range integers will no longer raise a `RangeError` with this change. They will now return `nil` if the value is not serializable.
 
     *Aaron Patterson*, *Eileen M. Uchitelle*
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -202,6 +202,7 @@ module ActiveRecord
           else
             binds.map do |value|
               if ActiveModel::Attribute === value
+                yield unless value.serializable?
                 type_cast(value.value_for_database)
               else
                 type_cast(value)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -41,7 +41,9 @@ module ActiveRecord
           materialize_transactions
           mark_transaction_written_if_write(sql)
 
-          type_casted_binds = type_casted_binds(binds)
+          type_casted_binds = type_casted_binds(binds) do
+            return ActiveRecord::Result.empty
+          end
 
           log(sql, name, binds, type_casted_binds) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -195,7 +195,7 @@ module ActiveRecord
         relation.select_values = columns
         result = skip_query_cache_if_necessary do
           if where_clause.contradiction?
-            ActiveRecord::Result.new([], [])
+            ActiveRecord::Result.empty
           else
             klass.connection.select_all(relation.arel, nil)
           end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -36,12 +36,19 @@ module ActiveRecord
 
     attr_reader :columns, :rows, :column_types
 
+    def self.empty # :nodoc:
+      EMPTY
+    end
+
     def initialize(columns, rows, column_types = {})
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
       @column_types = column_types
     end
+
+    EMPTY = new([], [])
+    private_constant :EMPTY
 
     # Returns true if this result set includes the column named +name+
     def includes_column?(name)

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -47,7 +47,7 @@ module ActiveRecord
       @column_types = column_types
     end
 
-    EMPTY = new([], [])
+    EMPTY = new([].freeze, [].freeze, {}.freeze)
     private_constant :EMPTY
 
     # Returns true if this result set includes the column named +name+

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -148,8 +148,6 @@ module ActiveRecord
       sql = query_builder.sql_for bind_values, connection
 
       klass.find_by_sql(sql, bind_values, preparable: true, &block)
-    rescue ::RangeError
-      nil
     end
 
     def self.unsupported_value?(value)

--- a/activerecord/test/cases/type/unsigned_integer_test.rb
+++ b/activerecord/test/cases/type/unsigned_integer_test.rb
@@ -10,9 +10,8 @@ module ActiveRecord
       end
 
       test "minus value is out of range" do
-        assert_raises(ActiveModel::RangeError) do
-          UnsignedInteger.new.serialize(-1)
-        end
+        assert_nil UnsignedInteger.new.serialize(-1)
+        assert_not UnsignedInteger.new.serializable?(-1)
       end
     end
   end


### PR DESCRIPTION
`serialize` shouldn't be used for validation and serialization. In all
cases in Rails this was true except for values that went through
`ensure_in_range` which would raise a `RangeError` that was subsequently
rescued.

Before serializing a value it should be checked whether the value is
serializable otherwise serializing may have unspecified results.

* `ensure_in_range?` has been removed
* This change implements `serializable?` to check whether a value is valid
for serialization.
* Added a new `empty` method on `ActiveRecord::Result` to return a
result with an empty set.
* Returns nil instead of raising when the value is not serializable.

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>