### PR TITLE
fix(guides): Update AWDwR book link in Releasing Rails guide [ci skip]

### DIFF
--- a/RELEASING_RAILS.md
+++ b/RELEASING_RAILS.md
@@ -21,7 +21,7 @@ https://buildkite.com/rails/rails
 
 Sam Ruby keeps a [test suite](https://github.com/rubys/awdwr) that makes
 sure the code samples in his book
-([Agile Web Development with Rails](https://pragprog.com/book/rails51/agile-web-development-with-rails-51))
+([Agile Web Development with Rails](https://pragprog.com/titles/rails6))
 all work. These are valuable system tests
 for Rails. You can check the status of these tests here:
 


### PR DESCRIPTION
### Summary
Point to the latest edition for `Rails 6`.

### Other Information
The current link responds with 404.