### PR TITLE
WIP: ENV access clean ups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -268,3 +268,6 @@ Performance/DeletePrefix:
 
 Performance/DeleteSuffix:
   Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true

--- a/actioncable/lib/action_cable/server/configuration.rb
+++ b/actioncable/lib/action_cable/server/configuration.rb
@@ -24,7 +24,7 @@ module ActionCable
       # If the adapter cannot be found, this will default to the Redis adapter.
       # Also makes sure proper dependencies are required.
       def pubsub_adapter
-        adapter = (cable.fetch("adapter") { "redis" })
+        adapter = cable.fetch("adapter", "redis")
 
         # Require the adapter itself and give useful feedback about
         #   1. Missing adapter gems and

--- a/actioncable/test/subscription_adapter/redis_test.rb
+++ b/actioncable/test/subscription_adapter/redis_test.rb
@@ -12,7 +12,7 @@ class RedisAdapterTest < ActionCable::TestCase
 
   def cable_config
     { adapter: "redis", driver: "ruby" }.tap do |x|
-      if host = URI(ENV["REDIS_URL"] || "").hostname
+      if host = URI(ENV.fetch("REDIS_URL", "")).hostname
         x[:host] = host
       end
     end
@@ -29,7 +29,7 @@ class RedisAdapterTest::AlternateConfiguration < RedisAdapterTest
   def cable_config
     alt_cable_config = super.dup
     alt_cable_config.delete(:url)
-    alt_cable_config.merge(host: URI(ENV["REDIS_URL"] || "").hostname || "127.0.0.1", port: 6379, db: 12)
+    alt_cable_config.merge(host: URI(ENV.fetch("REDIS_URL", "")).hostname || "127.0.0.1", port: 6379, db: 12)
   end
 end
 

--- a/actionmailbox/test/dummy/config/cable.yml
+++ b/actionmailbox/test/dummy/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: dummy_production

--- a/actionmailbox/test/dummy/config/database.yml
+++ b/actionmailbox/test/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -11,7 +11,7 @@ silence_warnings do
   Encoding.default_external = Encoding::UTF_8
 end
 
-PROCESS_COUNT = (ENV["MT_CPU"] || 4).to_i
+PROCESS_COUNT = ENV.fetch("MT_CPU", 4).to_i
 
 require "active_support/testing/autorun"
 require "abstract_controller"

--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -38,7 +38,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
 
   begin
     require "dalli"
-    servers = ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+    servers = ENV.fetch("MEMCACHE_SERVERS", "localhost:11211")
     ss = Dalli::Client.new(servers).stats
     raise Dalli::DalliError unless ss[servers]
 
@@ -198,7 +198,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
         @app = self.class.build_app(set) do |middleware|
           middleware.use ActionDispatch::Session::MemCacheStore,
             key: "_session_id", namespace: "mem_cache_store_test:#{SecureRandom.hex(10)}",
-            memcache_server: ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+            memcache_server: ENV.fetch("MEMCACHE_SERVERS", "localhost:11211")
           middleware.delete ActionDispatch::ShowExceptions
         end
 

--- a/actiontext/test/dummy/bin/webpack
+++ b/actiontext/test/dummy/bin/webpack
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["RAILS_ENV"] ||= ENV.fetch("RACK_ENV", "development")
 ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"

--- a/actiontext/test/dummy/bin/webpack-dev-server
+++ b/actiontext/test/dummy/bin/webpack-dev-server
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-ENV["RAILS_ENV"] ||= ENV["RACK_ENV"] || "development"
+ENV["RAILS_ENV"] ||= ENV.fetch("RACK_ENV", "development")
 ENV["NODE_ENV"]  ||= "development"
 
 require "pathname"

--- a/actiontext/test/dummy/config/cable.yml
+++ b/actiontext/test/dummy/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: dummy_production

