### PR TITLE
Clarify that `next` can be used to exit transaction early

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -328,7 +328,8 @@ module ActiveRecord
                   `Timeout.timeout(duration)`, pass an exception class as a second
                   argument so it doesn't use `throw` to abort its block. This results
                   in the transaction being committed, but in the next release of Rails
-                  it will rollback.
+                  it will rollback. Note that `next` can still be used to exit out
+                  of the transaction block early; the transaction will commit.
                 EOW
               end
               begin

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -185,6 +185,18 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_early_exit_from_transaction_using_next
+    assert_not_deprecated do
+      Topic.transaction do
+        @first.approved = true
+        @first.save!
+        next
+      end
+    end
+
+    assert Topic.find(1).approved?, "First should have been approved"
+  end
+
   def test_number_of_transactions_in_commit
     num = nil
 


### PR DESCRIPTION
### Summary

This clarifies that `next` could be used to exit a transaction early. This is basically a documentation change!

In my testing, the `next` only exits out of the block, so `completed` gets set to true. I included that test, but I'm happy to remove it if it isn't helpful

Hope this helps!


### Other Information

* https://github.com/rails/rails/pull/29333
* https://github.com/rails/rails/pull/39453

I recently wrote a transaction block that always marked the record as completed, but only conditionally wrote some more data after that write. So the fix in #39453 wouldn't have affected this case