### PR TITLE
`return_only_media_type_on_content_type` wrong on upgrading app

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2445,6 +2445,7 @@ module ApplicationTests
 
     test "ActionDispatch::Response.return_only_media_type_on_content_type can be configured in the new framework defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "5.2"'
 
       app_file "config/initializers/new_framework_defaults_6_0.rb", <<-RUBY
         Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false


### PR DESCRIPTION
### Summary

Similar to https://github.com/rails/rails/pull/37112

Our app is set up as follows:

config/application.rb:

```ruby
    config.load_defaults("5.2")
```

new_framework_defaults.rb:

```ruby
Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
```

When booting a test console (`bin/rails c -e test`):

```
Loading test environment (Rails 6.0.3.2)
Tanda @ Rails 6.0.3.2 (test) :001 > ActionDispatch::Response.return_only_media_type_on_content_type
true
Tanda @ Rails 6.0.3.2 (test) :002 > Rails.application.config.action_dispatch.return_only_media_type_on_content_type
false
```

Adding a test to see if I can replicate.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
