### PR TITLE
Catch invalid UTF-8 encodings on ActionDispatch::Http::Request#POST

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Catch invalid UTF-8 parameters for POST requests and respond with BadRequest.
+
+    Additionally, perform `#set_binary_encoding` in `ActionDispatch::Http::Request#GET` and
+    `ActionDispatch::Http::Request#POST` prior to validating encoding.
+
+    *Adrianna Chang*
+
 *   Allow `assert_recognizes` routing assertions to work on mounted root routes.
 
     *Gannon McGibbon*

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -64,6 +64,7 @@ module ActionDispatch
 
       def path_parameters=(parameters) #:nodoc:
         delete_header("action_dispatch.request.parameters")
+
         parameters = Request::Utils.set_binary_encoding(self, parameters)
         # If any of the path parameters has an invalid encoding then
         # raise since it's likely to trigger errors further on.

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -65,7 +65,7 @@ module ActionDispatch
       def path_parameters=(parameters) #:nodoc:
         delete_header("action_dispatch.request.parameters")
 
-        parameters = Request::Utils.set_binary_encoding(self, parameters)
+        parameters = Request::Utils.set_binary_encoding(self, parameters, parameters[:controller], parameters[:action])
         # If any of the path parameters has an invalid encoding then
         # raise since it's likely to trigger errors further on.
         Request::Utils.check_param_encoding(parameters)

--- a/actionpack/lib/action_dispatch/http/parameters.rb
+++ b/actionpack/lib/action_dispatch/http/parameters.rb
@@ -57,7 +57,6 @@ module ActionDispatch
                    query_parameters.dup
                  end
         params.merge!(path_parameters)
-        params = set_binary_encoding(params, params[:controller], params[:action])
         set_header("action_dispatch.request.parameters", params)
         params
       end
@@ -65,8 +64,7 @@ module ActionDispatch
 
       def path_parameters=(parameters) #:nodoc:
         delete_header("action_dispatch.request.parameters")
-
-        parameters = set_binary_encoding(parameters, parameters[:controller], parameters[:action])
+        parameters = Request::Utils.set_binary_encoding(self, parameters)
         # If any of the path parameters has an invalid encoding then
         # raise since it's likely to trigger errors further on.
         Request::Utils.check_param_encoding(parameters)
@@ -85,23 +83,6 @@ module ActionDispatch
       end
 
       private
-        def set_binary_encoding(params, controller, action)
-          return params unless controller && controller.valid_encoding?
-
-          if binary_params_for?(controller, action)
-            ActionDispatch::Request::Utils.each_param_value(params.except(:controller, :action)) do |param|
-              param.force_encoding ::Encoding::ASCII_8BIT
-            end
-          end
-          params
-        end
-
-        def binary_params_for?(controller, action)
-          controller_class_for(controller).binary_params_for?(action)
-        rescue MissingController
-          false
-        end
-
         def parse_formatted_parameters(parsers)
           return yield if content_length.zero? || content_mime_type.nil?
 

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -379,6 +379,7 @@ module ActionDispatch
     def GET
       fetch_header("action_dispatch.request.query_parameters") do |k|
         rack_query_params = super || {}
+        rack_query_params = Request::Utils.set_binary_encoding(self, rack_query_params)
         # Check for non UTF-8 parameter values, which would cause errors later
         Request::Utils.check_param_encoding(rack_query_params)
         set_header k, Request::Utils.normalize_encode_params(rack_query_params)
@@ -394,6 +395,7 @@ module ActionDispatch
         pr = parse_formatted_parameters(params_parsers) do |params|
           super || {}
         end
+        pr = Request::Utils.set_binary_encoding(self, pr)
         self.request_parameters = Request::Utils.normalize_encode_params(pr)
       end
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -379,7 +379,9 @@ module ActionDispatch
     def GET
       fetch_header("action_dispatch.request.query_parameters") do |k|
         rack_query_params = super || {}
-        rack_query_params = Request::Utils.set_binary_encoding(self, rack_query_params)
+        controller = path_parameters[:controller]
+        action = path_parameters[:action]
+        rack_query_params = Request::Utils.set_binary_encoding(self, rack_query_params, controller, action)
         # Check for non UTF-8 parameter values, which would cause errors later
         Request::Utils.check_param_encoding(rack_query_params)
         set_header k, Request::Utils.normalize_encode_params(rack_query_params)
@@ -395,7 +397,7 @@ module ActionDispatch
         pr = parse_formatted_parameters(params_parsers) do |params|
           super || {}
         end
-        pr = Request::Utils.set_binary_encoding(self, pr)
+        pr = Request::Utils.set_binary_encoding(self, pr, path_parameters[:controller], path_parameters[:action])
         Request::Utils.check_param_encoding(pr)
         self.request_parameters = Request::Utils.normalize_encode_params(pr)
       end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -396,6 +396,7 @@ module ActionDispatch
           super || {}
         end
         pr = Request::Utils.set_binary_encoding(self, pr)
