### PR TITLE
Fix `RouteSet#generate_extras` regression:

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -763,7 +763,6 @@ module ActionDispatch
       def generate_extras(options, recall = {})
         route_key = options.delete :use_route
         route_with_params = generate(route_key, options, recall)
-
         [route_with_params.path(nil), route_with_params.params.keys]
       end
 
@@ -788,12 +787,12 @@ module ActionDispatch
         options.delete(:relative_url_root) || relative_url_root
       end
 
-      def path_for(options, route_name = nil, reserved = RESERVED_OPTIONS)
-        url_for(options, route_name, PATH, nil, reserved)
+      def path_for(options, route_name = nil)
+        url_for(options, route_name, PATH)
       end
 
       # The +options+ argument must be a hash whose keys are *symbols*.
-      def url_for(options, route_name = nil, url_strategy = UNKNOWN, method_name = nil, reserved = RESERVED_OPTIONS)
+      def url_for(options, route_name = nil, url_strategy = UNKNOWN, method_name = nil)
         options = default_url_options.merge options
 
         user = password = nil
@@ -813,7 +812,7 @@ module ActionDispatch
         end
 
         path_options = options.dup
-        reserved.each { |ro| path_options.delete ro }
+        RESERVED_OPTIONS.each { |ro| path_options.delete ro }
 
         route_with_params = generate(route_name, path_options, recall)
         path = route_with_params.path(method_name)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -761,16 +761,10 @@ module ActionDispatch
       end
 
       def generate_extras(options, recall = {})
-        if recall
-          options = options.merge(_recall: recall)
-        end
+        route_key = options.delete :use_route
+        route_with_params = generate(route_key, options, recall)
 
-        route_name = options.delete :use_route
-        path = path_for(options, route_name, [])
-
-        uri = URI.parse(path)
-        params = Rack::Utils.parse_nested_query(uri.query).symbolize_keys
-        [uri.path, params.keys]
+        [route_with_params.path(nil), route_with_params.params.keys]
       end
 
       def generate(route_name, options, recall = {}, method_name = nil)

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2076,7 +2076,6 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
   def test_extras
     params = { controller: "people" }
     assert_equal [], @routes.extra_keys(params)
-    assert_equal({ controller: "people" }, params)
 
     params = { controller: "people", foo: "bar" }
     assert_equal [:foo], @routes.extra_keys(params)

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2084,10 +2084,6 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
     params = { controller: "people", action: "create", person: { name: "Josh" } }
     assert_equal [:person], @routes.extra_keys(params)
     assert_equal({ controller: "people", action: "create", person: { name: "Josh" } }, params)
-
-    params = { controller: "people", action: "create", domain: { foo: "Josh" } }
-    assert_equal [:domain], @routes.extra_keys(params)
-    assert_equal({ controller: "people", action: "create", domain: { foo: "Josh" } }, params)
   end
 
   def test_unicode_path

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -607,6 +607,12 @@ XML
     assert_equal "json", @request.format
   end
 
+  def test_using_as_json_with_empty_params
+    post :test_params, params: { foo: { bar: [] }}, as: :json
+
+    assert_equal({ "bar" => [] }, JSON.load(response.body)['foo'])
+  end
+
   def test_mutating_content_type_headers_for_plain_text_files_sets_the_header
     @request.headers["Content-Type"] = "text/plain"
     post :render_body, params: { name: "foo.txt" }


### PR DESCRIPTION
Fix `RouteSet#generate_extras` regression:

- In #39534, `RouteSet#generate_extras` relies on the URI to return
  the params from the query string. There is an assumption that
  all POST requests are of `www-encoded-url-form` and thus
  when a tests passes empty array/hash params, we loose them when
  building the query string.

  I don't have the full context on this change and I'm mainly opening
  this PR for discussion. This basically partially reverts #39534, as
  I don't see another way to fix this issue if you continue relying
  on the URI query string.

  I'm also reverting the previous change that fixed the first
  regression because it's no longer needed.

cc/ @rafaelfranca @etiennebarrie @eileencodes @casperisfine @tenderlove 