### PR TITLE
Allow content_for to be used within a fragment cache block

### DIFF
--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -124,7 +124,7 @@ class FunctionalFragmentCachingTest < BaseCachingTest
 
     assert_match expected_body, email.body.encoded
     assert_match expected_body,
-      @store.read("views/caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}/caching")
+      @store.read("views/caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}/caching")[:_fragment]
   end
 
   def test_fragment_caching_in_partials
@@ -132,8 +132,8 @@ class FunctionalFragmentCachingTest < BaseCachingTest
     expected_body = "Old fragment caching in a partial"
     assert_match(expected_body, email.body.encoded)
 
-    assert_match(expected_body,
-      @store.read("views/caching_mailer/_partial:#{template_digest("caching_mailer/_partial", "html")}/caching"))
+    assert_match expected_body,
+      @store.read("views/caching_mailer/_partial:#{template_digest("caching_mailer/_partial", "html")}/caching")[:_fragment]
   end
 
   def test_skip_fragment_cache_digesting
@@ -141,7 +141,7 @@ class FunctionalFragmentCachingTest < BaseCachingTest
     expected_body = "No Digest"
 
     assert_match expected_body, email.body.encoded
-    assert_match expected_body, @store.read("views/no_digest")
+    assert_match expected_body, @store.read("views/no_digest")[:_fragment]
   end
 
   def test_fragment_caching_options
@@ -164,9 +164,9 @@ class FunctionalFragmentCachingTest < BaseCachingTest
     assert_match expected_text_body, encoded_body
     assert_match expected_html_body, encoded_body
     assert_match expected_text_body,
-                 @store.read("views/text_caching")
+                 @store.read("views/text_caching")[:_fragment]
     assert_match expected_html_body,
-                 @store.read("views/html_caching")
+                 @store.read("views/html_caching")[:_fragment]
   end
 
   def test_fragment_cache_instrumentation

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -53,7 +53,7 @@ class FragmentCachingTest < BaseCachingTest
   def test_write_fragment_with_caching_enabled
     assert_nil @store.read("views/name")
     assert_equal "value", @mailer.write_fragment("name", "value")
-    assert_equal "value", @store.read("views/name")
+    assert_equal "value", @store.read("views/name")[:_fragment]
   end
 
   def test_write_fragment_with_caching_disabled
@@ -100,8 +100,8 @@ class FragmentCachingTest < BaseCachingTest
     assert_equal content, @mailer.write_fragment("name", content)
 
     cached = @store.read("views/name")
-    assert_equal content, cached
-    assert_equal String, cached.class
+    assert_equal content, cached[:_fragment]
+    assert_equal String, cached[:_fragment].class
 
     html_safe = @mailer.read_fragment("name")
     assert_equal content, html_safe
@@ -200,7 +200,7 @@ class CacheHelperOutputBufferTest < BaseCachingTest
       false
     end
 
-    def write_fragment(name, fragment, options)
+    def write_fragment_and_content_for(name, fragment, content_for, options)
       fragment
     end
   end

--- a/actionmailer/test/caching_test.rb
+++ b/actionmailer/test/caching_test.rb
@@ -53,7 +53,7 @@ class FragmentCachingTest < BaseCachingTest
   def test_write_fragment_with_caching_enabled
     assert_nil @store.read("views/name")
     assert_equal "value", @mailer.write_fragment("name", "value")
-    assert_equal "value", @store.read("views/name")[:_fragment]
+    assert_equal "value", @store.read("views/name")
   end
 
   def test_write_fragment_with_caching_disabled
@@ -100,8 +100,8 @@ class FragmentCachingTest < BaseCachingTest
     assert_equal content, @mailer.write_fragment("name", content)
 
     cached = @store.read("views/name")
-    assert_equal content, cached[:_fragment]
-    assert_equal String, cached[:_fragment].class
+    assert_equal content, cached
+    assert_equal String, cached.class
 
     html_safe = @mailer.read_fragment("name")
     assert_equal content, html_safe
@@ -124,7 +124,7 @@ class FunctionalFragmentCachingTest < BaseCachingTest
 
     assert_match expected_body, email.body.encoded
     assert_match expected_body,
-      @store.read("views/caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}/caching")[:_fragment]
+      @store.read("views/caching_mailer/fragment_cache:#{template_digest("caching_mailer/fragment_cache", "html")}/caching")
   end
 
   def test_fragment_caching_in_partials
