### PR TITLE
Wrap native adapters connection errors in ActiveRecord::ConnectionNotEstablished

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -18,7 +18,7 @@ module ActiveRecord
 
         # Quotes strings for use in SQL input.
         def quote_string(s) #:nodoc:
-          @connection.escape(s)
+          PG::Connection.escape(s)
         end
 
         # Checks the following cases:


### PR DESCRIPTION
Rescuing connection error with ActiveRecord has always been a bit wonky because it doesn't wrap the underlying client errors.

This is somewhat related to https://github.com/rails/rails/pull/40108 as I'd like to rescue connection errors during model eager loading as to improve resiliency.

cc @rafaelfranca @Edouard-chin 