### PR TITLE
Add `credentials:diff --disenroll`

### DIFF
--- a/railties/lib/rails/commands/credentials/USAGE
+++ b/railties/lib/rails/commands/credentials/USAGE
@@ -32,8 +32,8 @@ You could prepend that to your server's start command like this:
 
 === Set up Git to Diff Credentials
 
-Rails provides `rails credentials:diff --enroll` to instruct Git to call `rails credentials:diff`
-when `git diff` is run on a credentials file.
+Rails provides `bin/rails credentials:diff --enroll` to instruct Git to call
+`bin/rails credentials:diff` when `git diff` is run on a credentials file.
 
 Running the command enrolls the project such that all credentials files use the
 "rails_credentials" diff driver in .gitattributes.
@@ -44,6 +44,8 @@ that isn't tracked Rails automatically ensures it's configured when running
 
 Otherwise each co-worker would have to run enable manually, including on each new
 repo clone.
+
+To disenroll from this feature, run `bin/rails credentials:diff --disenroll`.
 
 === Editing Credentials
 

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -32,7 +32,7 @@ module Rails
 
         ensure_encryption_key_has_been_added if credentials.key.nil?
         ensure_credentials_have_been_added
-        ensure_rails_credentials_driver_is_set
+        ensure_diffing_driver_is_configured
 
         catch_editing_exceptions do
           change_credentials_in_system_editor

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -51,7 +51,10 @@ module Rails
       end
 
       option :enroll, type: :boolean, default: false,
-        desc: "Enrolls project in credential file diffing with `git diff`"
+        desc: "Enrolls project in credentials file diffing with `git diff`"
+
+      option :disenroll, type: :boolean, default: false,
+        desc: "Disenrolls project from credentials file diffing"
 
       def diff(content_path = nil)
         if @content_path = content_path
@@ -61,6 +64,7 @@ module Rails
           say credentials.read.presence || credentials.content_path.read
         else
           require_application!
+          disenroll_project_from_credentials_diffing if options[:disenroll]
           enroll_project_in_credentials_diffing if options[:enroll]
         end
       rescue ActiveSupport::MessageEncryptor::InvalidMessage

--- a/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
@@ -2,7 +2,7 @@
 
 module Rails::Command::CredentialsCommand::Diffing # :nodoc:
   def enroll_project_in_credentials_diffing
-    if enrolled?
+    if enrolled_in_credentials_diffing?
       true
     else
       gitattributes.write(<<~end_of_template, mode: "a")
@@ -15,23 +15,22 @@ module Rails::Command::CredentialsCommand::Diffing # :nodoc:
     end
   end
 
-  def ensure_rails_credentials_driver_is_set
-    set_driver if enrolled? && !driver_configured?
+  def ensure_diffing_driver_is_configured
+    configure_diffing_driver if enrolled_in_credentials_diffing? && !diffing_driver_configured?
   end
 
   private
-    def enrolled?
+    def enrolled_in_credentials_diffing?
       gitattributes.read.match?(/config\/credentials(\/\*)?\.yml\.enc diff=rails_credentials/)
     rescue Errno::ENOENT
       false
     end
 
-    def driver_configured?
+    def diffing_driver_configured?
       system "git config --get diff.rails_credentials.textconv", out: File::NULL
     end
 
-    def set_driver
-      puts "running"
+    def configure_diffing_driver
       system "git config diff.rails_credentials.textconv 'bin/rails credentials:diff'"
     end
 


### PR DESCRIPTION
This allows users to undo `credentials:diff --enroll` without having to know the details of its implementation.