### PR TITLE
Shorten inspect on ActionDispatch::Request

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -431,6 +431,10 @@ module ActionDispatch
       super || scheme == "wss"
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name} #{method} #{original_url.dump} for #{remote_ip}>"
+    end
+
     private
       def check_method(name)
         HTTP_METHOD_LOOKUP[name] || raise(ActionController::UnknownHttpMethod, "#{name}, accepted HTTP methods are #{HTTP_METHODS[0...-1].join(', ')}, and #{HTTP_METHODS[-1]}")

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1290,3 +1290,17 @@ class EarlyHintsRequestTest < BaseRequestTest
     assert_equal expected_hints, early_hints
   end
 end
+
+class RequestInspectTest < BaseRequestTest
+  test "inspect" do
+    request = stub_request(
+      "REQUEST_METHOD" => "POST",
+      "REMOTE_ADDR" => "1.2.3.4",
+      "HTTP_X_FORWARDED_PROTO" => "https",
+      "HTTP_X_FORWARDED_HOST" => "example.com:443",
+      "PATH_INFO" => "/path/",
+      "QUERY_STRING" => "q=1"
+    )
+    assert_match %r(#<ActionDispatch::Request POST "https://example.com/path/\?q=1" for 1.2.3.4>), request.inspect
+  end
+end


### PR DESCRIPTION
### Summary

Calling `request` in an action of a controller generates an endless stream of
characters, including the Rack app and middlewares.
This can be frustrating when using a debugger in a controller and
accidentally calling `request` generates output for a couple of seconds.

Inspect on ActionDispatch::Request is shortened to relevant attributes:

    "#<ActionDispatch::Request request_method=POST, original_url=https://glu.ttono.us/path/of/some/uri?mapped=1, remote_ip=1.2.3.4, media_type=application/x-www-form-urlencoded>"

### Other Information

This pull request splits an older pull request into two separate pull requests.
https://github.com/rails/rails/pull/39439

**Edit**:
I've changed the output to use the same format as used for requests in the logs:

    "#<ActionDispatch::Request POST "https://example.com/path/of/some/uri?q=1" for 1.2.3.4>"