### PR TITLE
Move Spring machinery to boot.rb

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1219,7 +1219,7 @@ If you want to use Spring as your application preloader you need to:
 
 1. Add `gem 'spring', group: :development` to your `Gemfile`.
 2. Install spring using `bundle install`.
-3. Springify your binstubs with `bundle exec spring binstub --all`.
+3. Generate the Spring binstub with `bundle exec spring binstub`.
 
 NOTE: User defined rake tasks will run in the `development` environment by
 default. If you want them to run in other environments consult the

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -31,11 +31,6 @@
 
     *Haroon Ahmed*, *Xavier Noria*
 
-*   Use explicit `config/boot_with_spring.rb` boot file for bin/rails and bin/rake, which allows us to restrict Spring loading
-    to only test and development, and everywhere to be able to skip spring by passing UNSPRUNG=1 as an env variable.
-
-    *DHH*
-
 *   The `classic` autoloader starts its deprecation cycle.
 
     New Rails projects are strongly discouraged from using `classic`, and we recommend that existing projects running on `classic` switch to `zeitwerk` mode when upgrading. Please check the [_Upgrading Ruby on Rails_](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) guide for tips.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -388,11 +388,6 @@ module Rails
         template "config/boot.rb"
       end
 
-      def create_boot_with_spring_file
-        return if options[:skip_spring]
-        template "config/boot_with_spring.rb"
-      end
-
       def create_active_record_files
         return if options[:skip_active_record]
         build(:database_yml)

--- a/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
@@ -1,7 +1,3 @@
 APP_PATH = File.expand_path('../config/application', __dir__)
-<% if options.skip_spring? -%>
 require_relative "../config/boot"
-<% else -%>
-require_relative "../config/boot_with_spring"
-<% end -%>
 require "rails/commands"

--- a/railties/lib/rails/generators/rails/app/templates/bin/rake.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rake.tt
@@ -1,7 +1,3 @@
-<% if options.skip_spring? -%>
 require_relative "../config/boot"
-<% else -%>
-require_relative "../config/boot_with_spring"
-<% end -%>
 require "rake"
 Rake.application.run

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,3 +1,11 @@
+<% unless options.skip_spring? -%>
+begin
+  load File.expand_path("../bin/spring", __dir__)
+rescue LoadError => e
+  raise unless e.path.end_with?("/bin/spring")
+end
+<% end -%>
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/railties/lib/rails/generators/rails/app/templates/config/boot_with_spring.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot_with_spring.rb.tt
@@ -1,9 +1,0 @@
-if ENV["UNSPRUNG"].nil? && (ENV["RAILS_ENV"].nil? || ENV["RAILS_ENV"] == "development" || ENV["RAILS_ENV"] == "test")
-  begin
-    load File.expand_path("../../bin/spring", __FILE__)
-  rescue LoadError => e
-    raise unless e.message.include?("spring")
-  end
-end
-
-require_relative "boot"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -859,6 +859,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match("config.cache_classes = false", contents)
       assert_match("config.action_view.cache_template_loading = true", contents)
     end
+    assert_file "config/boot.rb", %r{^\s*load .+/bin/spring"}
   end
 
   def test_bundler_binstub
@@ -891,6 +892,9 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "spring"
     assert_file("config/environments/test.rb") do |contents|
       assert_match("config.cache_classes = true", contents)
+    end
+    assert_file "config/boot.rb" do |contents|
+      assert_no_match %r{bin/spring}, contents
     end
   end
 


### PR DESCRIPTION
This partially reverts #39225, and folds `boot_with_spring.rb` into `boot.rb`.

Fixes #39622.

---

/cc @dhh Is this what you had in mind for https://github.com/rails/rails/issues/39622#issuecomment-643834058?
