### PR TITLE
Raise error when `from` is used with `delete_all`.

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -11,7 +11,7 @@ module ActiveRecord
                             :reverse_order, :distinct, :create_with, :skip_query_cache]
 
     CLAUSE_METHODS = [:where, :having, :from]
-    INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :group, :having]
+    INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :group, :having, :from]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS
 
@@ -577,8 +577,9 @@ module ActiveRecord
     def delete_all
       invalid_methods = INVALID_METHODS_FOR_DELETE_ALL.select do |method|
         value = @values[method]
-        method == :distinct ? value : value&.any?
+        [:distinct, :from].include?(method) ? value : value&.any?
       end
+
       if invalid_methods.any?
         raise ActiveRecordError.new("delete_all doesn't support #{invalid_methods.join(', ')}")
       end

--- a/activerecord/test/cases/relation/delete_all_test.rb
+++ b/activerecord/test/cases/relation/delete_all_test.rb
@@ -50,6 +50,7 @@ class DeleteAllTest < ActiveRecord::TestCase
     assert_raises(ActiveRecord::ActiveRecordError) { Author.distinct.delete_all }
     assert_raises(ActiveRecord::ActiveRecordError) { Author.group(:name).delete_all }
     assert_raises(ActiveRecord::ActiveRecordError) { Author.having("SUM(id) < 3").delete_all }
+    assert_raises(ActiveRecord::ActiveRecordError) { Author.from("(SELECT * FROM authors) AS authors").delete_all }
   end
 
   def test_delete_all_with_joins_and_where_part_is_hash


### PR DESCRIPTION
This prevents the `from` query method from being ignored silently in the
resulting SQL query that is generated.

Resolves https://github.com/rails/rails/issues/39767