### PR TITLE
Allow lazy construct attribute type after `load_schema!`

### DIFF
--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -56,6 +56,20 @@ module ActiveRecord
       assert_equal 255, UnoverloadedType.type_for_attribute("overloaded_string_with_limit").limit
     end
 
+    test "lazy construct cast type and overloaded default" do
+      klass = Class.new(UnoverloadedType) do
+        attribute :overloaded_string_with_limit, default: "the overloaded default" do |name|
+          type_for_attribute(name)
+        end
+      end
+
+      assert_equal 255, UnoverloadedType.type_for_attribute("overloaded_string_with_limit").limit
+      assert_equal 255, klass.type_for_attribute("overloaded_string_with_limit").limit
+
+      assert_nil UnoverloadedType.new.overloaded_string_with_limit
+      assert_equal "the overloaded default", klass.new.overloaded_string_with_limit
+    end
+
     test "extra options are forwarded to the type caster constructor" do
       klass = Class.new(OverloadedType) do
         attribute :starts_at, :datetime, precision: 3, limit: 2, scale: 1


### PR DESCRIPTION
I've been reported this issue from a friend.

We'd like to define attribute by mixin, espetially to specify/overload
default value.

e.g.

```ruby
module Mod
  included do
    attribute :reserved_column, :datetime, default: SENTINEL_VALUE
  end
end
```

Unfortunately, it will lose the original datetime precision.

I suggested using `define_attribute` and `type_for_attribute`
(`define_attribute :attr, type_for_attribute(:attr), default: "..."`),
but it will force `load_schema!` at mixin time.

It means that there is no way that overload default but maintain the
original type without force `load_schema!` happened.

So I'd propose a way to allow lazy construct attribute type after
`load_schema!`, it makes us achieve the purpose.

```ruby
module Mod
  included do
    attribute :reserved_column, default: SENTINEL_VALUE do |name|
      type_for_attribute(name)
    end
  end
end
```
