### PR TITLE
Add `#delete_by` into skipping callback methods [skip ci]

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -246,6 +246,7 @@ Just as with validations, it is also possible to skip callbacks by using the fol
 * `decrement_counter`
 * `delete`
 * `delete_all`
+* `delete_by`
 * `increment!`
 * `increment_counter`
 * `insert`


### PR DESCRIPTION
### Summary
This is a small modification of the guide.
`#delete_by` skip the callback. but, I added it because it was not in the list of target methods in the guide.

Ref: https://edgeguides.rubyonrails.org/active_record_callbacks.html#skipping-callbacks
