### PR TITLE
Passing Google Chrome options as capabilities

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -26,6 +26,8 @@ module ActionDispatch
           headless_chrome_browser_options
         when :headless_firefox
           headless_firefox_browser_options
+        when :chrome
+          chrome_browser_options
         end
       end
 
@@ -67,6 +69,10 @@ module ActionDispatch
           capabilities.args << "--headless"
           capabilities.args << "--disable-gpu" if Gem.win_platform?
 
+          capabilities
+        end
+        
+        def chrome_browser_options
           capabilities
         end
 

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -26,8 +26,8 @@ module ActionDispatch
           headless_chrome_browser_options
         when :headless_firefox
           headless_firefox_browser_options
-        when :chrome
-          chrome_browser_options
+        else
+          capabilities
         end
       end
 
@@ -72,10 +72,6 @@ module ActionDispatch
           capabilities
         end
         
-        def chrome_browser_options
-          capabilities
-        end
-
         def headless_firefox_browser_options
           capabilities.args << "-headless"
 

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -14,7 +14,7 @@ class DriverTest < ActiveSupport::TestCase
     driver = ActionDispatch::SystemTesting::Driver.new(:selenium, using: :chrome, screen_size: [1400, 1400], options: { url: "http://example.com/wd/hub" })
     assert_equal :selenium, driver.instance_variable_get(:@name)
     assert_equal :chrome, driver.instance_variable_get(:@browser).name
-    assert_nil driver.instance_variable_get(:@browser).options
+    assert_instance_of Selenium::WebDriver::Chrome::Options, driver.instance_variable_get(:@browser).options
     assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end


### PR DESCRIPTION
We need to write system tests that are simulating connecting via WebRTC. Chrome has two flags that allows browser to simulate giving permission for audio and video access - `--use-fake-ui-for-media-stream` and `--use-fake-device-for-media-stream`.

Unfortunately current implementation in `ActionDispatch::SystemTesting::Browser` does allow to pass these arguments to Chrome driver only when using "headless chrome".

So when using `driven_by` like this

```
driven_by :selenium, using: :chrome do |capabilities|
  capabilities.add_argument('--use-fake-ui-for-media-stream')
  capabilities.add_argument('--use-fake-device-for-media-stream')
end
```

these capabilities won't get pass unless you use `using: :headless_chrome`.

This PR fixes that and passes these capabilities when one is using desktop Chrome.
