### PR TITLE
feat(rubocop): Add new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -232,6 +232,9 @@ Style/RedundantReturn:
   Enabled: true
   AllowMultipleReturnValues: true
 
+Style/RedundantRegexpEscape:
+  Enabled: true
+
 Style/Semicolon:
   Enabled: true
   AllowAsExpressionSeparator: true

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -100,7 +100,7 @@ module ActionController
       # characters; and is terminated by a colon (":").
       # See https://tools.ietf.org/html/rfc3986#section-3.1
       # The protocol relative scheme starts with a double slash "//".
-      when /\A([a-z][a-z\d\-+\.]*:|\/\/).*/i
+      when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
         options
       when String
         request.protocol + request.host_with_port + options

--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -19,7 +19,7 @@ module ActionDispatch
       # The MIME type of the HTTP request, such as Mime[:xml].
       def content_mime_type
         fetch_header("action_dispatch.request.content_type") do |k|
-          v = if get_header("CONTENT_TYPE") =~ /^([^,\;]*)/
+          v = if get_header("CONTENT_TYPE") =~ /^([^,;]*)/
             Mime::Type.lookup($1.strip.downcase)
           else
             nil

--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -78,7 +78,7 @@ module ActionDispatch
         alias :symbol :regexp
         attr_reader :name
 
-        DEFAULT_EXP = /[^\.\/\?]+/
+        DEFAULT_EXP = /[^.\/?]+/
         GREEDY_EXP = /(.+)/
         def initialize(left, regexp = DEFAULT_EXP)
           super(left)

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -44,7 +44,7 @@ module ActionDispatch
 
           ESCAPED  = /%[a-zA-Z0-9]{2}/.freeze
 
