### PR TITLE
Fix application templates on existing projects

### DIFF
--- a/railties/lib/rails/tasks/framework.rake
+++ b/railties/lib/rails/tasks/framework.rake
@@ -13,6 +13,8 @@ namespace :app do
     require "rails/generators/rails/app/app_generator"
     generator = Rails::Generators::AppGenerator.new [Rails.root], {}, { destination_root: Rails.root }
     generator.apply template, verbose: false
+    generator.run_bundle
+    generator.run_after_bundle_callbacks
   end
 
   namespace :templates do

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -308,5 +308,12 @@ module ApplicationTests
       output = rails("app:template", "LOCATION=template.rb")
       assert_match(/Hello, World!/, output)
     end
+
+    def test_template_runs_after_bundle
+      app_file "template.rb", "after_bundle { puts 'after bundle run' }"
+
+      output = rails("app:template", "LOCATION=template.rb")
+      assert_match(/after bundle run/, output)
+    end
   end
 end


### PR DESCRIPTION
### Summary

When running an application template on a new project, we get the following:
1. template is applied and gems are added to the Gemfile
   https://guides.rubyonrails.org/rails_application_templates.html#gem-args
2. `bundle install` is run
3. The block passed to `after_bundle` is executed allowing you to run
commands added by gems included in the template.

The documentation for application templates states that they can be run
on existing projects via the syntax
(https://guides.rubyonrails.org/rails_application_templates.html#usage):

`rails app:template LOCATION=~/template.rb`

However, if you were to try this neither `bundle install` or the
`after_bundle` callback will be executed which makes this far less
useful.

This change adds the required calls so that application templates are
consistent even when added to an existing project.