### PR TITLE
Pass default parameters to url helper

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Fix linking to resources when generating routes with optional scope.
+    
+    When a resource was defined within an optional scope, if that route didn't
+    take parameters the scope was lost when using path helpers. 
+    
+    For example:
+    ```ruby
+    scope "(:account)" do
+      resources :courses
+    end
+    ```
+    
+    If we were on `example.com/5/courses`, and we did not pass parameters 
+    to `courses_path` would generate `example.com/courses`. 
+    
+    This commit amends the url helper so that `courses_path` 
+    would return `example.com/5/courses`
+    
+    Fixes #12178.
+
+    *Dainius Puzas*
 *   Fix `follow_redirect!` to follow redirection with same HTTP verb when following
     a 308 redirection.
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -197,7 +197,8 @@ module ActionDispatch
             def call(t, method_name, args, inner_options, url_strategy)
               if args.size == arg_size && !inner_options && optimize_routes_generation?(t)
                 options = t.url_options.merge @options
-                options[:path] = optimized_helper(args)
+                default_params = options.fetch(:_recall, {})
+                options[:path] = optimized_helper(args, default_params)
 
                 original_script_name = options.delete(:original_script_name)
                 script_name = t._routes.find_script_name(options)
@@ -215,12 +216,12 @@ module ActionDispatch
             end
 
             private
-              def optimized_helper(args)
+              def optimized_helper(args, default_params)
                 params = parameterize_args(args) do
                   raise_generation_error(args)
                 end
 
-                @route.format params
+                @route.format default_params.merge(params)
               end
 
               def optimize_routes_generation?(t)

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -5080,6 +5080,47 @@ class TestOptionalScopesWithOrWithoutParams < ActionDispatch::IntegrationTest
   end
 end
 
+class TestOptionalScopesWithResources < ActionDispatch::IntegrationTest
+  Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
+    app.draw do
+      scope module: "test_optional_scopes_with_resources" do
+        scope "(:account)" do
+          resources :users
+        end
+      end
+    end
+  end
+
+  class UsersController < ActionController::Base
+    include Routes.url_helpers
+
+    def index
+      render plain: users_path
+    end
+
+    def edit
+      render plain: edit_user_path(1)
+    end
+  end
+
+  APP = build_app Routes
+
+  def app
+    APP
+  end
+
+  def test_optional_scope_without_constraints
+    get "/users"
+    assert_equal "/users", response.body
+
+    get "/5/users"
+    assert_equal "/5/users", response.body
+
+    get "/5/users/1/edit"
+    assert_equal "/5/users/1/edit", response.body
+  end
+end
+
 class TestPathParameters < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do


### PR DESCRIPTION
Hello everyone! 

### The problem
I run into an issue recently where I had some routes defined like this
```ruby
scope "(:account)" do
  resources :courses
end
```
generating a URL with `courses_path` would generate `example.com/courses` even though I was on `example.com/5/courses`. 
I really expected it to retain the account id. So I started looking and found #12178 and some other issues and realised that this might actually be a bug. 

Since I am new to ruby and ruby on rails, the implementation might be bad, I do not have a deep understanding of how the internals of it work, so I would really appreciate any feedback. 

### The fix

My idea to fix it was to pass the default parameters (account: 5) in this case, and since `_recall` hash has it, I thought why not. However I could not quite figure out what that _recall hash is actually used for, so I don't really know if this is a good idea. Another option I tried
```
default_params = t.try(:params) || {}
```
which would also work, although that hash is bigger and somehow that `permitted: false` screams to not use it.  🤔 
Also wondering if this would not cause any security issues, but thought maybe other tests would cover it?

Thanks and looking forward to the feedback.