### PR TITLE
Add tests for enum saved as strings in the database

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -62,8 +62,8 @@ module ActiveRecord
   #     enum status: { active: 0, archived: 1 }
   #   end
   #
-  # Finally it's also possible to store the value as strings in the database
-  # with a hash:
+  # Finally it's also possible to use a non-integer column to persist the enumerated value.
+  # Note that this will likely lead to slower database queries:
   #
   #   class Conversation < ActiveRecord::Base
   #     enum status: { active: 'active', archived: 'archived' }

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -55,11 +55,18 @@ module ActiveRecord
   #
   # Good practice is to let the first declared status be the default.
   #
-  # Finally, it's also possible to explicitly map the relation between attribute and
+  # It's possible to explicitly map the relation between attribute and
   # database integer with a hash:
   #
   #   class Conversation < ActiveRecord::Base
   #     enum status: { active: 0, archived: 1 }
+  #   end
+  #
+  # Finally it's also possible to store the value as strings in the database
+  # with a hash:
+  #
+  #   class Conversation < ActiveRecord::Base
+  #     enum status: { active: 'active', archived: 'archived' }
   #   end
   #
   # Note that when an array is used, the implicit mapping from the values to database

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -32,6 +32,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "visible", @book.author_visibility
     assert_equal "visible", @book.illustrator_visibility
     assert_equal "medium", @book.difficulty
+    assert_equal "soft", @book.cover
   end
 
   test "find via scope" do
@@ -59,6 +60,7 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where(status: [written]).first
     assert_not_equal @book, Book.where("status <> ?", published).first
     assert_equal @book, Book.where("status <> ?", written).first
+    assert_equal @book, Book.where(cover: Book.covers[:soft]).first
   end
 
   test "find via where with symbols" do
@@ -69,6 +71,8 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
     assert_equal books(:ddd), Book.where(last_read: :forgotten).first
+    assert_equal @book, Book.where(cover: :soft).first
+    assert_equal @book, Book.where.not(cover: :hard).first
   end
 
   test "find via where with strings" do
@@ -79,6 +83,8 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_equal @book, Book.where.not(status: "published").first
     assert_equal @book, Book.where.not(status: "written").first
     assert_equal books(:ddd), Book.where(last_read: "forgotten").first
+    assert_equal @book, Book.where(cover: "soft").first
+    assert_equal @book, Book.where.not(cover: "hard").first
   end
 
   test "build from scope" do
@@ -102,11 +108,15 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate @book, :in_english?
     @book.author_visibility_visible!
     assert_predicate @book, :author_visibility_visible?
+    @book.hard!
+    assert_predicate @book, :hard?
   end
 
   test "update by setter" do
     @book.update! status: :written
     assert_predicate @book, :written?
+    @book.update! cover: :hard
+    assert_predicate @book, :hard?
   end
 
   test "enum methods are overwritable" do
@@ -117,11 +127,15 @@ class EnumTest < ActiveRecord::TestCase
   test "direct assignment" do
     @book.status = :written
     assert_predicate @book, :written?
+    @book.cover = :hard
+    assert_predicate @book, :hard?
   end
 
   test "assign string value" do
     @book.status = "written"
     assert_predicate @book, :written?
+    @book.cover = "hard"
+    assert_predicate @book, :hard?
   end
 
   test "enum changed attributes" do

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -11,6 +11,7 @@ awdr:
   font_size: :medium
   difficulty: :medium
   boolean_status: :enabled
+  cover: 'soft'
 
 rfr:
   author_id: 1

--- a/activerecord/test/fixtures/books.yml
+++ b/activerecord/test/fixtures/books.yml
@@ -11,7 +11,7 @@ awdr:
   font_size: :medium
   difficulty: :medium
   boolean_status: :enabled
-  cover: 'soft'
+  cover: "soft"
 
 rfr:
   author_id: 1


### PR DESCRIPTION
### Summary

There already seems to be support for using strings instead of integers with enums (see https://github.com/rails/rails/blob/5cdd4e5aba93e614ea286c10b7dbcc0a468497e7/activerecord/test/models/book.rb#L18) but nothing is using this in the tests. This PR adds more tests and updates the description to make this usage explicit.

### Other Information

Unblocks saving enums as strings in the database:
```ruby
enum status: { active: 'active', archived: 'archived' }
```

EDIT: this PR was also attempted [here](https://github.com/rails/rails/pull/28490) in 2017 and [here](https://github.com/rails/rails/pull/35353) in 2019