### PR TITLE
Speed up railties test test_skip_webpack_install currently ~10s

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -955,16 +955,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
 
     generator([destination_root], skip_webpack_install: true).stub(:rails_command, command_check) do
-      quietly { generator.invoke_all }
+      generator.stub :bundle_command, nil do
+        quietly { generator.invoke_all }
+      end
     end
 
     assert_gem "webpacker"
     assert_no_file "config/webpacker.yml"
 
     output = Dir.chdir(destination_root) do
-      `rails --help`
+      `bin/rails help`
     end
+
     assert_match(/The most common rails commands are:/, output)
+    assert_match(/webpacker:install/, output)
     assert_equal true, $?.success?
   end
 


### PR DESCRIPTION
### Summary

There is another test in the generators that is taking ~10s: `AppGeneratorTest#test_skip_webpack_install = 9.79s`

To repo: `b exec ruby -w -Itest test/generators/app_generator_test.rb -v  -n test_skip_webpack_install`

I have removed the `rails --help` as it does not seem to be part of generators, which reduced this test to ~5s. The `skip_bundle` reduced this test by a further 4s.

Related to: https://github.com/rails/rails/pull/39661

