### PR TITLE
PERF: 45% faster attributes for readonly usage

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -5,16 +5,16 @@ require "active_support/core_ext/object/duplicable"
 module ActiveModel
   class Attribute # :nodoc:
     class << self
-      def from_database(name, value, type)
-        FromDatabase.new(name, value, type)
+      def from_database(name, value_before_type_cast, type, value = nil)
+        FromDatabase.new(name, value_before_type_cast, type, nil, value)
       end
 
-      def from_user(name, value, type, original_attribute = nil)
-        FromUser.new(name, value, type, original_attribute)
+      def from_user(name, value_before_type_cast, type, original_attribute = nil)
+        FromUser.new(name, value_before_type_cast, type, original_attribute)
       end
 
-      def with_cast_value(name, value, type)
-        WithCastValue.new(name, value, type)
+      def with_cast_value(name, value_before_type_cast, type)
+        WithCastValue.new(name, value_before_type_cast, type)
       end
 
       def null(name)
@@ -30,11 +30,12 @@ module ActiveModel
 
     # This method should not be called directly.
     # Use #from_database or #from_user
-    def initialize(name, value_before_type_cast, type, original_attribute = nil)
+    def initialize(name, value_before_type_cast, type, original_attribute = nil, value = nil)
       @name = name
       @value_before_type_cast = value_before_type_cast
       @type = type
       @original_attribute = original_attribute
+      @value = value unless value.nil?
     end
 
     def value

--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -13,11 +13,11 @@ module ActiveModel
     end
 
     def [](name)
-      attributes[name] || Attribute.null(name)
+      @attributes[name] || default_attribute(name)
     end
 
     def []=(name, value)
-      attributes[name] = value
+      @attributes[name] = value
     end
 
     def values_before_type_cast
@@ -25,9 +25,9 @@ module ActiveModel
     end
 
     def to_hash
-      initialized_attributes.transform_values(&:value)
+      keys.index_with { |name| self[name].value }
     end
-    alias_method :to_h, :to_hash
+    alias :to_h :to_hash
 
     def key?(name)
       attributes.key?(name) && self[name].initialized?
@@ -42,38 +42,36 @@ module ActiveModel
     end
 
     def write_from_database(name, value)
-      attributes[name] = self[name].with_value_from_database(value)
+      @attributes[name] = self[name].with_value_from_database(value)
     end
 
     def write_from_user(name, value)
       raise FrozenError, "can't modify frozen attributes" if frozen?
-      attributes[name] = self[name].with_value_from_user(value)
+      @attributes[name] = self[name].with_value_from_user(value)
       value
     end
 
     def write_cast_value(name, value)
-      attributes[name] = self[name].with_cast_value(value)
+      @attributes[name] = self[name].with_cast_value(value)
       value
     end
 
     def freeze
-      @attributes.freeze
+      attributes.freeze
       super
     end
 
     def deep_dup
-      self.class.allocate.tap do |copy|
-        copy.instance_variable_set(:@attributes, attributes.deep_dup)
-      end
+      AttributeSet.new(attributes.deep_dup)
     end
 
     def initialize_dup(_)
-      @attributes = attributes.dup
+      @attributes = @attributes.dup
       super
     end
 
     def initialize_clone(_)
-      @attributes = attributes.clone
+      @attributes = @attributes.clone
       super
     end
 
@@ -84,7 +82,7 @@ module ActiveModel
     end
 
     def accessed
-      attributes.select { |_, attr| attr.has_been_read? }.keys
+      attributes.each_key.select { |name| self[name].has_been_read? }
     end
 
     def map(&block)
@@ -100,8 +98,8 @@ module ActiveModel
       attr_reader :attributes
 
     private
-      def initialized_attributes
-        attributes.select { |_, attr| attr.initialized? }
+      def default_attribute(name)
+        Attribute.null(name)
       end
   end
 end

--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -13,29 +13,94 @@ module ActiveModel
       end
 
       def build_from_database(values = {}, additional_types = {})
-        attributes = LazyAttributeHash.new(types, values, additional_types, default_attributes)
-        LazyAttributeSet.new(attributes)
+        LazyAttributeSet.new(values, types, additional_types, default_attributes)
       end
     end
   end
 
   class LazyAttributeSet < AttributeSet # :nodoc:
