### PR TITLE
Escape # in RFC 5987 pattern

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_disposition.rb
+++ b/actionpack/lib/action_dispatch/http/content_disposition.rb
@@ -14,13 +14,13 @@ module ActionDispatch
         @filename = filename
       end
 
-      TRADITIONAL_ESCAPED_CHAR = /[^ A-Za-z0-9!#$+.^_`|~-]/
+      TRADITIONAL_ESCAPED_CHAR = /[^ A-Za-z0-9!\#$+.^_`|~-]/
 
       def ascii_filename
         'filename="' + percent_escape(I18n.transliterate(filename), TRADITIONAL_ESCAPED_CHAR) + '"'
       end
 
-      RFC_5987_ESCAPED_CHAR = /[^A-Za-z0-9!#$&+.^_`|~-]/
+      RFC_5987_ESCAPED_CHAR = /[^A-Za-z0-9!\#$&+.^_`|~-]/
 
       def utf8_filename
         "filename*=UTF-8''" + percent_escape(filename, RFC_5987_ESCAPED_CHAR)

--- a/actionpack/test/dispatch/content_disposition_test.rb
+++ b/actionpack/test/dispatch/content_disposition_test.rb
@@ -28,6 +28,14 @@ module ActionDispatch
       assert_equal "inline; #{disposition.ascii_filename}; #{disposition.utf8_filename}", disposition.to_s
     end
 
+    test "encoding a filename with permitted chars" do
+      disposition = Http::ContentDisposition.new(disposition: :inline, filename: "argh+!#$-123_|&^`~.jpg")
+
+      assert_equal %(filename="argh+!\#$-123_|%26^`~.jpg"), disposition.ascii_filename
+      assert_equal "filename*=UTF-8''argh+!\#$-123_|&^`~.jpg", disposition.utf8_filename
+      assert_equal "inline; #{disposition.ascii_filename}; #{disposition.utf8_filename}", disposition.to_s
+    end
+
     test "without filename" do
       disposition = Http::ContentDisposition.new(disposition: :inline, filename: nil)
 


### PR DESCRIPTION
### Summary

The # seems to be missing an escape. Pasting `/[^A-Za-z0-9!#$&+.^_`|~-]/` into `irb` should also reveal the issue (# isn't there).

```ruby

# current
/[^A-Za-z0-9!#$&+.^_`|~-]/.match('#') # => no match
/[^A-Za-z0-9!#$&+.^_`|~-]/.match('$') # => no match

# suggestion
/[^A-Za-z0-9!\#$&+.^_`|~-]/.match('#') # => match
/[^A-Za-z0-9!\#$&+.^_`|~-]/.match('$') # => match

```
