### PR TITLE
Use deep_symbolize_keys instead of symbolize_names

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -244,7 +244,7 @@ module Rails
 
       if yaml.exist?
         require "erb"
-        all_configs    = ActiveSupport::ConfigurationFile.parse(yaml, symbolize_names: true)
+        all_configs    = ActiveSupport::ConfigurationFile.parse(yaml).deep_symbolize_keys
         config, shared = all_configs[env.to_sym], all_configs[:shared]
 
         if config.is_a?(Hash)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2080,6 +2080,19 @@ module ApplicationTests
       assert_equal "unicorn", Rails.application.config.my_custom_config[:key]
     end
 
+    test "config_for handles YAML patches (like safe_yaml) that disable the symbolize_names option" do
+      app_file "config/custom.yml", <<~RUBY
+        development:
+          key: value
+      RUBY
+
+      app "development"
+
+      YAML.stub :load, { "development" => { "key" => "value" } } do
+        assert_equal({ key: "value" }, Rails.application.config_for(:custom))
+      end
+    end
+
     test "api_only is false by default" do
       app "development"
       assert_not Rails.application.config.api_only


### PR DESCRIPTION
Fixes #40031

While removing deprecated non-symbol access to nested `config_for`
hashes in #37876, we also broke `config_for` for anyone using the
[safe_yaml] gem. The problem is that `safe_yaml` patches `YAML.load` in
a way that doesn't honor the `symbolize_names` options (I believe this
is on purpose, to prevent symbol-based DOS attacks).

In the description of #37876 there is mention of the fact that this was
the first place in Rails we used `symbolize_names`, and that
`deep_symbolize_keys` had been used in the past.

This commit switches over to `deep_symbolize_keys` to allow `config_for`
to continue working for people using [safe_yaml].

[safe_yaml]: https://rubygems.org/gems/safe_yaml