### PR TITLE
Fix index option for fields_for with nested attributes

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2528,7 +2528,7 @@ module ActionView
             association.each do |child|
               if explicit_child_index
                 options[:child_index] = explicit_child_index.call if explicit_child_index.respond_to?(:call)
-              else
+              elsif !options.key?(:index)
                 options[:child_index] = nested_child_index(name)
               end
               output << fields_for_nested_model("#{name}[#{options[:child_index]}]", child, options, block)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2783,6 +2783,29 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_nested_fields_for_with_existing_records_on_a_nested_attrobutes_collection_association_with_nil_index
+    @post.comments = Array.new(2) { |id| Comment.new(id + 1) }
+
+    form_for(@post) do |f|
+      concat f.text_field(:title)
+      @post.comments.each do |comment|
+        concat f.fields_for(:comments, comment, index: nil) { |cf|
+          cf.text_field(:name)
+        }
+      end
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
+      '<input id="post_comments_attributes__name" name="post[comments_attributes][][name]" type="text" value="comment #1" />' \
+      '<input id="post_comments_attributes__id" name="post[comments_attributes][][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes__name" name="post[comments_attributes][][name]" type="text" value="comment #2" />' \
+      '<input id="post_comments_attributes__id" name="post[comments_attributes][][id]" type="hidden" value="2" />'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_nested_fields_for_with_new_records_on_a_nested_attributes_collection_association
     @post.comments = [Comment.new, Comment.new]
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Closes: #39564

Fixes the name attribute on inputs when the `index` option is provided in `fields_for`. Currently, the default index is still included even when a custom index is provided, which leads to weirdly shaped params, specifically when `index: nil` is passed.

