### PR TITLE
Add config.active_record.check_schema_cache_dump_version to disable schema dump version check

### DIFF
--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -230,6 +230,16 @@ module ApplicationTests
       assert_not ActiveRecord::Base.connection.schema_cache.data_sources("posts")
     end
 
+    test "does not expire schema cache dump if check_schema_cache_dump_version is false" do
+      add_to_config <<-RUBY
+        config.active_record.check_schema_cache_dump_version = false
+      RUBY
+      rails %w(generate model post title:string)
+      rails %w(db:migrate db:schema:cache:dump db:rollback)
+      require "#{app_path}/config/environment"
+      assert ActiveRecord::Base.connection_pool.schema_cache.data_sources("posts")
+    end
+
     test "active record establish_connection uses Rails.env if DATABASE_URL is not set" do
       require "#{app_path}/config/environment"
       orig_database_url = ENV.delete("DATABASE_URL")


### PR DESCRIPTION
New take on: https://github.com/rails/rails/pull/36925

In an ideal world, you want your app to be able to boot fully without reaching the database at all. This is because if your database is unresponsive (say you just deployed code doing very slow queries) and you need to deploy a different version of your code to make it healthy again, you might end up in some kind of deadlock.

https://github.com/rails/rails/pull/36925 was disabling this check by default, but it seems it wasn't acceptable. So this new version leaves it enabled by default.

NB: right now this version check cause the connection to be established which later allow full model eager loading. So turning this check off also turns of model eager loading. That's a problem, but I'd rather address it in a follow up.

cc @rafaelfranca @Edouard-chin 
