### PR TITLE
Introduce Journey::Ast to avoid extra ast walks

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -77,7 +77,7 @@ module ActionDispatch
 
       def visualizer
         tt     = GTG::Builder.new(ast).transition_table
-        groups = partitioned_routes.first.map(&:ast).group_by(&:to_s)
+        groups = partitioned_routes.first.map(&:ast_root).group_by(&:to_s)
         asts   = groups.values.map(&:first)
         tt.visualizer(asts)
       end

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -50,8 +50,8 @@ module ActionDispatch
 
       def ast
         @ast ||= begin
-          asts = anchored_routes.map(&:ast)
-          Nodes::Or.new(asts)
+          nodes = anchored_routes.map(&:ast_root)
+          Nodes::Or.new(nodes)
         end
       end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -923,6 +923,39 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
     assert_not_nil hash
     assert_equal %w(cc ac), [hash[:controller], hash[:action]]
   end
+
+  def test_drawing_more_routes_after_eager_loading
+    rs = ::ActionDispatch::Routing::RouteSet.new
+    rs.disable_clear_and_finalize = true
+
+    rs.draw do
+      get "/plain" => "c#plain"
+      get "/:symbol" => "c#symbol"
+      get "/glob/*" => "c#glob"
+      get "/with#anchor" => "c#with_anchor"
+    end
+
+    hash = rs.recognize_path "/symbol"
+    assert_not_nil hash
+    assert_equal %w(c symbol), [hash[:controller], hash[:action]]
+
+    rs.eager_load!
+
+    rs.draw do
+      get "/more/plain" => "c#plain"
+      get "/more/:symbol" => "c#symbol"
+      get "/more/glob/*" => "c#glob"
+      get "/more/with#anchor" => "c#with_anchor"
+    end
+
+    hash = rs.recognize_path "/symbol"
+    assert_not_nil hash
+    assert_equal %w(c symbol), [hash[:controller], hash[:action]]
+
+    hash = rs.recognize_path "/more/symbol"
+    assert_not_nil hash
+    assert_equal %w(c symbol), [hash[:controller], hash[:action]]
+  end
 end
 
 class RouteSetTest < ActiveSupport::TestCase

--- a/actionpack/test/journey/nodes/ast_test.rb
+++ b/actionpack/test/journey/nodes/ast_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+module ActionDispatch
+  module Journey
+    module Nodes
+      class TestAst < ActiveSupport::TestCase
+        def test_ast_sets_regular_expressions
+          requirements = { name: /(tender|love)/, value: /./ }
+          path = "/page/:name/:value"
+          tree = Journey::Parser.new.parse(path)
+
+          ast = Ast.new(tree, true)
+          ast.requirements = requirements
+
+          nodes = ast.root.grep(Nodes::Symbol)
+          assert_equal 2, nodes.length
+          nodes.each do |node|
+            assert_equal requirements[node.to_sym], node.regexp
+          end
+        end
+
+        def test_sets_memo_for_terminal_nodes
+          route = Object.new
+          tree = Journey::Parser.new.parse("/path")
+
+          ast = Ast.new(tree, true)
+          ast.route = route
+
+          nodes = ast.root.grep(Nodes::Terminal)
+          nodes.each do |node|
+            assert_equal route, node.memo
+          end
+        end
+
+        def test_contains_glob
+          tree = Journey::Parser.new.parse("/*glob")
+          ast = Ast.new(tree, true)
+
+          assert_predicate ast, :glob?
+        end
+
+        def test_does_not_contain_glob
+          tree = Journey::Parser.new.parse("/")
+          ast = Ast.new(tree, true)
+
+          assert_not_predicate ast, :glob?
+        end
+
+        def test_names
+          tree = Journey::Parser.new.parse("/:path/:symbol")
+          ast = Ast.new(tree, true)
+
+          assert_equal ["path", "symbol"], ast.names
+        end
+
+        def test_path_params
+          tree = Journey::Parser.new.parse("/:path/:symbol")
+          ast = Ast.new(tree, true)
+
+          assert_equal [:path, :symbol], ast.path_params
+        end
+
+        def test_wildcard_options_when_formatted
+          tree = Journey::Parser.new.parse("/*glob")
+          ast = Ast.new(tree, true)
+
+          wildcard_options = ast.wildcard_options
+          assert_equal %r{.+?}, wildcard_options[:glob]
+        end
+
+        def test_wildcard_options_when_false
+          tree = Journey::Parser.new.parse("/*glob")
+          ast = Ast.new(tree, false)
+
+          wildcard_options = ast.wildcard_options
+          assert_nil wildcard_options[:glob]
+        end
+
+        def test_wildcard_options_when_nil
+          tree = Journey::Parser.new.parse("/*glob")
+          ast = Ast.new(tree, nil)
+
+          wildcard_options = ast.wildcard_options
+          assert_equal %r{.+?}, wildcard_options[:glob]
+        end
+      end
+    end
+  end
+end

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -133,22 +133,6 @@ module ActionDispatch
           assert_no_match(path, "/page/loving")
         end
 
