### PR TITLE
Docs: config.hosts: details re: regexp anchors

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -263,6 +263,10 @@ Every Rails application comes with a standard set of middleware which it uses in
    # `beta1.product.com`.
    Rails.application.config.hosts << /.*\.product\.com/
    ```
+   
+   The provided regexp will be wrapped with both anchors (`\A` and `\z`) so it
+   must match the entire hostname. `/product.com/`, for example, once anchored,
+   would fail to match `www.product.com`.
 
    A special case is supported that allows you to permit all sub-domains:
 


### PR DESCRIPTION
### Summary

Explains how `HostAuthorization` will wrap the provided regexp.
