### PR TITLE
Improve Action View `translate` helper

### DIFF
--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -102,6 +102,15 @@ class TranslationHelperTest < ActiveSupport::TestCase
     ActionView::Base.raise_on_missing_translations = false
   end
 
+  def test_raise_arg_overrides_raise_config_option
+    ActionView::Base.raise_on_missing_translations = true
+
+    expected = "translation missing: en.translations.missing"
+    assert_equal expected, translate(:"translations.missing", raise: false)
+  ensure
+    ActionView::Base.raise_on_missing_translations = false
+  end
+
   def test_raises_missing_translation_message_with_raise_option
     assert_raise(I18n::MissingTranslationData) do
       translate(:"translations.missing", raise: true)
@@ -162,6 +171,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_missing_translation_scoped_by_partial_yield_block
     expected = 'translations.templates.missing_yield_block.missing: <span class="translation_missing" title="translation missing: en.translations.templates.missing_yield_block.missing">Missing</span>'
     assert_equal expected, view.render(template: "translations/templates/missing_yield_block").strip
+  end
+
+  def test_missing_translation_scoped_by_partial_yield_block_without_debug_wrapper
+    old_debug_missing_translation = ActionView::Base.debug_missing_translation
+    ActionView::Base.debug_missing_translation = false
+
+    expected = "translations.templates.missing_yield_block.missing: translation missing: en.translations.templates.missing_yield_block.missing"
+    assert_equal expected, view.render(template: "translations/templates/missing_yield_block").strip
+  ensure
+    ActionView::Base.debug_missing_translation = old_debug_missing_translation
   end
 
   def test_missing_translation_with_default_scoped_by_partial_yield_block
@@ -229,6 +248,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     end
   end
 
+  def test_translate_with_html_key_and_missing_default_and_raise_option
+    assert_raise(I18n::MissingTranslationData) do
+      translate(:"translations.missing_html", default: :"translations.missing_html", raise: true)
+    end
+  end
+
   def test_translate_with_two_defaults_named_html
     translation = translate(:'translations.missing', default: [:'translations.missing_html', :'translations.hello_html'])
     assert_equal "<a>Hello World</a>", translation
@@ -287,6 +312,11 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_translate_with_nil_default
     translation = translate(:'translations.missing', default: nil)
     assert_nil translation
+  end
+
+  def test_translate_bulk_lookup
+    translations = translate([:"translations.foo", :"translations.foo"])
+    assert_equal ["Foo", "Foo"], translations
   end
 
   def test_translate_does_not_change_options

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -49,9 +49,18 @@ class TranslationHelperTest < ActiveSupport::TestCase
   end
 
   def test_delegates_setting_to_i18n
-    assert_called_with(I18n, :translate, [:foo, locale: "en", raise: true], returns: "") do
+    matcher_called = false
+    matcher = ->(key, options) do
+      matcher_called = true
+      assert_equal :foo, key
+      assert_equal "en", options[:locale]
+    end
+
+    I18n.stub(:translate, matcher) do
       translate :foo, locale: "en"
     end
+
+    assert matcher_called
   end
 
   def test_delegates_localize_to_i18n
@@ -229,15 +238,26 @@ class TranslationHelperTest < ActiveSupport::TestCase
     end
   end
 
+  def test_translate_with_default_and_raise_false
+    translation = translate(:"translations.missing", default: :"translations.foo", raise: false)
+    assert_equal "Foo", translation
+  end
+
   def test_translate_with_default_named_html
     translation = translate(:'translations.missing', default: :'translations.hello_html')
     assert_equal "<a>Hello World</a>", translation
     assert_equal true, translation.html_safe?
   end
 
+  def test_translate_with_default_named_html_and_raise_false
+    translation = translate(:"translations.missing", default: :"translations.hello_html", raise: false)
+    assert_equal "<a>Hello World</a>", translation
+    assert_predicate translation, :html_safe?
+  end
+
   def test_translate_with_missing_default
-    translation = translate(:'translations.missing', default: :'translations.missing_html')
-    expected = '<span class="translation_missing" title="translation missing: en.translations.missing_html">Missing Html</span>'
+    translation = translate(:"translations.missing", default: :also_missing)
+    expected = '<span class="translation_missing" title="translation missing: en.translations.missing">Missing</span>'
     assert_equal expected, translation
     assert_equal true, translation.html_safe?
   end
@@ -317,6 +337,27 @@ class TranslationHelperTest < ActiveSupport::TestCase
   def test_translate_bulk_lookup
     translations = translate([:"translations.foo", :"translations.foo"])
     assert_equal ["Foo", "Foo"], translations
