### PR TITLE
Only cast test parameters as JSON if it is called with `as: :json`.

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -244,9 +244,20 @@ XML
 
     post :test_params, params: { foo: klass.new }
 
-    assert_equal JSON.parse(@response.body)["foo"], "bar"
+    assert_equal "bar", JSON.parse(@response.body)["foo"]
   end
 
+  def test_handle_to_params_json
+    klass = Class.new do
+      def as_json(_ = nil)
+        { "type" => "bar" }
+      end
+    end
+
+    post :test_params, params: { foo: klass.new }, as: :json
+
+    assert_equal({ "type" => "bar" }, JSON.parse(@response.body)["foo"])
+  end
 
   def test_body_stream
     params = Hash[:page, { name: "page name" }, "some key", 123]


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/39653

Something that I'm not sure is documented, but as least is explicitly tested is that you can pass models as controller params in `ActionController::TestCase`.

https://github.com/rails/rails/pull/39653 broke that for `format: :json` tests, e.g.:

```ruby
Failure:
TestCaseTest#test_handle_to_params_json [/Users/byroot/src/github.com/Shopify/rails/actionpack/test/controller/test_case_test.rb:259]:
--- expected
+++ actual
@@ -1 +1 @@
-"#<#<Class:0xXXXXXX>:0xXXXXXX>"
+"bar"
```

I'm not super fan of my fix, having to check for `ActiveModel::Conversion` is rather unfortunate, but I couldn't figure any other way to tell models apart from all other values that respond to `to_param`.

@eileencodes @rafaelfranca @Edouard-chin @etiennebarrie 