### PR TITLE
Allow false as check_box unchecked value

### DIFF
--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -57,7 +57,7 @@ module ActionView
           end
 
           def hidden_field_for_checkbox(options)
-            @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
+            @unchecked_value.to_s.present? ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -57,7 +57,7 @@ module ActionView
           end
 
           def hidden_field_for_checkbox(options)
-            @unchecked_value.to_s.present? ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
+            !@unchecked_value.nil? ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
           end
       end
     end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -709,6 +709,12 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[secret]" type="hidden" value="true" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
       check_box("post", "secret", {}, false, true)
     )
+
+    @post.secret = false
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="false" /><input id="post_secret" name="post[secret]" type="checkbox" value="true" />',
+      check_box("post", "secret", {}, true, false)
+    )
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_integer

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -695,6 +695,12 @@ class FormHelperTest < ActionView::TestCase
       '<input name="post[secret]" type="hidden" value="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
       check_box("post", "secret", {}, "on", "off")
     )
+
+    @post.secret = "on"
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      check_box("post", "secret", {}, "on", "")
+    )
   end
 
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean


### PR DESCRIPTION
### Summary

When using boolean false as value for `check_box` unchecked value, the
hidden input for unchecked value is not generated.

Presently, the following example:

```ruby
<%= form_with :model do |form_builder| %>
  <%= form_builder.check_box :attribute, {}, true, false %>
<% end %>
```

will only output the input for true, ie:

```html
<input id="model_attribute name="model[attribute]" type="checkbox" value="true" />
```

instead of the expected behaviour:

```html
<input name="model[attribute]" type="hidden" value="false" />
<input id="model_attribute name="model[attribute]" type="checkbox" value="true" />
```

This is somewhat surprising behaviour, in particular since a different order of values will work correctly, ie:

```ruby
<%= form_with :model do |form_builder| %>
  <%= form_builder.check_box :attribute, {}, false, true %>
<% end %>
```

as well as using strings:

```ruby
<%= form_with :model do |form_builder| %>
  <%= form_builder.check_box :attribute, {}, "false", "true" %>
<% end %>
```

This is due to a ternary operator being used to determine if an unchecked value is present. On receiving a boolean false, an empty string is returned.

This PR changes the behaviour to cast the unchecked value to a string and calling `.present?` on it, so as to allow the expected behaviour to occur.