### PR TITLE
Make Time.at loseless with ActiveSupport::TimeWithZone argument

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -47,8 +47,10 @@ class Time
       # Time.at can be called with a time or numerical value
       time_or_number = args.first
 
-      if time_or_number.is_a?(ActiveSupport::TimeWithZone) || time_or_number.is_a?(DateTime)
-        at_without_coercion(time_or_number.to_f).getlocal
+      if time_or_number.is_a?(ActiveSupport::TimeWithZone)
+        at_without_coercion(time_or_number).getlocal
+      elsif time_or_number.is_a?(DateTime)
+        at_without_coercion(time_or_number.to_time).getlocal
       else
         at_without_coercion(time_or_number)
       end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -465,6 +465,16 @@ module ActiveSupport
       utc.to_r
     end
 
+    # Ruby protocol for +Time.at+ requires +to_int+ to be defined.
+    # In case +to_int+ is not defined, +Time.at+ performs a lossy
+    # conversion that is causing the loss of nanosecond precision.
+    # The return value doesn't matter, since `Time.at` never calls
+    # the method, it only checks if the object responds to it to
+    # make a distinction between a Time-like object and an object
+    # that coincidentally responds to +to_r+, like a String.
+    def to_int
+    end
+
     # Returns an instance of DateTime with the timezone's UTC offset
     #
     #   Time.zone.now.to_datetime                         # => Tue, 18 Aug 2015 02:32:20 +0000

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -887,13 +887,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_at_with_time_with_zone
     assert_equal Time.utc(2000, 1, 1, 0, 0, 0), Time.at(ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone["UTC"]))
-
-    # Only test this if the underlying Time.at raises a TypeError
-    begin
-      Time.at_without_coercion(Time.now, 0)
-    rescue TypeError
-      assert_raise(TypeError) { assert_equal(Time.utc(2000, 1, 1, 0, 0, 0), Time.at(ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone["UTC"]), 0)) }
-    end
+    assert_equal Time.utc(2000, 1, 1, 0, 0, 0), Time.at(ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone["UTC"]), 0)
   end
 
   def test_at_with_time_with_zone_returns_local_time

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -890,7 +890,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.utc(2000, 1, 1, 0, 0, 0), Time.at(ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone["UTC"]), 0)
   end
 
-  def test_at_with_time_precision
+  def test_at_with_time_with_zone_precision
     time_with_nsec = Time.at(500000000, 123456789, :nsec)
     time_with_zone = ActiveSupport::TimeWithZone.new(time_with_nsec, ActiveSupport::TimeZone["UTC"])
     assert_equal time_with_zone, Time.at(time_with_zone)

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -890,6 +890,15 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     assert_equal Time.utc(2000, 1, 1, 0, 0, 0), Time.at(ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone["UTC"]), 0)
   end
 
+  def test_at_with_time_precision
+    time_with_nsec = Time.at(500000000, 123456789, :nsec)
+    time_with_zone = ActiveSupport::TimeWithZone.new(time_with_nsec, ActiveSupport::TimeZone["UTC"])
+    assert_equal time_with_zone, Time.at(time_with_zone)
+    assert_equal time_with_zone.to_r, Time.at(time_with_zone).to_r
+    assert_equal time_with_zone.to_f, Time.at(time_with_zone).to_f
+    assert_equal time_with_zone.nsec, Time.at(time_with_zone).nsec
+  end
+
   def test_at_with_time_with_zone_returns_local_time
     with_env_tz "US/Eastern" do
       twz = ActiveSupport::TimeWithZone.new(Time.utc(2000, 1, 1, 0, 0, 0), ActiveSupport::TimeZone["London"])


### PR DESCRIPTION
### Summary

Float representation is not sufficient to preserve nanosecond precision. Previously, `to_f` conversion was needed because TimeWithZone failed to conform to `Time.at` protocol that requires the object to respond to `to_int` in addition to `to_r`.

https://bugs.ruby-lang.org/issues/17131#note-1

To use the precise `Rational` representation of time, `Time.at` requires `to_int` to be defined in addition to `to_r` to make a distinction and avoid using `to_r` with objects that are not time objects, e.g. a `String` "123.456" (`Rational(15432/125)`).

https://github.com/ruby/ruby/commit/7e1fddba4a609cb7bf4a696eccd892e68753bb21 
https://github.com/ruby/ruby/blob/7e1fddba4a609cb7bf4a696eccd892e68753bb21/spec/ruby/core/time/at_spec.rb#L96
https://bugs.ruby-lang.org/issues/17131#note-1

Time.at performs a check if the first argument is kind of a `::Time`, however it can't be tricked by overriding `kind_of?`, and it wouldn't be sufficient, since it uses the internal structure of the `Time` class to copy over the time data.

In case when `to_r` is defined and `to_int` is not, it fails fast with a TypeError. This was previously considered in a test (initially introduced by https://github.com/rails/rails/commit/b7f9de27f0558d6144f982cae83f32ca85a07f7e). The nature of origin of the exception was not determined at the moment.

fixes #38831
improves #9403

### Other Information

For `DateTime`, the coercion to `Time` is expensive, but most probably comparable to the effort needed to coerce it to floating point number and back to `Time` that `Time.at` does internally.