### PR TITLE
Get rid of the unused RuntimeRegistry.connection_handler

### DIFF
--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -14,9 +14,9 @@ module ActiveRecord
   class RuntimeRegistry # :nodoc:
     extend ActiveSupport::PerThreadRegistry
 
-    attr_accessor :connection_handler, :sql_runtime
+    attr_accessor :sql_runtime
 
-    [:connection_handler, :sql_runtime].each do |val|
+    [:sql_runtime].each do |val|
       class_eval %{ def self.#{val}; instance.#{val}; end }, __FILE__, __LINE__
       class_eval %{ def self.#{val}=(x); instance.#{val}=x; end }, __FILE__, __LINE__
     end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/34495
It's no longer used since https://github.com/rails/rails/commit/5ce3e022ef136324d288fb493e0938e76a74981a

@eileencodes @rafaelfranca @tenderlove 