### PR TITLE
Document dbconsole command for multiple database [ci skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -395,6 +395,12 @@ With the `helper` method it is possible to access Rails and your application's h
 
 INFO: You can also use the alias "db" to invoke the dbconsole: `bin/rails db`.
 
+If you are using multiple databases, `bin/rails dbconsole` will connect to the primary database by default. You can specify which database to connect to using `--database` or `--db`:
+
+```bash
+$ bin/rails dbconsole --database=animals
+```
+
 ### `bin/rails runner`
 
 `runner` runs Ruby code in the context of Rails non-interactively. For instance:


### PR DESCRIPTION
Had a hard time finding how to connect to the secondary databases in multiple database environments. Found `--database` or `--db` is already present and can be used so went ahead and tried to document it in the docs. Let me know if that helps 😊 