### PR TITLE
Avoid creating controller _helper modules until modification

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -74,7 +74,7 @@ module ActionView
         def helper_method(*methods)
           # Almost a duplicate from ActionController::Helpers
           methods.flatten.each do |method|
-            _helpers.module_eval <<-end_eval, __FILE__, __LINE__ + 1
+            _helpers_for_modification.module_eval <<-end_eval, __FILE__, __LINE__ + 1
               def #{method}(*args, &block)                    # def current_user(*args, &block)
                 _test_case.send(:'#{method}', *args, &block)  #   _test_case.send(:'current_user', *args, &block)
               end                                             # end


### PR DESCRIPTION
In applications which use :all helpers (the default), most controllers won't be making modifications to their _helpers module.

In CRuby this created many ICLASS objects which could cause a large increase in memory usage in applications with many controllers and helpers.

To avoid creating unnecessary modules this PR builds modules only when a modification is being made: ethier by calling `helper`, `helper_method`, or through having a default helper (one matching the controller's name) included onto it.


