### PR TITLE
Make `Enumerable.pluck` faster for single key

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -153,7 +153,8 @@ module Enumerable
     if keys.many?
       map { |element| keys.map { |key| element[key] } }
     else
-      map { |element| element[keys.first] }
+      key = keys.first
+      map { |element| element[key] }
     end
   end
 


### PR DESCRIPTION
### Summary
Make `Enumerable.pluck(key)` faster for single key

### Benchmark
macOS, ruby 2.7.1

```
Warming up --------------------------------------
       default_pluck   131.000  i/100ms
          fast_pluck   152.000  i/100ms
Calculating -------------------------------------
       default_pluck      1.377k (± 3.7%) i/s -      6.943k in   5.049080s
          fast_pluck      1.844k (± 2.8%) i/s -      9.272k in   5.031824s

Comparison:
          fast_pluck:     1844.2 i/s
       default_pluck:     1377.2 i/s - 1.34x  (± 0.00) slower
```

### Benchmark code

```ruby
module Enumerable
  def default_pluck(*keys)
    map { |element| element[keys.first] }
  end

  def fast_pluck(*keys)
    key = keys.first
    map { |element| element[key] }
  end
end

# [{ number: 3 }, { number: 11 }, ... n]
array = Array.new(10000) { {number: rand(1...10000)} }

Benchmark.ips do |x|
  x.report("default_pluck") { array.default_pluck(:number) }
  x.report("fast_pluck") { array.fast_pluck(:number) }

  x.compare!
end
```