### PR TITLE
More consistent usage of version option for commands in guides [skip ci]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -93,7 +93,7 @@ dollar sign `$` should be run in the command line. Verify that you have a
 current version of Ruby installed:
 
 ```bash
-$ ruby -v
+$ ruby --version
 ruby 2.5.0
 ```
 
@@ -139,7 +139,7 @@ instructions at the [Yarn website](https://classic.yarnpkg.com/en/docs/install).
 Running this command should print out Yarn version:
 
 ```bash
-$ yarn -v
+$ yarn --version
 ```
 
 If it says something like "1.22.0", Yarn has been installed correctly.


### PR DESCRIPTION
In the getting started guide intro section both `-v` and `--version` are used:

     $ ruby -v
     $ sqlite3 --version
     $ node --version
     $ yarn -v
     $ rails --version

Both ruby and yarn support `--version` as well, but sqlite3 does not support `-v`.
For consistency use `--version` option for `ruby` and `yarn` commands.