### PR TITLE
Reduce allocations in transition_table

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/builder.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/builder.rb
@@ -141,7 +141,7 @@ module ActionDispatch
           end
 
           def symbol(edge)
-            edge.is_a?(Journey::Nodes::Symbol) ? edge.regexp : edge.left
+            edge.symbol? ? edge.regexp : edge.left
           end
       end
     end

--- a/actionpack/lib/action_dispatch/journey/gtg/builder.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/builder.rb
@@ -13,45 +13,44 @@ module ActionDispatch
         def initialize(root)
           @root      = root
           @ast       = Nodes::Cat.new root, DUMMY
-          @followpos = nil
+          @followpos = build_followpos
         end
 
         def transition_table
           dtrans   = TransitionTable.new
           marked   = {}
           state_id = Hash.new { |h, k| h[k] = h.length }
+          dstates  = [firstpos(root)]
 
-          start   = firstpos(root)
-          dstates = [start]
           until dstates.empty?
             s = dstates.shift
             next if marked[s]
             marked[s] = true # mark s
 
             s.group_by { |state| symbol(state) }.each do |sym, ps|
-              u = ps.flat_map { |l| followpos(l) }
+              u = ps.flat_map { |l| @followpos[l] }
               next if u.empty?
 
-              if u.uniq == [DUMMY]
-                from = state_id[s]
+              from = state_id[s]
+
+              if u.all? { |pos| pos == DUMMY }
                 to   = state_id[Object.new]
                 dtrans[from, to] = sym
-
                 dtrans.add_accepting(to)
+
                 ps.each { |state| dtrans.add_memo(to, state.memo) }
               else
-                dtrans[state_id[s], state_id[u]] = sym
+                to = state_id[u]
+                dtrans[from, to] = sym
 
                 if u.include?(DUMMY)
-                  to = state_id[u]
+                  ps.each do |state|
+                    if @followpos[state].include?(DUMMY)
+                      dtrans.add_memo(to, state.memo)
+                    end
+                  end
 
-                  accepting = ps.find_all { |l| followpos(l).include?(DUMMY) }
-
-                  accepting.each { |accepting_state|
-                    dtrans.add_memo(to, accepting_state.memo)
-                  }
-
-                  dtrans.add_accepting(state_id[u])
+                  dtrans.add_accepting(to)
                 end
               end
 
@@ -92,7 +91,7 @@ module ActionDispatch
               firstpos(node.left)
             end
           when Nodes::Or
-            node.children.flat_map { |c| firstpos(c) }.uniq
+            node.children.flat_map { |c| firstpos(c) }.tap(&:uniq!)
           when Nodes::Unary
             firstpos(node.left)
           when Nodes::Terminal
@@ -107,7 +106,7 @@ module ActionDispatch
           when Nodes::Star
             firstpos(node.left)
           when Nodes::Or
-            node.children.flat_map { |c| lastpos(c) }.uniq
+            node.children.flat_map { |c| lastpos(c) }.tap(&:uniq!)
           when Nodes::Cat
             if nullable?(node.right)
               lastpos(node.left) | lastpos(node.right)
@@ -123,15 +122,7 @@ module ActionDispatch
           end
         end
 
-        def followpos(node)
-          followpos_table[node]
-        end
-
         private
-          def followpos_table
-            @followpos ||= build_followpos
-          end
-
           def build_followpos
             table = Hash.new { |h, k| h[k] = [] }
             @ast.each do |n|
@@ -150,12 +141,7 @@ module ActionDispatch
           end
 
           def symbol(edge)
-            case edge
-            when Journey::Nodes::Symbol
-              edge.regexp
-            else
-              edge.left
-            end
+            edge.is_a?(Journey::Nodes::Symbol) ? edge.regexp : edge.left
           end
       end
     end


### PR DESCRIPTION
### Summary

This PR makes a few modifications to the transition table from GTG builder to reduce allocations.