--- a/actiontext/test/dummy/config/database.yml
+++ b/actiontext/test/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/actiontext/test/dummy/config/puma.rb
+++ b/actiontext/test/dummy/config/puma.rb
@@ -4,16 +4,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+# workers ENV.fetch("WEB_CONCURRENCY", 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/activejob/test/support/integration/adapters/que.rb
+++ b/activejob/test/support/integration/adapters/que.rb
@@ -13,7 +13,7 @@ module QueJobsManager
   end
 
   def start_workers
-    que_url = ENV["QUE_DATABASE_URL"] || "postgres:///active_jobs_que_int_test"
+    que_url = ENV.fetch("QUE_DATABASE_URL", "postgres:///active_jobs_que_int_test")
     uri = URI.parse(que_url)
     user = uri.user || ENV["USER"]
     pass = uri.password

--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -3,7 +3,7 @@
 module ResqueJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :resque
-    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.new(url: ENV["REDIS_URL"] || "redis://127.0.0.1:6379/12", thread_safe: true)
+    Resque.redis = Redis::Namespace.new "active_jobs_int_test", redis: Redis.new(url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379/12"), thread_safe: true)
     Resque.logger = Rails.logger
     unless can_run?
       puts "Cannot run integration tests for resque. To be able to run integration tests for resque you need to install and start redis.\n"

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -7,7 +7,7 @@ module SneakersJobsManager
   def setup
     ActiveJob::Base.queue_adapter = :sneakers
     Sneakers.configure  heartbeat: 2,
-                        amqp: ENV["RABBITMQ_URL"] || "amqp://guest:guest@localhost:5672",
+                        amqp: ENV.fetch("RABBITMQ_URL", "amqp://guest:guest@localhost:5672"),
                         vhost: "/",
                         exchange: "active_jobs_sneakers_int_test",
                         exchange_type: :direct,

--- a/activerecord/examples/performance.rb
+++ b/activerecord/examples/performance.rb
@@ -3,8 +3,8 @@
 require "active_record"
 require "benchmark/ips"
 
-TIME    = (ENV["BENCHMARK_TIME"] || 20).to_i
-RECORDS = (ENV["BENCHMARK_RECORDS"] || TIME * 1000).to_i
+TIME    = ENV.fetch("BENCHMARK_TIME", 20).to_i
+RECORDS = ENV.fetch("BENCHMARK_RECORDS", TIME * 1000).to_i
 
 conn = { adapter: "sqlite3", database: ":memory:" }
 

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -5,7 +5,7 @@ require "tempfile"
 module ActiveRecord
   module Tasks # :nodoc:
     class PostgreSQLDatabaseTasks # :nodoc:
-      DEFAULT_ENCODING = ENV["CHARSET"] || "utf8"
+      DEFAULT_ENCODING = ENV.fetch("CHARSET", "utf8")
       ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
       SQL_COMMENT_BEGIN = "--"
 

--- a/activerecord/test/cases/type/type_map_test.rb
+++ b/activerecord/test/cases/type/type_map_test.rb
@@ -131,8 +131,8 @@ module ActiveRecord
         mapping = TypeMap.new
         mapping.register_type(1, "string")
 
-        assert_equal "string", mapping.fetch(1) { "int" }
-        assert_equal "int", mapping.fetch(2) { "int" }
+        assert_equal "string", mapping.fetch(1) { "int" } # rubocop:disable Style/RedundantFetchBlock
+        assert_equal "int", mapping.fetch(2) { "int" } # rubocop:disable Style/RedundantFetchBlock
       end
 
       def test_fetch_yields_args

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -23,9 +23,9 @@ connections:
 
   jdbcpostgresql:
     arunit:
-      username: <%= ENV['user'] || 'rails' %>
+      username: <%= ENV.fetch('user', 'rails') %>
     arunit2:
-      username: <%= ENV['user'] || 'rails' %>
+      username: <%= ENV.fetch('user', 'rails') %>
 
   jdbcsqlite3:
     arunit:
@@ -54,15 +54,15 @@ connections:
   oracle:
      arunit:
        adapter: oracle_enhanced
-       database: <%= ENV['ARUNIT_DB_NAME'] || 'orcl' %>
-       username: <%= ENV['ARUNIT_USER_NAME'] || 'arunit' %>
-       password: <%= ENV['ARUNIT_PASSWORD'] || 'arunit' %>
+       database: <%= ENV.fetch('ARUNIT_DB_NAME', 'orcl') %>
+       username: <%= ENV.fetch('ARUNIT_USER_NAME', 'arunit') %>
+       password: <%= ENV.fetch('ARUNIT_PASSWORD', 'arunit') %>
        emulate_oracle_adapter: true
      arunit2:
        adapter: oracle_enhanced
-       database: <%= ENV['ARUNIT_DB_NAME'] || 'orcl' %>
-       username: <%= ENV['ARUNIT2_USER_NAME'] || 'arunit2' %>
-       password: <%= ENV['ARUNIT2_PASSWORD'] || 'arunit2' %>
+       database: <%= ENV.fetch('ARUNIT_DB_NAME', 'orcl') %>
+       username: <%= ENV.fetch('ARUNIT2_USER_NAME', 'arunit2') %>
+       password: <%= ENV.fetch('ARUNIT2_PASSWORD', 'arunit2') %>
        emulate_oracle_adapter: true
 
   postgresql:

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -15,11 +15,13 @@ module ARTest
       end
 
       def read_config
-        unless File.exist?(config_file)
-          FileUtils.cp(File.join(TEST_ROOT, "config.example.yml"), config_file)
-        end
+        install_example_config unless File.exist?(config_file)
 
         expand_config ActiveSupport::ConfigurationFile.parse(config_file)
+      end
+
+      def install_example_config
+        FileUtils.cp(File.join(TEST_ROOT, "config.example.yml"), config_file)
       end
 
       def expand_config(config)

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -12,7 +12,7 @@ module ARTest
 
     private
       def config_file
-        Pathname.new(ENV["ARCONFIG"] || TEST_ROOT + "/config.yml")
+        Pathname.new(ENV.fetch("ARCONFIG", TEST_ROOT + "/config.yml"))
       end
 
       def read_config

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -12,12 +12,12 @@ module ARTest
 
     private
       def config_file
-        Pathname.new(ENV.fetch("ARCONFIG", TEST_ROOT + "/config.yml"))
+        Pathname.new(ENV.fetch("ARCONFIG", File.join(TEST_ROOT, "config.yml")))
       end
 
       def read_config
         unless config_file.exist?
-          FileUtils.cp TEST_ROOT + "/config.example.yml", config_file
+          FileUtils.cp(File.join(TEST_ROOT, "config.example.yml"), config_file)
         end
 
         expand_config ActiveSupport::ConfigurationFile.parse(config_file)

--- a/activerecord/test/support/config.rb
+++ b/activerecord/test/support/config.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "fileutils"
-require "pathname"
 require "active_support/configuration_file"
 
 module ARTest
@@ -12,11 +11,11 @@ module ARTest
 
     private
       def config_file
-        Pathname.new(ENV.fetch("ARCONFIG", File.join(TEST_ROOT, "config.yml")))
+        ENV.fetch("ARCONFIG", File.join(TEST_ROOT, "config.yml"))
       end
 
       def read_config
-        unless config_file.exist?
+        unless File.exist?(config_file)
           FileUtils.cp(File.join(TEST_ROOT, "config.example.yml"), config_file)
         end
 

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -8,7 +8,7 @@ require "models/other_dog"
 
 module ARTest
   def self.connection_name
-    ENV["ARCONN"] || config["default_connection"]
+    ENV.fetch("ARCONN", config["default_connection"])
   end
 
   def self.test_configuration_hashes

--- a/activestorage/test/dummy/config/database.yml
+++ b/activestorage/test/dummy/config/database.yml
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -16,13 +16,13 @@ module CacheStoreBehavior
   def test_fetch_without_cache_miss
     @cache.write("foo", "bar")
     assert_not_called(@cache, :write) do
-      assert_equal "bar", @cache.fetch("foo") { "baz" }
+      assert_equal "bar", @cache.fetch("foo") { "baz" } # rubocop:disable Style/RedundantFetchBlock
     end
   end
 
   def test_fetch_with_cache_miss
     assert_called_with(@cache, :write, ["foo", "baz", @cache.options]) do
-      assert_equal "baz", @cache.fetch("foo") { "baz" }
+      assert_equal "baz", @cache.fetch("foo") { "baz" } # rubocop:disable Style/RedundantFetchBlock
     end
   end
 
@@ -48,7 +48,7 @@ module CacheStoreBehavior
   def test_fetch_with_cached_nil
     @cache.write("foo", nil)
     assert_not_called(@cache, :write) do
-      assert_nil @cache.fetch("foo") { "baz" }
+      assert_nil @cache.fetch("foo") { "baz" } # rubocop:disable Style/RedundantFetchBlock
     end
   end
 
@@ -511,7 +511,7 @@ module CacheStoreBehavior
     ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) do |*args|
       @events << ActiveSupport::Notifications::Event.new(*args)
     end
