### PR TITLE
Fix `assert_recognizes` on mounted root routes.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `assert_recognizes` routing assertions to work on mounted root routes.
+
+    *Gannon McGibbon*
+
 *   Change default redirection status code for non-GET/HEAD requests to 308 Permanent Redirect for `ActionDispatch::SSL`.
 
     *Alan Tan*, *Oz Ben-David*

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -66,7 +66,8 @@ module ActionDispatch
         find_routes(rails_req).each do |match, parameters, route|
           unless route.path.anchored
             rails_req.script_name = match.to_s
-            rails_req.path_info   = match.post_match.sub(/^([^\/])/, '/\1')
+            rails_req.path_info   = match.post_match
+            rails_req.path_info   = "/" + rails_req.path_info unless rails_req.path_info.start_with? "/"
           end
 
           parameters = route.defaults.merge parameters

--- a/actionpack/test/dispatch/routing_assertions_test.rb
+++ b/actionpack/test/dispatch/routing_assertions_test.rb
@@ -14,11 +14,22 @@ class QueryBooksController < BooksController; end
 
 class RoutingAssertionsTest < ActionController::TestCase
   def setup
+    root_engine = Class.new(Rails::Engine) do
+      def self.name
+        "root_engine"
+      end
+    end
+
+    root_engine.routes.draw do
+      root to: "books#index"
+    end
+
     engine = Class.new(Rails::Engine) do
       def self.name
         "blog_engine"
       end
     end
+
     engine.routes.draw do
       resources :books
 
@@ -52,6 +63,8 @@ class RoutingAssertionsTest < ActionController::TestCase
       end
 
       mount engine => "/shelf"
+
+      mount root_engine => "/"
 
       get "/shelf/foo", controller: "query_articles", action: "index"
     end
@@ -116,6 +129,10 @@ class RoutingAssertionsTest < ActionController::TestCase
   def test_assert_recognizes_with_engine
     assert_recognizes({ controller: "books", action: "index" }, "/shelf/books")
     assert_recognizes({ controller: "books", action: "show", id: "1" }, "/shelf/books/1")
+  end
+
+  def test_assert_recognizes_with_engine_at_root
+    assert_recognizes({ controller: "books", action: "index" }, "/")
   end
 
   def test_assert_recognizes_with_engine_and_extras


### PR DESCRIPTION
### Summary

Allow `assert_recognizes` routing assertions to work on mounted root routes. Similar to 4a9d4c85c3ad188d188104a7154d916aab079146, but for recognizing the path in a test assertion.

The current recognition behaviour produces empty string `PATH_INFO` (`""`) when using `ActionDispatch::Journey::Patch::Pattern::MatchData#post_match` on a root route (`"/"`) with a regex of `/\A\//`. This gets forwarded to the mounted engine's routing as `""` [here](https://github.com/rails/rails/blob/23229d24533218bbbef04eba0fca8809ad00f9d7/actionpack/lib/action_dispatch/routing/route_set.rb#L882) and cannot find the route.
