### PR TITLE
Implement `equality?` rather than inheriting `Equality` for `In` node

### DIFF
--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -28,7 +28,7 @@ require "arel/nodes/with"
 # binary
 require "arel/nodes/binary"
 require "arel/nodes/equality"
-require "arel/nodes/in" # Why is this subclassed from equality?
+require "arel/nodes/in"
 require "arel/nodes/join_source"
 require "arel/nodes/delete_statement"
 require "arel/nodes/table_alias"

--- a/activerecord/lib/arel/nodes/in.rb
+++ b/activerecord/lib/arel/nodes/in.rb
@@ -2,7 +2,11 @@
 
 module Arel # :nodoc: all
   module Nodes
-    class In < Equality
+    class In < Arel::Nodes::Binary
+      include FetchAttribute
+
+      def equality?; true; end
+
       def invert
         Arel::Nodes::NotIn.new(left, right)
       end


### PR DESCRIPTION
Related #39644.

Historically subclasses of `Equality` has a special equality ability,
but it has migrated to `equality?` method.

Since we have added `HomogeneousIn`, `Equality === node` could no longer
detect all equality nodes, we should check the response of `equality?`
method for the purpose.

Originally, it wasn't common understanding that the `In` node was a
subclass of the `Equality` node, so it was unclear whether
`Equality === node` really wanted to detect the `In` node as well.

As another problem, we need to check `In === node` first if intend to
detect only `Equality` node.

Example:

https://github.com/rails/rails/blob/4148590ed99f76debd2a016ed03d2e2bd65eab37/activerecord/lib/active_record/relation/where_clause.rb#L98-L103

This solves the problems described above.
