### PR TITLE
Add support for `where` with not equal comparison operators.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add support for `where` with not equal comparison operator(`<>`, `!=`).
+
+    ```ruby
+    posts = Post.order(:id)
+
+    posts.where("id <>": 10).pluck(:id)  # => [9, 11]
+    posts.where("id !=": 10).pluck(:id)  # => [9, 11]
+    ```
+
+    *Abhay Nikam*
+
 *   Allow attribute's default to be configured but keeping its own type.
 
     ```ruby

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -124,7 +124,7 @@ module ActiveRecord
 
               grouping_queries(queries)
             end
-          elsif key.end_with?(">", ">=", "<", "<=") && /\A(?<key>.+?)\s*(?<operator>>|>=|<|<=)\z/ =~ key
+          elsif key.end_with?(">", ">=", "<", "<=", "<>", "!=") && /\A(?<key>.+?)\s*(?<operator>>|>=|<|<=|<>|!=)\z/ =~ key
             build(table.arel_attribute(key), value, OPERATORS[-operator])
           else
             build(table.arel_attribute(key), value)
@@ -132,7 +132,7 @@ module ActiveRecord
         end
       end
 
-      OPERATORS = { ">" => :gt, ">=" => :gteq, "<" => :lt, "<=" => :lteq }.freeze
+      OPERATORS = { ">" => :gt, ">=" => :gteq, "<" => :lt, "<=" => :lteq, "<>" => :not_eq, "!=" => :not_eq }.freeze
 
     private
       attr_reader :table

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2168,6 +2168,8 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal [9, 10, 11], posts.where("id >=": 9).pluck(:id)
     assert_equal [1, 2], posts.where("id <": 3).pluck(:id)
     assert_equal [1, 2, 3], posts.where("id <=": 3).pluck(:id)
+    assert_not_includes posts.where("id <>": 3).pluck(:id), 3
+    assert_not_includes posts.where("id !=": 3).pluck(:id), 3
   end
 
   def test_where_with_table_name_resolution


### PR DESCRIPTION
PR #39613 (Thanks to @kamipo ❤️  ) introduced an awesome change to support comparison operators and while using them I felt the `not equal` would be a good addition as well so wrote a small PR for it.

This change also benefits other finder methods which internally uses `where` clause. 
Example: 
```ruby
posts.find_by("id !=": 10)
posts.delete_by("id !=": 10)
posts.destroy_by("id <>": 10)
```

Please feel free to close the PR if the change is not required. We can always go back to `posts.where.not(id: 10)` which in my opinion is more readable.