### PR TITLE
Format the multiple database error to ignore default from the AdapterNotSpecified error message

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -205,12 +205,14 @@ module ActiveRecord
 
         configs.group_by(&:env_name).map do |env, config|
           names = config.map(&:name)
+          next if env == "default"
+
           if names.size > 1
             "#{env}: #{names.join(", ")}"
           else
             env
           end
-        end.join("\n")
+        end.compact.join("\n")
       end
 
       def build_db_config_from_raw_config(env_name, name, config)


### PR DESCRIPTION
**Maybe this is a cosmetic change. Please feel free to close it.**

An error is thrown in multiple databases application when a primary configurations are not added. 

**Before:** 
```
ActiveRecord::AdapterNotSpecified (The `primary` database is not configured for the `development` environment.

  Available databases configurations are:

  default
development: animals, animals_replica
test
production
):
```

**After:**
```
ActiveRecord::AdapterNotSpecified (The `primary` database is not configured for the `development` environment.

  Available databases configurations are:

  development: animals, animals_replica
test
production
)
```