### PR TITLE
Use indifferent access for config hash in actioncable postgresql test

### DIFF
--- a/actioncable/test/subscription_adapter/channel_prefix.rb
+++ b/actioncable/test/subscription_adapter/channel_prefix.rb
@@ -5,7 +5,7 @@ require "test_helper"
 module ChannelPrefixTest
   def test_channel_prefix
     server2 = ActionCable::Server::Base.new(config: ActionCable::Server::Configuration.new)
-    server2.config.cable = alt_cable_config
+    server2.config.cable = alt_cable_config.with_indifferent_access
     server2.config.logger = Logger.new(StringIO.new).tap { |l| l.level = Logger::UNKNOWN }
 
     adapter_klass = server2.config.pubsub_adapter


### PR DESCRIPTION
### Steps to reproduce
* Check that postgresql is running
* Check that redis is *not* running
* `cd actioncable`
* `bundle exec rake test TEST=test/subscription_adapter/postgresql_test.rb`

### Expected behavior
The tests pass ✅

### Actual behavior
`Error connecting to Redis on 127.0.0.1:6379 (Errno::ECONNREFUSED) (Redis::CannotConnectError)` 🤔

### System configuration
**Rails version**: master
**Ruby version**: 2.7.1

### Explanation
[ActionCable::Server::Configuration#pubsub_adapter expects a string key](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/server/configuration.rb#L27). The test classes use symbol keys syntactically, but then call #with_indifferent_access on the cable config hash when instantiating `ActionCable::Server::Base` instances. This one test breaks because the setup code in ChannelPrefixTest#test_channel_prefix is missing the #with_indifferent_access call.