### PR TITLE
Support `where` with comparison operators (`>`, `>=`, `<`, and `<=`) Take 2

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,35 @@
+*   Support `where` with comparison operators (`>`, `>=`, `<`, and `<=`).
+
+    ```ruby
+    posts = Post.order(:id)
+
+    posts.where("id >": 9).pluck(:id)  # => [10, 11]
+    posts.where("id >=": 9).pluck(:id) # => [9, 10, 11]
+    posts.where("id <": 3).pluck(:id)  # => [1, 2]
+    posts.where("id <=": 3).pluck(:id) # => [1, 2, 3]
+    ```
+
+    From type casting and table/column name resolution's point of view,
+    `where("created_at >=": time)` is better alternative than `where("created_at >= ?", time)`.
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      attribute :created_at, :datetime, precision: 3
+    end
+
+    time = Time.now.utc # => 2020-06-24 10:11:12.123456 UTC
+
+    Post.create!(created_at: time) # => #<Post id: 1, created_at: "2020-06-24 10:11:12.123000">
+
+    # SELECT `posts`.* FROM `posts` WHERE (created_at >= '2020-06-24 10:11:12.123456')
+    Post.where("created_at >= ?", time) # => []
+
+    # SELECT `posts`.* FROM `posts` WHERE `posts`.`created_at` >= '2020-06-24 10:11:12.123000'
+    Post.where("created_at >=": time) # => [#<Post id: 1, created_at: "2020-06-24 10:11:12.123000">]
+    ```
+
+    *Ryuta Kamizono*
+
 *   Type cast enum values by the original attribute type.
 
     The notable thing about this change is that unknown labels will no longer match 0 on MySQL.

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -122,11 +122,15 @@ module ActiveRecord
 
               grouping_queries(queries)
             end
+          elsif key.end_with?(">", ">=", "<", "<=") && /\A(?<key>.+?)\s*(?<operator>>|>=|<|<=)\z/ =~ key
+            self[key, value, OPERATORS[operator]]
           else
             self[key, value]
           end
         end
       end
+
+      OPERATORS = { ">" => :gt, ">=" => :gteq, "<" => :lt, "<=" => :lteq }.freeze
 
     private
       attr_reader :table

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -98,8 +98,12 @@ if supports_datetime_with_precision?
       date = ::Time.utc(2014, 8, 17, 12, 30, 0, 999999)
       Foo.create!(created_at: date, updated_at: date)
 
-      assert foo = Foo.find_by(created_at: date)
-      assert_equal 1, Foo.where(updated_at: date).count
+      assert_nil Foo.find_by("created_at >= ?", date)
+      assert_equal 0, Foo.where("updated_at >= ?", date).count
+
+      assert foo = Foo.find_by("created_at >=": date)
+      assert_equal 1, Foo.where("updated_at >=": date).count
+
       assert_equal date.to_s, foo.created_at.to_s
       assert_equal date.to_s, foo.updated_at.to_s
       assert_equal 000000, foo.created_at.usec

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -315,17 +315,15 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true, Topic.where(id: 1).or(Topic.where(id: 9223372036854775808)).exists?
     assert_equal true, Topic.where.not(id: 9223372036854775808).exists?
 
-    attr = Topic.predicate_builder
+    assert_predicate Topic.where("id >":  -9223372036854775809), :exists?
+    assert_predicate Topic.where("id >=": -9223372036854775809), :exists?
+    assert_predicate Topic.where("id <":  9223372036854775808),  :exists?
+    assert_predicate Topic.where("id <=": 9223372036854775808),  :exists?
 
-    assert_predicate Topic.where(attr[:id, -9223372036854775809, :gt]),   :exists?
-    assert_predicate Topic.where(attr[:id, -9223372036854775809, :gteq]), :exists?
-    assert_predicate Topic.where(attr[:id,  9223372036854775808, :lt]),   :exists?
-    assert_predicate Topic.where(attr[:id,  9223372036854775808, :lteq]), :exists?
-
-    assert_not_predicate Topic.where(attr[:id,  9223372036854775808, :gt]),   :exists?
-    assert_not_predicate Topic.where(attr[:id,  9223372036854775808, :gteq]), :exists?
-    assert_not_predicate Topic.where(attr[:id, -9223372036854775809, :lt]),   :exists?
-    assert_not_predicate Topic.where(attr[:id, -9223372036854775809, :lteq]), :exists?
+    assert_not_predicate Topic.where("id >":  9223372036854775808),  :exists?
+    assert_not_predicate Topic.where("id >=": 9223372036854775808),  :exists?
+    assert_not_predicate Topic.where("id <":  -9223372036854775809), :exists?
+    assert_not_predicate Topic.where("id <=": -9223372036854775809), :exists?
   end
 
   def test_exists_with_joins

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -268,10 +268,10 @@ class DefaultScopingTest < ActiveRecord::TestCase
   end
 
   def test_unscope_string_where_clauses_involved
-    dev_relation = Developer.order("salary DESC").where("legacy_created_at > ?", 1.year.ago)
+    dev_relation = Developer.order("salary DESC").where("created_at >": 1.year.ago)
     expected = dev_relation.collect(&:name)
 
-    dev_ordered_relation = DeveloperOrderedBySalary.where(name: "Jamis").where("legacy_created_at > ?", 1.year.ago)
+    dev_ordered_relation = DeveloperOrderedBySalary.where(name: "Jamis").where("created_at >": 1.year.ago)
     received = dev_ordered_relation.unscope(where: [:name]).collect(&:name)
 
     assert_equal expected.sort, received.sort

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -92,8 +92,12 @@ if supports_datetime_with_precision?
       time = ::Time.utc(2000, 1, 1, 12, 30, 0, 999999)
       Foo.create!(start: time, finish: time)
 
-      assert foo = Foo.find_by(start: time)
-      assert_equal 1, Foo.where(finish: time).count
+      assert_nil Foo.find_by("start >= ?", time)
+      assert_equal 0, Foo.where("finish >= ?", time).count
+
+      assert foo = Foo.find_by("start >=": time)
+      assert_equal 1, Foo.where("finish >=": time).count
+
       assert_equal time.to_s, foo.start.to_s
       assert_equal time.to_s, foo.finish.to_s
       assert_equal 000000, foo.start.usec

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -38,7 +38,7 @@ class Author < ActiveRecord::Base
            -> { where(title: "Welcome to the weblog").where(comments_count: 1) },
            class_name: "Post"
   has_many :welcome_posts_with_comments,
-           -> { where(title: "Welcome to the weblog").where("legacy_comments_count > 0") },
+           -> { where(title: "Welcome to the weblog").where("comments_count >": 0) },
            class_name: "Post"
 
   has_many :comments_desc, -> { order("comments.id DESC") }, through: :posts_sorted_by_id, source: :comments


### PR DESCRIPTION
Revert "Revert "Merge pull request #39613 from kamipo/where_with_custom_operator""

This reverts commit da022915d9a5ca29a11ea150f6d87fcedcff9b86.

```ruby
posts = Post.order(:id)

