### PR TITLE
Recover precision when serializing `Time`, `TimeWithZone` and `DateTime`.

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Introduce `ActiveJob.time_precision` to make time precision configurable when serializing `Time`, `TimeWithZone` and `DateTime` objects.
+*   Recover nano precision when serializing `Time`, `TimeWithZone` and `DateTime` objects.
 
     *Alan Tan*
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Introduce `ActiveJob.time_precision` to make time precision configurable when serializing `Time`, `TimeWithZone` and `DateTime` objects.
+
+    *Alan Tan*
+
 *   While using `perform_enqueued_jobs` test helper enqueued jobs must be stored for the later check with
     `assert_enqueued_with`.
 

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -17,8 +17,9 @@ module ActiveJob
     autoload :TimeSerializer
     autoload :ModuleSerializer
 
-    mattr_accessor :_additional_serializers
+    mattr_accessor :_additional_serializers, :time_precision
     self._additional_serializers = Set.new
+    self.time_precision = 0
 
     class << self
       # Returns serialized representative of the passed object.

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -9,6 +9,7 @@ module ActiveJob
     extend ActiveSupport::Autoload
 
     autoload :ObjectSerializer
+    autoload :TimeObjectSerializer
     autoload :SymbolSerializer
     autoload :DurationSerializer
     autoload :DateTimeSerializer
@@ -17,9 +18,8 @@ module ActiveJob
     autoload :TimeSerializer
     autoload :ModuleSerializer
 
-    mattr_accessor :_additional_serializers, :time_precision
+    mattr_accessor :_additional_serializers
     self._additional_serializers = Set.new
-    self.time_precision = 0
 
     class << self
       # Returns serialized representative of the passed object.

--- a/activejob/lib/active_job/serializers/date_time_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_time_serializer.rb
@@ -2,11 +2,7 @@
 
 module ActiveJob
   module Serializers
-    class DateTimeSerializer < ObjectSerializer # :nodoc:
-      def serialize(time)
-        super("value" => time.iso8601(ActiveJob::Serializers.time_precision))
-      end
-
+    class DateTimeSerializer < TimeObjectSerializer # :nodoc:
       def deserialize(hash)
         DateTime.iso8601(hash["value"])
       end

--- a/activejob/lib/active_job/serializers/date_time_serializer.rb
+++ b/activejob/lib/active_job/serializers/date_time_serializer.rb
@@ -4,7 +4,7 @@ module ActiveJob
   module Serializers
     class DateTimeSerializer < ObjectSerializer # :nodoc:
       def serialize(time)
-        super("value" => time.iso8601)
+        super("value" => time.iso8601(ActiveJob::Serializers.time_precision))
       end
 
       def deserialize(hash)

--- a/activejob/lib/active_job/serializers/time_object_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_object_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class TimeObjectSerializer < ObjectSerializer # :nodoc:
+      NANO_PRECISION = 9
+
+      def serialize(time)
+        super("value" => time.iso8601(NANO_PRECISION))
+      end
+    end
+  end
+end

--- a/activejob/lib/active_job/serializers/time_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_serializer.rb
@@ -2,11 +2,7 @@
 
 module ActiveJob
   module Serializers
-    class TimeSerializer < ObjectSerializer # :nodoc:
-      def serialize(time)
-        super("value" => time.iso8601(ActiveJob::Serializers.time_precision))
-      end
-
+    class TimeSerializer < TimeObjectSerializer # :nodoc:
       def deserialize(hash)
         Time.iso8601(hash["value"])
       end

--- a/activejob/lib/active_job/serializers/time_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_serializer.rb
@@ -4,7 +4,7 @@ module ActiveJob
   module Serializers
     class TimeSerializer < ObjectSerializer # :nodoc:
       def serialize(time)
-        super("value" => time.iso8601)
+        super("value" => time.iso8601(ActiveJob::Serializers.time_precision))
       end
 
       def deserialize(hash)

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -2,11 +2,7 @@
 
 module ActiveJob
   module Serializers
