### PR TITLE
Run `rails new` using specified prerelease version

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -270,6 +270,10 @@ module Rails
         end
       end
 
+      def rails_prerelease?
+        options.dev? || options.edge? || options.main?
+      end
+
       def rails_gemfile_entry
         if options.dev?
           [

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -268,6 +268,13 @@ module Rails
             version
           end
         end
+
+        def to_s
+          [ ("# #{comment}\n" if comment),
+            ("# " if commented_out), "gem \"#{name}\"", (", \"#{version}\"" if version),
+            *options.map { |key, val| ", #{key}: #{val.inspect}" }
+          ].compact.join
+        end
       end
 
       def rails_prerelease?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -303,6 +303,7 @@ module Rails
 
       public_task :set_default_accessors!
       public_task :create_root
+      public_task :target_rails_prerelease
 
       def create_root_files
         build(:readme)

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -2,14 +2,10 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby <%= "\"#{RUBY_VERSION}\"" -%>
-<% gemfile_entries.each do |gem| -%>
-<% if gem.comment %>
 
-# <%= gem.comment %>
+<% gemfile_entries.each do |gemfile_entry| %>
+<%= gemfile_entry %>
 <% end -%>
-<%= gem.commented_out ? "# " : "" %>gem "<%= gem.name %>"<%= %(, "#{gem.version}") if gem.version -%>
-<% if gem.options.any? -%>, <%= gem.options.map { |k,v| "#{k}: #{v.inspect}" }.join(", ") %><% end -%>
-<% end %>
 <% unless options.minimal? -%>
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -235,6 +235,10 @@ module Rails
       public_task :set_default_accessors!
       public_task :create_root
 
+      def target_rails_prerelease
+        super("plugin new")
+      end
+
       def create_root_files
         build(:readme)
         build(:rakefile)

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= "# " if options.dev? || options.edge? || options.main? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
+  <%= "# " if rails_prerelease? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -17,17 +17,8 @@ end
 <% if rails_prerelease? -%>
 # Your gem is dependent on a prerelease version of Rails. Once you can lock this
 # dependency down to a specific version, move it to your gemspec.
-<% max_width = gemfile_entries.map { |g| g.name.length }.max -%>
-<% gemfile_entries.each do |gem| -%>
-<% if gem.comment -%>
-
-# <%= gem.comment %>
-<% end -%>
-<%= gem.commented_out ? "# " : "" %>gem "<%= gem.name %>"<%= %(, "#{gem.version}") if gem.version -%>
-<% if gem.options.any? -%>
-, <%= gem.options.map { |k,v|
-  "#{k}: #{v.inspect}" }.join(", ") %>
-<% end -%>
+<% gemfile_entries.each do |gemfile_entry| -%>
+<%= gemfile_entry %>
 <% end -%>
 
 <% end -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>
-<%= "# " if options.dev? || options.edge? || options.main? -%>gem "rails", "<%= Array(rails_version_specifier).join("', '") %>"
+<%= "# " if rails_prerelease? -%>gem "rails", "<%= Array(rails_version_specifier).join("', '") %>"
 <% else -%>
 # Specify your gem's dependencies in <%= name %>.gemspec.
 gemspec
@@ -14,8 +14,8 @@ group :development do
 end
 <% end -%>
 
-<% if options.dev? || options.edge? -%>
-# Your gem is dependent on dev or edge Rails. Once you can lock this
+<% if rails_prerelease? -%>
+# Your gem is dependent on a prerelease version of Rails. Once you can lock this
 # dependency down to a specific version, move it to your gemspec.
 <% max_width = gemfile_entries.map { |g| g.name.length }.max -%>
 <% gemfile_entries.each do |gem| -%>

--- a/railties/lib/rails/generators/testing/behaviour.rb
+++ b/railties/lib/rails/generators/testing/behaviour.rb
@@ -66,8 +66,8 @@ module Rails
         # printed by the generator.
         def run_generator(args = default_arguments, config = {})
           capture(:stdout) do
-            args += ["--skip-bundle"] unless args.include? "--dev"
-            args |= ["--skip-bootsnap"] unless args.include? "--no-skip-bootsnap"
+            args += ["--skip-bundle"] unless args.include?("--no-skip-bundle") || args.include?("--dev")
+            args |= ["--skip-bootsnap"] unless args.include?("--no-skip-bootsnap")
 
             generator_class.start(args, config.reverse_merge(destination_root: destination_root))
           end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -677,48 +677,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_dev_option
-    generator([destination_root], dev: true)
-    run_generator_instance
-
-    assert_equal 1, @bundle_commands.count("install")
-    rails_path = File.expand_path("../../..", Rails.root)
-    assert_file "Gemfile", /^gem\s+["']rails["'],\s+path:\s+["']#{Regexp.escape(rails_path)}["']$/
-  end
-
-  def test_edge_option
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0")) do
-      generator([destination_root], edge: true)
-      run_generator_instance
-    end
-
-    assert_equal 1, @bundle_commands.count("install")
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']2-1-stable["']$}
-  end
-
-  def test_edge_option_during_alpha
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0.alpha")) do
-      generator([destination_root], edge: true)
-      run_generator_instance
-    end
-
-    assert_equal 1, @bundle_commands.count("install")
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
-  end
-
-  def test_master_option
-    run_generator [destination_root, "--master"]
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
-  end
-
-  def test_main_option
-    generator([destination_root], main: true)
-    run_generator_instance
-
-    assert_equal 1, @bundle_commands.count("install")
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
-  end
-
   def test_bundler_binstub
     generator([destination_root])
     run_generator_instance
