### PR TITLE
Avoid implicit `create_with` for `StiClass.all`

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -320,7 +320,6 @@ module ActiveRecord
 
           if finder_needs_type_condition? && !ignore_default_scope?
             relation.where!(type_condition)
-            relation.create_with!(inheritance_column.to_s => sti_name)
           else
             relation
           end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -686,6 +686,7 @@ module ActiveRecord
 
     def scope_for_create
       hash = where_values_hash
+      hash.delete(klass.inheritance_column) if klass.finder_needs_type_condition?
       create_with_value.each { |k, v| hash[k.to_s] = v } unless create_with_value.empty?
       hash
     end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -111,6 +111,11 @@ module ActiveRecord
       assert_equal expected, Post.order(id: :desc).typographically_interesting
     end
 
+    def test_or_with_sti_relation
+      expected = Post.where("id = 1 or id = 2").sort_by(&:id)
+      assert_equal expected, Post.where(id: 1).or(SpecialPost.all).sort_by(&:id)
+    end
+
     def test_or_on_loaded_relation
       expected = Post.where("id = 1 or id = 2").to_a
       p = Post.where("id = 1")

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -356,6 +356,10 @@ class FakeKlass
       Post.predicate_builder
     end
 
+    def finder_needs_type_condition?
+      false
+    end
+
     def base_class?
       true
     end


### PR DESCRIPTION
Regardless of whether doing implicit `create_with` or not, `sti_name` is
set by `ensure_proper_type`.

https://github.com/rails/rails/blob/11f54e12b992f6c8d29fd9bedd89ac438a928a2f/activerecord/lib/active_record/inheritance.rb#L289-L304

The purpose of the `create_with` is to suppress/override `type_condition`,
since `type_condition` will be an array of all sti subclass names for
`scope_for_create`, it is not desired behavior for `scope_for_create`,
and it will cause `find_sti_class` to fail.

That undesired behavior was derived from `In` arel node was accidentally
a subclass of `Equality` node, IMHO it is considered as almost a bug.
But someone depends on the behavior for now (see also #39288).

Unfortunately that implicit `create_with` had an unwanted side effect to
fail `or` with STI subclass relation #39956.

This changes a way to suppress/override `type_condition`, from doing
implicit `create_with` to excepting `type_condition` in `scope_for_create`,
to fix the `or` issue #39956.

Fixes #39956.