-        def test_ast_sets_regular_expressions
-          requirements = { name: /(tender|love)/, value: /./ }
-          path = build_path(
-            "/page/:name/:value",
-            requirements,
-            SEPARATORS,
-            true
-          )
-
-          nodes = path.ast.grep(Nodes::Symbol)
-          assert_equal 2, nodes.length
-          nodes.each do |node|
-            assert_equal requirements[node.to_sym], node.regexp
-          end
-        end
-
         def test_match_data_with_group
           path = build_path(
             "/page/:name",

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -24,7 +24,7 @@ module ActionDispatch
         path  = path_from_string "/:controller(/:action(/:id(.:format)))"
         route = Route.new(name: "name", app: app, path: path)
 
-        route.ast.grep(Nodes::Terminal).each do |node|
+        route.ast.root.grep(Nodes::Terminal).each do |node|
           assert_equal route, node.memo
         end
       end

--- a/actionpack/test/support/path_helper.rb
+++ b/actionpack/test/support/path_helper.rb
@@ -7,9 +7,10 @@ module ActionDispatch
         build_path(string, {}, "/.?", true)
       end
 
-      def build_path(path, requirements, separators, anchored)
+      def build_path(path, requirements, separators, anchored, formatted = true)
         parser = ActionDispatch::Journey::Parser.new
         ast = parser.parse path
+        ast = Journey::Ast.new(ast, formatted)
         ActionDispatch::Journey::Path::Pattern.new(
           ast,
           requirements,


### PR DESCRIPTION
This commit introduces a new `Journey::Ast` class that wraps the root
node of an ast. The purpose of this class is to reduce the number of
walks through the ast by consolidating necessary processing of nodes in
a single pass and holding onto values that can be used later.

Benefits
---

* Performance improvements (see benchmarks below)
* Keeps various ast manipulations together in a single class, rather
  than scattered throughout
* Adding some names to things will hopefully make this code a little
  easier to follow for future readers

Benchmarks
---

We benchmarked loading a real routes file with > 3500 routes.
master was at a9336a67b0 when we ran these. Note that these benchmarks
also include a few small changes that we didn't include in this commit,
but that we will follow up with after this gets merged - these
additional changes do not change the benchmarks significantly.

Time:

```
master      - 0.798 ± 0.024 (500 runs)
this branch - 0.695 ± 0.029 (500 runs)
```

Allocations:

```
master      - 980149 total allocated objects
this branch - 931357 total allocated objects
```

Stackprof:

Seeing `ActionDispatch::Journey::Visitors::Each#visit` more frequently
on the stack is what led us down this path in the first place. These
changes seem to have done the trick.

```
master:
  TOTAL    (pct)     SAMPLES    (pct)     FRAME
    52   (0.5%)          52   (0.5%)     ActionDispatch::Journey::Nodes::Node#symbol?
    58   (0.5%)          45   (0.4%)     ActionDispatch::Journey::Scanner#scan
    45   (0.4%)          45   (0.4%)     ActionDispatch::Journey::Nodes::Cat#type
    43   (0.4%)          43   (0.4%)     ActionDispatch::Journey::Visitors::FunctionalVisitor#terminal
    303  (2.7%)          43   (0.4%)     ActionDispatch::Journey::Visitors::Each#visit
    69   (0.6%)          40   (0.4%)     ActionDispatch::Routing::Mapper::Scope#each

this commit:
  TOTAL    (pct)     SAMPLES    (pct)     FRAME
    82   (0.6%)          42   (0.3%)     ActionDispatch::Journey::Scanner#next_token
    31   (0.2%)          31   (0.2%)     ActionDispatch::Journey::Nodes::Node#symbol?
    30   (0.2%)          30   (0.2%)     ActionDispatch::Journey::Nodes::Node#initialize
```

Co-authored-by: Eric Milford <ericmilford@gmail.com>

@eugeneius this could use an initial review, if you are interested