### PR TITLE
Fix deserializing enum mapping nil

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -136,7 +136,6 @@ module ActiveRecord
       end
 
       def deserialize(value)
-        return if value.nil?
         mapping.key(subtype.deserialize(value))
       end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -236,6 +236,10 @@ class EnumTest < ActiveRecord::TestCase
     assert_nil @book.reload.status
   end
 
+  test "deserialize nil value to enum which defines nil value to hash" do
+    assert_equal "forgotten", books(:ddd).last_read
+  end
+
   test "assign nil value" do
     @book.status = nil
     assert_nil @book.status


### PR DESCRIPTION
Follow up to #38086.

User assigned nil is type casted by #38086, but loaded nil from database
does not yet, this fixes that.
