### PR TITLE
Prepend X-Original-To to raw_email with Sendgrid envelope recipients

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Sendgrid ingress now passes through the envelope recipient as `X-Original-To`.
+
+    *Mark Haussmann*
+
 *   Update Mandrill inbound email route to respond appropriately to HEAD requests for URL health checks from Mandrill.
 
     *Bill Cromie*

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
@@ -48,7 +48,21 @@ module ActionMailbox
     before_action :authenticate_by_password
 
     def create
-      ActionMailbox::InboundEmail.create_and_extract_message_id! params.require(:email)
+      ActionMailbox::InboundEmail.create_and_extract_message_id! mail
+    rescue JSON::ParserError => error
+      logger.error error.message
+      head :unprocessable_entity
     end
+
+    private
+      def mail
+        params.require(:email).tap do |raw_email|
+          envelope["to"].each { |to| raw_email.prepend("X-Original-To: ", to, "\n") } if params.key?(:envelope)
+        end
+      end
+
+      def envelope
+        JSON.parse(params.require(:envelope))
+      end
   end
 end

--- a/actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/sendgrid/inbound_emails_controller_test.rb
@@ -18,6 +18,22 @@ class ActionMailbox::Ingresses::Sendgrid::InboundEmailsControllerTest < ActionDi
     assert_equal "0CB459E0-0336-41DA-BC88-E6E28C697DDB@37signals.com", inbound_email.message_id
   end
 
+  test "add X-Original-To to email from Sendgrid" do
+    assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+      post rails_sendgrid_inbound_emails_url,
+        headers: { authorization: credentials }, params: {
+          email: file_fixture("../files/welcome.eml").read,
+          envelope: "{\"to\":[\"replies@example.com\"],\"from\":\"jason@37signals.com\"}",
+        }
+    end
+
+    assert_response :no_content
+
+    inbound_email = ActionMailbox::InboundEmail.last
+    mail = Mail.from_source(inbound_email.raw_email.download)
+    assert_equal "replies@example.com", mail.header["X-Original-To"].decoded
+  end
+
   test "rejecting an unauthorized inbound email from Sendgrid" do
     assert_no_difference -> { ActionMailbox::InboundEmail.count } do
       post rails_sendgrid_inbound_emails_url, params: { email: file_fixture("../files/welcome.eml").read }


### PR DESCRIPTION
Sendgrid, like Mailgun, seems to only pass the BCC recipient as a
parameter in the envelope json in the original payload.

This PR adds code to prepend the recipients from the Sendgrid payload
to the raw_email under the X-Original-To header.

Heavily inspired by #38738
Related to #38446

CC: @jeremy and @kaspth