### PR TITLE
Allow subscribing with a single argument callable

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -91,13 +91,13 @@ module ActiveSupport
           if listener.respond_to?(:start) && listener.respond_to?(:finish)
             subscriber_class = Evented
           else
-            # Doing all this to detect a block like `proc { |x| }` vs
-            # `proc { |*x| }` or `proc { |**x| }`
-            if listener.respond_to?(:parameters)
-              params = listener.parameters
-              if params.length == 1 && params.first.first == :opt
-                subscriber_class = EventObject
-              end
+            # Doing this to detect a single argument block or callable
+            # like `proc { |x| }` vs `proc { |*x| }`, `proc { |**x| }`,
+            # or `proc { |x, **y| }`
+            procish = listener.respond_to?(:parameters) ? listener : listener.method(:call)
+
+            if procish.arity == 1 && procish.parameters.length == 1
+              subscriber_class = EventObject
             end
           end
 

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -80,6 +80,32 @@ module Notifications
     ensure
       ActiveSupport::Notifications.notifier = old_notifier
     end
+
+    def test_subscribe_with_a_single_arity_lambda_listener
+      event_name = nil
+      listener = ->(event) do
+        event_name = event.name
+      end
+
+      @notifier.subscribe(&listener)
+      ActiveSupport::Notifications.instrument("event_name")
+
+      assert_equal "event_name", event_name
+    end
+
+    def test_subscribe_with_a_single_arity_callable_listener
+      event_name = nil
+      listener = Class.new do
+        define_method :call do |event|
+          event_name = event.name
+        end
+      end
+
+      @notifier.subscribe(nil, listener.new)
+      ActiveSupport::Notifications.instrument("event_name")
+
+      assert_equal "event_name", event_name
+    end
   end
 
   class TimedAndMonotonicTimedSubscriberTest < TestCase


### PR DESCRIPTION
Fixes #39976

Prior to this commit it was possible to pass a single argument block to
`ActiveSupport::Notifications.subscribe`, rather than 5 separate
arguments:

```rb
ActiveSupport::Notifications.subscribe('some_event') do |event|
  puts "Reacting to #{event.name}"
end
```

But it was not possible to do the same with a lambda, since the lambda
parameter is a required (`:req`) parameter, but we were checking only
for an optional (`:opt`) parameter.

```rb
listener = ->(event) do
  puts "Reacting to #{event.name}"
end

ActiveSupport::Notifications.subscribe('some_event', &listener)
```

It was also not possible to do this with a custom callable object, since
the custom callable does not respond directly to `:parameters` (although
it's `:call` method object does).

```rb
class CustomListener
  def call(event)
    puts "Reacting to #{event.name}"
  end
end

ActiveSupport::Notifications.subscribe('some_event', CustomListener.new)
```

Prior to this commit these examples would have raised `ArgumentError:
wrong number of arguments (given 5, expected 1)`.

With this commit the single argument lambda and custom callable work
like the single argument block.