### PR TITLE
Generate compound index only for one join table attributes pair

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/migration/migration_generator.rb
@@ -43,9 +43,12 @@ module ActiveRecord
         end
 
         def set_index_names
-          attributes.each_with_index do |attr, i|
-            attr.index_name = [attr, attributes[i - 1]].map { |a| index_name_for(a) }
-          end
+          attr_one = attributes.first
+          attr_one.index_name = [attr_one, attributes[-1]].map { |a| index_name_for(a) }
+          attr_one.has_uniq_index = true
+
+          attr_two = attributes.second
+          attr_two.index_name = ":#{index_name_for(attr_two)}"
         end
 
         def index_name_for(attribute)

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -11,7 +11,7 @@ module Rails
 
       attr_accessor :name, :type
       attr_reader   :attr_options
-      attr_writer   :index_name
+      attr_writer   :index_name, :has_uniq_index
 
       class << self
         def parse(column_definition)

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -260,13 +260,13 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
 
   def test_create_join_table_migration
     migration = "add_media_join_table"
-    run_generator [migration, "artist_id", "musics:uniq"]
+    run_generator [migration, "artists", "musics"]
 
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/create_join_table :artists, :musics/, change)
-        assert_match(/# t\.index \[:artist_id, :music_id\]/, change)
-        assert_match(/  t\.index \[:music_id, :artist_id\], unique: true/, change)
+        assert_match(/# t\.index \[:artist_id, :music_id\], unique: true/, change)
+        assert_match(/# t\.index \:music_id/, change)
       end
     end
   end
@@ -368,13 +368,13 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   def test_create_join_table_migration_with_singular_table_name
     with_singular_table_name do
       migration = "add_media_join_table"
-      run_generator [migration, "artist_id", "music:uniq"]
+      run_generator [migration, "artist_id", "music"]
 
       assert_migration "db/migrate/#{migration}.rb" do |content|
         assert_method :change, content do |change|
           assert_match(/create_join_table :artist, :music/, change)
           assert_match(/# t\.index \[:artist_id, :music_id\]/, change)
-          assert_match(/  t\.index \[:music_id, :artist_id\], unique: true/, change)
+          assert_match(/# t\.index :music_id/, change)
         end
       end
     end


### PR DESCRIPTION
### Summary

Using `rails g migration create_join_table_product_user product user` command currently generates the following migration:

```
class CreateJoinTableProductUser < ActiveRecord::Migration[5.2]
  def change
    create_join_table :products, :users do |t|
      # t.index [:product_id, :user_id]
      # t.index [:user_id, :product_id]
    end
  end
end
```
It suggests adding two compound indexes on both foreign keys. This is not necessary. 

Normal usage of join table will only ever use a single column from indexes (I've removed some output for brevity):

```
Product.last.users.explain 

Bitmap Index Scan on index_products_users_on_product_id_and_user_id  
              Index Cond: (product_id = '74190'::bigint)

User.last.products.explain 

Bitmap Index Scan on index_products_users_on_user_id_and_product_id  
               Index Cond: (user_id = '2392'::bigint)
```
Accessing relation objects through join table will only ever use a single column from the compound index.

Only case where compound index would be used on both columns would take place if code like that was executed:

```
UsersProducts.where(user_id: 1, product_id: 2)
```
But if you know ids of both sides of the relation than join table is not needed.

I think that the only valid use case for compound index on join tables is making it unique to avoid duplicate entries.

This PR removes additional compound index suggestion and adds unique option to the first compound index resulting in the following output:

```
class CreateJoinTableProductUser < ActiveRecord::Migration[5.2]
  def change
    create_join_table :products, :users do |t|
      # t.index [:product_id, :user_id], unique: true
      # t.index :user_id
    end
  end
end
```