@@ -133,7 +133,7 @@ class FunctionalFragmentCachingTest < BaseCachingTest
     assert_match(expected_body, email.body.encoded)
 
     assert_match expected_body,
-      @store.read("views/caching_mailer/_partial:#{template_digest("caching_mailer/_partial", "html")}/caching")[:_fragment]
+      @store.read("views/caching_mailer/_partial:#{template_digest("caching_mailer/_partial", "html")}/caching")
   end
 
   def test_skip_fragment_cache_digesting
@@ -141,7 +141,7 @@ class FunctionalFragmentCachingTest < BaseCachingTest
     expected_body = "No Digest"
 
     assert_match expected_body, email.body.encoded
-    assert_match expected_body, @store.read("views/no_digest")[:_fragment]
+    assert_match expected_body, @store.read("views/no_digest")
   end
 
   def test_fragment_caching_options
@@ -164,9 +164,9 @@ class FunctionalFragmentCachingTest < BaseCachingTest
     assert_match expected_text_body, encoded_body
     assert_match expected_html_body, encoded_body
     assert_match expected_text_body,
-                 @store.read("views/text_caching")[:_fragment]
+                 @store.read("views/text_caching")
     assert_match expected_html_body,
-                 @store.read("views/html_caching")[:_fragment]
+                 @store.read("views/html_caching")
   end
 
   def test_fragment_cache_instrumentation

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   In addition to writing the main fragment content to the cache, change `cache` to also write to
+    the cache any content that is captured using `content_for` while inside the `cache` block. It
+    will get written in the cache as a hash under the same cache key as the fragment content, and
+    read back from the cache anytime that fragment is read from the cache.
+
+    *Steve Hull*, *Tyler Rick*
+
 *   When multiple domains are specified for a cookie, a domain will now be
     chosen only if it is equal to or is a superdomain of the request host.
 

--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -41,6 +41,8 @@ module AbstractController
 
       class_attribute :_view_cache_dependencies, default: []
       helper_method :view_cache_dependencies if respond_to?(:helper_method)
+
+      attr_internal :cached_content_for
     end
 
     module ClassMethods

--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -42,7 +42,7 @@ module AbstractController
       class_attribute :_view_cache_dependencies, default: []
       helper_method :view_cache_dependencies if respond_to?(:helper_method)
 
-      attr_internal :cached_content_for
+      attr_internal :cached_content_for_calls
     end
 
     module ClassMethods

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -75,13 +75,19 @@ module AbstractController
         cache_key
       end
 
-      # Writes both +fragment+ content and +content_for+ data (optional) in a
-      # combined hash to the location signified by +key+.
+      # If +content_for+ is provided, writes both +fragment+ content and
+      # +content_for+ data in a combined hash to the location signified by
+      # +key+.
+      # If only +fragment+, writes only +fragment+ (as a string).
       def write_fragment_and_content_for(key, fragment, content_for = nil, options = nil)
         return fragment unless cache_configured?
 
-        value_to_write = {_fragment: fragment.to_str}
-        value_to_write.merge!(content_for.transform_values(&:to_str)) if content_for
+        if content_for.present?
+          value_to_write = {_fragment: fragment.to_str}.
+            merge(content_for.transform_values(&:to_str))
+        else
+          value_to_write = fragment.to_str
+        end
         key = combined_fragment_cache_key(key)
         instrument_fragment_cache :write_fragment, key do
           cache_store.write(key, value_to_write, options)

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -167,7 +167,9 @@ module AbstractController
         # it, and use the rest as cached_content_for.
         def extract_fragment_value(result)
           if result.is_a?(Hash)
-            self.cached_content_for = result.except(:_fragment)
+            self.cached_content_for = result.except(:_fragment).transform_values { |v|
+              v.respond_to?(:html_safe) ? v.html_safe : v
+            }
             result = result[:_fragment]
           end
           result

--- a/actionpack/lib/abstract_controller/caching/fragments.rb
+++ b/actionpack/lib/abstract_controller/caching/fragments.rb
@@ -170,7 +170,6 @@ module AbstractController
       end
 
       private
