### PR TITLE
Fix issue with NoMethodError: undefined method `find_all'

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -278,12 +278,23 @@ module ActiveRecord
       # or saved. If +autosave+ is +false+ only new records will be returned,
       # unless the parent is/was a new record itself.
       def associated_records_to_validate_or_save(association, new_record, autosave)
+        return nil if association.nil?
+        return nil if association.target.nil?
+
         if new_record || custom_validation_context?
           association && association.target
         elsif autosave
-          association.target.find_all(&:changed_for_autosave?)
+          if association.target.is_a? Array
+            association.target.find_all(&:changed_for_autosave?)
+          else
+            [association.target] if association.target.changed_for_autosave?
+          end
         else
-          association.target.find_all(&:new_record?)
+          if association.target.is_a? Array
+            association.target.find_all(&:new_record?)
+          else
+            [association.target] if association.target.new_record?
+          end
         end
       end
 


### PR DESCRIPTION
This fixes #39822

### Summary

NoMethodError: undefined method find_all' for nil:NilClass or NoMethodError: undefined method find_all' for Class:...
~/.rvm/gems/ruby-2.6.5/gems/activerecord-6.0.3.2/lib/active_record/autosave_association.rb line 278 (method associated_records_to_validate_or_save)

In order to fix this we make sure the association target is not null and also deal with with a single object if it is not an array.

