### PR TITLE
Add Disabled Option to rich_text_area_tag

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -12,6 +12,7 @@ module ActionText
     #
     # ==== Options
     # * <tt>:class</tt> - Defaults to "trix-content" which ensures default styling is applied.
+    # * <tt>:disabled</tt> - If set to true, the user will not be able to use this input.
     #
     # ==== Example
     #
@@ -29,7 +30,7 @@ module ActionText
       options[:data][:blob_url_template] = main_app.rails_service_blob_url(":signed_id", ":filename")
 
       editor_tag = content_tag("trix-editor", "", options)
-      input_tag = hidden_field_tag(name, value, id: options[:input])
+      input_tag = hidden_field_tag(name, value, id: options[:input], disabled: options[:disabled])
 
       input_tag + editor_tag
     end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -53,6 +53,20 @@ class ActionText::FormHelperTest < ActionView::TestCase
       output_buffer
   end
 
+  test "form with rich text area disabled" do
+    form_with model: Message.new, scope: :message do |form|
+      form.rich_text_area :content, disabled: true
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" disabled="disabled" />' \
+        '<trix-editor disabled="disabled" id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename"></trix-editor>' \
+        "</form>",
+      output_buffer
+  end
+
+
   test "form with rich text area for non-attribute" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_text_area :not_an_attribute


### PR DESCRIPTION
Currently the disabled action has no effect when passed to `rich_text_area_tag`, which results in the value of the input being submitted with the form, perhaps unexpectedly.

This is sort of a partial solution, but I think an improvement: per https://github.com/basecamp/trix/issues/331 actually disabling the trix editor needs to be done by the user with either javascript or css, but by passing the disabled option down to the hidden input, we can at least meet the expectation that the value will not be submitted on the form when `disabled: true` is passed to `rich_text_area_tag`

