### PR TITLE
ActiveRecord PostgreSQL adapter: escape range bound values during serialization

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -195,8 +195,22 @@ module ActiveRecord
             end
           end
 
+          # Range bound values must be escaped if they contain the following
+          # characters.
+          # * https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO
+          RANGE_VALUE_ESCAPED_CHARACTERS = /[()\[\]\\,"]/
+          private_constant :RANGE_VALUE_ESCAPED_CHARACTERS
+
           def type_cast_range_value(value)
-            infinity?(value) ? "" : type_cast(value)
+            cast_value = infinity?(value) ? "" : type_cast(value)
+
+            if cast_value.is_a?(String) && RANGE_VALUE_ESCAPED_CHARACTERS.match?(cast_value)
+              cast_value = cast_value.gsub(/["\\]/, "\\&\\&")
+              cast_value.prepend('"')
+              cast_value.concat('"')
+            end
+
+            cast_value
           end
 
           def infinity?(value)

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -169,6 +169,10 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
     assert_nil @empty_range.float_range
   end
 
+  def test_custom_range_value_escaping
+    assert_equal_round_trip(@first_range, :string_range, "ca\\t"..."do\"g")
+  end
+
   def test_timezone_awareness_tzrange
     tz = "Pacific Time (US & Canada)"
 


### PR DESCRIPTION
## Summary

When formatting the bound values of range types, PostgreSQL quotes the value using double-quotes in certain conditions: if its formatted representation contains parentheses, commas, double quotes, backslashes or whitespace (manual section 8.17.5, 8.16.6). When parsing input, it requires escaping in nearly the same conditions: with the exception of whitespace.

As of rails/rails#37648, escaped output from Postgres is unescaped during deserialization of range values. However, Rails still does not escape values when serializing for Postgres.

Neglecting to escape doesn't actually cause issues with any of Postgres' pre-defined range types (integer, numeric, time, date), because none of them feature values that strictly require escaping on input (they are only escaped on output due to whitespace). However it's possible to define range types for which this would be an issue: for example, ranges defined over strings, enum values, or arrays.

This PR provides an implementation of bound escaping in `ActiveRecord::ConnectionAdapters::PostgreSQL::Quoting#type_cast_range_value`.

## Questions about the proposed implementation:

* What types are allowed in the return value of `type_cast`? In test runs, I see `Integer` and `String`. Is it safe to assume that any complex types that would require escaping will have already have been serialized to a string?
* Is the return value of `type_cast` guaranteed to be unaliased? If so the call to `gsub` could be changed to operate in place.


