### PR TITLE
Ensure Puma runs in 0:1 configuration

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/server.rb
+++ b/actionpack/lib/action_dispatch/system_testing/server.rb
@@ -20,7 +20,7 @@ module ActionDispatch
         end
 
         def set_server
-          Capybara.server = :puma, { Silent: self.class.silence_puma } if Capybara.server == Capybara.servers[:default]
+          Capybara.server = :puma, { Silent: self.class.silence_puma, Threads: '0:1' } if Capybara.server == Capybara.servers[:default]
         end
 
         def set_port


### PR DESCRIPTION
### Summary

Ensure Puma always runs in `0:1` configuration when running feature specs.

### Other Information

https://github.com/rails/rails/pull/28083
https://github.com/rails/rails/pull/30712
https://github.com/rails/rails/pull/30638

It seems at some point Rails was told to point to the default Puma server config baked into Capybara, but that never enforced the required `0:1` Puma thread config that's necessary for transactional fixtures.

https://github.com/rails/rails/pull/30638#commitcomment-40438794

This comment above gets at the issue.

@eileencodes and @twalpole have context here, @eileencodes I see you have done a lot of work since then on DB connection sharing for Rails 6. Unsure what the _correct_ configuration is now.