1. Build follow_pos table when initializing the builder
2. Remove the related memoizing methods and access the ivar directly
3. Switch `u.uniq == [DUMMY]` for `u.all? { |pos| pos == DUMMY }`
4. Use a single each loop to add memos, instead of finding and then adding the memos
5. Save one allocation for `Nodes::Or` branches by using `tap(&:uniq!)`
6. Switch `symbol` to use a ternary if instead of a case/when

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActionDispatch
  module Journey
    module GTG
      class Builder
        def initialize(root)
          @root      = root
          @ast       = Nodes::Cat.new root, DUMMY
          @followpos = fast_build_followpos
        end

        def fast_transition_table
          dtrans   = TransitionTable.new
          marked   = {}
          state_id = Hash.new { |h, k| h[k] = h.length }
          dstates = [fast_firstpos(root)]

          until dstates.empty?
            s = dstates.shift
            next if marked[s]
            marked[s] = true # mark s

            s.group_by { |state| fast_symbol(state) }.each do |sym, ps|
              u = ps.flat_map { |l| @followpos[l] }
              next if u.empty?

              from = state_id[s]

              if u.all? { |pos| pos == DUMMY }
                to   = state_id[Object.new]
                dtrans[from, to] = sym
                dtrans.add_accepting(to)

                ps.each { |state| dtrans.add_memo(to, state.memo) }
              else
                to = state_id[u]
                dtrans[from, to] = sym

                if u.include?(DUMMY)
                  ps.each do |state|
                    if @followpos[state].include?(DUMMY)
                      dtrans.add_memo(to, state.memo)
                    end
                  end

                  dtrans.add_accepting(to)
                end
              end

              dstates << u
            end
          end

          dtrans
        end

        def fast_symbol(edge)
          edge.is_a?(Journey::Nodes::Symbol) ? edge.regexp : edge.left
        end

        def fast_firstpos(node)
          case node
          when Nodes::Star
            fast_firstpos(node.left)
          when Nodes::Cat
            if nullable?(node.left)
              fast_firstpos(node.left) | fast_firstpos(node.right)
            else
              fast_firstpos(node.left)
            end
          when Nodes::Or
            node.children.flat_map { |c| fast_firstpos(c) }.tap(&:uniq!)
          when Nodes::Unary
            fast_firstpos(node.left)
          when Nodes::Terminal
            nullable?(node) ? [] : [node]
          else
            raise ArgumentError, "unknown firstpos: %s" % node.class.name
          end
        end

        def fast_lastpos(node)
          case node
          when Nodes::Star
            fast_firstpos(node.left)
          when Nodes::Or
            node.children.flat_map { |c| fast_lastpos(c) }.tap(&:uniq!)
          when Nodes::Cat
            if nullable?(node.right)
              fast_lastpos(node.left) | fast_lastpos(node.right)
            else
              fast_lastpos(node.right)
            end
          when Nodes::Terminal
            nullable?(node) ? [] : [node]
          when Nodes::Unary
            fast_lastpos(node.left)
          else
            raise ArgumentError, "unknown lastpos: %s" % node.class.name
          end
        end

        def fast_build_followpos
          @ast.each_with_object(Hash.new { |h, k| h[k] = [] }) do |n, table|
            case n
            when Nodes::Cat
              fast_lastpos(n.left).each do |i|
                table[i] += fast_firstpos(n.right)
              end
            when Nodes::Star
              fast_lastpos(n).each do |i|
                table[i] += fast_firstpos(n)
              end
            end
          end
        end
      end
    end
  end
end

route_set = ActionDispatch::Routing::RouteSet.new
route_set.draw do
  resources :users do
    resources :blogs do
      resources :posts do
        resources :comments
      end
    end
  end
end
router = route_set.router
builder = ActionDispatch::Journey::GTG::Builder.new(router.send(:ast))

Benchmark.ips do |x|
  x.report("transition_table")      { builder.transition_table }
  x.report("fast_transition_table") { builder.fast_transition_table }
  x.compare!
end

Benchmark.memory do |x|
  x.report("transition_table")      { builder.transition_table }
  x.report("fast_transition_table") { builder.fast_transition_table }
  x.compare!
end
```
### Results
```
Warming up --------------------------------------
    transition_table    77.000  i/100ms
fast_transition_table
                        91.000  i/100ms
Calculating -------------------------------------
    transition_table    739.809  (± 3.6%) i/s -      3.696k in   5.002892s
fast_transition_table
                        910.453  (± 4.6%) i/s -      4.550k in   5.009053s

Comparison:
fast_transition_table:      910.5 i/s
    transition_table:      739.8 i/s - 1.23x  (± 0.00) slower

Calculating -------------------------------------
    transition_table    53.264k memsize (     0.000  retained)
                       465.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
fast_transition_table
                        44.512k memsize (    40.000  retained)
                       334.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
fast_transition_table:      44512 allocated
    transition_table:      53264 allocated - 1.20x more
```