### PR TITLE
Adds role types accessor for delegated types

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -147,6 +147,7 @@ module ActiveRecord
     #
     #   Entry#entryable_class # => +Message+ or +Comment+
     #   Entry#entryable_name  # => "message" or "comment"
+    #   Entry#entryable_types # => ["Message", "Comment"]
     #   Entry.messages        # => Entry.where(entryable_type: "Message")
     #   Entry#message?        # => true when entryable_type == "Message"
     #   Entry#message         # => returns the message record, when entryable_type == "Message", otherwise nil
@@ -176,6 +177,10 @@ module ActiveRecord
       def define_delegated_type_methods(role, types:)
         role_type = "#{role}_type"
         role_id   = "#{role}_id"
+
+        define_singleton_method "#{role}_types" do
+          types
+        end
 
         define_method "#{role}_class" do
           public_send("#{role}_type").constantize

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -18,6 +18,10 @@ class DelegatedTypeTest < ActiveRecord::TestCase
     assert_equal Comment, @entry_with_comment.entryable_class
   end
 
+  test "role types" do
+    assert_equal ["Message", "Comment"].sort, Entry.entryable_types.sort
+  end
+
   test "delegated type name" do
     assert_equal "message", @entry_with_message.entryable_name
     assert @entry_with_message.entryable_name.message?


### PR DESCRIPTION
### Summary

Adds access to the role types of a class that is using delegated types. #39341

```rb
class Entry < ApplicationRecord
  delegated_type :entryable, types: %w[ Message Comment ]
end

Entry.entryable_types #=> ["Message", "Comment"]
```

For example, in a concern, you might want to add some dynamic method's based on the names of the possible types:

```rb
module Entryable
  extend ActiveSupport::Concern

  included do
    has_one :entry, as: :entryable, touch: true

    Entry.entryable_types.each do |type|
      scope = type.downcase.pluralize # ["messages", "comments"]

      define_method "similar_#{scope}" do
        # some custom logic
      end
    end
  end
end
```