@@ -778,7 +736,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_hotwire
-    run_generator [destination_root, "--dev"]
+    run_generator [destination_root, "--no-skip-bundle"]
     assert_gem "turbo-rails"
     assert_gem "stimulus-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
@@ -801,7 +759,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_asset_pipeline_tailwind
-    run_generator [destination_root, "--dev", "--css", "tailwind"]
+    run_generator [destination_root, "--css", "tailwind", "--no-skip-bundle"]
     assert_gem "tailwindcss-rails"
     assert_file "app/views/layouts/application.html.erb" do |content|
       assert_match(/tailwind/, content)
@@ -809,7 +767,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_cssbundling_gem
-    run_generator [destination_root, "--dev", "--css", "postcss"]
+    run_generator [destination_root, "--css", "postcss", "--no-skip-bundle"]
     assert_gem "cssbundling-rails"
     assert_file "app/assets/stylesheets/application.postcss.css"
   end
@@ -840,7 +798,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_bootsnap_with_dev_option
-    run_generator [destination_root, "--dev", "--skip-bundle"]
+    run_generator_using_prerelease [destination_root, "--dev"]
 
     assert_no_gem "bootsnap"
     assert_file "config/boot.rb" do |content|

--- a/railties/test/generators/db_system_change_generator_test.rb
+++ b/railties/test/generators/db_system_change_generator_test.rb
@@ -11,9 +11,10 @@ module Rails
           include GeneratorsTestHelper
 
           setup do
-            copy_gemfile(
-              GemfileEntry.new("sqlite3", nil, "Use sqlite3 as the database for Active Record")
-            )
+            copy_gemfile <<~ENTRY
+              # Use sqlite3 as the database for Active Record
+              gem 'sqlite3'
+            ENTRY
           end
 
           test "change to invalid database" do

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -92,6 +92,7 @@ module GeneratorsTestHelper
   private
     def gemfile_locals
       {
+        rails_prerelease: false,
         skip_active_storage: true,
         depend_on_bootsnap: false,
         depends_on_system_test: false,

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -20,12 +20,6 @@ module GeneratorsTestHelper
   include ActiveSupport::Testing::Stream
   include ActiveSupport::Testing::MethodCallAssertions
 
-  GemfileEntry = Struct.new(:name, :version, :comment, :options, :commented_out) do
-    def initialize(name, version, comment, options = {}, commented_out = false)
-      super
-    end
-  end
-
   def self.included(base)
     base.class_eval do
       destination File.expand_path("../fixtures/tmp", __dir__)

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -239,37 +239,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_empty @bundle_commands
   end
 
-  def test_dev_option
-    generator([destination_root], dev: true)
-    run_generator_instance
-
-    assert_empty @bundle_commands
-    rails_path = File.expand_path("../../..", Rails.root)
-    assert_file "Gemfile", /^gem\s+["']rails["'],\s+path:\s+["']#{Regexp.escape(rails_path)}["']$/
-  end
-
-  def test_edge_option
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0")) do
-      generator([destination_root], edge: true)
-      run_generator_instance
-    end
-
-    assert_empty @bundle_commands
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']2-1-stable["']$}
-  end
-
-  def test_edge_option_during_alpha
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0.alpha")) do
-      generator([destination_root], edge: true)
-      run_generator_instance
-    end
-
-    assert_empty @bundle_commands
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
-  end
-
   def test_generation_does_not_run_bundle_install_with_full_and_mountable
