### PR TITLE
Lazily deserialize job arguments in test helper

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -402,6 +402,18 @@ module ActiveJob
       end
 
       matching_job = jobs.find do |enqueued_job|
+        if expected_args[:job].present?
+          if expected_args[:job].respond_to?(:call)
+            if !expected_args[:job].call(enqueued_job[:job])
+              potential_matches << enqueued_job
+              next
+            end
+          elsif expected_args[:job] != enqueued_job[:job]
+            potential_matches << enqueued_job
+            next
+          end
+        end
+
         deserialized_job = deserialize_args_for_assertion(enqueued_job)
         potential_matches << deserialized_job
 


### PR DESCRIPTION
### Summary

If there is a job in `enqueued_jobs` whose arguments are not deserializable for some reason (for example, a deleted ActiveRecord model) `assert_enqueued_with` will raise an error even if the job we're looking for is in the `enqueued_jobs` array.

This solution isn't as tidy as I was hoping for - definitely open to suggestions on other approaches!

### Other Information

Fixes https://github.com/rails/rails/issues/39606