### PR TITLE
Ensure times-called assertions are evaluated

### DIFF
--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -754,11 +754,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       generator([destination_root], options)
 
       command_check = -> command do
-        case command
-        when "install"
-          flunk "install expected to not be called"
-        when "exec spring binstub --all"
-          # Called when running tests with spring, let through unscathed.
+        if command == "install"
+          flunk "`install` expected to not be called."
         end
       end
 


### PR DESCRIPTION
If an assertion is inside a method stub, it may never be evaluated.  This is particularly problematic when asserting a method is called a non-zero number of times.

This commit moves such assertions outside their method stubs.