-    generator([destination_root], mountable: true, full: true, dev: true)
+    generator([destination_root], mountable: true, full: true)
     run_generator_instance
 
     assert_empty @bundle_commands

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 #
 # Tests, setup, and teardown common to the application and plugin generator suites.
 #
@@ -312,13 +314,78 @@ module SharedGeneratorTests
     end
   end
 
+  def test_dev_option
+    run_generator_using_prerelease [destination_root, "--dev"]
+    rails_path = File.expand_path("../../..", Rails.root)
+    assert_file "Gemfile", %r{^gem ["']rails["'], path: ["']#{Regexp.escape rails_path}["']$}
+  end
+
+  def test_edge_option
+    Rails.stub(:gem_version, Gem::Version.new("2.1.0")) do
+      run_generator_using_prerelease [destination_root, "--edge"]
+    end
+    assert_file "Gemfile", %r{^gem ["']rails["'], github: ["']rails/rails["'], branch: ["']2-1-stable["']$}
+  end
+
+  def test_edge_option_during_alpha
+    Rails.stub(:gem_version, Gem::Version.new("2.1.0.alpha")) do
+      run_generator_using_prerelease [destination_root, "--edge"]
+    end
+    assert_file "Gemfile", %r{^gem ["']rails["'], github: ["']rails/rails["'], branch: ["']main["']$}
+  end
+
+  def test_main_option
+    run_generator_using_prerelease [destination_root, "--main"]
+    assert_file "Gemfile", %r{^gem ["']rails["'], github: ["']rails/rails["'], branch: ["']main["']$}
+  end
+
+  def test_master_option
+    run_generator_using_prerelease [destination_root, "--master"]
+    assert_file "Gemfile", %r{^gem ["']rails["'], github: ["']rails/rails["'], branch: ["']main["']$}
+  end
+
+  def test_target_rails_prerelease_with_relative_app_path
+    run_generator_using_prerelease ["myproject", "--main"]
+    assert_file "myproject/Gemfile", %r{^gem ["']rails["'], github: ["']rails/rails["'], branch: ["']main["']$}
+  end
+
   private
     def run_generator_instance
       @bundle_commands = []
-      bundle_command_stub = -> (command, *) { @bundle_commands << command }
+      @bundle_command_stub ||= -> (command, *) { @bundle_commands << command }
 
-      generator.stub(:bundle_command, bundle_command_stub) do
+      generator.stub(:bundle_command, @bundle_command_stub) do
         super
+      end
+    end
+
+    def run_generator_using_prerelease(args)
+      option_args, positional_args = args.partition { |arg| arg.start_with?("--") }
+      project_path = File.expand_path(positional_args.first, destination_root)
+      expected_args = [project_path, *positional_args.drop(1), *option_args]
+
+      generator(positional_args, option_args)
+
+      rails_gem_pattern = /^gem ["']rails["'], .+/
+      bundle_command_rails_gems = []
+      @bundle_command_stub = -> (command, *) do
+        @bundle_commands << command
+        assert_file File.expand_path("Gemfile", project_path) do |gemfile|
+          bundle_command_rails_gems << gemfile[rails_gem_pattern]
+        end
+      end
+
+      # run target_rails_prerelease on exit to mimic re-running generator
+      generator.stub :exit, generator.method(:target_rails_prerelease) do
+        run_generator_instance
+      end
+
+      assert_file File.expand_path("Gemfile", project_path) do |gemfile|
+        assert_equal "install", @bundle_commands[0]
+        assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[0]
+
+        assert_match %r"^exec rails (?:plugin )?new #{Regexp.escape Shellwords.join(expected_args)}", @bundle_commands[1]
+        assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[1]
       end
     end
 end


### PR DESCRIPTION
When running `rails new` with a prerelease flag like `--edge`, the project's Gemfile will point to the specified prerelease version, but the project itself is generated using the active version of Rails.  This can cause problems if, for example, the prerelease version expects a different file structure than the active version.  It also precludes using generator options that are new in the prerelease version.

This commit adds a mechanism to install and use prerelease versions of Rails when running `rails new`.

Closes #38761.

---

/cc @Schwad I added you as a co-author since you've been exploring this.
