### PR TITLE
Deprecate raw SQL in `group` method without marking the SQL as safe

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Deprecate raw SQL in `group` method without marking the SQL as safe.
+
+    ```ruby
+    # Before:
+    Post.group("<sql>").count
+
+    # After:
+    Post.group(Arel.sql("<sql>")).count
+    ```
+
+    *Andrew Kane*
+
 *   Improve performance of `one?` and `many?` by limiting the generated count query to 2 results.
 
     *Gonzalo Riestra*

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -149,6 +149,10 @@ module ActiveRecord
         COLUMN_NAME_WITH_ORDER
       end
 
+      def column_name_without_alias_matcher # :nodoc:
+        COLUMN_NAME_WITHOUT_ALIAS
+      end
+
       # Regexp for column names (with or without a table name prefix).
       # Matches the following:
       #
@@ -192,7 +196,24 @@ module ActiveRecord
         \z
       /ix
 
-      private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
+      # Regexp for column names (with or without a table name prefix).
+      # Matches the following:
+      #
+      #   "#{table_name}.#{column_name}"
+      #   "#{column_name}"
+      COLUMN_NAME_WITHOUT_ALIAS = /
+        \A
+        (
+          (?:
+            # table_name.column_name | function(one or no argument)
+            ((?:\w+\.)?\w+) | \w+\((?:|\g<2>)\)
+          )
+        )
+        (?:\s*,\s*\g<1>)*
+        \z
+      /ix
+
+      private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER, :COLUMN_NAME_WITHOUT_ALIAS
 
       private
         def type_casted_binds(binds)

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -42,6 +42,10 @@ module ActiveRecord
           COLUMN_NAME_WITH_ORDER
         end
 
+        def column_name_without_alias_matcher
+          COLUMN_NAME_WITHOUT_ALIAS
+        end
+
         COLUMN_NAME = /
           \A
           (
@@ -68,7 +72,19 @@ module ActiveRecord
           \z
         /ix
 
-        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
+        COLUMN_NAME_WITHOUT_ALIAS = /
+          \A
+          (
+            (?:
+              # `table_name`.`column_name` | function(one or no argument)
+              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)) | \w+\((?:|\g<2>)\)
+            )
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+
+        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER, :COLUMN_NAME_WITHOUT_ALIAS
 
         private
           # Override +_type_cast+ we pass to mysql2 Date and Time objects instead

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -86,6 +86,10 @@ module ActiveRecord
           COLUMN_NAME_WITH_ORDER
         end
 
+        def column_name_without_alias_matcher
+          COLUMN_NAME_WITHOUT_ALIAS
+        end
+
         COLUMN_NAME = /
           \A
           (
@@ -113,7 +117,19 @@ module ActiveRecord
           \z
         /ix
 
-        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
+        COLUMN_NAME_WITHOUT_ALIAS = /
+          \A
+          (
+            (?:
+              # "table_name"."column_name"::type_name | function(one or no argument)::type_name
+              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
+            )
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+
+        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER, :COLUMN_NAME_WITHOUT_ALIAS
 
         private
           def lookup_cast_type(sql_type)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -53,6 +53,10 @@ module ActiveRecord
           COLUMN_NAME_WITH_ORDER
         end
 
+        def column_name_without_alias_matcher
+          COLUMN_NAME_WITHOUT_ALIAS
+        end
+
         COLUMN_NAME = /
           \A
           (
@@ -79,7 +83,19 @@ module ActiveRecord
           \z
         /ix
 
-        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER
+        COLUMN_NAME_WITHOUT_ALIAS = /
+          \A
+          (
+            (?:
+              # "table_name"."column_name" | function(one or no argument)
+              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")) | \w+\((?:|\g<2>)\)
+            )
+          )
+          (?:\s*,\s*\g<1>)*
+          \z
+        /ix
+
+        private_constant :COLUMN_NAME, :COLUMN_NAME_WITH_ORDER, :COLUMN_NAME_WITHOUT_ALIAS
 
         private
           def _type_cast(value)

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -350,6 +350,7 @@ module ActiveRecord
     end
 
     def group!(*args) # :nodoc:
+      @klass.disallow_raw_sql!(args, permit: connection.column_name_without_alias_matcher, deprecated: true) unless args.empty?
       self.group_values += args
       self
     end

--- a/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/timestamp_test.rb
@@ -49,7 +49,7 @@ class PostgresqlTimestampFixtureTest < ActiveRecord::PostgreSQLTestCase
   fixtures :topics
 
   def test_group_by_date
-    keys = Topic.group("date_trunc('month', created_at)").count.keys
+    keys = Topic.group(Arel.sql("date_trunc('month', created_at)")).count.keys
     assert_operator keys.length, :>, 0
     keys.each { |k| assert_kind_of Time, k }
   end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -133,7 +133,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_group_by_multiple_fields_having_functions
-    c = Topic.group(:author_name, "COALESCE(type, title)").count(:all)
+    c = Topic.group(:author_name, Arel.sql("COALESCE(type, title)")).count(:all)
     assert_equal 1, c[["Carl", "The Third Topic of the day"]]
     assert_equal 1, c[["Mary", "Reply"]]
     assert_equal 1, c[["David", "The First Topic"]]


### PR DESCRIPTION
### Summary

This takes the approach from #27947 and applies it to the `group` and `calculate` methods (like `count`, `sum`, etc). Currently, both methods are susceptible to [SQL injection](https://rails-sqli.org/) with untrusted input.

Allowed

```ruby
Post.group(:title).count      
Post.group("posts.title").count
Post.group("UPPER(title)").count
```

Disallowed (unless wrapped in `Arel.sql`)

```ruby
Post.group("some injection --").count
```

It currently uses the default rules for `disallow_raw_sql!`, but we may want to refine them for certain methods (for instance, allow for `count("*")` and `count("DISTINCT column")`).