### PR TITLE
Backport #38254 to 6-0-stable

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -16,7 +16,7 @@ module ActiveSupport
       attr_reader :cache_path
 
       DIR_FORMATTER = "%03X"
-      FILENAME_MAX_SIZE = 228 # max filename size on file system is 255, minus room for timestamp and random characters appended by Tempfile (used by atomic write)
+      FILENAME_MAX_SIZE = 226 # max filename size on file system is 255, minus room for timestamp, pid, and random characters appended by Tempfile (used by atomic write)
       FILEPATH_MAX_SIZE = 900 # max is 1024, plus some room
       GITKEEP_FILES = [".gitkeep", ".keep"].freeze
 


### PR DESCRIPTION
This backports #38254 to `6-0-stable`, since it is a simple fix for a potentially flakey bug on Linux.

Closes #40082.