### PR TITLE
Add support for exclusion constraints (PostgreSQL-only)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Add support for exclusion constraints (PostgreSQL-only).
+
+    ```ruby
+    add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, name: "invoices_date_overlap"
+    remove_exclusion_constraint :invoices, name: "invoices_date_overlap"
+    ```
+
+    See PostgreSQL's [`CREATE TABLE ... EXCLUDE ...`](https://www.postgresql.org/docs/12/sql-createtable.html#SQL-CREATETABLE-EXCLUDE) documentation for more on exclusion constraints.
+
+    *Alex Robbin*
+
 *   `change_column_null` raises if a non-boolean argument is provided
 
     Previously if you provided a non-boolean argument, `change_column_null` would

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
       delegate :quote_column_name, :quote_table_name, :quote_default_expression, :type_to_sql,
         :options_include_default?, :supports_indexes_in_create?, :supports_foreign_keys?,
-        :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?,
+        :quoted_columns_for_index, :supports_partial_index?, :supports_check_constraints?, :supports_exclusion_constraints?,
         to: :@conn, private: true
 
       private
@@ -57,6 +57,10 @@ module ActiveRecord
 
           if supports_check_constraints?
             statements.concat(o.check_constraints.map { |chk| accept chk })
+          end
+
+          if supports_exclusion_constraints?
+            statements.concat(o.exclusion_constraints.map { |exc| accept exc })
           end
 
           create_sql << "(#{statements.join(', ')})" if statements.present?

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -409,6 +409,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support creating exclusion constraints?
+      def supports_exclusion_constraints?
+        false
+      end
+
       # Does this adapter support views?
       def supports_views?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -6,7 +6,10 @@ module ActiveRecord
       class SchemaCreation < SchemaCreation # :nodoc:
         private
           def visit_AlterTable(o)
-            super << o.constraint_validations.map { |fk| visit_ValidateConstraint fk }.join(" ")
+            sql = super
+            sql << o.constraint_validations.map { |fk| visit_ValidateConstraint fk }.join(" ")
+            sql << o.exclusion_constraint_adds.map { |con| visit_AddExclusionConstraint con }.join(" ")
+            sql << o.exclusion_constraint_drops.map { |con| visit_DropExclusionConstraint con }.join(" ")
           end
 
           def visit_AddForeignKey(o)
@@ -26,6 +29,25 @@ module ActiveRecord
 
           def visit_ValidateConstraint(name)
             "VALIDATE CONSTRAINT #{quote_column_name(name)}"
+          end
+
+          def visit_ExclusionConstraintDefinition(o)
+            sql = ["CONSTRAINT"]
+            sql << o.name
+            sql << "EXCLUDE"
+            sql << "USING #{o.using}" if o.using
+            sql << "(#{o.expression})"
+            sql << "WHERE (#{o.where})" if o.where
+
+            sql.join(" ")
+          end
+
+          def visit_AddExclusionConstraint(o)
+            "ADD #{accept(o)}"
+          end
+
+          def visit_DropExclusionConstraint(name)
+            "DROP CONSTRAINT #{quote_column_name(name)}"
           end
 
           def visit_ChangeColumnDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -555,6 +555,78 @@ module ActiveRecord
           end
         end
 
