### PR TITLE
Generate nicer scope names from enums

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -195,7 +195,7 @@ module ActiveRecord
               suffix = "_#{enum_suffix}"
             end
 
-            value_method_name = "#{prefix}#{label}#{suffix}"
+            value_method_name = "#{prefix}#{label.to_s.parameterize.underscore}#{suffix}"
             enum_values[label] = value
             label = label.to_s
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -592,6 +592,16 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { klass.proposed }
   end
 
+  test "scopes are named like methods" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "cats"
+      enum breed: { "American Bobtail" => 0, "Balinese-Javanese" => 1 }
+    end
+
+    assert_respond_to klass, :american_bobtail
+    assert_respond_to klass, :balinese_javanese
+  end
+
   test "enums with a negative condition log a warning" do
     old_logger = ActiveRecord::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new


### PR DESCRIPTION
I had an enum defined in my Rails model using string keys instead of symbols. One of the strings had a hyphen in it, and I noticed I didn't get the scope name I expected:

```ruby
# MyModel has `enum pattern: { "dot-fill" => 0 }`
>> puts MyModel.dot_fill.to_sql
Traceback (most recent call last):
        3: from /my_app/script/console:82:in `<main>'
        2: from (irb):1
        1: from /my_app/vendor/gems/2.6.6/ruby/2.6.0/gems/activerecord-6.0.3.2.5438067/lib/active_record/dynamic_matchers.rb:22:in `method_missing'
NoMethodError (undefined method `dot_fill' for #<Class:0x0000000125f6ede0>)
>> puts MyModel.public_send(:"dot-fill").to_sql
SELECT `my_table`.* FROM `my_table` WHERE `my_table`.`pattern` = 0
=> nil
```

This branch changes the generated scope names for an enum's values so that spaces and hyphens are replaced with underscores. This would allow me to do `MyModel.dot_fill` as expected.

Many thanks to `@eileencodes` for helping me get my local dev environment set up (I had trouble with Vagrant + Virtual Box timing out on my Mac) to run tests. 🙇‍♀️ 