posts.where("id >": 9).pluck(:id)  # => [10, 11]
posts.where("id >=": 9).pluck(:id) # => [9, 10, 11]
posts.where("id <": 3).pluck(:id)  # => [1, 2]
posts.where("id <=": 3).pluck(:id) # => [1, 2, 3]
```

From type casting and table/column name resolution's point of view,
`where("created_at >=": time)` is better alternative than `where("created_at >= ?", time)`.

```ruby
class Post < ActiveRecord::Base
  attribute :created_at, :datetime, precision: 3
end

time = Time.now.utc # => 2020-06-24 10:11:12.123456 UTC

Post.create!(created_at: time) # => #<Post id: 1, created_at: "2020-06-24 10:11:12.123000">

# SELECT `posts`.* FROM `posts` WHERE (created_at >= '2020-06-24 10:11:12.123456')
Post.where("created_at >= ?", time) # => []

# SELECT `posts`.* FROM `posts` WHERE `posts`.`created_at` >= '2020-06-24 10:11:12.123000'
Post.where("created_at >=": time) # => [#<Post id: 1, created_at: "2020-06-24 10:11:12.123000">]
```

As a main contributor of the predicate builder area, I'd recommend to
people use the hash syntax, the hash syntax also have other useful
effects (making boundable queries, unscopeable queries, hash-like
relation merging friendly, automatic other table references detection).

* Making boundable queries

While working on #23461, I realized that Active Record doesn't generate
boundable queries perfectly, so I've been improving generated queries to
be boundable for a long time.

e.g.

#26117
7d5399379cb9ac2d3ffafa28fdc844d7b6c18ab8
#39219

Now, `where` with the hash syntax will generate boundable queries
perfectly.

I also want to generate boundable queries with a comparison operator in
a third party gem, but currently there is no other way than calling
`predicate_builder` directly.

https://github.com/kufu/activerecord-bitemporal/pull/62

* Unscopeable queries, Hash-like relation merging friendly

Unscopeable, and Hash-like merging friendly queries are relying on where
clause is an array of attr with value, and attr name is normalized as a
string (i.e. using `User.arel_table[:name]` is not preferable for
`unscope` and `merge`).

Example:

```ruby
id = User.arel_table[:id]

users = User.where(id.gt(1).and(id.lteq(10)))

# no-op due to `id.gt(1).and(id.lteq(10))` is not an attr with value
users.unscope(:id)
```

* Automatic other table references detection

It works only for the hash syntax.

ee7f66603573fd441f1522cc73ec0b7f56c4d1af