-    assert_not @cache.fetch("bad_key") { }
+    assert_not @cache.fetch("bad_key") { } # rubocop:disable Style/RedundantFetchBlock
     assert_equal 3, @events.length
     assert_equal "cache_read.active_support", @events[0].name
     assert_equal "cache_generate.active_support", @events[1].name

--- a/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
@@ -55,9 +55,9 @@ module CacheStoreVersionBehavior
     m1v1 = ModelWithKeyAndVersion.new("model/1", 1)
     m1v2 = ModelWithKeyAndVersion.new("model/1", 2)
 
-    @cache.fetch(m1v1) { "bar" }
-    assert_equal "bar", @cache.fetch(m1v1) { "bu" }
-    assert_equal "bu", @cache.fetch(m1v2) { "bu" }
+    @cache.fetch(m1v1) { "bar" } # rubocop:disable Style/RedundantFetchBlock
+    assert_equal "bar", @cache.fetch(m1v1) { "bu" } # rubocop:disable Style/RedundantFetchBlock
+    assert_equal "bu", @cache.fetch(m1v2) { "bu" } # rubocop:disable Style/RedundantFetchBlock
   end
 
   def test_exist_with_model_supporting_cache_version

--- a/activesupport/test/cache/cache_store_logger_test.rb
+++ b/activesupport/test/cache/cache_store_logger_test.rb
@@ -12,7 +12,7 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
   end
 
   def test_logging
