### PR TITLE
Switch regex for delete_suffix in normalize_path

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -19,11 +19,13 @@ module ActionDispatch
           encoding = path.encoding
           path = +"/#{path}"
           path.squeeze!("/")
-          path.sub!(%r{/+\Z}, "")
-          path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
-          path = +"/" if path == ""
+
+          unless path == "/"
+            path.delete_suffix!("/")
+            path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
+          end
+
           path.force_encoding(encoding)
-          path
         end
 
         # URI path and fragment escaping


### PR DESCRIPTION
### Summary

This PR changes the logic for `normalize_path` slightly.

**Before**
1. squeeze string
2. Remove all `/` from the end of the string with the regex in `sub!`
3. If the result is an empty string (which happens for the root_path `/`), re-add the `/`

**After**
1. squeeze string
2. If string is already just a `/`, don't do anything
3. If not, then there should only be a single `/` in the end, since we already squeezed the string. In which case, a simple delete_suffix should be enough (nothing happens if there's no `/` in the end)

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

require "action_dispatch/journey/router/utils"

module ActionDispatch
  module Journey
    class Router
      class Utils
        def self.fast_normalize_path(path)
          path ||= ""
          encoding = path.encoding
          path = +"/#{path}"
          path.squeeze!("/")

          unless path == "/"
            path.delete_suffix!("/")
            path.gsub!(/(%[a-f0-9]{2})/) { $1.upcase }
          end

          path.force_encoding(encoding)
        end
      end
    end
  end
end

SCENARIOS = {
  "//foo///" => "//foo///",
  "/" => "/",
  "Empty" => ""
}

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  puts "IPS"
  Benchmark.ips do |x|
    x.report("normalize_path")      { ActionDispatch::Journey::Router::Utils.normalize_path(value) }
    x.report("fast_normalize_path") { ActionDispatch::Journey::Router::Utils.fast_normalize_path(value) }
    x.compare!
  end

  puts "MEMORY"
  Benchmark.memory do |x|
    x.report("normalize_path")      { ActionDispatch::Journey::Router::Utils.normalize_path(value) }
    x.report("fast_normalize_path") { ActionDispatch::Journey::Router::Utils.fast_normalize_path(value) }
    x.compare!
  end
end
```
### Results
```
=================================== //foo/// ===================================
IPS
Warming up --------------------------------------
      normalize_path    61.644k i/100ms
 fast_normalize_path   129.650k i/100ms
Calculating -------------------------------------
      normalize_path    629.801k (± 7.9%) i/s -      3.144M in   5.020790s
 fast_normalize_path      1.275M (± 2.6%) i/s -      6.482M in   5.087160s

Comparison:
 fast_normalize_path:  1275213.0 i/s
      normalize_path:   629801.5 i/s - 2.02x  (± 0.00) slower

MEMORY
Calculating -------------------------------------
      normalize_path   248.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
 fast_normalize_path    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
 fast_normalize_path:         40 allocated
      normalize_path:        248 allocated - 6.20x more

====================================== / =======================================
IPS
Warming up --------------------------------------
      normalize_path    68.022k i/100ms
 fast_normalize_path   230.683k i/100ms
Calculating -------------------------------------
      normalize_path    654.908k (± 6.5%) i/s -      3.265M in   5.003933s
 fast_normalize_path      2.269M (± 1.7%) i/s -     11.534M in   5.085914s

Comparison:
 fast_normalize_path:  2268553.2 i/s
      normalize_path:   654907.9 i/s - 3.46x  (± 0.00) slower

MEMORY
Calculating -------------------------------------
      normalize_path   288.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
 fast_normalize_path    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
 fast_normalize_path:         40 allocated
      normalize_path:        288 allocated - 7.20x more

==================================== Empty =====================================
IPS
Warming up --------------------------------------
      normalize_path    68.124k i/100ms
 fast_normalize_path   233.407k i/100ms
Calculating -------------------------------------
      normalize_path    660.497k (± 7.1%) i/s -      3.338M in   5.076182s
 fast_normalize_path      2.313M (± 1.7%) i/s -     11.670M in   5.046849s

Comparison:
 fast_normalize_path:  2313115.6 i/s
      normalize_path:   660496.6 i/s - 3.50x  (± 0.00) slower

MEMORY
Calculating -------------------------------------
      normalize_path   288.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
 fast_normalize_path    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
 fast_normalize_path:         40 allocated
      normalize_path:        288 allocated - 7.20x more
```