### PR TITLE
Show descriptions for all commands in Rails help

### DIFF
--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -88,22 +88,13 @@ module Rails
         end
       end
 
-      def print_commands # :nodoc:
-        commands.each { |command| puts("  #{command}") }
+      def printing_commands # :nodoc:
+        lookup!
+
+        (subclasses - hidden_commands).flat_map(&:printing_commands)
       end
 
       private
-        COMMANDS_IN_USAGE = %w(generate console server test test:system dbconsole new)
-        private_constant :COMMANDS_IN_USAGE
-
-        def commands
-          lookup!
-
-          visible_commands = (subclasses - hidden_commands).flat_map(&:printing_commands)
-
-          (visible_commands - COMMANDS_IN_USAGE).sort
-        end
-
         def command_type # :doc:
           @command_type ||= "command"
         end

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -70,7 +70,7 @@ module Rails
         end
 
         def printing_commands
-          namespaced_commands
+          namespaced_commands.map { |command| [command, ""] }
         end
 
         def executable

--- a/railties/lib/rails/commands/help/help_command.rb
+++ b/railties/lib/rails/commands/help/help_command.rb
@@ -8,8 +8,19 @@ module Rails
       def help(*)
         say self.class.desc
 
-        Rails::Command.print_commands
+        other_commands = printing_commands_not_in_usage.sort_by(&:first)
+        print_table(other_commands, indent: 1, truncate: true)
       end
+
+      private
+        COMMANDS_IN_USAGE = %w(generate console server test test:system dbconsole new)
+        private_constant :COMMANDS_IN_USAGE
+
+        def printing_commands_not_in_usage # :nodoc:
+          Rails::Command.printing_commands.reject do |command, _|
+            command.in?(COMMANDS_IN_USAGE)
+          end
+        end
     end
   end
 end

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -9,7 +9,7 @@ module Rails
 
       class << self
         def printing_commands
-          formatted_rake_tasks.map(&:first)
+          formatted_rake_tasks
         end
 
         def perform(task, args, config)

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -8,9 +8,9 @@ require "rails/commands/db/system/change/change_command"
 
 class Rails::Command::BaseTest < ActiveSupport::TestCase
   test "printing commands" do
-    assert_equal %w(generate), Rails::Command::GenerateCommand.printing_commands
-    assert_equal %w(secrets:setup secrets:edit secrets:show), Rails::Command::SecretsCommand.printing_commands
-    assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands
+    assert_equal [["generate", ""]], Rails::Command::GenerateCommand.printing_commands
+    assert_equal [["secrets:setup", ""], ["secrets:edit", ""], ["secrets:show", ""]], Rails::Command::SecretsCommand.printing_commands
+    assert_equal [["db:system:change", ""]], Rails::Command::Db::System::ChangeCommand.printing_commands
   end
 
   test "ARGV is isolated" do


### PR DESCRIPTION
### Summary

Calling `rails help` from the command line shows some commands without the descriptions.
This is a bit confusing when `rails -T` does show the descriptions.

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/28561/83968184-9d587600-a8c7-11ea-90db-62a8545ab9b8.png">

We can show the description after the command name and use some padding
to align the descriptions. Lines are truncated to the width of the
terminal.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/28561/83968198-b9f4ae00-a8c7-11ea-9ba9-c19d3091a984.png">

Rails::Command had logic for printing help commands not in 'usage':
`print_commands`, `commands` and the `COMMANDS_IN_USAGE` constant. As
these methods were only used by Rails::Command::HelpCommand, they have
been moved HelpCommand.

This also changes the `printing_commands` methods on several classes.
Instead of returning just the commands, they return the commands
with the descriptions. As these are only used for printing help it does
not affect any other code.

Some Thor commands (routes, credentials:diff, etc) show no description yet,
but these can be added later.