### PR TITLE
Include a hint on new default for form_with

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -575,6 +575,11 @@ user.highlights.second.filename # => "town.jpg"
 
 Existing applications can opt in to this new behavior by setting `config.active_storage.replace_on_assign_to_many` to `true`. The old behavior will be deprecated in Rails 6.1 and removed in a subsequent release.
 
+### `form_with` defaults to `remote:true`
+
+Starting with Rails 6, the `form_with` form helper defaults to `remote: true`. These forms will submit data using an XHR (Ajax) request.
+Either change your code to work with remote forms (also see the [Working with JavaScript in Rails](working_with_javascript_in_rails.html#remote-elements) guide) or opt into the previous default using `local: true`.
+
 Upgrading from Rails 5.1 to Rails 5.2
 -------------------------------------
 


### PR DESCRIPTION
### Summary

This Pull Request updates the upgrade instructions from Rails 5.2 to Rails 6.0 on using `form_with`.

In some private projects that I recently upgraded to Rails 6 I noticed that form submission didn't work properly after the upgrade. Cross-checking the [Form Helpers](https://guides.rubyonrails.org/form_helpers.html#how-do-forms-with-patch-put-or-delete-methods-work-questionmark) guide, I saw that it surely mentioned `remote: true` being the default for `form_with` and that one should use `local: true` to get "classic" form behaviour.

However, prior to the upgrade `form_with` seems to have submitted forms locally by default.

### Other Information

While writing this Pull Request I wanted to cross-check the [5.2 documentation](https://github.com/rails/rails/blob/5-2-stable/guides/source/form_helpers.md) on `form_with` and was surprised to not find it mentioned anywhere. Now I am wondering whether I was using an API that was not officially part of Rails 5.2 or whether it was just not documented in the guides back then.

Anyhow, `form_with` worked in Rails 5.2 and I might not be the only person that used it, so it's probably still worth including in the upgrade guide.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
