### PR TITLE
Adds ./script folder to a new rails app

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -216,6 +216,7 @@ of the files and folders that Rails created by default:
 |test/|Unit tests, fixtures, and other test apparatus. These are covered in [Testing Rails Applications](testing.html).|
 |tmp/|Temporary files (like cache and pid files).|
 |vendor/|A place for all third-party code. In a typical Rails application this includes vendored gems.|
+|script/|A place for all one-off or general purpose scripts. This could include benchmarks or cleanup code.|
 |.gitignore|This file tells git which files (or patterns) it should ignore. See [GitHub - Ignoring files](https://help.github.com/articles/ignoring-files) for more info about ignoring files.
 |.ruby-version|This file contains the default Ruby version.|
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -248,6 +248,10 @@ module Rails
       empty_directory_with_keep_file "vendor"
     end
 
+    def script
+      empty_directory_with_keep_file "script"
+    end
+
     def config_target_version
       defined?(@config_target_version) ? @config_target_version : Rails::VERSION::STRING.to_f
     end
@@ -540,6 +544,10 @@ module Rails
 
       def finish_template
         build(:leftovers)
+      end
+
+      def create_script_folder
+        build(:script)
       end
 
       public_task :apply_rails_template, :run_bundle

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -88,6 +88,7 @@ DEFAULT_APP_FILES = %w(
   test/integration
   test/system
   vendor
+  script
   tmp
   tmp/cache
   tmp/cache/assets
@@ -1051,6 +1052,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       lib/tasks
       lib/assets
       log
+      script
       test/fixtures/files
       test/controllers
       test/mailers


### PR DESCRIPTION
### Summary

Adds a new default folder called script, to the root of an app. This can hold your one-off scripts, benchmark code, cleanup scripts etc.

Discussion: https://discuss.rubyonrails.org/t/is-there-any-official-way-to-organize-one-off-scripts/74186/12

