### PR TITLE
Refactor code for the 'did you mean?' feature

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -16,27 +16,12 @@ module AbstractController
       super(message)
     end
 
-    class Correction
-      def initialize(error)
-        @error = error
-      end
+    if defined?(DidYouMean::SpellChecker) && defined?(DidYouMean::Correctable)
+      include DidYouMean::Correctable
 
       def corrections
-        if @error.action
-          maybe_these = @error.controller.class.action_methods
-
-          maybe_these.sort_by { |n|
-            DidYouMean::Jaro.distance(@error.action.to_s, n)
-          }.reverse.first(4)
-        else
-          []
-        end
+        DidYouMean::SpellChecker.new(dictionary: controller.class.action_methods).correct(action)
       end
-    end
-
-    # We may not have DYM, and DYM might not let us register error handlers
-    if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
-      DidYouMean.correct_error(self, Correction)
     end
   end
 

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -168,13 +168,13 @@ class PerformActionTest < ActionController::TestCase
     assert_equal "The action 'non_existent' could not be found for EmptyController", exception.message
   end
 
-  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+  if defined?(DidYouMean::SpellChecker)
     def test_exceptions_have_suggestions_for_fix
       use_controller SimpleController
       exception = assert_raise AbstractController::ActionNotFound do
-        get :non_existent
+        get :hlelo
       end
-      assert_match "Did you mean?", exception.message
+      assert_match "Did you mean?  hlelo", exception.message
     end
   end
 

--- a/actionpack/test/controller/required_params_test.rb
+++ b/actionpack/test/controller/required_params_test.rb
@@ -22,17 +22,17 @@ class ActionControllerRequiredParamsTest < ActionController::TestCase
     end
   end
 
-  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+  if defined?(DidYouMean::SpellChecker)
     test "exceptions have suggestions for fix" do
       error = assert_raise ActionController::ParameterMissing do
         post :create, params: { magazine: { name: "Mjallo!" } }
       end
-      assert_match "Did you mean?", error.message
+      assert_no_match "Did you mean?", error.message
 
       error = assert_raise ActionController::ParameterMissing do
-        post :create, params: { book: { title: "Mjallo!" } }
+        post :create, params: { boko: { title: "Mjallo!" } }
       end
-      assert_match "Did you mean?", error.message
+      assert_match 'Did you mean?  "boko"', error.message
     end
   end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4884,7 +4884,7 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
     assert_match message, error.message
   end
 
-  if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
+  if defined?(DidYouMean::SpellChecker)
     test "exceptions have suggestions for fix" do
       error = assert_raises(ActionController::UrlGenerationError) { product_path(nil, "id" => "url-tested") }
       assert_match "Did you mean?", error.message
@@ -4897,8 +4897,8 @@ class TestUrlGenerationErrors < ActionDispatch::IntegrationTest
   # we don't want to break other code.
   test "correct for empty UrlGenerationError" do
     err = ActionController::UrlGenerationError.new("oh no!")
-    correction = ActionController::UrlGenerationError::Correction.new(err)
-    assert_equal [], correction.corrections
+
+    assert_equal [], err.corrections
   end
 end
 


### PR DESCRIPTION
I'm just following up on the pull requests below:

 * https://github.com/rails/rails/pull/39240
 * https://github.com/rails/rails/pull/39318
 * https://github.com/rails/rails/pull/39319
 * https://github.com/rails/rails/pull/39338
 * https://github.com/rails/rails/pull/39347

I should probably update the documentation for DYM as well, but here are the summarized changes:

 * When we can directly update the exception classes we want to make correctable, we can simply `include DidYouMean::Correctable` and implement a `#corrections` method on that class to dock-type it. `DidYouMean.correct_error` is mainly for error classes someone else defines and you want to patch it for your own usage.
 * The Jaro distance alone isn't as accurate as it should. We should use the `DidYouMean::SpellChecker` class that is optimized for correcting human types in names used In programming.

cc @tenderlove @p8