### PR TITLE
Update service metadata for updated Blobs only

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -53,7 +53,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
     self.service_name ||= self.class.service.name
   end
 
-  after_commit :update_service_metadata, if: :content_type_previously_changed?
+  after_update_commit :update_service_metadata, if: :content_type_previously_changed?
 
   before_destroy(prepend: true) do
     raise ActiveRecord::InvalidForeignKey if attachments.exists?


### PR DESCRIPTION
Follow-up to #40013.

Newly created `Blob`s may not be uploaded yet, so do not try to update their service metadata.