### PR TITLE
Better error message when replacing an assoc fails

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -57,7 +57,9 @@ module ActiveRecord
 
                 if save && !record.save
                   nullify_owner_attributes(record)
-                  set_owner_attributes(target) if target
+                  if target && !target.destroyed?
+                    set_owner_attributes(target)
+                  end
                   raise RecordNotSaved, "Failed to save the new associated #{reflection.name}."
                 end
               end


### PR DESCRIPTION
### Summary

When replacing a has-one association and the replaced record fails to
save (e.g. because a validator triggers), the correct error should be

    RecordNotSaved, "Failed to save the new associated #{reflection.name}."

However, set_owner_attributes fails with the much less descriptive error

    Can't modify frozen hash

if `remove_target!` was called earlier:

    remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record

(this is because remove_target destroys target, and destroy freezes the underlying attributes hash).

This solution will skip the failing code, skipping to the correct error
message.

However, it skips set_owner_attributes completely, so the previous state
will not be restored - which is at least not worse than what happened in
the "Can't modify frozen hash" case.

### Other Information

I do not know if this is the correct approach. Especially if there is another way to correctly call set_owner_attributes in this case.

Maybe

```ruby
target.reload if target.destroyed?
set_owner_attributes(target)
```

?