### PR TITLE
Change the default log level from :debug to :info

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Change the default logging level from :debug to :info to avoid inadvertent exposure of personally
+  identifiable information (PII) in production environments.
+  
+  *Eric M. Payne*
+
 *   Create a new rails app using a minimal stack.
 
       `rails new cool_app --minimal`

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -43,7 +43,7 @@ module Rails
         @session_store                           = nil
         @time_zone                               = "UTC"
         @beginning_of_week                       = :monday
-        @log_level                               = :debug
+        @log_level                               = :info
         @generators                              = app_generators
         @cache_store                             = [ :file_store, "#{root}/tmp/cache/" ]
         @railties_order                          = [:all]

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -56,9 +56,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1564,12 +1564,17 @@ module ApplicationTests
       assert_equal session_options, app.config.session_options
     end
 
+    test "config.log_level defaults to info" do
+      make_basic_app
+      assert_equal Logger::INFO, Rails.logger.level
+    end
+
     test "config.log_level with custom logger" do
       make_basic_app do |application|
         application.config.logger = Logger.new(STDOUT)
-        application.config.log_level = :info
+        application.config.log_level = :debug
       end
-      assert_equal Logger::INFO, Rails.logger.level
+      assert_equal Logger::DEBUG, Rails.logger.level
     end
 
     test "respond_to? accepts include_private" do


### PR DESCRIPTION
### Summary
I recently learned that Rails logs at the :debug level (not the :info
level) by default in production environments. This is a surprising
behaviour, as other popular frameworks do not log at this level
by default. It would not be surprising if a developer accidentally
logged personally identifiable information (PII) in a production
environment due to this behaviour.

### Other Information
I noticed that [in 2014](https://github.com/rails/rails/pull/16622), the Rails project made an intentional decision 
to set the default log level to :debug. However, the landscape
around logging PII has changed since then with the introduction of
legislation like GDPR, so I thought it prudent to reopen this discussion.
