### PR TITLE
Fix issue #39286 (about digesting in ActiveStorage)

### DIFF
--- a/activestorage/app/controllers/active_storage/base_controller.rb
+++ b/activestorage/app/controllers/active_storage/base_controller.rb
@@ -6,6 +6,8 @@ class ActiveStorage::BaseController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  self.etag_with_template_digest = false
+
   private
     def stream(blob)
       blob.download do |chunk|


### PR DESCRIPTION
Error entries appear in the log when we request ActiveStorage controllers (`ActiveStorage::Representations::ProxyController#show`, `ActiveStorage::Blobs::ProxyController#show`).

These entries look like: 
```text
Couldn't find template for digesting: active_storage/representations/proxy/show
```

There is the issue about it (#39286). This change fixes it.

These controllers use the method `ActionController::ConditionalGet#http_cache_forever`, and therefore `ActionController::ConditionalGet#combine_etags` method, and therefore `ActionController::EtagWithTemplateDigest` module via `etaggers` array.

`ActionController::EtagWithTemplateDigest` module requires a template (view).

We have no views in ActiveStorage, so `EtagWithTemplateDigest` is now turned off in ActiveStorage controllers by `etag_with_template_digest` class attribute.

