### PR TITLE
Add image_processing section to upgrading guide [ci skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -182,7 +182,7 @@ The default HTTP status code used in `ActionDispatch::SSL` when redirecting non-
 
 ### Active Storage now requires Image Processing
 
-When processing variants in Active Storage, it's now required to have [image_processing gem](https://github.com/janko-m/image_processing) bundled instead of directly using `mini_magick`. Image Processing is configured by default to use `mini_magick` behind the scenes, so the easiest way to upgrade is just replacing the `mini_magick` gem for `image_processing` gem and making sure to remove the explicit usage of `combine_options` since it's no longer needed.
+When processing variants in Active Storage, it's now required to have the [image_processing gem](https://github.com/janko-m/image_processing) bundled instead of directly using `mini_magick`. Image Processing is configured by default to use `mini_magick` behind the scenes, so the easiest way to upgrade is by replacing the `mini_magick` gem for the `image_processing` gem and making sure to remove the explicit usage of `combine_options` since it's no longer needed.
 
 That said, it's recommended to change the calls to raw `resize` for `image_processing` macros as they also sharpen the thumbnail after resizing. For example, instead of:
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -180,6 +180,26 @@ Technically, however, controllers could configure `helpers_path` to point to a d
 
 The default HTTP status code used in `ActionDispatch::SSL` when redirecting non-GET/HEAD requests from HTTP to HTTPS has been changed to `308` as defined in https://tools.ietf.org/html/rfc7538.
 
+### Active Storage now requires Image Processing
+
+When processing variants in Active Storage, it's now required to have [image_processing gem](https://github.com/janko-m/image_processing) bundled instead of directly using `mini_magick`. Image Processing is configured by default to use `mini_magick` behind the scenes, so the easiest way to upgrade is just replacing the `mini_magick` gem for `image_processing` gem and making sure to remove the explicit usage of `combine_options` since it's no longer needed.
+
+That said, it's recommended to change the calls to raw `resize` for `image_processing` macros as they also sharpen the thumbnail after resizing. For example, instead of:
+
+```ruby
+video.preview(resize: "100x100")
+video.preview(resize: "100x100>")
+video.preview(resize: "100x100^")
+```
+
+you can respectively do:
+
+```ruby
+video.preview(resize_to_fit: [100, 100])
+video.preview(resize_to_limit: [100, 100])
+video.preview(resize_to_fill: [100, 100])
+```
+
 Upgrading from Rails 5.2 to Rails 6.0
 -------------------------------------
 


### PR DESCRIPTION
### Summary

We recently upgraded from MiniMagick to ImageProcessing in our app and it'd have been helpful to have an official doc confirming it's as easy as replacing a gem and a couple more of optional changes. 

I also saw this https://discuss.rubyonrails.org/t/switching-from-minimagick-to-imageprocessing/74881 so I decided to open the PR to help others.

My only doubt if this should be part of upgrading 5.2 to 6.0 or 6.0 to 6.1, since image_processing was introduced in rails 6.0 but it's deprecated for 6.1

cc @georgeclaghorn 