### PR TITLE
Add `#destroy_by` into trigger callbacks methods [skip ci]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -211,6 +211,7 @@ The following methods trigger callbacks:
 * `destroy`
 * `destroy!`
 * `destroy_all`
+* `destroy_by`
 * `save`
 * `save!`
 * `save(validate: false)`


### PR DESCRIPTION
### Summary
This is a small modification of the guide.
`#destroy_by` triggers the callback. but, I added it because it was not in the list of target methods in the guide.

Ref: https://edgeguides.rubyonrails.org/active_record_callbacks.html#running-callbacks
