### PR TITLE
Rename Error#detail method as details

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -135,14 +135,15 @@ module ActiveModel
       end
     end
 
-    # Returns the error detail.
+    # Returns the error details.
     #
     #   error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
-    #   error.detail
+    #   error.details
     #   # => { error: :too_short, count: 5 }
-    def detail
+    def details
       { error: raw_type }.merge(options.except(*CALLBACKS_OPTIONS + MESSAGE_OPTIONS))
     end
+    alias_method :detail, :details
 
     # Returns the full error message.
     #

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -347,7 +347,7 @@ module ActiveModel
     # compatibility, but this behavior is deprecated.
     def details
       hash = group_by_attribute.transform_values do |errors|
-        errors.map(&:detail)
+        errors.map(&:details)
       end
       DeprecationHandlingDetailsHash.new(hash)
     end

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -216,4 +216,35 @@ class ErrorTest < ActiveModel::TestCase
 
     assert error != person
   end
+
+  # details
+
+  test "details which ignores callback and message options" do
+    person = Person.new
+    error = ActiveModel::Error.new(
+      person,
+      :name,
+      :too_short,
+      foo: :bar,
+      if: :foo,
+      unless: :bar,
+      on: :baz,
+      allow_nil: false,
+      allow_blank: false,
+      strict: true,
+      message: "message"
+    )
+
+    assert_equal(
+      error.details,
+      { error: :too_short, foo: :bar }
+    )
+  end
+
+  test "details which has no raw_type" do
+    person = Person.new
+    error = ActiveModel::Error.new(person, :name, foo: :bar)
+
+    assert_equal(error.details, { error: :invalid, foo: :bar })
+  end
 end


### PR DESCRIPTION
### Summary

It was raised in https://github.com/rails/rails/pull/39735#pullrequestreview-438804641 that the Error#detail method name feels weird. it should be less surprising to use the plural form.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
