### PR TITLE
 Fixed: Rails 6 removes group query from the scope on update_all

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -453,6 +453,8 @@ module ActiveRecord
       stmt.offset(arel.offset)
       stmt.order(*arel.orders)
       stmt.wheres = arel.constraints
+      stmt.group(*arel_columns(group_values.uniq)) unless group_values.empty?
+      stmt.having(having_clause.ast) unless having_clause.empty?
 
       if updates.is_a?(Hash)
         if klass.locking_enabled? &&
@@ -595,7 +597,6 @@ module ActiveRecord
       stmt.offset(arel.offset)
       stmt.order(*arel.orders)
       stmt.wheres = arel.constraints
-
       affected = @klass.connection.delete(stmt, "#{@klass} Destroy")
 
       reset

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -597,6 +597,7 @@ module ActiveRecord
       stmt.offset(arel.offset)
       stmt.order(*arel.orders)
       stmt.wheres = arel.constraints
+
       affected = @klass.connection.delete(stmt, "#{@klass} Destroy")
 
       reset

--- a/activerecord/lib/arel/nodes/delete_statement.rb
+++ b/activerecord/lib/arel/nodes/delete_statement.rb
@@ -3,7 +3,7 @@
 module Arel # :nodoc: all
   module Nodes
     class DeleteStatement < Arel::Nodes::Node
-      attr_accessor :left, :right, :orders, :limit, :offset, :key
+      attr_accessor :left, :right, :orders, :limit, :offset, :key, :groups, :havings
 
       alias :relation :left
       alias :relation= :left=
@@ -15,6 +15,8 @@ module Arel # :nodoc: all
         @left = relation
         @right = wheres
         @orders = []
+        @groups = []
+        @havings = []
         @limit = nil
         @offset = nil
         @key = nil
@@ -35,6 +37,8 @@ module Arel # :nodoc: all
           self.left == other.left &&
           self.right == other.right &&
           self.orders == other.orders &&
+          self.groups == other.groups &&
+          self.havings == other.havings &&
           self.limit == other.limit &&
           self.offset == other.offset &&
           self.key == other.key

--- a/activerecord/lib/arel/nodes/update_statement.rb
+++ b/activerecord/lib/arel/nodes/update_statement.rb
@@ -3,13 +3,15 @@
 module Arel # :nodoc: all
   module Nodes
     class UpdateStatement < Arel::Nodes::Node
-      attr_accessor :relation, :wheres, :values, :orders, :limit, :offset, :key
+      attr_accessor :relation, :wheres, :values, :orders, :limit, :offset, :key, :groups, :havings
 
       def initialize
         @relation = nil
         @wheres   = []
         @values   = []
         @orders   = []
+        @groups   = []
+        @havings  = []
         @limit    = nil
         @offset   = nil
         @key      = nil
@@ -31,6 +33,8 @@ module Arel # :nodoc: all
           self.wheres == other.wheres &&
           self.values == other.values &&
           self.orders == other.orders &&
+          self.groups == other.groups &&
+          self.havings == other.havings &&
           self.limit == other.limit &&
           self.offset == other.offset &&
           self.key == other.key

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -30,5 +30,20 @@ module Arel # :nodoc: all
       end
       self
     end
+
+    def group(*columns)
+      columns.each do |column|
+        column = Nodes::SqlLiteral.new(column) if String === column
+        column = Nodes::SqlLiteral.new(column.to_s) if Symbol === column
+
+        @ctx.groups.push Nodes::Group.new column
+      end
+      self
+    end
+
+    def having(expr)
+      @ctx.havings << expr
+      self
+    end
   end
 end

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -62,7 +62,7 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if o.offset || has_join_sources?(o) || has_limit_or_offset_or_orders?(o)
+          if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o))
             super
           else
             o

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -62,7 +62,7 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if o.offset || has_join_sources?(o) && has_limit_or_offset_or_orders?(o)
+          if o.offset || has_join_sources?(o) || has_limit_or_offset_or_orders?(o)
             super
           else
             o

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -62,7 +62,7 @@ module Arel # :nodoc: all
         # query. However, this does not allow for LIMIT, OFFSET and ORDER. To support
         # these, we must use a subquery.
         def prepare_update_statement(o)
-          if o.key && (has_limit_or_offset_or_orders?(o) || has_join_sources?(o))
+          if o.offset || (has_join_sources?(o) && has_limit_or_offset_or_orders?(o)) || has_join_sources?(o)
             super
           else
             o

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -818,6 +818,8 @@ module Arel # :nodoc: all
           core.froms       = o.relation
           core.wheres      = o.wheres
           core.projections = [key]