-
         # Ensure that we mark all string values that we fetched from the cache
         # as html_safe.
         # In case the result read from the cache store is a Hash, extract the

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -99,7 +99,7 @@ class FragmentCachingTest < ActionController::TestCase
   def test_write_fragment_with_caching_enabled
     assert_nil @store.read("views/name")
     assert_equal "value", @controller.write_fragment("name", "value")
-    assert_equal "value", @store.read("views/name")[:_fragment]
+    assert_equal "value", @store.read("views/name")
   end
 
   def test_write_fragment_with_caching_disabled
@@ -146,8 +146,8 @@ class FragmentCachingTest < ActionController::TestCase
     assert_equal content, @controller.write_fragment("name", content)
 
     cached = @store.read("views/name")
-    assert_equal content, cached[:_fragment]
-    assert_equal String, cached[:_fragment].class
+    assert_equal content, cached
+    assert_equal String, cached.class
 
     html_safe = @controller.read_fragment("name")
     assert_equal content, html_safe
@@ -212,7 +212,7 @@ Ciao
     assert_equal expected_body, @response.body
 
     assert_equal "This bit's fragment cached",
-      @store.read("views/functional_caching/fragment_cached:#{template_digest("functional_caching/fragment_cached", "html")}/fragment")[:_fragment]
+      @store.read("views/functional_caching/fragment_cached:#{template_digest("functional_caching/fragment_cached", "html")}/fragment")
   end
 
   def test_fragment_caching_with_content_for
@@ -241,7 +241,7 @@ This fragment is cached
     assert_match(/Old fragment caching in a partial/, @response.body)
 
     assert_match "Old fragment caching in a partial",
-      @store.read("views/functional_caching/_partial:#{template_digest("functional_caching/_partial", "html")}/test.host/functional_caching/html_fragment_cached_with_partial")[:_fragment]
+      @store.read("views/functional_caching/_partial:#{template_digest("functional_caching/_partial", "html")}/test.host/functional_caching/html_fragment_cached_with_partial")
   end
 
   def test_skipping_fragment_cache_digesting
@@ -250,7 +250,7 @@ This fragment is cached
     expected_body = "<body>\n<p>ERB</p>\n</body>\n"
 
     assert_equal expected_body, @response.body
-    assert_equal "<p>ERB</p>", @store.read("views/nodigest")[:_fragment]
+    assert_equal "<p>ERB</p>", @store.read("views/nodigest")
   end
 
   def test_fragment_caching_with_options
@@ -271,7 +271,7 @@ This fragment is cached
     assert_match(/Some inline content/, @response.body)
     assert_match(/Some cached content/, @response.body)
     assert_match "Some cached content",
-      @store.read("views/functional_caching/inline_fragment_cached:#{template_digest("functional_caching/inline_fragment_cached", "html")}/test.host/functional_caching/inline_fragment_cached")[:_fragment]
+      @store.read("views/functional_caching/inline_fragment_cached:#{template_digest("functional_caching/inline_fragment_cached", "html")}/test.host/functional_caching/inline_fragment_cached")
   end
 
   def test_fragment_cache_instrumentation
@@ -299,7 +299,7 @@ This fragment is cached
     assert_equal expected_body, @response.body
 
     assert_equal "<p>ERB</p>",
-      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")[:_fragment]
+      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")
   end
 
   def test_xml_formatted_fragment_caching
@@ -311,7 +311,7 @@ This fragment is cached
     assert_equal expected_body, @response.body
 
     assert_equal "  <p>Builder</p>\n",
-      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")[:_fragment]
+      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")
   end
 
   def test_fragment_caching_with_variant
@@ -323,7 +323,7 @@ This fragment is cached
     assert_equal expected_body, @response.body
 
     assert_equal "<p>PHONE</p>",
-      @store.read("views/functional_caching/formatted_fragment_cached_with_variant:#{template_digest("functional_caching/formatted_fragment_cached_with_variant", format)}/fragment")[:_fragment]
+      @store.read("views/functional_caching/formatted_fragment_cached_with_variant:#{template_digest("functional_caching/formatted_fragment_cached_with_variant", format)}/fragment")
   end
 
   def test_fragment_caching_with_html_partials_in_xml

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -153,6 +153,26 @@ class FragmentCachingTest < ActionController::TestCase
     assert_equal content, html_safe
     assert_predicate html_safe, :html_safe?
   end
