### PR TITLE
Update example for Association callbacks section

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -616,8 +616,8 @@ module ActiveRecord
       # Similarly, if any of the +before_remove+ callbacks throw an exception, the object
       # will not be removed from the collection.
       #
-      # Note: In order to trigger remove callbacks use either +firm.clients.destroy_all+ or +firm.clients.destory(c).
-      # Attempting to remove them using +firm.clients.destory+ will not trigger callbacks.
+      # Note: In order to trigger remove callbacks use either +firm.clients.destroy_all+ or +firm.clients.destroy(c).
+      # Attempting to remove them using +firm.clients.destroy+ will not trigger callbacks.
       #
       # == Association extensions
       #

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -588,19 +588,24 @@ module ActiveRecord
       # you can also define callbacks that get triggered when you add an object to or remove an
       # object from an association collection.
       #
-      #   class Project
-      #     has_and_belongs_to_many :developers, after_add: :evaluate_velocity
+      #   class Firm < Company
+      #     has_many :clients, dependent: :destroy, after_add: :congratulate_client, after_remove: :log_after_remove
       #
-      #     def evaluate_velocity(developer)
+      #     def congratulate_client(record)
       #       ...
       #     end
-      #   end
+      #
+      #     def log_after_remove(record)
+      #       ...
+      #     end
       #
       # It's possible to stack callbacks by passing them as an array. Example:
       #
-      #   class Project
-      #     has_and_belongs_to_many :developers,
-      #                             after_add: [:evaluate_velocity, Proc.new { |p, d| p.shipping_date = Time.now}]
+      #   class Firm < Company
+      #     has_many :clients,
+      #              dependent: :destroy,
+      #              after_add: [:congratulate_client, Proc.new { |f, r| f.log << "after_adding#{r.id}" }],
+      #              after_remove: :log_after_remove
       #   end
       #
       # Possible callbacks are: +before_add+, +after_add+, +before_remove+ and +after_remove+.
@@ -610,6 +615,9 @@ module ActiveRecord
       #
       # Similarly, if any of the +before_remove+ callbacks throw an exception, the object
       # will not be removed from the collection.
+      #
+      # Note: In order to trigger remove callbacks use either +firm.clients.destroy_all+ or +firm.clients.destory(c).
+      # Attempting to remove them using +firm.clients.destory+ will not trigger callbacks.
       #
       # == Association extensions
       #


### PR DESCRIPTION
### Summary

There is an old open issue (https://github.com/rails/rails/issues/14365)
saying that callbacks are not triggered when assocations are destroyed.

I believe the issue does not represent a bug, but maybe just a small
gap in the docs about triggering callbacks when removing associations.

This update changes the example of the section to use the `Firm` class.
so that we can include an `after_remove`. This also adds a small `Note:`
section reminding users on how to destory associations so that callbacks
are triggered.