-    def fetch_value(name, &block)
-      attributes.fetch_value(name, &block)
+    def initialize(values, types, additional_types, default_attributes, attributes = {})
+      super(attributes)
+      @values = values
+      @types = types
+      @additional_types = additional_types
+      @default_attributes = default_attributes
+      @casted_values = {}
+      @materialized = false
     end
+
+    def key?(name)
+      (values.key?(name) || types.key?(name) || @attributes.key?(name)) && self[name].initialized?
+    end
+
+    def keys
+      keys = values.keys | types.keys | @attributes.keys
+      keys.keep_if { |name| self[name].initialized? }
+    end
+
+    def fetch_value(name, &block)
+      if attr = @attributes[name]
+        return attr.value(&block)
+      end
+
+      @casted_values.fetch(name) do
+        value_present = true
+        value = values.fetch(name) { value_present = false }
+
+        if value_present
+          type = additional_types.fetch(name, types[name])
+          @casted_values[name] = type.deserialize(value)
+        else
+          attr = default_attribute(name, value_present, value)
+          attr.value(&block)
+        end
+      end
+    end
+
+    protected
+      def attributes
+        unless @materialized
+          values.each_key { |key| self[key] }
+          types.each_key { |key| self[key] }
+          @materialized = true
+        end
+        @attributes
+      end
+
+    private
+      attr_reader :values, :types, :additional_types, :default_attributes
+
+      def default_attribute(
+        name,
+        value_present = true,
+        value = values.fetch(name) { value_present = false }
+      )
+        type = additional_types.fetch(name, types[name])
+
+        if value_present
+          @attributes[name] = Attribute.from_database(name, value, type, @casted_values[name])
+        elsif types.key?(name)
+          if attr = default_attributes[name]
+            @attributes[name] = attr.dup
+          else
+            @attributes[name] = Attribute.uninitialized(name, type)
+          end
+        else
+          Attribute.null(name)
+        end
+      end
   end
 
   class LazyAttributeHash # :nodoc:
-    delegate :transform_values, :each_key, :each_value, :fetch, :except, to: :materialize
+    delegate :transform_values, :each_value, :fetch, :except, to: :materialize
 
     def initialize(types, values, additional_types, default_attributes, delegate_hash = {})
       @types = types
       @values = values
       @additional_types = additional_types
-      @default_attributes = default_attributes
-      @delegate_hash = delegate_hash
-      @casted_values = {}
       @materialized = false
+      @delegate_hash = delegate_hash
+      @default_attributes = default_attributes
     end
 
     def key?(key)
@@ -50,25 +115,6 @@ module ActiveModel
       delegate_hash[key] = value
     end
 
-    def fetch_value(name, &block)
-      if attr = delegate_hash[name]
-        return attr.value(&block)
-      end
-
-      @casted_values.fetch(name) do
-        value_present = true
-        value = values.fetch(name) { value_present = false }
-
-        if value_present
-          type = additional_types.fetch(name, types[name])
-          @casted_values[name] = type.deserialize(value)
-        else
-          attr = assign_default_value(name, value_present, value) || Attribute.null(name)
-          attr.value(&block)
-        end
-      end
-    end
-
     def deep_dup
       dup.tap do |copy|
         copy.instance_variable_set(:@delegate_hash, delegate_hash.transform_values(&:dup))
@@ -80,14 +126,9 @@ module ActiveModel
       super
     end
 
-    def select
+    def each_key(&block)
       keys = types.keys | values.keys | delegate_hash.keys
-      keys.each_with_object({}) do |key, hash|
-        attribute = self[key]
-        if yield(key, attribute)
-          hash[key] = attribute
-        end
-      end
+      keys.each(&block)
     end
 
     def ==(other)
@@ -130,15 +171,13 @@ module ActiveModel
     private
       attr_reader :types, :values, :additional_types, :delegate_hash, :default_attributes
 
-      def assign_default_value(
-        name,
-        value_present = true,
-        value = values.fetch(name) { value_present = false }
-      )
+      def assign_default_value(name)
         type = additional_types.fetch(name, types[name])
+        value_present = true
+        value = values.fetch(name) { value_present = false }
 
         if value_present
