### PR TITLE
Use superclass name in inspect of anonymous ActionView::Base subclass

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -190,6 +190,14 @@ module ActionView #:nodoc:
           # correctly.
           define_method(:compiled_method_container)           { subclass }
           define_singleton_method(:compiled_method_container) { subclass }
+
+          def self.name
+            superclass.name
+          end
+
+          def inspect
+            "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+          end
         }
       end
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -327,6 +327,11 @@ module RenderTestCases
     assert_equal File.expand_path("#{FIXTURE_LOAD_PATH}/test/_raise.html.erb"), e.file_name
   end
 
+  def test_undefined_method_error_references_named_class
+    e = assert_raises(ActionView::Template::Error) { @view.render(inline: "<%= undefined %>") }
+    assert_match(/`undefined' for #<ActionView::Base:0x[0-9a-f]+>/, e.message)
+  end
+
   def test_render_object
     assert_equal "Hello: david", @view.render(partial: "test/customer", object: Customer.new("david"))
     assert_equal "FalseClass", @view.render(partial: "test/klass", object: false)


### PR DESCRIPTION
### Summary

When rendering views, an anonymous subclass is created by calling
`ActionView::Base.with_empty_template_cache`.
This causes inspect to return an unhelpful description: `#<#<Class:0x012345012345>:<0x012345012345>`.

This can be confusing when exceptions are raised because it's hard to
figure out where to look. For example calling an undefined method in a
template would raise the following exception:

    undefined method `undefined' for #<#<Class:0x012345012345>:<0x012345012345>

Instead we can return the superclass name.

    undefined method `undefined' for #<ActionView::Base:0x01234502345>

The anonymous class is created in ActionView::Base.with_empty_template_cache.
See f9bea6304dfba902b1937b3bc29b1ebc2f67e55b
This seems to be done for performance reasons only, without expecting a
change to calling `inspect`.


### Other Information

Fixes: #39129
