### PR TITLE
Add default key rotation for SHA1 to SHA256 for all new App on cookie generation and usage

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -22,6 +22,7 @@ module ActionDispatch
     config.action_dispatch.authenticated_encrypted_cookie_salt = "authenticated encrypted cookie"
     config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.use_cookies_with_metadata = false
+    config.action_dispatch.use_sha256_for_cookie_digest = false
     config.action_dispatch.perform_deep_munge = true
     config.action_dispatch.return_only_media_type_on_content_type = true
 

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -16,7 +16,7 @@ module ActiveSupport
       @iterations = options[:iterations] || 2**16
     end
 
-    # Returns a derived key suitable for use.  The default key_size is chosen
+    # Returns a derived key suitable for use. The default key_size is chosen
     # to be compatible with the default settings of ActiveSupport::MessageVerifier.
     # i.e. OpenSSL::Digest::SHA1#block_length
     def generate_key(salt, key_size = 64)

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -128,7 +128,7 @@ module ActiveSupport
     #    ActiveSupport::MessageEncryptor.new('secret', 'signature_secret')
     #
     # Options:
-    # * <tt>:cipher</tt>     - Cipher to use. Can be any cipher returned by
+    # * <tt>:cipher</tt> - Cipher to use. Can be any cipher returned by
     #   <tt>OpenSSL::Cipher.ciphers</tt>. Default is 'aes-256-gcm'.
     # * <tt>:digest</tt> - String of digest to use for signing. Default is
     #   +SHA1+. Ignored when using an AEAD cipher like 'aes-256-gcm'.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -278,6 +278,7 @@ module Rails
           "action_dispatch.use_authenticated_cookie_encryption" => config.action_dispatch.use_authenticated_cookie_encryption,
           "action_dispatch.encrypted_cookie_cipher" => config.action_dispatch.encrypted_cookie_cipher,
           "action_dispatch.signed_cookie_digest" => config.action_dispatch.signed_cookie_digest,
+          "action_dispatch.use_sha256_for_cookie_digest" => config.action_dispatch.use_sha256_for_cookie_digest,
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer,
           "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest,
           "action_dispatch.cookies_rotations" => config.action_dispatch.cookies_rotations,


### PR DESCRIPTION
Related #39373
- [ ] Ensure backwards compat for old Apps
- [ ] New Apps should use 256 for cookie digest
- [ ] Old Apps should get opted in to rotate to 256 by default on upgrade
- This approach is trying to move all the places away from old digests MessageEncryptor/MessageVerifier before we can migrate at places like `ActiveSupport::KeyGenerator` / `Digest`, etc.
- [ ] New framework defaults
- [ ] Changelog/Documentation

Opening for initial feeback and using CI.