### PR TITLE
Check environment before loading Spring in boot.rb

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -441,12 +441,6 @@ module Rails
         end
       end
 
-      def generate_spring_binstub
-        if bundle_install? && spring_install?
-          bundle_command("exec spring binstub")
-        end
-      end
-
       def empty_directory_with_keep_file(destination, config = {})
         empty_directory(destination, config)
         keep_file(destination)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -94,14 +94,13 @@ module Rails
         "#{shebang}\n" + content
       end
       chmod "bin", 0755 & ~File.umask, verbose: false
+
+      remove_file "bin/spring" unless spring_install?
+      remove_file "bin/yarn" if options[:skip_javascript]
     end
 
     def bin_when_updating
       bin
-
-      if options[:skip_javascript]
-        remove_file "bin/yarn"
-      end
     end
 
     def yarn_when_updating
@@ -543,16 +542,12 @@ module Rails
         end
       end
 
-      def delete_bin_yarn
-        remove_file "bin/yarn" if options[:skip_javascript]
-      end
-
       def finish_template
         build(:leftovers)
       end
 
       public_task :apply_rails_template, :run_bundle
-      public_task :generate_bundler_binstub, :generate_spring_binstub
+      public_task :generate_bundler_binstub
       public_task :run_webpack
 
       def run_after_bundle_callbacks

--- a/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
@@ -1,0 +1,7 @@
+# Load Spring without loading other gems in the Gemfile, for speed.
+require "bundler"
+Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+  Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+  gem "spring", spring.version
+  require "spring/binstub"
+end

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,12 +1,12 @@
-<% unless options.skip_spring? -%>
-begin
-  load File.expand_path("../bin/spring", __dir__)
-rescue LoadError => e
-  raise unless e.path.end_with?("/bin/spring")
-end
-<% end -%>
+# frozen_string_literal: true
 
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+<% if spring_install? -%>
+
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  load File.expand_path("../bin/spring", __dir__)
+end
+<% end -%>
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -880,12 +880,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_spring_no_fork
-    jruby_skip "spring doesn't run on JRuby"
-    assert_called_with(Process, :respond_to?, [[:fork], [:fork], [:fork], [:fork]], returns: false) do
+    respond_to = Process.method(:respond_to?)
+    respond_to_stub = -> (name) { name != :fork && respond_to[name] }
+    Process.stub(:respond_to?, respond_to_stub) do
       run_generator
-
-      assert_no_gem "spring"
     end
+
+    assert_no_gem "spring"
   end
 
   def test_skip_spring

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -856,27 +856,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_spring
+    jruby_skip "spring doesn't run on JRuby"
+
     run_generator
+
     assert_gem "spring"
+    assert_file "bin/spring", %r{^\s*require "spring/binstub"}
+    assert_file "config/boot.rb", %r{^\s*load .+\bbin/spring"}
     assert_file("config/environments/test.rb") do |contents|
       assert_match("config.cache_classes = false", contents)
       assert_match("config.action_view.cache_template_loading = true", contents)
     end
-    assert_file "config/boot.rb", %r{^\s*load .+/bin/spring"}
   end
 
   def test_bundler_binstub
     generator([destination_root], skip_webpack_install: true)
 
     assert_bundler_command_called("binstubs bundler")
-  end
-
-  def test_spring_binstub
-    jruby_skip "spring doesn't run on JRuby"
-
-    generator([destination_root], skip_webpack_install: true)
-
-    assert_bundler_command_called("exec spring binstub")
   end
 
   def test_spring_no_fork
@@ -898,7 +894,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match("config.cache_classes = true", contents)
     end
     assert_file "config/boot.rb" do |contents|
-      assert_no_match %r{bin/spring}, contents
+      assert_no_match %r{spring}, contents
     end
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1100,33 +1100,22 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_after_bundle_callback
-    path = "http://example.org/rails_template"
-    template = +%{ after_bundle { run 'echo ran after_bundle' } }
-    template.instance_eval "def read; self; end" # Make the string respond to read
+    sequence = []
 
-    check_open = -> *args do
-      assert_equal [ path, "Accept" => "application/x-thor-template" ], args
-      template
+    bundle_command_stub = -> *args do
+      sequence << [:bundle_command, *args]
     end
 
-    sequence = ["git init", "install", "binstubs bundler", "exec spring binstub", "webpacker:install", "echo ran after_bundle"]
-    @sequence_step ||= 0
-    ensure_bundler_first = -> command, options = nil do
-      assert_equal sequence[@sequence_step], command, "commands should be called in sequence #{sequence}"
-      @sequence_step += 1
+    generator([destination_root], skip_webpack_install: true).send(:after_bundle) do
+      sequence << [:after_bundle_callback]
     end
 
-    generator([destination_root], template: path).stub(:open, check_open, template) do
-      generator.stub(:bundle_command, ensure_bundler_first) do
-        generator.stub(:run, ensure_bundler_first) do
-          generator.stub(:rails_command, ensure_bundler_first) do
-            quietly { generator.invoke_all }
-          end
-        end
-      end
+    generator.stub(:bundle_command, bundle_command_stub) do
+      quietly { generator.invoke_all }
     end
 
-    assert_equal 6, @sequence_step
+    assert_operator sequence.length, :>, 1
+    assert_equal [:after_bundle_callback], sequence.last
   end
 
   def test_gitignore


### PR DESCRIPTION
In #39632, `boot.rb` was changed to load `bin/spring`, with the intention of adding a check to Spring itself that would prevent Spring from running in production environments.  However, in a production environment, the Spring gem may not be installed.  Furthermore, `bin/spring` may raise an error other than `LoadError` if it has been overwritten by e.g. `bundle binstubs` as part of the deployment process.  Therefore, this commit adds the environment check to `boot.rb`.

This commit also changes the app generator to generate `bin/spring` directly, instead of delegating to `bundle exec spring binstub`.  This addresses an issue with the `--skip-bundle` flag.  Previously, `--skip-bundle` caused `bin/spring` to not be generated. Thus the user had to manually run `bundle exec spring binstub` later, though that was not documented nor explained.  Now, `bin/spring` is always generated.  Additionally, by guaranteeing that `bin/stub` is generated, we avoid the need for `rescue LoadError` in `boot.rb`.
