### PR TITLE
Use Symbol#name if available in HashWithIndifferentAccess

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -363,8 +363,14 @@ module ActiveSupport
     end
 
     private
-      def convert_key(key)
-        key.kind_of?(Symbol) ? key.to_s : key
+      if Symbol.method_defined?(:name)
+        def convert_key(key)
+          key.kind_of?(Symbol) ? key.name : key
+        end
+      else
+        def convert_key(key)
+          key.kind_of?(Symbol) ? key.to_s : key
+        end
       end
 
       def convert_value(value, conversion: nil)


### PR DESCRIPTION
This is an old feature request that landed on ruby-head
https://github.com/ruby/ruby/commit/eb67c603ca7e435181684857e650b4633fda5bb6

This method returns an interned string, so it saves an allocation.
