### PR TITLE
Improve actioncable postgres docs

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -726,7 +726,6 @@ when using the same Redis server for multiple applications. See the [Redis PubSu
 
 The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
-This may change in the future. [#27214](https://github.com/rails/rails/issues/27214)
 
 ### Allowed Request Origins
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -727,7 +727,7 @@ when using the same Redis server for multiple applications. See the [Redis PubSu
 The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
 This connection will be outside of the regular connection pool limits, and will
-persist for the lifetime of the Action Cable process.
+persist for the lifetime of the server process.
 
 ### Allowed Request Origins
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -727,6 +727,10 @@ when using the same Redis server for multiple applications. See the [Redis PubSu
 The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
 
+Action Cable will take an extra connection from the connection pool beyond the
+configured size, and keep it for the lifetime of each process. Keep this in
+mind when designing your infrastructure and configuring connection limits.
+
 ### Allowed Request Origins
 
 Action Cable will only accept requests from specified origins, which are

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -726,10 +726,9 @@ when using the same Redis server for multiple applications. See the [Redis PubSu
 
 The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
-
-Action Cable will take an extra connection from the connection pool beyond the
-configured size, and keep it for the lifetime of each process. Keep this in
-mind when designing your infrastructure and configuring connection limits.
+This connection will be outside of the regular connection pool limits, and will
+persist for the lifetime of the Action Cable process. Keep this in mind when
+designing your infrastructure and configuring connection limits.
 
 ### Allowed Request Origins
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -727,8 +727,7 @@ when using the same Redis server for multiple applications. See the [Redis PubSu
 The PostgreSQL adapter uses Active Record's connection pool, and thus the
 application's `config/database.yml` database configuration, for its connection.
 This connection will be outside of the regular connection pool limits, and will
-persist for the lifetime of the Action Cable process. Keep this in mind when
-designing your infrastructure and configuring connection limits.
+persist for the lifetime of the Action Cable process.
 
 ### Allowed Request Origins
 


### PR DESCRIPTION
Improve Action Cable PostgreSQL adapter documentation in the guides by mentioning the caveat that an extra database connection will be created from the Active Record connection pool which can exceed the pool's configured size.

I've also removed the oblique reference to future work which seems confusing, at least for the moment.