### PR TITLE
consistent syntax for items in list

### DIFF
--- a/guides/source/autoloading_and_reloading_constants_classic_mode.md
+++ b/guides/source/autoloading_and_reloading_constants_classic_mode.md
@@ -8,9 +8,9 @@ This guide documents how constant autoloading and reloading works in `classic` m
 After reading this guide, you will know:
 
 * Key aspects of Ruby constants
-* What are the `autoload_paths` and how does eager loading work in production?
+* What the `autoload_paths` are and how eager loading works in production
 * How constant autoloading works
-* What is `require_dependency`
+* What `require_dependency` is
 * How constant reloading works
 * Solutions to common autoloading gotchas
 


### PR DESCRIPTION
The majority of items in this list are clauses that complete the sentence "...you will know...".  But the 2nd item was an independent question with its own question mark, and the other changed one had the syntax of a question despite lacking a question mark.

### Summary

There are no code changes here, just correcting grammar in the documentation.

### Other Information

The differences between the syntax of questions and the syntax of dependent clauses in English can be a little confusing to non-native speakers. If you would like me to, I can submit a subsequent pull request to switch to a format that may be easier for non-natives to understand, and just as clear to native speakers.  But for now, this PR will make the grammar consistent.

