### PR TITLE
Allow constructors for has_one :through

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow constructors (`build_association` and `create_association`) on
+    `has_one :through` associations.
+
+    *Santiago Perez Perret*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Add `connected_to_many` API.

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -690,11 +690,6 @@ module ActiveRecord
           Associations::HasOneAssociation
         end
       end
-
-      private
-        def calculate_constructable(macro, options)
-          !options[:through]
-        end
     end
 
     class BelongsToReflection < AssociationReflection # :nodoc:

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -49,9 +49,28 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
     assert_not_nil new_member.club
   end
 
+  def test_association_create_constructor_creates_through_record
+    new_member = Member.create(name: "Chris")
+    new_member.create_club
+    assert_not_nil new_member.current_membership
+    assert_not_nil new_member.club
+  end
+
   def test_creating_association_builds_through_record
     new_member = Member.create(name: "Chris")
     new_club = new_member.association(:club).build
+    assert new_member.current_membership
+    assert_equal new_club, new_member.club
+    assert_predicate new_club, :new_record?
+    assert_predicate new_member.current_membership, :new_record?
+    assert new_member.save
+    assert_predicate new_club, :persisted?
+    assert_predicate new_member.current_membership, :persisted?
+  end
+
+  def test_association_build_constructor_builds_through_record
+    new_member = Member.create(name: "Chris")
+    new_club = new_member.build_club
     assert new_member.current_membership
     assert_equal new_club, new_member.club
     assert_predicate new_club, :new_record?


### PR DESCRIPTION
### Summary

I couldn't find any reference to this in the guides or docs, but association constructors for `has_one :through` associations appear to be disabled. I simply enabled them and used them in the tests and nothing broke, so I'm trying to understand why they should be disabled. I would appreciate some guidance for figuring this out. Also, if there is a good reason for this, or this change is deemed unimportant or unnecessarily risky, I think the docs should be updated to reflect that `build_association` and `create_association` are not available for `has_one :through` (I'd be happy to make those changes instead if that's the case).
