### PR TITLE
Clear Resolvers' cache after AVLogSubscriberTest tests

### DIFF
--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -28,6 +28,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
 
   def teardown
     super
+    ActionController::Base.view_paths.map(&:clear_cache)
 
     ActiveSupport::LogSubscriber.log_subscribers.clear
 


### PR DESCRIPTION
### Summary

This pull request addresses the build failure below:
https://buildkite.com/rails/rails/builds/70853#29647167-4db2-4810-810e-d2c3a4e6dcf8

* This pull request addresses this error.

```ruby
$ bin/test test/template/log_subscriber_test.rb test/template/test_case_test.rb -n "/^(?:AVLogSubscriberTest#(?:test_render_collection_template)|ActionView::HelperInclusionTest#(?:test_helper_class_that_is_being_tested_is_always_included_in_view_instance))$/" --seed 54118
Run options: -n "/^(?:AVLogSubscriberTest#(?:test_render_collection_template)|ActionView::HelperInclusionTest#(?:test_helper_class_that_is_being_tested_is_always_included_in_view_instance))$/" --seed 54118

.E

Error:
ActionView::HelperInclusionTest#test_helper_class_that_is_being_tested_is_always_included_in_view_instance:
ActionView::Template::Error: undefined method `_test__customer_erb___3224798146126036163_10260' for #<#<Class:0x00005653f1b35768>:0x00005653f1b348e0>
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:276:in `_run'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:182:in `block in render'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:205:in `instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:384:in `instrument_render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:180:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:186:in `block in collection_with_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:66:in `block in each_with_info'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:66:in `each'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:66:in `each_with_info'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:177:in `each'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:177:in `map'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:177:in `collection_with_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:159:in `block (2 levels) in render_collection'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb:21:in `cache_collection_render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:158:in `block in render_collection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:203:in `block in instrument'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:203:in `instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:144:in `render_collection'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:116:in `render_collection_with_partial'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:75:in `render_partial_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:27:in `render_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:22:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/helpers/rendering_helper.rb:38:in `block in render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:306:in `in_rendering_context'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/helpers/rendering_helper.rb:34:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/test_case.rb:205:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/test/template/test_case_test.rb:126:in `render_from_helper'
    /home/yahonda/src/github.com/rails/rails/actionview/test/fixtures/test/_from_helper.erb:1:in `__home_yahonda_src_github_com_rails_rails_actionview_test_fixtures_test__from_helper_erb___900298654238864924_10340'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:276:in `_run'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:182:in `block in render'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:205:in `instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:384:in `instrument_render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:180:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/partial_renderer.rb:285:in `block in render_partial_template'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:203:in `block in instrument'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:203:in `instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/partial_renderer.rb:280:in `render_partial_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/partial_renderer.rb:271:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:84:in `render_partial_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:27:in `render_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:22:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/helpers/rendering_helper.rb:38:in `block in render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:306:in `in_rendering_context'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/helpers/rendering_helper.rb:34:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/test_case.rb:205:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/test_case.rb:122:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/test/template/test_case_test.rb:136:in `block in <class:HelperInclusionTest>'

bin/test test/template/test_case_test.rb:132

Finished in 0.076637s, 26.0970 runs/s, 39.1454 assertions/s.
2 runs, 3 assertions, 0 failures, 1 errors, 0 skips
$
```

Refer #36189 for the similar fix
