### PR TITLE
Documents other_than option for numericality validation [skip ci]

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -181,6 +181,7 @@ module ActiveModel
       # * <tt>:less_than</tt>
       # * <tt>:less_than_or_equal_to</tt>
       # * <tt>:only_integer</tt>
+      # * <tt>:other_than</tt>
       #
       # For example:
       #


### PR DESCRIPTION
Found this while debugging #40098. `other_than` option also accepts the proc or a symbol and the documented list missed the `other_than` in it. This PR fixes the documentation. 😊 