+        # Returns an array of exclusion constraints for the given table.
+        # The exclusion constraints are represented as ExclusionConstraintDefinition objects.
+        def exclusion_constraints(table_name)
+          scope = quoted_scope(table_name)
+
+          exclusion_info = exec_query(<<-SQL, "SCHEMA")
+            SELECT conname, pg_get_constraintdef(c.oid) AS constraintdef
+            FROM pg_constraint c
+            JOIN pg_class t ON c.conrelid = t.oid
+            JOIN pg_namespace n ON n.oid = c.connamespace
+            WHERE c.contype = 'x'
+              AND t.relname = #{scope[:name]}
+              AND n.nspname = #{scope[:schema]}
+          SQL
+
+          exclusion_info.map do |row|
+            method_and_elements, predicate = row["constraintdef"].split(" WHERE ")
+            method_and_elements_parts = method_and_elements.match(/EXCLUDE(?: USING (?<using>\S+))? \((?<expression>.+)\)/)
+            predicate = predicate.from(2).to(-3) if predicate # strip 2 opening and closing parentheses
+
+            options = {
+              name: row["conname"],
+              using: method_and_elements_parts["using"].to_sym,
+              where: predicate
+            }
+
+            ExclusionConstraintDefinition.new(table_name, method_and_elements_parts["expression"], options)
+          end
+        end
+
+        # Adds a new exclusion constraint to the table. +expression+ is a String
+        # representation of a list of exclusion elements and operators.
+        #
+        #   add_exclusion_constraint :products, "price WITH =, availability_range WITH &&", using: :gist, name: "price_check"
+        #
+        # generates:
+        #
+        #   ALTER TABLE "products" ADD CONSTRAINT price_check EXCLUDE USING gist (price WITH =, availability_range WITH &&)
+        #
+        # The +options+ hash can include the following keys:
+        # [<tt>:name</tt>]
+        #   The constraint name. Defaults to <tt>excl_rails_<identifier></tt>.
+        def add_exclusion_constraint(table_name, expression, **options)
+          options = exclusion_constraint_options(table_name, expression, options)
+          at = create_alter_table(table_name)
+          at.add_exclusion_constraint(expression, options)
+
+          execute schema_creation.accept(at)
+        end
+
+        def exclusion_constraint_options(table_name, expression, options) # :nodoc:
+          options = options.dup
+          options[:name] ||= exclusion_constraint_name(table_name, expression: expression, **options)
+          options
+        end
+
+        # Removes the given exclusion constraint from the table.
+        #
+        #   remove_exclusion_constraint :products, name: "price_check"
+        #
+        # The +expression+ parameter will be ignored if present. It can be helpful
+        # to provide this in a migration's +change+ method so it can be reverted.
+        # In that case, +expression+ will be used by #add_exclusion_constraint.
+        def remove_exclusion_constraint(table_name, expression = nil, **options)
+          excl_name_to_delete = exclusion_constraint_for!(table_name, expression: expression, **options).name
+
+          at = create_alter_table(table_name)
+          at.drop_exclusion_constraint(excl_name_to_delete)
+
+          execute schema_creation.accept(at)
+        end
+
         # Maps logical Rails types to PostgreSQL-specific data types.
         def type_to_sql(type, limit: nil, precision: nil, scale: nil, array: nil, enum_type: nil, **) # :nodoc:
           sql = \
@@ -785,6 +857,26 @@ module ActiveRecord
           def add_options_for_index_columns(quoted_columns, **options)
             quoted_columns = add_index_opclass(quoted_columns, **options)
             super
+          end
+
+          def exclusion_constraint_name(table_name, **options)
+            options.fetch(:name) do
+              expression = options.fetch(:expression)
+              identifier = "#{table_name}_#{expression}_excl"
+              hashed_identifier = Digest::SHA256.hexdigest(identifier).first(10)
+
+              "excl_rails_#{hashed_identifier}"
+            end
+          end
+
+          def exclusion_constraint_for(table_name, **options)
+            excl_name = exclusion_constraint_name(table_name, **options)
+            exclusion_constraints(table_name).detect { |excl| excl.name == excl_name }
+          end
+
+          def exclusion_constraint_for!(table_name, expression: nil, **options)
+            exclusion_constraint_for(table_name, expression: expression, **options) ||
+              raise(ArgumentError, "Table '#{table_name}' has no exclusion constraint for #{expression || options}")
           end
 
           def data_source_sql(name = nil, type: nil)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -206,6 +206,10 @@ module ActiveRecord
         true
       end
 
+      def supports_exclusion_constraints?
+        true
+      end
+
       def supports_validate_constraints?
         true
       end

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -9,6 +9,7 @@ module ActiveRecord
     # * add_column
     # * add_foreign_key
     # * add_check_constraint