-          FRAGMENT = /[^#{UNRESERVED}#{SUB_DELIMS}:@\/\?]/.freeze
+          FRAGMENT = /[^#{UNRESERVED}#{SUB_DELIMS}:@\/?]/.freeze
           SEGMENT  = /[^#{UNRESERVED}#{SUB_DELIMS}:@]/.freeze
           PATH     = /[^#{UNRESERVED}#{SUB_DELIMS}:@\/]/.freeze
 

--- a/actionpack/test/controller/live_stream_test.rb
+++ b/actionpack/test/controller/live_stream_test.rb
@@ -61,16 +61,16 @@ module ActionController
       get :basic_sse
 
       wait_for_response_stream_close
-      assert_match(/data: {\"name\":\"John\"}/, response.body)
-      assert_match(/data: {\"name\":\"Ryan\"}/, response.body)
+      assert_match(/data: {"name":"John"}/, response.body)
+      assert_match(/data: {"name":"Ryan"}/, response.body)
     end
 
     def test_sse_with_event_name
       get :sse_with_event
 
       wait_for_response_stream_close
-      assert_match(/data: {\"name\":\"John\"}/, response.body)
-      assert_match(/data: {\"name\":\"Ryan\"}/, response.body)
+      assert_match(/data: {"name":"John"}/, response.body)
+      assert_match(/data: {"name":"Ryan"}/, response.body)
       assert_match(/event: send-name/, response.body)
     end
 
@@ -79,10 +79,10 @@ module ActionController
 
       wait_for_response_stream_close
       first_response, second_response = response.body.split("\n\n")
-      assert_match(/data: {\"name\":\"John\"}/, first_response)
+      assert_match(/data: {"name":"John"}/, first_response)
       assert_match(/retry: 1000/, first_response)
 
-      assert_match(/data: {\"name\":\"Ryan\"}/, second_response)
+      assert_match(/data: {"name":"Ryan"}/, second_response)
       assert_match(/retry: 1500/, second_response)
     end
 
@@ -91,10 +91,10 @@ module ActionController
 
       wait_for_response_stream_close
       first_response, second_response = response.body.split("\n\n")
-      assert_match(/data: {\"name\":\"John\"}/, first_response)
+      assert_match(/data: {"name":"John"}/, first_response)
       assert_match(/id: 1/, first_response)
 
-      assert_match(/data: {\"name\":\"Ryan\"}/, second_response)
+      assert_match(/data: {"name":"Ryan"}/, second_response)
       assert_match(/id: 2/, second_response)
     end
 
@@ -512,7 +512,7 @@ class LiveStreamRouterTest < ActionDispatch::IntegrationTest
     get "/test"
 
     assert_response :ok
-    assert_match(/data: {\"name\":\"John\"}/, response.body)
-    assert_match(/data: {\"name\":\"Ryan\"}/, response.body)
+    assert_match(/data: {"name":"John"}/, response.body)
+    assert_match(/data: {"name":"Ryan"}/, response.body)
   end
 end

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -216,7 +216,7 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
   def test_regexp_precedence
     rs.draw do
       get "/whois/:domain", constraints: {
-        domain: /\w+\.[\w\.]+/ },
+        domain: /\w+\.[\w.]+/ },
         to: lambda { |env| [200, {}, %w{regexp}] }
 
       get "/whois/:id", to: lambda { |env| [200, {}, %w{id}] }
@@ -1203,7 +1203,7 @@ class RouteSetTest < ActiveSupport::TestCase
 
   def test_recognize_with_encoded_id_and_regex
     set.draw do
-      get "page/:id" => "pages#show", :id => /[a-zA-Z0-9\+]+/
+      get "page/:id" => "pages#show", :id => /[a-zA-Z0-9+]+/
     end
 
     assert_equal({ controller: "pages", action: "show", id: "10" }, request_path_params("/page/10"))

--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -360,14 +360,14 @@ class CookieStoreTest < ActionDispatch::IntegrationTest
   def test_session_store_without_domain
     with_test_route_set do
       get "/set_session_value"
-      assert_no_match(/domain\=/, headers["Set-Cookie"])
+      assert_no_match(/domain=/, headers["Set-Cookie"])
     end
   end
 
   def test_session_store_with_nil_domain
     with_test_route_set(domain: nil) do
       get "/set_session_value"
-      assert_no_match(/domain\=/, headers["Set-Cookie"])
+      assert_no_match(/domain=/, headers["Set-Cookie"])
     end
   end
 

--- a/actionpack/test/journey/router_test.rb
+++ b/actionpack/test/journey/router_test.rb
@@ -41,7 +41,7 @@ module ActionDispatch
       end
 
       def test_regexp_first_precedence
-        get "/whois/:domain", domain: /\w+\.[\w\.]+/, to: "foo#bar"
+        get "/whois/:domain", domain: /\w+\.[\w.]+/, to: "foo#bar"
         get "/whois/:id(.:format)", to: "foo#baz"
 
         env = rails_env "PATH_INFO" => "/whois/example.com"

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -190,7 +190,7 @@ module ActionView
         return "" if source.blank?
         return source if URI_REGEXP.match?(source)
 
-        tail, source = source[/([\?#].+)$/], source.sub(/([\?#].+)$/, "")
+        tail, source = source[/([?#].+)$/], source.sub(/([?#].+)$/, "")
 
         if extname = compute_asset_extname(source, options)
           source = "#{source}#{extname}"

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1125,7 +1125,7 @@ module ActionView
         # Returns the id attribute for the input tag.
         #  => "post_written_on_1i"
         def input_id_from_type(type)
-          id = input_name_from_type(type).gsub(/([\[\(])|(\]\[)/, "_").gsub(/[\]\)]/, "")
+          id = input_name_from_type(type).gsub(/([\[(])|(\]\[)/, "_").gsub(/[\])]/, "")
           id = @options[:namespace] + "_" + id if @options[:namespace]
 
           id

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -317,7 +317,7 @@ module ActionView
       #   cdata_section("hello]]>world")
       #   # => <![CDATA[hello]]]]><![CDATA[>world]]>
       def cdata_section(content)
-        splitted = content.to_s.gsub(/\]\]\>/, "]]]]><![CDATA[>")
+        splitted = content.to_s.gsub(/\]\]>/, "]]]]><![CDATA[>")
         "<![CDATA[#{splitted}]]>".html_safe
       end
 

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -137,7 +137,7 @@ module ActionView
           end
 
           def sanitized_value(value)
-            value.to_s.gsub(/[\s\.]/, "_").gsub(/[^-[[:word:]]]/, "").downcase
+            value.to_s.gsub(/[\s.]/, "_").gsub(/[^-[[:word:]]]/, "").downcase
           end
 
           def select_content_tag(option_tags, options, html_options)

--- a/actionview/test/template/atom_feed_helper_test.rb
+++ b/actionview/test/template/atom_feed_helper_test.rb
@@ -320,8 +320,8 @@ class AtomFeedTest < ActionController::TestCase
   def test_feed_xml_processing_instructions
     with_restful_routing(:scrolls) do
       get :index, params: { id: "feed_with_xml_processing_instructions" }
-      assert_match %r{<\?xml-stylesheet [^\?]*type="text/css"}, @response.body
-      assert_match %r{<\?xml-stylesheet [^\?]*href="t\.css"}, @response.body
+      assert_match %r{<\?xml-stylesheet [^?]*type="text/css"}, @response.body
+      assert_match %r{<\?xml-stylesheet [^?]*href="t\.css"}, @response.body
     end
   end
 

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -671,7 +671,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
       end
     end
     assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
+    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default"}/, error.message)
   end
 
   def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
@@ -683,7 +683,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
+    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default"}/, error.message)
   end
 
   def test_assert_enqueued_with_does_not_change_jobs_count
@@ -1898,7 +1898,7 @@ class PerformedJobsTest < ActiveJob::TestCase
       end
     end
     assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
+    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default"}/, error.message)
   end
 
   def test_assert_performed_with_without_block_failure_with_global_id_args
@@ -1911,7 +1911,7 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id=\"9\"\>\], :queue=>\"default\"}/, error.message)
+    assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default"}/, error.message)
   end
 
   def test_assert_performed_with_does_not_change_jobs_count

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       include Savepoints
 
       SIMPLE_INT = /\A\d+\z/
-      COMMENT_REGEX = %r{/\*(?:[^\*]|\*[^/])*\*/}m
+      COMMENT_REGEX = %r{/\*(?:[^*]|\*[^/])*\*/}m
 
       attr_accessor :pool
       attr_reader :visitor, :owner, :logger, :lock
@@ -69,7 +69,7 @@ module ActiveRecord
       def self.build_read_query_regexp(*parts) # :nodoc:
         parts += DEFAULT_READ_QUERY
         parts = parts.map { |part| /#{part}/i }
-        /\A(?:[\(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/
+        /\A(?:[(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/
       end
 
       def self.quoted_column_names # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -590,7 +590,7 @@ module ActiveRecord
         def extract_value_from_default(default)
           case default
             # Quoted types
-          when /\A[\(B]?'(.*)'.*::"?([\w. ]+)"?(?:\[\])?\z/m
+          when /\A[(B]?'(.*)'.*::"?([\w. ]+)"?(?:\[\])?\z/m
             # The default 'now'::date is CURRENT_DATE
             if $1 == "now" && $2 == "date"
               nil

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -491,7 +491,7 @@ module ActiveRecord
           end
         end
 
-        COLLATE_REGEX = /.*\"(\w+)\".*collate\s+\"(\w+)\".*/i.freeze
+        COLLATE_REGEX = /.*"(\w+)".*collate\s+"(\w+)".*/i.freeze
 
         def table_structure_with_collation(table_name, basic_structure)
           collation_hash = {}

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -115,7 +115,7 @@ module ActiveRecord
               fk_name = association.join_foreign_key
 
               if association.name.to_s != fk_name && value = @row.delete(association.name.to_s)
-                if association.polymorphic? && value.sub!(/\s*\(([^\)]*)\)\s*$/, "")
+                if association.polymorphic? && value.sub!(/\s*\(([^)]*)\)\s*$/, "")
                   # support polymorphic belongs_to as "label (Type)"
                   @row[association.join_foreign_type] = $1
                 end

--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -94,7 +94,7 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
 
   def test_join_conditions_added_to_join_clause
     queries = capture_sql { Author.left_outer_joins(:essays).to_a }
-    assert queries.any? { |sql| /writer_type.*?=.*?(Author|\?|\$1|\:a1)/i.match?(sql) }
+    assert queries.any? { |sql| /writer_type.*?=.*?(Author|\?|\$1|:a1)/i.match?(sql) }
     assert queries.none? { |sql| /WHERE/i.match?(sql) }
   end
 

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -143,7 +143,7 @@ if ActiveRecord::Base.connection.supports_comments?
         assert_match %r[t\.integer\s+"rating",\s+precision: 38,\s+comment: "I am running out of imagination"], output
       else
         assert_match %r[t\.integer\s+"rating",\s+comment: "I am running out of imagination"], output
-        assert_match %r[t\.index\s+.+\s+comment: "\\\"Very important\\\" index that powers all the performance.\\nAnd it's fun!"], output
+        assert_match %r[t\.index\s+.+\s+comment: "\\"Very important\\" index that powers all the performance.\\nAnd it's fun!"], output
         assert_match %r[t\.index\s+.+\s+name: "idx_obvious",\s+comment: "We need to see obvious comments"], output
       end
     end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -345,7 +345,7 @@ class EnumTest < ActiveRecord::TestCase
       e = assert_raises(ArgumentError) do
         klass.class_eval { enum name => ["value_#{i}"] }
       end
-      assert_match(/You tried to define an enum named \"#{name}\" on the model/, e.message)
+      assert_match(/You tried to define an enum named "#{name}" on the model/, e.message)
     end
   end
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -232,7 +232,7 @@ class MigrationTest < ActiveRecord::TestCase
           assert_match(/check that column\/key exists/, error.message)
         end
       elsif current_adapter?(:PostgreSQLAdapter)
-        assert_match(/column \"last_name\" of relation \"people\" does not exist/, error.message)
+        assert_match(/column "last_name" of relation "people" does not exist/, error.message)
       end
     end
   ensure

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -305,7 +305,7 @@ class SchemaDumperTest < ActiveRecord::TestCase
 
     def test_schema_dump_includes_limit_on_array_type
       output = dump_table_schema "bigint_array"
-      assert_match %r{t\.bigint\s+"big_int_data_points\",\s+array: true}, output
+      assert_match %r{t\.bigint\s+"big_int_data_points",\s+array: true}, output
     end
 
     def test_schema_dump_allows_array_of_decimal_defaults

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -194,7 +194,7 @@ class NamedScopingTest < ActiveRecord::TestCase
       e = assert_raises ArgumentError do
         Class.new(Post).class_eval { scope name, -> { where(approved: true) } }
       end
-      assert_match(/You tried to define a scope named \"#{name}\" on the model/, e.message)
+      assert_match(/You tried to define a scope named "#{name}" on the model/, e.message)
     end
   end
 
@@ -380,12 +380,12 @@ class NamedScopingTest < ActiveRecord::TestCase
       e = assert_raises(ArgumentError, "scope `#{name}` should not be allowed") do
         klass.class_eval { scope name, -> { where(approved: true) } }
       end
-      assert_match(/You tried to define a scope named \"#{name}\" on the model/, e.message)
+      assert_match(/You tried to define a scope named "#{name}" on the model/, e.message)
 
       e = assert_raises(ArgumentError, "scope `#{name}` should not be allowed") do
         subklass.class_eval { scope name, -> { where(approved: true) } }
       end
-      assert_match(/You tried to define a scope named \"#{name}\" on the model/, e.message)
+      assert_match(/You tried to define a scope named "#{name}" on the model/, e.message)
     end
 
     non_conflicts.each do |name|

--- a/activesupport/lib/active_support/duration/iso8601_parser.rb
+++ b/activesupport/lib/active_support/duration/iso8601_parser.rb
@@ -16,11 +16,11 @@ module ActiveSupport
       PERIOD = "."
       COMMA = ","
 
-      SIGN_MARKER = /\A\-|\+|/
+      SIGN_MARKER = /\A-|\+|/
       DATE_MARKER = /P/
       TIME_MARKER = /T/
-      DATE_COMPONENT = /(\-?\d+(?:[.,]\d+)?)(Y|M|D|W)/
-      TIME_COMPONENT = /(\-?\d+(?:[.,]\d+)?)(H|M|S)/
+      DATE_COMPONENT = /(-?\d+(?:[.,]\d+)?)(Y|M|D|W)/
+      TIME_COMPONENT = /(-?\d+(?:[.,]\d+)?)(H|M|S)/
 
       DATE_TO_PART = { "Y" => :years, "M" => :months, "W" => :weeks, "D" => :days }
       TIME_TO_PART = { "H" => :hours, "M" => :minutes, "S" => :seconds }

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -593,8 +593,8 @@ class HashToXmlTest < ActiveSupport::TestCase
       created_at: Time.utc(1999, 2, 2),
       local_created_at: Time.utc(1999, 2, 2).in_time_zone("Eastern Time (US & Canada)")
     }.to_xml(@xml_options)
-    assert_match %r{<created-at type=\"dateTime\">1999-02-02T00:00:00Z</created-at>}, xml
-    assert_match %r{<local-created-at type=\"dateTime\">1999-02-01T19:00:00-05:00</local-created-at>}, xml
+    assert_match %r{<created-at type="dateTime">1999-02-02T00:00:00Z</created-at>}, xml
+    assert_match %r{<local-created-at type="dateTime">1999-02-01T19:00:00-05:00</local-created-at>}, xml
   end
 
   def test_multiple_records_from_xml_with_attributes_other_than_type_ignores_them_without_exploding

--- a/guides/rails_guides/markdown.rb
+++ b/guides/rails_guides/markdown.rb
@@ -70,8 +70,8 @@ module RailsGuides
       end
 
       def extract_raw_header_and_body
-        if /^\-{40,}$/.match?(@raw_body)
-          @raw_header, _, @raw_body = @raw_body.partition(/^\-{40,}$/).map(&:strip)
+        if /^-{40,}$/.match?(@raw_body)
+          @raw_header, _, @raw_body = @raw_body.partition(/^-{40,}$/).map(&:strip)
         end
       end
 

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -148,7 +148,7 @@ module Rails
 
           def namespaced_commands
             commands.keys.map do |key|
-              if command_root_namespace.match?(/(\A|\:)#{key}\z/)
+              if command_root_namespace.match?(/(\A|:)#{key}\z/)
                 command_root_namespace
               else
                 "#{command_root_namespace}:#{key}"

--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -8,7 +8,7 @@ namespace :app do
   task template: :environment do
     template = ENV["LOCATION"]
     raise "No LOCATION value given. Please set LOCATION either as path to a file or a URL" if template.blank?
-    template = File.expand_path(template) unless %r{\A[A-Za-z][A-Za-z0-9+\-\.]*://}.match?(template)
+    template = File.expand_path(template) unless %r{\A[A-Za-z][A-Za-z0-9+\-.]*://}.match?(template)
     require "rails/generators"
     require "rails/generators/rails/app/app_generator"
     generator = Rails::Generators::AppGenerator.new [Rails.root], {}, { destination_root: Rails.root }

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -802,7 +802,7 @@ module ApplicationTests
       end
 
       get "/"
-      assert_match(/csrf\-param/, last_response.body)
+      assert_match(/csrf-param/, last_response.body)
     end
 
     test "default form builder specified as a string" do

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -348,7 +348,7 @@ module ApplicationTests
           args = ["generate", "model", "book", "title:string"]
           rails args
           rails "db:migrate", "db:schema:dump"
-          assert_match(/create_table \"books\"/, File.read("db/schema.rb"))
+          assert_match(/create_table "books"/, File.read("db/schema.rb"))
         end
       end
 
@@ -476,7 +476,7 @@ module ApplicationTests
           rails "generate", "model", "book", "title:string"
           rails "db:migrate", "db:structure:dump"
           structure_dump = File.read("db/structure.sql")
-          assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"books\"/, structure_dump)
+          assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"books"/, structure_dump)
           rails "environment", "db:drop", "db:structure:load"
           assert_match expected_database, ActiveRecord::Base.connection_db_config.database
           require "#{app_path}/app/models/book"
@@ -525,7 +525,7 @@ module ApplicationTests
         stderr_output = capture(:stderr) { rails("db:structure:dump", stderr: true, allow_failure: true) }
         assert_empty stderr_output
         structure_dump = File.read("#{app_path}/db/structure.sql")
-        assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"posts\"/, structure_dump)
+        assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"posts"/, structure_dump)
       end
 
       test "db:schema:load and db:structure:load do not purge the existing database" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -96,13 +96,13 @@ module ApplicationTests
           if schema_format == "ruby"
             schema_dump = File.read("db/schema.rb")
             schema_dump_animals = File.read("db/animals_schema.rb")
-            assert_match(/create_table \"books\"/, schema_dump)
-            assert_match(/create_table \"dogs\"/, schema_dump_animals)
+            assert_match(/create_table "books"/, schema_dump)
+            assert_match(/create_table "dogs"/, schema_dump_animals)
           else
             schema_dump = File.read("db/structure.sql")
             schema_dump_animals = File.read("db/animals_structure.sql")
-            assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"books\"/, schema_dump)
-            assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"dogs\"/, schema_dump_animals)
+            assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"books"/, schema_dump)
+            assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"dogs"/, schema_dump_animals)
           end
 
           rails "db:schema:load"
@@ -124,21 +124,21 @@ module ApplicationTests
             if database == "primary"
               schema_dump = File.read("db/#{format}.rb")
               assert_not(File.exist?("db/animals_#{format}.rb"))
-              assert_match(/create_table \"books\"/, schema_dump)
+              assert_match(/create_table "books"/, schema_dump)
             else
               assert_not(File.exist?("db/#{format}.rb"))
               schema_dump_animals = File.read("db/animals_#{format}.rb")
-              assert_match(/create_table \"dogs\"/, schema_dump_animals)
+              assert_match(/create_table "dogs"/, schema_dump_animals)
             end
           else
             if database == "primary"
               schema_dump = File.read("db/#{format}.sql")
               assert_not(File.exist?("db/animals_#{format}.sql"))
-              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"books\"/, schema_dump)
+              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"books"/, schema_dump)
             else
               assert_not(File.exist?("db/#{format}.sql"))
               schema_dump_animals = File.read("db/animals_#{format}.sql")
-              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"dogs\"/, schema_dump_animals)
+              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"dogs"/, schema_dump_animals)
             end
           end
 
@@ -175,21 +175,21 @@ module ApplicationTests
             if name == "primary"
               schema_dump = File.read("db/schema.rb")
               assert_not(File.exist?("db/animals_schema.rb"))
-              assert_match(/create_table \"books\"/, schema_dump)
+              assert_match(/create_table "books"/, schema_dump)
             else
               assert_not(File.exist?("db/schema.rb"))
               schema_dump_animals = File.read("db/animals_schema.rb")
-              assert_match(/create_table \"dogs\"/, schema_dump_animals)
+              assert_match(/create_table "dogs"/, schema_dump_animals)
             end
           else
             if name == "primary"
               schema_dump = File.read("db/structure.sql")
               assert_not(File.exist?("db/animals_structure.sql"))
-              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"books\"/, schema_dump)
+              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"books"/, schema_dump)
             else
               assert_not(File.exist?("db/structure.sql"))
               schema_dump_animals = File.read("db/animals_structure.sql")
-              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?\"dogs\"/, schema_dump_animals)
+              assert_match(/CREATE TABLE (?:IF NOT EXISTS )?"dogs"/, schema_dump_animals)
             end
           end
         end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1078,7 +1078,7 @@ module ApplicationTests
       def exercise_parallelization_regardless_of_machine_core_count(with:)
         app_path("test/test_helper.rb") do |file_name|
           file = File.read(file_name)
-          file.sub!(/parallelize\(([^\)]*)\)/, "parallelize(workers: 2, with: :#{with})")
+          file.sub!(/parallelize\(([^)]*)\)/, "parallelize(workers: 2, with: :#{with})")
           File.write(file_name, file)
         end
       end

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -78,7 +78,7 @@ class ActionsTest < Rails::Generators::TestCase
   def test_gem_should_put_gem_dependency_in_gemfile
     run_generator
     action :gem, "will-paginate"
-    assert_file "Gemfile", /gem 'will\-paginate'\n\z/
+    assert_file "Gemfile", /gem 'will-paginate'\n\z/
   end
 
   def test_gem_with_version_should_include_version_in_gemfile

--- a/railties/test/generators/controller_generator_test.rb
+++ b/railties/test/generators/controller_generator_test.rb
@@ -11,7 +11,7 @@ class ControllerGeneratorTest < Rails::Generators::TestCase
 
   def test_help_does_not_show_invoked_generators_options_if_they_already_exist
     content = run_generator ["--help"]
-    assert_no_match(/Helper options\:/, content)
+    assert_no_match(/Helper options:/, content)
   end
 
   def test_controller_skeleton_is_created

--- a/railties/test/generators/mailer_generator_test.rb
+++ b/railties/test/generators/mailer_generator_test.rb
@@ -46,13 +46,13 @@ class MailerGeneratorTest < Rails::Generators::TestCase
       assert_match(/test "bar"/, test)
     end
     assert_file "test/mailers/previews/notifier_mailer_preview.rb" do |preview|
-      assert_match(/\# Preview all emails at http:\/\/localhost\:3000\/rails\/mailers\/notifier_mailer/, preview)
+      assert_match(/\# Preview all emails at http:\/\/localhost:3000\/rails\/mailers\/notifier_mailer/, preview)
       assert_match(/class NotifierMailerPreview < ActionMailer::Preview/, preview)
-      assert_match(/\# Preview this email at http:\/\/localhost\:3000\/rails\/mailers\/notifier_mailer\/foo/, preview)
+      assert_match(/\# Preview this email at http:\/\/localhost:3000\/rails\/mailers\/notifier_mailer\/foo/, preview)
       assert_instance_method :foo, preview do |foo|
         assert_match(/NotifierMailer\.foo/, foo)
       end
-      assert_match(/\# Preview this email at http:\/\/localhost\:3000\/rails\/mailers\/notifier_mailer\/bar/, preview)
+      assert_match(/\# Preview this email at http:\/\/localhost:3000\/rails\/mailers\/notifier_mailer\/bar/, preview)
       assert_instance_method :bar, preview do |bar|
         assert_match(/NotifierMailer\.bar/, bar)
       end
@@ -126,9 +126,9 @@ class MailerGeneratorTest < Rails::Generators::TestCase
       assert_match(/en\.farm\.animal_mailer\.moos\.subject/, mailer)
     end
     assert_file "test/mailers/previews/farm/animal_mailer_preview.rb" do |preview|
-      assert_match(/\# Preview all emails at http:\/\/localhost\:3000\/rails\/mailers\/farm\/animal_mailer/, preview)
+      assert_match(/\# Preview all emails at http:\/\/localhost:3000\/rails\/mailers\/farm\/animal_mailer/, preview)
       assert_match(/class Farm::AnimalMailerPreview < ActionMailer::Preview/, preview)
-      assert_match(/\# Preview this email at http:\/\/localhost\:3000\/rails\/mailers\/farm\/animal_mailer\/moos/, preview)
+      assert_match(/\# Preview this email at http:\/\/localhost:3000\/rails\/mailers\/farm\/animal_mailer\/moos/, preview)
     end
     assert_file "app/views/farm/animal_mailer/moos.text.erb"
     assert_file "app/views/farm/animal_mailer/moos.html.erb"

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -39,7 +39,7 @@ module SharedGeneratorTests
 
   def test_invalid_database_option_raises_an_error
     content = capture(:stderr) { run_generator([destination_root, "-d", "unknown"]) }
-    assert_match(/Invalid value for \-\-database option/, content)
+    assert_match(/Invalid value for --database option/, content)
   end
 
   def test_test_files_are_skipped_if_required


### PR DESCRIPTION
[Style/RedundantRegexpEscape](https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpescape): This cop will help in removing unnecessary escaping inside Regexp literals.