### PR TITLE
Revert "Deprecate YAML loading from legacy format older than Rails 5.0"

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,7 +1,3 @@
-*   Deprecate YAML loading from legacy format older than Rails 5.0.
-
-    *Ryuta Kamizono*
-
 *   Added the setting `ActiveRecord::Base.immutable_strings_by_default`, which
     allows you to specify that all string columns should be frozen unless
     otherwise specified. This will reduce memory pressure for applications which

--- a/activerecord/lib/active_record/legacy_yaml_adapter.rb
+++ b/activerecord/lib/active_record/legacy_yaml_adapter.rb
@@ -1,17 +1,13 @@
 # frozen_string_literal: true
 
 module ActiveRecord
-  module LegacyYamlAdapter # :nodoc:
+  module LegacyYamlAdapter
     def self.convert(klass, coder)
       return coder unless coder.is_a?(Psych::Coder)
 
       case coder["active_record_yaml_version"]
       when 1, 2 then coder
       else
-        ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          YAML loading from legacy format older than Rails 5.0 is deprecated
-          and will be removed in Rails 6.2.
-        MSG
         if coder["attributes"].is_a?(ActiveModel::AttributeSet)
           Rails420.convert(klass, coder)
         else
@@ -20,7 +16,7 @@ module ActiveRecord
       end
     end
 
-    module Rails420 # :nodoc:
+    module Rails420
       def self.convert(klass, coder)
         attribute_set = coder["attributes"]
 
@@ -36,7 +32,7 @@ module ActiveRecord
       end
     end
 
-    module Rails41 # :nodoc:
+    module Rails41
       def self.convert(klass, coder)
         attributes = klass.attributes_builder
           .build_from_database(coder["attributes"])

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -94,9 +94,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_41_yaml
-    topic = assert_deprecated do
-      YAML.load(yaml_fixture("rails_4_1"))
-    end
+    topic = YAML.load(yaml_fixture("rails_4_1"))
 
     assert_predicate topic, :new_record?
     assert_nil topic.id
@@ -105,9 +103,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_4_2_0_yaml
-    topic = assert_deprecated do
-      YAML.load(yaml_fixture("rails_4_2_0"))
-    end
+    topic = YAML.load(yaml_fixture("rails_4_2_0"))
 
     assert_not_predicate topic, :new_record?
     assert_equal 1, topic.id


### PR DESCRIPTION
Reverts rails/rails#39630