### PR TITLE
Deprecate `map!` and `collect!` on `ActiveRecord::Result`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `map!` and `collect!` on `ActiveRecord::Result`.
+
+    *Ryuta Kamizono*
+
 *   Support `relation.and` for intersection as Set theory.
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -518,7 +518,7 @@ module ActiveRecord
               collation_hash[$1] = $2 if COLLATE_REGEX =~ column_string
             end
 
-            basic_structure.map! do |column|
+            basic_structure.map do |column|
               column_name = column["name"]
 
               if collation_hash.has_key? column_name

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -75,6 +75,8 @@ module ActiveRecord
 
     alias :map! :map
     alias :collect! :map
+    deprecate "map!": :map
+    deprecate "collect!": :map
 
     # Returns true if there are no records, otherwise false.
     def empty?

--- a/activerecord/test/cases/result_test.rb
+++ b/activerecord/test/cases/result_test.rb
@@ -12,6 +12,28 @@ module ActiveRecord
       ])
     end
 
+    test "map! is deprecated" do
+      assert_deprecated do
+        result.map! { nil }
+      end
+      assert_equal [
+        { "col_1" => "row 1 col 1", "col_2" => "row 1 col 2" },
+        { "col_1" => "row 2 col 1", "col_2" => "row 2 col 2" },
+        { "col_1" => "row 3 col 1", "col_2" => "row 3 col 2" },
+      ], result.to_a
+    end
+
+    test "collect! is deprecated" do
+      assert_deprecated do
+        result.collect! { nil }
+      end
+      assert_equal [
+        { "col_1" => "row 1 col 1", "col_2" => "row 1 col 2" },
+        { "col_1" => "row 2 col 1", "col_2" => "row 2 col 2" },
+        { "col_1" => "row 3 col 1", "col_2" => "row 3 col 2" },
+      ], result.to_a
+    end
+
     test "includes_column?" do
       assert result.includes_column?("col_1")
       assert_not result.includes_column?("foo")


### PR DESCRIPTION
These actually does not inplace mutate result. Use true `map` instead.
