### PR TITLE
Fix for signed_id to work with STI. ref #40187

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -90,7 +90,7 @@ module ActiveRecord
 
       # :nodoc:
       def combine_signed_id_purposes(purpose)
-        [ name.underscore, purpose.to_s ].compact_blank.join("/")
+        [ base_class.name.underscore, purpose.to_s ].compact_blank.join("/")
       end
     end
 

--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -11,7 +11,7 @@ SIGNED_ID_VERIFIER_TEST_SECRET = -> { "This is normally set by the railtie initi
 ActiveRecord::Base.signed_id_verifier_secret = SIGNED_ID_VERIFIER_TEST_SECRET
 
 class SignedIdTest < ActiveRecord::TestCase
-  fixtures :accounts, :toys
+  fixtures :accounts, :toys, :companies
 
   setup do
     @account = Account.first
@@ -24,6 +24,10 @@ class SignedIdTest < ActiveRecord::TestCase
 
   test "find signed record with custom primary key" do
     assert_equal @toy, Toy.find_signed(@toy.signed_id)
+  end
+
+  test "find signed record for single table inheritance (STI Models)" do
+    assert_equal Company.first, Company.find_signed(Company.first.signed_id)
   end
 
   test "raise UnknownPrimaryKey when model have no primary key" do


### PR DESCRIPTION
### Summary

Signed_id currently doesn't work with STI models because of combining **class.name** with the purpose. 

#### Example

```ruby
class User < ActiveRecord::Base; end
class Student < User; end
class Teacher < User; end

User.create(type: 'Student')
User.find_signed User.first.signed_id  # nil
```
By replacing **class.name** with **base_class.name**, it can handle both normal and STI models.