### PR TITLE
Add missing info to routing.md about anchors.

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -686,7 +686,7 @@ get 'photos/:id', to: 'photos#show', id: /[A-Z]\d{5}/
 get '/:id', to: 'articles#show', constraints: { id: /^\d/ }
 ```
 
-However, note that you don't need to use anchors because all routes are anchored at the start.
+However, note that you don't need to use anchors because all routes are anchored at the start and the end.
 
 For example, the following routes would allow for `articles` with `to_param` values like `1-hello-world` that always begin with a number and `users` with `to_param` values like `david` that never begin with a number to share the root namespace:
 


### PR DESCRIPTION
### Summary

Document the fact that regex constraints are anchored at **both** the start and the end. This was pretty confusing to me, and difficult to verify, whether and where regexes are implicitly anchored.

(Is this **true**? I.e., are regexes anchored both at the start and end? I couldn't find out from the API docs. I've just seen people assert this to be the case.)