### PR TITLE
fix: warning: instance variable @controller not initialized

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -199,7 +199,8 @@ module ActionDispatch
             method = :get
           end
 
-          request = ActionController::TestRequest.create @controller.class
+          controller = @controller if defined?(@controller)
+          request = ActionController::TestRequest.create controller&.class
 
           if %r{://}.match?(path)
             fail_on(URI::InvalidURIError, msg) do


### PR DESCRIPTION
Fixes #39937

### Summary

As described in the #39937, `@controller` is not always defined while testing routes, and thus the line
https://github.com/rails/rails/blob/23a9e29d9b1882e4d28530fca98b8c57b3de0410/actionpack/lib/action_dispatch/testing/assertions/routing.rb#L202
might raise `warning: instance variable @controller not initialized` in some instances.

This can be handled by checking `defined?(controller)` before accessing the instance variable.
```ruby
controller = @controller if defined?(@controller)
request = ActionController::TestRequest.create controller&.class
```

Thanks to @ioquatix for the report (and solution as well :) )