### PR TITLE
Add helper method for resetting connection handlers in tests

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1719,7 +1719,7 @@ class BasicsTest < ActiveRecord::TestCase
 
       assert_match %r/\AWrite query attempted while in readonly mode: INSERT /, conn2_error.message
     ensure
-      ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+      clean_up_connection_handler
       ActiveRecord::Base.establish_connection(:arunit)
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       end
 
       def teardown
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        clean_up_connection_handler
       end
 
       class MultiConnectionTestModel < ActiveRecord::Base
@@ -369,8 +369,6 @@ module ActiveRecord
       end
 
       def test_connection_handlers_are_per_thread_and_not_per_fiber
-        original_handlers = ActiveRecord::Base.connection_handlers
-
         ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler, reading: ActiveRecord::ConnectionAdapters::ConnectionHandler.new }
 
         reading_handler = ActiveRecord::Base.connection_handlers[:reading]
@@ -382,7 +380,7 @@ module ActiveRecord
         assert_not_equal reading, ActiveRecord::Base.connection_handler
         assert_equal reading, reading_handler
       ensure
-        ActiveRecord::Base.connection_handlers = original_handlers
+        clean_up_connection_handler
       end
 
       def test_connection_handlers_swapping_connections_in_fiber

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_pool_config_test.rb
@@ -15,7 +15,7 @@ module ActiveRecord
       end
 
       def teardown
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        clean_up_connection_handler
       end
 
       unless in_memory_db?

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -21,7 +21,7 @@ module ActiveRecord
       end
 
       def teardown
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        clean_up_connection_handler
       end
 
       unless in_memory_db?

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -12,7 +12,7 @@ module ActiveRecord
     end
 
     teardown do
-      ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+      clean_up_connection_handler
     end
 
     def test_empty_session

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1399,7 +1399,6 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
 
     def setup
       @old_handler = ActiveRecord::Base.connection_handler
-      @old_handlers = ActiveRecord::Base.connection_handlers
       @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
       db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(ENV["RAILS_ENV"], "readonly", readonly_config)
 
@@ -1413,7 +1412,7 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
     def teardown
       ActiveRecord::Base.configurations = @prev_configs
       ActiveRecord::Base.connection_handler = @old_handler
-      ActiveRecord::Base.connection_handlers = @old_handlers
+      clean_up_connection_handler
     end
 
     def test_uses_writing_connection_for_fixtures

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -149,6 +149,10 @@ def disable_extension!(extension, connection)
   connection.reconnect!
 end
 
+def clean_up_connection_handler
+  ActiveRecord::Base.connection_handlers = { ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler }
+end
+
 def load_schema
   # silence verbose schema loading
   original_stdout = $stdout

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -93,7 +93,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     mw.call({})
   ensure
-    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+    clean_up_connection_handler
   end
 
 
@@ -157,7 +157,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
       rd.close
     ensure
-      ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+      clean_up_connection_handler
     end
   end
 
@@ -607,7 +607,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     mw.call({})
   ensure
-    ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+    clean_up_connection_handler
   end
 
   test "query cache is enabled in threads with shared connection" do

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -1112,7 +1112,7 @@ module ActiveRecord
       def teardown
         SchemaMigration.delete_all
         InternalMetadata.delete_all
-        ActiveRecord::Base.connection_handlers = { writing: ActiveRecord::Base.default_connection_handler }
+        clean_up_connection_handler
       end
 
       def test_truncate_tables

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -43,7 +43,6 @@ class TestFixturesTest < ActiveRecord::TestCase
         end
       end
 
-      old_handlers = ActiveRecord::Base.connection_handlers
       old_handler = ActiveRecord::Base.connection_handler
       ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
       ActiveRecord::Base.connection_handlers = {}
@@ -53,7 +52,7 @@ class TestFixturesTest < ActiveRecord::TestCase
       assert_predicate(test_result, :passed?)
     ensure
       ActiveRecord::Base.connection_handler = old_handler
-      ActiveRecord::Base.connection_handlers = old_handlers
+      clean_up_connection_handler
       FileUtils.rm_r(tmp_dir)
     end
   end


### PR DESCRIPTION
This change makes a helper method for resetting connection handlers in
the Active Record tests. The change here is relatively small and may
seem unnecessary. The reason we're pushing this change is for upcoming
refactoring to connection management. This change will mean that we can
update one location instead of 9+ files to reset connections. It will
reduce the diff of our refactoring and make reusing this code easier in
the future.

The method name chosen is purposefully `clean_up_connection_handler`
over `clean_up_connection_handlers` because in the future there will
only be one handler.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>