### PR TITLE
Support multiple database migrations when running pending migrations.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -134,7 +134,7 @@ module ActiveRecord
     include ActiveSupport::ActionableError
 
     action "Run pending migrations" do
-      ActiveRecord::Tasks::DatabaseTasks.migrate
+      ActiveRecord::Tasks::DatabaseTasks.migrate_all
     end
 
     def initialize(message = nil)

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -241,6 +241,23 @@ module ActiveRecord
         Migration.verbose = verbose_was
       end
 
+      def migrate_all
+        original_db_config = ActiveRecord::Base.connection_db_config
+
+        each_local_configuration do |db_config|
+          ActiveRecord::Base.establish_connection(db_config)
+          migrate
+
+          if ActiveRecord::Base.dump_schema_after_migration
+            dump_schema(db_config, ActiveRecord::Base.schema_format)
+          end
+        end
+      ensure
+        if original_db_config
+          ActiveRecord::Base.establish_connection(original_db_config)
+        end
+      end
+
       def migrate_status
         unless ActiveRecord::Base.connection.schema_migration.table_exists?
           Kernel.abort "Schema migrations table does not exist yet."

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -905,25 +905,6 @@ module ActiveRecord
     end
 
     class DatabaseTasksMigrateTest < DatabaseTasksMigrationTestCase
-      def test_can_migrate_from_pending_migration_error_action_dispatch
-        verbose, version = ENV["VERBOSE"], ENV["VERSION"]
-        ENV["VERSION"] = "2"
-        ENV["VERBOSE"] = "false"
-
-        # run down migration because it was already run on copied db
-        assert_empty capture_migration_output
-
-        ENV.delete("VERSION")
-        ENV.delete("VERBOSE")
-
-        # re-run up migration
-        assert_includes(capture(:stdout) do
-          ActiveSupport::ActionableError.dispatch ActiveRecord::PendingMigrationError, "Run pending migrations"
-        end, "migrating")
-      ensure
-        ENV["VERBOSE"], ENV["VERSION"] = verbose, version
-      end
-
       def test_migrate_set_and_unset_empty_values_for_verbose_and_version_env_vars
         verbose, version = ENV["VERBOSE"], ENV["VERSION"]
 


### PR DESCRIPTION
### Summary

Support multiple database migrations when running pending migrations.

Also fixes the issue where running pending migrations does not dump the
schema.

### Other Information

Related to https://github.com/rails/rails/pull/34788 and https://github.com/rails/rails/pull/26542

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
