### PR TITLE
Fix argument naming in `AbstractStore#set_cookie`

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -82,7 +82,7 @@ module ActionDispatch
       include SessionObject
 
       private
-        def set_cookie(request, session_id, cookie)
+        def set_cookie(request, response, cookie)
           request.cookie_jar[key] = cookie
         end
     end
@@ -97,7 +97,7 @@ module ActionDispatch
       end
 
       private
-        def set_cookie(request, session_id, cookie)
+        def set_cookie(request, response, cookie)
           request.cookie_jar[key] = cookie
         end
     end


### PR DESCRIPTION

### Summary

The signature in Rack https://github.com/rack/rack/blob/master/lib/rack/session/abstract/id.rb#L415 expects a response as the second argument

This PR changes the argument namesin `AbstractStore#set_cookie` to match. (They are unused currently)
