### PR TITLE
Use native `Hash#except` if it is defined

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -11,7 +11,7 @@ class Hash
   #   @person.update(params[:person].except(:admin))
   def except(*keys)
     slice(*self.keys - keys)
-  end
+  end unless {}.respond_to?(:except)
 
   # Removes the given keys from hash and returns it.
   #   hash = { a: true, b: false, c: nil }


### PR DESCRIPTION
Now Ruby master has native `Hash#except`.

https://bugs.ruby-lang.org/issues/15822
