### PR TITLE
Load Rails Rake tasks only once

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -16,7 +16,6 @@ module Rails
           require_rake
 
           Rake.with_application do |rake|
-            load "rails/tasks.rb"
             rake.init("rails", [task, *args])
             rake.load_rakefile
             if Rails.respond_to?(:root)

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -25,6 +25,10 @@ module ApplicationTests
       assert $task_loaded
     end
 
+    test "framework tasks are evaluated only once" do
+      assert_equal ["Rails version"], rails("about").scan(/^Rails version/)
+    end
+
     test "task backtrace is silenced" do
       add_to_config <<-RUBY
         rake_tasks do


### PR DESCRIPTION
In #39137, a new `Rake::Application` instance was created per Rake command invocation.  To ensure that the Rails tasks were defined for each `Rake::Application`, `rails/tasks.rb` was loaded per instance.  However, `Rake::Application#load_rakefile` loads the application's Rakefile, which should invoke `Rails.application.load_tasks`, which, in turn, also loads the Rails tasks.  When a Rake task is defined more than once, all definition blocks are executed when the task is run.  Hence, Rails task blocks were being executed twice.

This commit removes the unnecessary load and avoids double execution.

Fixes #40136.
