### PR TITLE
Backport #37850 to 6-0-stable

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2055,6 +2055,22 @@ module ApplicationTests
       end
     end
 
+    test "config_for does not assume config is a hash" do
+      app_file "config/custom.yml", <<~RUBY
+        development:
+          - foo
+          - bar
+      RUBY
+
+      add_to_config <<~RUBY
+        config.my_custom_config = config_for('custom')
+      RUBY
+
+      app "development"
+
+      assert_equal %w( foo bar ), Rails.application.config.my_custom_config
+    end
+
     test "config_for uses the Pathname object if it is provided" do
       app_file "config/custom.yml", <<-RUBY
       development:


### PR DESCRIPTION
This backports 21c7199c0f0a0187298621631fbc3864c93ec8b9 of #37850 to `6-0-stable`, since #37800 was technically a regression.

I did my best to preserve the style of 21c7199c0f0a0187298621631fbc3864c93ec8b9 while adhering to 6.0 expected behavior.

