### PR TITLE
Improve symbol key access in `HashWithIndifferentAccess` with Ruby 3.0

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -363,6 +363,14 @@ module ActiveSupport
     end
 
     private
+      if Symbol.method_defined?(:name)
+        using Module.new {
+          refine Symbol do
+            alias :to_s :name
+          end
+        }
+      end
+
       def convert_key(key)
         key.kind_of?(Symbol) ? key.to_s : key
       end


### PR DESCRIPTION
I raised a discussion at RubyKaigi Takeout 2020 about how to get
deduplicated strings from symbols, and after the discussion Matz
approved the introduction of `Symbol#name`.

https://rubykaigi.org/2020-takeout
https://bugs.ruby-lang.org/issues/16150#note-68
https://github.com/ruby/ruby/pull/3514

This change improves symbol key access in `HashWithIndifferentAccess`
with Ruby 3.0 by using the `Symbol#name`.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "activesupport", github: "rails/rails"
  gem "benchmark-ips"
  gem "benchmark-memory"
end

require "active_support/core_ext/hash/indifferent_access"

hash = { a: 1, b: 2 }.with_indifferent_access

benchmark = -> x {
  x.report("hash_with_indifferent_access") do
    hash[:a]; hash[:b]; hash[:c]; hash[:d]
  end
}

puts "IPS"
Benchmark.ips(&benchmark)

puts "MEMORY"
Benchmark.memory(&benchmark)
```

Before with ruby-head (https://github.com/ruby/ruby/commit/de30450d91a8dda9dd415512ba5a1709704cae12):

```
IPS
Warming up --------------------------------------
hash_with_indifferent_access
                        43.146k i/100ms
Calculating -------------------------------------
hash_with_indifferent_access
                        433.481k (± 3.2%) i/s -      2.200M in   5.081428s
MEMORY
Calculating -------------------------------------
hash_with_indifferent_access
                       320.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
```

After with ruby-head (https://github.com/ruby/ruby/commit/de30450d91a8dda9dd415512ba5a1709704cae12):

```
IPS
Warming up --------------------------------------
hash_with_indifferent_access
                        44.115k i/100ms
Calculating -------------------------------------
hash_with_indifferent_access
                        455.515k (± 3.0%) i/s -      2.294M in   5.040846s
MEMORY
Calculating -------------------------------------
hash_with_indifferent_access
                       160.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```
