### PR TITLE
Update outdated bundler in gemspec

### DIFF
--- a/rails.gemspec
+++ b/rails.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |s|
   s.add_dependency "actiontext",    version
   s.add_dependency "railties",      version
 
-  s.add_dependency "bundler",         ">= 1.3.0"
+  s.add_dependency "bundler",         ">= 1.15.0"
   s.add_dependency "sprockets-rails", ">= 2.0.0"
 end


### PR DESCRIPTION
### Summary

The bundler version specified in the gemspec is quite outdated and doesn't work with Ruby 2.5 and Rails 6.x due to a bug that's only fixed in bundler 1.15.0.pre.3.

### Other Information

Currently, `rails.gemspec` adds the dependency bundler `>= 1.3.0`. However, a new Rails 6.0.3 application generates a `Gemfile` that uses `git_source` that was only introduced in bundler 1.6. See:

https://github.com/rails/rails/blob/49348a95ad0c501688d83295565a3807ec05a6e2/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L1-L2

I generated a new Rails app in the following environment to verify if bundler 1.6 works with the rails 6.0:

```
Ruby 2.5.5
Rubygems 2.7.6.2
Bundler 1.6.9
Rails 6.0.3.2
```

The Rails app is generated, `bundle install` works, and even the javascript packages are installed successfully. However, there's a step in the generation process that fails:

```bash
$ bundle exec spring binstub --all
Traceback (most recent call last):
    20: from /Users/mikong/.rbenv/versions/2.5.5/bin/spring:23:in `<main>'
    19: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems.rb:304:in `activate_bin_path'
    18: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems.rb:304:in `synchronize'
    17: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems.rb:306:in `block in activate_bin_path'
    16: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems.rb:243:in `finish_resolve'
    15: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/request_set.rb:397:in `resolve_current'
    14: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/request_set.rb:385:in `resolve'
    13: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:188:in `resolve'
    12: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolver.rb:42:in `resolve'
    11: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:64:in `resolve'
    10: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:106:in `start_resolution'
     9: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/resolution.rb:165:in `initial_state'
     8: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:51:in `sort_dependencies'
     7: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:69:in `with_no_such_dependency_error_handling'
     6: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver/molinillo/lib/molinillo/delegates/specification_provider.rb:52:in `block in sort_dependencies'
     5: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:277:in `sort_dependencies'
     4: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:277:in `with_index'
     3: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:277:in `sort_by'
     2: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:277:in `each'
     1: from /Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:283:in `block in sort_dependencies'
/Users/mikong/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/resolver.rb:231:in `search_for': Unable to resolve dependency: user requested 'did_you_mean (= 1.2.0)' (Gem::UnsatisfiableDependencyError)
```

This bundler issue is described in the following rubygems Github issues:

* rubygems/rubygems#1911
* rubygems/rubygems#1915

As mentioned in the comments section of the above issues, the bug is fixed in 1.15.0.pre.3. Specifically in the PR rubygems/bundler#5637 that describes the issue in more detail.

Given this, the `rails.gemspec` should require bundler `>= 1.15.0` to avoid this problem where `finish_resolve` incorrectly raises gem incompatibility exceptions.
