### PR TITLE
Support reversing of Arel expressions in reverse_order, last etc.

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1360,6 +1360,8 @@ module ActiveRecord
             o.desc
           when Arel::Nodes::Ordering
             o.reverse
+          when Arel::Nodes::NodeExpression
+            o.desc
           when String
             if does_not_support_reverse?(o)
               raise IrreversibleOrderError, "Order #{o.inspect} cannot be reversed automatically"

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -306,6 +306,11 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal topics(:third).title, topics.first.title
   end
 
+  def test_reverse_arel_order_with_function
+    topics = Topic.order(Topic.arel_table[:title].lower).reverse_order
+    assert_equal topics(:third).title, topics.first.title
+  end
+
   def test_reverse_arel_assoc_order_with_function
     topics = Topic.order(Arel.sql("lower(title)") => :asc).reverse_order
     assert_equal topics(:third).title, topics.first.title


### PR DESCRIPTION
The current behaviour of `reverse_order`, when presented with an order that is an Arel expression, is to ignore it. This isn't quite in keeping with how it handles Arel attributes (which it reverses) or arbitrary strings (which cause an exception).

The easy path to handling such expressions would be to throw the same exception, but I don't think we have to be so unrefined, by relying on this expectation: any SQL expression that is a valid default sort expression (i.e. has an implicit ASC) can be reversed with DESC.

It follows isomorphically that if there's an existing Arel::Nodes::NodeExpression not already wrapped with an Arel::Nodes::Ordering, then it should be reversible with `.desc`.

### Summary

Resolves #40176 in favour of DESC.

### Other Information

One could resolve #40176 in favour of throwing an `IrreversibleOrderError` instead, but I think this is a nicer outcome. It solves an actual bug I'd encountered.
