### PR TITLE
Add config.action_dispatch.cookies_default_options

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow setting default values for cookie attributes globally.
+
+    Added new option `config.action_dispatch.cookies_default_options = {}`.
+    This allows cookie attributes such as `domain` and `path` to be set for
+    every cookie.
+
+    *Hugo Peixoto*
+
 *   Change default redirection status code for non-GET/HEAD requests to 308 Permanent Redirect for `ActionDispatch::SSL`.
 
     *Alan Tan*, *Oz Ben-David*

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -457,7 +457,7 @@ module ActionDispatch
           options.symbolize_keys!
 
           options.transform_values { |v|
-            if v.is_a? Proc
+            if v.respond_to?(:call)
               v.call
             else
               v

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -112,6 +112,11 @@ class CookiesTest < ActionController::TestCase
       head :ok
     end
 
+    def authenticate_admin_path
+      cookies[:user_name] = { value: "david", path: "/admin/" }
+      head :ok
+    end
+
     def set_multiple_cookies
       cookies["user_name"] = { "value" => "david", "expires" => Time.utc(2005, 10, 10, 5) }
       cookies["login"]     = "XJ-122"
@@ -130,6 +135,11 @@ class CookiesTest < ActionController::TestCase
 
     def logout
       cookies.delete("user_name")
+      head :ok
+    end
+
+    def logout_admin_path
+      cookies.delete("user_name", path: "/admin/")
       head :ok
     end
 
@@ -349,6 +359,7 @@ class CookiesTest < ActionController::TestCase
 
     @request.env["action_dispatch.key_generator"] = ActiveSupport::KeyGenerator.new(SECRET_KEY_BASE, iterations: 2)
     @request.env["action_dispatch.cookies_rotations"] = ActiveSupport::Messages::RotationConfiguration.new
+    @request.env["action_dispatch.cookies_default_options"] = {}
 
     @request.env["action_dispatch.secret_key_base"] = SECRET_KEY_BASE
     @request.env["action_dispatch.use_authenticated_cookie_encryption"] = true
@@ -769,6 +780,38 @@ class CookiesTest < ActionController::TestCase
     get :delete_and_set_cookie
     assert_cookie_header "user_name=david; path=/; expires=Mon, 10 Oct 2005 05:00:00 GMT; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
+  end
+
+  def test_cookie_with_default_options
+    @request.env["action_dispatch.cookies_default_options"] = { path: "/not-admin/" }
+    get :authenticate
+    assert_cookie_header "user_name=david; path=/not-admin/; SameSite=Lax"
+  end
+
+  def test_cookie_with_default_options_proc
+    @request.env["action_dispatch.cookies_default_options"] = { path: -> { "/not-admin/" } }
+    get :authenticate
+    assert_cookie_header "user_name=david; path=/not-admin/; SameSite=Lax"
+  end
+
+  def test_deleting_cookie_with_default_options
+    @request.env["action_dispatch.cookies_default_options"] = { path: "/not-admin/" }
+    get :authenticate
+    get :logout
+    assert_cookie_header "user_name=; path=/not-admin/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
+  end
+
+  def test_overriding_cookie_default_options
+    @request.env["action_dispatch.cookies_default_options"] = { path: "/not-admin/" }
+    get :authenticate_admin_path
+    assert_cookie_header "user_name=david; path=/admin/; SameSite=Lax"
+  end
+
+  def test_deleting_cookie_with_overriden_default_options
+    @request.env["action_dispatch.cookies_default_options"] = { path: "/not-admin/" }
+    get :authenticate_admin_path
+    get :logout_admin_path
+    assert_cookie_header "user_name=; path=/admin/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax"
   end
 
   def test_raise_data_overflow

--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -643,6 +643,32 @@ manually when reading the values on subsequent requests.
 If you use the cookie session store, this would apply to the `session` and
 `flash` hash as well.
 
+
+You may also set cookie attributes, such as the path to which it applies:
+
+```ruby
+class CookiesController < ApplicationController
+  def set_cookie
+    cookies[:commenter_name] = { value: "david", path: "/blog/" }
+  end
+end
+```
+
+Refer to the [API
+documentation](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html)
+for a list of all available options.
+
+These options can be set globally in an initializer. Values can be `Proc`
+objects:
+
+```ruby
+Rails.application.config.action_dispatch.cookies_default_options = {
+  path: "/blog/",
+  expires: -> { 1.day.from_now }
+}
+```
+
+
 Rendering XML and JSON data
 ---------------------------
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -279,6 +279,7 @@ module Rails
           "action_dispatch.encrypted_cookie_cipher" => config.action_dispatch.encrypted_cookie_cipher,
           "action_dispatch.signed_cookie_digest" => config.action_dispatch.signed_cookie_digest,
           "action_dispatch.cookies_serializer" => config.action_dispatch.cookies_serializer,
+          "action_dispatch.cookies_default_options" => config.action_dispatch.cookies_default_options,
           "action_dispatch.cookies_digest" => config.action_dispatch.cookies_digest,
           "action_dispatch.cookies_rotations" => config.action_dispatch.cookies_rotations,
           "action_dispatch.cookies_same_site_protection" => config.action_dispatch.cookies_same_site_protection,


### PR DESCRIPTION
Right now, cookie attributes could be set on each individual cookie by using:

```ruby
cookies[:commenter_name] = { value: "david", path: "/blog/" }
```

This PR allows these attributes to be set globally in an initializer:

```ruby
Rails.application.config.action_dispatch.cookies_default_options = {
  path: "/admin/",
  expires: -> { 1.day.from_now }
}
```

It supports `Proc` objects to delay execution to run time (vs initialization time).

This was particularly helpful when hosting a Rails app under a subdirectory, to avoid cookie collisions with other apps in different paths.

This PR is a new version of https://github.com/rails/rails/pull/27439. I had deleted the original fork so I don't know how I can reuse the issue.

I have tried to address @gmcgibbon's review notes, but I don't know how to interpret this comment:

https://github.com/rails/rails/pull/27439#discussion_r205312034