### PR TITLE
Remove unused `Equality#operator`

### DIFF
--- a/activerecord/lib/arel/nodes/equality.rb
+++ b/activerecord/lib/arel/nodes/equality.rb
@@ -3,8 +3,6 @@
 module Arel # :nodoc: all
   module Nodes
     class Equality < Arel::Nodes::Binary
-      def operator; :== end
-
       def equality?; true; end
 
       def invert

--- a/activerecord/test/cases/arel/nodes/equality_test.rb
+++ b/activerecord/test/cases/arel/nodes/equality_test.rb
@@ -7,14 +7,6 @@ module Arel
     describe "equality" do
       # FIXME: backwards compat
       describe "backwards compat" do
-        describe "operator" do
-          it "returns :==" do
-            attr = Table.new(:users)[:id]
-            left = attr.eq(10)
-            _(left.operator).must_equal :==
-          end
-        end
-
         describe "to_sql" do
           it "takes an engine" do
             engine = FakeRecord::Base.new


### PR DESCRIPTION
The `operator` method was added at 87b6856, to refer the method in
Active Record 12b3eca.

Since we have added `HomogeneousIn` which has no `operator` unlike `In`
node, so the referring `operator` no longer works for compatibility as
before.

It should use `equality?` for the purpose instead.