+
+  def test_html_safety_for_content_for
+    assert_nil @store.read("views/name")
+    content = "value".html_safe
+    footer = "<p>footer</p>".html_safe
+    assert_equal content, @controller.write_fragment_and_content_for("name", content, {footer: footer})
+
+    cached = @store.read("views/name")
+    assert_equal content, cached[:_fragment]
+    assert_equal footer, cached[:footer]
+    assert_equal String, cached[:_fragment].class
+    assert_equal String, cached[:footer].class
+
+    content_from_cache = @controller.read_fragment("name")
+    footer_from_cache = @controller.cached_content_for[:footer]
+    assert_equal content, content_from_cache
+    assert_equal footer, footer_from_cache
+    assert_predicate content_from_cache, :html_safe?
+    assert_predicate footer_from_cache, :html_safe?
+  end
 end
 
 class FunctionalCachingController < CachingController
@@ -219,12 +239,14 @@ Ciao
     get :fragment_cached_with_content_for
     assert_response :success
     expected_body = <<-CACHED
-This fragment is cached
+  
+  This fragment is cached
 <title>My Title: Enhanced!</title>
-<footer>P.S. This footer is cached.</footer>
+<footer><p>P.S. This footer is cached.</p></footer>
     CACHED
+
     assert_equal expected_body, @response.body
-    expected_hash = {_fragment: "This fragment is cached\n", title: ": Enhanced!", footer: "P.S. This footer is cached."}
+    expected_hash = {_fragment: "  \n  This fragment is cached\n", title: ": Enhanced!", footer: "<p>P.S. This footer is cached.</p>"}
     assert_equal expected_hash,
       @store.read("views/functional_caching/fragment_cached_with_content_for:#{template_digest("functional_caching/fragment_cached_with_content_for", "html")}/test.host/functional_caching/fragment_cached_with_content_for")
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -212,7 +212,27 @@ Ciao
     assert_equal expected_body, @response.body
 
     assert_equal "This bit's fragment cached",
-      @store.read("views/functional_caching/fragment_cached:#{template_digest("functional_caching/fragment_cached", "html")}/fragment")
+      @store.read("views/functional_caching/fragment_cached:#{template_digest("functional_caching/fragment_cached", "html")}/fragment")[:_fragment]
+  end
+
+  def test_fragment_caching_with_content_for
+    get :fragment_cached_with_content_for
+    assert_response :success
+    expected_body = <<-CACHED
+This fragment is cached
+<title>My Title: Enhanced!</title>
+<footer>P.S. This footer is cached.</footer>
+    CACHED
+    assert_equal expected_body, @response.body
+    expected_hash = {_fragment: "This fragment is cached\n", title: ": Enhanced!", footer: "P.S. This footer is cached."}
+    assert_equal expected_hash,
+      @store.read("views/functional_caching/fragment_cached_with_content_for:#{template_digest("functional_caching/fragment_cached_with_content_for", "html")}/test.host/functional_caching/fragment_cached_with_content_for")
+
+    get :fragment_cached_with_content_for
+    assert_response :success
+    assert_equal expected_body, @response.body
+    assert_equal expected_hash,
+      @store.read("views/functional_caching/fragment_cached_with_content_for:#{template_digest("functional_caching/fragment_cached_with_content_for", "html")}/test.host/functional_caching/fragment_cached_with_content_for")
   end
 
   def test_fragment_caching_in_partials
@@ -220,8 +240,8 @@ Ciao
     assert_response :success
     assert_match(/Old fragment caching in a partial/, @response.body)
 
-    assert_match("Old fragment caching in a partial",
-      @store.read("views/functional_caching/_partial:#{template_digest("functional_caching/_partial", "html")}/test.host/functional_caching/html_fragment_cached_with_partial"))
+    assert_match "Old fragment caching in a partial",
+      @store.read("views/functional_caching/_partial:#{template_digest("functional_caching/_partial", "html")}/test.host/functional_caching/html_fragment_cached_with_partial")[:_fragment]
   end
 
   def test_skipping_fragment_cache_digesting
@@ -230,7 +250,7 @@ Ciao
     expected_body = "<body>\n<p>ERB</p>\n</body>\n"
 
     assert_equal expected_body, @response.body
-    assert_equal "<p>ERB</p>", @store.read("views/nodigest")
+    assert_equal "<p>ERB</p>", @store.read("views/nodigest")[:_fragment]
   end
 
   def test_fragment_caching_with_options
