### PR TITLE
Save allocations in build middleware

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -41,12 +41,9 @@ module ActionController
 
       def build_middleware(klass, args, block)
         options = args.extract_options!
-        only   = Array(options.delete(:only)).map(&:to_s)
-        except = Array(options.delete(:except)).map(&:to_s)
+        only   = Array(options.delete(:only)).map!(&:to_s)
+        except = Array(options.delete(:except)).map!(&:to_s)
         args << options unless options.empty?
-
-        strategy = NULL
-        list     = nil
 
         if only.any?
           strategy = INCLUDE
@@ -54,6 +51,9 @@ module ActionController
         elsif except.any?
           strategy = EXCLUDE
           list     = except
+        else
+          strategy = NULL
+          list     = nil
         end
 
         Middleware.new(klass, args, list, strategy, block)


### PR DESCRIPTION
### Summary

This PR just uses `map!` instead of `map` for building the `only` and `except` options of middlewares to save a few allocations. It is slightly faster, although the deviation is quite high for this benchmark.

Also moved defaults into an else branch of the conditionals.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActionController
  class MiddlewareStack < ActionDispatch::MiddlewareStack
    def fast_build_middleware(klass, args, block)
      options = args.extract_options!
      only   = Array(options.delete(:only)).map!(&:to_s)
      except = Array(options.delete(:except)).map!(&:to_s)
      args << options unless options.empty?

      if only.any?
        strategy = INCLUDE
        list     = only
      elsif except.any?
        strategy = EXCLUDE
        list     = except
      else
        strategy = NULL
        list     = nil
      end

      Middleware.new(klass, args, list, strategy, block)
    end
  end

  class Metal
    class << self
      def fast_use(*args, &block)
        middleware_stack.fast_use(*args, &block)
      end
    end
  end
end

module ActionDispatch
  class MiddlewareStack
    def fast_use(klass, *args, &block)
      middlewares.push(fast_build_middleware(klass, args, block))
    end
  end
end

class SomeMiddleware
  def initialize(app)
    @app = app
  end

  def call(env)
    @app.call(env)
  end
end

class PostsController < ActionController::Base; end

Benchmark.ips do |x|
  x.report("use")      { PostsController.use(SomeMiddleware, only: :index) }
  x.report("fast_use") { PostsController.fast_use(SomeMiddleware, only: :index) }
  x.compare!
end

Benchmark.memory do |x|
  x.report("use")      { PostsController.use(SomeMiddleware, only: :index) }
  x.report("fast_use") { PostsController.fast_use(SomeMiddleware, only: :index) }
  x.compare!
end
```

### Results
```
Warming up --------------------------------------
                 use    46.468k i/100ms
            fast_use    44.369k i/100ms
Calculating -------------------------------------
                 use    359.433k (±47.1%) i/s -      1.301M in   5.146410s
            fast_use    481.782k (±36.9%) i/s -      1.642M in   5.039612s

Comparison:
            fast_use:   481782.3 i/s
                 use:   359432.6 i/s - same-ish: difference falls within error

Calculating -------------------------------------
                 use   696.000  memsize (   200.000  retained)
                        10.000  objects (     4.000  retained)
                         1.000  strings (     1.000  retained)
            fast_use   448.000  memsize (   200.000  retained)
                         7.000  objects (     4.000  retained)
                         1.000  strings (     1.000  retained)

Comparison:
            fast_use:        448 allocated
                 use:        696 allocated - 1.55x more
```