### PR TITLE
Active support cache - memcached store - consume dalli’s cache_nils option as skip_nil

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -2,5 +2,9 @@
 
     *Nathaniel Woodthorpe*
 
+*   consume dalli’s `cache_nils` configuration as `ActiveSupport::Cache`'s `skip_nil` when using `MemCacheStore`.
+
+    *Ritikesh G*
+
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -22,7 +22,7 @@ module ActiveSupport
 
     # These options mean something to all cache implementations. Individual cache
     # implementations may support additional options.
-    UNIVERSAL_OPTIONS = [:namespace, :compress, :compress_threshold, :expires_in, :race_condition_ttl, :coder]
+    UNIVERSAL_OPTIONS = [:namespace, :compress, :compress_threshold, :expires_in, :race_condition_ttl, :coder, :skip_nil]
 
     module Strategy
       autoload :LocalCache, "active_support/cache/strategy/local_cache"

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -86,6 +86,9 @@ module ActiveSupport
       def initialize(*addresses)
         addresses = addresses.flatten
         options = addresses.extract_options!
+        if options.key?(:cache_nils)
+          options[:skip_nil] = !options.delete(:cache_nils)
+        end
         super(options)
 
         unless [String, Dalli::Client, NilClass].include?(addresses.first.class)

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -112,6 +112,16 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_dalli_cache_nils
+    cache = lookup_store(cache_nils: false)
+    cache.fetch("nil_foo") { nil }
+    assert_equal "bar", cache.fetch("nil_foo") { "bar" }
+
+    cache1 = lookup_store(cache_nils: true)
+    cache1.fetch("not_nil_foo") { nil }
+    assert_nil cache.fetch("not_nil_foo") { "bar" }
+  end
+
   def test_local_cache_raw_values_with_marshal
     cache = lookup_store(raw: true)
     cache.with_local_cache do


### PR DESCRIPTION
### Summary
Dalli provides an option to cache_nils as a performance optimisation configuration - https://github.com/petergoldstein/dalli/#configuration -> `cache_nils`.

Rails' `MemCacheStore` doesn't handle this config very well. If passed, it returns an object of `Dalli::Server::NOT_FOUND`. It should ideally return `nil`.

Solutions would be:
1. return `nil` instead of `Dalli::Server::NOT_FOUND` for every `deserialize` call - this was my first take on the issue - https://github.com/rails/rails/pull/39702. But it felt less intuitive.
2. if `cache_nils` is passed as an option to `mem_cache_store`, convert it to `skip_nil`.

### Before
```ruby
# config/application.rb
config.cache_store = :mem_cache_store, { 
    servers: %w(memcached:11211),
    namespace: 'namespace',
    compress: true,
    cache_nils: true
}

> Rails.cache.fetch(:z) { nil }
=> #<Dalli::Server::NilObject:0x00007ff30da57028>
> Rails.cache.fetch(:z) { 1 }
=> #<Dalli::Server::NilObject:0x00007ff30da57028>
```
### After
```ruby
# config/application.rb
config.cache_store = :mem_cache_store, { 
    servers: %w(memcached:11211),
    namespace: 'namespace',
    compress: true,
    cache_nils: true
}

> Rails.cache.fetch(:z) { nil }
=> nil
> Rails.cache.fetch(:z) { 1 }
=> nil
```