### PR TITLE
Prevent loop when using `bin/yarn`.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -1,5 +1,9 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
+  # exclude bin from PATH to prevent loop.
+  ENV["PATH"] = ENV["PATH"].split(File::PATH_SEPARATOR).reject do |path|
+    File.expand_path(path) == __dir__
+  end.join(File::PATH_SEPARATOR)
   exec "yarn", *ARGV
 rescue Errno::ENOENT
   $stderr.puts "Yarn executable was not detected in the system."


### PR DESCRIPTION
### Summary
When updating a rails application to the master branch, and running `rails app:update`,  if you have `bin` in your `PATH` you would get thrown into an infinite loop.

This excludes `bin` from the `PATH` variable, so when `bin/yarn` is called, it does not loop on itself when calling `exec "yarn"`.

Related Issue: https://github.com/rails/rails/issues/38666
Also briefly mentioned here: https://github.com/rails/rails/pull/39282#issuecomment-636550325

### Other Information
I just see this as an starting point, if renaming is considered to not be the better option. 
I'm willing to do further changes on notice.