### PR TITLE
Include warning about S3 timeout behavior [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -120,7 +120,7 @@ amazon:
   bucket: ""
 ```
 
-Optionally provide a Hash of upload options:
+Optionally provide client and upload options:
 
 ```yaml
 amazon:
@@ -129,9 +129,13 @@ amazon:
   secret_access_key: ""
   region: ""
   bucket: ""
+  http_open_timeout: 0
+  http_read_timeout: 0
+  retry_limit: 0
   upload: 
     server_side_encryption: "" # 'aws:kms' or 'AES256'
 ```
+TIP: Set sensible client HTTP timeouts and retry limits for your application. In certain failure scenarios, the default AWS client configuration may cause connections to be held for up to several minutes and lead to request queuing.
 
 Add the [`aws-sdk-s3`](https://github.com/aws/aws-sdk-ruby) gem to your `Gemfile`:
 


### PR DESCRIPTION
### Summary
Update ActiveStorage S3 guide to clarify the ability to set client configuration for timeout and retry behavior. The default `http_read_timeout` and `retry_limit` configuration for specific clients, in this case `aws-sdk-ruby`, can lead to long running connections and request queueing as identified [here](https://github.com/rails/rails/issues/39327).


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
