### PR TITLE
Resurrect doc explaining Basic Auth behavior [skip ci]

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -76,6 +76,8 @@ module ActionController
 
         def http_basic_authenticate_or_request_with(name:, password:, realm: nil, message: nil)
           authenticate_or_request_with_http_basic(realm, message) do |given_name, given_password|
+            # This comparison uses & so that it doesn't short circuit and
+            # uses `secure_compare` so that length information isn't leaked.
             ActiveSupport::SecurityUtils.secure_compare(given_name, name) &
               ActiveSupport::SecurityUtils.secure_compare(given_password, password)
           end


### PR DESCRIPTION
Bring back mislaid comment that explains why HTTP Basic Auth check uses `&`; it is useful for learners and mitigates `&` being accidentally replaced with `&&` one day.

(Comment originally mislaid in https://github.com/rails/rails/commit/a5b2fff64ca0c1fa7be5124f40a251d991c10a85#diff-a1a584ca75e21b3e2a45b6a4e2d0e9cfL75-L77)


