### PR TITLE
Save an allocation in visit CAT

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -81,7 +81,7 @@ module ActionDispatch
           end
 
           def visit_CAT(node)
-            [visit(node.left), visit(node.right)].join
+            "#{visit(node.left)}#{visit(node.right)}"
           end
 
           def visit_SYMBOL(node)


### PR DESCRIPTION
### Summary

Similar to #39725. Save an allocation in visit CAT by interpolating the string without using an array.

/cc @eugeneius 

### Benchmark
```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

require "action_dispatch/journey/path/pattern"

module ActionDispatch
  module Journey # :nodoc:
    module Path # :nodoc:
      class Pattern # :nodoc:
        class AnchoredRegexp < Journey::Visitors::Visitor
          def fast_visit_CAT(node)
            "#{visit(node.left)}#{visit(node.right)}"
          end
        end
      end
    end
  end
end

anchored = ActionDispatch::Journey::Path::Pattern::AnchoredRegexp.new(%w( / . ? ).join, { format: /.+/ })
ast = ActionDispatch::Journey::Parser.parse "/store/:name(*rest)"

Benchmark.ips do |x|
  x.report("visit_CAT")      { anchored.visit_CAT(ast) }
  x.report("fast_visit_CAT") { anchored.fast_visit_CAT(ast) }
  x.compare!
end

Benchmark.memory do |x|
  x.report("visit_CAT")      { anchored.visit_CAT(ast) }
  x.report("fast_visit_CAT") { anchored.fast_visit_CAT(ast) }
  x.compare!
end
```
### Results
```
Warming up --------------------------------------
           visit_CAT    25.108k i/100ms
      fast_visit_CAT    24.247k i/100ms
Calculating -------------------------------------
           visit_CAT    234.348k (± 9.9%) i/s -      1.180M in   5.083142s
      fast_visit_CAT    258.413k (±12.4%) i/s -      1.285M in   5.050561s

Comparison:
      fast_visit_CAT:   258413.4 i/s
           visit_CAT:   234348.2 i/s - same-ish: difference falls within error

Calculating -------------------------------------
           visit_CAT   493.000  memsize (     0.000  retained)
                        11.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)
      fast_visit_CAT   474.000  memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)

Comparison:
      fast_visit_CAT:        474 allocated
           visit_CAT:        493 allocated - 1.04x more
```