### PR TITLE
Fixed the column type typo in the scaffold command for multi-database guide [ci skip]

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -191,7 +191,7 @@ If you are using Rails generators, the scaffold and model generators will create
 class for you. Simply pass the database key to the command line
 
 ```bash
-$ bin/rails generate scaffold Dog name:title --database animals
+$ bin/rails generate scaffold Dog name:string --database animals
 ```
 
 A class with the database name and `Record` will be created. In this example
@@ -222,7 +222,7 @@ If you already have an abstract class and its name differs from `AnimalsRecord` 
 the `--parent` option to indicate you want a different abstract class:
 
 ```bash
-$ bin/rails generate scaffold Dog name:title --database animals --parent Animals::Record
+$ bin/rails generate scaffold Dog name:string --database animals --parent Animals::Record
 ```
 
 This will skip generating `AnimalsRecord` since you've indicated to Rails that you want to


### PR DESCRIPTION
```
bin/rails d scaffold Dog name:title --database animals
```
The above scaffold command mentioned in the guide generates a migration with column type as `title`. This PR fixes the scaffold command to avoid the issue. 