### PR TITLE
Fix generated default index names in API doc [ci skip]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -722,7 +722,7 @@ module ActiveRecord
       #
       # generates:
       #
-      #   CREATE INDEX suppliers_name_index ON suppliers(name)
+      #   CREATE INDEX index_suppliers_on_name ON suppliers(name)
       #
       # ====== Creating a index which already exists
       #
@@ -730,7 +730,7 @@ module ActiveRecord
       #
       # generates:
       #
-      #   CREATE INDEX IF NOT EXISTS suppliers_name_index ON suppliers(name)
+      #   CREATE INDEX IF NOT EXISTS index_suppliers_on_name ON suppliers(name)
       #
       # Note: Not supported by MySQL.
       #
@@ -740,7 +740,7 @@ module ActiveRecord
       #
       # generates:
       #
-      #   CREATE UNIQUE INDEX accounts_branch_id_party_id_index ON accounts(branch_id, party_id)
+      #   CREATE UNIQUE INDEX index_accounts_on_branch_id_and_party_id ON accounts(branch_id, party_id)
       #
       # ====== Creating a named index
       #
@@ -770,7 +770,7 @@ module ActiveRecord
       #
       # ====== Creating an index with a sort order (desc or asc, asc is the default)
       #
-      #   add_index(:accounts, [:branch_id, :party_id, :surname], order: {branch_id: :desc, party_id: :asc})
+      #   add_index(:accounts, [:branch_id, :party_id, :surname], name: 'by_branch_desc_party', order: {branch_id: :desc, party_id: :asc})
       #
       # generates:
       #


### PR DESCRIPTION
### Summary

In the `ActiveRecord::ConnectionAdapters::SchemaStatements#add_index` API documentation, the generated SQL statements have incorrect default index names in some of the examples.

### Other Information

The default index name has the format:

```
index_<TABLE>_on_<COL1>_and_<COL2>
```

This is already reflected in the other examples in the `add_index` API doc. This PR simply updates the remaining SQL statements that don't reflect this format. I have verified this default index name format in a test Rails application with the following environment details:

```
Rails 6.0.3.2
Ruby 2.5.5
PostgreSQL 11.5
```

Some of the examples have provided a `name` option to `add_index` and therefore do not have this default index name format. Notably, the last SQL statement that this PR fixes under the section **Creating an index with a sort order (desc or asc, asc is the default)** has the index name `by_branch_desc_party` which suggests that a `name` option was passed, but if we look at the Ruby code, a `name` option was not provided:

```ruby
add_index(:accounts, [:branch_id, :party_id, :surname], order: {branch_id: :desc, party_id: :asc})
```

I fixed the SQL statement to have the default index name `index_accounts_on_branch_id_and_party_id_and_surname`. An alternative fix which I didn't do would be to update the `add_index` code to have a `name` option passed with the value `by_branch_desc_party` and in that case we would keep the same index name in the SQL statement. Please let me know if this alternative is preferred.