@@ -250,8 +270,8 @@ Ciao
     assert_response :success
     assert_match(/Some inline content/, @response.body)
     assert_match(/Some cached content/, @response.body)
-    assert_match("Some cached content",
-      @store.read("views/functional_caching/inline_fragment_cached:#{template_digest("functional_caching/inline_fragment_cached", "html")}/test.host/functional_caching/inline_fragment_cached"))
+    assert_match "Some cached content",
+      @store.read("views/functional_caching/inline_fragment_cached:#{template_digest("functional_caching/inline_fragment_cached", "html")}/test.host/functional_caching/inline_fragment_cached")[:_fragment]
   end
 
   def test_fragment_cache_instrumentation
@@ -279,7 +299,7 @@ Ciao
     assert_equal expected_body, @response.body
 
     assert_equal "<p>ERB</p>",
-      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")
+      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")[:_fragment]
   end
 
   def test_xml_formatted_fragment_caching
@@ -291,7 +311,7 @@ Ciao
     assert_equal expected_body, @response.body
 
     assert_equal "  <p>Builder</p>\n",
-      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")
+      @store.read("views/functional_caching/formatted_fragment_cached:#{template_digest("functional_caching/formatted_fragment_cached", format)}/fragment")[:_fragment]
   end
 
   def test_fragment_caching_with_variant
@@ -303,7 +323,7 @@ Ciao
     assert_equal expected_body, @response.body
 
     assert_equal "<p>PHONE</p>",
-      @store.read("views/functional_caching/formatted_fragment_cached_with_variant:#{template_digest("functional_caching/formatted_fragment_cached_with_variant", format)}/fragment")
+      @store.read("views/functional_caching/formatted_fragment_cached_with_variant:#{template_digest("functional_caching/formatted_fragment_cached_with_variant", format)}/fragment")[:_fragment]
   end
 
   def test_fragment_caching_with_html_partials_in_xml

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -239,7 +239,7 @@ Ciao
     get :fragment_cached_with_content_for
     assert_response :success
     expected_body = <<-CACHED
-  
+#{'  '}
   This fragment is cached
 <title>My Title: Enhanced!</title>
 <footer><p>P.S. This footer is cached.</p></footer>
@@ -250,7 +250,7 @@ Ciao
       _fragment: "  \n  This fragment is cached\n",
       content_for: [
         [:title, ": Enhanced!", {}],
-        [:footer, "<p>P.S. This footer is cached.</p>", {flush: true}]
+        [:footer, "<p>P.S. This footer is cached.</p>", { flush: true }]
       ]
     }
     assert_equal expected_hash,

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -158,16 +158,16 @@ class FragmentCachingTest < ActionController::TestCase
     assert_nil @store.read("views/name")
     content = "value".html_safe
     footer = "<p>footer</p>".html_safe
-    assert_equal content, @controller.write_fragment_and_content_for("name", content, {footer: footer})
+    assert_equal content, @controller.write_fragment_and_content_for("name", content, [[:footer, footer]])
 
     cached = @store.read("views/name")
     assert_equal content, cached[:_fragment]
-    assert_equal footer, cached[:footer]
+    assert_equal [:footer, footer], cached[:content_for][0]
     assert_equal String, cached[:_fragment].class
-    assert_equal String, cached[:footer].class
+    assert_equal String, cached[:content_for][0][1].class
 
     content_from_cache = @controller.read_fragment("name")
-    footer_from_cache = @controller.cached_content_for[:footer]
+    footer_from_cache = @controller.cached_content_for_calls[0][1]
     assert_equal content, content_from_cache
     assert_equal footer, footer_from_cache
     assert_predicate content_from_cache, :html_safe?
@@ -246,7 +246,13 @@ Ciao
     CACHED
 
     assert_equal expected_body, @response.body
-    expected_hash = {_fragment: "  \n  This fragment is cached\n", title: ": Enhanced!", footer: "<p>P.S. This footer is cached.</p>"}
+    expected_hash = {
+      _fragment: "  \n  This fragment is cached\n",
+      content_for: [
+        [:title, ": Enhanced!", {}],
+        [:footer, "<p>P.S. This footer is cached.</p>", {flush: true}]
+      ]
+    }
     assert_equal expected_hash,
       @store.read("views/functional_caching/fragment_cached_with_content_for:#{template_digest("functional_caching/fragment_cached_with_content_for", "html")}/test.host/functional_caching/fragment_cached_with_content_for")
 

