### PR TITLE
Add supports_advisory_locks detection for Strict SQL Mode in abstract_mysql_adapter.rb

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -126,6 +126,10 @@ module ActiveRecord
       end
 
       def supports_advisory_locks?
+        suppress(ActiveRecord::StatementInvalid) do
+          return false if ActiveRecord::Base.connection.query("SELECT @@SESSION.sql_mode;").first.first.split(",").include?("STRICT_TRANS_TABLES")
+          return false if ActiveRecord::Base.connection.query("SELECT @@SESSION.sql_mode;").first.first.split(",").include?("STRICT_ALL_TABLES")
+        end
         true
       end
 


### PR DESCRIPTION
### Summary

A mode where at least one of STRICT_TRANS_TABLES or STRICT_ALL_TABLES is enabled is called strict mode[1],[2]. Running migrations will fail in this mode, so we need to adjust the adapter to behave accordingly. This is implementing the fix proposed in issue #28666.

[1]: https://mariadb.com/kb/en/sql-mode/#strict-mode
[2]: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sql-mode-strict

### Other Information

This is set by default from MariaDB 10.2.4, especially needed when running in a clustered environment ([Percona XtraDB Cluster](https://www.percona.com/software/mysql-database/percona-xtradb-cluster)).