### PR TITLE
disable compression for MemoryStore's by default

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Ensure `MemoryStore` disables compression by default. Reverts behavior of
+    `MemoryStore` to its prior rails `5.1` behavior.
+
+    *Max Gurewitz*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Calling `iso8601` on negative durations retains the negative sign on individual

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -16,6 +16,12 @@ module ActiveSupport
     # a cleanup will occur which tries to prune the cache down to three quarters
     # of the maximum size by removing the least recently used entries.
     #
+    # Unlike other Cache store implementations, MemoryStore does not compress
+    # values by default. MemoryStore does not benefit from compression as much
+    # as other Store implementations, as it does not send data over a network.
+    # However, when compression is enabled, it still pays the full cost of
+    # compression in terms of cpu use.
+    #
     # MemoryStore is thread-safe.
     class MemoryStore < Store
       module DupCoder # :nodoc:
@@ -37,6 +43,8 @@ module ActiveSupport
 
       def initialize(options = nil)
         options ||= {}
+        # Disable compression by default.
+        options[:compress] ||= false
         super(options)
         @data = {}
         @max_size = options[:size] || 32.megabytes

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -218,10 +218,6 @@ module CacheStoreBehavior
     assert_compressed(SMALL_OBJECT, compress: true, compress_threshold: 1)
   end
 
-  def test_large_string_with_default_compression_settings
-    assert_compressed(LARGE_STRING)
-  end
-
   def test_large_string_with_compress_true
     assert_compressed(LARGE_STRING, compress: true)
   end
@@ -232,10 +228,6 @@ module CacheStoreBehavior
 
   def test_large_string_with_high_compress_threshold
     assert_uncompressed(LARGE_STRING, compress: true, compress_threshold: 1.megabyte)
-  end
-
-  def test_large_object_with_default_compression_settings
-    assert_compressed(LARGE_OBJECT)
   end
 
   def test_large_object_with_compress_true

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -196,6 +196,14 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_large_string_with_default_compression_settings
+    assert_compressed(LARGE_STRING)
+  end
+
+  def test_large_object_with_default_compression_settings
+    assert_compressed(LARGE_OBJECT)
+  end
+
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -19,6 +19,14 @@ class MemoryStoreTest < ActiveSupport::TestCase
   include CacheDeleteMatchedBehavior
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior
+
+  def test_large_string_with_default_compression_settings
+    assert_uncompressed(LARGE_STRING)
+  end
+
+  def test_large_object_with_default_compression_settings
+    assert_uncompressed(LARGE_OBJECT)
+  end
 end
 
 class MemoryStorePruningTest < ActiveSupport::TestCase

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -200,6 +200,14 @@ module ActiveSupport::Cache::RedisCacheStoreTests
         @cache.decrement "dar", 1, expires_in: 60
       end
     end
+
+    def test_large_string_with_default_compression_settings
+      assert_compressed(LARGE_STRING)
+    end
+
+    def test_large_object_with_default_compression_settings
+      assert_compressed(LARGE_OBJECT)
+    end
   end
 
   class ConnectionPoolBehaviourTest < StoreTest


### PR DESCRIPTION
- Compression has reduced effectiveness for MemoryStore, which does not
send data over a network.