--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -99,7 +99,7 @@ class FragmentCachingTest < ActionController::TestCase
   def test_write_fragment_with_caching_enabled
     assert_nil @store.read("views/name")
     assert_equal "value", @controller.write_fragment("name", "value")
-    assert_equal "value", @store.read("views/name")
+    assert_equal "value", @store.read("views/name")[:_fragment]
   end
 
   def test_write_fragment_with_caching_disabled
@@ -146,8 +146,8 @@ class FragmentCachingTest < ActionController::TestCase
     assert_equal content, @controller.write_fragment("name", content)
 
     cached = @store.read("views/name")
-    assert_equal content, cached
-    assert_equal String, cached.class
+    assert_equal content, cached[:_fragment]
+    assert_equal String, cached[:_fragment].class
 
     html_safe = @controller.read_fragment("name")
     assert_equal content, html_safe
@@ -343,7 +343,7 @@ class CacheHelperOutputBufferTest < ActionController::TestCase
       false
     end
 
-    def write_fragment(name, fragment, options)
+    def write_fragment_and_content_for(name, fragment, content_for, options)
       fragment
     end
   end

--- a/actionpack/test/fixtures/functional_caching/fragment_cached_with_content_for.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached_with_content_for.html.erb
@@ -1,8 +1,8 @@
-<%- content_for :title, "My Title" -%>
-<%- cache do -%>
-  <%- content_for :title, ": Enhanced!" -%>
-  <%- content_for :footer, "P.S. This footer is cached." -%>
-This fragment is cached
-<%- end -%>
+<% content_for :title, "My Title" %>
+<% cache do %>
+  <% content_for :title, ": Enhanced!" %>
+  <% content_for :footer do %><p>P.S. This footer is cached.</p><% end %>
+  This fragment is cached
+<% end %>
 <title><%= content_for :title %></title>
 <footer><%= content_for :footer %></footer>

--- a/actionpack/test/fixtures/functional_caching/fragment_cached_with_content_for.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached_with_content_for.html.erb
@@ -1,7 +1,8 @@
 <% content_for :title, "My Title" %>
+<% content_for :footer, 'Some default footer' %>
 <% cache do %>
   <% content_for :title, ": Enhanced!" %>
-  <% content_for :footer do %><p>P.S. This footer is cached.</p><% end %>
+  <% content_for :footer, flush: true do %><p>P.S. This footer is cached.</p><% end %>
   This fragment is cached
 <% end %>
 <title><%= content_for :title %></title>

--- a/actionpack/test/fixtures/functional_caching/fragment_cached_with_content_for.html.erb
+++ b/actionpack/test/fixtures/functional_caching/fragment_cached_with_content_for.html.erb
@@ -1,0 +1,8 @@
+<%- content_for :title, "My Title" -%>
+<%- cache do -%>
+  <%- content_for :title, ": Enhanced!" -%>
+  <%- content_for :footer, "P.S. This footer is cached." -%>
+This fragment is cached
+<%- end -%>
+<title><%= content_for :title %></title>
+<footer><%= content_for :footer %></footer>

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   In addition to writing the main fragment content to the cache, change `cache` to also write to
+    the cache any content that is captured using `content_for` while inside the `cache` block. It
+    will get written in the cache as a hash under the same cache key as the fragment content, and
+    read back from the cache anytime that fragment is read from the cache.
+
+    *Steve Hull*, *Tyler Rick*
+
 *   Ensure cache fragment digests include all relevant template dependencies when
     fragments are contained in a block passed to the render helper. Remove the
     virtual_path keyword arguments found in CacheHelper as they no longer possess

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -164,7 +164,7 @@ module ActionView
       # This will include both records as part of the cache key and updating either of them will
       # expire the cache.
       def cache(name = {}, options = {}, &block)
-        if controller.respond_to?(:perform_caching) && controller.perform_caching
+        if controller.try(:perform_caching)
           name_options = options.slice(:skip_digest)
           safe_concat(fragment_for(cache_fragment_name(name, **name_options), options, &block))
         else

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -269,19 +269,28 @@ module ActionView
         if output_safe
           self.output_buffer = output_buffer.class.new(output_buffer)
         end
