### PR TITLE
Avoid to use slower `define_method` for `AcceptsMultiparameterTime`

### DIFF
--- a/activemodel/lib/active_model/type/date_time.rb
+++ b/activemodel/lib/active_model/type/date_time.rb
@@ -35,8 +35,8 @@ module ActiveModel
         end
 
         def value_from_multiparameter_assignment(values_hash)
-          missing_parameters = (1..3).select { |key| !values_hash.key?(key) }
-          if missing_parameters.any?
+          missing_parameters = [1, 2, 3].delete_if { |key| values_hash.key?(key) }
+          unless missing_parameters.empty?
             raise ArgumentError, "Provided hash #{values_hash} doesn't contain necessary keys: #{missing_parameters}"
           end
           super

--- a/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb
+++ b/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb
@@ -4,12 +4,12 @@ module ActiveModel
   module Type
     module Helpers # :nodoc: all
       class AcceptsMultiparameterTime < Module
-        def initialize(defaults: {})
-          define_method(:serialize) do |value|
+        module InstanceMethods
+          def serialize(value)
             super(cast(value))
           end
 
-          define_method(:cast) do |value|
+          def cast(value)
             if value.is_a?(Hash)
               value_from_multiparameter_assignment(value)
             else
@@ -17,7 +17,7 @@ module ActiveModel
             end
           end
 
-          define_method(:assert_valid_value) do |value|
+          def assert_valid_value(value)
             if value.is_a?(Hash)
               value_from_multiparameter_assignment(value)
             else
@@ -25,16 +25,20 @@ module ActiveModel
             end
           end
 
-          define_method(:value_constructed_by_mass_assignment?) do |value|
+          def value_constructed_by_mass_assignment?(value)
             value.is_a?(Hash)
           end
+        end
+
+        def initialize(defaults: {})
+          include InstanceMethods
 
           define_method(:value_from_multiparameter_assignment) do |values_hash|
             defaults.each do |k, v|
               values_hash[k] ||= v
             end
             return unless values_hash[1] && values_hash[2] && values_hash[3]
-            values = values_hash.sort.map(&:last)
+            values = values_hash.sort.map!(&:last)
             ::Time.send(default_timezone, *values)
           end
           private :value_from_multiparameter_assignment


### PR DESCRIPTION
This makes `datetime.serialize` about 10% faster.

```ruby
type = ActiveRecord::Type.lookup(:datetime)
time = Time.now.utc

Benchmark.ips do |x|
  x.report("type.serialize(time)") do
    type.serialize(time)
    type.serialize(time)
    type.serialize(time)
    type.serialize(time)
  end
end
```

Before:

```
Warming up --------------------------------------
type.serialize(time)    12.899k i/100ms
Calculating -------------------------------------
type.serialize(time)    131.293k (± 1.6%) i/s -    657.849k in   5.011870s
```

After:

```
Warming up --------------------------------------
type.serialize(time)    14.603k i/100ms
Calculating -------------------------------------
type.serialize(time)    145.941k (± 1.1%) i/s -    730.150k in   5.003639s
```