### PR TITLE
Uniform paths joining in the code generated by `rails new`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join('tmp/caching-dev.txt').exist?
     <%- unless options.api? -%>
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true


### PR DESCRIPTION
### Summary

Adds uniformity when joining paths (`Rails.root.join(...)`) in the code generated by `rails new` command.

`rails new` currently generates the code with slashes in this places:

https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/test_unit/generator/templates/generator_test.rb.tt#L7
https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt#L3
https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt#L7
https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt#L21

And using arguments here:

https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt#L17 (this PR changes it to slashes also).

### Other Information

Based on my personal experience, having Rubocop running while teaching school kids Ruby/Rails is a huge time saver. No need to point them to same mistakes all the time. We also create new Rails apps a lot and each time `config/environments/development.rb:17:6: C: Rails/FilePath: Please use Rails.root.join('path/to') instead.` offence is reported. We have rule disabled for a long time and I finally gather up the courage to submit this PR 💪😄.

I understand that this change could be considered cosmetic in nature and not accepted but the change from slashes to arguments https://github.com/rails/rails/pull/31530/files was in fact also cosmetic cause we already knew it does not change anything https://twitter.com/tenderlove/status/842064491936280576 😄