### PR TITLE
Add a setting to specify that all string columns should be immutable

### DIFF
--- a/activemodel/lib/active_model/type/immutable_string.rb
+++ b/activemodel/lib/active_model/type/immutable_string.rb
@@ -3,6 +3,12 @@
 module ActiveModel
   module Type
     class ImmutableString < Value # :nodoc:
+      def initialize(**args)
+        @true  = -(args.delete(:true)&.to_s  || "t")
+        @false = -(args.delete(:false)&.to_s || "f")
+        super
+      end
+
       def type
         :string
       end
@@ -10,21 +16,19 @@ module ActiveModel
       def serialize(value)
         case value
         when ::Numeric, ::Symbol, ActiveSupport::Duration then value.to_s
-        when true then "t"
-        when false then "f"
+        when true then @true
+        when false then @false
         else super
         end
       end
 
       private
         def cast_value(value)
-          result = \
-            case value
-            when true then "t"
-            when false then "f"
-            else value.to_s
-            end
-          result.freeze
+          case value
+          when true then @true
+          when false then @false
+          else value.to_s.freeze
+          end
         end
     end
   end

--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -8,6 +8,11 @@ module ActiveModel
         @registrations = []
       end
 
+      def initialize_dup(other)
+        @registrations = @registrations.dup
+        super
+      end
+
       def register(type_name, klass = nil, **options, &block)
         unless block_given?
           block = proc { |_, *args| klass.new(*args) }

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -11,6 +11,14 @@ module ActiveModel
         end
       end
 
+      def to_immutable_string
+        ImmutableString.new(
+          limit: limit,
+          precision: precision,
+          scale: scale,
+        )
+      end
+
       private
         def cast_value(value)
           case value

--- a/activemodel/lib/active_model/type/string.rb
+++ b/activemodel/lib/active_model/type/string.rb
@@ -13,6 +13,8 @@ module ActiveModel
 
       def to_immutable_string
         ImmutableString.new(
+          true: @true,
+          false: @false,
           limit: limit,
           precision: precision,
           scale: scale,
@@ -23,8 +25,8 @@ module ActiveModel
         def cast_value(value)
           case value
           when ::String then ::String.new(value)
-          when true then "t"
-          when false then "f"
+          when true then @true
+          when false then @false
           else value.to_s
           end
         end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added the setting `ActiveRecord::Base.immutable_strings_by_default`, which
+    allows you to specify that all string columns should be frozen unless
+    otherwise specified. This will reduce memory pressure for applications which
+    do not generally mutate string properties of Active Record objects.
+
+    *Sean Griffin*
+
 *   Deprecate `map!` and `collect!` on `ActiveRecord::Result`.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -63,6 +63,7 @@ module ActiveRecord
     Decimal = ActiveModel::Type::Decimal
     Float = ActiveModel::Type::Float
     Integer = ActiveModel::Type::Integer
+    ImmutableString = ActiveModel::Type::ImmutableString
     String = ActiveModel::Type::String
     Value = ActiveModel::Type::Value
 
@@ -74,6 +75,7 @@ module ActiveRecord
     register(:decimal, Type::Decimal, override: false)
     register(:float, Type::Float, override: false)
     register(:integer, Type::Integer, override: false)
+    register(:immutable_string, Type::ImmutableString, override: false)
     register(:json, Type::Json, override: false)
     register(:string, Type::String, override: false)
     register(:text, Type::Text, override: false)

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -318,6 +318,13 @@ module ActiveRecord
       end
     end
 
+    test "serialize boolean for both string types" do
+      default_string_type = Type.lookup(:string)
+      immutable_string_type = Type.lookup(:immutable_string)
+      assert_equal default_string_type.serialize(true), immutable_string_type.serialize(true)
+      assert_equal default_string_type.serialize(false), immutable_string_type.serialize(false)
+    end
+
     private
       def with_immutable_strings
         old_value = ActiveRecord::Base.immutable_strings_by_default

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -588,7 +588,7 @@ end
 class InheritanceAttributeMappingTest < ActiveRecord::TestCase
   setup do
     @old_registry = ActiveRecord::Type.registry
-    ActiveRecord::Type.registry = ActiveRecord::Type::AdapterSpecificRegistry.new
+    ActiveRecord::Type.registry = ActiveRecord::Type.registry.dup
     ActiveRecord::Type.register :omg_sti, InheritanceAttributeMappingTest::OmgStiType
     Company.delete_all
     Sponsor.delete_all

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1125,6 +1125,7 @@ ActiveRecord::Schema.define do
     t.float :unoverloaded_float
     t.string :overloaded_string_with_limit, limit: 255
     t.string :string_with_default, default: "the original default"
+    t.string :inferred_string, limit: 255
   end
 
   create_table :users, force: true do |t|


### PR DESCRIPTION
#29938 with boolean serialization fix for MySQL.

I've been working on improving the attributes performance for a long time, the (mutable) string type cast is one of the inefficient part of attributes.

To detect inplace mutation, string type will dup all loading/assigning values to protect original value from mutation, that is the reason why (mutable) string type is inefficient.

Immutable string type avoids the dup, since that type will freeze all loading/assigning values, and so frozen values are not allowed inplace mutation.

Simple (one string attribute) benchmark with this branch for immutable string type:

```ruby
ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :name
    t.string :fast_name
  end
end

class User < ActiveRecord::Base
  attribute :fast_name, :immutable_string
end

user = User.new

Benchmark.ips do |x|
  x.report("user.name") do
    user.name = "foo"
    user.name_changed?
  end
  x.report("user.fast_name") do
    user.fast_name = "foo"
    user.fast_name_changed?
  end
end
```

```
Warming up --------------------------------------
           user.name    34.811k i/100ms
      user.fast_name    39.505k i/100ms
Calculating -------------------------------------
           user.name    343.864k (± 3.6%) i/s -      1.741M in   5.068576s
      user.fast_name    384.033k (± 2.7%) i/s -      1.936M in   5.044425s
```

Quoted original description from #29938:

> In Rails 4.2 we introduced mutation detection, to remove the need to
> call `attribute_will_change!` after modifying a field. One side effect
> of that change was that we needed to enforce that the
> `_before_type_cast` form of a value is a different object than the post
> type cast value, if the value is mutable. That contract is really only
> relevant for strings, but it meant we needed to dup them.
>
> In Rails 5 we added the `ImmutableString` type, to allow people to opt
> out of this duping in places where the memory usage was causing
> problems, and they don't need to mutate that field.
>
> This takes that a step further, and adds a class-level setting to
> specify whether strings should be frozen by default or not. The default
> value of this setting is `false` (strings are mutable), and I do not
> plan on changing that.
>
> While I think that immutable strings by default would be a reasonable
> default for new applications, I do not think that we would be able to
> document the value of this setting in a place that people will be
> looking when they can't figure out why some string is frozen.
> Realistically, the number of applications where this setting is relevant
> is fairly small, so I don't think it would make sense to ever enable it
> by default.