### PR TITLE
Use bash code fences and prompts for shell code [ci skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -728,7 +728,7 @@ div.important p, div.caution p, div.warning p, div.note p, div.info p {
   margin-bottom: 1em;
 }
 
-/* Prevent shell prompt from being selectable when selecting commands*/
+/* When triple-clicking shell code, select only the command, not the prompt */
 code.language-shell-session span.token.command {
   display: inline-flex;
 }

--- a/guides/source/2_2_release_notes.md
+++ b/guides/source/2_2_release_notes.md
@@ -51,8 +51,8 @@ All told, the Guides provide tens of thousands of words of guidance for beginnin
 
 If you want to generate these guides locally, inside your application:
 
-```
-rake doc:guides
+```bash
+$ rake doc:guides
 ```
 
 This will put the guides inside `Rails.root/doc/guides` and you may start surfing straight away by opening `Rails.root/doc/guides/index.html` in your favourite browser.

--- a/guides/source/2_3_release_notes.md
+++ b/guides/source/2_3_release_notes.md
@@ -561,8 +561,8 @@ Rails Metal is a new mechanism that provides superfast endpoints inside of your 
 
 Rails 2.3 incorporates Jeremy McAnally's [rg](https://github.com/jm/rg) application generator. What this means is that we now have template-based application generation built right into Rails; if you have a set of plugins you include in every application (among many other use cases), you can just set up a template once and use it over and over again when you run the `rails` command. There's also a rake task to apply a template to an existing application:
 
-```
-rake rails:template LOCATION=~/template.rb
+```bash
+$ rake rails:template LOCATION=~/template.rb
 ```
 
 This will layer the changes from the template on top of whatever code the project already contains.

--- a/guides/source/4_0_release_notes.md
+++ b/guides/source/4_0_release_notes.md
@@ -26,8 +26,8 @@ If you're upgrading an existing application, it's a great idea to have good test
 Creating a Rails 4.0 application
 --------------------------------
 
-```
- You should have the 'rails' RubyGem installed
+```bash
+# You should have the 'rails' RubyGem installed
 $ rails new myapp
 $ cd myapp
 ```
@@ -42,13 +42,13 @@ More information: [Bundler homepage](https://bundler.io)
 
 `Bundler` and `Gemfile` makes freezing your Rails application easy as pie with the new dedicated `bundle` command. If you want to bundle straight from the Git repository, you can pass the `--edge` flag:
 
-```
+```bash
 $ rails new myapp --edge
 ```
 
 If you have a local checkout of the Rails repository and want to generate an application using that, you can pass the `--dev` flag:
 
-```
+```bash
 $ ruby /path/to/rails/railties/bin/rails new myapp --dev
 ```
 

--- a/guides/source/4_1_release_notes.md
+++ b/guides/source/4_1_release_notes.md
@@ -44,19 +44,19 @@ spring environments.
 
 **Running rake tasks:**
 
-```
-bin/rake test:models
+```bash
+$ bin/rake test:models
 ```
 
 **Running a Rails command:**
 
-```
-bin/rails console
+```bash
+$ bin/rails console
 ```
 
 **Spring introspection:**
 
-```
+```bash
 $ bin/spring status
 Spring is running:
 

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1012,7 +1012,7 @@ NOTE: Configuration files are not reloaded on each request, so you have to resta
 
 Now the user can request to get a PDF version of a client just by adding ".pdf" to the URL:
 
-```bash
+```
 GET /clients/1.pdf
 ```
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -69,8 +69,8 @@ providing the `URL` of the relay ingress and the `INGRESS_PASSWORD` you
 previously generated. If your application lived at `https://example.com`, the
 full command would look like this:
 
-```shell
-bin/rails action_mailbox:ingress:exim URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
+```bash
+$ bin/rails action_mailbox:ingress:exim URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
 ```
 
 ### Mailgun
@@ -159,7 +159,7 @@ the `URL` of the Postfix ingress and the `INGRESS_PASSWORD` you previously
 generated. If your application lived at `https://example.com`, the full command
 would look like this:
 
-```shell
+```bash
 $ bin/rails action_mailbox:ingress:postfix URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
 ```
 
@@ -225,8 +225,8 @@ providing the `URL` of the relay ingress and the `INGRESS_PASSWORD` you
 previously generated. If your application lived at `https://example.com`, the
 full command would look like this:
 
-```shell
-bin/rails action_mailbox:ingress:qmail URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
+```bash
+$ bin/rails action_mailbox:ingress:qmail URL=https://example.com/rails/action_mailbox/relay/inbound_emails INGRESS_PASSWORD=...
 ```
 
 ### SendGrid

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -834,7 +834,7 @@ $ bin/rails db:migrate RAILS_ENV=test
 By default migrations tell you exactly what they're doing and how long it took.
 A migration creating a table and adding an index might produce output like this
 
-```bash
+```
 ==  CreateProducts: migrating =================================================
 -- create_table(:products)
    -> 0.0028s
@@ -877,7 +877,7 @@ end
 
 generates the following output
 
-```bash
+```
 ==  CreateProducts: migrating =================================================
 -- Created a table
    -> and an index!

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -678,7 +678,7 @@ SELECT viewable_by, locked FROM clients
 
 Be careful because this also means you're initializing a model object with only the fields that you've selected. If you attempt to access a field that is not in the initialized record you'll receive:
 
-```bash
+```
 ActiveModel::MissingAttributeError: missing attribute: <attribute>
 ```
 

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -20,7 +20,7 @@ The [Rails API documentation](https://api.rubyonrails.org) is generated with
 in the rails root directory, run `bundle install` and execute:
 
 ```bash
-  bundle exec rake rdoc
+$ bundle exec rake rdoc
 ```
 
 Resulting HTML files can be found in the ./doc/rdoc directory.

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -370,7 +370,7 @@ Inside the `bin/rails console` you have access to the `app` and `helper` instanc
 
 With the `app` method you can access named route helpers, as well as do requests.
 
-```bash
+```ruby
 >> app.root_path
 => "/"
 
@@ -381,7 +381,7 @@ Started GET "/" for 127.0.0.1 at 2014-06-19 10:41:57 -0300
 
 With the `helper` method it is possible to access Rails and your application's helpers.
 
-```bash
+```ruby
 >> helper.time_ago_in_words 30.days.ago
 => "about 1 month"
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -418,8 +418,8 @@ $ bundle exec rake test:sqlite3
 You can now run the tests as you did for `sqlite3`. The tasks are respectively:
 
 ```bash
-test:mysql2
-test:postgresql
+$ bundle exec rake test:mysql2
+$ bundle exec rake test:postgresql
 ```
 
 Finally,

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -353,7 +353,7 @@ processing the entire request.
 
 For example:
 
-```bash
+```
 => Booting Puma
 => Rails 6.0.0 application starting in development
 => Run `bin/rails server --help` for more startup options
@@ -876,7 +876,7 @@ will be stopped and you will have to start it again.
 TIP: You can save these settings in an `.byebugrc` file in your home directory.
 The debugger reads these global settings when it starts. For example:
 
-```bash
+```
 set callstyle short
 set listsize 25
 ```

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -240,7 +240,7 @@ applications into engines.
 
 NOTE: Because of the way that Ruby does constant lookup you may run into a situation
 where your engine controller is inheriting from the main application controller and
-not your engine's application controller. Ruby is able to resolve the `ApplicationController` constant, and therefore the autoloading mechanism is not triggered. See the section [When Constants Aren't Missed](autoloading_and_reloading_constants_classic_mode.html#when-constants-aren-t-missed). 
+not your engine's application controller. Ruby is able to resolve the `ApplicationController` constant, and therefore the autoloading mechanism is not triggered. See the section [When Constants Aren't Missed](autoloading_and_reloading_constants_classic_mode.html#when-constants-aren-t-missed).
 The best way to prevent this from happening is to use `require_dependency` to ensure that the engine's application
 controller is loaded. For example:
 
@@ -730,7 +730,7 @@ from the engine. When run the next time, it will only copy over migrations that
 haven't been copied over already. The first run for this command will output
 something such as this:
 
-```bash
+```
 Copied migration [timestamp_1]_create_blorgh_articles.blorgh.rb from blorgh
 Copied migration [timestamp_2]_create_blorgh_comments.blorgh.rb from blorgh
 ```

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -149,7 +149,7 @@ Generators Lookup
 
 When you run `bin/rails generate initializer core_extensions` Rails requires these files in turn until one is found:
 
-```bash
+```
 rails/generators/initializer/initializer_generator.rb
 generators/initializer/initializer_generator.rb
 rails/generators/initializer_generator.rb

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -316,7 +316,7 @@ $ bin/rails generate controller articles index
 
 Rails will create several files and a route for you.
 
-```bash
+```
 create  app/controllers/articles_controller.rb
   route  get 'articles/index'
 invoke  erb
@@ -790,7 +790,7 @@ $ bin/rails db:migrate
 Rails will execute this migration command and tell you it created the Articles
 table.
 
-```bash
+```
 ==  CreateArticles: migrating ==================================================
 -- create_table(:articles)
    -> 0.0019s
@@ -1664,7 +1664,7 @@ $ bin/rails db:migrate
 Rails is smart enough to only execute the migrations that have not already been
 run against the current database, so in this case you will just see:
 
-```bash
+```
 ==  CreateComments: migrating =================================================
 -- create_table(:comments)
    -> 0.0115s

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -58,7 +58,7 @@ You can navigate to the directory that contains the plugin, run the `bundle inst
 
 You should see:
 
-```bash
+```
   1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
 ```
 
@@ -85,7 +85,7 @@ end
 
 Run `bin/test` to run the test. This test should fail because we haven't implemented the `to_squawk` method:
 
-```bash
+```
 E
 
 Error:
@@ -131,7 +131,7 @@ end
 
 To test that your method does what it says it does, run the unit tests with `bin/test` from your plugin directory.
 
-```bash
+```
   2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
 ```
 
@@ -353,7 +353,7 @@ end
 
 When you run `bin/test`, you should see the tests all pass:
 
-```bash
+```
   4 runs, 4 assertions, 0 failures, 0 errors, 0 skips
 ```
 
@@ -458,16 +458,16 @@ When the gem is ready to be shared as a formal release, it can be published to [
 
 Alternatively, you can benefit from Bundler's Rake tasks. You can see a full list with the following:
 
-```
-bundle exec rake -T
+```bash
+$ bundle exec rake -T
 
-bundle exec rake build
+$ bundle exec rake build
 # Build yaffle-0.1.0.gem into the pkg directory
 
-bundle exec rake install
+$ bundle exec rake install
 # Build and install yaffle-0.1.0.gem into system gems
 
-bundle exec rake release
+$ bundle exec rake release
 # Create tag v0.1.0 and build and push yaffle-0.1.0.gem to Rubygems
 ```
 

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -63,7 +63,7 @@ gem "nokogiri"
 Please note that this will NOT install the gems for you and you will have to run `bundle install` to do that.
 
 ```bash
-bundle install
+$ bundle install
 ```
 
 ### gem_group(*names, &block)

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1229,7 +1229,7 @@ edit_user GET    /users/:id/edit(.:format) users#edit
 
 You can also use the `--expanded` option to turn on the expanded table formatting mode.
 
-```
+```bash
 $ bin/rails routes --expanded
 
 --[ Route 1 ]----------------------------------------------------
@@ -1256,7 +1256,7 @@ Controller#Action | users#edit
 
 You can search through your routes with the grep option: -g. This outputs any routes that partially match the URL helper method name, the HTTP verb, or the URL path.
 
-```
+```bash
 $ bin/rails routes -g new_comment
 $ bin/rails routes -g POST
 $ bin/rails routes -g admin
@@ -1264,7 +1264,7 @@ $ bin/rails routes -g admin
 
 If you only want to see the routes that map to a specific controller, there's the -c option.
 
-```
+```bash
 $ bin/rails routes -c users
 $ bin/rails routes -c admin/users
 $ bin/rails routes -c Comments

--- a/guides/source/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ruby_on_rails_guides_guidelines.md
@@ -117,23 +117,23 @@ To install the latest version of Bundler, run `gem install bundler`.
 
 To generate all the guides, just `cd` into the `guides` directory, run `bundle install`, and execute:
 
-```
-bundle exec rake guides:generate
+```bash
+$ bundle exec rake guides:generate
 ```
 
 or
 
-```
-bundle exec rake guides:generate:html
+```bash
+$ bundle exec rake guides:generate:html
 ```
 
 Resulting HTML files can be found in the `./output` directory.
 
 To process `my_guide.md` and nothing else use the `ONLY` environment variable:
 
-```
-touch my_guide.md
-bundle exec rake guides:generate ONLY=my_guide
+```bash
+$ touch my_guide.md
+$ bundle exec rake guides:generate ONLY=my_guide
 ```
 
 By default, guides that have not been modified are not processed, so `ONLY` is rarely needed in practice.
@@ -142,22 +142,22 @@ To force processing all the guides, pass `ALL=1`.
 
 If you want to generate guides in a language other than English, you can keep them in a separate directory under `source` (e.g. `source/es`) and use the `GUIDES_LANGUAGE` environment variable:
 
-```
-bundle exec rake guides:generate GUIDES_LANGUAGE=es
+```bash
+$ bundle exec rake guides:generate GUIDES_LANGUAGE=es
 ```
 
 If you want to see all the environment variables you can use to configure the generation script just run:
 
-```
-rake
+```bash
+$ rake
 ```
 
 ### Validation
 
 Please validate the generated HTML with:
 
-```
-bundle exec rake guides:validate
+```bash
+$ bundle exec rake guides:validate
 ```
 
 Particularly, titles get an ID generated from their content and this often leads to duplicates. Please set `WARNINGS=1` when generating guides to detect them. The warning messages suggest a solution.
@@ -169,6 +169,6 @@ Kindle Guides
 
 To generate guides for the Kindle, use the following rake task:
 
-```
-bundle exec rake guides:generate:kindle
+```bash
+$ bundle exec rake guides:generate:kindle
 ```

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -189,7 +189,7 @@ end
 
 Running this test shows the friendlier assertion message:
 
-```bash
+```
 Failure:
 ArticleTest#test_should_not_save_article_without_title [/path/to/blog/test/models/article_test.rb:6]:
 Saved the article without a title
@@ -489,7 +489,7 @@ parallelize your local test suite differently from your CI, so an environment va
 to be able to easily change the number of workers a test run should use:
 
 ```bash
-PARALLEL_WORKERS=15 bin/rails test
+$ PARALLEL_WORKERS=15 bin/rails test
 ```
 
 When parallelizing tests, Active Record automatically handles creating a database and loading the schema into the database for each
@@ -542,7 +542,7 @@ want to parallelize your local test suite differently from your CI, so an enviro
 to be able to easily change the number of workers a test run should use:
 
 ```bash
-PARALLEL_WORKERS=15 bin/rails test
+$ PARALLEL_WORKERS=15 bin/rails test
 ```
 
 ### Testing Parallel Transactions
@@ -829,7 +829,7 @@ $ bin/rails generate system_test articles
 It should have created a test file placeholder for us. With the output of the
 previous command you should see:
 
-```bash
+```
       invoke  test_unit
       create    test/system/articles_test.rb
 ```
@@ -852,7 +852,7 @@ The test should see that there is an `h1` on the articles index page and pass.
 Run the system tests.
 
 ```bash
-bin/rails test:system
+$ bin/rails test:system
 ```
 
 NOTE: By default, running `bin/rails test` won't run your system tests.
@@ -978,7 +978,7 @@ $ bin/rails generate integration_test blog_flow
 It should have created a test file placeholder for us. With the output of the
 previous command we should see:
 
-```bash
+```
       invoke  test_unit
       create    test/integration/blog_flow_test.rb
 ```

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -191,8 +191,8 @@ If you want to use Webpacker, then include it in your Gemfile and install it:
 gem "webpacker"
 ```
 
-```sh
-bin/rails webpacker:install
+```bash
+$ bin/rails webpacker:install
 ```
 
 ### Force SSL
@@ -317,7 +317,7 @@ However, `classic` mode infers file names from missing constant names (`undersco
 
 Compatibility can be checked with the `zeitwerk:check` task:
 
-```
+```bash
 $ bin/rails zeitwerk:check
 Hold on, I am eager loading the application.
 All is good!


### PR DESCRIPTION
Follow-up to #39594, which added CSS in order to select shell commands sans prompts on triple-click.

This commit adds several bash code fences and prompts where they were missing, and removes a few where they were inappropriate.
