### PR TITLE
Ensures Calculate methods work with order and limit.

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -294,7 +294,12 @@ module ActiveRecord
           query_builder = build_count_subquery(spawn, column_name, distinct)
         else
           # PostgreSQL doesn't like ORDER BY when there are no GROUP BY
-          relation = unscope(:order).distinct!(false)
+          if has_limit_or_offset? && order_values.any?
+            limited_ids = limited_ids_for(self)
+            relation = limited_ids.empty? ? none : where(primary_key => limited_ids).unscope(:order).distinct!(false)
+          else
+            relation = unscope(:order).distinct!(false)
+          end
 
           column = aggregate_column(column_name)
           select_value = operation_over_aggregate_column(column, operation, distinct)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1359,4 +1359,15 @@ class CalculationsTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test "calculate works with order and limit" do
+    conn = ActiveRecord::Base.connection
+    quoted_posts_table = conn.quote_table_name(Post.table_name)
+    quoted_post_id = "#{quoted_posts_table}.#{conn.quote_column_name('id')}"
+
+    assert_sql(
+      /SELECT DISTINCT.* #{quoted_post_id} FROM #{quoted_posts_table} ORDER BY #{quoted_post_id} DESC LIMIT/,
+      /SELECT.*FROM #{quoted_posts_table} WHERE #{quoted_post_id} IN \(.*\) LIMIT/
+    ) { Post.order(id: :desc).limit(5).average(:comments_count) }
+  end
 end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
* Use two queries to obtain actual calculation aggregates. First query
fetches the IDs of the actual order / limit query, the second query
ignores the order clause and uses a where query to filter results
correctly.

* This is similar to the behavior used when the Relation contains eager
loaded values.

Fixes https://github.com/rails/rails/issues/39900
### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

I am unsure what the upstream implications to this change could be, so please review carefully.

The logic used here is nearly identical to the logic used when a Calculate method is issued against a relation containing eager loading values:
```ruby
# Incorrect SQL, it drops the order clause, which will return an indeterminate result set:
irb(main):002:0> Post.order(id: :desc).limit(5).average(:comments_count)
   (0.3ms)  SELECT AVG("posts"."comments_count") FROM "posts" LIMIT ?  [["LIMIT", 5]]

# Correct SQL, uses two queries to perform the aggregation on the correct records:
irb(main):003:0> Post.includes(:comments).order(id: :desc).limit(5).average(:comments_count)
  SQL (0.2ms)  SELECT DISTINCT "posts"."id" FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" ORDER BY "posts"."id" DESC LIMIT ?  [["LIMIT", 5]]
   (0.7ms)  SELECT AVG("posts"."comments_count") FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" WHERE "posts"."id" IN (?, ?, ?, ?, ?)  [["id", 101], ["id", 100], ["id", 99], ["id", 98], ["id", 97]]
```