### PR TITLE
Raise ConnectionNotEstablished rather than StatementInvalid in Mysql2Adapter#quote_string

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -650,6 +650,12 @@ module ActiveRecord
 
         def translate_exception(exception, message:, sql:, binds:)
           case error_number(exception)
+          when nil
+            if exception.message.match?(/MySQL client is not connected/i)
+              ConnectionNotEstablished.new(exception)
+            else
+              super
+            end
           when ER_DB_CREATE_EXISTS
             DatabaseAlreadyExists.new(message, sql: sql, binds: binds)
           when ER_DUP_ENTRY

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -478,6 +478,12 @@ module ActiveRecord
           return exception unless exception.respond_to?(:result)
 
           case exception.result.try(:error_field, PG::PG_DIAG_SQLSTATE)
+          when nil
+            if exception.message.match?(/connection is closed/i)
+              ConnectionNotEstablished.new(exception)
+            else
+              super
+            end
           when UNIQUE_VIOLATION
             RecordNotUnique.new(message, sql: sql, binds: binds)
           when FOREIGN_KEY_VIOLATION

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -475,17 +475,18 @@ module ActiveRecord
         end
 
         def translate_exception(exception, message:, sql:, binds:)
-          case exception.message
           # SQLite 3.8.2 returns a newly formatted error message:
           #   UNIQUE constraint failed: *table_name*.*column_name*
           # Older versions of SQLite return:
           #   column *column_name* is not unique
-          when /column(s)? .* (is|are) not unique/, /UNIQUE constraint failed: .*/
+          if exception.message.match?(/(column(s)? .* (is|are) not unique|UNIQUE constraint failed: .*)/i)
             RecordNotUnique.new(message, sql: sql, binds: binds)
-          when /.* may not be NULL/, /NOT NULL constraint failed: .*/
+          elsif exception.message.match?(/(.* may not be NULL|NOT NULL constraint failed: .*)/i)
             NotNullViolation.new(message, sql: sql, binds: binds)
-          when /FOREIGN KEY constraint failed/i
+          elsif exception.message.match?(/FOREIGN KEY constraint failed/i)
             InvalidForeignKey.new(message, sql: sql, binds: binds)
+          elsif exception.message.match?(/called on a closed database/i)
+            ConnectionNotEstablished.new(exception)
           else
             super
           end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -58,7 +58,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   def test_execute_after_disconnect
     @connection.disconnect!
 
-    error = assert_raise(ActiveRecord::StatementInvalid) do
+    error = assert_raise(ActiveRecord::ConnectionNotEstablished) do
       @connection.execute("SELECT 1")
     end
     assert_kind_of Mysql2::Error, error.cause
@@ -67,7 +67,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   def test_quote_after_disconnect
     @connection.disconnect!
 
-    assert_raise(ActiveRecord::StatementInvalid) do
+    assert_raise(ActiveRecord::ConnectionNotEstablished) do
       @connection.quote("string")
     end
   end

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -22,7 +22,7 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
     test "can't execute statements while disconnected" do
       @connection.execute "SELECT count(*) from products"
       @connection.disconnect!
-      assert_raises(ActiveRecord::StatementInvalid) do
+      assert_raises(ActiveRecord::ConnectionNotEstablished) do
         silence_warnings do
           @connection.execute "SELECT count(*) from products"
         end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/40148 (apologies I should have put more thought into it initially)

`ConnectionNotEstablished` is probably a much better exception for this case. cc @kamipo 