### PR TITLE
Implement #inspect for ActiveSupport::OrderedOptions

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -62,6 +62,10 @@ module ActiveSupport
     def extractable_options?
       true
     end
+
+    def inspect
+      "#<#{self.class.name} #{self}>"
+    end
   end
 
   # +InheritableOptions+ provides a constructor to build an +OrderedOptions+

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -115,4 +115,14 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     end
     assert_raises(KeyError) { a.non_existing_key! }
   end
+
+  def test_inspect
+    a = ActiveSupport::OrderedOptions.new
+    assert_equal "#<ActiveSupport::OrderedOptions {}>", a.inspect
+
+    a.foo   = :bar
+    a[:baz] = :quz
+
+    assert_equal "#<ActiveSupport::OrderedOptions {:foo=>:bar, :baz=>:quz}>", a.inspect
+  end
 end


### PR DESCRIPTION
### Summary
This PR adds `#inspect` method to `ActiveSupport::OrderedOptions`. Previously inspect call on instance of `ActiveSupport::OrderedOptions` was returning `"{}"` which is unhelpful. 

#### Before 
```ruby
instance = ActiveSupport::OrderedOptions.new
instance.inspect #=> "{}"
```

#### After 
```ruby
instance = ActiveSupport::OrderedOptions.new
instance.foo   = :bar
instance[:baz] = :quz
instance.inspect #=> "#<ActiveSupport::OrderedOptions {:foo=>:bar, :baz=>:quz}>"
``` 
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
