### PR TITLE
Enable Zeitwerk by default on TruffleRuby

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -128,7 +128,7 @@ module Rails
         when "6.0"
           load_defaults "5.2"
 
-          self.autoloader = :zeitwerk if RUBY_ENGINE == "ruby"
+          self.autoloader = :zeitwerk if %w[ruby truffleruby].include?(RUBY_ENGINE)
 
           if respond_to?(:action_view)
             action_view.default_enforce_utf8 = false


### PR DESCRIPTION
### Summary

Since the Zeitwerk test suite now [passes on TruffleRuby](https://twitter.com/fxn/status/1299654012065718272), I think it is time to enable it by default when running Rails on TruffleRuby.

I generated a new empty Rails app with this change and it worked fine.
![Screenshot from 2020-08-30 13-54-51](https://user-images.githubusercontent.com/168854/91658440-68c01900-eac8-11ea-9a5d-81bc4f30a2c3.png)

In general, I'd like to have as few differences as possible between running Rails on TruffleRuby and running Rails on CRuby.
So that way, it would be possible to switch between both at any time without changing anything (notably, no need to change the Gemfile, configuration, etc), and have minimal behavior changes too.

cc @fxn 