### PR TITLE
Fix incorrect removal of current_shard in establish_connection

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -49,7 +49,7 @@ module ActiveRecord
     def establish_connection(config_or_env = nil)
       config_or_env ||= DEFAULT_ENV.call.to_sym
       db_config, owner_name = resolve_config_for_connection(config_or_env)
-      connection_handler.establish_connection(db_config, owner_name: owner_name)
+      connection_handler.establish_connection(db_config, owner_name: owner_name, shard: current_shard)
     end
 
     # Connects a model to the databases specified. The +database+ keyword


### PR DESCRIPTION
If we enter a `connected_to` block and call `establish_connection` like
the test added here we need to ensure that `shard: current_shard` is passed
to the handler, otherwise the connection will be established on
`default` not on `shard_one`.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>