### PR TITLE
Use statement cache for STI classes

### DIFF
--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -67,8 +67,8 @@ if ActiveRecord::Base.connection.prepared_statements
         topic_sql = cached_statement(Topic, Topic.primary_key)
         assert_includes statement_cache, to_sql_key(topic_sql)
 
-        e = assert_raise { cached_statement(SillyReply, SillyReply.primary_key) }
-        assert_equal "SillyReply has no cached statement by \"id\"", e.message
+        reply_sql = cached_statement(SillyReply, SillyReply.primary_key)
+        assert_includes statement_cache, to_sql_key(reply_sql)
 
         replies = SillyReply.where(id: 2).limit(1)
         assert_includes statement_cache, to_sql_key(replies.arel)
@@ -83,8 +83,8 @@ if ActiveRecord::Base.connection.prepared_statements
         topic_sql = cached_statement(Topic, ["id"])
         assert_includes statement_cache, to_sql_key(topic_sql)
 
-        e = assert_raise { cached_statement(SillyReply, ["id"]) }
-        assert_equal "SillyReply has no cached statement by [\"id\"]", e.message
+        reply_sql = cached_statement(SillyReply, ["id"])
+        assert_includes statement_cache, to_sql_key(reply_sql)
 
         replies = SillyReply.where(id: 2).limit(1)
         assert_includes statement_cache, to_sql_key(replies.arel)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -501,11 +501,6 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
   include InheritanceTestHelper
   fixtures :companies
 
-  teardown do
-    self.class.const_remove :FirmOnTheFly rescue nil
-    Firm.const_remove :FirmOnTheFly rescue nil
-  end
-
   def test_instantiation_doesnt_try_to_require_corresponding_file
     without_store_full_sti_class do
       foo = Firm.first.clone
@@ -530,6 +525,9 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
       assert_nothing_raised { assert_kind_of Firm::FirmOnTheFly, Firm.find(foo.id) }
       assert_nothing_raised { assert_kind_of Firm::FirmOnTheFly, Firm.find_by!(id: foo.id) }
     end
+  ensure
+    self.class.send(:remove_const, :FirmOnTheFly) rescue nil
+    Firm.send(:remove_const, :FirmOnTheFly) rescue nil
   end
 
   def test_sti_type_from_attributes_disabled_in_non_sti_class


### PR DESCRIPTION
Currently statement cache is disabled for STI classes, since
`klass.descendants` is dynamic if the klass will be inherited.

But in practice `klass.descendants` is mostly static at runtime, and we
could easily detect when `klass.descendants` is changed by `inherited`
hook.

Instead of disable statement cache, clear staled statement cache if
`klass.descendants` is changed.
