### PR TITLE
Pre-calculate size for cache entries

### DIFF
--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -79,8 +79,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   def test_raw_read_entry_compression
     cache = lookup_store(raw: true)
     cache.write("foo", 2)
-
-    assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compress! do
+    assert_not_called Zlib::Deflate, :deflate do
       cache.read("foo")
     end
   end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -317,7 +317,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     test "does not compress values read with \"raw\" enabled" do
       @cache.write("foo", "bar", raw: true)
 
-      assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compress! do
+      assert_not_called Zlib::Deflate, :deflate do
         @cache.read("foo", raw: true)
       end
     end


### PR DESCRIPTION
### Summary

👋 I was looking at a production profile in Speedscope (https://github.com/jlfwong/speedscope) and noticed this call sequence:

<img width="350" alt="Screen Shot 2020-04-21 at 5 25 13 PM" src="https://user-images.githubusercontent.com/7451862/79915535-1f164200-83f5-11ea-8ec0-d54ce21ad075.png">

I thought it odd that computing the size of a cache entry (here: https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/memory_store.rb#L119-L121) would require uncompressing the value.

I changed the code to save the precomputed size when the entry is created. If the entry is compressed, it is the size of the entry after compression is applied. This way, the size of the entry (which was already available, just not being stored) will only have to be calculated once. 