+    # * add_exclusion_constraint
     # * add_index
     # * add_reference
     # * add_timestamps
@@ -27,6 +28,7 @@ module ActiveRecord
     # * remove_columns (must specify at least one column name or more)
     # * remove_foreign_key (must supply a second table)
     # * remove_check_constraint
+    # * remove_exclusion_constraint
     # * remove_index
     # * remove_reference
     # * remove_timestamps
@@ -42,7 +44,8 @@ module ActiveRecord
         :change_column, :execute, :remove_columns, :change_column_null,
         :add_foreign_key, :remove_foreign_key,
         :change_column_comment, :change_table_comment,
-        :add_check_constraint, :remove_check_constraint
+        :add_check_constraint, :remove_check_constraint,
+        :add_exclusion_constraint, :remove_exclusion_constraint
       ]
       include JoinTable
 
@@ -140,6 +143,7 @@ module ActiveRecord
               add_reference:     :remove_reference,
               add_foreign_key:   :remove_foreign_key,
               add_check_constraint: :remove_check_constraint,
+              add_exclusion_constraint: :remove_exclusion_constraint,
               enable_extension:  :disable_extension
             }.each do |cmd, inv|
               [[inv, cmd], [cmd, inv]].uniq.each do |method, inverse|
@@ -271,6 +275,11 @@ module ActiveRecord
 
         def invert_remove_check_constraint(args)
           raise ActiveRecord::IrreversibleMigration, "remove_check_constraint is only reversible if given an expression." if args.size < 2
+          super
+        end
+
+        def invert_remove_exclusion_constraint(args)
+          raise ActiveRecord::IrreversibleMigration, "remove_exclusion_constraint is only reversible if given an expression." if args.size < 2
           super
         end
 

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -148,6 +148,20 @@ module ActiveRecord
             t.xml :foo, :bar
           end
         end
+
+        def test_exclusion_constraint_creates_exclusion_constraint
+          with_change_table do |t|
+            @connection.expect :add_exclusion_constraint, nil, [:delete_me, "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"]
+            t.exclusion_constraint "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "date_overlap"
+          end
+        end
+
+        def test_remove_exclusion_constraint_removes_exclusion_constraint
+          with_change_table do |t|
+            @connection.expect :remove_exclusion_constraint, nil, [:delete_me, name: "date_overlap"]
+            t.remove_exclusion_constraint name: "date_overlap"
+          end
+        end
       end
 
       def test_column_creates_column

