### PR TITLE
Rename horrible and dirty to puzzled and confused in test models

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -297,7 +297,7 @@ class InverseHasOneTests < ActiveRecord::TestCase
   end
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
-    assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Human.first.dirty_face }
+    assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Human.first.confused_face }
   end
 end
 
@@ -648,7 +648,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_trying_to_use_inverses_that_dont_exist_should_raise_an_error
-    assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.horrible_human }
+    assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.puzzled_human }
   end
 
   def test_building_has_many_parent_association_inverses_one_record
@@ -766,12 +766,12 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
 
   def test_trying_to_access_inverses_that_dont_exist_shouldnt_raise_an_error
     # Ideally this would, if only for symmetry's sake with other association types
-    assert_nothing_raised { Face.first.horrible_polymorphic_human }
+    assert_nothing_raised { Face.first.puzzled_polymorphic_human }
   end
 
   def test_trying_to_set_polymorphic_inverses_that_dont_exist_at_all_should_raise_an_error
-    # fails because no class has the correct inverse_of for horrible_polymorphic_human
-    assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.horrible_polymorphic_human = Human.first }
+    # fails because no class has the correct inverse_of for puzzled_polymorphic_human
+    assert_raise(ActiveRecord::InverseOfAssociationNotFoundError) { Face.first.puzzled_polymorphic_human = Human.first }
   end
 
   def test_trying_to_set_polymorphic_inverses_that_dont_exist_on_the_instance_being_set_should_raise_an_error

--- a/activerecord/test/models/face.rb
+++ b/activerecord/test/models/face.rb
@@ -7,8 +7,8 @@ class Face < ActiveRecord::Base
   # Oracle identifier length is limited to 30 bytes or less, `polymorphic` renamed `poly`
   belongs_to :poly_human_without_inverse, polymorphic: true
   # These are "broken" inverse_of associations for the purposes of testing
-  belongs_to :horrible_human, class_name: "Human", inverse_of: :horrible_face
-  belongs_to :horrible_polymorphic_human, polymorphic: true, inverse_of: :horrible_polymorphic_face
+  belongs_to :puzzled_human, class_name: "Human", inverse_of: :puzzled_face
+  belongs_to :puzzled_polymorphic_human, polymorphic: true, inverse_of: :puzzled_polymorphic_face
 
   validate do
     human

--- a/activerecord/test/models/human.rb
+++ b/activerecord/test/models/human.rb
@@ -23,7 +23,7 @@ class Human < ActiveRecord::Base
     after_add: :add_called,
     inverse_of: :polymorphic_human
   # These are "broken" inverse_of associations for the purposes of testing
-  has_one :dirty_face, class_name: "Face", inverse_of: :dirty_human
+  has_one :confused_face, class_name: "Face", inverse_of: :confused_human
   has_many :secret_interests, class_name: "Interest", inverse_of: :secret_human
   has_one :mixed_case_monkey
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1020,8 +1020,8 @@ ActiveRecord::Schema.define do
     t.string  :polymorphic_human_type
     t.integer :poly_human_without_inverse_id
     t.string  :poly_human_without_inverse_type
-    t.integer :horrible_polymorphic_human_id
-    t.string  :horrible_polymorphic_human_type
+    t.integer :puzzled_polymorphic_human_id
+    t.string  :puzzled_polymorphic_human_type
     t.references :super_human, polymorphic: true, index: false
   end
 


### PR DESCRIPTION
### Summary

In 7f938ca the test model `Man` was renamed to `Human`. Maybe this is a
good time to also change `horrible_human` and `dirty_human` to
`puzzled_human` and `confused_human`.

While this change is mostly cosmetic change, the phrase "dirty man" has
a negative meaning and might be confused with dirty tracking.

The adjectives "confused" and "puzzled" were chosen because they are
used for defining associations with errors.

cc @composerinteralia 