### PR TITLE
Remove unused @cache_hit Hash assignment

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -267,7 +267,6 @@ module ActionView #:nodoc:
       @view_renderer = ActionView::Renderer.new @lookup_context
       @current_template = nil
 
-      @cache_hit = {}
       assign(assigns)
       assign_controller(controller)
       _prepare_context


### PR DESCRIPTION
In 2abf6ca0c8304a3cfcdae6e14060b561780be43c @cache_hit got introduced.
This was renamed to @cache_hits and revised in the subsequent commit 8240636beda7b2b487217be1d945eb0d36145c4d
But it seems one assignment was overlooked.

See also: https://github.com/rails/rails/pull/28637