### PR TITLE
Rename `pool_key` to `shard` and use kwargs for connection methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1031,7 +1031,7 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
-      def establish_connection(config, pool_key = Base.default_pool_key, owner_name = Base.name)
+      def establish_connection(config, shard = Base.default_shard, owner_name = Base.name)
         owner_name = config.to_s if config.is_a?(Symbol)
 
         pool_config = resolve_pool_config(config, owner_name)
@@ -1040,7 +1040,7 @@ module ActiveRecord
         # Protects the connection named `ActiveRecord::Base` from being removed
         # if the user calls `establish_connection :primary`.
         if owner_to_pool_manager.key?(pool_config.connection_specification_name)
-          remove_connection_pool(pool_config.connection_specification_name, pool_key)
+          remove_connection_pool(pool_config.connection_specification_name, shard)
         end
 
         message_bus = ActiveSupport::Notifications.instrumenter
@@ -1052,7 +1052,7 @@ module ActiveRecord
 
         owner_to_pool_manager[pool_config.connection_specification_name] ||= PoolManager.new
         pool_manager = get_pool_manager(pool_config.connection_specification_name)
-        pool_manager.set_pool_config(pool_key, pool_config)
+        pool_manager.set_pool_config(shard, pool_config)
 
         message_bus.instrument("!connection.active_record", payload) do
           pool_config.pool
@@ -1094,12 +1094,12 @@ module ActiveRecord
       # active or defined connection: if it is the latter, it will be
       # opened and set as the active connection for the class it was defined
       # for (not necessarily the current class).
-      def retrieve_connection(spec_name, pool_key = ActiveRecord::Base.default_pool_key) # :nodoc:
-        pool = retrieve_connection_pool(spec_name, pool_key)
+      def retrieve_connection(spec_name, shard = ActiveRecord::Base.default_shard) # :nodoc:
+        pool = retrieve_connection_pool(spec_name, shard)
 
         unless pool
-          if pool_key != ActiveRecord::Base.default_pool_key
-            message = "No connection pool for '#{spec_name}' found for the '#{pool_key}' shard."
+          if shard != ActiveRecord::Base.default_shard
+            message = "No connection pool for '#{spec_name}' found for the '#{shard}' shard."
           elsif ActiveRecord::Base.connection_handler != ActiveRecord::Base.default_connection_handler
             message = "No connection pool for '#{spec_name}' found for the '#{ActiveRecord::Base.current_role}' role."
           else
@@ -1114,8 +1114,8 @@ module ActiveRecord
 
       # Returns true if a connection that's accessible to this class has
       # already been opened.
-      def connected?(spec_name, pool_key = ActiveRecord::Base.default_pool_key)
-        pool = retrieve_connection_pool(spec_name, pool_key)
+      def connected?(spec_name, shard = ActiveRecord::Base.default_shard)
+        pool = retrieve_connection_pool(spec_name, shard)
         pool && pool.connected?
       end
 
@@ -1123,14 +1123,14 @@ module ActiveRecord
       # connection and the defined connection (if they exist). The result
       # can be used as an argument for #establish_connection, for easily
       # re-establishing the connection.
-      def remove_connection(owner, pool_key = ActiveRecord::Base.default_pool_key)
-        remove_connection_pool(owner, pool_key)&.configuration_hash
+      def remove_connection(owner, shard = ActiveRecord::Base.default_shard)
+        remove_connection_pool(owner, shard)&.configuration_hash
       end
       deprecate remove_connection: "Use #remove_connection_pool, which now returns a DatabaseConfig object instead of a Hash"
 
-      def remove_connection_pool(owner, pool_key = ActiveRecord::Base.default_pool_key)
+      def remove_connection_pool(owner, shard = ActiveRecord::Base.default_shard)
         if pool_manager = get_pool_manager(owner)
-          pool_config = pool_manager.remove_pool_config(pool_key)
+          pool_config = pool_manager.remove_pool_config(shard)
 
           if pool_config
             pool_config.disconnect!
@@ -1142,8 +1142,8 @@ module ActiveRecord
       # Retrieving the connection pool happens a lot, so we cache it in @owner_to_pool_manager.
       # This makes retrieving the connection pool O(1) once the process is warm.
       # When a connection is established or removed, we invalidate the cache.
