### PR TITLE
Fix missed establish_connection

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -49,7 +49,7 @@ module ActiveRecord
     def establish_connection(config_or_env = nil)
       config_or_env ||= DEFAULT_ENV.call.to_sym
       db_config, owner_name = resolve_config_for_connection(config_or_env)
-      connection_handler.establish_connection(db_config, owner_name: owner_name, shard: current_shard)
+      connection_handler.establish_connection(db_config, owner_name: owner_name)
     end
 
     # Connects a model to the databases specified. The +database+ keyword
@@ -89,7 +89,7 @@ module ActiveRecord
         db_config, owner_name = resolve_config_for_connection(database_key)
         handler = lookup_connection_handler(role.to_sym)
 
-        connections << handler.establish_connection(db_config, owner_name: owner_name, shard: default_shard)
+        connections << handler.establish_connection(db_config, owner_name: owner_name)
       end
 
       shards.each do |shard, database_keys|
@@ -154,7 +154,7 @@ module ActiveRecord
         db_config, owner_name = resolve_config_for_connection(database)
         handler = lookup_connection_handler(role)
 
-        handler.establish_connection(db_config, default_shard, owner_name)
+        handler.establish_connection(db_config, owner_name: owner_name)
 
         with_handler(role, &blk)
       elsif shard

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -217,6 +217,14 @@ module ActiveRecord
           assert_equal "`connected_to` cannot accept a `database` argument with any other arguments.", error.message
         end
 
+        def test_database_argument_is_deprecated
+          assert_deprecated do
+            ActiveRecord::Base.connected_to(database: { writing: { adapter: "sqlite3", database: "test/db/primary.sqlite3" } }) { }
+          end
+        ensure
+          ActiveRecord::Base.establish_connection(:arunit)
+        end
+
         def test_switching_connections_without_database_and_role_raises
           error = assert_raises(ArgumentError) do
             ActiveRecord::Base.connected_to { }


### PR DESCRIPTION
In `connected_to` one of the deprecated arguments wasn't well tested so
the incorrect methods signature wasn't caught by the tests.

This change updates the caller when `connected_to` uses the database
key.

I've also cleaned up a few arguments that weren't necessary. Since
the handler methods set defaults for the `shard` key, we don't need to
pass that in `establish_connection` when not using the sharding API.
