### PR TITLE
Remove invalid autoloads

### DIFF
--- a/actioncable/lib/action_cable/server.rb
+++ b/actioncable/lib/action_cable/server.rb
@@ -11,7 +11,6 @@ module ActionCable
       autoload :Configuration
 
       autoload :Worker
-      autoload :ActiveRecordConnectionManagement, "action_cable/server/worker/active_record_connection_management"
     end
   end
 end

--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -2,6 +2,7 @@
 
 require "active_support/callbacks"
 require "active_support/core_ext/module/attribute_accessors_per_thread"
+require "action_cable/server/worker/active_record_connection_management"
 require "concurrent"
 
 module ActionCable

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -10,7 +10,6 @@ module ActionController
   autoload :API
   autoload :Base
   autoload :Metal
-  autoload :Middleware
   autoload :Renderer
   autoload :FormBuilder
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -77,7 +77,6 @@ module ActiveRecord
   autoload :Translation
   autoload :Validations
   autoload :SecureToken
-  autoload :DatabaseSelector, "active_record/middleware/database_selector"
 
   eager_autoload do
     autoload :ConnectionAdapters

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_record/migration/join_table"
 require "active_support/core_ext/string/access"
 require "digest/sha2"
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -530,6 +530,7 @@ module ActiveRecord
   class Migration
     autoload :CommandRecorder, "active_record/migration/command_recorder"
     autoload :Compatibility, "active_record/migration/compatibility"
+    autoload :JoinTable, "active_record/migration/join_table"
 
     # This must be defined before the inherited hook, below
     class Current < Migration #:nodoc:


### PR DESCRIPTION
### Summary

Some autoload declarations are invalid, this removes them or fixes them, depending on the case.

### Other Information

While trying to have all constants loaded for another issues I want to raise, I encountered these four invalid `ActiveSupport::Autoload#autoload` declarations. 

I haven't added a test for this since I'm not sure we want a test that loads the universe, and there were very few mistakes anyway. This is the important part of the script to load the universe:

```ruby
load_modules = ->(mod) do
  [mod] + mod.constants(false)
    .map {|const_name| mod.const_get(const_name) }
    .select { |constant| Module === constant }
    .flat_map { |mod| load_modules.(mod) }
end
                                                                                                 
before = Object.constants
require "rails/all"
                                                                                                 
toplevel_constants = (Object.constants - before).grep(/^Act/).map {|mod| Object.const_get(mod) }
toplevel_constants.flat_map {|mod| load_modules.(mod) }
```

This is a reproduction script which fails on master and on the latest release but passes on the branch:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # gem "rails", github: "rails/rails"
  # gem "rails", "6.0.3.1"
  gemspec
end

require "minitest/autorun"

class BugTest < Minitest::Test
  def assert_proper_autoload_failure
    before = $LOADED_FEATURES.dup
    assert_raises(NameError) { yield }
    assert_empty $LOADED_FEATURES - before
  end

  def test_nonexisting_action_controller_middleare_raises_NameError
    require "action_controller/railtie"
    assert_proper_autoload_failure { ActionController::Middleware  }
  end

  def test_wrong_autoload_for_active_record_database_selector_doesnt_load_file
    require "active_record"
    assert_proper_autoload_failure { ActiveRecord::DatabaseSelector }
  end

  def test_action_cable_server_active_record_connection_management
    require "action_cable"
    _ = ActionCable::Server
    assert_proper_autoload_failure { ActionCable::Server::ActiveRecordConnectionManagement }
  end

  def test_active_record_migration_command_recorder_can_load
    require "active_record"
    _ = ActiveRecord::Migration::CommandRecorder
  end
end
```