-          delegate_hash[name] = Attribute.from_database(name, value, type, @casted_values[name])
+          delegate_hash[name] = Attribute.from_database(name, value, type)
         elsif types.key?(name)
           attr = default_attributes[name]
           if attr

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -219,6 +219,12 @@ module ActiveModel
 
     test "marshalling dump/load legacy materialized attribute hash" do
       builder = AttributeSet::Builder.new(foo: Type::String.new)
+
+      def builder.build_from_database(values = {}, additional_types = {})
+        attributes = LazyAttributeHash.new(types, values, additional_types, default_attributes)
+        AttributeSet.new(attributes)
+      end
+
       attributes = builder.build_from_database(foo: "1")
 
       attributes.instance_variable_get(:@attributes).instance_eval do


### PR DESCRIPTION
Instantiating attributes hash from raw database values is one of the
slower part of attributes.

Why that is necessary is to detect mutations. In other words, that isn't
necessary until mutations are happened.

`LazyAttributeHash` which was introduced at 0f29c21 is to instantiate
attribute lazily until first accessing the attribute (i.e.
`Model.find(1)` isn't slow yet, but `Model.find(1).attr_name` is still
slow).

This introduces `LazyAttributeSet` to instantiate attribute more lazily,
it doesn't instantiate attribute until first assigning/dirty checking
the attribute (i.e. `Model.find(1).attr_name` is no longer slow).

It makes attributes access about 35% faster for readonly (non-mutation)
usage.

<details>
<summary>https://gist.github.com/kamipo/4002c96a02859d8fe6503e26d7be4ad8</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails"
  gem "sqlite3"
  gem "benchmark-ips"
  gem "benchmark-memory"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :models, force: true do |t|
    t.string :col1
    t.string :col2
    t.string :col3
    t.string :col4
    t.string :col5
    t.string :col6
    t.string :col7
    t.string :col8
    t.string :col9
  end
end

ActiveRecord::Base.immutable_strings_by_default = true

class Model < ActiveRecord::Base; end

ENV["RECORDS"] ||= "10000"

Model.transaction do
  ENV["RECORDS"].to_i.times do |i|
    Model.create!(
      col1: "hello, world!",
      col2: "hello, world!",
      col3: "hello, world!",
      col4: "hello, world!",
      col5: "hello, world!",
      col6: "hello, world!",
      col7: "hello, world!",
      col8: "hello, world!",
      col9: "hello, world!"
    )
  end
end

benchmark = -> x {
  x.report("attribute access") do
    records = Model.find_by_sql("SELECT * FROM models")
    records.each do |record|
      record.id
      record.col1
      record.col2
      record.col3
      record.col4
      record.col5
      record.col6
      record.col7
      record.col8
      record.col9
    end
  end
}

puts "IPS"
Benchmark.ips(&benchmark)

puts "MEMORY"
Benchmark.memory(&benchmark)
```
</details>

Before:

```
IPS
Warming up --------------------------------------
    attribute access     1.000  i/100ms
Calculating -------------------------------------
    attribute access      3.444  (± 0.0%) i/s -     18.000  in   5.259030s
MEMORY
Calculating -------------------------------------
    attribute access    38.902M memsize (     0.000  retained)
                       350.044k objects (     0.000  retained)
                        15.000  strings (     0.000  retained)
```

After (with `immutable_strings_by_default = true`):

```
IPS
Warming up --------------------------------------
    attribute access     1.000  i/100ms
Calculating -------------------------------------
    attribute access      4.652  (±21.5%) i/s -     23.000  in   5.034853s
MEMORY
Calculating -------------------------------------
    attribute access    27.782M memsize (     0.000  retained)
                       170.044k objects (     0.000  retained)
                        15.000  strings (     0.000  retained)
```

* PERF: Avoid extra delegation to `LazyAttributeHash`

The extra delegation to `LazyAttributeHash` has non-negligible overhead.

Avoiding that delegation makes attributes access about 45% faster for
readonly (non-mutation) usage.

After (with `immutable_strings_by_default = true`):

```
IPS
Warming up --------------------------------------
    attribute access     1.000  i/100ms
Calculating -------------------------------------
    attribute access      5.066  (±19.7%) i/s -     25.000  in   5.024650s
MEMORY
Calculating -------------------------------------
    attribute access    27.382M memsize (     0.000  retained)
                       160.044k objects (     0.000  retained)
                        15.000  strings (     0.000  retained)
```