### PR TITLE
Move belongs_to's `association_primary_key` into `BelongsToReflection`

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -289,14 +289,6 @@ module ActiveRecord
         )
       end
 
-      def join_primary_key(klass = nil)
-        foreign_key
-      end
-
-      def join_foreign_key
-        active_record_primary_key
-      end
-
       def strict_loading?
         options[:strict_loading]
       end
@@ -455,17 +447,20 @@ module ActiveRecord
         @association_foreign_key ||= -(options[:association_foreign_key]&.to_s || class_name.foreign_key)
       end
 
-      # klass option is necessary to support loading polymorphic associations
       def association_primary_key(klass = nil)
-        if primary_key = options[:primary_key]
-          @association_primary_key ||= -primary_key.to_s
-        else
-          primary_key(klass || self.klass)
-        end
+        primary_key(klass || self.klass)
       end
 
       def active_record_primary_key
         @active_record_primary_key ||= -(options[:primary_key]&.to_s || primary_key(active_record))
+      end
+
+      def join_primary_key(klass = nil)
+        foreign_key
+      end
+
+      def join_foreign_key
+        active_record_primary_key
       end
 
       def check_validity!
@@ -681,10 +676,6 @@ module ActiveRecord
           Associations::HasManyAssociation
         end
       end
-
-      def association_primary_key(klass = nil)
-        primary_key(klass || self.klass)
-      end
     end
 
     class HasOneReflection < AssociationReflection # :nodoc:
@@ -716,6 +707,15 @@ module ActiveRecord
           Associations::BelongsToPolymorphicAssociation
         else
           Associations::BelongsToAssociation
+        end
+      end
+
+      # klass option is necessary to support loading polymorphic associations
+      def association_primary_key(klass = nil)
+        if primary_key = options[:primary_key]
+          @association_primary_key ||= -primary_key.to_s
+        else
+          primary_key(klass || self.klass)
         end
       end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -328,7 +328,7 @@ class ReflectionTest < ActiveRecord::TestCase
   def test_association_primary_key
     # Normal association
     assert_equal "id",   Author.reflect_on_association(:posts).association_primary_key.to_s
-    assert_equal "name", Author.reflect_on_association(:essay).association_primary_key.to_s
+    assert_equal "id",   Author.reflect_on_association(:essay).association_primary_key.to_s
     assert_equal "name", Essay.reflect_on_association(:writer).association_primary_key.to_s
 
     # Through association (uses the :primary_key option from the source reflection)


### PR DESCRIPTION
Most association key methods on the base `AssociationReflection` class
are for has_many and has_one associations, but only
`association_primary_key` is for belongs_to association, it is very
confusing, and so it had a bug for has_one association.

This assorts association key methods on `AssociationReflection`, to have
methods for has_many and has_one associations, and move belongs_to's one
into `BelongsToReflection`.
