### PR TITLE
Make AR::Middleware::DatabaseSelector loadable without full core ext

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record/middleware/database_selector/resolver/session"
+require "active_support/core_ext/numeric/time"
 
 module ActiveRecord
   module Middleware


### PR DESCRIPTION
### Summary

This pull request fixes a NoMethodError on loading `ActiveRecord::MIddleware::DatabaseSelector` without full core extensions of Active Support.


Reproduce:


```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", path: '.'
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"

class BugTest < Minitest::Test
  def test_association_stuff
    ActiveRecord::Middleware::DatabaseSelector
  end
end
```

```bash
$ ruby test.rb

(snip)

# Running:

E

Error:
BugTest#test_association_stuff:
NoMethodError: undefined method `seconds' for 2:Integer
Did you mean?  send
    test.rb:17:in `test_association_stuff'

rails test test.rb:16



Finished in 0.002213s, 451.7991 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```


### Other Information

I found this problem while I tried to load all autoloaded constants to just inspect Active Record. So I'm not a user of AR::Middleware::DatabaseSelector.
I'm not sure AR::Middleware::DatabaseSelector should work without Rails or full extensions of Active Support. I guess this patch is unnecessary if the middleware is always used with Rails.
So feel free to close this pull request if the module is designed to work on Rails.

Thanks.