### PR TITLE
Stop EventedFileUpdateChecker's listener only

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -100,11 +100,12 @@ module ActiveSupport
       def boot!
         normalize_dirs!
 
-        Listen.to(*@dtw, &method(:changed)).start if @dtw.any?
+        @listener = @dtw.any? ? Listen.to(*@dtw, &method(:changed)) : nil
+        @listener&.start
       end
 
       def shutdown!
-        Listen.stop
+        @listener&.stop
       end
 
       def normalize_dirs!

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -120,6 +120,26 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     assert_not_predicate checker, :updated?
     assert_not checker.execute_if_updated
   end
+
+  test "does not stop other checkers when nonexistent directory is added later" do
+    dir1 = File.join(tmpdir, "app")
+    dir2 = File.join(tmpdir, "test")
+
+    Dir.mkdir(dir2)
+
+    checker1 = new_checker([], dir1 => ".rb") { }
+    checker2 = new_checker([], dir2 => ".rb") { }
+
+    Dir.mkdir(dir1)
+
+    touch(File.join(dir1, "a.rb"))
+    assert_predicate checker1, :updated?
+
+    assert_not_predicate checker2, :updated?
+
+    touch(File.join(dir2, "a.rb"))
+    assert_predicate checker2, :updated?
+  end
 end
 
 class EventedFileUpdateCheckerPathHelperTest < ActiveSupport::TestCase


### PR DESCRIPTION
When an `EventedFileUpdateChecker` instance detects a watched directory that previously did not exist, it calls `shutdown!` and then `boot!` to reinitialize its underlying listener.  Prior to this commit, `shutdown!` invoked `Listen.stop` which stops **all** listeners, globally.  This commit changes `shutdown!` to stop the checker's listener only.

Fixes #38174.
