### PR TITLE
Update obsolete 'rake' references to 'rails test'

### DIFF
--- a/actionmailbox/test/dummy/config/database.yml
+++ b/actionmailbox/test/dummy/config/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/actionmailbox/test/dummy/config/database.yml
+++ b/actionmailbox/test/dummy/config/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/actiontext/test/dummy/config/database.yml
+++ b/actiontext/test/dummy/config/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/actiontext/test/dummy/config/database.yml
+++ b/actiontext/test/dummy/config/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/activestorage/test/dummy/config/database.yml
+++ b/activestorage/test/dummy/config/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/activestorage/test/dummy/config/database.yml
+++ b/activestorage/test/dummy/config/database.yml
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
@@ -13,7 +13,7 @@
 #   database: <%= app_name %>_development
 #
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 #
 # test:
@@ -48,7 +48,7 @@ development:
   url: jdbc:db://localhost/<%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbc.yml.tt
@@ -13,7 +13,7 @@
 #   database: <%= app_name %>_development
 #
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 #
 # test:
@@ -48,7 +48,7 @@ development:
   url: jdbc:db://localhost/<%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -21,7 +21,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -21,7 +21,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
@@ -37,7 +37,7 @@ development:
   #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
@@ -37,7 +37,7 @@ development:
   #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
@@ -13,7 +13,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcsqlite3.yml.tt
@@ -13,7 +13,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -26,7 +26,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -26,7 +26,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
@@ -27,7 +27,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/oracle.yml.tt
@@ -27,7 +27,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -53,7 +53,7 @@ development:
   #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -53,7 +53,7 @@ development:
   #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -14,7 +14,7 @@ development:
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml.tt
@@ -20,7 +20,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
+# re-generated from your development database when you run "rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlserver.yml.tt
@@ -20,7 +20,7 @@ development:
   database: <%= app_name %>_development
 
 # Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rails test".
+# re-generated from your development database when you run "bin/rails test".
 # Do not set this db to the same as development or production.
 test:
   <<: *default

--- a/railties/lib/rails/test_unit/reporter.rb
+++ b/railties/lib/rails/test_unit/reporter.rb
@@ -6,7 +6,7 @@ require "minitest"
 module Rails
   class TestUnitReporter < Minitest::StatisticsReporter
     class_attribute :app_root
-    class_attribute :executable, default: "rails test"
+    class_attribute :executable, default: "bin/rails test"
 
     def record(result)
       super


### PR DESCRIPTION
### Summary

A comment in database.yml referred to the deprecated `rake` technique for running the test suite.
The currently recommended way to run the tests is with `rails test`.