### PR TITLE
Remove the magic `:chain` parameter from `Relation#where`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -655,13 +655,13 @@ module ActiveRecord
     #
     # If the condition is any blank-ish object, then #where is a no-op and returns
     # the current relation.
-    def where(opts = :chain, *rest)
-      if :chain == opts
+    def where(*args)
+      if args.empty?
         WhereChain.new(spawn)
-      elsif opts.blank?
+      elsif args.length == 1 && args.first.blank?
         self
       else
-        spawn.where!(opts, *rest)
+        spawn.where!(*args)
       end
     end
 


### PR DESCRIPTION

### Summary

Removes the magic `:chain` parameter from `Relation#where`.
It appears to be unnecessary as this method is either called with no parameters (as in `where.not`) or with valid parameters.
No functionality is changed

### Motivation

Magic parameters are bad. In this case it makes it hard to extend the method as there is no guarantee that `:chain` would never be a valid argument. Say I wanted to write an extension with syntax `where(:title).like('%rails%')` - that would break as soon as someone had a database field called `:chain`

### Other Information

Although I prefer avoiding magic parameters where unnecessary, the alternative is to use the object constant pattern used elsewhere in Rails. Something like 
```ruby
  CHAIN = Object.new
  private_constant :CHAIN
  
   def where(opts = CHAIN, *rest)
      if CHAIN == opts
     <etc>  
```
though, IMO, this makes the method harder to extend than simply not having it at all 

