### PR TITLE
Rename exclusive end value "max_value"

### DIFF
--- a/activemodel/lib/active_model/type/big_integer.rb
+++ b/activemodel/lib/active_model/type/big_integer.rb
@@ -6,7 +6,7 @@ module ActiveModel
   module Type
     class BigInteger < Integer # :nodoc:
       private
-        def max_value
+        def after_max_value
           ::Float::INFINITY
         end
     end

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -11,7 +11,7 @@ module ActiveModel
 
       def initialize(**)
         super
-        @range = min_value...max_value
+        @range = min_value...after_max_value
       end
 
       def type
@@ -51,12 +51,12 @@ module ActiveModel
           value
         end
 
-        def max_value
+        def after_max_value
           1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
         end
 
         def min_value
-          -max_value
+          -after_max_value
         end
 
         def _limit

--- a/activerecord/lib/active_record/type/unsigned_integer.rb
+++ b/activerecord/lib/active_record/type/unsigned_integer.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Type
     class UnsignedInteger < ActiveModel::Type::Integer # :nodoc:
       private
-        def max_value
+        def after_max_value
           super * 2
         end
 


### PR DESCRIPTION
### Summary

Looking at these two methods convinced me that a bug must be buried here:

```ruby
# activemodel/lib/active_model/type/integer.rb

def max_value
  1 << (_limit * 8 - 1) # 8 bits per byte with one bit for sign
end

def min_value
  -max_value
end
```

With a 4 bytes limit, `max_value` is `2147483648`, while `min_value` is `-2147483648`. This seems like `2147483648` overflows for 4 bytes.

I then spent way too much time finding out that `@range` is an exclusive range. So there's no functional bug. Still `max_value` is always to be considered inclusive, right?

I suggest renaming it.

### Compatibility

This could break code of people implementing their own types based on `ActiveModel::Type::Integer`.
