### PR TITLE
Proxying: sanitize Content-Type and Content-Disposition

### DIFF
--- a/activestorage/app/controllers/concerns/active_storage/set_headers.rb
+++ b/activestorage/app/controllers/concerns/active_storage/set_headers.rb
@@ -5,8 +5,8 @@ module ActiveStorage::SetHeaders #:nodoc:
 
   private
     def set_content_headers_from(blob)
-      response.headers["Content-Type"] = blob.content_type
+      response.headers["Content-Type"] = blob.content_type_for_serving
       response.headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format \
-        disposition: params[:disposition] || "inline", filename: blob.filename.sanitized
+        disposition: blob.forced_disposition_for_serving || params[:disposition] || "inline", filename: blob.filename.sanitized
     end
 end

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -90,6 +90,12 @@ class ActiveStorage::Variant
     service.download key, &block
   end
 
+  alias_method :content_type_for_serving, :content_type
+
+  def forced_disposition_for_serving #:nodoc:
+    nil
+  end
+
   # Returns the receiving variant. Allows ActiveStorage::Variant and ActiveStorage::Preview instances to be used interchangeably.
   def image
     self

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -4,18 +4,24 @@ require "test_helper"
 require "database/setup"
 
 class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTest
-  setup do
-    @blob = create_file_blob filename: "racecar.jpg"
-  end
-
   test "invalid signed ID" do
     get rails_service_blob_proxy_url("invalid", "racecar.jpg")
     assert_response :not_found
   end
 
   test "HTTP caching" do
-     get rails_storage_proxy_url(@blob)
-     assert_response :success
-     assert_equal "max-age=3155695200, public", response.headers["Cache-Control"]
-   end
+    get rails_storage_proxy_url(create_file_blob(filename: "racecar.jpg"))
+    assert_response :success
+    assert_equal "max-age=3155695200, public", response.headers["Cache-Control"]
+  end
+
+  test "forcing Content-Type to binary" do
+    get rails_storage_proxy_url(create_blob(content_type: "text/html"))
+    assert_equal "application/octet-stream", response.headers["Content-Type"]
+  end
+
+  test "forcing Content-Disposition to attachment" do
+    get rails_storage_proxy_url(create_blob(content_type: "application/zip"))
+    assert_match(/^attachment; /, response.headers["Content-Disposition"])
+  end
 end


### PR DESCRIPTION
Prevent XSS where unsafe content is served inline on the application origin.

Follows up on #34477. References 06ab7b2 and d40284b.