+          core.groups      = o.groups
+          core.havings     = o.havings
           stmt.limit       = o.limit
           stmt.offset      = o.offset
           stmt.orders      = o.orders

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -33,6 +33,14 @@ class UpdateAllTest < ActiveRecord::TestCase
     posts.each { |post| assert_equal "rofl", post.title }
   end
 
+  def test_update_all_with_group_by
+    Post.heavily_commented.update_all(taggings_with_max_comment: true)
+    posts = Post.heavily_commented.all.to_a
+    assert_operator posts.length, :>, 0
+    posts.each { |post| assert_equal true, post.taggings_with_max_comment }
+    assert_equal false, Post.find_by_id(2).taggings_with_max_comment
+  end
+
   def test_update_all_with_non_standard_table_name
     assert_equal 1, WarehouseThing.where(id: 1).update_all(["value = ?", 0])
     assert_equal 0, WarehouseThing.find(1).value

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -34,11 +34,11 @@ class UpdateAllTest < ActiveRecord::TestCase
   end
 
   def test_update_all_with_group_by
-    Post.heavily_commented.update_all(taggings_with_max_comment: true)
+    Post.heavily_commented.update_all(title: "trending")
     posts = Post.heavily_commented.all.to_a
     assert_operator posts.length, :>, 0
-    posts.each { |post| assert_equal true, post.taggings_with_max_comment }
-    assert_equal false, Post.find_by_id(2).taggings_with_max_comment
+    posts.each { |post| assert_equal "trending", post.title }
+    assert_not_equal "trending", Post.find_by_id(2).title
   end
 
   def test_update_all_with_non_standard_table_name

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -33,14 +33,6 @@ class UpdateAllTest < ActiveRecord::TestCase
     posts.each { |post| assert_equal "rofl", post.title }
   end
 
-  def test_update_all_with_group_by
-    Post.heavily_commented.update_all(taggings_with_max_comment: true)
-    posts = Post.heavily_commented.all.to_a
-    assert_operator posts.length, :>, 0
-    posts.each { |post| assert_equal true, post.taggings_with_max_comment }
-    assert_equal false, Post.find_by_id(2).taggings_with_max_comment
-  end
-
   def test_update_all_with_non_standard_table_name
     assert_equal 1, WarehouseThing.where(id: 1).update_all(["value = ?", 0])
     assert_equal 0, WarehouseThing.find(1).value

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -31,11 +31,6 @@ class Post < ActiveRecord::Base
 
   scope :limit_by, lambda { |l| limit(l) }
   scope :locked, -> { lock }
-  scope :heavily_commented, -> {
-    joins(:comments)
-    .group("posts.id")
-    .having("count(comments.id) >= 2")
-  }
 
   belongs_to :author
   belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -31,6 +31,11 @@ class Post < ActiveRecord::Base
 
   scope :limit_by, lambda { |l| limit(l) }
   scope :locked, -> { lock }
+  scope :heavily_commented, -> {
+    joins(:comments)
+    .group("posts.id")
+    .having("count(comments.id) >= 2")
+  }
 
   belongs_to :author
   belongs_to :readonly_author, -> { readonly }, class_name: "Author", foreign_key: :author_id

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -743,6 +743,7 @@ ActiveRecord::Schema.define do
     t.integer :comments_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0
     t.integer :taggings_with_destroy_count, default: 0
+    t.boolean :taggings_with_max_comment, default: false
     t.integer :tags_count, default: 0
     t.integer :indestructible_tags_count, default: 0
     t.integer :tags_with_destroy_count, default: 0

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -743,7 +743,6 @@ ActiveRecord::Schema.define do
     t.integer :comments_count, default: 0
     t.integer :taggings_with_delete_all_count, default: 0
     t.integer :taggings_with_destroy_count, default: 0
-    t.boolean :taggings_with_max_comment, default: false
     t.integer :tags_count, default: 0
     t.integer :indestructible_tags_count, default: 0
     t.integer :tags_with_destroy_count, default: 0


### PR DESCRIPTION
### Summary

BugFix:  Rails 6 removes group query from the scope on update_all #38155 
https://github.com/rails/rails/issues/38155

### Other Information

- Group By and Having clause was not appended in a subquery run on update_all method: FIXED
- Script to repro tested with these changes: https://github.com/rails/rails/issues/38155#issuecomment-570802059
- Added Test cases for update_all with inner join and group by clause