### PR TITLE
Load plugin VERSION constant by default

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/lib/%namespaced_name%.rb.tt
@@ -1,3 +1,4 @@
+require "<%= namespaced_name %>/version"
 <% if engine? -%>
 require "<%= namespaced_name %>/engine"
 <% else -%>

--- a/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/%namespaced_name%_test.rb.tt
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class <%= camelized_modules %>Test < ActiveSupport::TestCase
-  test "truth" do
-    assert_kind_of Module, <%= camelized_modules %>
+  test "it has a version number" do
+    assert <%= camelized_modules %>::VERSION
   end
 end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -75,10 +75,13 @@ class PluginGeneratorTest < Rails::Generators::TestCase
       assert_match(/Rails::TestUnitReporter\.executable = 'bin\/test'/, content)
     end
     assert_file "lib/bukkits/railtie.rb", /module Bukkits\n  class Railtie < ::Rails::Railtie\n  end\nend/
-    assert_file "lib/bukkits.rb", /require "bukkits\/railtie"/
+    assert_file "lib/bukkits.rb" do |content|
+      assert_match(/require "bukkits\/version"/, content)
+      assert_match(/require "bukkits\/railtie"/, content)
+    end
     assert_file "test/bukkits_test.rb" do |content|
       assert_match(/class BukkitsTest < ActiveSupport::TestCase/, content)
-      assert_match(/assert_kind_of Module, Bukkits/, content)
+      assert_match(/assert Bukkits::VERSION/, content)
     end
     assert_file "bin/test"
     assert_no_file "bin/rails"


### PR DESCRIPTION
For example, for a plugin like `my_plugin`, this makes the `MyPlugin::VERSION` constant available to all consumers by default.

This commit also replaces the default generated test with a test that the developer is less likely to delete.
