### PR TITLE
Documentation: Add touch_all to callbacks and validations guides [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -508,8 +508,8 @@ module ActiveRecord
       update_all updates
     end
 
-    # Touches all records in the current relation without instantiating records first with the +updated_at+/+updated_on+ attributes
-    # set to the current time or the time specified.
+    # Touches all records in the current relation, setting the +updated_at+/+updated_on+ attributes to the current time or the time specified.
+    # It does not instantiate the involved models, and it does not trigger Active Record callbacks or validations.
     # This method can be passed attribute names and an optional time argument.
     # If attribute names are passed, they are updated along with +updated_at+/+updated_on+ attributes.
     # If no time argument is passed, the current time is used as default.

--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -247,6 +247,7 @@ Just as with validations, it is also possible to skip callbacks by using the fol
 * `delete_all`
 * `increment!`
 * `increment_counter`
+* `touch_all`
 * `update_column`
 * `update_columns`
 * `update_all`

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -135,6 +135,7 @@ database regardless of its validity. They should be used with caution.
 * `increment_counter`
 * `toggle!`
 * `touch`
+* `touch_all`
 * `update_all`
 * `update_attribute`
 * `update_column`


### PR DESCRIPTION
### Summary

Just a minor change, but I noticed in the guides it wasn't mentioned the `touch_all` behavior regarding callbacks and validations.