### PR TITLE
Fix ActiveStorage public_url documentation [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -106,9 +106,9 @@ module ActiveStorage
     end
 
     # Returns the URL for the file at the +key+. This returns a permanent URL for public files, and returns a
-    # short-lived URL for private files. You must provide the +disposition+ (+:inline+ or +:attachment+),
-    # +filename+, and +content_type+ that you wish the file to be served with on request. In addition, for
-    # private files, you must also provide the amount of seconds the URL will be valid for, specified in +expires_in+.
+    # short-lived URL for private files. For private files you can provide the +disposition+ (+:inline+ or +:attachment+),
+    # +filename+, and +content_type+ that you wish the file to be served with on request. Additionally, you can also provide
+    # the amount of seconds the URL will be valid for, specified in +expires_in+.
     def url(key, **options)
       instrument :url, key: key do |payload|
         generated_url =


### PR DESCRIPTION
### Summary

- I think it's valuable to make it clear that - at least for now - `public_url`s production services (s3, azure,  gcs) don't support none of `disposition`, `filename` or `content_type` options.
- Changing wording `must` for `can` since they are optional arguments.