### PR TITLE
Add back support for other syntax highlighting [skip-ci]

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -68,14 +68,14 @@ module RailsGuides
 
         def lexer_language(code_type)
           case code_type
-          when "css", "js", "html", "ruby", "sql", "yaml"
-            code_type
-          when "erb", "html+erb"
+          when "html+erb"
             "erb"
           when "bash"
             "console"
-          else
+          when nil
             "plaintext"
+          else
+            ::Rouge::Lexer.find(language) ? code_type : "plaintext"
           end
         end
 

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -156,7 +156,7 @@ required for running Active Record tests.
 
 In order to be able to run the test suite against MySQL you need to create a user named `rails` with privileges on the test databases:
 
-```bash
+```sql
 $ mysql -uroot -p
 
 mysql> CREATE USER 'rails'@'localhost';


### PR DESCRIPTION
### Summary
We recently switched to use Rouge for syntax highlighting in the guides,
but in doing so we dropped support for highlighting the following
syntaxes, which are used in the guides:

apache
diff
json
markdown
nginx
scss
xml

There was also css and the "javascript" alias, but @eugeneius already
addressed these two.

These syntaxes were all being converted to "plaintext". This change allows
all the lexers mentioned above as well as any other lexers available
through Rouge. This makes it easier for anybody needing to include a
syntax we didn't think of and allows for more custom lexer options when
necessary.

Cheers :)