+  end
+
+  def test_translate_bulk_lookup_with_default
+    translations = translate([:"translations.missing", :"translations.missing"], default: :"translations.foo")
+    assert_equal ["Foo", "Foo"], translations
+  end
+
+  def test_translate_bulk_lookup_html
+    translations = translate([:"translations.html", :"translations.hello_html"])
+    assert_equal ["<a>Hello World</a>", "<a>Hello World</a>"], translations
+    translations.each do |translation|
+      assert_predicate translation, :html_safe?
+    end
+  end
+
+  def test_translate_bulk_lookup_html_with_default
+    translations = translate([:"translations.missing", :"translations.missing"], default: :"translations.html")
+    assert_equal ["<a>Hello World</a>", "<a>Hello World</a>"], translations
+    translations.each do |translation|
+      assert_predicate translation, :html_safe?
+    end
   end
 
   def test_translate_does_not_change_options


### PR DESCRIPTION
This disentangles the control flow between Action View's `translate` and I18n's `translate`.  In doing so, it fixes a handful of corner cases, for which tests have now been added.  It also reduces memory allocations, and improves speed when using a default:

**Memory**

```ruby
require "benchmark/memory"

Benchmark.memory do |x|
  x.report("warmup") { translate(:"translations.foo"); translate(:"translations.html") }
  x.report("text") { translate(:"translations.foo") }
  x.report("html") { translate(:"translations.html") }
  x.report("text 1 default") { translate(:"translations.missing", default: :"translations.foo") }
  x.report("html 1 default") { translate(:"translations.missing", default: :"translations.html") }
  x.report("text 2 defaults") { translate(:"translations.missing", default: [:"translations.missing", :"translations.foo"]) }
  x.report("html 2 defaults") { translate(:"translations.missing", default: [:"translations.missing", :"translations.html"]) }
end
```

Before:

```
                text     1.240k memsize (     0.000  retained)
                        13.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
                html     1.600k memsize (     0.000  retained)
                        19.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
      text 1 default     4.728k memsize (     1.200k retained)
                        39.000  objects (     4.000  retained)
                         5.000  strings (     0.000  retained)
      html 1 default     5.056k memsize (     1.160k retained)
                        41.000  objects (     3.000  retained)
                         4.000  strings (     0.000  retained)
     text 2 defaults     7.464k memsize (     2.392k retained)
                        54.000  objects (     6.000  retained)
                         4.000  strings (     0.000  retained)
     html 2 defaults     7.944k memsize (     2.384k retained)
                        60.000  objects (     6.000  retained)
                         4.000  strings (     0.000  retained)
```

After:

```
                text   952.000  memsize (     0.000  retained)
                         9.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
                html     1.008k memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
      text 1 default     2.400k memsize (    40.000  retained)
                        24.000  objects (     1.000  retained)
                         4.000  strings (     0.000  retained)
      html 1 default     2.464k memsize (     0.000  retained)
                        22.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
     text 2 defaults     3.232k memsize (     0.000  retained)
                        30.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
     html 2 defaults     3.456k memsize (     0.000  retained)
                        32.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
```

**Speed**

```ruby
require "benchmark/ips"

Benchmark.ips do |x|
  x.report("text") { translate(:"translations.foo") }
  x.report("html") { translate(:"translations.html") }
  x.report("text 1 default") { translate(:"translations.missing", default: :"translations.foo") }
  x.report("html 1 default") { translate(:"translations.missing", default: :"translations.html") }
  x.report("text 2 defaults") { translate(:"translations.missing", default: [:"translations.missing", :"translations.foo"]) }
  x.report("html 2 defaults") { translate(:"translations.missing", default: [:"translations.missing", :"translations.html"]) }
end
```

Before:

```
                text     35.685k (± 0.7%) i/s -    179.050k in   5.017773s
                html     28.569k (± 3.1%) i/s -    143.871k in   5.040128s
      text 1 default     13.953k (± 2.0%) i/s -     70.737k in   5.071651s
      html 1 default     12.507k (± 0.4%) i/s -     63.546k in   5.080908s
     text 2 defaults      9.103k (± 0.3%) i/s -     46.308k in   5.087323s
     html 2 defaults      8.570k (± 4.3%) i/s -     43.071k in   5.034322s
```

After:

```
                text     36.694k (± 2.0%) i/s -    186.864k in   5.094367s
                html     30.415k (± 0.5%) i/s -    152.900k in   5.027226s
      text 1 default     18.095k (± 2.7%) i/s -     91.086k in   5.036857s
      html 1 default     15.934k (± 1.7%) i/s -     80.223k in   5.036085s
     text 2 defaults     12.179k (± 0.6%) i/s -     61.659k in   5.062910s
     html 2 defaults     11.193k (± 2.1%) i/s -     56.406k in   5.041433s
```

---

In an effort to make this easier to review, I have broken it down into two logical commits.  The original code is complicated, but the changes are a bit easier to understand if you view each commit individually.  If I need to break this down further, let me know, and I will do my best.