--- a/activerecord/test/cases/migration/exclusion_constraint_test.rb
+++ b/activerecord/test/cases/migration/exclusion_constraint_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/schema_dumping_helper"
+
+if ActiveRecord::Base.connection.supports_exclusion_constraints?
+  module ActiveRecord
+    class Migration
+      class ExclusionConstraintTest < ActiveRecord::TestCase
+        include SchemaDumpingHelper
+
+        class Invoice < ActiveRecord::Base
+        end
+
+        setup do
+          @connection = ActiveRecord::Base.connection
+          @connection.create_table "invoices", force: true do |t|
+            t.date :start_date
+            t.date :end_date
+          end
+        end
+
+        teardown do
+          @connection.drop_table "invoices", if_exists: true
+        end
+
+        def test_exclusion_constraints
+          exclusion_constraints = @connection.exclusion_constraints("test_exclusion_constraints")
+          assert_equal 1, exclusion_constraints.size
+
+          constraint = exclusion_constraints.first
+          assert_equal "test_exclusion_constraints", constraint.table_name
+          assert_equal "test_exclusion_constraints_date_overlap", constraint.name
+          assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+          assert_equal :gist, constraint.using
+          assert_equal "(start_date IS NOT NULL) AND (end_date IS NOT NULL)", constraint.where
+        end
+
+        def test_exclusion_constraints_scoped_to_schemas
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist
+
+          assert_no_changes -> { @connection.exclusion_constraints("invoices").size } do
+            @connection.create_schema "test_schema"
+            @connection.create_table "test_schema.invoices" do |t|
+              t.date :start_date
+              t.date :end_date
+            end
+            @connection.add_exclusion_constraint "test_schema.invoices", "daterange(start_date, end_date) WITH &&", using: :gist
+          end
+        ensure
+          @connection.drop_schema "test_schema"
+        end
+
+        def test_add_exclusion_constraint
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist
+
+          exclusion_constraints = @connection.exclusion_constraints("invoices")
+          assert_equal 1, exclusion_constraints.size
+
+          constraint = exclusion_constraints.first
+          assert_equal "invoices", constraint.table_name
+          assert_equal "excl_rails_74c9160f55", constraint.name
+
+          assert_equal "daterange(start_date, end_date) WITH &&", constraint.expression
+        end
+
+        def test_added_exclusion_constraint_ensures_valid_values
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist
+
+          Invoice.create(start_date: "2020-01-01", end_date: "2021-01-01")
+
+          assert_raises(ActiveRecord::StatementInvalid) do
+            Invoice.create(start_date: "2020-12-31", end_date: "2021-01-01")
+          end
+        end
+
+        def test_remove_exclusion_constraint
+          assert_equal 0, @connection.exclusion_constraints("invoices").size
+
+          @connection.add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, name: "invoices_date_overlap"
+          assert_equal 1, @connection.exclusion_constraints("invoices").size
+          @connection.remove_exclusion_constraint :invoices, name: "invoices_date_overlap"
+          assert_equal 0, @connection.exclusion_constraints("invoices").size
+        end
+
+        def test_remove_non_existing_exclusion_constraint
+          assert_raises(ArgumentError) do
+            @connection.remove_exclusion_constraint :invoices, name: "nonexistent"
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -222,6 +222,15 @@ class SchemaDumperTest < ActiveRecord::TestCase
     end
   end
 
+  if ActiveRecord::Base.connection.supports_exclusion_constraints?
+    def test_schema_dumps_exclusion_constraints
+      constraint_definitions = dump_table_schema("test_exclusion_constraints").split(/\n/).grep(/test_exclusion_constraints_date_overlap/)
+
+      assert_equal 1, constraint_definitions.size
+      assert_equal 't.exclusion_constraint "daterange(start_date, end_date) WITH &&", where: "(start_date IS NOT NULL) AND (end_date IS NOT NULL)", using: :gist, name: "test_exclusion_constraints_date_overlap"', constraint_definitions.first.strip
+    end
+  end
+
   def test_schema_dump_should_honor_nonstandard_primary_keys
     output = standard_dump
     match = output.match(%r{create_table "movies"(.*)do})

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -128,6 +128,13 @@ _SQL
     t.string :subject
   end
 
+  create_table :test_exclusion_constraints, force: true do |t|
+    t.date :start_date
+    t.date :end_date
+
+    t.exclusion_constraint "daterange(start_date, end_date) WITH &&", using: :gist, where: "start_date IS NOT NULL AND end_date IS NOT NULL", name: "test_exclusion_constraints_date_overlap"
+  end
+
   if supports_partitioned_indexes?
     create_table(:measurements, id: false, force: true, options: "PARTITION BY LIST (city_id)") do |t|
       t.string :city_id, null: false


### PR DESCRIPTION
### Summary

Similar to #31323, this extends Active Record's migration/schema dumping to support [exclusion constraints](https://www.postgresql.org/docs/12/sql-createtable.html#SQL-CREATETABLE-EXCLUDE)!

```ruby
add_exclusion_constraint :invoices, "daterange(start_date, end_date) WITH &&", using: :gist, name: "invoices_date_overlap"
remove_exclusion_constraint :invoices, name: "invoices_date_overlap"
```

Hopefully the approach is reasonable, but definitely let me know if there is anything that looks out of whack.