### PR TITLE
Alias TagHelper#class_names to #token_list

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Rename the new `TagHelper#class_names` method to `TagHelper#token_list`,
+    and make the original available as an alias.
+
+        token_list("foo", "foo bar")
+        # => "foo bar"
+
+    *Sean Doyle*
+
 *   ARIA Array and Hash attributes are treated as space separated `DOMTokenList`
     values. This is useful when declaring lists of label text identifiers in
     `aria-labelledby` or `aria-describedby`.
@@ -53,7 +61,7 @@
 
 *   Remove deprecated support to pass an object that is not a `ActionView::LookupContext` as the first argument
     in `ActionView::Base#initialize`.
- 
+
     *Rafael Mendonça França*
 
 *   Remove deprecated `format` argument `ActionView::Base#initialize`.

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -305,18 +305,23 @@ module ActionView
         end
       end
 
-      # Returns a string of class names built from +args+.
+      # Returns a string of tokens built from +args+.
       #
       # ==== Examples
-      #   class_names("foo", "bar")
+      #   token_list("foo", "bar")
       #    # => "foo bar"
-      #   class_names({ foo: true, bar: false })
+      #   token_list("foo", "foo bar")
+      #    # => "foo bar"
+      #   token_list({ foo: true, bar: false })
       #    # => "foo"
-      #   class_names(nil, false, 123, "", "foo", { bar: true })
+      #   token_list(nil, false, 123, "", "foo", { bar: true })
       #    # => "123 foo bar"
-      def class_names(*args)
-        safe_join(build_tag_values(*args), " ")
+      def token_list(*args)
+        tokens = build_tag_values(*args).flat_map { |value| value.to_s.split(/\s+/) }.uniq
+
+        safe_join(tokens, " ")
       end
+      alias_method :class_names, :token_list
 
       # Returns a CDATA section with the given +content+. CDATA sections
       # are used to escape blocks of text containing characters which would

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -344,16 +344,23 @@ class TagHelperTest < ActionView::TestCase
     assert_equal "<p class=\"song play>\">limelight</p>", str
   end
 
-  def test_class_names
-    assert_equal "song play", class_names(["song", { "play": true }])
-    assert_equal "song", class_names({ "song": true, "play": false })
-    assert_equal "song", class_names([{ "song": true }, { "play": false }])
-    assert_equal "song", class_names({ song: true, play: false })
-    assert_equal "song", class_names([{ song: true }, nil, false])
-    assert_equal "song", class_names(["song", { foo: false }])
-    assert_equal "song play", class_names({ "song": true, "play": true })
-    assert_equal "", class_names({ "song": false, "play": false })
-    assert_equal "123", class_names(nil, "", false, 123, { "song": false, "play": false })
+  def test_token_list_and_class_names
+    [:token_list, :class_names].each do |helper_method|
+      helper = ->(*arguments) { public_send(helper_method, *arguments) }
+
+      assert_equal "song play", helper.(["song", { "play": true }])
+      assert_equal "song", helper.({ "song": true, "play": false })
+      assert_equal "song", helper.([{ "song": true }, { "play": false }])
+      assert_equal "song", helper.({ song: true, play: false })
+      assert_equal "song", helper.([{ song: true }, nil, false])
+      assert_equal "song", helper.(["song", { foo: false }])
+      assert_equal "song play", helper.({ "song": true, "play": true })
+      assert_equal "", helper.({ "song": false, "play": false })
+      assert_equal "123", helper.(nil, "", false, 123, { "song": false, "play": false })
+      assert_equal "song", helper.("song", "song")
+      assert_equal "song", helper.("song song")
+      assert_equal "song", helper.("song\nsong")
+    end
   end
 
   def test_content_tag_with_data_attributes


### PR DESCRIPTION
Rename the new `TagHelper#class_names` method to `TagHelper#token_list`,
and make the original available as an alias.

Inspired by a discussion on [rails/rails#40121][]

Once rendered by a browser, [an element's `class` attribute is
represented as a `DOMTokenList`][mdn-domtokenlist]. It's a
space-delimited list with unique elements.

Outside of the HTML `[class]` attribute, there are other attributes that
are represented as space-delimited lists. A non-exhaustive list
includes:

* [aria-labelledby][mdn-aria-labelledby]
* [aria-describedby][mdn-aria-describedby]
* [data-controller][data-controller] (in StimulusJS applications)
* [data-action][data-action] (in StimulusJS applications)

To support these attributes, ensure the collection of values from the
`class_names` helper is a unique Set.

[rails/rails#40121]: https://github.com/rails/rails/pull/40121#issuecomment-683366103
[mdn-domtokenlist]: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList
[class_names]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-class_names
[mdn-aria-labelledby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute#Value
[mdn-aria-describedby]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute#Value
[data-action]: https://stimulusjs.org/reference/actions
[data-controller]: https://stimulusjs.org/reference/controllers

