### PR TITLE
Save a string allocation in visit_STAR

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -107,8 +107,8 @@ module ActionDispatch
           end
 
           def visit_STAR(node)
-            re = @matchers[node.left.to_sym] || ".+"
-            "(#{re})"
+            re = @matchers[node.left.to_sym]
+            re ? "(#{re})" : "(.+)"
           end
 
           def visit_OR(node)


### PR DESCRIPTION
### Summary

This simple PR avoids a string interpolation in `visit_STAR`.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

require "action_dispatch/journey/path/pattern"

module ActionDispatch
  module Journey # :nodoc:
    module Path # :nodoc:
      class Pattern # :nodoc:
        class AnchoredRegexp < Journey::Visitors::Visitor
          def fast_visit_STAR(node)
            re = @matchers[node.left.to_sym]
            re ? "(#{re})" : "(.+)"
          end
        end
      end
    end
  end
end

anchored = ActionDispatch::Journey::Path::Pattern::AnchoredRegexp.new(%w( / . ? ).join, { format: /.+/ })
ast = ActionDispatch::Journey::Parser.parse "/store/:name(*rest)"

Benchmark.ips do |x|
  x.report("visit_STAR")      { anchored.visit_STAR(ast) }
  x.report("fast_visit_STAR") { anchored.fast_visit_STAR(ast) }
  x.compare!
end

Benchmark.memory do |x|
  x.report("visit_STAR")      { anchored.visit_STAR(ast) }
  x.report("fast_visit_STAR") { anchored.fast_visit_STAR(ast) }
  x.compare!
end
```
### Results
```
Warming up --------------------------------------
          visit_STAR   150.702k i/100ms
     fast_visit_STAR   188.962k i/100ms
Calculating -------------------------------------
          visit_STAR      1.480M (± 3.2%) i/s -      7.535M in   5.095847s
     fast_visit_STAR      1.820M (± 2.1%) i/s -      9.259M in   5.088799s

Comparison:
     fast_visit_STAR:  1820324.3 i/s
          visit_STAR:  1480419.6 i/s - 1.23x  (± 0.00) slower

Calculating -------------------------------------
          visit_STAR    80.000  memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
     fast_visit_STAR    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
     fast_visit_STAR:         40 allocated
          visit_STAR:         80 allocated - 2.00x more
```
