### PR TITLE
Create database via UI when ActiveRecord::NoDatabaseError

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -30,7 +30,11 @@ module ActiveRecord
 
   module ConnectionAdapters
     class Mysql2Adapter < AbstractMysqlAdapter
-      ER_BAD_DB_ERROR = 1049
+      ER_BAD_DB_ERROR        = 1049
+      ER_ACCESS_DENIED_ERROR = 1045
+      ER_CONN_HOST_ERROR     = 2003
+      ER_UNKOWN_HOST_ERROR   = 2005
+
       ADAPTER_NAME = "Mysql2"
 
       include MySQL::DatabaseStatements
@@ -40,7 +44,11 @@ module ActiveRecord
           Mysql2::Client.new(config)
         rescue Mysql2::Error => error
           if error.error_number == ConnectionAdapters::Mysql2Adapter::ER_BAD_DB_ERROR
-            raise ActiveRecord::NoDatabaseError
+            raise ActiveRecord::NoDatabaseError.db_error(config[:database])
+          elsif error.error_number == ConnectionAdapters::Mysql2Adapter::ER_ACCESS_DENIED_ERROR
+            raise ActiveRecord::DatabaseConnectionError.username_error(config[:username])
+          elsif [ConnectionAdapters::Mysql2Adapter::ER_CONN_HOST_ERROR, ConnectionAdapters::Mysql2Adapter::ER_UNKOWN_HOST_ERROR].include?(error.error_number)
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -33,7 +33,7 @@ module ActiveRecord
       ER_BAD_DB_ERROR        = 1049
       ER_ACCESS_DENIED_ERROR = 1045
       ER_CONN_HOST_ERROR     = 2003
-      ER_UNKOWN_HOST_ERROR   = 2005
+      ER_UNKNOWN_HOST_ERROR  = 2005
 
       ADAPTER_NAME = "Mysql2"
 
@@ -47,7 +47,7 @@ module ActiveRecord
             raise ActiveRecord::NoDatabaseError.db_error(config[:database])
           elsif error.error_number == ConnectionAdapters::Mysql2Adapter::ER_ACCESS_DENIED_ERROR
             raise ActiveRecord::DatabaseConnectionError.username_error(config[:username])
-          elsif [ConnectionAdapters::Mysql2Adapter::ER_CONN_HOST_ERROR, ConnectionAdapters::Mysql2Adapter::ER_UNKOWN_HOST_ERROR].include?(error.error_number)
+          elsif [ConnectionAdapters::Mysql2Adapter::ER_CONN_HOST_ERROR, ConnectionAdapters::Mysql2Adapter::ER_UNKNOWN_HOST_ERROR].include?(error.error_number)
             raise ActiveRecord::DatabaseConnectionError.hostname_error(config[:host])
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -78,7 +78,11 @@ module ActiveRecord
           PG.connect(conn_params)
         rescue ::PG::Error => error
           if conn_params && conn_params[:dbname] && error.message.include?(conn_params[:dbname])
-            raise ActiveRecord::NoDatabaseError
+            raise ActiveRecord::NoDatabaseError.db_error(conn_params[:dbname])
+          elsif conn_params && conn_params[:user] && error.message.include?(conn_params[:user])
+            raise ActiveRecord::DatabaseConnectionError.username_error(conn_params[:user])
+          elsif conn_params && conn_params[:hostname] && error.message.include?(conn_params[:hostname])
+            raise ActiveRecord::DatabaseConnectionError.hostname_error(conn_params[:hostname])
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -229,8 +229,8 @@ module ActiveRecord
 
         To resolve this issue:
 
-        - Not created a database for this app, or deleted it? You may need to create your database.
-        - Database name changed? Check your database.yml config has the correct database name.
+        - Did you create the database for this app, or delete it? You may need to create your database.
+        - Has the database name changed? Check your database.yml config has the correct database name.
 
         To create your database, run:\n\n        bin/rails db:create
         MSG
@@ -246,14 +246,14 @@ module ActiveRecord
     class << self
       def hostname_error(hostname)
         DatabaseConnectionError.new(<<~MSG)
-        We are having an issue connecting with your hostname: #{hostname}.\n
-        Please check your database configuration or ensure there is a connection open to your hostname.
+        There is an issue connecting with your hostname: #{hostname}.\n
+        Please check your database configuration and ensure there is a valid connection to your database.
         MSG
       end
 
       def username_error(username)
         DatabaseConnectionError.new(<<~MSG)
-        We are having an issue connecting to your database with your username/password, username: #{username}.\n
+        There is an issue connecting to your database with your username/password, username: #{username}.\n
         Please check your database configuration to ensure the username/password are valid.
         MSG
       end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -212,6 +212,52 @@ module ActiveRecord
 
   # Raised when a given database does not exist.
   class NoDatabaseError < StatementInvalid
+    include ActiveSupport::ActionableError
+
+    action "Create database" do
+      ActiveRecord::Tasks::DatabaseTasks.create_current
+    end
+
+    def initialize(message = nil)
+      super(message || "Database not found")
+    end
+
+    class << self
+      def db_error(db_name)
+        NoDatabaseError.new(<<~MSG)
+        We could not find your database: #{db_name}. Which can be found in the database configuration file located at config/database.yml.
+
+        To resolve this issue:
+
+        - Not created a database for this app, or deleted it? You may need to create your database.
+        - Database name changed? Check your database.yml config has the correct database name.
+
+        To create your database, run:\n\n        bin/rails db:create
+        MSG
+      end
+    end
+  end
+
+  class DatabaseConnectionError < StatementInvalid
+    def initialize(message = nil)
+      super(message || "Database connection error")
+    end
+
+    class << self
+      def hostname_error(hostname)
+        DatabaseConnectionError.new(<<~MSG)
+        We are having an issue connecting with your hostname: #{hostname}.\n
+        Please check your database configuration or ensure there is a connection open to your hostname.
+        MSG
+      end
+
+      def username_error(username)
+        DatabaseConnectionError.new(<<~MSG)
+        We are having an issue connecting to your database with your username/password, username: #{username}.\n
+        Please check your database configuration to ensure the username/password are valid.
+        MSG
+      end
+    end
   end
 
   # Raised when creating a database if it exists.


### PR DESCRIPTION
### Summary

Create the database via the UI when database has not been created in development mode. 

Related: https://discuss.rubyonrails.org/t/pending-migration-error-usability-concerns/75330/3

I have split out the errors for connection and no database errors and added the button to create the database.

<img width="1344" alt="Screenshot 2020-07-17 at 21 09 08" src="https://user-images.githubusercontent.com/658005/87827135-21f8c580-c872-11ea-9b10-ff21744fd93e.png">

<img width="1346" alt="Screenshot 2020-07-17 at 21 09 59" src="https://user-images.githubusercontent.com/658005/87827148-26bd7980-c872-11ea-9ee7-04b19d338630.png">
