### PR TITLE
Fix minor typos in i18n docs [ci-skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -261,7 +261,7 @@ end
 
 With this approach you will not get a `Routing Error` when accessing your resources such as `http://localhost:3001/books` without a locale. This is useful for when you want to use the default locale when one is not specified.
 
-Of course, you need to take special care of the root URL (usually "homepage" or "dashboard") of your application. A URL like `http://localhost:3001/nl` will not work automatically, because the `root to: "books#index"` declaration in your `routes.rb` doesn't take locale into account. (And rightly so: there's only one "root" URL.)
+Of course, you need to take special care of the root URL (usually "homepage" or "dashboard") of your application. A URL like `http://localhost:3001/nl` will not work automatically, because the `root to: "dashboard#index"` declaration in your `routes.rb` doesn't take locale into account. (And rightly so: there's only one "root" URL.)
 
 You would probably need to map URLs like these:
 
@@ -954,7 +954,7 @@ errors.attributes.name.blank
 errors.messages.blank
 ```
 
-This way you can provide special translations for various error messages at different points in your models inheritance chain and in the attributes, models, or default scopes.
+This way you can provide special translations for various error messages at different points in your model's inheritance chain and in the attributes, models, or default scopes.
 
 #### Error Message Interpolation
 
@@ -1159,7 +1159,7 @@ I18n.exception_handler = I18n::JustRaiseExceptionHandler.new
 
 This would re-raise only the `MissingTranslationData` exception, passing all other input to the default exception handler.
 
-However, if you are using `I18n::Backend::Pluralization` this handler will also raise `I18n::MissingTranslationData: translation missing: en.i18n.plural.rule` exception that should normally be ignored to fall back to the default pluralization rule for English locale. To avoid this you may use additional check for translation key:
+However, if you are using `I18n::Backend::Pluralization` this handler will also raise `I18n::MissingTranslationData: translation missing: en.i18n.plural.rule` exception that should normally be ignored to fall back to the default pluralization rule for English locale. To avoid this you may use an additional check for the translation key:
 
 ```ruby
 if exception.is_a?(MissingTranslation) && key.to_s != 'i18n.plural.rule'


### PR DESCRIPTION
### Summary

The surrounding examples after line 274 refer to `dashboard#index`, not `books#index` (which was used as the `resources` route before this line).

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
