### PR TITLE
Add top-level Rails.application.url for canonical reference

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -31,6 +31,7 @@ module ActionMailer
       # make sure readers methods get compiled
       options.asset_host          ||= app.config.asset_host
       options.relative_url_root   ||= app.config.relative_url_root
+      options.default_url_options ||= app.default_url_options
 
       ActiveSupport.on_load(:action_mailer) do
         include AbstractController::UrlFor

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -47,8 +47,9 @@ module ActionController
       options.stylesheets_dir ||= paths["public/stylesheets"].first
 
       # Ensure readers methods get compiled.
-      options.asset_host        ||= app.config.asset_host
-      options.relative_url_root ||= app.config.relative_url_root
+      options.asset_host          ||= app.config.asset_host
+      options.relative_url_root   ||= app.config.relative_url_root
+      options.default_url_options ||= app.default_url_options
 
       ActiveSupport.on_load(:action_controller) do
         include app.routes.mounted_helpers

--- a/actionpack/lib/action_dispatch/http/uri.rb
+++ b/actionpack/lib/action_dispatch/http/uri.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class ActionDispatch::Http::URI
+  mattr_accessor :tld_length, default: 1
+
+  delegate :scheme, :host, :port, :path, :query, :to_s, to: :uri
+  delegate :scheme=, :host=, :port=, :path=, :query=, to: :uri
+
+  def initialize(uri_string)
+    @uri = URI.parse(uri_string)
+  end
+
+  def protocol
+    "#{scheme}://"
+  end
+
+  # Returns a \host:\port string for this request, such as "example.com" or
+  # "example.com:8080". Port is only included if it is not a default port
+  # (80 or 443).
+  def host_with_port
+    "#{host}#{port_string}"
+  end
+
+  # Returns a string \port suffix, including colon, like ":8080" if the \port
+  # number of this request is not the default HTTP \port 80 or HTTPS \port 443.
+  def port_string
+    standard_port? ? "" : ":#{port}"
+  end
+
+  # Returns the standard \port number for this request's protocol.
+  def standard_port
+    scheme == "https" ? 443 : 80
+  end
+
+  # Returns whether this request is using the standard port.
+  def standard_port?
+    port == standard_port
+  end
+
+  # Returns a hash with the host and the protocol, for use with URL calls.
+  def host_and_protocol
+    { host: host, protocol: protocol }
+  end
+
+  # Returns the \domain part of a \host, such as "rubyonrails.org" in "www.rubyonrails.org". You can specify
+  # a different <tt>tld_length</tt>, such as 2 to catch rubyonrails.co.uk in "www.rubyonrails.co.uk".
+  def domain(tld_length = @@tld_length)
+    ActionDispatch::Http::URL.extract_domain(host, tld_length)
+  end
+
+  # Returns all the \subdomains as an array, so <tt>["dev", "www"]</tt> would be
+  # returned for "dev.www.rubyonrails.org". You can specify a different <tt>tld_length</tt>,
+  # such as 2 to catch <tt>["www"]</tt> instead of <tt>["www", "rubyonrails"]</tt>
+  # in "www.rubyonrails.co.uk".
+  def subdomains(tld_length = @@tld_length)
+    ActionDispatch::Http::URL.extract_subdomains(host, tld_length)
+  end
+
+  # Returns all the \subdomains as a string, so <tt>"dev.www"</tt> would be
+  # returned for "dev.www.rubyonrails.org". You can specify a different <tt>tld_length</tt>,
+  # such as 2 to catch <tt>"www"</tt> instead of <tt>"www.rubyonrails"</tt>
+  # in "www.rubyonrails.co.uk".
+  def subdomain(tld_length = @@tld_length)
+    ActionDispatch::Http::URL.extract_subdomain(host, tld_length)
+  end
+
+  private
+    attr_accessor :uri
+end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -117,7 +117,7 @@ module Rails
       public :new
     end
 
-    attr_accessor :assets, :sandbox
+    attr_accessor :assets, :sandbox, :url
     alias_method :sandbox?, :sandbox
     attr_reader :reloaders, :reloader, :executor
 
@@ -140,6 +140,8 @@ module Rails
       @executor          = Class.new(ActiveSupport::Executor)
       @reloader          = Class.new(ActiveSupport::Reloader)
       @reloader.executor = @executor
+
+      @url               = nil
 
       # are these actually used?
       @initial_variable_values = initial_variable_values

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -53,6 +53,14 @@ module Rails
         Rails.logger.level = ActiveSupport::Logger.const_get(config.log_level.to_s.upcase)
       end
 
+      # Sets the Rails.application.url config
+      initializer :initialize_url, group: :all do
+        if config.url
+          Rails.application.url = config.url
+          Rails.application.default_url_options = config.url.host_and_protocol
+        end
+      end
+
       # Initialize cache early in the stack so railties can make use of it.
       initializer :initialize_cache, group: :all do
         unless Rails.cache

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -24,7 +24,7 @@ module Rails
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
                     :rake_eager_load
 
-      attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
+      attr_reader :encoding, :api_only, :loaded_config_version, :autoloader, :url
 
       def initialize(*)
         super
@@ -74,6 +74,7 @@ module Rails
         @add_autoload_paths_to_load_path         = true
         @feature_policy                          = nil
         @rake_eager_load                         = false
+        @url                                     = nil
       end
 
       # Loads default configurations. See {the result of the method for each version}[https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults].
@@ -343,6 +344,11 @@ module Rails
         else
           raise ArgumentError, "config.autoloader may be :classic or :zeitwerk, got #{autoloader.inspect} instead"
         end
+      end
+
+      def url=(url)
+        require "action_dispatch/http/uri"
+        @url = ActionDispatch::Http::URI.new(url)
       end
 
       def default_log_file


### PR DESCRIPTION
Experimental implementation for #39566 (So no test/docs 😅 yet)


Add a top-level Rails.application.url (piggy backing on config.url).
This also sets the default_url_options on the application instance, mailers and controller

These are what get initialized by default on a new application using config.url:
```ruby
class Application < Rails::Application
  config.url = "https://hey.test"
end

Loading development environment (Rails 6.1.0.alpha)
irb(main):001:0> Rails.application.url
=> #<ActionDispatch::Http::URI:0x00007fa4038c4598 @uri=#<URI::HTTPS https://hey.test>>
irb(main):002:0> Rails.application.default_url_options
=> {:host=>"hey.test", :protocol=>"https://"}
irb(main):003:0> ApplicationMailer.default_url_options
=> {:host=>"hey.test", :protocol=>"https://"}
irb(main):004:0> ApplicationController.default_url_options
=> {:host=>"hey.test", :protocol=>"https://"}
```

This does not make use of parts of existing ActionDispatch::Http::URL, since its tightly coupled currently with ActionDispatch:Request and relies on extracting port/host, etc from request headers. A natural next step would be refactoring it to use this class.

// cc @dhh