### PR TITLE
Adds db:migrate:redo:NAME support for multidbs

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -142,6 +142,8 @@ db_namespace = namespace :db do
 
     desc "Rolls back the database one migration and re-migrates up (options: STEP=x, VERSION=x)."
     task redo: :load_config do
+      ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:migrate:redo")
+
       raise "Empty VERSION provided" if ENV["VERSION"] && ENV["VERSION"].empty?
 
       if ENV["VERSION"]
@@ -150,6 +152,23 @@ db_namespace = namespace :db do
       else
         db_namespace["rollback"].invoke
         db_namespace["migrate"].invoke
+      end
+    end
+
+    namespace :redo do
+      ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+        desc "Rolls back #{name} database one migration and re-migrates up (options: STEP=x, VERSION=x)."
+        task name => :load_config do
+          raise "Empty VERSION provided" if ENV["VERSION"] && ENV["VERSION"].empty?
+
+          if ENV["VERSION"]
+            db_namespace["migrate:down:#{name}"].invoke
+            db_namespace["migrate:up:#{name}"].invoke
+          else
+            db_namespace["rollback:#{name}"].invoke
+            db_namespace["migrate:#{name}"].invoke
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Summary

Hi there, We started using Multiple DBs in production recently, and it was really easy to do it! Thanks 🎉 

I noticed that db:migrate:redo is no longer working when using multidbs(even on master). Making a call to db:migrate:redo fails when calling db:rollback/up/down internally. 

As other commands have namespaced versions(i.e: like db:rollback:NAME, db:migrate:up:NAME, ettc) db:migrate:redo is a nice convenience to have. Unless there is a reason to not support it.

I've tried to do the same for it following the same strategy used for db:rollback.

```
» bin/rails db:migrate:redo
rake aborted!
You're using a multiple database application. To use `db:rollback` you must run the namespaced task with a VERSION. Available tasks are db:rollback:primary and db:rollback:secondary.
Tasks: TOP => db:rollback
(See full trace by running task with --trace)
```

After this patch:

```
» bin/rails db:migrate:redo
rake aborted!
You're using a multiple database application. To use `db:migrate:redo` you must run the namespaced task with a VERSION. Available tasks are db:migrate:redo:primary and db:migrate:redo:secondary.
Tasks: TOP => db:migrate:redo
(See full trace by running task with --trace)
```

Running with a namespaced version:

```
» bin/rails db:migrate:redo:secondary
== 20200728162820 CreateAnimals: reverting ====================================
-- drop_table(:animals)
   -> 0.0025s
== 20200728162820 CreateAnimals: reverted (0.0047s) ===========================

== 20200728162820 CreateAnimals: migrating ====================================
-- create_table(:animals)
   -> 0.0028s
== 20200728162820 CreateAnimals: migrated (0.0029s) ===========================
```