### PR TITLE
Support storing demodulized class name for polymorphic type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support storing demodulized class name for polymorphic type.
+
+    Before Rails 6.1, storing demodulized class name is supported only for STI type
+    by `store_full_sti_class` class attribute.
+
+    Now `store_full_class_name` class attribute can handle both STI and polymorphic types.
+
+    *Ryuta Kamizono*
+
 *   Deprecate `rails db:structure:{load, dump}` tasks and extend
     `rails db:schema:{load, dump}` tasks to work with either `:ruby` or `:sql` format,
     depending on `config.active_record.schema_format` configuration value.

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -38,6 +38,8 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     included do
+      class_attribute :store_full_class_name, instance_writer: false, default: true
+
       # Determines whether to store the full constant name including namespace when using STI.
       # This is true, by default.
       class_attribute :store_full_sti_class, instance_writer: false, default: true
@@ -164,14 +166,14 @@ module ActiveRecord
 
       # Returns the value to be stored in the inheritance column for STI.
       def sti_name
-        store_full_sti_class ? name : name.demodulize
+        store_full_sti_class && store_full_class_name ? name : name.demodulize
       end
 
       # Returns the class for the provided +type_name+.
       #
       # It is used to find the class correspondent to the value stored in the inheritance column.
       def sti_class_for(type_name)
-        if store_full_sti_class
+        if store_full_sti_class && store_full_class_name
           ActiveSupport::Dependencies.constantize(type_name)
         else
           compute_type(type_name)
@@ -186,14 +188,18 @@ module ActiveRecord
 
       # Returns the value to be stored in the polymorphic type column for Polymorphic Associations.
       def polymorphic_name
-        base_class.name
+        store_full_class_name ? base_class.name : base_class.name.demodulize
       end
 
       # Returns the class for the provided +name+.
       #
       # It is used to find the class correspondent to the value stored in the polymorphic type column.
       def polymorphic_class_for(name)
-        name.constantize
+        if store_full_class_name
+          ActiveSupport::Dependencies.constantize(name)
+        else
+          compute_type(name)
+        end
       end
 
       def inherited(subclass)


### PR DESCRIPTION
This is an alternative of #29722.

Before Rails 6.1, storing demodulized class name is supported only for
STI type by `store_full_sti_class` class attribute.

Now `store_full_class_name` class attribute can handle both STI and
polymorphic types.

Closes #29722.

See also #29601, #32048, #32148.

cc @jeremy @matthewd 