### PR TITLE
fix active storage cors configuration [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -617,9 +617,8 @@ No CORS configuration is required for the Disk service since it shares your appâ
 #### Example: S3 CORS configuration
 
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-<CORSRule>
+<CORSConfiguration>
+  <CORSRule>
     <AllowedOrigin>https://www.example.com</AllowedOrigin>
     <AllowedMethod>PUT</AllowedMethod>
     <AllowedHeader>Origin</AllowedHeader>
@@ -627,7 +626,7 @@ No CORS configuration is required for the Disk service since it shares your appâ
     <AllowedHeader>Content-MD5</AllowedHeader>
     <AllowedHeader>Content-Disposition</AllowedHeader>
     <MaxAgeSeconds>3600</MaxAgeSeconds>
-</CORSRule>
+  </CORSRule>
 </CORSConfiguration>
 ```
 


### PR DESCRIPTION
### Summary

When configuring CORS for a S3 bucket, the XML declaration and the namespace attribute don't seem to be necessary anymore.

Reference: https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html#how-do-i-enable-cors

### Other Information

I fixed the indentation of the opening and closing `CORSRule` tag as well.