### PR TITLE
Fix option not being passed with fetch_multi

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixed issue in `ActiveSupport::Cache::RedisCacheStore` not passing options
+    to `read_multi` causing `fetch_multi` to not work properly
+
+    *Rajesh Sharma*
+
 *   Fixed issue in `ActiveSupport::Cache::MemCacheStore` which caused duplicate compression,
     and caused the provided `compression_threshold` to not be respected.
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -351,7 +351,7 @@ module ActiveSupport
 
         def read_multi_entries(names, **options)
           if mget_capable?
-            read_multi_mget(*names)
+            read_multi_mget(*names, **options)
           else
             super
           end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -142,6 +142,14 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       end
     end
 
+    def test_fetch_multi_with_namespace
+      assert_called_with(@cache.redis, :mget, ["custom-namespace:a", "custom-namespace:b", "custom-namespace:c"], returns: []) do
+        @cache.fetch_multi("a", "b", "c", namespace: "custom-namespace") do |key|
+          key * 2
+        end
+      end
+    end
+
     def test_fetch_multi_without_names
       assert_not_called(@cache.redis, :mget) do
         @cache.fetch_multi() { }


### PR DESCRIPTION
In redis cache store, options to `fetch_multi` are passed correctly to
`write_multi` but not to `read_multi`. This causes cache always to be missed
when passing `namespace` option to it.


here is a snippet to reproduce the issue fixed in this PR. Also added a test.

```
      store = ActiveSupport::Cache::RedisCacheStore.new

      store.fetch_multi("ab", "xy", namespace: "mynamespace") { |key| puts "missed cache for #{key}"; key }

      store.fetch_multi("ab", "xy", namespace: "mynamespace") { |key| puts "missed cache for #{key}"; key }

```