-    class TimeWithZoneSerializer < ObjectSerializer # :nodoc:
-      def serialize(time)
-        super("value" => time.iso8601(ActiveJob::Serializers.time_precision))
-      end
-
+    class TimeWithZoneSerializer < TimeObjectSerializer # :nodoc:
       def deserialize(hash)
         Time.iso8601(hash["value"]).in_time_zone
       end

--- a/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
+++ b/activejob/lib/active_job/serializers/time_with_zone_serializer.rb
@@ -4,7 +4,7 @@ module ActiveJob
   module Serializers
     class TimeWithZoneSerializer < ObjectSerializer # :nodoc:
       def serialize(time)
-        super("value" => time.iso8601)
+        super("value" => time.iso8601(ActiveJob::Serializers.time_precision))
       end
 
       def deserialize(hash)

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -671,28 +671,6 @@ module ActiveJob
             at_range = arguments[:at] - 1..arguments[:at] + 1
             arguments[:at] = ->(at) { at_range.cover?(at) }
           end
-          arguments[:args] = round_time_arguments(arguments[:args]) if arguments[:args]
-        end
-      end
-
-      def round_time_arguments(argument)
-        case argument
-        when Time, ActiveSupport::TimeWithZone, DateTime
-          nsec =
-            if ActiveJob::Serializers.time_precision > 0
-              nsec = argument.nsec
-              nsec - (nsec % (10 ** (9 - ActiveJob::Serializers.time_precision)))
-            else
-              0
-            end
-
-          argument.change(nsec: nsec)
-        when Hash
-          argument.transform_values { |value| round_time_arguments(value) }
-        when Array
-          argument.map { |element| round_time_arguments(element) }
-        else
-          argument
         end
       end
 

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -678,7 +678,15 @@ module ActiveJob
       def round_time_arguments(argument)
         case argument
         when Time, ActiveSupport::TimeWithZone, DateTime
-          argument.change(usec: 0)
+          nsec =
+            if ActiveJob::Serializers.time_precision > 0
+              nsec = argument.nsec
+              nsec - (nsec % (10 ** (9 - ActiveJob::Serializers.time_precision)))
+            else
+              0
+            end
+
+          argument.change(nsec: nsec)
         when Hash
           argument.transform_values { |value| round_time_arguments(value) }
         when Array

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -20,16 +20,19 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
 
   [ nil, 1, 1.0, 1_000_000_000_000_000_000_000,
     "a", true, false, BigDecimal(5),
-    :a, 1.day, Date.new(2001, 2, 3), Time.new(2002, 10, 31, 2, 2, 2, "+02:00"),
-    DateTime.new(2001, 2, 3, 4, 5, 6, "+03:00"),
-    ActiveSupport::TimeWithZone.new(Time.utc(1999, 12, 31, 23, 59, 59), ActiveSupport::TimeZone["UTC"]),
+    :a,
+    1.day,
+    Date.new(2001, 2, 3),
+    Time.new(2002, 10, 31, 2, 2, 2.123456789r, "+02:00"),
+    DateTime.new(2001, 2, 3, 4, 5, 6.123456r, "+03:00"),
+    ActiveSupport::TimeWithZone.new(Time.utc(1999, 12, 31, 23, 59, "59.123456789".to_r), ActiveSupport::TimeZone["UTC"]),
     [ 1, "a" ],
     { "a" => 1 },
     ModuleArgument,
     ModuleArgument::ClassArgument,
     ClassArgument
   ].each do |arg|
-    test "serializes #{arg.class} - #{arg} verbatim" do
+    test "serializes #{arg.class} - #{arg.inspect} verbatim" do
       assert_arguments_unchanged arg
     end
   end

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -608,6 +608,21 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
   end
 
