### PR TITLE
don't add preload headers for deferred scripts and add nopush

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -87,10 +87,15 @@ module ActionView
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
         preload_links = []
+        nopush = options["nopush"].nil? ? true : options.delete("nopush")
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
-          preload_links << "<#{href}>; rel=preload; as=script; nopush" unless options["defer"]
+          unless options["defer"]
+            preload_link = "<#{href}>; rel=preload; as=script"
+            preload_link += "; nopush" if nopush
+            preload_links << preload_link
+          end
           tag_options = {
             "src" => href
           }.merge!(options)
@@ -137,10 +142,13 @@ module ActionView
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "host", "skip_pipeline").symbolize_keys
         preload_links = []
+        nopush = options["nopush"].nil? ? true : options.delete("nopush")
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
-          preload_links << "<#{href}>; rel=preload; as=style; nopush"
+          preload_link = "<#{href}>; rel=preload; as=style"
+          preload_link += "; nopush" if nopush
+          preload_links << preload_link
           tag_options = {
             "rel" => "stylesheet",
             "media" => "screen",

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -90,7 +90,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
-          preload_links << "<#{href}>; rel=preload; as=script"
+          preload_links << "<#{href}>; rel=preload; as=script; nopush" unless options["defer"]
           tag_options = {
             "src" => href
           }.merge!(options)
@@ -140,7 +140,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
-          preload_links << "<#{href}>; rel=preload; as=style"
+          preload_links << "<#{href}>; rel=preload; as=style; nopush"
           tag_options = {
             "rel" => "stylesheet",
             "media" => "screen",

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -522,6 +522,13 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal "", @response.headers["Link"]
   end
 
+  def test_should_allow_caller_to_remove_nopush
+    stylesheet_link_tag("http://example.com/style.css", nopush: false)
+    javascript_include_tag("http://example.com/all.js", nopush: false)
+    expected = "<http://example.com/style.css>; rel=preload; as=style,<http://example.com/all.js>; rel=preload; as=script"
+    assert_equal expected, @response.headers["Link"]
+  end
+
   def test_image_path
     ImagePathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -513,8 +513,13 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_should_set_preload_links
     stylesheet_link_tag("http://example.com/style.css")
     javascript_include_tag("http://example.com/all.js")
-    expected = "<http://example.com/style.css>; rel=preload; as=style,<http://example.com/all.js>; rel=preload; as=script"
+    expected = "<http://example.com/style.css>; rel=preload; as=style; nopush,<http://example.com/all.js>; rel=preload; as=script; nopush"
     assert_equal expected, @response.headers["Link"]
+  end
+
+  def test_should_not_preload_links_with_defer
+    javascript_include_tag("http://example.com/all.js", defer: true)
+    assert_equal "", @response.headers["Link"]
   end
 
   def test_image_path


### PR DESCRIPTION
### Summary

deployed the latest rails/master and noticed all my assets were getting server pushed! 

- rails should ensure assets don't get pushed, this is a bad practice https://youtu.be/sgjxuhFQktE?t=2962

- defer is used to give scripts a low network priority https://addyosmani.com/blog/script-priorities/. Rails shouldn't add link headers for deferred scripts, this goes against what the user is trying to accomplish with defer.

More information from this comment in the PR that introduced this functionality: https://github.com/rails/rails/pull/39939#issuecomment-677710179

cc @casperisfine @eileencodes
