### PR TITLE
Make the test AppGeneratorTest#test_new_application_load_defaults faster

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2614,6 +2614,12 @@ module ApplicationTests
       assert_equal true, Rails.application.config.rake_eager_load
     end
 
+    test "unknown_asset_fallback is false by default" do
+      app "development"
+
+      assert_equal false, Rails.application.config.assets.unknown_asset_fallback
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -207,16 +207,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_new_application_load_defaults
     app_root = File.join(destination_root, "myfirstapp")
     run_generator [app_root]
-
-    output = nil
-
     assert_file "#{app_root}/config/application.rb", /\s+config\.load_defaults #{Rails::VERSION::STRING.to_f}/
-
-    Dir.chdir(app_root) do
-      output = `SKIP_REQUIRE_WEBPACKER=true ./bin/rails r "puts Rails.application.config.assets.unknown_asset_fallback"`
-    end
-
-    assert_equal "false\n", output
   end
 
   def test_csp_initializer_include_connect_src_example


### PR DESCRIPTION
### Summary

Make the test `AppGeneratorTest#test_new_application_load_defaults` faster. 

Currently taking ~5s to run because we are calling the rails runner.

I have changed the test to load the defaults for the rails application then, use the rails app to test the default config value. 

NOTE: SharedGeneratorTests#setup assigns the Rails.application, which I'm assuming why the method `load_defaults` never gets called.

`Rails.application = TestApp::Application` 

To reproduce:
```
b exec ruby -w -Itest test/generators/app_generator_test.rb -v  -n test_new_application_load_defaults
Before:
AppGeneratorTest#test_new_application_load_defaults = 5.31 s = .

After:
AppGeneratorTest#test_new_application_load_defaults = 0.16 s = .
```

Original code was introduced here: https://github.com/rails/rails/pull/28475