### PR TITLE
Serialize aria- namespaced list attributes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,16 @@
+*  Serialize `aria:` and `"aria" =>` namespaced `Array` attributes passed to
+   `ActionView::Helpers::TagHelper#tag`as `" "`-delimited Strings:
+
+      tag.input type: 'checkbox', name: 'published', aria: {
+        labelledby: ['published_context', 'published_label'],
+        describedby: ['published_errors']
+      }
+      #=> <input
+      #     type="checkbox" name="published"
+      #     aria-labelledby="published_context published_label"
+      #     aria-describedby="published_errors"
+      #   >
+
 *   `ActionView::Helpers::TranslationHelper#translate` accepts a block, yielding
     the translated text and the fully resolved translation key:
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -72,7 +72,11 @@ module ActionView
               value.each_pair do |k, v|
                 next if v.nil?
                 output << sep
-                output << prefix_tag_option(key, k, v, escape)
+                if key.to_s == "aria" && v.is_a?(Array)
+                  output << tag_option("aria-#{k.to_s.dasherize}", v, escape)
+                else
+                  output << prefix_tag_option(key, k, v, escape)
+                end
               end
             elsif type == :boolean
               if value
@@ -161,7 +165,7 @@ module ActionView
       #   tag.input type: 'text', disabled: true
       #   # => <input type="text" disabled="disabled">
       #
-      # HTML5 <tt>data-*</tt> attributes can be set with a single +data+ key
+      # HTML5 <tt>data-*</tt> and <tt>aria-*</tt> attributes can be set with a single +data+ key
       # pointing to a hash of sub-attributes.
       #
       # To play nicely with JavaScript conventions, sub-attributes are dasherized.
@@ -178,6 +182,19 @@ module ActionView
       #
       #   tag.div data: { city_state: %w( Chicago IL ) }
       #   # => <div data-city-state="[&quot;Chicago&quot;,&quot;IL&quot;]"></div>
+      #
+      # ARIA Array attribute values are space separated to be treated as <tt>DOMTokenList</tt> values.
+      # This is useful when declaring lists of label text identifiers in <tt>aria-labelledby</tt> or <tt>aria-describedby</tt>.
+      #
+      #   tag.input type: 'checkbox', name: 'published', aria: {
+      #     labelledby: ['published_context', 'published_label'],
+      #     describedby: ['published_errors']
+      #   }
+      #   #=> <input
+      #         type="checkbox" name="published"
+      #         aria-labelledby="published_context published_label"
+      #         aria-describedby="published_errors"
+      #       >
       #
       # The generated attributes are escaped by default. This can be disabled using
       # +escape_attributes+.

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -435,11 +435,12 @@ class TagHelperTest < ActionView::TestCase
 
   def test_aria_attributes
     ["aria", :aria].each { |aria|
-      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="[1,2,3]" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
+      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="1 2 3" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
         tag("a", aria => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
-      assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="[1,2,3]" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
-        tag.a(aria: { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
     }
+
+    assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-array="1 2 3" aria-hash="{&quot;key&quot;:&quot;value&quot;}" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
+      tag.a(aria: { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })
   end
 
   def test_link_to_data_nil_equal


### PR DESCRIPTION
### Summary

Prior to this commit, calls passing `aria: { labelledby: [...] }`
serialized the `aria-labelledby` Array value as JSON.

An element's [`aria-labelledby` attribute][aria-labelledby] and
[`aria-describedby` attribute][aria-describedby] can accept a
space-delimited list of identifier values (much like the [`class`
attribute][class] accepts a space delimited [`DOMTokenList`
value][DOMTokenList]).

This commit introduces special case logic to skip serializing `aria-`
prefixed `Array` values to JSON.

Testing
---

This change moves an assertion _outside_ of a loop over `["aria",
:aria]`. Prior to this change, the second assertion within the loop
wasn't utilizing the iterated value as a Hash key. That is to say:
`aria:` (where an `aria` local variable is declared) is not equivalent
an equivalent syntax to `aria =>`.

Since the migration to `**options` in response to Ruby 2.7 deprecations,
invoking `tag.a("aria" => {...})` incorrectly coerces the `"aria" =>
{...}` has to be the `TagBuilder#a` method `content = nil` ordered
argument, instead of its `options` keyword arguments. This commit does
not modify that behavior, but it _does_ move the assertion outside the
block so that it isn't run unnecessarily.

[ee61b76]: https://github.com/rails/rails/commit/ee61b76a810ad67ca064be2922a8b481fa840043
[aria-labelledby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute
[aria-describedby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute
[class]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class
[DOMTokenList]: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList
[class_names]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-class_names

