### PR TITLE
Fix route params using reserved keywords:

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -766,7 +766,7 @@ module ActionDispatch
         end
 
         route_name = options.delete :use_route
-        path = path_for(options, route_name)
+        path = path_for(options, route_name, [])
 
         uri = URI.parse(path)
         params = Rack::Utils.parse_nested_query(uri.query).symbolize_keys
@@ -794,12 +794,12 @@ module ActionDispatch
         options.delete(:relative_url_root) || relative_url_root
       end
 
-      def path_for(options, route_name = nil)
-        url_for(options, route_name, PATH)
+      def path_for(options, route_name = nil, reserved = RESERVED_OPTIONS)
+        url_for(options, route_name, PATH, nil, reserved)
       end
 
       # The +options+ argument must be a hash whose keys are *symbols*.
-      def url_for(options, route_name = nil, url_strategy = UNKNOWN, method_name = nil)
+      def url_for(options, route_name = nil, url_strategy = UNKNOWN, method_name = nil, reserved = RESERVED_OPTIONS)
         options = default_url_options.merge options
 
         user = password = nil
@@ -819,7 +819,7 @@ module ActionDispatch
         end
 
         path_options = options.dup
-        RESERVED_OPTIONS.each { |ro| path_options.delete ro }
+        reserved.each { |ro| path_options.delete ro }
 
         route_with_params = generate(route_name, path_options, recall)
         path = route_with_params.path(method_name)

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2085,6 +2085,10 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     params = { controller: "people", action: "create", person: { name: "Josh" } }
     assert_equal [:person], @routes.extra_keys(params)
     assert_equal({ controller: "people", action: "create", person: { name: "Josh" } }, params)
+
+    params = { controller: "people", action: "create", domain: { foo: "Josh" } }
+    assert_equal [:domain], @routes.extra_keys(params)
+    assert_equal({ controller: "people", action: "create", domain: { foo: "Josh" } }, params)
   end
 
   def test_unicode_path


### PR DESCRIPTION
Fix route params using reserved keywords:

- In #39534, `Routing::RouteSet#generate_extras` (which get called)
  by ActionController::TestCase now go through `path_for` which strips
  out all key in the options hash that have the same name as the ones
  defined in `RESERVED_OPTIONS`.

cc/ @eileencodes @tenderlove 