### PR TITLE
Bump minimum web-console version to 4.0.3

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -49,7 +49,7 @@ group :development do
   <%- if options.dev? || options.edge? || options.master? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
-  gem 'web-console', '>= 3.3.0'
+  gem 'web-console', '>= 4.0.3'
   <%- end -%>
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -784,7 +784,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console', '>= 3\.3\.0'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 4\.0\.3'\z/, content)
     end
   end
 
@@ -793,7 +793,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console', '>= 3\.3\.0'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 4\.0\.3'\z/, content)
     end
   end
 
@@ -802,7 +802,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console', '>= 3\.3\.0'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 4\.0\.3'\z/, content)
     end
   end
 


### PR DESCRIPTION
### Summary

Following up on https://github.com/rails/rails/issues/33677 this PR updates the minimum version of [web-console to 4.0.3](https://github.com/rails/web-console/blob/master/CHANGELOG.markdown#403) which deprecates the usage of `whitelisted_ips`, indicating the usage of [`permissions` or `allowed_ips`](https://github.com/rails/web-console#configweb_consolepermissions) for it.

Also related to https://github.com/rails/rails/pull/39591
