### PR TITLE
Corrects the documentation for AciveSupport::Configurable config class [ci skip]

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -5,7 +5,7 @@ require "active_support/ordered_options"
 
 module ActiveSupport
   # Configurable provides a <tt>config</tt> method to store and retrieve
-  # configuration options as an <tt>OrderedHash</tt>.
+  # configuration options as an <tt>OrderedOptions</tt>.
   module Configurable
     extend ActiveSupport::Concern
 
@@ -124,7 +124,7 @@ module ActiveSupport
       private :config_accessor
     end
 
-    # Reads and writes attributes from a configuration <tt>OrderedHash</tt>.
+    # Reads and writes attributes from a configuration <tt>OrderedOptions</tt>.
     #
     #   require "active_support/configurable"
     #


### PR DESCRIPTION
### Summary

This PR corrects the class name in the documentation for `AciveSupport::Configurable`. 
`AciveSupport::Configurable::Configuration` inherits from `ActiveSupport::InheritableOptions` which is `OrderedOptions`.
Other Note: `OrderedHash` has been deprecated.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
