### PR TITLE
Allow extra client config options forAzureStorage

### DIFF
--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -10,8 +10,8 @@ module ActiveStorage
   class Service::AzureStorageService < Service
     attr_reader :client, :blobs, :container, :signer
 
-    def initialize(storage_account_name:, storage_access_key:, container:)
-      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key)
+    def initialize(storage_account_name:, storage_access_key:, container:, **options)
+      @client = Azure::Storage::Client.create(storage_account_name: storage_account_name, storage_access_key: storage_access_key, **options)
       @signer = Azure::Storage::Core::Auth::SharedAccessSignature.new(storage_account_name, storage_access_key)
       @blobs = client.blob_client
       @container = container


### PR DESCRIPTION
### Summary
This is a backport of updates made to [master](https://github.com/rails/rails/pull/35096).

In order to set custom options (e.g. a custom domain name) on the azure storage client, the ActiveStorage adapter must allow more options to be passed to the initializer. Currently `ActiveStorage::Service::AzureStorage` only allows for a fixed set of options.

Here we add the ability to pass additional options to the initializer.

### Other Information
This change allows government entities using the `core.usgovcloudapi.net` domain to use this service.