### PR TITLE
Add ActiveModel::Name#singular_ivar / #plural_ivar

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -8,9 +8,9 @@ module ActiveModel
   class Name
     include Comparable
 
-    attr_accessor :singular, :plural, :element, :collection,
+    attr_accessor :name, :singular, :plural, :element, :collection,
       :singular_route_key, :route_key, :param_key, :i18n_key,
-      :name
+      :singular_ivar, :plural_ivar
 
     alias_method :cache_key, :collection
 
@@ -175,6 +175,8 @@ module ActiveModel
       @collection   = ActiveSupport::Inflector.tableize(@name)
       @param_key    = (namespace ? _singularize(@unnamespaced) : @singular)
       @i18n_key     = @name.underscore.to_sym
+      @singular_ivar = :"@#{@singular}"
+      @plural_ivar   = :"@#{@plural}"
 
       @route_key          = (namespace ? ActiveSupport::Inflector.pluralize(@param_key) : @plural.dup)
       @singular_route_key = ActiveSupport::Inflector.singularize(@route_key)

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -42,6 +42,14 @@ class NamingTest < ActiveModel::TestCase
   def test_i18n_key
     assert_equal :"post/track_back", @model_name.i18n_key
   end
+
+  def test_singular_ivar
+    assert_equal :@post_track_back, @model_name.singular_ivar
+  end
+
+  def test_plural_ivar
+    assert_equal :@post_track_backs, @model_name.plural_ivar
+  end
 end
 
 class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase


### PR DESCRIPTION
These are useful when metaprogramming.  For example, instead of writing:

```ruby
instance_variable_get(:"@#{model_class.model_name.singular}")
```

One can write:

```ruby
instance_variable_get(model_class.model_name.singular_ivar)
```

Which is simpler and avoids allocating a new String.
