### PR TITLE
fix misleading section on associations guide

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -568,7 +568,7 @@ Here are a few things you should know to make efficient use of Active Record ass
 All of the association methods are built around caching, which keeps the result of the most recent query available for further operations. The cache is even shared across methods. For example:
 
 ```ruby
-author.books                 # retrieves books from the database
+author.books.load            # retrieves books from the database
 author.books.size            # uses the cached copy of books
 author.books.empty?          # uses the cached copy of books
 ```
@@ -576,7 +576,7 @@ author.books.empty?          # uses the cached copy of books
 But what if you want to reload the cache, because data might have been changed by some other part of the application? Just call `reload` on the association:
 
 ```ruby
-author.books                 # retrieves books from the database
+author.books.load            # retrieves books from the database
 author.books.size            # uses the cached copy of books
 author.books.reload.empty?   # discards the cached copy of books
                              # and goes back to the database


### PR DESCRIPTION
### Summary

After https://github.com/rails/rails/pull/28592 calling `inspect` no longer causes associations to become loaded. The association basics guide is misleading as it suggest that `author.books` retrieves books from the database and it causes some confusion: https://github.com/rails/rails/issues/29570 https://github.com/rails/rails/issues/39778

This PR updates the guide to use `author.books.load` instead of `author.books`