### PR TITLE
prevents raw redis and memcached compression

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Prevent `RedisCacheStore` and `MemCacheStore` from performing compression
+    when reading entries written with `raw: true`.
+
+    *Max Gurewitz*
+
 *   `URI.parser` is deprecated and will be removed in Rails 6.2. Use
     `URI::DEFAULT_PARSER` instead.
 

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -189,7 +189,7 @@ module ActiveSupport
 
         def deserialize_entry(entry)
           if entry
-            entry.is_a?(Entry) ? entry : Entry.new(entry)
+            entry.is_a?(Entry) ? entry : Entry.new(entry, compress: false)
           end
         end
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -454,7 +454,7 @@ module ActiveSupport
         def deserialize_entry(serialized_entry, raw:)
           if serialized_entry
             if raw
-              Entry.new(serialized_entry)
+              Entry.new(serialized_entry, compress: false)
             else
               Marshal.load(serialized_entry)
             end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -76,6 +76,15 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     assert_equal "2", cache.read("foo")
   end
 
+  def test_raw_read_entry_compression
+    cache = lookup_store(raw: true)
+    cache.write("foo", 2)
+
+    assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compress! do
+      cache.read("foo")
+    end
+  end
+
   def test_raw_values_with_marshal
     cache = lookup_store(raw: true)
     cache.write("foo", Marshal.dump([]))

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -304,4 +304,14 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_not cache.exist?("fu")
     end
   end
+
+  class RawTest < StoreTest
+    test "does not compress values read with \"raw\" enabled" do
+      @cache.write("foo", "bar", raw: true)
+
+      assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compress! do
+        @cache.read("foo", raw: true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Fixes issue where reads with raw: true using redis or memcached cache
store, will compress values on reads.
- Should speed up raw cache reads by preventing unnecessary cpu intensive
operation.