### PR TITLE
Fix eager loading that non-select columns will be loaded

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Respect the `select` values for eager loading.
+
+    ```ruby
+    post = Post.select("UPPER(title) AS title").first
+    post.title # => "WELCOME TO THE WEBLOG"
+    post.body  # => ActiveModel::MissingAttributeError
+
+    # Rails 6.0 (ignore the `select` values)
+    post = Post.select("UPPER(title) AS title").eager_load(:comments).first
+    post.title # => "Welcome to the weblog"
+    post.body  # => "Such a lovely day"
+
+    # Rails 6.1 (respect the `select` values)
+    post = Post.select("UPPER(title) AS title").eager_load(:comments).first
+    post.title # => "WELCOME TO THE WEBLOG"
+    post.body  # => ActiveModel::MissingAttributeError
+    ```
+
+    *Ryuta Kamizono*
+
 *   Allow attribute's default to be configured but keeping its own type.
 
     ```ruby

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -34,7 +34,7 @@ module ActiveRecord
         Table = Struct.new(:node, :columns) do # :nodoc:
           def column_aliases
             t = node.table
-            columns.map { |column| t[column.name].as Arel.sql column.alias }
+            columns.map { |column| t[column.name].as(column.alias) }
           end
         end
         Column = Struct.new(:name, :alias)
@@ -105,13 +105,20 @@ module ActiveRecord
         parents = model_cache[join_root]
 
         column_aliases = aliases.column_aliases(join_root)
-        column_names = explicit_selections(column_aliases, result_set)
+        column_names = []
+
+        result_set.columns.each do |name|
+          column_names << name unless /\At\d+_r\d+\z/.match?(name)
+        end
 
         if column_names.empty?
           column_types = {}
         else
           column_types = result_set.column_types
-          column_types = column_types.slice(*column_names) unless column_types.empty?
+          unless column_types.empty?
+            attribute_types = join_root.attribute_types
+            column_types = column_types.slice(*column_names).delete_if { |k, _| attribute_types.key?(k) }
+          end
           column_aliases += column_names.map! { |name| Aliases::Column.new(name, name) }
         end
 
@@ -134,6 +141,7 @@ module ActiveRecord
       end
 
       def apply_column_aliases(relation)
+        @join_root_alias = relation.select_values.empty?
         relation._select!(-> { aliases.columns })
       end
 
@@ -145,18 +153,18 @@ module ActiveRecord
         attr_reader :join_root, :join_type
 
       private
-        attr_reader :alias_tracker
-
-        def explicit_selections(root_column_aliases, result_set)
-          root_names = root_column_aliases.map(&:name).to_set
-          result_set.columns.each_with_object([]) do |name, result|
-            result << name unless /\At\d+_r\d+\z/.match?(name) || root_names.include?(name)
-          end
-        end
+        attr_reader :alias_tracker, :join_root_alias
 
         def aliases
           @aliases ||= Aliases.new join_root.each_with_index.map { |join_part, i|
-            columns = join_part.column_names.each_with_index.map { |column_name, j|
+            column_names = if join_part == join_root && !join_root_alias
+              primary_key = join_root.primary_key
+              primary_key ? [primary_key] : []
+            else
+              join_part.column_names
+            end
+
+            columns = column_names.each_with_index.map { |column_name, j|
               Aliases::Column.new column_name, "t#{i}_r#{j}"
             }
             Aliases::Table.new(join_part, columns)

--- a/activerecord/lib/active_record/associations/join_dependency/join_part.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_part.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         # association.
         attr_reader :base_klass, :children
 
-        delegate :table_name, :column_names, :primary_key, to: :base_klass
+        delegate :table_name, :column_names, :primary_key, :attribute_types, to: :base_klass
 
         def initialize(base_klass, children)
           @base_klass = base_klass

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1375,7 +1375,14 @@ class FinderTest < ActiveRecord::TestCase
       limit: 3, order: "posts.id"
     ).to_a
     assert_equal 3, posts.size
-    assert_equal [0, 1, 1], posts.map(&:author_id).sort
+    assert_equal [1, 1, nil], posts.map(&:author_id)
+  end
+
+  def test_custom_select_takes_precedence_over_original_value
+    posts = Post.select("UPPER(title) AS title")
+    assert_equal "WELCOME TO THE WEBLOG", posts.first.title
+    assert_equal "WELCOME TO THE WEBLOG", posts.preload(:comments).first.title
+    assert_equal "WELCOME TO THE WEBLOG", posts.eager_load(:comments).first.title
   end
 
   def test_eager_load_for_no_has_many_with_limit_and_joins_for_has_many


### PR DESCRIPTION
Related to #35210.

We sometimes use `select` to limit unused columns for performance.

For example, `GET /posts/1` (post detail) usually use (almost) all
columns, but `GET /posts` (post list) does not always use all columns
(e.g. use `id` and `title` for the list view, but `body` is not used).

If an association is eager loaded, the limited `select` doesn't works as
expected, eager loading will load all columns on the model, plus also
load the `select` columns additionally. It works differently with
natural load and preload. It means that changing natural load or preload
to eager load (or vice versa) is unsafe.

This fixes eager loading that always load all columns (plus extra
`select` columns), to respect the `select` columns like as others.

```ruby
post = Post.select("UPPER(title) AS title").first
post.title # => "WELCOME TO THE WEBLOG"
post.body  # => ActiveModel::MissingAttributeError

# Rails 6.0 (ignore the `select` values)
post = Post.select("UPPER(title) AS title").eager_load(:comments).first
post.title # => "Welcome to the weblog"
post.body  # => "Such a lovely day"

# Rails 6.1 (respect the `select` values)
post = Post.select("UPPER(title) AS title").eager_load(:comments).first
post.title # => "WELCOME TO THE WEBLOG"
post.body  # => ActiveModel::MissingAttributeError
```
