### PR TITLE
update Engine getting started generation instructions for consistency

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -465,7 +465,7 @@ commenting functionality as well. To do this, you'll need to generate a comment
 model, a comment controller, and then modify the articles scaffold to display
 comments and allow people to create new ones.
 
-From the application root, run the model generator. Tell it to generate a
+From the engine root, run the model generator. Tell it to generate a
 `Comment` model, with the related table having two columns: an `article_id` integer
 and `text` text column.
 
@@ -561,7 +561,7 @@ end
 This creates a nested route for the comments, which is what the form requires.
 
 The route now exists, but the controller that this route goes to does not. To
-create it, run this command from the application root:
+create it, run this command from the engine root:
 
 ```bash
 $ bin/rails generate controller comments


### PR DESCRIPTION
### Summary

New to Rails but looks like everything for an engine should be done inside the engine's folder. The updated text has been there for a long time so I hope I'm not just missing something. At this point in the example the user does not have an application (that comes in the next section) and elsewhere in the doc there is talk of the importance of running the commands from the *engine* root so it seems more consistent to talk about "engine root" as updated.

