### PR TITLE
Make system tests respect default_url_options

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -166,7 +166,10 @@ module ActionDispatch
               include ActionDispatch.test_app.routes.mounted_helpers
 
               def url_options
-                default_url_options.reverse_merge(host: Capybara.app_host || Capybara.current_session.server_url)
+                test_url_options = ActionDispatch.test_app.routes.default_url_options
+                  .merge("ApplicationController".safe_constantize&.new&.default_url_options || {})
+                  .merge(host: Capybara.app_host || Capybara.current_session.server_url)
+                default_url_options.reverse_merge(test_url_options)
               end
             end.new
           end


### PR DESCRIPTION
### Summary

As part of the [May of WTFs](https://weblog.rubyonrails.org/2020/5/7/A-May-of-WTFs/) (thanks @bhaibel ❤️), this PR enables system tests to use `default_url_options` from config files or `ApplicationController`.

### Other Information

As [posted on the RoR discussion forums](https://discuss.rubyonrails.org/t/system-tests-ignore-default-url-options-and-default-locale-other-tests-dont), system tests so far ignore any `default_url_options`.

There is also a [Rails issue regarding this problem](https://github.com/rails/rails/issues/37820).