### PR TITLE
Raise error when passing invalid arguments on subscription instead of failing silently

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -231,6 +231,12 @@ module ActiveSupport
       #   ActiveSupport::Notifications.subscribe(/render/) do |event|
       #     @event = event
       #   end
+      #
+      # Raises an error if invalid event name type is passed:
+      #
+      #  ActiveSupport::Notifications.subscribe(:render) {|*args| ...}
+      #  #=> ArgumentError (pattern must be specified as a String, Regexp or empty)
+      #
       def subscribe(pattern = nil, callback = nil, &block)
         notifier.subscribe(pattern, callback, monotonic: false, &block)
       end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -24,12 +24,15 @@ module ActiveSupport
       def subscribe(pattern = nil, callable = nil, monotonic: false, &block)
         subscriber = Subscribers.new(pattern, callable || block, monotonic)
         synchronize do
-          if String === pattern
+          case pattern
+          when String
             @string_subscribers[pattern] << subscriber
             @listeners_for.delete(pattern)
-          else
+          when NilClass, Regexp
             @other_subscribers << subscriber
             @listeners_for.clear
+          else
+            raise ArgumentError,  "pattern must be specified as a String, Regexp or empty"
           end
         end
         subscriber

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -443,6 +443,17 @@ module Notifications
       assert_not not_child.parent_of?(parent)
     end
 
+    def test_subscribe_raises_error_on_non_supported_arguments
+      notifier = ActiveSupport::Notifications::Fanout.new
+
+      assert_raises ArgumentError do
+        notifier.subscribe(:symbol) { |*_| }
+      end
+      assert_raises ArgumentError do
+        notifier.subscribe(Object.new) { |*_| }
+      end
+    end
+
     private
       def random_id
         @random_id ||= SecureRandom.hex(10)


### PR DESCRIPTION
Currently subscription api on notifications is only supported for String, Regex or nil. If we pass anything different, this causes issues like  #39610 because it gets added to "other subscribers" silently.

We now raise an argument error instead if something invalid is passed.

Partially accesses original class implementation from https://github.com/rails/rails/commit/4f2a04cc085b9117e8af8079a95a063f671d7a3d which used the case/when

Does not do the same ArgumentError on unsubscribe, since subscribe would already fail.

Closes #39610