### PR TITLE
Allow subscribers to be detached from namespace per event

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -3,13 +3,13 @@
 
     ```ruby
     class StatsSubscriber < ActiveSupport::Subscriber
-        attach_to :active_record
+      attach_to :active_record
     
-        def sql(event)
-            Statsd.timing("sql.#{event.payload[:name]}", event.duration)
-        end
+      def sql(event)
+        Statsd.timing("sql.#{event.payload[:name]}", event.duration)
+      end
 
-        detach_from: :active_record, events: [:sql]
+      detach_from: :active_record, events: [:sql]
     end
     ```
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,20 @@
+*  `ActiveSupport::Subscriber#detach_from` updated to take an `events:` argument, allowing
+    subscribers to detach from specific methods in a namespace while still receiving events for others.
+
+    ```ruby
+    class StatsSubscriber < ActiveSupport::Subscriber
+        attach_to :active_record
+    
+        def sql(event)
+            Statsd.timing("sql.#{event.payload[:name]}", event.duration)
+        end
+
+        detach_from: :active_record, events: [:sql]
+    end
+    ```
+
+    *Adrianna Chang*
+
 *   Add `ActiveSupport::Duration` conversion methods
 
     `in_seconds`, `in_minutes`, `in_hours`, `in_days`, `in_weeks`, `in_months`, and `in_years` return the respective duration covered.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,5 +1,5 @@
-*  `ActiveSupport::Subscriber#detach_from` updated to take an `events:` argument, allowing
-    subscribers to detach from specific methods in a namespace while still receiving events for others.
+*  `ActiveSupport::Subscriber#detach_from` now accepts an `events:` argument that allows
+    subscribers to detach from specific methods in a namespace while still receiving events from others.
 
     ```ruby
     class StatsSubscriber < ActiveSupport::Subscriber
@@ -9,7 +9,7 @@
         Statsd.timing("sql.#{event.payload[:name]}", event.duration)
       end
 
-      detach_from: :active_record, events: [:sql]
+      detach_from :active_record, events: [:sql]
     end
     ```
 

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -63,12 +63,13 @@ module ActiveSupport
           subscriber.public_methods(false).each do |event|
             remove_event_subscriber(event)
           end
-
-          # Reset notifier so that event subscribers will not add for new methods added to the class.
-          @notifier = nil
         end
 
-        subscribers.delete(subscriber) unless subscriber.patterns.any?
+        unless subscriber.patterns.any?
+          # Reset notifier so that event subscribers will not add for new methods added to the class.
+          @notifier = nil
+          subscribers.delete(subscriber)
+        end
       end
 
       # Adds event subscribers for all new methods added to the class.

--- a/activesupport/test/subscriber_test.rb
+++ b/activesupport/test/subscriber_test.rb
@@ -4,8 +4,6 @@ require_relative "abstract_unit"
 require "active_support/subscriber"
 
 class TestSubscriber < ActiveSupport::Subscriber
-  attach_to :doodle
-
   cattr_reader :events
 
   def self.clear
@@ -13,6 +11,10 @@ class TestSubscriber < ActiveSupport::Subscriber
   end
 
   def open_party(event)
+    events << event
+  end
+
+  def another_open_party(event)
     events << event
   end
 
@@ -21,64 +23,6 @@ class TestSubscriber < ActiveSupport::Subscriber
       events << event
     end
 end
-
-class TestSubscriber2 < ActiveSupport::Subscriber
-  attach_to :doodle
-
-  cattr_reader :events
-
-  def self.clear
-    @@events = []
-  end
-
-  def open_party(event)
-    events << event
-  end
-
-  detach_from :doodle
-end
-
-class TestSubscriber3 < ActiveSupport::Subscriber
-  attach_to :doodle
-
-  cattr_reader :events
-
-  def self.clear
-    @@events = []
-  end
-
-  def open_party(event)
-    events << event
-  end
-
-  def another_open_party(event)
-    events << event
-  end
-
-  detach_from :doodle, events: [:open_party]
-end
-
-class TestSubscriber4 < ActiveSupport::Subscriber
-  attach_to :doodle
-
-  cattr_reader :events
-
-  def self.clear
-    @@events = []
-  end
-
-  def open_party(event)
-    events << event
-  end
-
-  def another_open_party(event)
-    events << event
-  end
-
-  detach_from :doodle, events: [:events]
-  detach_from :doodle, events: [:open_party, :another_open_party]
-end
-
 
 # Monkey patch subscriber to test that only one subscriber per method is added.
 class TestSubscriber
