### PR TITLE
Document ActiveModel errors methods

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -103,7 +103,7 @@ module ActiveModel
       @options = options
     end
 
-    def initialize_dup(other)
+    def initialize_dup(other) # :nodoc:
       @attribute = @attribute.dup
       @raw_type = @raw_type.dup
       @type = @type.dup
@@ -121,6 +121,11 @@ module ActiveModel
     # The options provided when calling `errors#add`
     attr_reader :options
 
+    # Returns the error message.
+    #
+    #   error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+    #   error.message
+    #   # => "is too short (minimum is 5 characters)"
     def message
       case raw_type
       when Symbol
@@ -130,15 +135,27 @@ module ActiveModel
       end
     end
 
+    # Returns the error detail.
+    #
+    #   error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+    #   error.detail
+    #   # => { error: :too_short, count: 5 }
     def detail
       { error: raw_type }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
     end
 
+    # Returns the full error message.
+    #
+    #   error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
+    #   error.full_message
+    #   # => "Name is too short (minimum is 5 characters)"
     def full_message
       self.class.full_message(attribute, message, @base.class)
     end
 
     # See if error matches provided +attribute+, +type+ and +options+.
+    #
+    # Omitted params are not checked for a match.
     def match?(attribute, type = nil, **options)
       if @attribute != attribute || (type && @type != type)
         return false
@@ -153,18 +170,22 @@ module ActiveModel
       true
     end
 
+    # See if error matches provided +attribute+, +type+ and +options+ exactly.
+    #
+    # All params must be equal to Error's own attributes to be considered a
+    # strict match.
     def strict_match?(attribute, type, **options)
       return false unless match?(attribute, type)
 
       options == @options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS)
     end
 
-    def ==(other)
+    def ==(other) # :nodoc:
       other.is_a?(self.class) && attributes_for_hash == other.attributes_for_hash
     end
     alias eql? ==
 
-    def hash
+    def hash # :nodoc:
       attributes_for_hash.hash
     end
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -335,10 +335,18 @@ module ActiveModel
       to_hash.transform_values { |values| values.last }
     end
 
+    # Returns a Hash of attributes with an array of their error messages.
+    #
+    # Updating this hash would still update errors state for backward
+    # compatibility, but this behavior is deprecated.
     def messages
       DeprecationHandlingMessageHash.new(self)
     end
 
+    # Returns a Hash of attributes with an array of their error details.
+    #
+    # Updating this hash would still update errors state for backward
+    # compatibility, but this behavior is deprecated.
     def details
       hash = {}
       group_by_attribute.each do |attribute, errors|
@@ -347,6 +355,10 @@ module ActiveModel
       DeprecationHandlingDetailsHash.new(hash)
     end
 
+    # Returns a Hash of attributes with an array of their Error objects.
+    #
+    #   person.errors.group_by_attribute
+    #   # => {:name=>[<#ActiveModel::Error>, <#ActiveModel::Error>]}
     def group_by_attribute
       @errors.group_by(&:attribute)
     end
@@ -484,6 +496,16 @@ module ActiveModel
       where(attribute).map(&:full_message).freeze
     end
 
+    # Returns all the error messages for a given attribute in an array.
+    #
+    #   class Person
+    #     validates_presence_of :name, :email
+    #     validates_length_of :name, in: 5..30
+    #   end
+    #
+    #   person = Person.create()
+    #   person.errors.messages_for(:name)
+    #   # => ["is too short (minimum is 5 characters)", "can't be blank"]
     def messages_for(attribute)
       where(attribute).map(&:message)
     end


### PR DESCRIPTION
### Summary

Fill-in descriptions for those `ActiveModel::Errors` related methods without descriptions. (I missed those in my earlier PR)

Related to #32313 

