### PR TITLE
Fix the ActionController::TestCase#process parameters serialization

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -74,21 +74,14 @@ module ActionController
       non_path_parameters = {}
       path_parameters = {}
 
-      if parameters[:format] == :json
-        parameters = JSON.load(JSON.dump(parameters))
-        query_string_keys = query_string_keys.map(&:to_s)
-      end
-
       parameters.each do |key, value|
         if query_string_keys.include?(key)
           non_path_parameters[key] = value
         else
-          unless parameters["format"] == "json"
-            if value.is_a?(Array)
-              value = value.map(&:to_param)
-            else
-              value = value.to_param
-            end
+          if value.is_a?(Array)
+            value = value.map(&:to_param)
+          else
+            value = value.to_param
           end
 
           path_parameters[key] = value

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -766,11 +766,9 @@ module ActionDispatch
         end
 
         route_name = options.delete :use_route
-        path = path_for(options, route_name, [])
-
-        uri = URI.parse(path)
-        params = Rack::Utils.parse_nested_query(uri.query).symbolize_keys
-        [uri.path, params.keys]
+        generator = generate(route_name, options, recall)
+        path_info = path_for(options, route_name, [])
+        [URI(path_info).path, generator.params.except(:_recall).keys]
       end
 
       def generate(route_name, options, recall = {}, method_name = nil)


### PR DESCRIPTION
Alternative to https://github.com/rails/rails/pull/39696
Followup: https://github.com/rails/rails/pull/39653

So I dug more into the problem, and found this solution. I ran it as a monkey patch against our CI, and got all our test controllers passing without having to modify parameters.

The main issue was `params = Rack::Utils.parse_nested_query(uri.query).symbolize_keys`, this wasn't properly listing the query string parameters.

@eileencodes @rafaelfranca @Edouard-chin @etiennebarrie 