@@ -91,54 +35,79 @@ end
 class SubscriberTest < ActiveSupport::TestCase
   def setup
     TestSubscriber.clear
-    TestSubscriber2.clear
-    TestSubscriber3.clear
-    TestSubscriber4.clear
   end
 
   def test_attaches_subscribers
+    TestSubscriber.attach_to :doodle
+
     ActiveSupport::Notifications.instrument("open_party.doodle")
 
     assert_equal "open_party.doodle", TestSubscriber.events.first.name
+  ensure
+    TestSubscriber.detach_from :doodle
   end
 
   def test_attaches_only_one_subscriber
+    TestSubscriber.attach_to :doodle
+
     ActiveSupport::Notifications.instrument("open_party.doodle")
 
     assert_equal 1, TestSubscriber.events.size
+  ensure
+    TestSubscriber.detach_from :doodle
   end
 
   def test_does_not_attach_private_methods
+    TestSubscriber.attach_to :doodle
+
     ActiveSupport::Notifications.instrument("private_party.doodle")
+
+    assert_equal [], TestSubscriber.events
+  ensure
+    TestSubscriber.detach_from :doodle
+  end
+
+  def test_detaches_subscribers
+    TestSubscriber.attach_to :doodle
+    TestSubscriber.detach_from :doodle
+
+    ActiveSupport::Notifications.instrument("open_party.doodle")
 
     assert_equal [], TestSubscriber.events
   end
 
-  def test_detaches_subscribers
-    ActiveSupport::Notifications.instrument("open_party.doodle")
-
-    assert_equal [], TestSubscriber2.events
-    assert_equal 1, TestSubscriber.events.size
-  end
-
   def test_detaches_subscribers_from_specific_events
+    TestSubscriber.attach_to :doodle
+    TestSubscriber.detach_from :doodle, events: [:open_party]
+
     ActiveSupport::Notifications.instrument("open_party.doodle")
     ActiveSupport::Notifications.instrument("another_open_party.doodle")
 
-    assert_equal 1, TestSubscriber3.events.size
-    assert_equal "another_open_party.doodle", TestSubscriber3.events.first.name
+    assert_equal 1, TestSubscriber.events.size
+    assert_equal "another_open_party.doodle", TestSubscriber.events.first.name
+  ensure
+    TestSubscriber.detach_from :doodle
   end
 
   def test_detach_from_does_not_remove_subscriber_if_only_detaching_from_some_events
-    assert TestSubscriber3.subscribers.find { |subscriber| subscriber.is_a?(TestSubscriber3) }
+    TestSubscriber.attach_to :doodle
+    TestSubscriber.detach_from :doodle, events: [:open_party]
+
+    assert_includes ActiveSupport::Subscriber.subscribers.map(&:class), TestSubscriber
+  ensure
+    TestSubscriber.detach_from :doodle
   end
 
   def test_detach_from_with_events_can_be_called_multiple_times_in_a_row
+    TestSubscriber.attach_to :doodle
+    TestSubscriber.detach_from :doodle, events: [:events]
+    TestSubscriber.detach_from :doodle, events: [:open_party, :another_open_party]
+
     ActiveSupport::Notifications.instrument("open_party.doodle")
     ActiveSupport::Notifications.instrument("another_open_party.doodle")
 
-    assert_equal [], TestSubscriber4.events
+    assert_equal [], TestSubscriber.events
 
-    assert_nil TestSubscriber4.subscribers.find { |subscriber| subscriber.is_a?(TestSubscriber4) }
+    assert_not_includes ActiveSupport::Subscriber.subscribers.map(&:class), TestSubscriber
   end
 end


### PR DESCRIPTION
### Summary

It would be nice to be able to detach a subscriber from a namespace on a per-event-type basis, rather than having to opt in or out of notifications from the entire namespace.

A particular use case we've encountered: the `ActionController::LogSubscriber` kicks in to log information on events to `ActionController`. We would like to implement our own logs for `start_processing` (makes it easier for us to aggregate them in fluentd), but would like to retain default logging for other events in `ActionController`.

Right now, we have to iterate over `LogSubscribers` to find the one for `ActionController`, find the specific listener pertaining to `"start_processing.action_controller"`, etc... It would be great to simply detach from a given event via the `ActiveSupport::Subscriber#detach_from` API.

The proposed solution here is to add an optional `events:` argument to `#detach_from`, which allows a list of `events` to be specified, and will remove event subscribers from those methods only.