### PR TITLE
Add HTTP_REFERER when following redirects on integration tests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,10 @@
 *   Fix `authenticate_with_http_basic` to allow for missing password.
+*   Add `HTTP_REFERER` when following redirects on integration tests
+
+    This makes `follow_redirect!` a closer simulation of what happens in a real browser
+
+    *Felipe Sateler*
+
 
     Before Rails 7.0 it was possible to handle basic authentication with only a username.
     

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -58,7 +58,8 @@ module ActionDispatch
       # the same HTTP verb will be used when redirecting, otherwise a GET request
       # will be performed. Any arguments are passed to the
       # underlying request.
-      def follow_redirect!(**args)
+      # The HTTP_REFERER header will be set to the previous url
+      def follow_redirect!(headers: {}, **args)
         raise "not a redirect! #{status} #{status_message}" unless redirect?
 
         method =
@@ -68,7 +69,11 @@ module ActionDispatch
             :get
           end
 
-        public_send(method, response.location, **args)
+        if [ :HTTP_REFERER, "HTTP_REFERER" ].none? { |key| headers.key? key }
+          headers["HTTP_REFERER"] = request.url
+        end
+
+        public_send(method, response.location, headers: headers, **args)
         status
       end
     end

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -354,6 +354,7 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
       assert_equal 1, request_count
 
       follow_redirect!
+      assert_equal "http://www.example.com/redirect", request.referer
       assert_response :success
       assert_equal "/get", path
 


### PR DESCRIPTION
### Summary

This changes `follow_redirect!` to set `HTTP_REFERER` on the next request, unless it was set in the `**args`.

### Other Information

This makes a closer simulation of what happens in a real browser session
