### PR TITLE
Correct engine generator docs

### DIFF
--- a/railties/lib/rails/generators/base.rb
+++ b/railties/lib/rails/generators/base.rb
@@ -19,7 +19,7 @@ module Rails
       include Rails::Generators::Actions
 
       class_option :skip_namespace, type: :boolean, default: false,
-                                    desc: "Skip namespace (affects only isolated applications)"
+                                    desc: "Skip namespace (affects only isolated engines)"
       class_option :skip_collision_check, type: :boolean, default: false,
                                           desc: "Skip collision check"
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -183,7 +183,7 @@ task default: :test
                                   desc: "Generate a rails engine with bundled Rails application for testing"
 
       class_option :mountable,    type: :boolean, default: false,
-                                  desc: "Generate mountable isolated application"
+                                  desc: "Generate mountable isolated engine"
 
       class_option :skip_gemspec, type: :boolean, default: false,
                                   desc: "Skip gemspec file"


### PR DESCRIPTION


### Summary

Engines are not applications, indeed 'Application < Engine', so it's the other way round - applications are engines.

The difference can be confusing anyway, so we should make sure the documentation is clear.
