### PR TITLE
Check url_for options params is hash before merging it into actual pa…

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -825,7 +825,7 @@ module ActionDispatch
         path = route_with_params.path(method_name)
         params = route_with_params.params
 
-        if options.key? :params
+        if options.key?(:params) && options[:params].is_a?(Hash)
           params.merge! options[:params]
         end
 

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -354,12 +354,17 @@ module AbstractController
         assert_equal({ p2: "Y2" }.to_query, params[1])
       end
 
-      def test_params_option
+      def test_params_hash_option
         url = W.new.url_for(only_path: true, controller: "c", action: "a", params: { domain: "foo", id: "1" })
         params = extract_params(url)
         assert_equal("/c/a?domain=foo&id=1", url)
         assert_equal({ domain: "foo" }.to_query, params[0])
         assert_equal({ id: "1" }.to_query, params[1])
+      end
+
+      def test_params_string_ignores_option
+        url = W.new.url_for(only_path: true, controller: "c", action: "a", params: "p")
+        assert_equal("/c/a", url)
       end
 
       def test_hash_parameter


### PR DESCRIPTION
This is based on https://github.com/rails/rails/pull/33256#issuecomment-401328051 and https://github.com/kaminari/kaminari/issues/1025#issuecomment-629745613.

TL;DR; currently any application re-using `params` for `url_for` (as is for example used in popular kaminari gem) explodes when you add manually `&params=whatever` to url.

## before 

```ruby
url_for(only_path: true, controller: "c", action: "a", params: "p")

TypeError: no implicit conversion of String into Hash                       
    /home/retro/code/oss/rails/actionpack/lib/action_dispatch/routing/route_set.rb:829:in `merge!'
    /home/retro/code/oss/rails/actionpack/lib/action_dispatch/routing/route_set.rb:829:in `url_for'
    /home/retro/code/oss/rails/actionpack/lib/action_dispatch/routing/url_for.rb:181:in `full_url_for'
    /home/retro/code/oss/rails/actionpack/lib/action_dispatch/routing/url_for.rb:171:in `url_for'
    /home/retro/code/oss/rails/actionpack/test/controller/url_for_test.rb:366:in `test_params_string_option'
```

## after (it is ignored)

```ruby
url_for(only_path: true, controller: "c", action: "a", params: "p") #=> "/c/a"
```