### PR TITLE
[ci skip] 4.2 Release Notes - Update link to autoloading guide to classic mode guide inst…

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -871,7 +871,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
     `module Foo; extend ActiveSupport::Concern; end` boilerplate.
     ([Commit](https://github.com/rails/rails/commit/b16c36e688970df2f96f793a759365b248b582ad))
 
-*   New [guide](autoloading_and_reloading_constants.html) about constant autoloading and reloading.
+*   New [guide](autoloading_and_reloading_constants_classic_mode.html) about constant autoloading and reloading.
 
 Credits
 -------


### PR DESCRIPTION
…ead of Zeitwerk guide

### Summary

Rails 4.2.x doesn't utilize Zeitwerk mode for autoloading, so it seems to make more sense to link to the classic mode guide in the 4.2 release notes.