### PR TITLE
Consolidate delegated type interpolated strings

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -174,15 +174,16 @@ module ActiveRecord
 
     private
       def define_delegated_type_methods(role, types:)
-        role_type = "#{role}_type"
-        role_id   = "#{role}_id"
+        role_type  = "#{role}_type"
+        role_id    = "#{role}_id"
+        role_class = "#{role}_class"
 
-        define_method "#{role}_class" do
-          public_send("#{role}_type").constantize
+        define_method role_class do
+          public_send(role_type).constantize
         end
 
         define_method "#{role}_name" do
-          public_send("#{role}_class").model_name.singular.inquiry
+          public_send(role_class).model_name.singular.inquiry
         end
 
         types.each do |type|


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I was reading through #39341 and noticed we can get rid of a couple redundant string interpolations:

- `"#{role}_type"` already exists and is closed around by the block
- `"#{role}_class"` is used twice in similar scopes

We're already using the pre-interpolated `role_type` and `role_id` in the `query` and `"#{singular}_id"` methods. Re-applying this pattern makes things more consistent, and reduces interpolations at "run time".

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
