### PR TITLE
Call uniq! on the `reorder` arguments.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -405,6 +405,7 @@ module ActiveRecord
     # Same as #reorder but operates on relation in-place instead of copying.
     def reorder!(*args) # :nodoc:
       preprocess_order_args(args) unless args.all?(&:blank?)
+      args.uniq!
       self.reordering_value = true
       self.order_values = args
       self

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -425,6 +425,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal ["The First Topic", "The Second Topic of the day", "The Third Topic of the day", "The Fourth Topic of the day", "The Fifth Topic of the day"], topics_titles
   end
 
+  def test_reorder_deduplication
+    topics = Topic.reorder("id desc", "id desc")
+    assert_equal ["id desc"], topics.order_values
+  end
+
   def test_finding_with_reorder_by_aliased_attributes
     topics = Topic.order("author_name").reorder(:heading)
     assert_equal 5, topics.to_a.size


### PR DESCRIPTION
Before 29874cc4e220edadfdf50ba93db57d2df396e395 the order values
would be deduplicated when the SQL query is generated, but now
it has to be eager.

This is a minor regression we spotted when doing our weekly Rails upgrade.

cc @kamipo @rafaelfranca @Edouard-chin 