### PR TITLE
Use COMPONENT_ROOT as app_root when present in test unit reporting.

### DIFF
--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -82,6 +82,8 @@ module Rails
         @app_root ||=
           if defined?(ENGINE_ROOT)
             ENGINE_ROOT
+          elsif defined?(COMPONENT_ROOT)
+            COMPONENT_ROOT
           elsif Rails.respond_to?(:root)
             Rails.root
           end

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -5,6 +5,7 @@ require "minitest"
 
 module Rails
   class TestUnitReporter < Minitest::StatisticsReporter
+    class_attribute :app_root
     class_attribute :executable, default: "rails test"
 
     def record(result)
@@ -79,11 +80,9 @@ module Rails
       end
 
       def app_root
-        @app_root ||=
+        @app_root ||= self.class.app_root ||
           if defined?(ENGINE_ROOT)
             ENGINE_ROOT
-          elsif defined?(COMPONENT_ROOT)
-            COMPONENT_ROOT
           elsif Rails.respond_to?(:root)
             Rails.root
           end

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -11,14 +11,6 @@ require "rails/test_unit/line_filtering"
 require "active_support"
 require "active_support/test_case"
 
-class << Rails
-  # Necessary to get rerun-snippets working.
-  def root
-    @root ||= Pathname.new(COMPONENT_ROOT)
-  end
-  alias __root root
-end
-
 ActiveSupport::TestCase.extend Rails::LineFiltering
 Rails::TestUnitReporter.executable = "bin/test"
 

--- a/tools/test.rb
+++ b/tools/test.rb
@@ -12,6 +12,7 @@ require "active_support"
 require "active_support/test_case"
 
 ActiveSupport::TestCase.extend Rails::LineFiltering
+Rails::TestUnitReporter.app_root = COMPONENT_ROOT
 Rails::TestUnitReporter.executable = "bin/test"
 
 Rails::TestUnit::Runner.parse_options(ARGV)


### PR DESCRIPTION
Currently running test via bundle `bin/test` command provides wrong rerun command.

```
bin/test home/retro/code/oss/rails/actionpack/test/controller/url_for_test.rb:357
```

There are two problems:

1. it strips leading `/` in path (thanks to have `Rails.root` nil in here)
https://github.com/rails/rails/blob/00c2d3e1e61093451a00b1b70548cfd9ae549c53/railties/lib/rails/test_unit/reporter.rb#L53-L55
2. full path instead of relative one is used

`Rails.root` is being re-defined in `tools/test.rb`, but it is already too late when this happens. Instead of hacking `Rails.root` I have decided to enhance `app_root` in `test_unit/reporter.rb`.

## before

```
[retro@retro  actionpack (master *$=)]❤ bin/test test/controller/url_for_test.rb:357
Run options: --seed 63991
                                               
# Running:     

F                                                                                              
                                                                                               
Failure:                                      
AbstractController::Testing::UrlForTest#test_params_option [/home/retro/code/oss/rails/actionpack/test/controller/url_for_test.rb:360]:
Expected: "/c/a?domain=foo&id=1"   
  Actual: "/c/a"
                                               
                                                                                               
bin/test home/retro/code/oss/rails/actionpack/test/controller/url_for_test.rb:357

```

## after

```
[retro@retro  actionpack (master *$=)]❤ bin/test test/controller/url_for_test.rb:357
Run options: --seed 63991
                                               
# Running:     

F                                                                                              
                                                                                               
Failure:                                      
AbstractController::Testing::UrlForTest#test_params_option [/home/retro/code/oss/rails/actionpack/test/controller/url_for_test.rb:360]:
Expected: "/c/a?domain=foo&id=1"   
  Actual: "/c/a"
                                               
                                                                                               
bin/test test/controller/url_for_test.rb:357

```