### PR TITLE
Fixes to_query when value is nil

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -11,7 +11,7 @@ class Object
   # Converts an object into a string suitable for use as a URL query string,
   # using the given <tt>key</tt> as the param name.
   def to_query(key)
-    "#{CGI.escape(key.to_param)}=#{CGI.escape(to_param.to_s)}"
+    self.nil? ? "#{CGI.escape(key.to_param)}" : "#{CGI.escape(key.to_param)}=#{CGI.escape(to_param.to_s)}"
   end
 end
 

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -49,7 +49,7 @@ class ToQueryTest < ActiveSupport::TestCase
   end
 
   def test_empty_array
-    assert_equal "person%5B%5D=", [].to_query("person")
+    assert_equal "person%5B%5D", [].to_query("person")
   end
 
   def test_nested_empty_hash
@@ -59,7 +59,7 @@ class ToQueryTest < ActiveSupport::TestCase
       a: 1, b: { c: 3, d: {} }
     assert_query_equal "",
       a: { b: { c: {} } }
-    assert_query_equal "b%5Bc%5D=false&b%5Be%5D=&b%5Bf%5D=&p=12",
+    assert_query_equal "b%5Bc%5D=false&b%5Be%5D&b%5Bf%5D=&p=12",
       p: 12, b: { c: false, e: nil, f: "" }
     assert_query_equal "b%5Bc%5D=3&b%5Bf%5D=",
       b: { c: 3, k: {}, f: "" }


### PR DESCRIPTION
Tries to fix https://github.com/rails/rails/issues/39662

### Summary

Makes the output from Hash#to_query parseable back into the same values as what were given, with respect to nil values.

#### Before

```ruby
hash = { a: nil, b: 'abc' }
query = hash.to_query
# => "a=&b=abc"

Rack::Utils.parse_nested_query(query)
# => {"a"=>"", "b"=>"abc"}
```

#### After

```ruby
hash = { a: nil, b: 'abc' }
query = hash.to_query
# => "a&b=abc"

Rack::Utils.parse_nested_query(query)
# => {"a"=>nil, "b"=>"abc"}
```

Let me know in case of any feedback.