### PR TITLE
Fix path_parameters key type inconsistency in ActionController::TestCase

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -91,7 +91,7 @@ module ActionController
             end
           end
 
-          path_parameters[key] = value
+          path_parameters[key.to_sym] = value
         end
       end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -613,6 +613,12 @@ XML
     assert_equal({ "bar" => [] }, JSON.load(response.body)["foo"])
   end
 
+  def test_using_as_json_with_path_parameters
+    post :test_params, params: { id: "12345" }, as: :json
+
+    assert_equal("12345", @request.path_parameters[:id])
+  end
+
   def test_mutating_content_type_headers_for_plain_text_files_sets_the_header
     @request.headers["Content-Type"] = "text/plain"
     post :render_body, params: { name: "foo.txt" }


### PR DESCRIPTION
### Summary

This fixes the following issue: #39739.

The issue was inconsistent keys in path_parameters Hash between HTML and JSON requests in controller tests. For HTML requests keys were Symbols, but for JSON requests they were String. See the issue #39739 for details.

The fix is to forcefully convert path_parameters keys to Symbols.

ActionController::TestCase simulates the request, so that simulated request does not go through the actual request dispatch. 

In the code that does the actual request dispatching, path parameters keys are also forcefully converted to Symbols:
https://github.com/rails/rails/blob/c2441b00db3e5bdea74ace25388795f9e6a7f67d/actionpack/lib/action_dispatch/journey/router.rb#L127

That I think justifies my change.

Thank you!