-    @cache.fetch("foo") { "bar" }
+    @cache.fetch("foo") { "bar" } # rubocop:disable Style/RedundantFetchBlock
     assert_predicate @buffer.string, :present?
   end
 
@@ -30,7 +30,7 @@ class CacheStoreLoggerTest < ActiveSupport::TestCase
   end
 
   def test_mute_logging
-    @cache.mute { @cache.fetch("foo") { "bar" } }
+    @cache.mute { @cache.fetch("foo") { "bar" } } # rubocop:disable Style/RedundantFetchBlock
     assert_predicate @buffer.string, :blank?
   end
 end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -25,7 +25,7 @@ end
 
 class MemCacheStoreTest < ActiveSupport::TestCase
   begin
-    servers = ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+    servers = ENV.fetch("MEMCACHE_SERVERS", "localhost:11211")
     ss = Dalli::Client.new(servers).stats
     raise Dalli::DalliError unless ss[servers]
 
@@ -167,7 +167,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
 
     def store
-      [:mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"]
+      [:mem_cache_store, ENV.fetch("MEMCACHE_SERVERS", "localhost:11211")]
     end
 
     def emulating_latency

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -219,7 +219,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   class RedisDistributedConnectionPoolBehaviourTest < ConnectionPoolBehaviourTest
     private
       def store_options
-        { url: [ENV["REDIS_URL"] || "redis://localhost:6379/0"] * 2 }
+        { url: [ENV.fetch("REDIS_URL", "redis://localhost:6379/0")] * 2 }
       end
   end
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -711,7 +711,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
   channel_prefix: <%= app_name %>_production

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
@@ -38,7 +38,7 @@
 
 default: &default
   adapter: jdbc
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: <%= app_name %>
   password:
   driver:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -11,7 +11,7 @@
 #
 default: &default
   adapter: mysql
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
   host: localhost

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
@@ -6,7 +6,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: root
   password:
 <% if mysql_socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
@@ -18,7 +18,7 @@
 #
 default: &default
   adapter: oracle_enhanced
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   username: <%= app_name %>
   password:
 

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -19,7 +19,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
 
 development:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   timeout: 5000
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -4,20 +4,20 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count)
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+# workers ENV.fetch("WEB_CONCURRENCY", 2)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -79,11 +79,11 @@ module Rails
           end
 
           def default_test_glob
