### PR TITLE
Reduce allocations in TransitionTable transitions

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -135,11 +135,17 @@ module ActionDispatch
         end
 
         def transitions
-          @string_states.flat_map { |from, hash|
-            hash.map { |s, to| [from, s, to] }
-          } + @regexp_states.flat_map { |from, hash|
-            hash.map { |s, to| [from, s, to] }
-          }
+          transitions = []
+
+          @string_states.each do |from, hash|
+            hash.each { |s, to| transitions << [from, s, to] }
+          end
+
+          @regexp_states.each do |from, hash|
+            hash.each { |s, to| transitions << [from, s, to] }
+          end
+
+          transitions
         end
 
         private


### PR DESCRIPTION
### Summary

This PR switches using `map` and `flat_map` for `each` to save a few allocations.

### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActionDispatch
  module Journey
    module GTG
      class TransitionTable
        def fast_transitions
          transitions = []

          @string_states.each do |from, hash|
            hash.each { |s, to| transitions << [from, s, to] }
          end

          @regexp_states.each do |from, hash|
            hash.each { |s, to| transitions << [from, s, to] }
          end

          transitions
        end
      end
    end
  end
end

route_set = ActionDispatch::Routing::RouteSet.new
route_set.draw do
  resources :users do
    resources :blogs do
      resources :posts do
        resources :comments
      end
    end
  end
end
router = route_set.router
table = ActionDispatch::Journey::GTG::Builder.new(router.send(:ast)).transition_table

Benchmark.ips do |x|
  x.report("transitions")      { table.transitions }
  x.report("fast_transitions") { table.fast_transitions }
  x.compare!
end

Benchmark.memory do |x|
  x.report("transitions")      { table.transitions }
  x.report("fast_transitions") { table.fast_transitions }
  x.compare!
end
```

### Results
```
Warming up --------------------------------------
         transitions     5.422k i/100ms
    fast_transitions     8.855k i/100ms
Calculating -------------------------------------
         transitions     53.800k (± 3.9%) i/s -    271.100k in   5.047047s
    fast_transitions     89.140k (± 5.4%) i/s -    451.605k in   5.082630s

Comparison:
    fast_transitions:    89140.2 i/s
         transitions:    53799.7 i/s - 1.66x  (± 0.00) slower

Calculating -------------------------------------
         transitions     6.992k memsize (     0.000  retained)
                       152.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
    fast_transitions     3.000k memsize (     0.000  retained)
                        58.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
    fast_transitions:       3000 allocated
         transitions:       6992 allocated - 2.33x more
```