### PR TITLE
Add a new `server` Railtie block:

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Added `Railtie#server` hook called when Rails starts a server.
+    This is useful in case your application or a library needs to run
+    another process next to the Rails server. This is quite common in development
+    for instance to run the Webpack or the React server.
+
+    It can be used like this:
+
+    ```ruby
+      class MyRailtie < Rails::Railtie
+        server do
+          WebpackServer.run
+        end
+      end
+    ```
+
+    *Edouard Chin*
+
 *   Automatically generate abstract class when using multiple databases.
 
     When generating a scaffold for a multiple database application, Rails will now automatically generate the abstract class for the database when the database argument is passed. This abstract class will include the connection information for the writing configuration and any models generated for that database will automatically inherit from the abstract class.
@@ -39,7 +56,6 @@
     ```
 
     *Eileen M. Uchitelle*, *John Crepezzi*
-
 
 *   Accept params from url to prepopulate the Inbound Emails form in Rails conductor.
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -323,6 +323,12 @@ module Rails
       self.class.generators(&blk)
     end
 
+    # Sends any server called in the instance of a new application up
+    # to the +server+ method defined in Rails::Railtie.
+    def server(&blk)
+      self.class.server(&blk)
+    end
+
     # Sends the +isolate_namespace+ method up to the class method.
     def isolate_namespace(mod)
       self.class.isolate_namespace(mod)
@@ -548,6 +554,11 @@ module Rails
 
     def run_console_blocks(app) #:nodoc:
       railties.each { |r| r.run_console_blocks(app) }
+      super
+    end
+
+    def run_server_blocks(app) #:nodoc:
+      railties.each { |r| r.run_server_blocks(app) }
       super
     end
 

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -470,6 +470,13 @@ module Rails
       self
     end
 
+    # Invoke the server registered hooks.
+    # Check <tt>Rails::Railtie.server</tt> for more info.
+    def load_server(app = self)
+      run_server_blocks(app)
+      self
+    end
+
     def eager_load!
       # Already done by Zeitwerk::Loader.eager_load_all. We need this guard to
       # easily provide a compatible API for both zeitwerk and classic modes.

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -140,6 +140,7 @@ module Rails
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
 
       config
+      configru
 
       unless cookie_serializer_config_exist
         gsub_file "config/initializers/cookies_serializer.rb", /json(?!,)/, "marshal"

--- a/railties/lib/rails/generators/rails/app/templates/config.ru.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config.ru.tt
@@ -3,3 +3,4 @@
 require_relative "config/environment"
 
 run Rails.application
+Rails.application.load_server

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -108,6 +108,23 @@ module Rails
   # Since filenames on the load path are shared across gems, be sure that files you load
   # through a railtie have unique names.
   #
+  # == Run another program when the Rails server starts
+  #
+  # In development, it's very usual to have to run another process next to the Rails Server. In example
+  # you might want to start the Webpack or React server. Or maybe you need to run your job scheduler process
+  # like Sidekiq. This is usually done by opening a new shell and running the program from here.
+  #
+  # Rails allow you to specify a +server+ block which will get called when a Rails server starts.
+  # This way, your users don't need to remember to have to open a new shell and run another program, making
+  # this less confusing for everyone.
+  # It can be used like this:
+  #
+  # class MyRailtie < Rails::Railtie
+  #   server do
+  #     WebpackServer.start
+  #   end
+  # end
+  #
   # == Application and Engine
   #
   # An engine is nothing more than a railtie with some initializers already set. And since
@@ -150,6 +167,10 @@ module Rails
 
       def generators(&blk)
         register_block_for(:generators, &blk)
+      end
+
+      def server(&blk)
+        register_block_for(:server, &blk)
       end
 
       def abstract_railtie?
@@ -244,6 +265,10 @@ module Rails
       def run_tasks_blocks(app) #:nodoc:
         extend Rake::DSL
         each_registered_block(:rake_tasks) { |block| instance_exec(app, &block) }
+      end
+
+      def run_server_blocks(app) #:nodoc:
+        each_registered_block(:server) { |block| block.call(app) }
       end
 
     private

--- a/railties/test/application/server_test.rb
+++ b/railties/test/application/server_test.rb
@@ -42,6 +42,32 @@ module ApplicationTests
       end
     end
 
+    test "run +server+ blocks after the server starts" do
+      skip "PTY unavailable" unless available_pty?
+
+      File.open("#{app_path}/config/boot.rb", "w") do |f|
+        f.puts "ENV['BUNDLE_GEMFILE'] = '#{Bundler.default_gemfile}'"
+        f.puts 'require "bundler/setup"'
+      end
+
+      add_to_config(<<~CODE)
+        server do
+          puts 'Hello world'
+        end
+      CODE
+
+      primary, replica = PTY.open
+      pid = nil
+
+      Bundler.with_original_env do
+        pid = Process.spawn("bin/rails server -b localhost", chdir: app_path, in: replica, out: primary, err: replica)
+        assert_output("Hello world", primary)
+        assert_output("Listening", primary)
+      ensure
+        kill(pid) if pid
+      end
+    end
+
     private
       def kill(pid)
         Process.kill("TERM", pid)

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -170,6 +170,22 @@ module RailtiesTest
       assert $ran_block
     end
 
+    test "server block is executed when MyApp.load_server is called" do
+      $ran_block = false
+
+      class MyTie < Rails::Railtie
+        server do
+          $ran_block = true
+        end
+      end
+
+      require "#{app_path}/config/environment"
+
+      assert_not $ran_block
+      Rails.application.load_server
+      assert $ran_block
+    end
+
     test "runner block is executed when MyApp.load_runner is called" do
       $ran_block = false
 


### PR DESCRIPTION
Add a new `server` Railtie block:

- This is similar to other railties blocks (such as `console`,
  `tasks` ...). The goal of this block is to allow the application
  or a railtie to load code after the server start.

  The use case can be to fire the webpack or react server in
  development or start some job worker like sidekiq or resque.

  Right now, all these tasks needs to be done in a separate
  shell and gem maintainer needs to add documentation on
  how to run their libraries if another program needs to run
  next to the Rails server.

  This feature can be used like this:

  ```ruby
    class SuperRailtie < Rails::Railtie
      server do
        WebpackServer.run
      end
    end
  ```

cc/ @rafaelfranca @casperisfine