### PR TITLE
Deprecate YAML loading from legacy format older than Rails 5.0

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate YAML loading from legacy format older than Rails 5.0.
+
+    *Ryuta Kamizono*
+
 *   Added the setting `ActiveRecord::Base.immutable_strings_by_default`, which
     allows you to specify that all string columns should be frozen unless
     otherwise specified. This will reduce memory pressure for applications which

--- a/activerecord/lib/active_record/legacy_yaml_adapter.rb
+++ b/activerecord/lib/active_record/legacy_yaml_adapter.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module LegacyYamlAdapter
+  module LegacyYamlAdapter # :nodoc:
     def self.convert(klass, coder)
       return coder unless coder.is_a?(Psych::Coder)
 
       case coder["active_record_yaml_version"]
       when 1, 2 then coder
       else
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          YAML loading from legacy format older than Rails 5.0 is deprecated
+          and will be removed in Rails 6.2.
+        MSG
         if coder["attributes"].is_a?(ActiveModel::AttributeSet)
           Rails420.convert(klass, coder)
         else
@@ -16,7 +20,7 @@ module ActiveRecord
       end
     end
 
-    module Rails420
+    module Rails420 # :nodoc:
       def self.convert(klass, coder)
         attribute_set = coder["attributes"]
 
@@ -32,7 +36,7 @@ module ActiveRecord
       end
     end
 
-    module Rails41
+    module Rails41 # :nodoc:
       def self.convert(klass, coder)
         attributes = klass.attributes_builder
           .build_from_database(coder["attributes"])

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -94,7 +94,9 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_41_yaml
-    topic = YAML.load(yaml_fixture("rails_4_1"))
+    topic = assert_deprecated do
+      YAML.load(yaml_fixture("rails_4_1"))
+    end
 
     assert_predicate topic, :new_record?
     assert_nil topic.id
@@ -103,7 +105,9 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_4_2_0_yaml
-    topic = YAML.load(yaml_fixture("rails_4_2_0"))
+    topic = assert_deprecated do
+      YAML.load(yaml_fixture("rails_4_2_0"))
+    end
 
     assert_not_predicate topic, :new_record?
     assert_equal 1, topic.id


### PR DESCRIPTION
`LegacyYamlAdapter` was added at afc124c (and 4e72170), to be able to
load the previous version formatted YAML.

Now, that has became quite useless, since we sometimes removed/added
dedicated type classes which are referred in the legacy format (e.g.
`MysqlDateTime`, `MysqlString`, `SQLite3Integer`), so it is unlikely
that is able to load it correctly any longer.