### PR TITLE
be able to edit the initial value of the editor

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Be able to add a default value to `rich_text_area`.
+
+    ```ruby
+    form.rich_text_area :content, value: "<h1>Hello world</h1>"
+    #=> <input type="hidden" name="message[content]" id="message_content_trix_input_message_1" value="<h1>Hello world</h1>">
+    ```
+
+    *Paulo Ancheta*
+
 *   Add method to confirm rich text content existence by adding `?` after rich
     text attribute.
 

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -46,7 +46,7 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
-      @template_object.rich_text_area_tag(options.delete("name"), editable_value, options)
+      @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { editable_value }, options.except("value"))
     end
 
     def editable_value
@@ -60,12 +60,19 @@ module ActionView::Helpers
     #
     # ==== Options
     # * <tt>:class</tt> - Defaults to "trix-content" which ensures default styling is applied.
+    # * <tt>:value</tt> - Adds a default value to the HTML input tag.
     #
     # ==== Example
     #   form_with(model: @message) do |form|
     #     form.rich_text_area :content
     #   end
     #   # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1">
+    #   # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
+    #
+    #   form_with(model: @message) do |form|
+    #     form.rich_text_area :content, value: "<h1>Default message</h1>"
+    #   end
+    #   # <input type="hidden" name="message[content]" id="message_content_trix_input_message_1" value="<h1>Default message</h1>">
     #   # <trix-editor id="content" input="message_content_trix_input_message_1" class="trix-content" ...></trix-editor>
     def rich_text_area(object_name, method, options = {})
       Tags::ActionText.new(object_name, method, self, options).render

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -110,4 +110,18 @@ class ActionText::FormHelperTest < ActionView::TestCase
       "</form>",
       output_buffer
   end
+
+  test "form with rich text area with value" do
+    form_with model: Message.new, scope: :message do |form|
+      form.rich_text_area :title, value: "<h1>hello world</h1>"
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;" />' \
+        '<trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
 end


### PR DESCRIPTION
### Summary

Hello rails team! I've been trying to add a rich text area that is not backed by a model. Here I'm proposing to add functionality with the same behaviour as `text_area` where we can add a `value` through `input_html` would solve the problem.

At the moment this snippet:
```html
<%= f.rich_text_area :description, input_html: { value: "<h1>hello world</h1>" } %>
```

yields this:
```html
<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">
  <input type="hidden" name="message[title]" id="message_title_trix_input_message" />
  <trix-editor input_html="value &lt;h1&gt;hello world&lt;/h1&gt;" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">
  </trix-editor>
</form>
```

With the changes in this pull-request, it should add the correct hidden_input
```html
<input type="hidden" name="message[title]" id="message_title_trix_input_message" value="<h1>hello world</h1>" />
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

Please let me know if there are other ways to do this currently or if there's better ways that I can improve the code
