### PR TITLE
Introduce `ActiveRecord::Base#persisted_pool_key` to track stored shard

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1109,7 +1109,9 @@ module ActiveRecord
           raise ConnectionNotEstablished, message
         end
 
-        pool.connection
+        pool.connection.tap do |conn|
+          conn.current_pool_key = pool_key
+        end
       end
 
       # Returns true if a connection that's accessible to this class has

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       SIMPLE_INT = /\A\d+\z/
       COMMENT_REGEX = %r{/\*(?:[^\*]|\*[^/])*\*/}m
 
-      attr_accessor :pool
+      attr_accessor :pool, :current_pool_key
       attr_reader :visitor, :owner, :logger, :lock
       alias :in_use? :owner
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -380,11 +380,13 @@ module ActiveRecord
     # Initialize an empty model object from +attributes+.
     # +attributes+ should be an attributes object, and unlike the
     # `initialize` method, no assignment calls are made per attribute.
-    def init_with_attributes(attributes, new_record = false) # :nodoc:
+    def init_with_attributes(attributes, new_record = false, persisted_pool_key = nil) # :nodoc:
       @new_record = new_record
       @attributes = attributes
 
       init_internals
+
+      @persisted_pool_key = persisted_pool_key
 
       yield self if block_given?
 
@@ -431,6 +433,7 @@ module ActiveRecord
       @previously_new_record    = false
       @destroyed                = false
       @_start_transaction_state = nil
+      @persisted_pool_key       = nil
 
       super
     end

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -46,7 +46,11 @@ module ActiveRecord
       name = colorize_payload_name(name, payload[:name])
       sql  = color(sql, sql_color(sql), true) if colorize_logging
 
-      debug "  #{name}  #{sql}#{binds}"
+      shard_info = ""
+      shard = payload[:connection]&.current_pool_key
+      shard_info = color("[Shard: #{shard}] ", GREEN, true) if shard && shard != ActiveRecord::Base.default_pool_key
+
+      debug "  #{shard_info}#{name}  #{sql}#{binds}"
     end
 
     private

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -755,12 +755,19 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal false, Topic.find(1).previously_new_record?
   end
 
+  def test_presisted_pool_key_returns_default_or_nil
+    assert_nil Topic.new.persisted_pool_key
+    assert_equal :default, Topic.create.persisted_pool_key
+    assert_equal :default, Topic.find(1).persisted_pool_key
+  end
+
   def test_dup
     topic = Topic.find(1)
     duped_topic = nil
     assert_nothing_raised { duped_topic = topic.dup }
     assert_equal topic.title, duped_topic.title
     assert_not_predicate duped_topic, :persisted?
+    assert_nil duped_topic.persisted_pool_key
 
     # test if the attributes have been duped
     topic.title = "a"

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -307,6 +307,12 @@ module ActiveRecord
         # from :default
         assert_not ShardConnectionTestModel.find_by_shard_key("bar")
         assert ShardConnectionTestModel.find_by_shard_key("foo")
+
+        # Make sure the persisted_pool_key result corresponds to its shard
+        assert_equal :default, ShardConnectionTestModel.first.persisted_pool_key
+        ActiveRecord::Base.connected_to(shard: :one) do
+          assert_equal :one, ShardConnectionTestModel.first.persisted_pool_key
+        end
       end
 
       def test_swapping_shards_in_a_multi_threaded_environment


### PR DESCRIPTION
### Summary

In horizontal sharding environments, there are use cases that records are collected from multiple shards, aggregated, and then updated based on the results.
In such cases, it is useful to know in which shard the records were stored.

This introduces `ActiveRecord::Base#persisted_pool_key` method to obtain from which shard the record is taken.
The pool key returned from this method can be specified to `ActiveRecord::Base#connected_to` 's shard keyword argument.

For example, using this featrue, we can set a flag to the `is_top` field on the user who has the highest score in multiple shards like:

```ruby
top_user =
  [:one, :two].map { |shard|
    ActiveRecord::Base.connected_to(shard: shard) { User.order(score: :desc).first }
  }.max_by(&:score)

ActiveRecord::Base.connected_to(shard: top_user.persisted_pool_key) { top_user.update(is_top: true) }
```

SInce multiple shards may have records with the same primary key, it is important to distinguish from which shard the record is taken from when they are updated after aggregated.


This also adds shard information to debug SQL logging when non-default shard is used, in order to make it easier to debug multi-sharded application.
E.g.
```ruby
> ActiveRecord::Base.connected_to(shard: :one) { User.first }
  [Shard: one] User Load (0.4ms)  SELECT `users`.* FROM `users` ORDER BY `users`.`id` ASC LIMIT 1
  ~~~~~~~~~~~~~
```

### Other Information

[Octopus gem](https://github.com/thiagopradi/octopus) have a similar method `current_shard`, which returns a shard key which can be specified to its `Octopus.using` method that corresponds to `connected_to` in AR 6.


