### PR TITLE
Allow capital characters for enum names

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -195,7 +195,7 @@ module ActiveRecord
               suffix = "_#{enum_suffix}"
             end
 
-            value_method_name = "#{prefix}#{label.to_s.parameterize.underscore}#{suffix}"
+            value_method_name = "#{prefix}#{label}#{suffix}"
             enum_values[label] = value
             label = label.to_s
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -592,16 +592,6 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { klass.proposed }
   end
 
-  test "scopes are named like methods" do
-    klass = Class.new(ActiveRecord::Base) do
-      self.table_name = "cats"
-      enum breed: { "American Bobtail" => 0, "Balinese-Javanese" => 1 }
-    end
-
-    assert_respond_to klass, :american_bobtail
-    assert_respond_to klass, :balinese_javanese
-  end
-
   test "enums with a negative condition log a warning" do
     old_logger = ActiveRecord::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -592,6 +592,17 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { klass.proposed }
   end
 
+  test "capital characters for enum names" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "computers"
+      enum extendedWarranty: [:extendedSilver, :extendedGold]
+    end
+
+    computer = klass.extendedSilver.build
+    assert_predicate computer, :extendedSilver?
+    assert_not_predicate computer, :extendedGold?
+  end
+
   test "enums with a negative condition log a warning" do
     old_logger = ActiveRecord::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new


### PR DESCRIPTION
#39673 has changed the enum names restriction to prohibit to generate capital characters methods, it is considered as a breaking change.

I've prepared two branches.
If we'd not intend to break existing apps, it should be reverted for now. This branch is for the revert.

As another direction, if the breaking change is intentional (i.e. existing apps should migrate to new restriction), at least it should be deprecated before removing the existed one.

https://github.com/rails/rails/compare/master...kamipo:deprecate_capital_characters_for_enum_scopes

```patch
From f00472af9e898437f0deb4b3e6c2664f7a8c4d6a Mon Sep 17 00:00:00 2001
From: Ryuta Kamizono <kamipo@gmail.com>
Date: Sat, 20 Jun 2020 12:40:46 +0900
Subject: [PATCH] Deprecate capital characters for enum names

After #39673, capital characters for enum names are no longer allowed.
Use new enum names instead.
---
 activerecord/CHANGELOG.md              |  4 +++
 activerecord/lib/active_record/enum.rb | 48 ++++++++++++++++++++++++++
 activerecord/test/cases/enum_test.rb   | 10 ++++++
 3 files changed, 62 insertions(+)

diff --git a/activerecord/CHANGELOG.md b/activerecord/CHANGELOG.md
index 5929a6f17581..b9d27d8c4182 100644
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate capital characters for enum names.
+
+    *Sarah Vessels*
+
 *   Deprecate YAML loading from legacy format older than Rails 5.0.
 
     *Ryuta Kamizono*
diff --git a/activerecord/lib/active_record/enum.rb b/activerecord/lib/active_record/enum.rb
index cb7d19939f3f..a6d54fe306b6 100644
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -199,24 +199,72 @@ def enum(definitions)
             enum_values[label] = value
             label = label.to_s
 
+            legacy_method_name = "#{prefix}#{label}#{suffix}"
+            legacy_method_name = nil if legacy_method_name == value_method_name
+
             # def active?() status == "active" end
             klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
             define_method("#{value_method_name}?") { self[attr] == label }
 
+            if legacy_method_name
+              klass.send(:detect_enum_conflict!, name, "#{legacy_method_name}?")
+              define_method("#{legacy_method_name}?") {
+                ActiveSupport::Deprecation.warn(<<-MSG.squish)
+                  `#{legacy_method_name}?` is deprecated and will be removed in Rails 6.2.
+                  Use `#{value_method_name}?` instead.
+                MSG
+                self[attr] == label
+              }
+            end
+
             # def active!() update!(status: 0) end
             klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
             define_method("#{value_method_name}!") { update!(attr => value) }
 
+            if legacy_method_name
+              klass.send(:detect_enum_conflict!, name, "#{legacy_method_name}!")
+              define_method("#{legacy_method_name}!") {
+                ActiveSupport::Deprecation.warn(<<-MSG.squish)
+                  `#{legacy_method_name}!` is deprecated and will be removed in Rails 6.2.
+                  Use `#{value_method_name}!` instead.
+                MSG
+                update!(attr => value)
+              }
+            end
+
             # scope :active, -> { where(status: 0) }
             # scope :not_active, -> { where.not(status: 0) }
             if enum_scopes != false
               klass.send(:detect_negative_condition!, value_method_name)
+              klass.send(:detect_negative_condition!, legacy_method_name) if legacy_method_name
 
               klass.send(:detect_enum_conflict!, name, value_method_name, true)
               klass.scope value_method_name, -> { where(attr => value) }
 
+              if legacy_method_name
+                klass.send(:detect_enum_conflict!, name, legacy_method_name, true)
+                klass.scope legacy_method_name, -> {
+                  ActiveSupport::Deprecation.warn(<<-MSG.squish)
+                    `#{legacy_method_name}` is deprecated and will be removed in Rails 6.2.
+                    Use `#{value_method_name}` instead.
+                  MSG
+                  where(attr => value)
+                }
+              end
+
               klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
               klass.scope "not_#{value_method_name}", -> { where.not(attr => value) }
+
+              if legacy_method_name
+                klass.send(:detect_enum_conflict!, name, "not_#{legacy_method_name}", true)
+                klass.scope "not_#{legacy_method_name}", -> {
+                  ActiveSupport::Deprecation.warn(<<-MSG.squish)
+                    `not_#{legacy_method_name}` is deprecated and will be removed in Rails 6.2.
+                    Use `not_#{value_method_name}` instead.
+                  MSG
+                  where.not(attr => value)
+                }
+              end
             end
           end
         end
diff --git a/activerecord/test/cases/enum_test.rb b/activerecord/test/cases/enum_test.rb
index 63629be4be80..9dc92485fe1e 100644
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -592,6 +592,16 @@ def self.name; "Book"; end
     assert_raises(NoMethodError) { klass.proposed }
   end
 
+  test "capital characters for scopes are deprecated" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "computers"
+      enum extendedWarranty: [:extendedSilver, :extendedGold]
+    end
+
+    assert_deprecated { klass.extendedSilver }
+    assert_deprecated { klass.extendedGold }
+  end
+
   test "scopes are named like methods" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "cats"
```

cc @tenderlove @cheshire137