### PR TITLE
fix: duplicated load /bin/spring

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,6 +1,6 @@
 <% unless options.skip_spring? -%>
 begin
-  load File.expand_path("../bin/spring", __dir__)
+  require File.expand_path("../bin/spring", __dir__)
 rescue LoadError => e
   raise unless e.path.end_with?("/bin/spring")
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -859,7 +859,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match("config.cache_classes = false", contents)
       assert_match("config.action_view.cache_template_loading = true", contents)
     end
-    assert_file "config/boot.rb", %r{^\s*load .+/bin/spring"}
+    assert_file "config/boot.rb", %r{^\s*require .+/bin/spring"}
   end
 
   def test_bundler_binstub


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

when I use `rails s`, it raise an error:
```
You've tried to invoke Spring when it's already loaded (i.e. the Spring constant is defined).

This is probably because you generated binstubs with Spring 1.0, and you now have a Spring version > 1.0 on your system. To solve this, upgrade your bundle to the latest Spring version and then run `bundle exec spring binstub --all` to regenerate your binstubs. This is a one-time step necessary to upgrade from 1.0 to 1.1.

Here's the backtrace:

/usr/local/bundle/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `load'
/usr/local/bundle/gems/spring-2.1.0/lib/spring/binstub.rb:11:in `<top (required)>'
/usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/workspace/bin/spring:15:in `<top (required)>'
/workspace/config/boot.rb:2:in `load'
/workspace/config/boot.rb:2:in `<top (required)>'
./bin/rails:2:in `require_relative'
./bin/rails:2:in `<main>'
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
