### PR TITLE
Soft deprecate Rails::Application secrets

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -393,20 +393,6 @@ module Rails
 
     attr_writer :config
 
-    # Returns secrets added to config/secrets.yml.
-    #
-    # Example:
-    #
-    #     development:
-    #       secret_key_base: 836fa3665997a860728bcb9e9a1e704d427cfc920e79d847d79c8a9a907b9e965defa4154b2b86bdec6930adbe33f21364523a6f6ce363865724549fdfc08553
-    #     test:
-    #       secret_key_base: 5a37811464e7d378488b0f073e2193b093682e4e21f5d6f3ae0a4e1781e61a351fdc878a843424e81c73fb484a40d23f92c8dafac4870e74ede6e5e174423010
-    #     production:
-    #       secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
-    #       namespace: my_app_production
-    #
-    # +Rails.application.secrets.namespace+ returns +my_app_production+ in the
-    # production environment.
     def secrets
       @secrets ||= begin
         secrets = ActiveSupport::OrderedOptions.new

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -421,7 +421,7 @@ module Rails
       end
     end
 
-    attr_writer :secrets
+    attr_writer :secrets, :credentials
 
     # The secret_key_base is used as the input secret to the application's key generator, which in turn
     # is used to create all MessageVerifiers/MessageEncryptors, including the ones that sign and encrypt cookies.

--- a/railties/lib/rails/commands/secrets/USAGE
+++ b/railties/lib/rails/commands/secrets/USAGE
@@ -1,3 +1,9 @@
+=== ** DEPRECATED **
+
+Rails 5.2 has introduced a new `credentials` API that replaces Rails secrets.
+Please use the Rails `credentials` commands instead.
+Run `rails credentials:help` for more information.
+
 === Storing Encrypted Secrets in Source Control
 
 The Rails `secrets` commands helps encrypting secrets to slim a production


### PR DESCRIPTION
### Summary

- Adds `attr_writer` for `credentials` to `Rails::Application`
- Removes a couple references to `secrets.yml` from our documentation
- Adds a header indicating that Rails `secrets` is deprecated to `USAGE` for the secrets commands

Anything else to include as a part of the soft deprecation of secrets?
