### PR TITLE
Adds a fix to whitelist hostnames with case-insensitive matching

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -46,9 +46,9 @@ module ActionDispatch
 
         def sanitize_string(host)
           if host.start_with?(".")
-            /\A(.+\.)?#{Regexp.escape(host[1..-1])}\z/
+            /\A(.+\.)?#{Regexp.escape(host[1..-1])}\z/i
           else
-            host
+            /\A#{host}\z/i
           end
         end
     end

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -42,6 +42,50 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal "Success", body
   end
 
+  test "hosts are matched case insensitive" do
+    @app = ActionDispatch::HostAuthorization.new(App, "Example.local")
+
+    get "/", env: {
+      "HOST" => "example.local",
+    }
+
+    assert_response :ok
+    assert_equal "Success", body
+  end
+
+  test "hosts are matched case insensitive with titlecased host" do
+    @app = ActionDispatch::HostAuthorization.new(App, "example.local")
+
+    get "/", env: {
+      "HOST" => "Example.local",
+    }
+
+    assert_response :ok
+    assert_equal "Success", body
+  end
+
+  test "hosts are matched case insensitive with hosts array" do
+    @app = ActionDispatch::HostAuthorization.new(App, ["Example.local"])
+
+    get "/", env: {
+      "HOST" => "example.local",
+    }
+
+    assert_response :ok
+    assert_equal "Success", body
+  end
+
+  test "regex matches are not title cased" do
+    @app = ActionDispatch::HostAuthorization.new(App, [/www.Example.local/])
+
+    get "/", env: {
+      "HOST" => "www.example.local",
+    }
+
+    assert_response :forbidden
+    assert_match "Blocked host: www.example.local", response.body
+  end
+
   test "passes requests to allowed hosts with domain name notation" do
     @app = ActionDispatch::HostAuthorization.new(App, ".example.com")
 


### PR DESCRIPTION
FIXES #40041

### Summary
This PR makes the hostnames whitelisting case-insensitive.
With this fix, following should be working.
```
config.hosts << "Example.local"
```

### Other Information
This change is being added to `string` hostnames; `regex` hostnames will strictly behave as per the regex.
Check the issue for more information #40041