### PR TITLE
Handling negative numbers with pluralize method

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -34,7 +34,7 @@ class String
   # See ActiveSupport::Inflector.pluralize.
   def pluralize(count = nil, locale = :en)
     locale = count if count.is_a?(Symbol)
-    if count == 1
+    if count == 1 || count == -1
       dup
     else
       ActiveSupport::Inflector.pluralize(self, locale)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -65,6 +65,8 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("blargles", "blargle".pluralize(0))
     assert_equal("blargle", "blargle".pluralize(1))
     assert_equal("blargles", "blargle".pluralize(2))
+    assert_equal("blargle", "blargle".pluralize(-1))
+    assert_equal("blargles", "blargle".pluralize(-2))
   end
 
   test "pluralize with count = 1 still returns new string" do


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Currently, the pluralize method handles only positive numbers, we have to use `abs` to handle negative numbers. 

```rb
"Due in #{count} #{'day'.pluralize(count.abs)}"
```

We can write like this instead of `count == -1`.

```rb
    if count.abs == 1
```
You can merge this PR if you'd like.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
