### PR TITLE
Fix flakey test due to non-deterministic order

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -587,7 +587,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_preloading_has_many_through_with_implicit_source
-    authors = Author.includes(:very_special_comments).to_a
+    authors = Author.includes(:very_special_comments).to_a.sort_by(&:id)
     assert_no_queries do
       special_comment_authors = authors.map { |author| [author.name, author.very_special_comments.size] }
       assert_equal [["David", 1], ["Mary", 0], ["Bob", 0]], special_comment_authors


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/70840#d213df74-a2e6-45e5-8302-d75a6c31f700/1021-1033

The test's assertion expects the authors to be ordered by ID, but that order is not guaranteed without an explicit sort.
