### PR TITLE
Reduce memory consumption when calling first & last on dirty association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Avoid loading association when calling first, last or other finder methods (e.g.
+    take, second, third) on a dirty association. Instead of loading all records in
+    an association from the database, load no more than the requested limit. If the
+    number of available database records falls short of the requested limit, pad as
+    needed with new records.
+
+    Fixes #39455.
+
+    *Aaron Lipman*
+
 *   Allow attribute's default to be configured but keeping its own type.
 
     ```ruby

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -216,11 +216,15 @@ module ActiveRecord
         elsif !association_scope.group_values.empty?
           load_target.size
         elsif !association_scope.distinct_value && !target.empty?
-          unsaved_records = target.select(&:new_record?)
           unsaved_records.size + count_records
         else
           count_records
         end
+      end
+
+      # Returns a collection's unsaved records
+      def unsaved_records
+        target.select(&:new_record?)
       end
 
       # Returns true if the collection is empty.

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -310,14 +310,6 @@ module ActiveRecord
         owner.new_record? && !foreign_key_present?
       end
 
-      def find_from_target?
-        loaded? ||
-          owner.strict_loading? ||
-          reflection.strict_loading? ||
-          owner.new_record? ||
-          target.any? { |record| record.new_record? || record.changed? }
-      end
-
       private
         # We have some records loaded from the database (persisted) and some that are
         # in-memory (memory). The same record may be represented in the persisted array

--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1002,6 +1002,11 @@ module ActiveRecord
         load_target
       end
 
+      # Returns a collection's unsaved records
+      def unsaved_records
+        @association.unsaved_records
+      end
+
       # Adds one or more +records+ to the collection by setting their foreign keys
       # to the association's primary key. Since <tt><<</tt> flattens its argument list and
       # inserts each record, +push+ and +concat+ behave identically. Returns +self+

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -317,7 +317,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate devel.projects, :loaded?
 
     assert_equal devel.projects.last, proj
-    assert_predicate devel.projects, :loaded?
+    assert_not_predicate devel.projects, :loaded?
 
     assert_not_predicate proj, :persisted?
     devel.save
@@ -333,7 +333,7 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_not_predicate devel.projects, :loaded?
 
     assert_equal devel.projects.last, proj
-    assert_predicate devel.projects, :loaded?
+    assert_not_predicate devel.projects, :loaded?
 
     assert_not_predicate proj, :persisted?
     devel.save

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1134,6 +1134,16 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal size1, size2
   end
 
+  def test_collection_unsaved_records
+    company = companies(:first_firm)
+    company.contracts.create
+    assert_empty company.contracts.unsaved_records
+    company.contracts.build
+    assert_not_empty company.contracts.unsaved_records
+    company.contracts.reload
+    assert_empty company.contracts.unsaved_records
+  end
+
   def test_build_many
     company = companies(:first_firm)
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2182,24 +2182,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_not_predicate firm.clients, :loaded?
-
-    author = Author.create!(name: "Carl")
-    third  = topics(:third)
-    fourth = topics(:fourth).becomes(Topic)
-
-    new_topic = author.topics_without_type.build
-
-    assert_not_predicate author.topics_without_type, :loaded?
-
-    assert_queries(1) do
-      if current_adapter?(:Mysql2Adapter, :SQLite3Adapter)
-        assert_equal fourth, author.topics_without_type.first
-        assert_equal third, author.topics_without_type.second
-      end
-      assert_equal new_topic, author.topics_without_type.last
-    end
-
-    assert_predicate author.topics_without_type, :loaded?
   end
 
   def test_calling_last_on_existing_record_with_build_should_not_use_query

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -175,8 +175,6 @@ class Author < ActiveRecord::Base
   has_many :other_top_posts, -> { order(id: :asc) }, class_name: "Post"
 
   has_many :topics, primary_key: "name", foreign_key: "author_name"
-  has_many :topics_without_type, -> { select(:id, :title, :author_name) },
-    class_name: "Topic", primary_key: "name", foreign_key: "author_name"
 
   has_many :lazy_readers_skimmers_or_not, through: :posts
   has_many :lazy_readers_skimmers_or_not_2, through: :posts_with_no_comments, source: :lazy_readers_skimmers_or_not

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -966,7 +966,6 @@ ActiveRecord::Schema.define do
     t.string   :type
     t.string   :group
     t.timestamps null: true
-    t.index [:author_name, :title]
   end
 
   create_table :toys, primary_key: :toy_id, force: true do |t|


### PR DESCRIPTION
Avoid loading association when calling first, last or other finder methods (e.g. take, second, third) on a dirty association. Instead of loading all records in an association from the database, load no more than the requested limit. If the number of available database records falls short of the requested limit, pad as needed with unsaved records.

Fixes #39455.