### PR TITLE
Fix an error for `FileStore.cleanup` when using Sprockets

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -74,7 +74,8 @@ module ActiveSupport
       private
         def read_entry(key, **options)
           if File.exist?(key)
-            File.open(key) { |f| Marshal.load(f) }
+            entry = File.open(key) { |f| Marshal.load(f) }
+            entry if entry.is_a?(Cache::Entry)
           end
         rescue => e
           logger.error("FileStoreError (#{e}): #{e.message}") if logger

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -124,6 +124,14 @@ class FileStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_cleanup_when_non_active_support_cache_file_exists
+    cache_file_path = @cache.send(:normalize_key, "foo", nil)
+    FileUtils.makedirs(File.dirname(cache_file_path))
+    File.atomic_write(cache_file_path, cache_dir) { |f| Marshal.dump({ "foo": "bar" }, f) }
+    assert_nothing_raised { @cache.cleanup }
+    assert_equal 1, Dir.glob(File.join(cache_dir, "**")).size
+  end
+
   def test_write_with_unless_exist
     assert_equal true, @cache.write(1, "aaaaaaaaaa")
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)


### PR DESCRIPTION
### Summary

This PR fixes `NoMethodError` for `ActiveSupport::Cache::FileStore.cleanup` when using [Sprockets](https://github.com/rails/sprockets).

`FileStore.cleanup` assumes entry object is a `Cache::Entry`.
An entry obejct is returned from `FileStore.read_entry` method.
If `FileStore.read_entry` returns object that cannot respond to `expired?` method, `FileStore.cleanup` will fail.

Sprockets generates cache file in tmp/cache/assets.
If `FileStore.read_entry` gets these Sprocket's cache file, this method creates entry object which cannot respond to `expired?` method.

In my project, this error occured and failed to execute `ActiveSupport::Cache::FileStore.cleanup`.

This PR adds a `is_a?` checking to entry object in `read_entry` method.
