### PR TITLE
Return 400 for invalid POST params

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -838,6 +838,7 @@ module ActionDispatch
 
       def call(env)
         req = make_request(env)
+        req.parameters
         req.path_info = Journey::Router::Utils.normalize_path(req.path_info)
         @router.serve(req)
       end

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -266,7 +266,8 @@ module ActionDispatch
 
       params = { "PATH_INFO" => path,
                  "REQUEST_METHOD" => method,
-                 "HTTP_HOST" => host }
+                 "HTTP_HOST" => host,
+                 "rack.input" => StringIO.new }
 
       routes.call(params)
     end

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4564,6 +4564,10 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
     def show
       render plain: "foo#show"
     end
+
+    def update
+      render plain: "foo#update"
+    end
   end
 
   test "invalid UTF-8 encoding returns a bad request" do
@@ -4619,6 +4623,21 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
       assert_response :bad_request
 
       get "/foo/show/%E2%EF%BF%BD%A6?something_else=%E2%EF%BF%BD%A6"
+      assert_response :bad_request
+    end
+  end
+
+  test "invalid POST params with a method override cause a bad request" do
+    with_routing do |set|
+      set.draw do
+        patch "/foo/:id", to: "test_invalid_urls/foo#update"
+      end
+
+      patch_method_override = "_method=PATCH"
+      invalid_params = "%"
+
+      post "/foo/1", params: "#{patch_method_override}&#{invalid_params}"
+
       assert_response :bad_request
     end
   end

--- a/railties/test/path_generation_test.rb
+++ b/railties/test/path_generation_test.rb
@@ -42,7 +42,8 @@ class PathGenerationTest < ActiveSupport::TestCase
 
     params = { "PATH_INFO" => path,
               "REQUEST_METHOD" => method,
-              "HTTP_HOST"      => host }
+              "HTTP_HOST"      => host,
+              "rack.input"     => StringIO.new }
 
     params["SCRIPT_NAME"] = script_name if script_name
 


### PR DESCRIPTION


Closes #40036

Prior to this commit POST requests with invalid parameters did not
consistently return 400 responses. In the case of a request with a
`_method` override, any invalid parameters prevent the [rack method
override middleware][] from determining the method override. At that
point the request comes into Rails as a POST request and the response
status depends on whether another route happens to match the POST
request.

In the case where a route happens to match the POST request, Rails
attempts to serve the request and then fails with
`ActionController::BadRequest` when referencing the invalid [request
parameters][]. This turns into a 400 response.

But if no route matches the POST request, Rails never gets far enough to
reference the invalid request parameters. Instead, the request fails
with `ActionController::RoutingError`, turning into a 404 response.
This is confusing, since it is a 404 for different route than we would
have expected to hit, given the `_method` override.

This commit ensures that we respond with a 400 status regardless of
whether an unrelated route happens to match. It does this by referencing
the parameters before passing the request off to Journey. If they are
invalid, referencing them will raise the `ActionController::BadRequest`,
triggering the 400 response.

Because this commit references the parameters earlier than before, it
also needs to set "rack.input" in the `ActionDispatch::RoutingVerbs`
test class to keep the tests green. In a real application I believe
"rack.input" should have already been set by the handler (see [Puma][],
for example).

[rack method override middleware]: https://github.com/rack/rack/blob/249dd785625f0cbe617d3144401de90ecf77025a/lib/rack/method_override.rb
[request parameters]: https://github.com/rails/rails/blob/7af59e16a255da5aee2863af0eefaa9f0cfd857d/actionpack/lib/action_dispatch/http/parameters.rb#L50
[Puma]: https://github.com/puma/puma/blob/1b302a5de07b974f08b20b87c86326ee0e57271d/lib/puma/server.rb#L557

