### PR TITLE
Cache the result of type-related queries (specifically for PSQL)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Create SchemaCache interface for type-related queries in each adapter.
+
+    *Zhang Kang*
+    *Ted Hanson*
+
 *   Support `where` with comparison operators (`>`, `>=`, `<`, and `<=`).
 
     ```ruby

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -22,7 +22,7 @@ module ActiveRecord
   module ConnectionAdapters
     module AbstractPool # :nodoc:
       def get_schema_cache(connection)
-        self.schema_cache ||= SchemaCache.new(connection)
+        self.schema_cache ||= connection.init_schema_cache
         schema_cache.connection = connection
         schema_cache
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_cache.rb
@@ -49,21 +49,21 @@ module ActiveRecord
       def encode_with(coder)
         reset_version!
 
-        coder["columns"]          = @columns
-        coder["primary_keys"]     = @primary_keys
-        coder["data_sources"]     = @data_sources
-        coder["indexes"]          = @indexes
-        coder["version"]          = @version
-        coder["database_version"] = database_version
+        coder["columns"]                  = @columns
+        coder["primary_keys"]             = @primary_keys
+        coder["data_sources"]             = @data_sources
+        coder["indexes"]                  = @indexes
+        coder["version"]                  = @version
+        coder["database_version"]         = database_version
       end
 
       def init_with(coder)
-        @columns          = coder["columns"]
-        @primary_keys     = coder["primary_keys"]
-        @data_sources     = coder["data_sources"]
-        @indexes          = coder["indexes"] || {}
-        @version          = coder["version"]
-        @database_version = coder["database_version"]
+        @columns                  = coder["columns"]
+        @primary_keys             = coder["primary_keys"]
+        @data_sources             = coder["data_sources"]
+        @indexes                  = coder["indexes"] || {}
+        @version                  = coder["version"]
+        @database_version         = coder["database_version"]
 
         derive_columns_hash_and_deduplicate_values
       end
@@ -166,7 +166,6 @@ module ActiveRecord
 
       def marshal_dump
         reset_version!
-
         [@version, @columns, {}, @primary_keys, @data_sources, @indexes, database_version]
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_cache.rb
@@ -49,21 +49,21 @@ module ActiveRecord
       def encode_with(coder)
         reset_version!
 
-        coder["columns"]                  = @columns
-        coder["primary_keys"]             = @primary_keys
-        coder["data_sources"]             = @data_sources
-        coder["indexes"]                  = @indexes
-        coder["version"]                  = @version
-        coder["database_version"]         = database_version
+        coder["columns"]          = @columns
+        coder["primary_keys"]     = @primary_keys
+        coder["data_sources"]     = @data_sources
+        coder["indexes"]          = @indexes
+        coder["version"]          = @version
+        coder["database_version"] = database_version
       end
 
       def init_with(coder)
-        @columns                  = coder["columns"]
-        @primary_keys             = coder["primary_keys"]
-        @data_sources             = coder["data_sources"]
-        @indexes                  = coder["indexes"] || {}
-        @version                  = coder["version"]
-        @database_version         = coder["database_version"]
+        @columns          = coder["columns"]
+        @primary_keys     = coder["primary_keys"]
+        @data_sources     = coder["data_sources"]
+        @indexes          = coder["indexes"] || {}
+        @version          = coder["version"]
+        @database_version = coder["database_version"]
 
         derive_columns_hash_and_deduplicate_values
       end
@@ -166,6 +166,7 @@ module ActiveRecord
 
       def marshal_dump
         reset_version!
+
         [@version, @columns, {}, @primary_keys, @data_sources, @indexes, database_version]
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -5,6 +5,7 @@ require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/mysql/column"
 require "active_record/connection_adapters/mysql/explain_pretty_printer"
 require "active_record/connection_adapters/mysql/quoting"
+require "active_record/connection_adapters/mysql/schema_cache"
 require "active_record/connection_adapters/mysql/schema_creation"
 require "active_record/connection_adapters/mysql/schema_definitions"
 require "active_record/connection_adapters/mysql/schema_dumper"
@@ -52,6 +53,10 @@ module ActiveRecord
 
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
+      end
+
+      def init_schema_cache
+        MySQL::SchemaCache.new(self)
       end
 
       def get_database_version #:nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_cache.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class SchemaCache < ConnectionAdapters::SchemaCache # :nodoc:
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_cache.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaCache < ConnectionAdapters::SchemaCache # :nodoc:
+        attr_accessor :additional_type_records, :known_coder_type_records
+
+        def initialize(conn)
+          @additional_type_records = {}
+          @known_coder_type_records = []
+          super
+        end
+
+        def encode_with(coder)
+          super
+          reset_type_records!
+          coder["additional_type_records"]  = @additional_type_records
+          coder["known_coder_type_records"] = @known_coder_type_records
+        end
+
+        def init_with(coder)
+          super
+          @additional_type_records  = coder["additional_type_records"]
+          @known_coder_type_records = coder["known_coder_type_records"]
+        end
+
+        def marshal_dump
+          reset_type_records!
+          super + [@additional_type_records, @known_coder_type_records]
+        end
+
+        def marshal_load(array)
+          @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, @database_version, @additional_type_records, @known_coder_type_records = array
+          @indexes ||= {}
+
+          derive_columns_hash_and_deduplicate_values
+          push_type_records_cache!
+        end
+
+        def clear!
+          super
+          reset_type_records!
+        end
+
+        private
+          def derive_columns_hash_and_deduplicate_values
+            super
+            @additional_type_records ||= {}
+            @additional_type_records = deep_deduplicate(@additional_type_records)
+
+            @known_coder_type_records ||= []
+            @known_coder_type_records = deep_deduplicate(@known_coder_type_records)
+          end
+
+          def reset_type_records!
+            # handling for cases of a SchemaCache w/out a connection (ie. when it's first loaded)
+            @connection ||= nil
+            return unless @connection.is_a?(ConnectionAdapters::SchemaCache)
+
+            @additional_type_records = @connection.class&.additional_type_records_cache
+            @known_coder_type_records = @connection.class&.known_coder_type_records_cache
+          end
+
+          def push_type_records_cache!
+            # handling for cases of a SchemaCache w/out a connection (ie. when it's first loaded)
+            @connection ||= nil
+            return unless @connection.is_a?(ConnectionAdapters::SchemaCache)
+
+            @connection.class&.additional_type_records_cache = @additional_type_records
+            @connection.class&.known_coder_type_records_cache = @known_coder_type_records
+          end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_cache.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLite3
+      class SchemaCache < ConnectionAdapters::SchemaCache # :nodoc:
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -5,6 +5,7 @@ require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/sqlite3/explain_pretty_printer"
 require "active_record/connection_adapters/sqlite3/quoting"
 require "active_record/connection_adapters/sqlite3/database_statements"
+require "active_record/connection_adapters/sqlite3/schema_cache"
 require "active_record/connection_adapters/sqlite3/schema_creation"
 require "active_record/connection_adapters/sqlite3/schema_definitions"
 require "active_record/connection_adapters/sqlite3/schema_dumper"
@@ -96,6 +97,10 @@ module ActiveRecord
       def initialize(connection, logger, connection_options, config)
         super(connection, logger, config)
         configure_connection
+      end
+
+      def init_schema_cache
+        SQLite3::SchemaCache.new(self)
       end
 
       def self.database_exists?(config)

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -477,6 +477,7 @@ db_namespace = namespace :db do
             db_config.name,
             schema_cache_path: db_config.schema_cache_path,
           )
+
           ActiveRecord::Tasks::DatabaseTasks.dump_schema_cache(
             ActiveRecord::Base.connection,
             filename,


### PR DESCRIPTION
### Summary

SchemaCache interface heavily based off PR #39077 but with a generic cache interface + a specific one for mysql, psql, and sqlite3

The major purpose of this PR is that using the schema cache file (generated by rake db:schema:cache:dump) would also cache the result of type-related queries for PostgreSQL, so it will reduce 2 queries for each new database connection. As a side effect, it will also reduce 2 queries for checking-out new PostgreSQL connection within a connection pool.