-      def retrieve_connection_pool(owner, pool_key = ActiveRecord::Base.default_pool_key)
-        pool_config = get_pool_manager(owner)&.get_pool_config(pool_key)
+      def retrieve_connection_pool(owner, shard = ActiveRecord::Base.default_shard)
+        pool_config = get_pool_manager(owner)&.get_pool_config(shard)
         pool_config&.pool
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1031,7 +1031,7 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
-      def establish_connection(config, shard = Base.default_shard, owner_name = Base.name)
+      def establish_connection(config, owner_name: Base.name, shard: Base.default_shard)
         owner_name = config.to_s if config.is_a?(Symbol)
 
         pool_config = resolve_pool_config(config, owner_name)
@@ -1040,7 +1040,7 @@ module ActiveRecord
         # Protects the connection named `ActiveRecord::Base` from being removed
         # if the user calls `establish_connection :primary`.
         if owner_to_pool_manager.key?(pool_config.connection_specification_name)
-          remove_connection_pool(pool_config.connection_specification_name, shard)
+          remove_connection_pool(pool_config.connection_specification_name, shard: shard)
         end
 
         message_bus = ActiveSupport::Notifications.instrumenter
@@ -1094,8 +1094,8 @@ module ActiveRecord
       # active or defined connection: if it is the latter, it will be
       # opened and set as the active connection for the class it was defined
       # for (not necessarily the current class).
-      def retrieve_connection(spec_name, shard = ActiveRecord::Base.default_shard) # :nodoc:
-        pool = retrieve_connection_pool(spec_name, shard)
+      def retrieve_connection(spec_name, shard: ActiveRecord::Base.default_shard) # :nodoc:
+        pool = retrieve_connection_pool(spec_name, shard: shard)
 
         unless pool
           if shard != ActiveRecord::Base.default_shard
@@ -1114,8 +1114,8 @@ module ActiveRecord
 
       # Returns true if a connection that's accessible to this class has
       # already been opened.
-      def connected?(spec_name, shard = ActiveRecord::Base.default_shard)
-        pool = retrieve_connection_pool(spec_name, shard)
+      def connected?(spec_name, shard: ActiveRecord::Base.default_shard)
+        pool = retrieve_connection_pool(spec_name, shard: shard)
         pool && pool.connected?
       end
 
@@ -1123,12 +1123,12 @@ module ActiveRecord
       # connection and the defined connection (if they exist). The result
       # can be used as an argument for #establish_connection, for easily
       # re-establishing the connection.
-      def remove_connection(owner, shard = ActiveRecord::Base.default_shard)
-        remove_connection_pool(owner, shard)&.configuration_hash
+      def remove_connection(owner, shard: ActiveRecord::Base.default_shard)
+        remove_connection_pool(owner, shard: shard)&.configuration_hash
       end
       deprecate remove_connection: "Use #remove_connection_pool, which now returns a DatabaseConfig object instead of a Hash"
 
-      def remove_connection_pool(owner, shard = ActiveRecord::Base.default_shard)
+      def remove_connection_pool(owner, shard: ActiveRecord::Base.default_shard)
         if pool_manager = get_pool_manager(owner)
           pool_config = pool_manager.remove_pool_config(shard)
 
@@ -1142,7 +1142,7 @@ module ActiveRecord
       # Retrieving the connection pool happens a lot, so we cache it in @owner_to_pool_manager.
       # This makes retrieving the connection pool O(1) once the process is warm.
       # When a connection is established or removed, we invalidate the cache.
-      def retrieve_connection_pool(owner, shard = ActiveRecord::Base.default_shard)
+      def retrieve_connection_pool(owner, shard: ActiveRecord::Base.default_shard)
         pool_config = get_pool_manager(owner)&.get_pool_config(shard)
         pool_config&.pool
       end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -49,7 +49,7 @@ module ActiveRecord
     def establish_connection(config_or_env = nil)
       config_or_env ||= DEFAULT_ENV.call.to_sym
       db_config, owner_name = resolve_config_for_connection(config_or_env)
-      connection_handler.establish_connection(db_config, current_shard, owner_name)
+      connection_handler.establish_connection(db_config, owner_name: owner_name, shard: current_shard)
     end
 
     # Connects a model to the databases specified. The +database+ keyword
@@ -89,7 +89,7 @@ module ActiveRecord
         db_config, owner_name = resolve_config_for_connection(database_key)
         handler = lookup_connection_handler(role.to_sym)
 
-        connections << handler.establish_connection(db_config, default_shard, owner_name)
+        connections << handler.establish_connection(db_config, owner_name: owner_name, shard: default_shard)
       end
 
       shards.each do |shard, database_keys|
