### PR TITLE
Update wording for cookies [ci-skip]

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -88,11 +88,10 @@ module ActionDispatch
     # :startdoc:
   end
 
-  # \Cookies are read and written through ActionController#cookies.
+  # Read and write data to cookies through ActionController#cookies.
   #
-  # The cookies being read are the ones received along with the request, the cookies
-  # being written will be sent out with the response. Reading a cookie does not get
-  # the cookie object itself back, just the value it holds.
+  # When reading cookie data, the data is read from the HTTP request header, Cookie.
+  # When writing cookie data, the data is sent out in the HTTP response header, Set-Cookie.
   #
   # Examples of writing:
   #

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -10,8 +10,8 @@ module ActionDispatch
     # dramatically faster than the alternatives.
     #
     # Sessions typically contain at most a user_id and flash message; both fit
-    # within the 4K cookie size limit. A CookieOverflow exception is raised if
-    # you attempt to store more than 4K of data.
+    # within the 4096 bytes cookie size limit. A CookieOverflow exception is raised if
+    # you attempt to store more than 4096 bytes of data.
     #
     # The cookie jar used for storage is automatically configured to be the
     # best possible option given your application's configuration.


### PR DESCRIPTION
### Summary

Added the word bytes to the cookie size limit, so it's clearer.

I also updated the docs on the cookie class, to refer to the http request header where the cookie data is read from and the http response header, Set-Cookie where the cookie data is stored.
