### PR TITLE
Remove unnecessary `compact`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1027,7 +1027,7 @@ module ActiveRecord
       end
 
       def connection_pool_list
-        owner_to_pool_manager.values.compact.flat_map { |m| m.pool_configs.map(&:pool) }
+        owner_to_pool_manager.values.flat_map { |m| m.pool_configs.map(&:pool) }
       end
       alias :connection_pools :connection_pool_list
 


### PR DESCRIPTION
Looking at the history this is holdover from the pre-pool manager and
changes made by Shopify. The tests pass without it and we've had enough
changes that it doesn't appear necessary anymore.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>