### PR TITLE
Add `Time#ceil` and `Time#floor` core extensions.

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -105,6 +105,20 @@ class Time
     subsec
   end
 
+  unless Time.method_defined?(:floor)
+    def floor(precision = 0)
+      change(nsec: 0) + subsec.floor(precision)
+    end
+  end
+
+  # Restricted Ruby version due to a bug in `Time#ceil`
+  # See https://bugs.ruby-lang.org/issues/17025 for more details
+  if RUBY_VERSION <= "2.7.1"
+    def ceil(precision = 0)
+      change(nsec: 0) + subsec.ceil(precision)
+    end
+  end
+
   # Returns a new Time where one or more of the elements have been changed according
   # to the +options+ parameter. The time options (<tt>:hour</tt>, <tt>:min</tt>,
   # <tt>:sec</tt>, <tt>:usec</tt>, <tt>:nsec</tt>) reset cascadingly, so if only

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -125,6 +125,29 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal 0.001.to_r / 1000000, time.sec_fraction.to_f
   end
 
+  def test_floor
+    time = Time.utc(2016, 4, 23, 0, 0, "0.123456789".to_r)
+
+    assert_equal "0".to_r, time.floor.subsec
+    assert_equal "0.1".to_r, time.floor(1).subsec
+    assert_equal "0.12".to_r, time.floor(2).subsec
+    assert_equal "0.123456789".to_r, time.floor(9).subsec
+    assert_equal "0.123456789".to_r, time.floor(10).subsec
+  end
+
+  def test_ceil
+    time = Time.utc(2016, 4, 30, 23, 59, "59.123456789".to_r)
+
+    assert_equal "0".to_r, time.ceil.subsec
+    assert_equal Time.utc(2016, 5, 1, 0, 0), time.ceil
+
+    assert_equal "0.124".to_r, time.ceil(3).subsec
+    assert_equal "0.12346".to_r, time.ceil(5).subsec
+    assert_equal "0.12345679".to_r, time.ceil(8).subsec
+    assert_equal "0.123456789".to_r, time.ceil(9).subsec
+    assert_equal "0.123456789".to_r.to_f, time.ceil(11).subsec.to_f
+  end
+
   def test_beginning_of_day
     assert_equal Time.local(2005, 2, 4, 0, 0, 0), Time.local(2005, 2, 4, 10, 10, 10).beginning_of_day
     with_env_tz "US/Eastern" do


### PR DESCRIPTION
### Summary

As per the discussion in https://github.com/rails/rails/pull/39698#discussion_r450779219

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
