### PR TITLE
Don't override module name on AV::Base subclass

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -191,12 +191,8 @@ module ActionView #:nodoc:
           define_method(:compiled_method_container)           { subclass }
           define_singleton_method(:compiled_method_container) { subclass }
 
-          def self.name
-            superclass.name
-          end
-
           def inspect
-            "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+            "#<ActionView::Base:#{'%#016x' % (object_id << 1)}>"
           end
         }
       end


### PR DESCRIPTION
We should avoid overriding name if possible because it is confusing to developers (it confused me at least 😅) and it also can causes bugs in code which deal with modules but aren't using the `Module.instance_method(:name).bind` workaround.

I believe 🤞 we can still achieve the desired "method missing" behaviour by only redefining `inspect`.

Refs https://github.com/rails/rails/pull/39819 cc @p8