### PR TITLE
fix(action_dispatch): Hostnames must be case insensitive

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -34,7 +34,7 @@ module ActionDispatch
           Array(hosts).map do |host|
             case host
             when Regexp then sanitize_regexp(host)
-            when String then sanitize_string(host)
+            when String then sanitize_string(host.downcase)
             else host
             end
           end


### PR DESCRIPTION
Fixes #40041

### Summary
Prior to this commit giving mixed-case in hosts
```ruby 
config.hosts << 'Example.CoM'
```
would disallow requests from `example.com`

To fix this, host is downcased before sending to sanitize_string.
This will allow `example.com` to be recognized.

### Other Information
Additional information can be found in #40041

Thanks @dmolesUC for the report