### PR TITLE
ActionView::Base.sanitized_allowed_tags call Sanitizer's allowed_tags class method 

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   SanitizeHelper.sanitized_allowed_attributes and SanitizeHelper.sanitized_allowed_tags
+    call safe_list_sanitizer's class method
+
+    Fixes #39586
+
+    *Taufiq Muhammadi*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Yield translated strings to calls of `ActionView::FormBuilder#button`

--- a/actionview/lib/action_view/helpers/sanitize_helper.rb
+++ b/actionview/lib/action_view/helpers/sanitize_helper.rb
@@ -129,11 +129,11 @@ module ActionView
         end
 
         def sanitized_allowed_tags
-          safe_list_sanitizer.allowed_tags
+          sanitizer_vendor.safe_list_sanitizer.allowed_tags
         end
 
         def sanitized_allowed_attributes
-          safe_list_sanitizer.allowed_attributes
+          sanitizer_vendor.safe_list_sanitizer.allowed_attributes
         end
 
         # Gets the Rails::Html::FullSanitizer instance used by +strip_tags+. Replace with

--- a/actionview/test/template/sanitize_helper_test.rb
+++ b/actionview/test/template/sanitize_helper_test.rb
@@ -40,4 +40,17 @@ class SanitizeHelperTest < ActionView::TestCase
   def test_sanitize_is_marked_safe
     assert_predicate sanitize("<html><script></script></html>"), :html_safe?
   end
+
+  def test_sanitized_allowed_tags_class_method
+    expected = Set.new(["strong", "em", "b", "i", "p", "code", "pre", "tt", "samp", "kbd", "var",
+      "sub", "sup", "dfn", "cite", "big", "small", "address", "hr", "br", "div", "span", "h1", "h2",
+      "h3", "h4", "h5", "h6", "ul", "ol", "li", "dl", "dt", "dd", "abbr", "acronym", "a", "img",
+      "blockquote", "del", "ins"])
+    assert_equal(expected, self.class.sanitized_allowed_tags)
+  end
+
+  def test_sanitized_allowed_attributes_class_method
+    expected = Set.new(["href", "src", "width", "height", "alt", "cite", "datetime", "title", "class", "name", "xml:lang", "abbr"])
+    assert_equal(expected, self.class.sanitized_allowed_attributes)
+  end
 end


### PR DESCRIPTION
### Summary

Fix #39586

`#allowed_tags` is now private
https://github.com/rails/rails-html-sanitizer/blob/51dc564c6509201070f72456bb2c13f87bb373d6/lib/rails/html/sanitizer.rb#L144


