### PR TITLE
Check that TruffleRuby is recent enough to enable Zeitwerk

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   The `zeitwerk` autoloader is now enabled by default on TruffleRuby 20.3+ and 20.3 development builds.
+
+    *Benoit Daloze*
+
 *   Automatically generate abstract class when using multiple databases.
 
     When generating a scaffold for a multiple database application, Rails will now automatically generate the abstract class for the database when the database argument is passed. This abstract class will include the connection information for the writing configuration and any models generated for that database will automatically inherit from the abstract class.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -128,7 +128,9 @@ module Rails
         when "6.0"
           load_defaults "5.2"
 
-          self.autoloader = :zeitwerk if %w[ruby truffleruby].include?(RUBY_ENGINE)
+          zeitwerk = RUBY_ENGINE == "ruby" ||
+            RUBY_ENGINE == "truffleruby" && Gem::Version.new(RUBY_ENGINE_VERSION) >= Gem::Version.new("20.3.0-dev-a")
+          self.autoloader = :zeitwerk if zeitwerk
 
           if respond_to?(:action_view)
             action_view.default_enforce_utf8 = false


### PR DESCRIPTION
* To ensure that TruffleRuby version passes the zeitwerk test suite.
* Add ChangeLog entry.

I believe this is completely safe. Zeitwerk will only be used on (upcoming) TruffleRuby 20.3, or on development builds which already pass the zeitwerk test suite.

See discussion in #40141.
cc @fxn