### PR TITLE
Support passing record to uniqueness validator's :conditions option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Support passing record to uniqueness validator `:conditions` callable:
+
+    ```ruby
+    class Article < ApplicationRecord
+      validates_uniqueness_of :title, conditions: ->(article) {
+        published_at = article.published_at
+        where(published_at: published_at.beginning_of_year..published_at.end_of_year)
+      }
+    end
+    ```
+
+    *Eliot Sykes*
+
 *   `BatchEnumerator#update_all` and `BatchEnumerator#delete_all` now return the
     total number of rows affected, just like their non-batched counterparts.
 


### PR DESCRIPTION
Support passing record to uniqueness validator's `:conditions` option.

This allows building conditions based on the record's attributes.

E.g. To validate slug must be unique for the day of publication:

```rb
class Article < ApplicationRecord

  validates_uniqueness_of :slug,
    conditions: ->(record) {
      where(published_at: record.published_at.beginning_of_day..record.published_at.end_of_day)
    }
```

If this is a welcome addition, please say and I'll refine this and add test coverage.
