### PR TITLE
Enroll new apps in decrypted diffs of credentials

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Enroll new apps in decrypted diffs of credentials by default.  This behavior
+    can be opted out of with the app generator's `--skip-decrypted-diffs` flag.
+
+    *Jonathan Hefner*
+
 *   Support declarative-style test name filters with `bin/rails test`.
 
     This makes it possible to run a declarative-style test such as:

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -64,7 +64,6 @@ module Rails
 
           say credentials.read.presence || credentials.content_path.read
         else
-          require_application!
           disenroll_project_from_credentials_diffing if options[:disenroll]
           enroll_project_in_credentials_diffing if options[:enroll]
         end

--- a/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command/diffing.rb
@@ -46,6 +46,6 @@ module Rails::Command::CredentialsCommand::Diffing # :nodoc:
     end
 
     def gitattributes
-      Rails.root.join(".gitattributes")
+      @gitattributes ||= (Rails::Command.root || Pathname.pwd).join(".gitattributes")
     end
 end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -182,6 +182,12 @@ module Rails
       Rails::Generators::CredentialsGenerator.new([], quiet: options[:quiet]).add_credentials_file_silently
     end
 
+    def credentials_diff_enroll
+      return if options[:skip_decrypted_diffs] || options[:skip_git] || options[:dummy_app] || options[:pretend]
+
+      rails_command "credentials:diff --enroll", inline: true, shell: @generator.shell
+    end
+
     def database_yml
       template "config/databases/#{options[:database]}.yml", "config/database.yml"
     end
@@ -260,6 +266,7 @@ module Rails
       class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
       class_option :css, type: :string, aliases: "-c", desc: "Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass... check https://github.com/rails/cssbundling-rails]"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
+      class_option :skip_decrypted_diffs, type: :boolean, default: false, desc: "Don't configure git to show decrypted diffs of encrypted credentials"
 
       def initialize(*args)
         super
@@ -347,6 +354,7 @@ module Rails
 
       def create_credentials
         build(:credentials)
+        build(:credentials_diff_enroll)
       end
 
       def display_upgrade_guide_info

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -123,6 +123,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
 
 
   test "diff enroll diffing" do
+    FileUtils.rm(app_path(".gitattributes"))
     assert_match(/\benrolled project/i, run_diff_command(enroll: true))
 
     assert_includes File.read(app_path(".gitattributes")), <<~EOM

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -514,6 +514,18 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", /^# gem "redis"/
   end
 
+  def test_generator_configures_decrypted_diffs_by_default
+    run_generator
+    assert_file ".gitattributes", /\.enc diff=/
+  end
+
+  def test_generator_does_not_configure_decrypted_diffs_when_skip_decrypted_diffs_is_given
+    run_generator [destination_root, "--skip-decrypted-diffs"]
+    assert_file ".gitattributes" do |content|
+      assert_no_match %r/\.enc diff=/, content
+    end
+  end
+
   def test_generator_if_skip_test_is_given
     run_generator [destination_root, "--skip-test"]
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -100,6 +100,7 @@ module SharedGeneratorTests
   def test_skip_git
     run_generator [destination_root, "--skip-git", "--full"]
     assert_no_file(".gitignore")
+    assert_no_file(".gitattributes")
     assert_no_directory(".git")
   end
 


### PR DESCRIPTION
Users, especially those who are creating an app for the first time, might not be aware of the `rails credentials:diff --enroll` command.  This commit enrolls new apps in decrypted diffs by default so that users benefit automatically.  This behavior can be opted out of with the `--skip-decrypted-diffs` flag.
