### PR TITLE
Move Path::Pattern factories into test helper

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -6,16 +6,6 @@ module ActionDispatch
       class Pattern # :nodoc:
         attr_reader :spec, :requirements, :anchored
 
-        def self.from_string(string)
-          build(string, {}, "/.?", true)
-        end
-
-        def self.build(path, requirements, separators, anchored)
-          parser = Journey::Parser.new
-          ast = parser.parse path
-          new ast, requirements, separators, anchored
-        end
-
         def initialize(ast, requirements, separators, anchored)
           @spec         = ast
           @requirements = requirements

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
+require "support/path_helper"
 
 module ActionDispatch
   module Journey
     class TestRoute < ActiveSupport::TestCase
+      include PathHelper
+
       def test_initialize
         app      = Object.new
-        path     = Path::Pattern.from_string "/:controller(/:action(/:id(.:format)))"
+        path     = path_from_string "/:controller(/:action(/:id(.:format)))"
         defaults = {}
         route    = Route.new(name: "name", app: app, path: path, defaults: defaults)
 
@@ -18,7 +21,7 @@ module ActionDispatch
 
       def test_route_adds_itself_as_memo
         app   = Object.new
-        path  = Path::Pattern.from_string "/:controller(/:action(/:id(.:format)))"
+        path  = path_from_string "/:controller(/:action(/:id(.:format)))"
         route = Route.new(name: "name", app: app, path: path)
 
         route.ast.grep(Nodes::Terminal).each do |node|
@@ -27,28 +30,28 @@ module ActionDispatch
       end
 
       def test_path_requirements_override_defaults
-        path     = Path::Pattern.build(":name", { name: /love/ }, "/", true)
+        path     = build_path(":name", { name: /love/ }, "/", true)
         defaults = { name: "tender" }
         route    = Route.new(name: "name", path: path, defaults: defaults)
         assert_equal(/love/, route.requirements[:name])
       end
 
       def test_ip_address
-        path  = Path::Pattern.from_string "/messages/:id(.:format)"
+        path  = path_from_string "/messages/:id(.:format)"
         route = Route.new(name: "name", path: path, constraints: { ip: "192.168.1.1" },
                           defaults: { controller: "foo", action: "bar" })
         assert_equal "192.168.1.1", route.ip
       end
 
       def test_default_ip
-        path  = Path::Pattern.from_string "/messages/:id(.:format)"
+        path  = path_from_string "/messages/:id(.:format)"
         route = Route.new(name: "name", path: path,
                           defaults: { controller: "foo", action: "bar" })
         assert_equal(//, route.ip)
       end
 
       def test_format_with_star
-        path  = Path::Pattern.from_string "/:controller/*extra"
+        path  = path_from_string "/:controller/*extra"
         route = Route.new(name: "name", path: path,
                           defaults: { controller: "foo", action: "bar" })
         assert_equal "/foo/himom", route.format(
@@ -57,7 +60,7 @@ module ActionDispatch
       end
 
       def test_connects_all_match
-        path  = Path::Pattern.from_string "/:controller(/:action(/:id(.:format)))"
+        path  = path_from_string "/:controller(/:action(/:id(.:format)))"
         route = Route.new(name: "name", path: path, constraints: { action: "bar" },
                           defaults: { controller: "foo" })
 
@@ -68,21 +71,21 @@ module ActionDispatch
       end
 
       def test_extras_are_not_included_if_optional
-        path  = Path::Pattern.from_string "/page/:id(/:action)"
+        path  = path_from_string "/page/:id(/:action)"
         route = Route.new(name: "name", path: path, defaults: { action: "show" })
 
         assert_equal "/page/10", route.format(id: 10)
       end
 
       def test_extras_are_not_included_if_optional_with_parameter
-        path  = Path::Pattern.from_string "(/sections/:section)/pages/:id"
+        path  = path_from_string "(/sections/:section)/pages/:id"
         route = Route.new(name: "name", path: path, defaults: { action: "show" })
 
         assert_equal "/pages/10", route.format(id: 10)
       end
 
       def test_extras_are_not_included_if_optional_parameter_is_nil
-        path  = Path::Pattern.from_string "(/sections/:section)/pages/:id"
+        path  = path_from_string "(/sections/:section)/pages/:id"
         route = Route.new(name: "name", path: path, defaults: { action: "show" })
 
         assert_equal "/pages/10", route.format(id: 10, section: nil)
@@ -91,10 +94,10 @@ module ActionDispatch
       def test_score
         defaults = { controller: "pages", action: "show" }
 
-        path = Path::Pattern.from_string "/page/:id(/:action)(.:format)"
+        path = path_from_string "/page/:id(/:action)(.:format)"
         specific = Route.new name: "name", path: path, required_defaults: [:controller, :action], defaults: defaults
 
-        path = Path::Pattern.from_string "/:controller(/:action(/:id))(.:format)"
+        path = path_from_string "/:controller(/:action(/:id))(.:format)"
         generic = Route.new name: "name", path: path
 
         knowledge = { "id" => true, "controller" => true, "action" => true }

--- a/actionpack/test/support/path_helper.rb
+++ b/actionpack/test/support/path_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  module Journey
+    module PathHelper
+      def path_from_string(string)
+        build_path(string, {}, "/.?", true)
+      end
+
+      def build_path(path, requirements, separators, anchored)
+        parser = ActionDispatch::Journey::Parser.new
+        ast = parser.parse path
+        ActionDispatch::Journey::Path::Pattern.new(
+          ast,
+          requirements,
+          separators,
+          anchored
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
`Pattern#from_string` was introduced in bb207ea7 to support creating
patterns from strings in tests (removing a conditional in the initialize
method that had been there only for the sake of those tests).

`Pattern#build` was introduced in 947ebe9a, and was similarly used only
in tests.

My understanding is that [`Mapping#path`][path] is the only place where
we initialize a `Path::Pattern` in library code.

Since these two methods appear to be used only in tests, this
commit moves them out of the class and into a test helper.

My reasoning for doing this is that I am doing some performance work
that may involve a modification to how `Path::Pattern`s get initialized,
and I will have more confidence in that work if I know for sure that
these methods are test helpers that can be modified freely.

[path]: https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/mapper.rb#L192-L194

cc @eugeneius (I am tagging you because you seem interested in these Journey PRs, but can stop doing that if you are getting too many notifications)
