### PR TITLE
Fix ArgumentError (or TypeError) when ActiveStorage::Blob initialized through nested attributes

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -65,7 +65,7 @@ module ActiveStorage
             **attachable.reverse_merge(
               record: record,
               service_name: attachment_service_name
-            )
+            ).symbolize_keys
           )
         when String
           ActiveStorage::Blob.find_signed!(attachable, record: record)

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -319,6 +319,13 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_equal 2736, @user.avatar.metadata[:height]
   end
 
+  test "creating an attachment as part of an autosave association through nested attributes" do
+    group = Group.create!(users_attributes: [{ name: "John", avatar: { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" } }])
+    group.save!
+    new_user = User.find_by(name: "John")
+    assert new_user.avatar.attached?
+  end
+
   test "updating an attachment as part of an autosave association" do
     group = Group.create!(users: [@user])
     @user.avatar = fixture_file_upload("racecar.jpg")

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -127,6 +127,8 @@ end
 class Group < ActiveRecord::Base
   has_one_attached :avatar
   has_many :users, autosave: true
+
+  accepts_nested_attributes_for :users
 end
 
 require_relative "../../tools/test_common"


### PR DESCRIPTION
### Summary

Fix #37411

@metheglin described the scenario in detail in #37411 and pointed out the root cause.

In short, `attachable` could be an `ActiveSupport::HashWithIndifferentAccess` instead of a simple `Hash` when using with nested attributes.  Because `ActiveSupport::HashWithIndifferentAccess` store its key as `String` (instead of Symbol) so it won't map to `build_after_unfurling`'s kwargs.

Before https://github.com/rails/rails/commit/dea19d4ead79fe0d7a1c81eb0be1c8958c80659e , the error will be:
```
ArgumentError (wrong number of arguments (given 1, expected 0; required keywords: io, filename))
```

After https://github.com/rails/rails/commit/dea19d4ead79fe0d7a1c81eb0be1c8958c80659e , the error will be something like: 
```
TypeError: hash key "record" is not a Symbol
```

### Other Information

The [added test](https://github.com/rails/rails/pull/39908/files#diff-164f255eaa0009a51c647e92ab27f916R322) case will fail this way without [the fix](https://github.com/rails/rails/pull/39908/files#diff-4812e33629a9ccb43c37f3430085dc34R68):
<img width="1333" alt="Screen Shot 2020-07-23 at 12 46 52 AM" src="https://user-images.githubusercontent.com/12410942/88205127-e5b4d300-cc7e-11ea-847a-053f5fc798d5.png">
