### PR TITLE
Deprecate building saveable records from read-only relations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate calling `create` and `create!` on a read-only relation, and deprecate
+    `new` and `build` returning saveable records when called on a read-only relation.
+
+    *Eugene Kenny*
+
 *   Support `where` with comparison operators (`>`, `>=`, `<`, and `<=`).
 
     ```ruby

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -852,7 +852,7 @@ module ActiveRecord
       where!("1=0").extending!(NullRelation)
     end
 
-    # Sets readonly attributes for the returned relation. If value is
+    # Sets the returned relation to readonly mode. If value is
     # true (default), attempting to update a record will result in an error.
     #
     #   users = User.readonly

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -44,6 +44,34 @@ class ReadOnlyTest < ActiveRecord::TestCase
     Developer.readonly.each { |d| assert d.readonly? }
   end
 
+  def test_build_with_readonly_option
+    assert_not_predicate Developer.all.new, :readonly?
+    assert_deprecated do
+      assert_not_predicate Developer.readonly.new, :readonly?
+    end
+    assert_predicate Developer.readonly(:new).new, :readonly?
+
+    assert_not_predicate Developer.all.build, :readonly?
+    assert_deprecated do
+      assert_not_predicate Developer.readonly.build, :readonly?
+    end
+    assert_predicate Developer.readonly(:build).build, :readonly?
+  end
+
+  def test_create_with_readonly_option
+    assert_not_predicate Developer.all.create(name: "omg"), :readonly?
+    assert_deprecated do
+      assert_not_predicate Developer.readonly.create(name: "omg"), :readonly?
+      assert_not_predicate Developer.readonly.create([name: "omg"]).first, :readonly?
+    end
+
+    assert_not_predicate Developer.all.create!(name: "omg"), :readonly?
+    assert_deprecated do
+      assert_not_predicate Developer.readonly.create!(name: "omg"), :readonly?
+      assert_not_predicate Developer.readonly.create!([name: "omg"]).first, :readonly?
+    end
+  end
+
   def test_find_with_joins_option_does_not_imply_readonly
     Developer.joins("  ").each { |d| assert_not d.readonly? }
     Developer.joins("  ").readonly(true).each { |d| assert d.readonly? }


### PR DESCRIPTION
Currently records loaded from read-only relations are read-only, but records built from them are not. It shouldn't be possible to modify the data underlying a read-only relation, including adding new records.