### PR TITLE
Ensure `connects_to` can only be called on base or abstract classes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `connects_to` can only be called on `ActiveRecord::Base` or abstract classes.
+
+    Ensure that `connects_to` can only be called from `ActiveRecord::Base` or abstract classes. This protects the application from opening duplicate or too many connections.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   All connection adapters `execute` now raises `ActiveRecord::ConnectionNotEstablished` rather than
     `ActiveRecord::InvalidStatement` when they encounter a connection error.
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -79,6 +79,8 @@ module ActiveRecord
     #
     # Returns an array of database connections.
     def connects_to(database: {}, shards: {})
+      raise NotImplementedError, "connects_to can only be called on ActiveRecord::Base or abstract classes" unless self == Base || abstract_class?
+
       if database.present? && shards.present?
         raise ArgumentError, "connects_to can only accept a `database` or `shards` argument, but not both arguments."
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1661,6 +1661,14 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
+  test "cannot call connects_to on non-abstract or non-ActiveRecord::Base classes" do
+    error = assert_raises(NotImplementedError) do
+      Bird.connects_to(database: { writing: :arunit })
+    end
+
+    assert_equal "connects_to can only be called on ActiveRecord::Base or abstract classes", error.message
+  end
+
   test "cannot call connected_to on subclasses of ActiveRecord::Base" do
     error = assert_raises(NotImplementedError) do
       Bird.connected_to(role: :reading) { }

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -24,7 +24,11 @@ module ActiveRecord
         clean_up_connection_handler
       end
 
-      class MultiConnectionTestModel < ActiveRecord::Base
+      class SecondaryBase < ActiveRecord::Base
+        self.abstract_class = true
+      end
+
+      class MultiConnectionTestModel < SecondaryBase
       end
 
       def test_multiple_connection_handlers_works_in_a_threaded_environment
@@ -33,7 +37,7 @@ module ActiveRecord
 
         # We need to use a role for reading not named reading, otherwise we'll prevent writes
         # and won't be able to write to the second connection.
-        MultiConnectionTestModel.connects_to database: { writing: { database: tf_writing.path, adapter: "sqlite3" }, secondary: { database: tf_reading.path, adapter: "sqlite3" } }
+        SecondaryBase.connects_to database: { writing: { database: tf_writing.path, adapter: "sqlite3" }, secondary: { database: tf_reading.path, adapter: "sqlite3" } }
 
         MultiConnectionTestModel.connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")
         MultiConnectionTestModel.connection.execute("INSERT INTO multi_connection_test_models VALUES ('writing')")
@@ -73,7 +77,7 @@ module ActiveRecord
       def test_loading_relations_with_multi_db_connection_handlers
         # We need to use a role for reading not named reading, otherwise we'll prevent writes
         # and won't be able to write to the second connection.
-        MultiConnectionTestModel.connects_to database: { writing: { database: ":memory:", adapter: "sqlite3" }, secondary: { database: ":memory:", adapter: "sqlite3" } }
+        SecondaryBase.connects_to database: { writing: { database: ":memory:", adapter: "sqlite3" }, secondary: { database: ":memory:", adapter: "sqlite3" } }
 
         relation = ActiveRecord::Base.connected_to(role: :secondary) do
           MultiConnectionTestModel.connection.execute("CREATE TABLE `multi_connection_test_models` (connection_role VARCHAR (255))")


### PR DESCRIPTION
`connectes_to` should only be called on `ActiveRecord::Base` or abstract
classes. This is recommended in the documentation but until now was not
enforced by the code. It's unsafe to open too many connections to mysql
(and probably other databases), so it's safest to have 1 class for the
connection and subclass from that.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>