### PR TITLE
Fix Enumerable#pluck undefined method error

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -151,10 +151,10 @@ module Enumerable
   #   # => [[1, "David"], [2, "Rafael"]]
   def pluck(*keys)
     if keys.many?
-      map { |element| keys.map { |key| element[key] } }
+      map { |element| keys.map { |key| element.respond_to?(key) ? element.public_send(key) : element[key] } }
     else
       key = keys.first
-      map { |element| element[key] }
+      map { |element| element.respond_to?(key) ? element.public_send(key) : element[key] }
     end
   end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -11,6 +11,14 @@ class SummablePayment < Payment
   def +(p) self.class.new(price + p.price) end
 end
 
+class AttrReader
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+end
+
 class EnumerableTests < ActiveSupport::TestCase
   class GenericEnumerable
     include Enumerable
@@ -244,6 +252,14 @@ class EnumerableTests < ActiveSupport::TestCase
 
     assert_equal [], [].pluck(:price)
     assert_equal [], [].pluck(:dollars, :cents)
+
+    attr_reader_collection = [
+      AttrReader.new(1),
+      AttrReader.new(2),
+      AttrReader.new(3),
+    ]
+
+    assert_equal([1, 2, 3], attr_reader_collection.pluck(:id))
   end
 
   def test_pick


### PR DESCRIPTION
### Summary

Currently `Enumerable#pluck` only works with objects implementing a `[]` method like Hash or Struct.

This commit implements support to work with any class responding to the `key` like POROs with attribute readers.

#### Exampe

```ruby
[{ name: 'David' }].pluck(:name)
# ['David']

ContributerStruct = Struct.new(:name)
[ContributerStruct.new('David')].pluck(:name)
# ['David']

class Contributer
  attr_reader :name

  def initialize(name)
    @name = name
  end
end

[Contributer.new('David')].pluck(:name)
# undefined method [] for Contributor
```

### Other Information

None