@@ -97,7 +97,7 @@ module ActiveRecord
           db_config, owner_name = resolve_config_for_connection(database_key)
           handler = lookup_connection_handler(role.to_sym)
 
-          connections << handler.establish_connection(db_config, shard.to_sym, owner_name)
+          connections << handler.establish_connection(db_config, owner_name: owner_name, shard: shard.to_sym)
         end
       end
 
@@ -247,16 +247,16 @@ module ActiveRecord
     end
 
     def connection_pool
-      connection_handler.retrieve_connection_pool(connection_specification_name, current_shard) || raise(ConnectionNotEstablished)
+      connection_handler.retrieve_connection_pool(connection_specification_name, shard: current_shard) || raise(ConnectionNotEstablished)
     end
 
     def retrieve_connection
-      connection_handler.retrieve_connection(connection_specification_name, current_shard)
+      connection_handler.retrieve_connection(connection_specification_name, shard: current_shard)
     end
 
     # Returns +true+ if Active Record is connected.
     def connected?
-      connection_handler.connected?(connection_specification_name, current_shard)
+      connection_handler.connected?(connection_specification_name, shard: current_shard)
     end
 
     def remove_connection(name = nil)
@@ -264,11 +264,11 @@ module ActiveRecord
       # if removing a connection that has a pool, we reset the
       # connection_specification_name so it will use the parent
       # pool.
-      if connection_handler.retrieve_connection_pool(name, current_shard)
+      if connection_handler.retrieve_connection_pool(name, shard: current_shard)
         self.connection_specification_name = nil
       end
 
-      connection_handler.remove_connection_pool(name, current_shard)
+      connection_handler.remove_connection_pool(name, shard: current_shard)
     end
 
     def clear_cache! # :nodoc:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -135,7 +135,7 @@ module ActiveRecord
 
       class_attribute :default_connection_handler, instance_writer: false
 
-      class_attribute :default_pool_key, instance_writer: false
+      class_attribute :default_shard, instance_writer: false
 
       self.filter_attributes = []
 
@@ -147,16 +147,16 @@ module ActiveRecord
         Thread.current.thread_variable_set(:ar_connection_handler, handler)
       end
 
-      def self.current_pool_key
-        Thread.current.thread_variable_get(:ar_pool_key) || default_pool_key
+      def self.current_shard
+        Thread.current.thread_variable_get(:ar_shard) || default_shard
       end
 
-      def self.current_pool_key=(pool_key)
-        Thread.current.thread_variable_set(:ar_pool_key, pool_key)
+      def self.current_shard=(shard)
+        Thread.current.thread_variable_set(:ar_shard, shard)
       end
 
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
-      self.default_pool_key = :default
+      self.default_shard = :default
     end
 
     module ClassMethods

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -31,10 +31,10 @@ module ActiveRecord
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
           @writing_handler.establish_connection(:primary)
-          @writing_handler.establish_connection(:primary, :pool_config_two)
+          @writing_handler.establish_connection(:primary, shard: :pool_config_two)
 
-          default_pool = @writing_handler.retrieve_connection_pool("primary", :default)
-          other_pool = @writing_handler.retrieve_connection_pool("primary", :pool_config_two)
+          default_pool = @writing_handler.retrieve_connection_pool("primary", shard: :default)
+          other_pool = @writing_handler.retrieve_connection_pool("primary", shard: :pool_config_two)
 
           assert_not_nil default_pool
           assert_not_equal default_pool, other_pool
@@ -59,13 +59,13 @@ module ActiveRecord
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
           @writing_handler.establish_connection(:primary)
-          @writing_handler.establish_connection(:primary, :pool_config_two)
+          @writing_handler.establish_connection(:primary, shard: :pool_config_two)
 
           # remove default
           @writing_handler.remove_connection_pool("primary")
 
           assert_nil @writing_handler.retrieve_connection_pool("primary")
-          assert_not_nil @writing_handler.retrieve_connection_pool("primary", :pool_config_two)
+          assert_not_nil @writing_handler.retrieve_connection_pool("primary", shard: :pool_config_two)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)
@@ -84,14 +84,14 @@ module ActiveRecord
           @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
 
           @writing_handler.establish_connection(:primary)
-          @writing_handler.establish_connection(:primary, :pool_config_two)
+          @writing_handler.establish_connection(:primary, shard: :pool_config_two)
 
           # connect to default
           @writing_handler.connection_pool_list.first.checkout
 
           assert @writing_handler.connected?("primary")
