### PR TITLE
Anchor BacktraceCleaner gem filter regexp

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -91,7 +91,7 @@ module ActiveSupport
         gems_paths = (Gem.path | [Gem.default_dir]).map { |p| Regexp.escape(p) }
         return if gems_paths.empty?
 
-        gems_regexp = %r{(#{gems_paths.join('|')})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}
+        gems_regexp = %r{\A(#{gems_paths.join('|')})/(bundler/)?gems/([^/]+)-([\w.]+)/(.*)}
         gems_result = '\3 (\4) \5'
         add_filter { |line| line.sub(gems_regexp, gems_result) }
       end

--- a/activesupport/test/clean_backtrace_test.rb
+++ b/activesupport/test/clean_backtrace_test.rb
@@ -124,4 +124,10 @@ class BacktraceCleanerDefaultFilterAndSilencerTest < ActiveSupport::TestCase
     result = @bc.clean(backtrace)
     assert_equal %w[other/file.rb], result
   end
+
+  test "should preserve lines that have a subpath matching a gem path" do
+    backtrace = [Gem.default_dir, *Gem.path].map { |path| "/parent#{path}/gems/nosuchgem-1.2.3/lib/foo.rb" }
+
+    assert_equal backtrace, @bc.clean(backtrace)
+  end
 end


### PR DESCRIPTION
This ensures the default gem filter does not affect backtrace lines that have a subpath incidentally matching a gem path.

Fixes #40196.
