### PR TITLE
Remove reference to deleting sessions via nil [ci-skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -585,7 +585,7 @@ class CommentsController < ApplicationController
 end
 ```
 
-Note that while for session values you set the key to `nil`, to delete a cookie value you should use `cookies.delete(:key)`.
+Note that while for session values you can set the key to `nil`, to delete a cookie value you should use `cookies.delete(:key)`.
 
 Rails also provides a signed cookie jar and an encrypted cookie jar for storing
 sensitive data. The signed cookie jar appends a cryptographic signature on the


### PR DESCRIPTION
### Summary

In the previous section "Accessing the Session" a code example uses `session.delete(:current_user_id)`. This confused me because a later reference implied the only way to delete a session was via setting it to `nil`. Based on the age of the line I removed, I assume that the `delete` method was added at some point to the session class.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