-            ENV["DEFAULT_TEST"] || "test/**/*_test.rb"
+            ENV.fetch("DEFAULT_TEST", "test/**/*_test.rb")
           end
 
           def default_test_exclude_glob
-            ENV["DEFAULT_TEST_EXCLUDE"] || "test/{system,dummy}/**/*_test.rb"
+            ENV.fetch("DEFAULT_TEST_EXCLUDE", "test/{system,dummy}/**/*_test.rb")
           end
 
           def regexp_filter?(arg)

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
         development:
            database: <%= Rails.application.config.database %>
            adapter: sqlite3
-           pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+           pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
            timeout: 5000
       YAML
 
@@ -44,7 +44,7 @@ module ApplicationTests
       app_file "config/database.yml", <<-YAML
         default: &default
           adapter: sqlite3
-          pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+          pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
           timeout: 5000
 
         development:

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -125,7 +125,7 @@ module ApplicationTests
             database: db/development.sqlite3
 
           development:
-            <<: *<%= ENV["DB"] || "sqlite" %>
+            <<: *<%= ENV.fetch("DB", "sqlite") %>
         YAML
 
         app_file "config/environments/development.rb", <<-RUBY


### PR DESCRIPTION
### Summary

- Change `ENV.fetch(k) { "fish" }` to `ENV.fetch(k, "fish"`)

There are numerous calls to `ENV#fetch()` which use a single expression block to specify the return value if the key is missing.  Block creation is unnecessary in this situation, because the return value can be given to `fetch()` directly.  In my opinion, specifying the default value directly is a simpler use of the Hash-like ENV API.  In the YAML files immediately encountered by a Rails developer, an opportunity is presented to teach the API for this common use-case (i.e., get key `a`, else `b`).  There are occurrences of `#fetch(a, 'other')` elsewhere in Rails code, so the change here also makes Rails code more consistent.

- Change `ENV[k] || "fish"` to `ENV.fetch(k, "fish")` (leave `ENV[k] || "fish" || "other"` alone)

In code where an `ENV` key accessed and `||` is used for a value if it missing, prefer `ENV#fetch()` with a default value.  Obviously `ENV[k] || "fish"` is not equivalent to `ENV.fetch(k, "fish")` when `ENV[k] == false`, but `ENV` values are usually  (always?) string and so in practice they are equivalent, as no Ruby string is falsy.  However, in an "or-chain" (i.e., `a || b || c`) do not adjust the first two terms, because intent is clearer and the value of `b` makes this usage more complicated.  Let's wait to see what the Rails test-suite reports.

- Micro-cleanups while code reading

### Other Information

Ran rubocop locally, with no violations.  Waiting on the Rails testsuite via the PR.
