### PR TITLE
Unify `decorate_attribute_type` and `attribute`

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -129,7 +129,7 @@ module ActiveRecord
             Coders::YAMLColumn.new(attr_name, class_name_or_coder)
           end
 
-          decorate_attribute_type(attr_name.to_s, **options) do |cast_type|
+          attribute(attr_name, **options) do |cast_type|
             if type_incompatible_with_serialize?(cast_type, class_name_or_coder)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -183,7 +183,7 @@ module ActiveRecord
 
         attr = attribute_alias?(name) ? attribute_alias(name) : name
 
-        decorate_attribute_type(attr, **default) do |subtype|
+        attribute(attr, **default) do |subtype|
           EnumType.new(attr, enum_values, subtype)
         end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -68,6 +68,15 @@ module ActiveRecord
       assert_equal "the overloaded default", klass.new.overloaded_string_with_limit
     end
 
+    test "attributes with overridden types keep their type when a default value is configured separately" do
+      child = Class.new(OverloadedType) do
+        attribute :overloaded_float, default: "123"
+      end
+
+      assert_equal OverloadedType.type_for_attribute("overloaded_float"), child.type_for_attribute("overloaded_float")
+      assert_equal 123, child.new.overloaded_float
+    end
+
     test "extra options are forwarded to the type caster constructor" do
       klass = Class.new(OverloadedType) do
         attribute :starts_at, :datetime, precision: 3, limit: 2, scale: 1, default: -> { Time.now.utc }
@@ -293,6 +302,15 @@ module ActiveRecord
       model = child.last
 
       assert_equal 123, model.non_existent_decimal
+    end
+
+    test "attributes not backed by database columns keep their type when a default value is configured separately" do
+      child = Class.new(OverloadedType) do
+        attribute :non_existent_decimal, default: "123"
+      end
+
+      assert_equal OverloadedType.type_for_attribute("non_existent_decimal"), child.type_for_attribute("non_existent_decimal")
+      assert_equal 123, child.new.non_existent_decimal
     end
 
     test "attributes not backed by database columns properly interact with mutation and dirty" do


### PR DESCRIPTION
Follow-up to 75c309c7ad6517a7fad482f1efd50baadf4bdf45.

As a result of these changes, attributes can have their type and default value configured separately.  Similar behavior was implemented in #39830, but only for attributes that derive (and do not override) their type from the database.
