### PR TITLE
Fix spelling of DigitalOcean in docs [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -151,7 +151,7 @@ and `region` keys in the example above. The S3 Service supports all of the
 authentication options described in the [AWS SDK documentation]
 (https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html).
 
-To connect to an S3-compatible object storage API such as Digital Ocean Spaces, provide the `endpoint`:
+To connect to an S3-compatible object storage API such as DigitalOcean Spaces, provide the `endpoint`:
 
 ```yaml
 digitalocean:


### PR DESCRIPTION
### Summary

Fixes the spelling of DigitalOcean (it was originally written as "Digital Ocean" in the guide, but our legal name is "DigitalOcean") in the Active Storage guide.

### Other Information

I noticed that most PRs that affect only the guides seem to have the magic `[ci-skip]` text in the PR title, so I hope that's correct for this 🙂 