### PR TITLE
Support `relation.and` for intersection as Set theory

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Support `relation.and` for intersection as Set theory.
+
+    ```ruby
+    david_and_mary = Author.where(id: [david, mary])
+    mary_and_bob   = Author.where(id: [mary, bob]) # => [bob]
+
+    david_and_mary.merge(mary_and_bob) # => [mary, bob]
+
+    david_and_mary.and(mary_and_bob) # => [mary]
+    david_and_mary.or(mary_and_bob)  # => [david, mary, bob]
+    ```
+
+    *Ryuta Kamizono*
+
 *   Merging conditions on the same column no longer maintain both conditions,
     and will be consistently replaced by the latter condition in Rails 6.2.
     To migrate to Rails 6.2's behavior, use `relation.merge(other, rewhere: true)`.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,9 +13,10 @@ module ActiveRecord
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly, :extending, :or,
-      :having, :create_with, :distinct, :references, :none, :unscope, :optimizer_hints, :merge, :except, :only,
-      :count, :average, :minimum, :maximum, :sum, :calculate, :annotate,
+      :where, :rewhere, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
+      :and, :or, :annotate, :optimizer_hints, :extending,
+      :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
+      :count, :average, :minimum, :maximum, :sum, :calculate,
       :pluck, :pick, :ids, :strict_loading
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -19,6 +19,10 @@ module ActiveRecord
         WhereClause.new(predicates - other.predicates)
       end
 
+      def |(other)
+        WhereClause.new(predicates | other.predicates)
+      end
+
       def merge(other, rewhere = nil)
         predicates = if rewhere
           except_predicates(other.extract_attributes)

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -14,7 +14,7 @@ class RelationMergingTest < ActiveRecord::TestCase
   fixtures :developers, :comments, :authors, :author_addresses, :posts
 
   def test_merge_in_clause
-    david, mary, bob = authors(:david, :mary, :bob)
+    david, mary, bob = authors = authors(:david, :mary, :bob)
 
     david_and_mary = Author.where(id: [david, mary]).order(:id)
     mary_and_bob   = Author.where(id: [mary, bob]).order(:id)
@@ -35,18 +35,24 @@ class RelationMergingTest < ActiveRecord::TestCase
 
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob)
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
+    assert_equal [mary], david_and_mary.and(mary_and_bob)
+    assert_equal authors, david_and_mary.or(mary_and_bob)
 
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary)
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
+    assert_equal [mary], david_and_mary.and(mary_and_bob)
+    assert_equal authors, david_and_mary.or(mary_and_bob)
 
-    david_and_bob = Author.where(id: david).or(Author.where(name: "Bob"))
+    david_and_bob = Author.where(id: david).or(Author.where(name: "Bob")).order(:id)
 
     assert_equal [david], david_and_mary.merge(david_and_bob)
     assert_equal [david], david_and_mary.merge(david_and_bob, rewhere: true)
+    assert_equal [david], david_and_mary.and(david_and_bob)
+    assert_equal authors, david_and_mary.or(david_and_bob)
   end
 
   def test_merge_between_clause
-    david, mary, bob = authors(:david, :mary, :bob)
+    david, mary, bob = authors = authors(:david, :mary, :bob)
 
     david_and_mary = Author.where(id: david.id..mary.id).order(:id)
     mary_and_bob   = Author.where(id: mary.id..bob.id).order(:id)
@@ -80,20 +86,26 @@ class RelationMergingTest < ActiveRecord::TestCase
       assert_equal [mary], david_and_mary.merge(mary_and_bob)
     end
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
+    assert_equal [mary], david_and_mary.and(mary_and_bob)
+    assert_equal authors, david_and_mary.or(mary_and_bob)
 
     assert_deprecated(message) do
       assert_equal [mary], mary_and_bob.merge(david_and_mary)
     end
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
+    assert_equal [mary], david_and_mary.and(mary_and_bob)
+    assert_equal authors, david_and_mary.or(mary_and_bob)
 
-    david_and_bob = Author.where(id: david).or(Author.where(name: "Bob"))
+    david_and_bob = Author.where(id: david).or(Author.where(name: "Bob")).order(:id)
 
     assert_equal [david], david_and_mary.merge(david_and_bob)
     assert_equal [david], david_and_mary.merge(david_and_bob, rewhere: true)
+    assert_equal [david], david_and_mary.and(david_and_bob)
+    assert_equal authors, david_and_mary.or(david_and_bob)
   end
 
   def test_merge_or_clause
-    david, mary, bob = authors(:david, :mary, :bob)
+    david, mary, bob = authors = authors(:david, :mary, :bob)
 
     david_and_mary = Author.where(id: david).or(Author.where(id: mary)).order(:id)
     mary_and_bob   = Author.where(id: mary).or(Author.where(id: bob)).order(:id)
@@ -127,16 +139,22 @@ class RelationMergingTest < ActiveRecord::TestCase
       assert_equal [mary], david_and_mary.merge(mary_and_bob)
     end
     assert_equal [mary, bob], david_and_mary.merge(mary_and_bob, rewhere: true)
+    assert_equal [mary], david_and_mary.and(mary_and_bob)
+    assert_equal authors, david_and_mary.or(mary_and_bob)
 
     assert_deprecated(message) do
       assert_equal [mary], mary_and_bob.merge(david_and_mary)
     end
     assert_equal [david, mary], mary_and_bob.merge(david_and_mary, rewhere: true)
+    assert_equal [mary], david_and_mary.and(mary_and_bob)
+    assert_equal authors, david_and_mary.or(mary_and_bob)
 
-    david_and_bob = Author.where(id: david).or(Author.where(name: "Bob"))
+    david_and_bob = Author.where(id: david).or(Author.where(name: "Bob")).order(:id)
 
     assert_equal [david], david_and_mary.merge(david_and_bob)
     assert_equal [david], david_and_mary.merge(david_and_bob, rewhere: true)
+    assert_equal [david], david_and_mary.and(david_and_bob)
+    assert_equal authors, david_and_mary.or(david_and_bob)
   end
 
   def test_merge_not_in_clause


### PR DESCRIPTION
As described at #39328, `relation.merge` behaves inspired as Hash-like
merge for where clause. In other words, currently there is no official
way to intersect the result by both relation conditions (i.e. there is
no official way to maintain both relation conditions).

To resolve that issue, I'd like to support a way to intersect relations
as `relation.and`.

```ruby
david_and_mary = Author.where(id: [david, mary])
mary_and_bob   = Author.where(id: [mary, bob])

david_and_mary.merge(mary_and_bob) # => [mary, bob]

david_and_mary.and(mary_and_bob) # => [mary]
david_and_mary.or(mary_and_bob)  # => [david, mary, bob]
```

Fixes #39232.
