### PR TITLE
Strict match when choosing cookie domain for host

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   When multiple domains are specified for a cookie, a domain will now be
+    chosen only if it is equal to or is a superdomain of the request host.
+
+    *Jonathan Hefner*
+
 *   `ActionDispatch::Static` handles precompiled Brotli (.br) files.
 
     Adds to existing support for precompiled gzip (.gz) files.

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -457,8 +457,11 @@ module ActionDispatch
               ".#{$&}"
             end
           elsif options[:domain].is_a? Array
-            # If host matches one of the supplied domains without a dot in front of it.
-            options[:domain] = options[:domain].find { |domain| request.host.include? domain.sub(/^\./, "") }
+            # If host matches one of the supplied domains.
+            options[:domain] = options[:domain].find do |domain|
+              domain = domain.delete_prefix(".")
+              request.host == domain || request.host.end_with?(".#{domain}")
+            end
           end
         end
     end

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -1106,6 +1106,27 @@ class CookiesTest < ActionController::TestCase
     assert_cookie_header "user_name=rizwanreza; domain=example1.com; path=/; SameSite=Lax"
   end
 
+  def test_cookie_with_several_preset_domains_using_subdomain
+    @request.host = "subdomain.example1.com"
+    get :set_cookie_with_domains
+    assert_response :success
+    assert_cookie_header "user_name=rizwanreza; domain=example1.com; path=/; SameSite=Lax"
+  end
+
+  def test_cookie_with_several_preset_domains_using_similar_tld
+    @request.host = "example1.com.au"
+    get :set_cookie_with_domains
+    assert_response :success
+    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+  end
+
+  def test_cookie_with_several_preset_domains_using_similar_domain
+    @request.host = "myexample1.com"
+    get :set_cookie_with_domains
+    assert_response :success
+    assert_cookie_header "user_name=rizwanreza; path=/; SameSite=Lax"
+  end
+
   def test_cookie_with_several_preset_domains_using_other_domain
     @request.host = "other-domain.com"
     get :set_cookie_with_domains


### PR DESCRIPTION
Prior to this commit, when multiple cookie domains were specified, the first domain that was a substring of the request host was chosen.  This allowed, for example, the "example.com" domain to be chosen when the request host was "example.com.au" or even "myexample.com".

This commit ensures a domain is chosen only if it is equal to or is a superdomain of the request host.

Fixes #37760.
