### PR TITLE
Update translation efforts Spanish link.

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -171,7 +171,7 @@ NOTE: The Redcarpet Gem doesn't work with JRuby.
 Translation efforts we know about (various versions):
 
 * **Italian**: [https://github.com/rixlabs/docrails](https://github.com/rixlabs/docrails)
-* **Spanish**: [https://github.com/gramos/docrails/wiki](https://github.com/gramos/docrails/wiki)
+* **Spanish**: [https://github.com/latinadeveloper/railsguides.es](https://github.com/latinadeveloper/railsguides.es)
 * **Polish**: [https://github.com/apohllo/docrails](https://github.com/apohllo/docrails)
 * **French** : [https://github.com/railsfrance/docrails](https://github.com/railsfrance/docrails)
 * **Czech** : [https://github.com/rubyonrails-cz/docrails/tree/czech](https://github.com/rubyonrails-cz/docrails/tree/czech)


### PR DESCRIPTION
### Summary

Update Spanish link translation effort.

### Other Information
Provide a link with more current and a more complete translation of the Rails Guides 6.

I attempted to contact the original contributor to the repository as well as the last person that contributed to the repository and both attempts to get hold on any of the recent contributors have been unsuccessful. It has been a couple of months and still have not heard anything back.

This repo follows the recommended steps as mentioned on [Translating Rails Guides](https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#translating-rails-guides) to translate them.

Current link listed her has few translated items and was last updated May of 2017.

