### PR TITLE
Remove unnecessary with_temporary_connection_pool calls

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -445,17 +445,15 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_cache_is_available_when_using_a_not_connected_connection
     skip "In-Memory DB can't test for using a not connected connection" if in_memory_db?
-    with_temporary_connection_pool do
-      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").dup
-      db_config.owner_name = "test2"
-      ActiveRecord::Base.connection_handler.establish_connection(db_config)
-      assert_not_predicate Task, :connected?
+    db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").dup
+    db_config.owner_name = "test2"
+    ActiveRecord::Base.connection_handler.establish_connection(db_config)
+    assert_not_predicate Task, :connected?
 
-      Task.cache do
-        assert_queries(1) { Task.find(1); Task.find(1) }
-      ensure
-        ActiveRecord::Base.connection_handler.remove_connection_pool(db_config.owner_name)
-      end
+    Task.cache do
+      assert_queries(1) { Task.find(1); Task.find(1) }
+    ensure
+      ActiveRecord::Base.connection_handler.remove_connection_pool(db_config.owner_name)
     end
   end
 
@@ -532,44 +530,38 @@ class QueryCacheTest < ActiveRecord::TestCase
   end
 
   def test_query_cache_does_not_establish_connection_if_unconnected
-    with_temporary_connection_pool do
-      ActiveRecord::Base.clear_active_connections!
-      assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
+    ActiveRecord::Base.clear_active_connections!
+    assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
 
-      middleware {
-        assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in setup"
-      }.call({})
+    middleware {
+      assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in setup"
+    }.call({})
 
-      assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in cleanup"
-    end
+    assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in cleanup"
   end
 
   def test_query_cache_is_enabled_on_connections_established_after_middleware_runs
-    with_temporary_connection_pool do
-      ActiveRecord::Base.clear_active_connections!
-      assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
+    ActiveRecord::Base.clear_active_connections!
+    assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
 
-      middleware {
-        assert_predicate ActiveRecord::Base.connection, :query_cache_enabled
-      }.call({})
-      assert_not_predicate ActiveRecord::Base.connection, :query_cache_enabled
-    end
+    middleware {
+      assert_predicate ActiveRecord::Base.connection, :query_cache_enabled
+    }.call({})
+    assert_not_predicate ActiveRecord::Base.connection, :query_cache_enabled
   end
 
   def test_query_caching_is_local_to_the_current_thread
-    with_temporary_connection_pool do
-      ActiveRecord::Base.clear_active_connections!
+    ActiveRecord::Base.clear_active_connections!
 
-      middleware {
-        assert ActiveRecord::Base.connection_pool.query_cache_enabled
-        assert ActiveRecord::Base.connection.query_cache_enabled
+    middleware {
+      assert ActiveRecord::Base.connection_pool.query_cache_enabled
+      assert ActiveRecord::Base.connection.query_cache_enabled
 
-        Thread.new {
-          assert_not ActiveRecord::Base.connection_pool.query_cache_enabled
-          assert_not ActiveRecord::Base.connection.query_cache_enabled
-        }.join
-      }.call({})
-    end
+      Thread.new {
+        assert_not ActiveRecord::Base.connection_pool.query_cache_enabled
+        assert_not ActiveRecord::Base.connection.query_cache_enabled
+      }.join
+    }.call({})
   end
 
   def test_query_cache_is_enabled_on_all_connection_pools
@@ -583,39 +575,37 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_clear_query_cache_is_called_on_all_connections
     skip "with in memory db, reading role won't be able to see database on writing role" if in_memory_db?
-    with_temporary_connection_pool do
-      ActiveRecord::Base.connection_handlers = {
-        writing: ActiveRecord::Base.default_connection_handler,
-        reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new
-      }
+    ActiveRecord::Base.connection_handlers = {
+      writing: ActiveRecord::Base.default_connection_handler,
+      reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+    }
 
+    ActiveRecord::Base.connected_to(role: :reading) do
+      db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+      ActiveRecord::Base.establish_connection(db_config)
+    end
+
+    mw = middleware { |env|
       ActiveRecord::Base.connected_to(role: :reading) do
-        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        ActiveRecord::Base.establish_connection(db_config)
+        @topic = Topic.first
       end
 
-      mw = middleware { |env|
-        ActiveRecord::Base.connected_to(role: :reading) do
-          @topic = Topic.first
-        end
+      assert @topic
 
-        assert @topic
+      ActiveRecord::Base.connected_to(role: :writing) do
+        @topic.title = "It doesn't have to be crazy at work"
+        @topic.save!
+      end
 
-        ActiveRecord::Base.connected_to(role: :writing) do
-          @topic.title = "It doesn't have to be crazy at work"
-          @topic.save!
-        end
+      assert_equal "It doesn't have to be crazy at work", @topic.title
 
+      ActiveRecord::Base.connected_to(role: :reading) do
+        @topic = Topic.first
         assert_equal "It doesn't have to be crazy at work", @topic.title
+      end
+    }
 
-        ActiveRecord::Base.connected_to(role: :reading) do
-          @topic = Topic.first
-          assert_equal "It doesn't have to be crazy at work", @topic.title
-        end
-      }
-
-      mw.call({})
-    end
+    mw.call({})
   ensure
     ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
   end


### PR DESCRIPTION
While debugging a different problem I'm working on I realized that this
method `with_temporary_connection_pool` isn't necessary in most of the
cases we're using it for.

Anywhere we establish new connections inside the block won't throw away
those new connections. I also removed this from places that can use the
existing connection and don't need a new temporary pool. I'm not sure if
this file was using it in many places because of copy / paste or real
issues that are no longer present.