### PR TITLE
Append development routes after reload hook

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow appended root routes to take precedence over internal welcome controller.
+
+    *Gannon McGibbon*
+
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Added `Railtie#server` hook called when Rails starts a server.

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -82,20 +82,6 @@ module Rails
         end
       end
 
-      initializer :add_builtin_route do |app|
-        if Rails.env.development?
-          app.routes.prepend do
-            get "/rails/info/properties" => "rails/info#properties", internal: true
-            get "/rails/info/routes"     => "rails/info#routes", internal: true
-            get "/rails/info"            => "rails/info#index", internal: true
-          end
-
-          app.routes.append do
-            get "/"                      => "rails/welcome#index", internal: true
-          end
-        end
-      end
-
       # Setup default session store if not already set in config/application.rb
       initializer :setup_default_session_store, before: :build_middleware_stack do |app|
         unless app.config.session_store?
@@ -206,6 +192,22 @@ module Rails
           # some sort of reloaders dependency support, to be added.
           require_unload_lock!
           reloader.execute
+        end
+      end
+
+      initializer :add_builtin_route do |app|
+        if Rails.env.development?
+          app.routes.prepend do
+            get "/rails/info/properties" => "rails/info#properties", internal: true
+            get "/rails/info/routes"     => "rails/info#routes", internal: true
+            get "/rails/info"            => "rails/info#index", internal: true
+          end
+
+          app.routes.append do
+            get "/"                      => "rails/welcome#index", internal: true
+          end
+
+          routes_reloader.execute
         end
       end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -283,12 +283,12 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
 
     get "/c"
-    assert_equal "3", last_response.body
+    assert_equal "5", last_response.body
 
     app_file "db/schema.rb", ""
 
     get "/c"
-    assert_equal "7", last_response.body
+    assert_equal "11", last_response.body
   end
 
   test "columns migrations also trigger reloading" do

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -82,6 +82,30 @@ module ApplicationTests
       assert_equal "foo", last_response.body
     end
 
+    test "appended root takes precedence over internal welcome controller" do
+      controller :foo, <<-RUBY
+        class FooController < ApplicationController
+          def index
+            render plain: "foo"
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+        end
+
+        Rails.application.routes.append do
+          get "/", to: "foo#index"
+        end
+      RUBY
+
+      app("development")
+      get "/"
+
+      assert_equal "foo", last_response.body
+    end
+
     test "rails/welcome in production" do
       app("production")
       get "/"


### PR DESCRIPTION
### Summary

Allow appended root routes to take precedence over internal welcome controller.

The specific use-case I'm solving for is an app with no root route, and an engine that appends a root route. Routing files appear to be initially loaded [here](https://github.com/rails/rails/blob/98135434d29bcafbc36cfcb53e1370c5c044cc8a/railties/lib/rails/application/finisher.rb#L195) while the internal welcome controller route is appended [here](https://github.com/rails/rails/blob/98135434d29bcafbc36cfcb53e1370c5c044cc8a/railties/lib/rails/application/finisher.rb#L94). This means that you currently have to create an engine initializer that runs _before_ the builtin routes are appended in `add_builtin_route `. With this patch, the builtin routes are added to the application _after_ routing files are evaluated.