### PR TITLE
Added documentation for _default option added to ActiveRecord::Enum [ci skip]

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -47,13 +47,14 @@ module ActiveRecord
   #     enum status: [ :active, :archived ], _scopes: false
   #   end
   #
-  # You can set the default value from the database declaration, like:
+  # You can set the default enum value by setting +:_default+, like:
   #
-  #   create_table :conversations do |t|
-  #     t.column :status, :integer, default: 0
+  #   class Conversation < ActiveRecord::Base
+  #     enum status: [ :active, :archived ], _default: "active"
   #   end
   #
-  # Good practice is to let the first declared status be the default.
+  #   conversation = Conversation.new
+  #   conversation.status # => "active"
   #
   # Finally, it's also possible to explicitly map the relation between attribute and
   # database integer with a hash:


### PR DESCRIPTION
The `_default` option was added in the PR: https://github.com/rails/rails/pull/39820 but the documentation weren't updated to mention the new change. This PR update the documentation to showcase the `_default` option addition instead of setting it on the default for enum on the database column.

**Question**
I am not sure if this is the right place to add the question but here it goes. Why do the options for enum start with an underscore? example: `_default`, `_suffix`, `_prefix`, '_scopes'. Just curious 😄 