### PR TITLE
Use a subquery when filtering `information_schema.tables` by `table_name`.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -203,10 +203,14 @@ module ActiveRecord
           def data_source_sql(name = nil, type: nil)
             scope = quoted_scope(name, type: type)
 
-            sql = +"SELECT table_name FROM information_schema.tables"
-            sql << " WHERE table_schema = #{scope[:schema]}"
-            sql << " AND table_name = #{scope[:name]}" if scope[:name]
-            sql << " AND table_type = #{scope[:type]}" if scope[:type]
+            sql = +"SELECT table_name FROM (SELECT * FROM information_schema.tables "
+            sql << " WHERE table_schema = #{scope[:schema]}) _subquery"
+            if scope[:type] || scope[:name]
+              conditions = []
+              conditions << "_subquery.table_type = #{scope[:type]}" if scope[:type]
+              conditions << "_subquery.table_name = #{scope[:name]}" if scope[:name]
+              sql << " WHERE #{conditions.join(" AND ")}"
+            end
             sql
           end
 


### PR DESCRIPTION
### Summary

This is a workaround for a MySQL bug we've encountered when using a database user that only has been granted `SELECT` permissions on a subset of the tables that exist in a given database.

When requesting data from the `information_schema.tables` **without** specifying a table name explicitly, MySQL only returns data for tables that can be accessed by the current user.

But when requested data **with** specifying a condition for a specific table, MySQL will return data even if the specified table can not be accessed by the current user.

We found out that using a subquery would make MySQL behave as expected. 🙈 

Here's an example:

```sql
SELECT table_name FROM information_schema.tables WHERE table_schema = database()
```

This query will only return table names for tables where the current user has been granted `SELECT`.

```sql
SELECT table_name FROM information_schema.tables WHERE table_schema = database() AND table_name = 'some_table'
```

This query will return a single row containing `'some_table'`, if `some_table` exists but the current user has not been granted `SELECT` on it.

```sql
SELECT table_name FROM (SELECT * FROM information_schema.tables WHERE table_schema = database()) _subquery WHERE _subquery.table_name = 'some_table'
```

This query will return an empty result set if `some_table` exists but the current user has not been granted `SELECT` on it.

### Other Information

We're not sure which versions of MySQL are affected by this (we know it exists on MySQL 5.7.28), but the proposed change should be compatible with all versions of MySQL
