### PR TITLE
Output a warning when the `index` kwarg is passed to #add_column.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -606,6 +606,14 @@ module ActiveRecord
       def add_column(table_name, column_name, type, **options)
         return if options[:if_not_exists] == true && column_exists?(table_name, column_name, type)
 
+        if options.key?(:index)
+          warn <<~WARNING
+            WARNING: #add_column ignores the :index keyword argument.
+
+            To create an index, use #add_index.
+          WARNING
+        end
+
         at = create_alter_table table_name
         at.add_column(column_name, type, **options)
         execute schema_creation.accept at

--- a/activerecord/test/cases/add_column_index_test.rb
+++ b/activerecord/test/cases/add_column_index_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class AddColumnIndexTest < ActiveRecord::TestCase
+  INDEX_KWARG_WARNING = <<~WARNING
+    WARNING: #add_column ignores the :index keyword argument.
+
+    To create an index, use #add_index.
+  WARNING
+
+  setup do
+    @connection = ActiveRecord::Base.connection
+
+    @connection.create_table("add_column_tests", force: true) do |t|
+      t.string "name"
+    end
+  end
+
+  teardown do
+    @connection.drop_table "add_column_tests", if_exists: true
+  end
+
+  def test_no_index_kwarg
+    warning = capture(:stderr) do
+      @connection.add_column :add_column_tests, :height, :integer
+    end
+    assert_no_match(INDEX_KWARG_WARNING, warning)
+  end
+
+  def test_index_true_kwarg
+    warning = capture(:stderr) do
+      @connection.add_column :add_column_tests, :height, :integer, index: true
+    end
+    assert_match(INDEX_KWARG_WARNING, warning)
+  end
+
+  def test_index_false_kwarg
+    warning = capture(:stderr) do
+      @connection.add_column :add_column_tests, :height, :integer, index: false
+    end
+    assert_match(INDEX_KWARG_WARNING, warning)
+  end
+end


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/39230

cc https://github.com/rails/rails/issues/20400
cc https://makandracards.com/makandra/32353-psa-index-true-in-rails-migrations-does-not-work-as-you-d-expect

### Summary

The `index: true` kwarg works on many methods in ActiveRecord migrations but does _not_ work in `add_column`. Rather than failing silently, provide a big quality of life improvement and let the user know that their migration _did not_ create an index.

### Other Information

I think a better long term solution would be to warn on all unexpected options keys but AR adapters could pass down random options keys that they use. Since solving perfectly is a little tricky, I'm pushing this PR up as a solid first step.

I also considered erroring on the `index` kwarg but we'll break backwards compatibility of old mutations with `index` kwargs.

Many cases of people mistakenly using `index: true` with `add_column`:  https://github.com/search?q=%22add_column%22+%22index%3A+true%22&type=Code