### PR TITLE
Translate Mysql2 errors in Mysql2Adapter#quote_string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -101,6 +101,8 @@ module ActiveRecord
 
       def quote_string(string)
         @connection.escape(string)
+      rescue Mysql2::Error => error
+        raise translate_exception(error, message: error.message, sql: "<escape>", binds: [])
       end
 
       #--

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -67,7 +67,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   def test_quote_after_disconnect
     @connection.disconnect!
 
-    assert_raise(Mysql2::Error) do
+    assert_raise(ActiveRecord::StatementInvalid) do
       @connection.quote("string")
     end
   end


### PR DESCRIPTION
`Mysql2::Client#escape` uses the `mysql_real_escape_string` C API which requires an healthy connection because it's behavior is dependent on the connection locale etc.

In some cases this can cause `quote_string` to raise `Mysql2::Error`, and I believe it should be translated into an Active Record error like the others.

cc @Edouard-chin @rafaelfranca 

@kamipo since @rafaelfranca is away, maybe I can catch your eye on this?