### PR TITLE
Fix typo s/delegates/delegate/

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -120,7 +120,7 @@ module ActiveRecord
   #
   #   class Entry < ApplicationRecord
   #     delegated_type :entryable, types: %w[ Message Comment ]
-  #     delegates :title, to: :entryable
+  #     delegate :title, to: :entryable
   #   end
   #
   #   class Message < ApplicationRecord


### PR DESCRIPTION
### Summary

Fix typo in https://github.com/rails/rails/blob/master/activerecord/lib/active_record/delegated_type.rb#L123

### Other Information
