### PR TITLE
fix misleading variant test

### DIFF
--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -162,12 +162,12 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   test "resized variation of BMP blob" do
-    blob = create_file_blob(filename: "colors.bmp")
+    blob = create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
     variant = blob.variant(resize: "15x15").processed
-    assert_match(/colors\.bmp/, variant.url)
+    assert_match(/colors\.png/, variant.url)
 
     image = read_image(variant)
-    assert_equal "BMP", image.type
+    assert_equal "PNG", image.type
     assert_equal 15, image.width
     assert_equal 8, image.height
   end


### PR DESCRIPTION
### Summary

This commit fixes the "resized variation of BMP blob" test.

By default `create_file_blob` use "image/jpeg" as content type, since this test does not specify the correct `content_type` for the `"colors.bmp"` image ("image/bmp") the `ActiveStorage::Variant#specification` consider the blob as a web image (since it use "image/jpeg" as content type) which causes the variant to return a `*.bmp` URL and a "BMP" type, this is an incorrect behavior since if you upload a `*.bmp` image the variant will have a PNG format with "image/png" as content type.

After this change the test will cover the current activestorage behavior.

Changes:

* Specify correct `content_type` on "resized variation of BMP blob" test.
* Change asserts to cover the current activestorage behavior.

### Other Information

This is causing issues while debugging other errors and trying to make all the tests to pass.

