### PR TITLE
Add `db_runtime` to Active Job instrumentation

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `perform.active_job` notification payloads now include `:db_runtime`, which
+    is the total time (in ms) taken by database queries while performing a job.
+    This value can be used to better understand how a job's time is spent.
+
+    *Jonathan Hefner*
+
 *   Update `ActiveJob::QueueAdapters::QueAdapter` te remove deprecation warning
 
     Remove a deprecation warning introduced in que 1.2 to prepare for changes in

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -276,11 +276,16 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
-    # Expose database runtime to controller for logging.
+    # Expose database runtime for logging.
     initializer "active_record.log_runtime" do
       require "active_record/railties/controller_runtime"
       ActiveSupport.on_load(:action_controller) do
         include ActiveRecord::Railties::ControllerRuntime
+      end
+
+      require "active_record/railties/job_runtime"
+      ActiveSupport.on_load(:active_job) do
+        include ActiveRecord::Railties::JobRuntime
       end
     end
 

--- a/activerecord/lib/active_record/railties/job_runtime.rb
+++ b/activerecord/lib/active_record/railties/job_runtime.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_record/log_subscriber"
+
+module ActiveRecord
+  module Railties # :nodoc:
+    module JobRuntime # :nodoc:
+      private
+        def instrument(operation, payload = {}, &block)
+          if operation == :perform && block
+            super(operation, payload) do
+              db_runtime_before_perform = ActiveRecord::LogSubscriber.runtime
+              result = block.call
+              payload[:db_runtime] = ActiveRecord::LogSubscriber.runtime - db_runtime_before_perform
+              result
+            end
+          else
+            super
+          end
+        end
+    end
+  end
+end

--- a/activerecord/test/activejob/job_runtime_test.rb
+++ b/activerecord/test/activejob/job_runtime_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "activejob/helper"
+require "active_record/railties/job_runtime"
+
+class JobRuntimeTest < ActiveSupport::TestCase
+  class TestJob < ActiveJob::Base
+    include ActiveRecord::Railties::JobRuntime
+
+    def perform(*)
+      ActiveRecord::LogSubscriber.runtime += 42
+    end
+  end
+
+  test "job notification payload includes db_runtime" do
+    ActiveRecord::LogSubscriber.runtime = 0
+
+    assert_equal 42, notification_payload[:db_runtime]
+  end
+
+  test "db_runtime tracks database runtime for job only" do
+    ActiveRecord::LogSubscriber.runtime = 100
+
+    assert_equal 42, notification_payload[:db_runtime]
+    assert_equal 142, ActiveRecord::LogSubscriber.runtime
+  end
+
+  private
+    def notification_payload
+      payload = nil
+      subscriber = ActiveSupport::Notifications.subscribe("perform.active_job") do |*, _payload|
+        payload = _payload
+      end
+
+      TestJob.perform_now
+
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+
+      payload
+    end
+end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -540,10 +540,11 @@ INFO. Cache stores may add their own keys
 
 #### perform.active_job
 
-| Key          | Value                                  |
-| ------------ | -------------------------------------- |
-| `:adapter`   | QueueAdapter object processing the job |
-| `:job`       | Job object                             |
+| Key           | Value                                         |
+| ------------- | --------------------------------------------- |
+| `:adapter`    | QueueAdapter object processing the job        |
+| `:job`        | Job object                                    |
+| `:db_runtime` | Amount spent executing database queries in ms |
 
 #### retry_stopped.active_job
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2774,7 +2774,7 @@ Below is a comprehensive list of all the initializers found in Rails in the orde
 
 * `active_record.initialize_database`: Loads the database configuration (by default) from `config/database.yml` and establishes a connection for the current environment.
 
-* `active_record.log_runtime`: Includes `ActiveRecord::Railties::ControllerRuntime` which is responsible for reporting the time taken by Active Record calls for the request back to the logger.
+* `active_record.log_runtime`: Includes `ActiveRecord::Railties::ControllerRuntime` and `ActiveRecord::Railties::JobRuntime` which are responsible for reporting the time taken by Active Record calls for the request back to the logger.
 
 * `active_record.set_reloader_hooks`: Resets all reloadable connections to the database if `config.enable_reloading` is set to `true`.
 


### PR DESCRIPTION
This adds `db_runtime` to the notification payload of a `"perform.active_job"` event.  `db_runtime` tracks the total time taken by database queries while performing a job, which helps in understanding how a job's time is spent.  This is similar to what is done for controller actions in `ActiveRecord::Railties::ControllerRuntime`.

Closes #35354.

---

/cc @gwincr11  I added you as a co-author since you began investigating this in #35354.
/cc @jeremy  Since you expressed interest in this in https://github.com/rails/rails/pull/35354#issuecomment-607347998.
