### PR TITLE
Use LoadError#original_message if available in safe_constantize

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -334,7 +334,8 @@ module ActiveSupport
     rescue ArgumentError => e
       raise unless /not missing constant #{const_regexp(camel_cased_word)}!$/.match?(e.message)
     rescue LoadError => e
-      raise unless /Unable to autoload constant #{const_regexp(camel_cased_word)}/.match?(e.message)
+      message = e.respond_to?(:original_message) ? e.original_message : e.message
+      raise unless /Unable to autoload constant #{const_regexp(camel_cased_word)}/.match?(message)
     end
 
     # Returns the suffix that should be added to a number to denote the position


### PR DESCRIPTION
In Ruby 2.8/3.0, [`LoadError#message` is extended by `DidYouMean`](https://github.com/ruby/did_you_mean/pull/143), and will do a fairly expensive glob in your `$LOAD_PATH` to suggest some correction.

This makes accessing `message` fairly expensive, particularly if you have a large `$LOAD_PATH`.

That same problem is already handled for `NameError#message`, so I used the same approach: https://github.com/rails/rails/blob/35ebac1fb862ba3827aab4a3e3b7473abf0be5d0/activesupport/lib/active_support/core_ext/name_error.rb#L16-L17

@rafaelfranca 