### PR TITLE
Add zero width space support for blank? method

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -102,6 +102,7 @@ end
 
 class String
   BLANK_RE = /\A[[:space:]]*\z/
+  ZERO_WIDTH_SPACE_RE = /^\u200B+/
   ENCODED_BLANKS = Concurrent::Map.new do |h, enc|
     h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
   end
@@ -124,7 +125,7 @@ class String
     # penalty for the rest of strings is marginal.
     empty? ||
       begin
-        BLANK_RE.match?(self)
+        ZERO_WIDTH_SPACE_RE.match?(self) || BLANK_RE.match?(self)
       rescue Encoding::CompatibilityError
         ENCODED_BLANKS[self.encoding].match?(self)
       end

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -101,7 +101,7 @@ class Hash
 end
 
 class String
-  BLANK_RE = /\A[[:space:]\u200B]*\z/
+  BLANK_RE = /\A[[:space:]#{"\u200B"}#{"\uFEFF"}]*\z/
   ENCODED_BLANKS = Concurrent::Map.new do |h, enc|
     h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
   end
@@ -119,6 +119,7 @@ class String
   #
   # Unicode zero width space is supported:
   #   "\u200b".blank? # => true
+  #   "\uFEFF".blank? # => true
 
   # @return [true, false]
   def blank?

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -101,8 +101,7 @@ class Hash
 end
 
 class String
-  BLANK_RE = /\A[[:space:]]*\z/
-  ZERO_WIDTH_SPACE_RE = /^\u200B+/
+  BLANK_RE = /\A[[:space:]\u200B]*\z/
   ENCODED_BLANKS = Concurrent::Map.new do |h, enc|
     h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
   end
@@ -118,6 +117,9 @@ class String
   #
   #   "\u00a0".blank? # => true
   #
+  # Unicode zero width space is supported:
+  #   "\u200b".blank? # => true
+
   # @return [true, false]
   def blank?
     # The regexp that matches blank strings is expensive. For the case of empty
@@ -125,7 +127,7 @@ class String
     # penalty for the rest of strings is marginal.
     empty? ||
       begin
-        ZERO_WIDTH_SPACE_RE.match?(self) || BLANK_RE.match?(self)
+        BLANK_RE.match?(self)
       rescue Encoding::CompatibilityError
         ENCODED_BLANKS[self.encoding].match?(self)
       end

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -120,7 +120,7 @@ class String
   #   "\u00a0".blank? # => true
   #   "\u200b".blank? # => true
   #   "\uFEFF".blank? # => true
-
+  #
   # @return [true, false]
   def blank?
     # The regexp that matches blank strings is expensive. For the case of empty

--- a/activesupport/lib/active_support/core_ext/object/blank.rb
+++ b/activesupport/lib/active_support/core_ext/object/blank.rb
@@ -101,7 +101,9 @@ class Hash
 end
 
 class String
-  BLANK_RE = /\A[[:space:]#{"\u200B"}#{"\uFEFF"}]*\z/
+  BLANK_RE = /\A[[:space:]]*\z/
+  OTHER_FORMAT_RE = /\A[[:space:]\p{Cf}]*\z/
+
   ENCODED_BLANKS = Concurrent::Map.new do |h, enc|
     h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
   end
@@ -113,11 +115,9 @@ class String
   #   "\t\n\r".blank? # => true
   #   ' blah '.blank? # => false
   #
-  # Unicode whitespace is supported:
+  # Unicode whitespace and zero width space are supported:
   #
   #   "\u00a0".blank? # => true
-  #
-  # Unicode zero width space is supported:
   #   "\u200b".blank? # => true
   #   "\uFEFF".blank? # => true
 
@@ -128,7 +128,7 @@ class String
     # penalty for the rest of strings is marginal.
     empty? ||
       begin
-        BLANK_RE.match?(self)
+        OTHER_FORMAT_RE.match?(self)
       rescue Encoding::CompatibilityError
         ENCODED_BLANKS[self.encoding].match?(self)
       end

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,7 +16,7 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", [], {}, " ".encode("UTF-16LE") ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", [], {}, " ".encode("UTF-16LE") ]
   NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
 
   def test_blank

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,7 +16,7 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", "\u200b  ", "  \u200b", "  \u200b  ", [], {}, " ".encode("UTF-16LE") ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", "\u200b  ", "  \u200b", "  \u200b  ", "\uFEFF",  [], {}, " ".encode("UTF-16LE") ]
   NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
 
   def test_blank

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,7 +16,7 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", "\u200b  ", "  \u200b", "  \u200b  ", "\uFEFF",  [], {}, " ".encode("UTF-16LE") ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", "\u200b  ", "  \u200b", "  \u200b  ", "\uFEFF", [], {}, " ".encode("UTF-16LE") ]
   NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
 
   def test_blank

--- a/activesupport/test/core_ext/object/blank_test.rb
+++ b/activesupport/test/core_ext/object/blank_test.rb
@@ -16,7 +16,7 @@ class BlankTest < ActiveSupport::TestCase
     end
   end
 
-  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", [], {}, " ".encode("UTF-16LE") ]
+  BLANK = [ EmptyTrue.new, nil, false, "", "   ", "  \n\t  \r ", "　", "\u00a0", "\u200b", "\u200B", "\u200b  ", "  \u200b", "  \u200b  ", [], {}, " ".encode("UTF-16LE") ]
   NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, "a", [nil], { nil => 0 }, Time.now, "my value".encode("UTF-16LE") ]
 
   def test_blank


### PR DESCRIPTION
This PR adds support for zero width space for blank? method

Reference:

Someone added a zero width comment in lobsters, I thought blank? already supported it usecase. Since it is not supporting, I thought I will add support as part of this PR

You can find more info here https://github.com/lobsters/lobsters/issues/871

My first PR in Rails, go easy on me 🖌️ 

