### PR TITLE
Make usec parsing faster

### DIFF
--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -59,20 +59,19 @@ module ActiveModel
             end
           end
 
-          ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(\.\d+)?\z/
+          ISO_DATETIME = /\A(\d{4})-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)(?:\.(\d{1,6})\d*)?\z/
 
           # Doesn't handle time zones.
           def fast_string_to_time(string)
-            if string =~ ISO_DATETIME
-              microsec_part = $7
-              if microsec_part && microsec_part.start_with?(".") && microsec_part.length == 7
-                microsec_part[0] = ""
-                microsec = microsec_part.to_i
-              else
-                microsec = (microsec_part.to_r * 1_000_000).to_i
-              end
-              new_time $1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, microsec
+            return unless ISO_DATETIME =~ string
+
+            usec = $7.to_i
+            usec_len = $7&.length
+            if usec_len&.< 6
+              usec *= 10 ** (6 - usec_len)
             end
+
+            new_time($1.to_i, $2.to_i, $3.to_i, $4.to_i, $5.to_i, $6.to_i, usec)
           end
       end
     end

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -54,8 +54,10 @@ module ActiveModel
 
               time -= offset
               is_utc? ? time : time.getlocal
+            elsif is_utc?
+              ::Time.utc(year, mon, mday, hour, min, sec, microsec) rescue nil
             else
-              ::Time.public_send(default_timezone, year, mon, mday, hour, min, sec, microsec) rescue nil
+              ::Time.local(year, mon, mday, hour, min, sec, microsec) rescue nil
             end
           end
 


### PR DESCRIPTION
This intends to avoid extra Rational creation for usec parsing
especially in the no usec case.

This makes all usec variations faster.

```ruby
type = ActiveRecord::Type.lookup(:datetime)
time1 = "2020-06-19 19:18:43"
time2 = "2020-06-19 19:18:43.123456"
time3 = "2020-06-19 19:18:43.123"
time4 = "2020-06-19 19:18:43.1234567"

Benchmark.ips do |x|
  x.report("type.cast(usec=0len)") { type.cast(time1); type.cast(time1) }
  x.report("type.cast(usec=6len)") { type.cast(time2); type.cast(time2) }
  x.report("type.cast(usec=3len)") { type.cast(time3); type.cast(time3) }
  x.report("type.cast(usec=7len)") { type.cast(time4); type.cast(time4) }
end
```

Before:

```
Warming up --------------------------------------
type.cast(usec=0len)     7.343k i/100ms
type.cast(usec=6len)     8.993k i/100ms
type.cast(usec=3len)     8.301k i/100ms
type.cast(usec=7len)     8.209k i/100ms
Calculating -------------------------------------
type.cast(usec=0len)     85.825k (± 5.4%) i/s -    433.237k in   5.062319s
type.cast(usec=6len)     82.045k (± 4.3%) i/s -    413.678k in   5.051260s
type.cast(usec=3len)     78.659k (± 4.4%) i/s -    398.448k in   5.074891s
type.cast(usec=7len)     77.477k (± 4.4%) i/s -    394.032k in   5.095355s
```

After:

```
Warming up --------------------------------------
type.cast(usec=0len)     9.439k i/100ms
type.cast(usec=6len)     9.282k i/100ms
type.cast(usec=3len)     9.111k i/100ms
type.cast(usec=7len)     9.059k i/100ms
Calculating -------------------------------------
type.cast(usec=0len)     90.341k (± 4.2%) i/s -    453.072k in   5.023724s
type.cast(usec=6len)     84.970k (± 3.7%) i/s -    426.972k in   5.031444s
type.cast(usec=3len)     84.043k (± 4.3%) i/s -    428.217k in   5.104155s
type.cast(usec=7len)     83.443k (± 5.3%) i/s -    416.714k in   5.008011s
```
