### PR TITLE
`IsDistinctFrom` is not equality node

### DIFF
--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -73,6 +73,22 @@ module Arel # :nodoc: all
       end
     end
 
+    class IsDistinctFrom < Binary
+      include FetchAttribute
+
+      def invert
+        Arel::Nodes::IsNotDistinctFrom.new(left, right)
+      end
+    end
+
+    class IsNotDistinctFrom < Binary
+      include FetchAttribute
+
+      def invert
+        Arel::Nodes::IsDistinctFrom.new(left, right)
+      end
+    end
+
     class NotEqual < Binary
       include FetchAttribute
 

--- a/activerecord/lib/arel/nodes/equality.rb
+++ b/activerecord/lib/arel/nodes/equality.rb
@@ -3,30 +3,12 @@
 module Arel # :nodoc: all
   module Nodes
     class Equality < Arel::Nodes::Binary
+      include FetchAttribute
+
       def equality?; true; end
 
       def invert
         Arel::Nodes::NotEqual.new(left, right)
-      end
-
-      def fetch_attribute
-        if left.is_a?(Arel::Attributes::Attribute)
-          yield left
-        elsif right.is_a?(Arel::Attributes::Attribute)
-          yield right
-        end
-      end
-    end
-
-    class IsDistinctFrom < Equality
-      def invert
-        Arel::Nodes::IsNotDistinctFrom.new(left, right)
-      end
-    end
-
-    class IsNotDistinctFrom < Equality
-      def invert
-        Arel::Nodes::IsDistinctFrom.new(left, right)
       end
     end
   end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -50,6 +50,12 @@ module ActiveRecord
     def test_empty_where_values_hash
       relation = Relation.new(FakeKlass)
       assert_equal({}, relation.where_values_hash)
+
+      relation.where!(relation.table[:id].not_eq(10))
+      assert_equal({}, relation.where_values_hash)
+
+      relation.where!(relation.table[:id].is_distinct_from(10))
+      assert_equal({}, relation.where_values_hash)
     end
 
     def test_where_values_hash_with_in_clause

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1260,6 +1260,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_kind_of Bird, same_parrot
     assert_predicate same_parrot, :persisted?
     assert_equal parrot, same_parrot
+
+    canary = Bird.where(Bird.arel_attribute(:color).is_distinct_from("green")).first_or_create(name: "canary")
+    assert_equal "canary", canary.name
+    assert_nil canary.color
   end
 
   def test_first_or_create_with_no_parameters
@@ -1380,6 +1384,10 @@ class RelationTest < ActiveRecord::TestCase
     assert_predicate parrot, :new_record?
     assert_equal "parrot", parrot.name
     assert_equal "green", parrot.color
+
+    canary = Bird.where(Bird.arel_attribute(:color).is_distinct_from("green")).first_or_initialize(name: "canary")
+    assert_equal "canary", canary.name
+    assert_nil canary.color
   end
 
   def test_first_or_initialize_with_no_parameters


### PR DESCRIPTION
`IsDistinctFrom` which was added at #34451 is almost same with
`NotEqual`.

Historically subclasses of `Equality` has a special ability, it has
migrated to `equality?` method, so newer class should implement the
method rather than inheriting the `Equality` if want to have an equality
ability, at least `IsDistinctFrom` should not be an equality node
(actually `IsNotDistinctFrom` is almost same with `Equality`, but I'd
not interested to give a special ability to the node which is rarely
used).
