### PR TITLE
Easier shell command selection in Rails guide

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -728,6 +728,15 @@ div.important p, div.caution p, div.warning p, div.note p, div.info p {
   margin-bottom: 1em;
 }
 
+/* Prevent shell prompt from being selectable when selecting commands*/
+code.language-shell-session span.token.command {
+  display: inline-flex;
+}
+span.token.sh.important {
+  margin-right: 0.5em;
+  user-select: none;
+}
+
 /* Edge Badge
 --------------------------------------- */
 

--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -734,7 +734,6 @@ code.language-shell-session span.token.command {
 }
 span.token.sh.important {
   margin-right: 0.5em;
-  user-select: none;
 }
 
 /* Edge Badge


### PR DESCRIPTION
### Summary

While reading ActionMailbox and ActiveStorage guide I noticed that when you want to copy past a command the shell sign is always selected if you double click on the text.

This pull request provide a way to do not select shell prompt.

![Jun-10-2020 16-35-26](https://user-images.githubusercontent.com/8417720/84281117-79e83200-ab38-11ea-9509-7fd8978af8ca.gif)

I tested the patch on 3 browsers: Firefox, Chrome and Safari.

Percy diff is null https://percy.io/RSpec/railsguidemultiple/builds/5636214

Maintainers, feel free to push on my branch if you want to make changes.