### PR TITLE
Add support for aliasing selected fields.

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -277,7 +277,7 @@ module ActiveRecord
       def aggregate_column(column_name)
         return column_name if Arel::Expressions === column_name
 
-        arel_column(column_name.to_s) do |name|
+        arel_column_attribute(column_name.to_s) do |name|
           Arel.sql(column_name == :all ? "*" : name)
         end
       end


### PR DESCRIPTION
### Summary

Often I would like to include some calculation for grouped value within SELECT statement. I need to reselect default selection and add sql fragment for aliasing aggregation function result.

```ruby
Account.joins(:users).group(:id).select('accounts.*, count(users.id) AS user_count')
#=> SELECT accounts.*, count(users.id) AS user_count FROM "accounts" INNER JOIN "users" ON "users"."account_id" = "accounts"."id" GROUP BY "accounts"."id" LIMIT $1
```

With this patch I can get same query with following:

```ruby
Account.joins(:users).group(:id).select('accounts.*', 'count(users.id)' => :user_count)
#=> SELECT accounts.*, count(users.id) AS user_count FROM "accounts" INNER JOIN "users" ON "users"."account_id" = "accounts"."id" GROUP BY "accounts"."id" LIMIT $1
```

When combined with https://github.com/rails/rails/pull/39873, it is possible to use (IMHO) nicer approach:

```ruby
Account.joins(:users).group(:id).select_append('count(users.id)' => :user_count)
#=> SELECT accounts.*, count(users.id) AS user_count FROM "accounts" INNER JOIN "users" ON "users"."account_id" = "accounts"."id" GROUP BY "accounts"."id" LIMIT $1
```

### TODO
- [ ] changelog entry
- [ ] documentation