### PR TITLE
Fix parsing of jsonified expiry date on AS::Message::Metadata for old json format

### DIFF
--- a/activesupport/lib/active_support/messages/metadata.rb
+++ b/activesupport/lib/active_support/messages/metadata.rb
@@ -7,7 +7,7 @@ module ActiveSupport
     class Metadata #:nodoc:
       def initialize(message, expires_at = nil, purpose = nil)
         @message, @purpose = message, purpose
-        @expires_at = expires_at.is_a?(String) ? Time.iso8601(expires_at) : expires_at
+        @expires_at = expires_at.is_a?(String) ? parse_expires_at(expires_at) : expires_at
       end
 
       def as_json(options = {})
@@ -66,6 +66,14 @@ module ActiveSupport
 
         def fresh?
           @expires_at.nil? || Time.now.utc < @expires_at
+        end
+
+        def parse_expires_at(expires_at)
+          if ActiveSupport.use_standard_json_time_format
+            Time.iso8601(expires_at)
+          else
+            Time.parse(expires_at)
+          end
         end
     end
   end

--- a/activesupport/test/message_verifier_test.rb
+++ b/activesupport/test/message_verifier_test.rb
@@ -161,6 +161,14 @@ class MessageVerifierMetadataTest < ActiveSupport::TestCase
     end
   end
 
+  def test_verify_with_use_standard_json_time_format_as_false
+    format_before = ActiveSupport.use_standard_json_time_format
+    ActiveSupport.use_standard_json_time_format = false
+    assert_equal "My Name", @verifier.verify(generate("My Name"))
+  ensure
+    ActiveSupport.use_standard_json_time_format = format_before
+  end
+
   def test_verify_raises_when_expired
     signed_message = generate(data, expires_in: 1.month)
 


### PR DESCRIPTION
Fix parsing of jsonified expiry date when on AS::Message::Metadata, when `ActiveSupport.use_standard_json_time_format = false`

Fixes #39548

cc @kaspth 
