### PR TITLE
Use appropriate code fences [ci skip]

### DIFF
--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -150,7 +150,7 @@ Railties
 
 * Allow scaffold/model/migration generators to accept "index" and "uniq" modifiers. For example,
 
-    ```ruby
+    ```bash
     bin/rails g scaffold Post title:string:index author:uniq price:decimal{7,2}
     ```
 

--- a/guides/source/action_mailbox_basics.md
+++ b/guides/source/action_mailbox_basics.md
@@ -279,7 +279,7 @@ end
 
 Then set up a mailbox:
 
-```ruby
+```bash
 # Generate new mailbox
 $ bin/rails generate mailbox forwards
 ```

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -86,13 +86,15 @@ end
 We can see how it works by looking at some `bin/rails console` output:
 
 ```ruby
-$ bin/rails console
 >> p = Person.new(name: "John Doe")
 => #<Person id: nil, name: "John Doe", created_at: nil, updated_at: nil>
+
 >> p.new_record?
 => true
+
 >> p.save
 => true
+
 >> p.new_record?
 => false
 ```

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -135,10 +135,9 @@ To test that your method does what it says it does, run the unit tests with `bin
   2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
 ```
 
-To see this in action, change to the `test/dummy` directory, fire up a console, and start squawking:
+To see this in action, change to the `test/dummy` directory, start `bin/rails console`, and commence squawking:
 
-```bash
-$ bin/rails console
+```ruby
 >> "Hello World".to_squawk
 => "squawk! Hello World"
 ```


### PR DESCRIPTION
Follow-up to #39620.

This commit changes a few overlooked code fences to `bash`, and changes a few IRB session snippets to be only Ruby code with a `ruby` fence.
