### PR TITLE
Use a unique controller class per ActionView::TestCase

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -126,7 +126,7 @@ module ActionController
     # ==== Returns
     # * <tt>string</tt>
     def self.controller_name
-      @controller_name ||= name.demodulize.delete_suffix("Controller").underscore
+      @controller_name ||= (name.demodulize.delete_suffix("Controller").underscore unless anonymous?)
     end
 
     def self.make_response!(request)

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -16,11 +16,12 @@ module ActionView
       attr_accessor :request, :response, :params
 
       class << self
-        attr_writer :controller_path
+        # Overrides AbstractController::Base#controller_path
+        attr_accessor :controller_path
       end
 
       def controller_path=(path)
-        self.class.controller_path = (path)
+        self.class.controller_path = path
       end
 
       def initialize
@@ -101,7 +102,7 @@ module ActionView
       end
 
       def setup_with_controller
-        @controller = ActionView::TestCase::TestController.new
+        @controller = Class.new(ActionView::TestCase::TestController).new
         @request = @controller.request
         @view_flow = ActionView::OutputFlow.new
         # empty string ensures buffer has UTF-8 encoding as

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -156,6 +156,13 @@ module ActionView
 
       assert_equal "controller_helper_method", some_method
     end
+
+    class AnotherTestClass < ActionView::TestCase
+      test "doesn't use controller helpers from other tests" do
+        assert_not_respond_to view, :render_from_helper
+        assert_not_includes @controller._helpers.instance_methods, :render_from_helper
+      end
+    end
   end
 
   class ViewAssignsTest < ActionView::TestCase


### PR DESCRIPTION
This PR makes the controllers generated in `ActionView::TestCase` each have a unique controller class, a subclass of `ActionView::TestCase::TestController`. This fixes a minor issue where a test adding a `helper` or `helper_methods` directly to the test controller would have that leak between all tests (and there's a test for this, so apparently we want to support doing that).

I discovered this while working on (what will now be) a follow up PR which aims to make `_helpers` from controllers copy-on-write. This seemed to be a bug on it's own and it will simplify the future PR so I am submitting it separately.

This change also allowed easily removing two unnecessary `module_eval`s to the helpers module, which can instead be defined in a regular `helper` block.