### PR TITLE
Allow ActiveStorage Azure service to have retry policy.

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -17,6 +17,12 @@ module ActiveStorage
       @signer = Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
       @container = container
       @public = public
+      if options[:retry_policy] == :exponential_retry_policy_filter
+        retry_count = options[:retry_count] || 3
+        min_retry_interval = options[:min_retry_interval] || 10
+        max_retry_interval = options[:max_retry_interval] || 90
+        @client.with_filter(Azure::Storage::Common::Core::Filter::ExponentialRetryPolicyFilter.new(retry_count, min_retry_interval, max_retry_interval))
+      end
     end
 
     def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, **)


### PR DESCRIPTION
### Summary
When connection to Azure times out, the request simply fails with Faraday::TimeoutError. azure-storage-ruby implements retry filters - https://github.com/Azure/azure-storage-ruby/tree/0d3e5acf3327652fa2ffe1ed1df73b61a5a17c1e/common/lib/azure/storage/common/core/filter.
This change enables such retry configuration.

To enable, add `retry_policy` with optional parameters to storage.yml:
```
azure:
  service: AzureStorage
  storage_account_name: ...
  storage_access_key: ...
  container: ...
  retry_policy: :exponential_retry_policy_filter
  retry_count: 3
  min_retry_interval: 10
  max_retry_interval: 90
```

`retry_count` defaults to 3 if not specified
`min_retry_interval` defaults to 10 if not specified
`max_retry_interval` defaults to 90 if not specified 