### PR TITLE
Reduce allocations in expanded_version and expanded_key

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -617,13 +617,7 @@ module ActiveSupport
         # Deletes multiples entries in the cache implementation. Subclasses MAY
         # implement this method.
         def delete_multi_entries(entries, **options)
-          entries.inject(0) do |sum, key|
-            if delete_entry(key, **options)
-              sum + 1
-            else
-              sum
-            end
-          end
+          entries.count { |key| delete_entry(key, **options) }
         end
 
         # Merges the default options with ones specific to a method call.
@@ -687,7 +681,7 @@ module ActiveSupport
               expanded_key(key.first)
             end
           when Hash
-            key.collect { |k, v| "#{k}=#{v}" }.sort
+            key.collect { |k, v| "#{k}=#{v}" }.sort!
           else
             key
           end.to_param
@@ -700,7 +694,7 @@ module ActiveSupport
         def expanded_version(key)
           case
           when key.respond_to?(:cache_version) then key.cache_version.to_param
-          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact.to_param
+          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact!.to_param
           when key.respond_to?(:to_a)          then expanded_version(key.to_a)
           end
         end

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -694,7 +694,7 @@ module ActiveSupport
         def expanded_version(key)
           case
           when key.respond_to?(:cache_version) then key.cache_version.to_param
-          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact!.to_param
+          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.tap(&:compact!).to_param
           when key.respond_to?(:to_a)          then expanded_version(key.to_a)
           end
         end


### PR DESCRIPTION
### Summary

This PR adds three simple changes to cache methods.

1. Prefer `sort!` to save allocations in expanded_key, since we create the array with `collect`
2. Prefer `compact!` to save allocations in expanded_version, since we create the array with `map`
3. Use `count` with a block to simplify `delete_multi_entries`. This is slightly faster than inject, but same number of allocations.

#### Benchmark
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", require: "rails/all"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

module ActiveSupport
  module Cache
    class Store
      private
        def fast_delete_multi_entries(entries, **options)
          entries.count { |key| delete_entry(key, **options) }
        end

        def fast_expanded_key(key)
          return key.cache_key.to_s if key.respond_to?(:cache_key)

          case key
          when Array
            if key.size > 1
              key.collect { |element| expanded_key(element) }
            else
              expanded_key(key.first)
            end
          when Hash
            key.collect { |k, v| "#{k}=#{v}" }.sort!
          else
            key
          end.to_param
        end

        def fast_expanded_version(key)
          case
          when key.respond_to?(:cache_version) then key.cache_version.to_param
          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.tap(&:compact!).to_param
          when key.respond_to?(:to_a)          then expanded_version(key.to_a)
          end
        end
    end
  end
end

cache = ActiveSupport::Cache::MemoryStore.new

keys = (0..1000).map do |i|
  cache.write("key_#{i}", "value_#{i}")
end

puts "** delete_multi_entries **"
Benchmark.ips do |x|
  x.report("delete_multi_entries")      { cache.send(:delete_multi_entries, keys) }
  x.report("fast_delete_multi_entries") { cache.send(:fast_delete_multi_entries, keys) }
  x.compare!
end

Benchmark.memory do |x|
  x.report("delete_multi_entries")      { cache.send(:delete_multi_entries, keys) }
  x.report("fast_delete_multi_entries") { cache.send(:fast_delete_multi_entries, keys) }
  x.compare!
end

puts "** delete_multi_entries **"
Benchmark.ips do |x|
  x.report("expanded_key")      { cache.send(:expanded_key, { some: "hash", cache: "key" }) }
  x.report("fast_expanded_key") { cache.send(:fast_expanded_key, { some: "hash", cache: "key" }) }
  x.compare!
end

Benchmark.memory do |x|
  x.report("expanded_key")      { cache.send(:expanded_key, { some: "hash", cache: "key" }) }
  x.report("fast_expanded_key") { cache.send(:fast_expanded_key, { some: "hash", cache: "key" }) }
  x.compare!
end

puts "** delete_multi_entries **"
Benchmark.ips do |x|
  x.report("expanded_version")      { cache.send(:expanded_version, keys) }
  x.report("fast_expanded_version") { cache.send(:fast_expanded_version, keys) }
  x.compare!
end

Benchmark.memory do |x|
  x.report("expanded_version")      { cache.send(:expanded_version, keys) }
  x.report("fast_expanded_version") { cache.send(:fast_expanded_version, keys) }
  x.compare!
end
```
#### Results
```
** delete_multi_entries **
Warming up --------------------------------------
delete_multi_entries   257.000  i/100ms
fast_delete_multi_entries
                       270.000  i/100ms
Calculating -------------------------------------
delete_multi_entries      2.563k (± 2.1%) i/s -     12.850k in   5.016853s
fast_delete_multi_entries
                          2.683k (± 2.4%) i/s -     13.500k in   5.033634s

Comparison:
fast_delete_multi_entries:     2683.5 i/s
delete_multi_entries:     2562.6 i/s - 1.05x  (± 0.00) slower

Calculating -------------------------------------
delete_multi_entries    80.120k memsize (     0.000  retained)
                         2.003k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
fast_delete_multi_entries
                        80.120k memsize (     0.000  retained)
                         2.003k objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
delete_multi_entries:      80120 allocated
fast_delete_multi_entries:      80120 allocated - same


** expanded_key **
Warming up --------------------------------------
        expanded_key    59.059k i/100ms
   fast_expanded_key    60.977k i/100ms
Calculating -------------------------------------
        expanded_key    594.976k (± 2.7%) i/s -      3.012M in   5.066225s
   fast_expanded_key    603.980k (± 3.3%) i/s -      3.049M in   5.053411s

Comparison:
   fast_expanded_key:   603980.4 i/s
        expanded_key:   594976.0 i/s - same-ish: difference falls within error

Calculating -------------------------------------
        expanded_key   528.000  memsize (   168.000  retained)
                        10.000  objects (     1.000  retained)
                         5.000  strings (     0.000  retained)
   fast_expanded_key   488.000  memsize (   168.000  retained)
                         9.000  objects (     1.000  retained)
                         5.000  strings (     0.000  retained)

Comparison:
   fast_expanded_key:        488 allocated
        expanded_key:        528 allocated - 1.08x more


** expanded_version **
Warming up --------------------------------------
    expanded_version   518.000  i/100ms
fast_expanded_version
                       514.000  i/100ms
Calculating -------------------------------------
    expanded_version      5.081k (± 3.9%) i/s -     25.382k in   5.003905s
fast_expanded_version
                          5.323k (± 2.2%) i/s -     26.728k in   5.024021s

Comparison:
fast_expanded_version:     5322.8 i/s
    expanded_version:     5080.5 i/s - same-ish: difference falls within error

Calculating -------------------------------------
    expanded_version     8.168k memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)
fast_expanded_version
                       120.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Comparison:
fast_expanded_version:        120 allocated
    expanded_version:       8168 allocated - 68.07x more
```