### PR TITLE
Fix possible XSS vector in JS escape helper for 4.2-stable, CVE-2020-5267

### DIFF
--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -9,6 +9,8 @@ module ActionView
         "\r\n"  => '\n',
         "\n"    => '\n',
         "\r"    => '\n',
+        "`"     => "\\`",
+        "$"     => "\\$",
         '"'     => '\\"',
         "'"     => "\\'"
       }
@@ -24,7 +26,7 @@ module ActionView
       #   $('some_element').replaceWith('<%=j render 'some/element_template' %>');
       def escape_javascript(javascript)
         if javascript
-          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"'])/u) {|match| JS_ESCAPE_MAP[match] }
+          result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u) {|match| JS_ESCAPE_MAP[match] }
           javascript.html_safe? ? result.html_safe : result
         else
           ''
@@ -47,8 +49,8 @@ module ActionView
       # tag.
       #
       #   javascript_tag "alert('All is good')", defer: 'defer'
-      # 
-      # Returns: 
+      #
+      # Returns:
       #   <script defer="defer">
       #   //<![CDATA[
       #   alert('All is good')

--- a/actionview/test/template/javascript_helper_test.rb
+++ b/actionview/test/template/javascript_helper_test.rb
@@ -32,6 +32,14 @@ class JavaScriptHelperTest < ActionView::TestCase
 
     assert_equal %(dont <\\/close> tags), j(%(dont </close> tags))
   end
+  
+  def test_escape_backtick
+    assert_equal "\\`", escape_javascript("`")
+  end
+
+  def test_escape_dollar_sign
+    assert_equal "\\$", escape_javascript("$")
+  end
 
   def test_escape_javascript_with_safebuffer
     given = %('quoted' "double-quoted" new-line:\n </closed>)

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -108,7 +108,7 @@ class BigDecimal
   # raises TypeError exception. Checking here on the runtime whether BigDecimal
   # will allow dup or not.
   begin
-    BigDecimal.new('4.56').dup
+    BigDecimal('4.56').dup
 
     def duplicable?
       true


### PR DESCRIPTION
### Summary

This PR backports the patch for CVE-2020-5267 from @mathieujobin & @tenderlove to Rails 4.2-stable:
* Patch: https://gist.github.com/tenderlove/c042ff49f0347c37e99183a6502accc6
* Fix to core: https://github.com/rails/rails/commit/033a738817abd6e446e1b320cb7d1a5c15224e9a

The code fixes a possible XSS vulnerability in the `j` and `escape_javascript` methods in ActionView. These methods are used for escaping JavaScript string literals.

### Other Information

I'm aware Rails 4.2 is out of support, and the monkey patch included below does work on 4.2.

But since there have been some security updates to [4-2-stable](https://github.com/rails/rails/commits/4-2-stable/) since this CVE was patched in 5.2 and 6.x, I figure this is worth a push. Given the medium severity, if accepted, this can probably sit around until a maintainer feels like doing 4.2.11.4.

In case this PR is rejected and anyone has customers still running 4.2 the original monkey patch I've included below is in: https://github.com/rails/rails/security/advisories/GHSA-65cv-r6x7-79hv.

```
ActionView::Helpers::JavaScriptHelper::JS_ESCAPE_MAP.merge!(
  {
    "`" => "\\`",
    "$" => "\\$"
  }
)

module ActionView::Helpers::JavaScriptHelper
  alias :old_ej :escape_javascript
  alias :old_j :j

  def escape_javascript(javascript)
    javascript = javascript.to_s
    if javascript.empty?
      result = ""
    else
      result = javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
    end
    javascript.html_safe? ? result.html_safe : result
  end

  alias :j :escape_javascript
end
```