### PR TITLE
Add support for `NOT VALID` check constraints in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for check constraints that are `NOT VALID` via `validate: false` (PostgreSQL-only).
+
+    *Alex Robbin*
+
 *   Ensure the default configuration is considered primary or first for an environment
 
     If a multiple database application provides a configuration named primary, that will be treated as default. In applications that do not have a primary entry, the default database configuration will be the first configuration for an environment.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -132,6 +132,11 @@ module ActiveRecord
         options[:name]
       end
 
+      def validate?
+        options.fetch(:validate, true)
+      end
+      alias validated? validate?
+
       def export_name_on_schema_dump?
         !ActiveRecord::SchemaDumper.chk_ignore_pattern.match?(name) if name
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1142,6 +1142,11 @@ module ActiveRecord
       #
       #   ALTER TABLE "products" ADD CONSTRAINT price_check CHECK (price > 0)
       #
+      # The +options+ hash can include the following keys:
+      # [<tt>:name</tt>]
+      #   The constraint name. Defaults to <tt>chk_rails_<identifier></tt>.
+      # [<tt>:validate</tt>]
+      #   (PostgreSQL only) Specify whether or not the constraint should be validated. Defaults to +true+.
       def add_check_constraint(table_name, expression, **options)
         return unless supports_check_constraints?
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -13,6 +13,10 @@ module ActiveRecord
             super.dup.tap { |sql| sql << " NOT VALID" unless o.validate? }
           end
 
+          def visit_CheckConstraintDefinition(o)
+            super.dup.tap { |sql| sql << " NOT VALID" unless o.validate? }
+          end
+
           def visit_ValidateConstraint(name)
             "VALIDATE CONSTRAINT #{quote_column_name(name)}"
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -523,7 +523,7 @@ module ActiveRecord
           scope = quoted_scope(table_name)
 
           check_info = exec_query(<<-SQL, "SCHEMA")
-            SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef
+            SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef, c.convalidated AS valid
             FROM pg_constraint c
             JOIN pg_class t ON c.conrelid = t.oid
             WHERE c.contype = 'c'
@@ -532,7 +532,8 @@ module ActiveRecord
 
           check_info.map do |row|
             options = {
-              name: row["conname"]
+              name: row["conname"],
+              validate: row["valid"]
             }
             expression = row["constraintdef"][/CHECK \({2}(.+)\){2}/, 1]
 
@@ -630,6 +631,19 @@ module ActiveRecord
           fk_name_to_validate = foreign_key_for!(from_table, to_table: to_table, **options).name
 
           validate_constraint from_table, fk_name_to_validate
+        end
+
+        # Validates the given check constraint.
+        #
+        #   validate_check_constraint :products, name: "price_check"
+        #
+        # The +options+ hash accepts the same keys as add_check_constraint[rdoc-ref:ConnectionAdapters::SchemaStatements#add_check_constraint].
+        def validate_check_constraint(table_name, **options)
+          return unless supports_validate_constraints?
+
+          chk_name_to_validate = check_constraint_for!(table_name, **options).name
+
+          validate_constraint table_name, chk_name_to_validate
         end
 
         private


### PR DESCRIPTION
### Summary

Active Record already supports adding `NOT VALID` foreign key constraints in PostgreSQL, but back in #31323 when check constraint support was initially added, the ability to add a check constraint and validate it separately was not included. This adds that functionality!