### PR TITLE
Do not use submit_tag auto-disabling when disable_with is set to false

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -897,16 +897,15 @@ module ActionView
         end
 
         def set_default_disable_with(value, tag_options)
-          return unless ActionView::Base.automatically_disable_submit_tag
           data = tag_options["data"]
 
-          unless tag_options["data-disable-with"] == false || (data && data["disable_with"] == false)
+          if tag_options["data-disable-with"] == false || (data && data["disable_with"] == false)
+            data.delete("disable_with") if data
+          elsif ActionView::Base.automatically_disable_submit_tag
             disable_with_text = tag_options["data-disable-with"]
             disable_with_text ||= data["disable_with"] if data
             disable_with_text ||= value.to_s.clone
             tag_options.deep_merge!("data" => { "disable_with" => disable_with_text })
-          else
-            data.delete("disable_with") if data
           end
 
           tag_options.delete("data-disable-with")

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -538,6 +538,16 @@ class FormTagHelperTest < ActionView::TestCase
     ActionView::Base.automatically_disable_submit_tag = true
   end
 
+  def test_empty_submit_tag_with_opt_out_and_explicit_disabling
+    ActionView::Base.automatically_disable_submit_tag = false
+    assert_dom_equal(
+      %(<input name='commit' type="submit" value="Save" />),
+      submit_tag("Save", data: { disable_with: false })
+    )
+  ensure
+    ActionView::Base.automatically_disable_submit_tag = true
+  end
+
   def test_submit_tag_having_data_disable_with_string
     assert_dom_equal(
       %(<input data-disable-with="Processing..." data-confirm="Are you sure?" name='commit' type="submit" value="Save" />),


### PR DESCRIPTION
### Summary

If we have `data: { disable_with: false }` then auto-disabling is turned off, but if we set `automatically_disable_submit_tag` to `false` it changes the behaviour of `disable_with` in an unexpected way, so explicit usage of `disalbe_with: false` starts to enable auto-disabling with `false` as the value of a disabled button.

It looks like a more convenient way to have auto-disabling turned off if we have explicit `disalbe_with: false` no matter what is set in `automatically_disable_submit_tag`