### PR TITLE
Properly support `reverse_order` on relations with `nulls_first` or `nulls_last` calls

### DIFF
--- a/activerecord/lib/arel/nodes/ordering.rb
+++ b/activerecord/lib/arel/nodes/ordering.rb
@@ -12,7 +12,16 @@ module Arel # :nodoc: all
       end
     end
 
-    class NullsFirst < Ordering; end
-    class NullsLast < Ordering; end
+    class NullsFirst < Ordering
+      def reverse
+        NullsLast.new(expr.reverse)
+      end
+    end
+
+    class NullsLast < Ordering
+      def reverse
+        NullsFirst.new(expr.reverse)
+      end
+    end
   end
 end

--- a/activerecord/test/cases/arel/visitors/postgres_test.rb
+++ b/activerecord/test/cases/arel/visitors/postgres_test.rb
@@ -330,6 +330,20 @@ module Arel
             "users"."first_name" DESC NULLS LAST
           }
         end
+
+        it "should handle nulls first reversed" do
+          test = Table.new(:users)[:first_name].desc.nulls_first.reverse
+          _(compile(test)).must_be_like %{
+            "users"."first_name" ASC NULLS LAST
+          }
+        end
+
+        it "should handle nulls last reversed" do
+          test = Table.new(:users)[:first_name].desc.nulls_last.reverse
+          _(compile(test)).must_be_like %{
+            "users"."first_name" ASC NULLS FIRST
+          }
+        end
       end
 
       describe "Nodes::InfixOperation" do


### PR DESCRIPTION
If you're using the `nulls_first` or `nulls_last` functionality with an explicit ordering, then previously it wasn't properly handling calls to `#reverse` (called through `reverse_order`). This commit changes the behavior to match what would be expected.