### PR TITLE
Refactor `process` method

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -499,58 +499,10 @@ module ActionController
           parameters[:format] = format
         end
 
-        generated_extras = @routes.generate_extras(parameters.merge(controller: controller_class_name, action: action))
-        generated_path = generated_path(generated_extras)
-        query_string_keys = query_parameter_names(generated_extras)
-
-        @request.assign_parameters(@routes, controller_class_name, action, parameters, generated_path, query_string_keys)
-
-        @request.session.update(session) if session
-        @request.flash.update(flash || {})
-
-        if xhr
-          @request.set_header "HTTP_X_REQUESTED_WITH", "XMLHttpRequest"
-          @request.fetch_header("HTTP_ACCEPT") do |k|
-            @request.set_header k, [Mime[:js], Mime[:html], Mime[:xml], "text/xml", "*/*"].join(", ")
-          end
-        end
-
-        @request.fetch_header("SCRIPT_NAME") do |k|
-          @request.set_header k, @controller.config.relative_url_root
-        end
-
-        begin
-          @controller.recycle!
-          @controller.dispatch(action, @request, @response)
-        ensure
-          @request = @controller.request
-          @response = @controller.response
-
-          if @request.have_cookie_jar?
-            unless @request.cookie_jar.committed?
-              @request.cookie_jar.write(@response)
-              cookies.update(@request.cookie_jar.instance_variable_get(:@cookies))
-            end
-          end
-          @response.prepare!
-
-          if flash_value = @request.flash.to_session_value
-            @request.session["flash"] = flash_value
-          else
-            @request.session.delete("flash")
-          end
-
-          if xhr
-            @request.delete_header "HTTP_X_REQUESTED_WITH"
-            @request.delete_header "HTTP_ACCEPT"
-          end
-          @request.query_string = ""
-
-          @response.sent!
-        end
-
-        @response
+        setup_request(controller_class_name, action, parameters, session, flash, xhr)
+        process_controller_response(action, cookies, xhr)
       end
+
 
       def controller_class_name
         @controller.class.anonymous? ? "anonymous" : @controller.class.controller_path
@@ -605,6 +557,62 @@ module ActionController
       end
 
       private
+        def setup_request(controller_class_name, action, parameters, session, flash, xhr)
+          generated_extras = @routes.generate_extras(parameters.merge(controller: controller_class_name, action: action))
+          generated_path = generated_path(generated_extras)
+          query_string_keys = query_parameter_names(generated_extras)
+
+          @request.assign_parameters(@routes, controller_class_name, action, parameters, generated_path, query_string_keys)
+
+          @request.session.update(session) if session
+          @request.flash.update(flash || {})
+
+          if xhr
+            @request.set_header "HTTP_X_REQUESTED_WITH", "XMLHttpRequest"
+            @request.fetch_header("HTTP_ACCEPT") do |k|
+              @request.set_header k, [Mime[:js], Mime[:html], Mime[:xml], "text/xml", "*/*"].join(", ")
+            end
+          end
+
+          @request.fetch_header("SCRIPT_NAME") do |k|
+            @request.set_header k, @controller.config.relative_url_root
+          end
+        end
+
+        def process_controller_response(action, cookies, xhr)
+          begin
+            @controller.recycle!
+            @controller.dispatch(action, @request, @response)
+          ensure
+            @request = @controller.request
+            @response = @controller.response
+
+            if @request.have_cookie_jar?
+              unless @request.cookie_jar.committed?
+                @request.cookie_jar.write(@response)
+                cookies.update(@request.cookie_jar.instance_variable_get(:@cookies))
+              end
+            end
+            @response.prepare!
+
+            if flash_value = @request.flash.to_session_value
+              @request.session["flash"] = flash_value
+            else
+              @request.session.delete("flash")
+            end
+
+            if xhr
+              @request.delete_header "HTTP_X_REQUESTED_WITH"
+              @request.delete_header "HTTP_ACCEPT"
+            end
+            @request.query_string = ""
+
+            @response.sent!
+          end
+
+          @response
+        end
+
         def scrub_env!(env)
           env.delete_if do |k, _|
             k.start_with?("rack.request", "action_dispatch.request", "action_dispatch.rescue")


### PR DESCRIPTION
Awhile back tenderlove and I worked to improve performance of
integration tests and remove controller tests. The second never
happened, we ended up soft deprecating them but never did that
completely.

Now that we're revisting that work we need a way to override these two
methods in tests so that we can convert tests in Rails to be integration
tests instead of controller tests. Splitting these two concerns into two
methods allows us to overwrite them to work for our needs while
refactoring the test harness code.

These methods are private because they should not be used by an
application or gems, they will be removed when the refactoring has been
completed.

Co-authored-by: Aaron Patterson <tenderlove@ruby-lang.org>