-        content_for = @_content_for_to_cache if instance_variable_defined?(:@_content_for_to_cache) && @_content_for_to_cache
-        controller.write_fragment_and_content_for(name, fragment, content_for, options)
+        controller.write_fragment_and_content_for(name, fragment, content_for_to_cache, options)
       end
 
-      def restore_cached_content_for
-        return unless controller.try(:perform_caching)
+      def content_for_to_cache
+        return unless instance_variable_defined?(:@_content_for_to_cache)
 
-        if controller.cached_content_for.is_a?(Hash)
-          controller.cached_content_for.each { |k, v|
-            content_for(k, v)
-          }
+        @_content_for_to_cache.presence
+      end
+
+      private
+
+        # Takes the content_for that was read from cache store and add it back to view_flow using
+        # content_for as it was done originally within the cache block.
+        def restore_cached_content_for
+          return unless controller.try(:perform_caching)
+
+          if controller.cached_content_for.is_a?(Hash)
+            controller.cached_content_for.each { |k, v|
+              content_for(k, v)
+            }
+          end
         end
-      end
     end
   end
 end

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -269,9 +269,8 @@ module ActionView
         if output_safe
           self.output_buffer = output_buffer.class.new(output_buffer)
         end
-        value_to_write = {_fragment: fragment}
-        value_to_write.merge!(@_content_for_to_cache) if instance_variable_defined?(:@_content_for_to_cache) && @_content_for_to_cache
-        controller.write_fragment(name, value_to_write, options)
+        content_for = @_content_for_to_cache if instance_variable_defined?(:@_content_for_to_cache) && @_content_for_to_cache
+        controller.write_fragment_and_content_for(name, fragment, content_for, options)
       end
 
       def restore_cached_content_for

--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -279,7 +279,6 @@ module ActionView
       end
 
       private
-
         # Takes the content_for that was read from cache store and add it back to view_flow using
         # content_for as it was done originally within the cache block.
         def replay_cached_content_for_calls

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -159,7 +159,7 @@ module ActionView
             content = capture(&block)
           end
           if content
-            save_content_for_to_cache(name, content)
+            save_content_for_call_to_cache(name, content, options)
             options[:flush] ? @view_flow.set(name, content) : @view_flow.append(name, content)
           end
           nil
@@ -214,15 +214,14 @@ module ActionView
       end
 
       private
-        # In case we are currently inside of a cache block, save the content passed to content_for
-        # calls so that we can write it to the cache when we write the fragment content.
-        def save_content_for_to_cache(name, content)
+        # In case we are currently inside of a cache block, save the arguments passed to content_for
+        # so that we can write these calls to the cache when we write the fragment content, so that
+        # they can be replayed when we fetch that fragment from the cache.
+        def save_content_for_call_to_cache(*args)
           return unless controller.try(:perform_caching)
+          return unless instance_variable_defined?(:@_content_for_calls_to_cache)
 
-          if instance_variable_defined?(:@_content_for_to_cache)
-            @_content_for_to_cache[name] ||= Array.new
-            @_content_for_to_cache[name] << content
-          end
+          @_content_for_calls_to_cache << args
         end
     end
   end

--- a/actionview/lib/action_view/helpers/capture_helper.rb
+++ b/actionview/lib/action_view/helpers/capture_helper.rb
@@ -152,6 +152,7 @@ module ActionView
       #   <% content_for :script, javascript_include_tag(:defaults) %>
       #
       def content_for(name, content = nil, options = {}, &block)
+        options.assert_valid_keys(:flush)
         if content || block_given?
           if block_given?
             options = content if content

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -19,7 +19,7 @@ class RelationCacheTest < ActionView::TestCase
     assert_queries(1) do
       cache(Project.all) { concat("Hello World") }
     end
-    assert_equal "Hello World", controller.cache_store.read("views/test/hello_world:fa9482a68ce25bf7589b8eddad72f736/projects-#{Project.count}")[:_fragment]
+    assert_equal "Hello World", controller.cache_store.read("views/test/hello_world:fa9482a68ce25bf7589b8eddad72f736/projects-#{Project.count}")
   end
 
   def view_cache_dependencies; []; end

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -19,7 +19,7 @@ class RelationCacheTest < ActionView::TestCase
     assert_queries(1) do
       cache(Project.all) { concat("Hello World") }
     end
