### PR TITLE
Fix incorrect result when eager loading with duplicated through association with join scope Part 2

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -21,19 +21,19 @@ module ActiveRecord
           super && reflection == other.reflection
         end
 
-        def join_constraints(foreign_table, foreign_klass, join_type, alias_tracker, &block)
+        def join_constraints(foreign_table, foreign_klass, join_type, alias_tracker)
           joins = []
           chain = []
 
           reflection.chain.each do |reflection|
             table, terminated = yield reflection
+            @table ||= table
 
             if terminated
               foreign_table, foreign_klass = table, reflection.klass
               break
             end
 
-            @table ||= table
             chain << [reflection, table]
           end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1072,6 +1072,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   def test_duplicated_has_many_through_with_join_scope
     Categorization.create!(author: authors(:david), post: posts(:thinking), category: categories(:technology))
 
+    expected = [categorizations(:david_welcome_general)]
+    assert_equal expected, Author.preload(:general_posts, :general_categorizations).first.general_categorizations
+    assert_equal expected, Author.eager_load(:general_posts, :general_categorizations).first.general_categorizations
+
     expected = [posts(:welcome)]
     assert_equal expected, Author.preload(:general_categorizations, :general_posts).first.general_posts
     assert_equal expected, Author.eager_load(:general_categorizations, :general_posts).first.general_posts


### PR DESCRIPTION
Follow up of #40000.

In #40000, `eager_load(:general_categorizations, :general_posts)` works,
but `eager_load(:general_posts, :general_categorizations)` doesn't work
yet.

This implements the deduplication for the case of reversed eager loading
order.
