### PR TITLE
Fix typo: change Punt to Print [ci skip]

### DIFF
--- a/railties/lib/rails/commands/application/application_command.rb
+++ b/railties/lib/rails/commands/application/application_command.rb
@@ -19,7 +19,7 @@ module Rails
       hide_command!
 
       def help
-        perform # Punt help output to the generator.
+        perform # Print help output to the generator.
       end
 
       def perform(*args)


### PR DESCRIPTION
### Summary

Fix typo: Change the word `Punt` to `Print` in application_command.rb