### PR TITLE
Load Rails tasks for each new Rake::Application

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -514,7 +514,7 @@ module Rails
     def run_tasks_blocks(app) #:nodoc:
       railties.each { |r| r.run_tasks_blocks(app) }
       super
-      require "rails/tasks"
+      load "rails/tasks.rb"
       task :environment do
         ActiveSupport.on_load(:before_initialize) { config.eager_load = config.rake_eager_load }
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -29,6 +29,18 @@ module ApplicationTests
       assert_equal ["Rails version"], rails("about").scan(/^Rails version/)
     end
 
+    test "tasks can invoke framework tasks via Rails::Command.invoke" do
+      add_to_config <<~RUBY
+        rake_tasks do
+          task :invoke_about do
+            Rails::Command.invoke :about
+          end
+        end
+      RUBY
+
+      assert_match(/^Rails version/, rails("invoke_about"))
+    end
+
     test "task backtrace is silenced" do
       add_to_config <<-RUBY
         rake_tasks do


### PR DESCRIPTION
Follow-up to #40143.

Rails Rake tasks are loaded for each new `Rake::Application` instance via `Rails.application.load_tasks`.  However, under the hood, `Rails.application.load_tasks` used `require` instead of `load`, which caused Rails tasks to be loaded for only the first `Rake::Application` instance.

This commit changes the relevant `require` to `load`.

Fixes #40184.

---

For reference, using `load` here should be safe because `Rails::Application#run_tasks_blocks` [calls `Rails::Engine#run_tasks_blocks`](https://github.com/rails/rails/blob/722ca6ba353cf44e3b66d77a6e174a2715c8cd5a/railties/lib/rails/application.rb#L516), which itself [calls `load`](https://github.com/rails/rails/blob/722ca6ba353cf44e3b66d77a6e174a2715c8cd5a/railties/lib/rails/engine.rb#L664).

/cc @eugeneius since you already have context for this.  (Sorry about that! :sweat_smile:)
