### PR TITLE
Follow naming conventions in generated plugin test

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class <%= camelized_modules %>::Test < ActiveSupport::TestCase
+class <%= camelized_modules %>Test < ActiveSupport::TestCase
   test "truth" do
     assert_kind_of Module, <%= camelized_modules %>
   end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -76,7 +76,10 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
     assert_file "lib/bukkits/railtie.rb", /module Bukkits\n  class Railtie < ::Rails::Railtie\n  end\nend/
     assert_file "lib/bukkits.rb", /require "bukkits\/railtie"/
-    assert_file "test/bukkits_test.rb", /assert_kind_of Module, Bukkits/
+    assert_file "test/bukkits_test.rb" do |content|
+      assert_match(/class BukkitsTest < ActiveSupport::TestCase/, content)
+      assert_match(/assert_kind_of Module, Bukkits/, content)
+    end
     assert_file "bin/test"
     assert_no_file "bin/rails"
   end


### PR DESCRIPTION
This commit ensures that a generated test file like "foo/bar_test.rb" defines the class `Foo::BarTest` rather than `Foo::Bar::Test`.