-    assert_equal "Hello World", controller.cache_store.read("views/test/hello_world:fa9482a68ce25bf7589b8eddad72f736/projects-#{Project.count}")
+    assert_equal "Hello World", controller.cache_store.read("views/test/hello_world:fa9482a68ce25bf7589b8eddad72f736/projects-#{Project.count}")[:_fragment]
   end
 
   def view_cache_dependencies; []; end

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -163,6 +163,22 @@ class CaptureHelperTest < ActionView::TestCase
     assert_predicate content_for(:title), :html_safe?
   end
 
+  def test_cache_with_content_for
+    content_for(:uncached, "content")
+
+    cache 'something' do
+      assert_not_nil @_content_for_to_cache
+      assert_nil content_for_to_cache
+      content_for(:widget, "content")
+      assert_equal "content", content_for(:widget)
+      assert_equal "content", content_for_to_cache[:widget]
+    end
+    assert_nil @_content_for_to_cache
+    assert_nil content_for_to_cache
+    assert_equal "content", content_for(:uncached)
+    assert_equal "content", content_for(:widget)
+  end
+
   def test_provide
     assert_not content_for?(:title)
     provide :title, "hi"

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -166,7 +166,7 @@ class CaptureHelperTest < ActionView::TestCase
   def test_cache_with_content_for
     content_for(:uncached, "content")
 
-    cache 'something' do
+    cache "something" do
       assert_not_nil @_content_for_calls_to_cache
       assert_nil content_for_calls_to_cache
 
@@ -181,7 +181,7 @@ class CaptureHelperTest < ActionView::TestCase
       assert_equal "new", content_for(:widget)
       expected = [
         [:widget, "content", {}],
-        [:widget, "new", {flush: true}]
+        [:widget, "new", { flush: true }]
       ]
       assert_equal expected, content_for_calls_to_cache
     end

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -167,16 +167,28 @@ class CaptureHelperTest < ActionView::TestCase
     content_for(:uncached, "content")
 
     cache 'something' do
-      assert_not_nil @_content_for_to_cache
-      assert_nil content_for_to_cache
+      assert_not_nil @_content_for_calls_to_cache
+      assert_nil content_for_calls_to_cache
+
       content_for(:widget, "content")
       assert_equal "content", content_for(:widget)
-      assert_equal "content", content_for_to_cache[:widget]
+      expected = [
+        [:widget, "content", {}],
+      ]
+      assert_equal expected, content_for_calls_to_cache
+
+      content_for(:widget, "new", flush: true)
+      assert_equal "new", content_for(:widget)
+      expected = [
+        [:widget, "content", {}],
+        [:widget, "new", {flush: true}]
+      ]
+      assert_equal expected, content_for_calls_to_cache
     end
-    assert_nil @_content_for_to_cache
-    assert_nil content_for_to_cache
+    assert_nil @_content_for_calls_to_cache
+    assert_nil content_for_calls_to_cache
     assert_equal "content", content_for(:uncached)
-    assert_equal "content", content_for(:widget)
+    assert_equal "new", content_for(:widget)
   end
 
   def test_provide


### PR DESCRIPTION
### Summary

The fact that you can’t use `content_for` within a `cache` block has been documented (as a warning on [`content_for`](https://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html#method-i-content_for)), but it is a surprising and very easy-to-forget behavior with no good workaround.

There has been interest in fixing this behavior so that it "just works" as far back as 2009 (over 10 years ago!) in [this issue](https://rails.lighthouseapp.com/projects/8994/tickets/3409-content_for-and-fragment-caching) and as recently as this feature request #20513 from @davydotcom and [this feature request](https://discuss.rubyonrails.org/t/feature-request-ability-to-use-content-for-within-a-fragment-cache-block/75607).

This merge request builds off the work begun by Steve Hull (and @stackng, etc., who provided a patch for Rails 3.x as a gist), plus fixes some edge cases such as passing `flush: true` to `content_for` within a `cache` block.

### Design goals

- idempotency: make the page have the same content (including `content_for` content) both the 1st time page is loaded (cache miss) and the 2nd time (content loaded from cache). Simply reloading the page should not change the content for the page.
- minimize overhead and space used:
    - don't have any additional storage overhead unless needed (unless using `content_for`)
    - don't require extra writes/fetches from the cache backend (combine into a single write/fetch when possible)