### PR TITLE
Replace space/hyphen in enum scope names

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -195,7 +195,8 @@ module ActiveRecord
               suffix = "_#{enum_suffix}"
             end
 
-            value_method_name = "#{prefix}#{label}#{suffix}"
+            method_friendly_label = label.to_s.gsub(/\W+/, "_")
+            value_method_name = "#{prefix}#{method_friendly_label}#{suffix}"
             enum_values[label] = value
             label = label.to_s
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -592,6 +592,16 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { klass.proposed }
   end
 
+  test "scopes are named like methods" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "cats"
+      enum breed: { "American Bobtail" => 0, "Balinese-Javanese" => 1 }
+    end
+
+    assert_respond_to klass, :American_Bobtail
+    assert_respond_to klass, :Balinese_Javanese
+  end
+
   test "capital characters for enum names" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "computers"


### PR DESCRIPTION
This is a follow-up to #39677 to restore my intended changes from #39673 without breaking capitalization in generated `enum` scope names. This replaces characters like `-`, `+`, and space from `enum` labels with underscores, to make sure the generated scopes are callable methods that you don't have to use `public_send` to access. cc @kamipo @tenderlove 