### PR TITLE
Fix json encoded controller tests

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -74,14 +74,21 @@ module ActionController
       non_path_parameters = {}
       path_parameters = {}
 
+      if parameters[:format] == :json
+        parameters = JSON.load(JSON.dump(parameters))
+        query_string_keys = query_string_keys.map(&:to_s)
+      end
+
       parameters.each do |key, value|
         if query_string_keys.include?(key)
           non_path_parameters[key] = value
         else
-          if value.is_a?(Array)
-            value = value.map(&:to_param)
-          else
-            value = value.to_param
+          unless parameters["format"] == "json"
+            if value.is_a?(Array)
+              value = value.map(&:to_param)
+            else
+              value = value.to_param
+            end
           end
 
           path_parameters[key] = value

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -597,14 +597,20 @@ XML
     post :render_body, params: { bool_value: true, str_value: "string", num_value: 2 }, as: :json
 
     assert_equal "application/json", @request.headers["CONTENT_TYPE"]
-    assert_equal true, @request.request_parameters[:bool_value]
-    assert_equal "string", @request.request_parameters[:str_value]
-    assert_equal 2, @request.request_parameters[:num_value]
+    assert_equal true, @request.request_parameters["bool_value"]
+    assert_equal "string", @request.request_parameters["str_value"]
+    assert_equal 2, @request.request_parameters["num_value"]
   end
 
   def test_using_as_json_sets_format_json
     post :render_body, params: { bool_value: true, str_value: "string", num_value: 2 }, as: :json
     assert_equal "json", @request.format
+  end
+
+  def test_using_as_json_with_empty_params
+    post :test_params, params: { foo: { bar: [] } }, as: :json
+
+    assert_equal({ "bar" => [] }, JSON.load(response.body)["foo"])
   end
 
   def test_mutating_content_type_headers_for_plain_text_files_sets_the_header


### PR DESCRIPTION
The controller test case is trying to encode json parameters in the same
way it encodes query parameters. However we need to encode json
parameters as json.

This was broken in #39534 because `generate_extras` is encoding
everything into query parameters. But json parameters are in the post
body and need to be treated differently than the query parameters.

Followup to #39651

Aaron Patterson <tenderlove@ruby-lang.org>

cc/ @rafaelfranca @etiennebarrie @casperisfine @tenderlove @Edouard-chin 