### PR TITLE
load relationship after autosave if it's not already loaded

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow the inverse of a `has_one` association that was previously autosaved to be loaded.
+
+    Fixes #34255.
+
+    *Steven Weber*
+
 *   Optimise the length of index names for polymorphic references by using the reference name rather than the type and id column names.
 
     Because the default behaviour when adding an index with multiple columns is to use all column names in the index name, this could frequently lead to overly long index names for polymorphic references which would fail the migration if it exceeded the database limit.

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -463,7 +463,7 @@ module ActiveRecord
               unless reflection.through_reflection
                 record[reflection.foreign_key] = key
                 if inverse_reflection = reflection.inverse_of
-                  record.association(inverse_reflection.name).loaded!
+                  record.association(inverse_reflection.name).inversed_from(self)
                 end
               end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -781,6 +781,17 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
     assert_same old_inversed_human, new_inversed_human
   end
 
+  def test_inversed_instance_should_load_after_autosave_if_it_is_not_already_loaded
+    human = Human.create!
+    human.create_autosave_face!
+
+    human.autosave_face.reload # clear cached load of autosave_human
+    human.autosave_face.description = "new description"
+    human.save!
+
+    assert_not_nil human.autosave_face.autosave_human
+  end
+
   def test_should_not_try_to_set_inverse_instances_when_the_inverse_is_a_has_many
     interest = interests(:llama_wrangling)
     human = interest.polymorphic_human

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -2,6 +2,7 @@
 
 class Face < ActiveRecord::Base
   belongs_to :human, inverse_of: :face
+  belongs_to :autosave_human, class_name: "Human", foreign_key: :human_id, inverse_of: :autosave_face
   belongs_to :super_human, polymorphic: true
   belongs_to :polymorphic_human, polymorphic: true, inverse_of: :polymorphic_face
   # Oracle identifier length is limited to 30 bytes or less, `polymorphic` renamed `poly`

--- a/activerecord/test/models/human.rb
+++ b/activerecord/test/models/human.rb
@@ -4,6 +4,7 @@ class Human < ActiveRecord::Base
   self.table_name = "humans"
 
   has_one :face, inverse_of: :human
+  has_one :autosave_face, class_name: "Face", autosave: true, foreign_key: :human_id, inverse_of: :autosave_human
   has_one :polymorphic_face, class_name: "Face", as: :polymorphic_human, inverse_of: :polymorphic_human
   has_one :polymorphic_face_without_inverse, class_name: "Face", as: :poly_human_without_inverse
   has_many :interests, inverse_of: :human


### PR DESCRIPTION
fixes: #34255
pair: @rebeldroid12

### Summary

This fixes an issue where a relationship wasn't being loaded causing a nil return value. The behavior looks to have been introduced apart of #31214, an optimization to not reload associations that had been loaded.