### PR TITLE
respect dalli’s cache_nil setting

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -187,9 +187,8 @@ module ActiveSupport
         end
 
         def deserialize_entry(entry)
-          if entry
-            entry.is_a?(Entry) ? entry : Entry.new(entry)
-          end
+          return if entry.nil? || (@options[:cache_nils] && entry.eql?(Dalli::Server::NOT_FOUND))
+          entry.is_a?(Entry) ? entry : Entry.new(entry)
         end
 
         def rescue_error_with(fallback)


### PR DESCRIPTION
### Summary

Dalli provides an option to `cache_nils` as a performance optimisation configuration - https://github.com/petergoldstein/dalli/#configuration -> `cache_nils`.

`ActiveSupport::Cache::MemCacheStore` should deserialize the cached nils and return nil instead of `Dalli::Server::NOT_FOUND`.


### Other Information

```ruby
# config/application.rb
config.cache_store = :mem_cache_store, { 
    servers: %w(memcached:11211),
    namespace: 'namespace',
    compress: true,
    cache_nils: true
}

$memcached = Dalli::Client.new(%w(memcached:11211), {
    namespace: 'namespace',
    compress: true,
    cache_nils: true
})

> $memcached.fetch(:a) { nil }
=> nil
> $memcached.fetch(:a) { 1 }
=> nil

> Rails.cache.fetch(:z) { nil }
=> #<Dalli::Server::NilObject:0x00007ff30da57028>
> Rails.cache.fetch(:z) { 1 }
=> #<Dalli::Server::NilObject:0x00007ff30da57028>
```

reproducible on both 6-0-stable and master branches.