### PR TITLE
Deduplicate some routing data

### DIFF
--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -89,7 +89,7 @@ module ActionDispatch
           return params unless controller && controller.valid_encoding?
 
           if binary_params_for?(controller, action)
-            ActionDispatch::Request::Utils.each_param_value(params) do |param|
+            ActionDispatch::Request::Utils.each_param_value(params.except(:controller, :action)) do |param|
               param.force_encoding ::Encoding::ASCII_8BIT
             end
           end

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -348,7 +348,7 @@ module ActionDispatch
 
           def split_to(to)
             if /#/.match?(to)
-              to.split("#")
+              to.split("#").map!(&:-@)
             else
               []
             end
@@ -357,9 +357,9 @@ module ActionDispatch
           def add_controller_module(controller, modyoule)
             if modyoule && !controller.is_a?(Regexp)
               if controller&.start_with?("/")
-                controller[1..-1]
+                -controller[1..-1]
               else
-                [modyoule, controller].compact.join("/")
+                -[modyoule, controller].compact.join("/")
               end
             else
               controller

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -15,7 +15,7 @@ class ParameterEncodingController < ActionController::Base
   end
 
   def test_all_values_encoding
-    render body: ::JSON.dump(params.values.map(&:encoding).map(&:name))
+    render body: ::JSON.dump(params.except(:action, :controller).values.map(&:encoding).map(&:name))
   end
 end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4599,9 +4599,13 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
     with_routing do |set|
       set.draw do
         get "/foo/show(/:id)", to: "test_invalid_urls/foo#show"
+        get "/bar/show(/:id)", controller: "test_invalid_urls/foo", action: "show"
       end
 
       get "/foo/show/%E2%EF%BF%BD%A6"
+      assert_response :ok
+
+      get "/bar/show/%E2%EF%BF%BD%A6"
       assert_response :ok
     end
   end


### PR DESCRIPTION
While memory profiling our application I noticed some string duplication originating from the router:

```ruby
Retained String Report
-----------------------------------
       102  "admin/timeline_comments"
       100  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:362
... 
        93  "admin/comments"
        90  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:362
... 
        90  "show"
        48  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:351
... 
        80  "admin/abandoned_checkouts"
        76  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:362
...
        80  "services/internal/shops"
        77  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:362
... 
        76  "services/internal/shopify_payments"
        36  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:362
... 
        75  "admin/orders"
        72  ~/gems/rails-9734dfa1a1a2/actionpack/lib/action_dispatch/routing/mapper.rb:362
... 
```

It's not a lot, but it's also trivial to deduplicate them.

@rafaelfranca @Edouard-chin @etiennebarrie 