### PR TITLE
Generate abstract class when generating scaffold in another database

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/templates/abstract_base_class.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/abstract_base_class.rb.tt
@@ -1,0 +1,7 @@
+<% module_namespacing do -%>
+class <%= abstract_class_name %> < ApplicationRecord
+  self.abstract_class = true
+
+  connects_to database: { <%= ActiveRecord::Base.writing_role %>: :<%= database -%> }
+end
+<% end -%>

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,46 @@
+*   Automatically generate abstract class when using multiple databases.
+
+    When generating a scaffold for a multiple database application, Rails will now automatically generate the abstract class for the database when the database argument is passed. This abstract class will include the connection information for the writing configuration and any models generated for that database will automatically inherit from the abstract class.
+
+    Usage:
+
+    ```
+    rails generate scaffold Pet name:string --database=animals
+    ```
+
+    Will create an abstract class for the animals connection.
+
+    ```ruby
+    class AnimalsRecord < ApplicationRecord
+      self.abstract_class = true
+
+      connects_to database: { writing: :animals }
+    end
+    ```
+
+    And generate a `Pet` model that inherits from the new `AnimalsRecord`:
+
+    ```ruby
+    class Pet < AnimalsRecord
+    end
+    ```
+
+    If you already have an abstract class and it follows a different pattern than Rails defaults, you can pass a parent class with the database argument.
+
+    ```
+    rails generate scaffold Pet name:string --database=animals --parent=SecondaryBase
+    ```
+
+    This will ensure the model inherits from the `SecondaryBase` parent instead of `AnimalsRecrd`
+
+    ```ruby
+    class Pet < SecondaryBase
+    end
+    ```
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
+
 *   Accept params from url to prepopulate the Inbound Emails form in Rails conductor.
 
     *Chris Oliver*

--- a/railties/test/application/multi_db_rake_test.rb
+++ b/railties/test/application/multi_db_rake_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "env_helpers"
+
+module ApplicationTests
+  class MultiDbRakeTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation, EnvHelpers
+
+    def setup
+      build_app(multi_db: true)
+      @output = rails("generate", "scaffold", "Pet", "name:string", "--database=animals")
+    end
+
+    def teardown
+      teardown_app
+    end
+
+    def test_generate_scaffold_creates_abstract_model
+      assert_match %r{app/models/pet\.rb}, @output
+      assert_match %r{app/models/animals_record\.rb}, @output
+    end
+
+    def test_destroy_scaffold_doesnt_remove_abstract_model
+      output = rails("destroy", "scaffold", "Pet", "--database=animals")
+
+      assert_match %r{app/models/pet\.rb}, output
+      assert_no_match %r{app/models/animals_record\.rb}, output
+    end
+
+    def test_creates_a_directory_for_migrations
+      assert_match %r{db/animals_migrate/}, @output
+    end
+  end
+end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -519,11 +519,16 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_scaffold_generator_database
+  def test_scaffold_generator_multi_db_abstract_class
     with_secondary_database_configuration do
       run_generator ["posts", "--database=secondary"]
 
       assert_migration "db/secondary_migrate/create_posts.rb"
+      assert_file "app/models/secondary_record.rb" do |content|
+        assert_match(/class SecondaryRecord < ApplicationRecord/, content)
+        assert_match(/connects_to database: { writing: :secondary }/, content)
+        assert_match(/self.abstract_class = true/, content)
+      end
     end
   end
 


### PR DESCRIPTION
This PR ensures that when you're generating a scaffold or model and that
model should belong to another database it will create an abstract class
if it doesn't already exist.

The new abstract class will ensure that the new model inherits from that
class, but will not be deleted if the scaffold is deleted. This is
because Rails can't know if you have other models inheriting from that
class so we don't want to revoke that if the scaffold is destroyed.

If the abstract class already exists it won't be created twice. If the
options for `parent` are set, the generator will use that as the
abstract class instead of creating one. The generated abstract class
will add the writing connection automatically, users need to add the
reading connection themselves as Rails doesn't know which is the reading
connection.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>