### PR TITLE
Should not accidentally return decorated time object after `changes_applied`

### DIFF
--- a/activerecord/lib/active_record/type/time.rb
+++ b/activerecord/lib/active_record/type/time.rb
@@ -16,6 +16,16 @@ module ActiveRecord
           value
         end
       end
+
+      private
+        def cast_value(value)
+          case value = super
+          when Value
+            value.__getobj__
+          else
+            value
+          end
+        end
     end
   end
 end

--- a/activerecord/test/cases/type/time_test.rb
+++ b/activerecord/test/cases/type/time_test.rb
@@ -11,11 +11,17 @@ module ActiveRecord
         topic = Topic.new(bonus_time: { 4 => 10, 5 => 30 })
 
         assert_equal expected_time, topic.bonus_time
+        assert_instance_of ::Time, topic.bonus_time
 
         topic.save!
+
+        assert_equal expected_time, topic.bonus_time
+        assert_instance_of ::Time, topic.bonus_time
+
         topic.reload
 
         assert_equal expected_time, topic.bonus_time
+        assert_instance_of ::Time, topic.bonus_time
       end
     end
   end


### PR DESCRIPTION
Originally, time object is decorated after `changes_applied` by
`forgetting_assignment` (`value_for_database`).

https://github.com/rails/rails/blob/d2cdf0be675b44771f950697fc0b19ef0ea453f9/activemodel/lib/active_model/attribute.rb#L67-L69
https://github.com/rails/rails/blob/d2cdf0be675b44771f950697fc0b19ef0ea453f9/activemodel/lib/active_model/attribute.rb#L55-L57

Before #36352, fortunately `apply_seconds_precision` will return
undecorated new time object by everytime `value.change` is called.

Now, we need to explicitly check a time value is decorated or not in
`cast_value`.

Fixes #36910.
