### PR TITLE
Demonstrate how to use Relation#merge in Join Table conditions  [ci skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1243,7 +1243,7 @@ You can specify conditions on the joined tables using the regular [Array](#array
 
 ```ruby
 time_range = (Time.now.midnight - 1.day)..Time.now.midnight
-Customer.joins(:orders).where('orders.created_at' => time_range)
+Customer.joins(:orders).where('orders.created_at' => time_range).distinct
 ```
 
 This will find all customers who have orders that were created yesterday, using a `BETWEEN` SQL expression to compare `created_at`.
@@ -1252,7 +1252,26 @@ An alternative and cleaner syntax is to nest the hash conditions:
 
 ```ruby
 time_range = (Time.now.midnight - 1.day)..Time.now.midnight
-Customer.joins(:orders).where(orders: { created_at: time_range })
+Customer.joins(:orders).where(orders: { created_at: time_range }).distinct
+```
+
+For more advanced conditions or to reuse an existing named scope, `Relation#merge` may be used.  First, let's add a new named scope to the Order model:
+
+```ruby
+class Order < ApplicationRecord
+  belongs_to :customer
+
+  scope :created_in_time_range, ->(time_range) {
+    where(created_at: time_range)
+  }
+end
+```
+
+Now we can use `Relation#merge`:
+
+```ruby
+time_range = (Time.now.midnight - 1.day)..Time.now.midnight
+Customer.joins(:orders).merge(Order.created_in_time_range(time_range)).distinct
 ```
 
 This will find all customers who have orders that were created yesterday, again using a `BETWEEN` SQL expression.

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1267,7 +1267,7 @@ class Order < ApplicationRecord
 end
 ```
 
-Now we can use `Relation#merge`:
+Now we can use `Relation#merge` to merge in the `created_in_time_range` scope:
 
 ```ruby
 time_range = (Time.now.midnight - 1.day)..Time.now.midnight

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1255,7 +1255,7 @@ time_range = (Time.now.midnight - 1.day)..Time.now.midnight
 Customer.joins(:orders).where(orders: { created_at: time_range }).distinct
 ```
 
-For more advanced conditions or to reuse an existing named scope, `Relation#merge` may be used.  First, let's add a new named scope to the Order model:
+For more advanced conditions or to reuse an existing named scope, `Relation#merge` may be used. First, let's add a new named scope to the Order model:
 
 ```ruby
 class Order < ApplicationRecord


### PR DESCRIPTION
### Summary

The current Active Record Querying guide, Section "Specifying Conditions on the Joined Tables",  is missing an example showing how to use `Relation#merge`.

The existing examples are sufficient to generate relatively basic join table conditions; however, `Relation#merge` must be used to generate advanced SQL queries or to use existing named scopes.

### Other Information

This PR is *only for documentation*.  