+        Request::Utils.check_param_encoding(pr)
         self.request_parameters = Request::Utils.normalize_encode_params(pr)
       end
     rescue Rack::Utils::ParameterTypeError, Rack::Utils::InvalidParameterError => e

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -41,8 +41,8 @@ module ActionDispatch
         end
       end
 
-      def self.set_binary_encoding(request, params)
-        BinaryParamEncoder.encode(request, params)
+      def self.set_binary_encoding(request, params, controller, action)
+        BinaryParamEncoder.encode(request, params, controller, action)
       end
 
       class ParamEncoder # :nodoc:
@@ -79,10 +79,7 @@ module ActionDispatch
       end
 
       class BinaryParamEncoder # :nodoc:
-        def self.encode(request, params)
-          controller = request.path_parameters[:controller]
-          action = request.path_parameters[:action]
-
+        def self.encode(request, params, controller, action)
           return params unless controller && controller.valid_encoding?
 
           if binary_params_for?(request, controller, action)

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -78,10 +78,10 @@ module ActionDispatch
         end
       end
 
-      class BinaryParamEncoder < ParamEncoder # :nodoc:
+      class BinaryParamEncoder # :nodoc:
         def self.encode(request, params)
-          controller = params[:controller] || request.path_parameters[:controller]
-          action = params[:action] || request.path_parameters[:action]
+          controller = request.path_parameters[:controller]
+          action = request.path_parameters[:action]
 
           return params unless controller && controller.valid_encoding?
 
@@ -90,6 +90,7 @@ module ActionDispatch
               param.force_encoding ::Encoding::ASCII_8BIT
             end
           end
+
           params
         end
 

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -118,6 +118,8 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   end
 
   test "parses mixed files" do
+    TestController.class_eval { skip_parameter_encoding :parse }
+
     params = parse_multipart("mixed_files")
     assert_equal %w(files foo), params.keys.sort
     assert_equal "bar", params["foo"]

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -6,6 +6,20 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     class << self
       attr_accessor :last_request_parameters, :last_parameters
+
+      def binary_params_for?(action)
+        action == "parse_binary"
+      end
+    end
+
+    def parse_binary
+      self.class.last_request_parameters = begin
+        request.request_parameters
+      rescue EOFError
+        {}
+      end
+      self.class.last_parameters = request.parameters
+      head :ok
     end
 
     def parse
@@ -118,9 +132,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   end
 
   test "parses mixed files" do
-    TestController.class_eval { skip_parameter_encoding :parse }
-
-    params = parse_multipart("mixed_files")
+    params = parse_multipart("mixed_files", "/parse_binary")
     assert_equal %w(files foo), params.keys.sort
     assert_equal "bar", params["foo"]
 
@@ -182,10 +194,10 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def parse_multipart(name)
+    def parse_multipart(name, path = "/parse")
       with_test_routing do
         headers = fixture(name)
-        post "/parse", params: headers.delete("rack.input"), headers: headers
+        post path, params: headers.delete("rack.input"), headers: headers
         assert_response :ok
         TestController.last_request_parameters
       end


### PR DESCRIPTION
### Summary

This PR does two things:

1) Similar to the [fix performed here](https://github.com/rails/rails/commit/59ab2d1ee5995d9ea27ca60e92576518c1898c59), we should call `Request::Utils.check_param_encoding(params)` in `ActionDispatch::Http::Request#POST`. Currently, bad input is able to reach the controller for POST requests - we should disallow input with invalid encoding from even reaching the controllers by raising an exception further up the stack.
2) Changes some of the logic around binary encoding. Previously the control flow looked something like this:
In `ActionDispatch::Http::Parameters#parameters`:
- get `query_params` (which  was checking param encoding)
- merge with `request_params` (which was NOT checking param encoding)
- merge with `path_parameters` (which are encoded to binary + then have their encoding checked at the point where they're set, see [here](https://github.com/rails/rails/commit/9f38a3fb0c9c71102da283b014503ccad92da581))
- Perform binary encoding (if necessary)

Since we are now raising in `GET` and `POST` for invalid encoding, we need the binary encoding to happen in `ActionDispatch::Http::Request` so that we only raise an invalid encoding exception _if_ the controller doesn't want the encoding in binary. This required the following changes:

- Extracted binary encoding logic to `ActionDispatch::Request::Utils`
- Added calls to `ActionDispatch::Request::Utils#set_binary_encoding` to happen prior to the encoding checks in `GET` and `POST`
- Changed `ActionDispatch::Http::Parameters#path_parameters=` to use the new interface, and removed the binary encoding logic from `ActionDispatch::Http::Parameters`
- Removed the extraneous call to `#set_binary_encoding` happening in `ActionDispatch::Http::Parameters#parameters`, since now `GET`, `POST`, and `path_parameters` are all responsible for encoding to binary before performing the encoding check