### PR TITLE
Improve error when EncryptedFile key length wrong

### DIFF
--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -55,6 +55,22 @@ class EncryptedFileTest < ActiveSupport::TestCase
     end
   end
 
+  test "raise InvalidKeyLengthError when key is too short" do
+    File.write(@key_path, ActiveSupport::EncryptedFile.generate_key[0..-2])
+
+    assert_raise ActiveSupport::EncryptedFile::InvalidKeyLengthError do
+      @encrypted_file.write(@content)
+    end
+  end
+
+  test "raise InvalidKeyLengthError when key is too long" do
+    File.write(@key_path, ActiveSupport::EncryptedFile.generate_key + "0")
+
+    assert_raise ActiveSupport::EncryptedFile::InvalidKeyLengthError do
+      @encrypted_file.write(@content)
+    end
+  end
+
   test "respects existing content_path symlink" do
     @encrypted_file.write(@content)
 


### PR DESCRIPTION
When given a key of invalid length, `OpenSSL::Cipher` raises a "key must be X bytes" error.  However, `EncryptedFile` keys are packed before they are passed to `OpenSSL::Cipher`, so the actual length requirement is "2*X characters".

This commit checks the key length, and raises a more helpful error if the key length is invalid.

Closes #39528.
