### PR TITLE
Shorten inspect on AbstractController::Base

### DIFF
--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -204,6 +204,10 @@ module AbstractController
       true
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
+    end
+
     private
       # Returns true if the name can be considered an action because
       # it has a method defined in the controller.

--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -147,6 +147,10 @@ class ControllerInstanceTests < ActiveSupport::TestCase
   ensure
     ActionDispatch::Response.default_headers = original_default_headers
   end
+
+  def test_inspect
+    assert_match(/\A#<EmptyController:0x[0-9a-f]+>\z/, @empty.inspect)
+  end
 end
 
 class PerformActionTest < ActionController::TestCase

--- a/actionpack/test/controller/metal_test.rb
+++ b/actionpack/test/controller/metal_test.rb
@@ -29,4 +29,9 @@ class MetalControllerInstanceTests < ActiveSupport::TestCase
   ensure
     ActionDispatch::Response.default_headers = original_default_headers
   end
+
+  def test_inspect
+    controller = SimpleController.new
+    assert_match(/\A#<MetalControllerInstanceTests::SimpleController:0x[0-9a-f]+>\z/, controller.inspect)
+  end
 end


### PR DESCRIPTION
### Summary

Calling self in an action of a controller generates an endless stream of
characters, including the request object and all instances variables.
This can be frustrating when using a debugger in a controller and
accidentally calling `self` generates output for a couple of seconds.

This shortens inspect to only show the class name.

    MyController.new.inspect # => "#<MyController:0x00000000005028>"


### Other Information
This pull request splits an older pull request into two separate pull requests.
https://github.com/rails/rails/pull/39439
