### PR TITLE
Fix for #40010 (WIP)

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -195,6 +195,10 @@ module Rails
           if reference? && !polymorphic?
             options[:foreign_key] = true
           end
+
+          if reference? && Rails.application.config.generators.options.dig(:activerecord, :primary_key_type) == :uuid
+            options[:type] = :uuid
+          end
         end
       end
     end


### PR DESCRIPTION
### Summary
Add a conditional to see if config option `orm(:activerecord, primary_key_type: :uuid)` is `:uuid`  
If so, adds the appropriate option to the migration. 

Fixes #40010 