-          assert @writing_handler.connected?("primary", :default)
-          assert_not @writing_handler.connected?("primary", :pool_config_two)
+          assert @writing_handler.connected?("primary", shard: :default)
+          assert_not @writing_handler.connected?("primary", shard: :pool_config_two)
         ensure
           ActiveRecord::Base.configurations = @prev_configs
           ActiveRecord::Base.establish_connection(:arunit)

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -43,13 +43,13 @@ module ActiveRecord
           })
 
           base_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
-          default_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :default)
+          default_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", shard: :default)
 
           assert_equal base_pool, default_pool
           assert_equal "test/db/primary.sqlite3", default_pool.db_config.database
           assert_equal "primary", default_pool.db_config.name
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", shard: :shard_one)
           assert_equal "test/db/primary_shard_one.sqlite3", pool.db_config.database
           assert_equal "primary_shard_one", pool.db_config.name
         ensure
@@ -77,23 +77,23 @@ module ActiveRecord
             shard_one: { writing: :primary_shard_one, reading: :primary_shard_one_replica }
           })
 
-          default_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :default)
+          default_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", shard: :default)
           base_writing_pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base")
           assert_equal base_writing_pool, default_writing_pool
           assert_equal "test/db/primary.sqlite3", default_writing_pool.db_config.database
           assert_equal "primary", default_writing_pool.db_config.name
 
-          default_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", :default)
+          default_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", shard: :default)
           base_reading_pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base")
           assert_equal base_reading_pool, default_reading_pool
           assert_equal "test/db/primary.sqlite3", default_reading_pool.db_config.database
           assert_equal "primary_replica", default_reading_pool.db_config.name
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:writing].retrieve_connection_pool("ActiveRecord::Base", shard: :shard_one)
           assert_equal "test/db/primary_shard_one.sqlite3", pool.db_config.database
           assert_equal "primary_shard_one", pool.db_config.name
 
-          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", :shard_one)
+          assert_not_nil pool = ActiveRecord::Base.connection_handlers[:reading].retrieve_connection_pool("ActiveRecord::Base", shard: :shard_one)
           assert_equal "test/db/primary_shard_one.sqlite3", pool.db_config.database
           assert_equal "primary_shard_one_replica", pool.db_config.name
         ensure
@@ -233,10 +233,10 @@ module ActiveRecord
 
         def test_retrieve_connection_pool_with_invalid_shard
           assert_not_nil @rw_handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_nil @rw_handler.retrieve_connection_pool("ActiveRecord::Base", :foo)
+          assert_nil @rw_handler.retrieve_connection_pool("ActiveRecord::Base", shard: :foo)
 
           assert_not_nil @ro_handler.retrieve_connection_pool("ActiveRecord::Base")
-          assert_nil @ro_handler.retrieve_connection_pool("ActiveRecord::Base", :foo)
+          assert_nil @ro_handler.retrieve_connection_pool("ActiveRecord::Base", shard: :foo)
         end
 
         def test_calling_connected_to_on_a_non_existent_shard_raises


### PR DESCRIPTION
I have 2 commits here because this PR does 2 distinct things but they are related so I didn't want to open 2 PRs.

---

**Rename `pool_key` to `shard`**

This change renames the following:

* `current_pool_key` -> `current_shard`
* `default_pool_key` -> `default_shard`
* `pool_key` -> `shard`

Originally we had intended to name the `shard` as `pool_key` because
when we implemented the internal private API we weren't sure how it was
going to be used for sharding and wanted to implement behavior without
promising a public API. Now that we have a public API for sharding it's
better to use the same name everywhere rather than have one name for
private APIs and one name for public APIs. This should make
contributions and tracking down bugs easier in the future.

This PR doesn't require any deprecations because the sharding API is
unreleased and so is all the internal code that was using `pool_key`.

**Update connection methods to use kwargs**

This change ensures that the connection methods are using kwargs instead
of positional arguments. This change may look unnecessary but we're
working on refactoring connection management to make it more robust and
flexible so the method signatures of the methods changed here will
continue to evolve and change.

This commit does not change any released public APIs. The `shard` and
`owner_name` arguments were added in 6.1 which is not released yet.
Using kwargs will allow these methods to be more flexible and not get
super ugly as we change their underlying behavior. The kwargs let us
support multiple non-positional arguments with default.

Co authored by @seejohnrun 