### PR TITLE
Add Concerns section in Refactoring portion of Getting Started guide

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1994,7 +1994,7 @@ we defined it as an instance variable.
 
 ### Using Concerns
 
-  A concern is any module that contains methods you would like to be able to share across multiple controllers or models. In other frameworks they are often known as mixins. They are a good way to keep your controllers and models small and keep your code DRY.
+A concern is any module that contains methods representing a well-defined slice of the functionality that a model or controller is responsible for. In other frameworks they are often known as mixins. Concerns are a way to make large controllers or models easier to understand and manage. This also has the advantage of reusability when multiple models (or controllers) share the same concerns.
 
  You can use concerns in your controller or model the same way you would use any module. When you first created your app with `rails new blog` , two folders were created within `app/` along with the rest:
 
@@ -2069,7 +2069,7 @@ Then, in our `index` action template (`app/views/articles/index.html.erb`) we wo
 
 However, if you look again at our models now, you can see that the logic is duplicated. If in future we increase the functionality of our blog - to include private messages, for instance -  we might find ourselves duplicating the logic yet again. This is where concerns come in handy.
 
-Let's call our new concern (module) `Visible`, a module to use for any model that has a status. We can create a new file inside `app/models/concerns` called `visible.rb` , and store all of the status methods that were duplicated in the models.
+A concern is only responsible for a focused subset of the model's responsibility; the methods in our concern will all be related to the visibility of a model. Let's call our new concern (module) `Visible`. We can create a new file inside `app/models/concerns` called `visible.rb` , and store all of the status methods that were duplicated in the models.
 
 `app/models/concerns/visible.rb`
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1994,9 +1994,9 @@ we defined it as an instance variable.
 
 ### Using Concerns
 
-A concern is any module that contains methods representing a well-defined slice of the functionality that a model or controller is responsible for. In other frameworks they are often known as mixins. Concerns are a way to make large controllers or models easier to understand and manage. This also has the advantage of reusability when multiple models (or controllers) share the same concerns.
+Concerns are a way to make large controllers or models easier to understand and manage. This also has the advantage of reusability when multiple models (or controllers) share the same concerns. Concerns are implemented using modules that contain methods representing a well-defined slice of the functionality that a model or controller is responsible for. In other languages, modules are often known as mixins.
 
- You can use concerns in your controller or model the same way you would use any module. When you first created your app with `rails new blog` , two folders were created within `app/` along with the rest:
+You can use concerns in your controller or model the same way you would use any module. When you first created your app with `rails new blog`, two folders were created within `app/` along with the rest:
 
  ```
  app/controllers/concerns
@@ -2067,7 +2067,7 @@ Then, in our `index` action template (`app/views/articles/index.html.erb`) we wo
 </table>
 ```
 
-However, if you look again at our models now, you can see that the logic is duplicated. If in future we increase the functionality of our blog - to include private messages, for instance -  we might find ourselves duplicating the logic yet again. This is where concerns come in handy.
+However, if you look again at our models now, you can see that the logic is duplicated. If in the future we increase the functionality of our blog - to include private messages, for instance -  we might find ourselves duplicating the logic yet again. This is where concerns come in handy.
 
 A concern is only responsible for a focused subset of the model's responsibility; the methods in our concern will all be related to the visibility of a model. Let's call our new concern (module) `Visible`. We can create a new file inside `app/models/concerns` called `visible.rb` , and store all of the status methods that were duplicated in the models.
 
@@ -2123,7 +2123,7 @@ class Comment < ApplicationRecord
 end
 ```
 
-Class methods can also added to concerns. If we want a count of public articles or comments to display on our main page, we might add a class method to Visible as follows:
+Class methods can also be added to concerns. If we want a count of public articles or comments to display on our main page, we might add a class method to Visible as follows:
 
 ```ruby
 module Visible
@@ -2137,7 +2137,7 @@ module Visible
 
   class_methods do
     def public_count
-      self.where(status: 'public').count
+      where(status: 'public').count
     end
   end
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2137,7 +2137,7 @@ module Visible
 
   class_methods do
     def public_count
-      self.where(status: 'public')
+      self.where(status: 'public').count
     end
   end
 


### PR DESCRIPTION
### Summary
* Adds a new Concerns section to the Getting Started guide, underneath the Refactoring header
* Updates a later code snippet to reflect the changes made in the Concern section

**Why?**
* This addresses the need for documentation on concerns; a new Rails app contains `concerns` folders for controllers and models but their purpose is not explained.
* This has been requested by many people over the years (see previous [PR](https://github.com/rails/rails/pull/21114) and corresponding [Discourse thread](https://discuss.rubyonrails.org/t/helping-devs-understand-concerns-faster/74619/44))
### Other Information
~  I am addressing feedback in new commits and will squash all before merging. :) 