### PR TITLE
[Guides] Update web_console settings to use allowed_ips

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -930,7 +930,7 @@ do that with `local_variables`.
 
 ### Settings
 
-* `config.web_console.whitelisted_ips`: Authorized list of IPv4 or IPv6
+* `config.web_console.allowed_ips`: Authorized list of IPv4 or IPv6
 addresses and networks (defaults: `127.0.0.1/8, ::1`).
 * `config.web_console.whiny_requests`: Log a message when a console rendering
 is prevented (defaults: `true`).


### PR DESCRIPTION
### Summary

Update Debugging Rails Applications guide to use the [new setting from WebConsole gem](https://github.com/rails/web-console/pull/291/).
