### PR TITLE
Use URI::DEFAULT_PARSER rather than instantiate a new one

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1990,7 +1990,7 @@ module ActionDispatch
               name_for_action(options.delete(:as), action)
             end
 
-            path = Mapping.normalize_path URI.parser.escape(path), formatted
+            path = Mapping.normalize_path URI::DEFAULT_PARSER.escape(path), formatted
             ast = Journey::Parser.parse path
 
             mapping = Mapping.build(@scope, @set, ast, controller, default_action, to, via, formatted, options_constraints, anchor, options)

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -865,7 +865,7 @@ module ActionDispatch
           params.each do |key, value|
             if value.is_a?(String)
               value = value.dup.force_encoding(Encoding::BINARY)
-              params[key] = URI.parser.unescape(value)
+              params[key] = URI::DEFAULT_PARSER.unescape(value)
             end
           end
           req.path_parameters = params

--- a/actionpack/test/controller/parameter_encoding_test.rb
+++ b/actionpack/test/controller/parameter_encoding_test.rb
@@ -44,7 +44,7 @@ class ParameterEncodingTest < ActionController::TestCase
   end
 
   test "does not raise an error when passed a param declared as ASCII-8BIT that contains invalid bytes" do
-    get :test_bar, params: { "bar" => URI.parser.escape("bar\xE2baz".b) }
+    get :test_bar, params: { "bar" => URI::DEFAULT_PARSER.escape("bar\xE2baz".b) }
 
     assert_response :success
     assert_equal "ASCII-8BIT", @response.body

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -2092,11 +2092,11 @@ class RackMountIntegrationTests < ActiveSupport::TestCase
   end
 
   def test_unicode_path
-    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI.parser.escape("こんにちは/世界"), method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::DEFAULT_PARSER.escape("こんにちは/世界"), method: :get))
   end
 
   def test_downcased_unicode_path
-    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI.parser.escape("こんにちは/世界").downcase, method: :get))
+    assert_equal({ controller: "news", action: "index" }, @routes.recognize_path(URI::DEFAULT_PARSER.escape("こんにちは/世界").downcase, method: :get))
   end
 
   private

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -549,14 +549,14 @@ module ActionView
         return false unless request.get? || request.head?
 
         check_parameters ||= options.is_a?(Hash) && options.delete(:check_parameters)
-        url_string = URI.parser.unescape(url_for(options)).force_encoding(Encoding::BINARY)
+        url_string = URI::DEFAULT_PARSER.unescape(url_for(options)).force_encoding(Encoding::BINARY)
 
         # We ignore any extra parameters in the request_uri if the
         # submitted URL doesn't have any either. This lets the function
         # work with things like ?order=asc
         # the behaviour can be disabled with check_parameters: true
         request_uri = url_string.index("?") || check_parameters ? request.fullpath : request.path
-        request_uri = URI.parser.unescape(request_uri).force_encoding(Encoding::BINARY)
+        request_uri = URI::DEFAULT_PARSER.unescape(request_uri).force_encoding(Encoding::BINARY)
 
         if url_string.start_with?("/") && url_string != "/"
           url_string.chomp!("/")

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `URI.parser` is deprecated and will be removed in Rails 6.2. Use
+    `URI::DEFAULT_PARSER` instead.
+
+    *Jean Boussier*
+
 *   `require_dependency` has been documented to be _obsolete_ in `:zeitwerk`
     mode. The method is not deprecated as such (yet), but applications are
     encouraged to not use it.

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -19,7 +19,11 @@ end
 module URI
   class << self
     def parser
-      @parser ||= URI::Parser.new
+      ActiveSupport::Deprecation.warn(<<-MSG.squish)
+        URI.parser is deprecated and will be removed in Rails 6.2.
+        Use `URI::DEFAULT_PARSER` instead.
+      MSG
+      URI::DEFAULT_PARSER
     end
   end
 end

--- a/activesupport/test/core_ext/uri_ext_test.rb
+++ b/activesupport/test/core_ext/uri_ext_test.rb
@@ -8,7 +8,7 @@ class URIExtTest < ActiveSupport::TestCase
   def test_uri_decode_handle_multibyte
     str = "\xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E" # Ni-ho-nn-go in UTF-8, means Japanese.
 
-    parser = URI.parser
+    parser = URI::DEFAULT_PARSER
     assert_equal str + str, parser.unescape(str + parser.escape(str).encode(Encoding::UTF_8))
   end
 end

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -20,7 +20,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
 
   def routes
     if path = params[:path]
-      path = URI.parser.escape path
+      path = URI::DEFAULT_PARSER.escape path
       normalized_path = with_leading_slash path
       render json: {
         exact: match_route { |it| it.match normalized_path },

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -325,7 +325,7 @@ module ApplicationTests
       # Load app env
       app "development"
 
-      get "/assets/#{URI.parser.escape(asset_path)}"
+      get "/assets/#{URI::DEFAULT_PARSER.escape(asset_path)}"
       assert_match "not an image really", last_response.body
       assert_file_exists("#{app_path}/public/assets/#{asset_path}")
     end


### PR DESCRIPTION
I was investigating Regexp duplication, and noticed many big regexps duplicated in `URI::Parser`. After digging a bit more it is because ActiveSupport instantiate a second parser even though it isn't needed.

I checked, [`DEFAULT_PARSER` was added 12 years ago](https://github.com/ruby/ruby/blame/609ac6ee2c30ec8d91f3a97648565cf0bcaa3b0d/lib/uri/common.rb#L21).

Also I kinda question the usefulness of `URI.parser`, it is only used in a handful of places in Rails so it could totally be removed. It's not documented, but it's not `:nodoc:` either, so not sure if it is considered public API.

@rafaelfranca 