+  def test_assert_enqueued_with_time_and_time_precision
+    original_time_precision = ActiveJob::Serializers.time_precision
+    ActiveJob::Serializers.time_precision = 3
+    time_with_zone = Time.now.in_time_zone("Tokyo")
+    time = Time.at(946702800, 1234567, :nanosecond)
+    date_time = DateTime.now
+    args = [{ argument1: [time_with_zone, time, date_time] }]
+
+    assert_enqueued_with(job: MultipleKwargsJob, args: args) do
+      MultipleKwargsJob.perform_later(argument1: [time_with_zone, time, date_time])
+    end
+  ensure
+    ActiveJob::Serializers.time_precision = original_time_precision
+  end
+
   def test_assert_enqueued_with_with_no_block_args
     assert_raise ArgumentError do
       NestedJob.set(wait_until: Date.tomorrow.noon).perform_later

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -609,18 +609,18 @@ class EnqueuedJobsTest < ActiveJob::TestCase
   end
 
   def test_assert_enqueued_with_time_and_time_precision
-    original_time_precision = ActiveJob::Serializers.time_precision
-    ActiveJob::Serializers.time_precision = 3
-    time_with_zone = Time.now.in_time_zone("Tokyo")
+    time_with_zone = ActiveSupport::TimeWithZone.new(
+      Time.utc(1999, 12, 31, 23, 59, "59.123456789".to_r),
+      ActiveSupport::TimeZone["Tokyo"]
+    )
+
     time = Time.at(946702800, 1234567, :nanosecond)
-    date_time = DateTime.now
+    date_time = DateTime.new(2001, 2, 3, 4, 5, 6.123456, "+03:00")
     args = [{ argument1: [time_with_zone, time, date_time] }]
 
     assert_enqueued_with(job: MultipleKwargsJob, args: args) do
       MultipleKwargsJob.perform_later(argument1: [time_with_zone, time, date_time])
     end
-  ensure
-    ActiveJob::Serializers.time_precision = original_time_precision
   end
 
   def test_assert_enqueued_with_with_no_block_args

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -263,7 +263,7 @@ Every Rails application comes with a standard set of middleware which it uses in
    # `beta1.product.com`.
    Rails.application.config.hosts << /.*\.product\.com/
    ```
-   
+
    The provided regexp will be wrapped with both anchors (`\A` and `\z`) so it
    must match the entire hostname. `/product.com/`, for example, once anchored,
    would fail to match `www.product.com`.
@@ -888,8 +888,6 @@ There are a few configuration options available in Active Support:
 * `config.active_job.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Active Job. You can retrieve this logger by calling `logger` on either an Active Job class or an Active Job instance. Set to `nil` to disable logging.
 
 * `config.active_job.custom_serializers` allows to set custom argument serializers. Defaults to `[]`.
-
-* `config.active_job.time_precision` sets the precision of serialized time values. Defaults to `0`.
 
 * `config.active_job.return_false_on_aborted_enqueue` change the return value of `#enqueue` to false instead of the job instance when the enqueuing is aborted. Defaults to `false`.
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -889,6 +889,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_job.custom_serializers` allows to set custom argument serializers. Defaults to `[]`.
 
+* `config.active_job.time_precision` sets the precision of serialized time values. Defaults to `0`.
+
 * `config.active_job.return_false_on_aborted_enqueue` change the return value of `#enqueue` to false instead of the job instance when the enqueuing is aborted. Defaults to `false`.
 
 * `config.active_job.log_arguments` controls if the arguments of a job are logged. Defaults to `true`.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1768,25 +1768,6 @@ class ProductTest < ActiveSupport::TestCase
 end
 ```
 
-### Asserting Time Arguments in Jobs
-
-When serializing job arguments, `Time`, `DateTime`, and `ActiveSupport::TimeWithZone` lose microsecond precision. This means comparing deserialized time with actual time doesn't always work. To compensate for the loss of precision, `assert_enqueued_with` and `assert_performed_with` will remove microseconds from time objects in argument assertions.
-
-```ruby
-require "test_helper"
-
-class ProductTest < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
-  test "that product is reserved at a given time" do
-    now = Time.now
-    assert_performed_with(job: ReservationJob, args: [product, now]) do
-      product.reserve(now)
-    end
-  end
-end
-```
-
 Testing Action Cable
 --------------------
 


### PR DESCRIPTION
Resolves https://github.com/rails/rails/issues/39648
Related https://github.com/rails/rails/pull/35713