### PR TITLE
Default forgery protection strategy

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -131,7 +131,7 @@ module ActionController #:nodoc:
       def protect_from_forgery(options = {})
         options = options.reverse_merge(prepend: false)
 
-        self.forgery_protection_strategy = protection_method_class(options[:with] || :null_session)
+        self.forgery_protection_strategy = protection_method_class(options[:with] || :exception)
         self.request_forgery_protection_token ||= :authenticity_token
         before_action :verify_authenticity_token, options
         append_after_action :verify_same_origin_request


### PR DESCRIPTION
### Summary
This set `:exception` as default forgery protection strategy, what is a
more secure default.

It would prevent users from setting a less secure strategy if they do not specify it.

### Other Information
Some related PR's would be:
- [Default protect from forgery #29742](https://github.com/rails/rails/pull/29742)
- [configure how unverified request will be handled #5326](https://github.com/rails/rails/pull/5326)