### PR TITLE
Fix instrumenting internal server errors

### DIFF
--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -35,6 +35,9 @@ module ActionController
         payload[:response] = response
         payload[:status]   = response.status
         result
+      rescue => error
+        payload[:status] = ActionDispatch::ExceptionWrapper.status_code_for_exception(error.class.name)
+        raise
       ensure
         append_info_to_payload(payload)
       end


### PR DESCRIPTION
### Summary

In case of an exception we never reach setting the status in the payload so it is unset afterward.

Let's catch the exception and set status based on the exception class name. Then re-raise it.

### Other Information

This is basically the equivalent of what happens in

ActionController::LogSubscriber.process_action
