### PR TITLE
fix(guides): Add maintenance policy link in contributing guides [ci skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -677,6 +677,8 @@ $ git checkout 4-0-stable
 
 TIP: You may want to [put your Git branch name in your shell prompt](http://qugstart.com/blog/git-and-svn/add-colored-git-branch-name-to-your-shell-prompt/) to make it easier to remember which version of the code you're working with.
 
+NOTE: Before working on older versions, please check the [maintenance policy](maintenance_policy.html).
+
 #### Backporting
 
 Changes that are merged into master are intended for the next major release of Rails. Sometimes, it might be beneficial for your changes to propagate back to the maintenance releases for older stable branches. Generally, security fixes and bug fixes are good candidates for a backport, while new features and patches that introduce a change in behavior will not be accepted. When in doubt, it is best to consult a Rails team member before backporting your changes to avoid wasted effort.


### PR DESCRIPTION
Related to #40063 

Linking contribution guide to maintenance policy can help contributors to make sure that the issue/PR being created against a rails version complies with the maintenance policy.

This PR can be expanded to explore similar issues where a user might stumble upon an unsupported version of rails and might create issue/PR that does not complies with the maintenance policy.
Knowing what could be an acceptable issue report or PR for this repository will help contributors avoid unnecessary reporting time and help maintainers with their time and review cost.
This has been done quite a few places but we still see issues for unsupported version of rails being reported.
This PR explores if such unacceptable issue reporting can be reduced. 

There are some suggestions [here](https://github.com/rails/rails/issues/40063#issuecomment-675265765) that can be explored in this regard.

EDIT: Copying here to save a roundtrip
>But this issue has raised a good concern when someone stumbles upon an outdated versions of guides.
I think we can add a warning banner on all those version pages that the community has stopped maintaining.
_Some documentation sites does (take [django](https://docs.djangoproject.com/en/2.0/) for example) that._

>We can add this warning in _issue template_ **or** in _documentation_ **or** _[CONTRIBUTING](https://github.com/rails/rails/blob/bdfffd1355bbff4df29d59fc479b72027160950a/CONTRIBUTING.md) guide_ **or** _contributing to fixes for older versions in [guides](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#older-versions-of-ruby-on-rails)_ **or** maintain a _new file_ (*maintenance policy) that clearly define what changes for which version are accepted (like `5.2` is now limited to security fixes AFAIK but there are issues/PR created that reports bug fixes)

Adding the same document link under [creating-a-bug-report](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report) might get redundant but could be useful here as well. Thoughts?

## **Before**
![](https://user-images.githubusercontent.com/16557539/90960744-73bfeb80-e4c1-11ea-9ad4-eb424b22b5b2.png)
## **After**
![](https://user-images.githubusercontent.com/16557539/90960752-791d3600-e4c1-11ea-94cc-af621b2e8105.png)
