### PR TITLE
The abstract parent class file generated via generator should not be pluralized

### DIFF
--- a/activerecord/lib/rails/generators/active_record/model/model_generator.rb
+++ b/activerecord/lib/rails/generators/active_record/model/model_generator.rb
@@ -66,7 +66,7 @@ module ActiveRecord
         end
 
         def abstract_class_name
-          "#{database.classify}Record"
+          "#{database.camelize}Record"
         end
 
         def database

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -48,13 +48,13 @@ module GeneratorsTestHelper
     end
   end
 
-  def with_secondary_database_configuration
+  def with_database_configuration(database_name = "secondary")
     original_configurations = ActiveRecord::Base.configurations
     ActiveRecord::Base.configurations = {
       test: {
-        secondary: {
-          database: "db/secondary.sqlite3",
-          migrations_paths: "db/secondary_migrate",
+        "#{database_name}": {
+          database: "db/#{database_name}.sqlite3",
+          migrations_paths: "db/#{database_name}_migrate",
         },
       },
     }

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -317,7 +317,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_database_puts_migrations_in_configured_folder
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["create_books", "--database=secondary"]
       assert_migration "db/secondary_migrate/create_books.rb" do |content|
         assert_method :change, content do |change|
@@ -328,7 +328,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_database_puts_migrations_in_configured_folder_with_aliases
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["create_books", "--db=secondary"]
       assert_migration "db/secondary_migrate/create_books.rb" do |content|
         assert_method :change, content do |change|

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -50,7 +50,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_model_with_database_option
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["account", "--database", "secondary"]
       assert_file "app/models/secondary_record.rb", /class SecondaryRecord < ApplicationRecord/
       assert_file "app/models/account.rb", /class Account < SecondaryRecord/
@@ -59,7 +59,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_model_with_parent_and_database_option
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["account", "--parent", "Admin::Account", "--database", "secondary"]
       assert_file "app/models/account.rb", /class Account < Admin::Account/
       assert_migration "db/secondary_migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
@@ -67,7 +67,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_model_with_no_migration_and_database_option
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["account", "--migration", "false", "--database", "secondary"]
       assert_file "app/models/account.rb", /class Account < SecondaryRecord/
       assert_no_migration "db/secondary_migrate/create_accounts.rb"
@@ -81,10 +81,19 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_model_with_parent_option_database_option_and_no_migration_option
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["account", "--migration", "false", "--database", "secondary", "--migration", "false", "--parent", "Admin::Account"]
       assert_file "app/models/account.rb", /class Account < Admin::Account/
       assert_no_migration "db/secondary_migrate/create_accounts.rb"
+    end
+  end
+
+  def test_model_with_underscored_database_option
+    with_database_configuration("admin_accounts") do
+      run_generator ["account", "--database", "admin_accounts"]
+      assert_file "app/models/admin_accounts_record.rb", /class AdminAccountsRecord < ApplicationRecord/
+      assert_file "app/models/account.rb", /class Account < AdminAccountsRecord/
+      assert_migration "db/admin_accounts_migrate/create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
     end
   end
 
@@ -440,7 +449,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_database_puts_migrations_in_configured_folder
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["account", "--database=secondary"]
       assert_migration "db/secondary_migrate/create_accounts.rb" do |content|
         assert_method :change, content do |change|
@@ -451,7 +460,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_database_puts_migrations_in_configured_folder_with_aliases
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["account", "--db=secondary"]
       assert_migration "db/secondary_migrate/create_accounts.rb" do |content|
         assert_method :change, content do |change|

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -520,7 +520,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_generator_multi_db_abstract_class
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["posts", "--database=secondary"]
 
       assert_migration "db/secondary_migrate/create_posts.rb"
@@ -533,7 +533,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_scaffold_generator_database_with_aliases
-    with_secondary_database_configuration do
+    with_database_configuration do
       run_generator ["posts", "--db=secondary"]
 
       assert_migration "db/secondary_migrate/create_posts.rb"


### PR DESCRIPTION
The change was introduced in #39866

Currently, the file generated via the generator is pluralized
but the parent class is singular.

Example: `bundle exec rails g scaffold Pet name:string --database=animals`

The above command should generate: `apps/models/animals_record.rb`
but the pets model would inherit from `AnimalRecord` as
`"animals".classify` would be `Animal`

This will throw the `uninitialized constant AnimalRecord Did you mean? AnimalsRecord`
error. This PR fixes the issue by making the abstract parent class file as singular.

@eileencodes I found the issue while I was trying something else. Maybe I'll raise a PR for another scenario as well. Thanks 😊 