### PR TITLE
Set default variant format from blob content type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ PATH
       activerecord (= 6.1.0.alpha)
       activesupport (= 6.1.0.alpha)
       marcel (~> 0.3.1)
+      mimemagic (~> 0.3.2)
     activesupport (6.1.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -36,5 +36,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activejob",     version
   s.add_dependency "activerecord",  version
 
-  s.add_dependency "marcel", "~> 0.3.1"
+  s.add_dependency "marcel",    "~> 0.3.1"
+  s.add_dependency "mimemagic", "~> 0.3.2"
 end

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -324,6 +324,10 @@ class ActiveStorage::Blob < ActiveRecord::Base
       ActiveStorage.content_types_allowed_inline.include?(content_type)
     end
 
+    def web_image?
+      ActiveStorage.web_image_content_types.include?(content_type)
+    end
+
     def service_metadata
       if forcibly_serve_as_binary?
         { content_type: ActiveStorage.binary_content_type, disposition: :attachment, filename: filename }

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -30,7 +30,7 @@ module ActiveStorage::Blob::Representable
   # variable, call ActiveStorage::Blob#variable?.
   def variant(transformations)
     if variable?
-      variant_class.new(self, transformations)
+      variant_class.new(self, ActiveStorage::Variation.wrap(transformations).default_to(default_transformations))
     else
       raise ActiveStorage::InvariableError
     end
@@ -95,6 +95,26 @@ module ActiveStorage::Blob::Representable
   end
 
   private
+    def default_transformations
+      { format: default_variant_format }
+    end
+
+    def default_variant_format
+      if web_image?
+        format || :png
+      else
+        :png
+      end
+    end
+
+    def format
+      if filename.extension.present? && MiniMime.lookup_by_extension(filename.extension)&.content_type == content_type
+        filename.extension
+      else
+        MiniMime.lookup_by_content_type(content_type)&.extension
+      end
+    end
+
     def variant_class
       ActiveStorage.track_variants ? ActiveStorage::VariantWithRecord : ActiveStorage::Variant
     end

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -108,10 +108,10 @@ module ActiveStorage::Blob::Representable
     end
 
     def format
-      if filename.extension.present? && MiniMime.lookup_by_extension(filename.extension)&.content_type == content_type
+      if filename.extension.present? && MimeMagic.by_extension(filename.extension)&.to_s == content_type
         filename.extension
       else
-        MiniMime.lookup_by_content_type(content_type)&.extension
+        MimeMagic.new(content_type).extensions.first
       end
     end
 

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -30,7 +30,7 @@ module ActiveStorage::Blob::Representable
   # variable, call ActiveStorage::Blob#variable?.
   def variant(transformations)
     if variable?
-      variant_class.new(self, ActiveStorage::Variation.wrap(transformations).default_to(default_transformations))
+      variant_class.new(self, ActiveStorage::Variation.wrap(transformations).default_to(default_variant_transformations))
     else
       raise ActiveStorage::InvariableError
     end
@@ -95,7 +95,7 @@ module ActiveStorage::Blob::Representable
   end
 
   private
-    def default_transformations
+    def default_variant_transformations
       { format: default_variant_format }
     end
 

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -32,14 +32,9 @@ class ActiveStorage::VariantWithRecord
   private
     def transform_blob
       blob.open do |input|
-        if blob.content_type.in?(ActiveStorage.web_image_content_types)
-          variation.transform(input) do |output|
-            yield io: output, filename: blob.filename, content_type: blob.content_type, service_name: blob.service.name
-          end
-        else
-          variation.transform(input, format: "png") do |output|
-            yield io: output, filename: "#{blob.filename.base}.png", content_type: "image/png", service_name: blob.service.name
-          end
+        variation.transform(input) do |output|
+          yield io: output, filename: "#{blob.filename.base}.#{variation.format}",
+            content_type: variation.content_type, service_name: blob.service.name
         end
       end
     end

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -48,9 +48,7 @@ class ActiveStorage::Variation
   end
 
   # Accepts a File object, performs the +transformations+ against it, and
-  # saves the transformed image into a temporary file. If +format+ is specified
-  # it will be the format of the result image, otherwise the result image
-  # retains the source format.
+  # saves the transformed image into a temporary file.
   def transform(file, &block)
     ActiveSupport::Notifications.instrument("transform.active_storage") do
       transformer.transform(file, format: format, &block)

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -57,14 +57,14 @@ class ActiveStorage::Variation
 
   def format
     transformations.fetch(:format, :png).tap do |format|
-      if Mime::Type.lookup_by_extension(format).nil?
+      if MimeMagic.by_extension(format).nil?
         raise ArgumentError, "Invalid variant format (#{format.inspect})"
       end
     end
   end
 
   def content_type
-    Mime::Type.lookup_by_extension(format).to_s
+    MimeMagic.by_extension(format).to_s
   end
 
   # Returns a signed key for all the +transformations+ that this variation was instantiated with.

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -43,14 +43,30 @@ class ActiveStorage::Variation
     @transformations = transformations.deep_symbolize_keys
   end
 
+  def default_to(defaults)
+    self.class.new transformations.reverse_merge(defaults)
+  end
+
   # Accepts a File object, performs the +transformations+ against it, and
   # saves the transformed image into a temporary file. If +format+ is specified
   # it will be the format of the result image, otherwise the result image
   # retains the source format.
-  def transform(file, format: nil, &block)
+  def transform(file, &block)
     ActiveSupport::Notifications.instrument("transform.active_storage") do
       transformer.transform(file, format: format, &block)
     end
+  end
+
+  def format
+    transformations.fetch(:format, :png).tap do |format|
+      if Mime::Type.lookup_by_extension(format).nil?
+        raise ArgumentError, "Invalid variant format (#{format.inspect})"
+      end
+    end
+  end
+
+  def content_type
+    Mime::Type.lookup_by_extension(format).to_s
   end
 
   # Returns a signed key for all the +transformations+ that this variation was instantiated with.
@@ -64,6 +80,10 @@ class ActiveStorage::Variation
 
   private
     def transformer
+      transformer_class.new(transformations.except(:format))
+    end
+
+    def transformer_class
       if ActiveStorage.variant_processor
         begin
           require "image_processing"
@@ -73,12 +93,12 @@ class ActiveStorage::Variation
             Please add `gem 'image_processing', '~> 1.2'` to your Gemfile.
           WARNING
 
-          ActiveStorage::Transformers::MiniMagickTransformer.new(transformations)
+          ActiveStorage::Transformers::MiniMagickTransformer
         else
-          ActiveStorage::Transformers::ImageProcessingTransformer.new(transformations)
+          ActiveStorage::Transformers::ImageProcessingTransformer
         end
       else
-        ActiveStorage::Transformers::MiniMagickTransformer.new(transformations)
+        ActiveStorage::Transformers::MiniMagickTransformer
       end
     end
 end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -180,6 +180,14 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "PNG variation of JPEG blob" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(format: :png).processed
+    assert_equal "racecar.png", variant.filename.to_s
+    assert_equal "image/png", variant.content_type
+    assert_equal "PNG", read_image(variant).type
+  end
+
   test "variation of invariable blob" do
     assert_raises ActiveStorage::InvariableError do
       create_file_blob(filename: "report.pdf", content_type: "application/pdf").variant(resize: "100x100")


### PR DESCRIPTION
VIPS determines the destination file format from its extension, and unlike ImageMagick, it never defaults to the source format. ImageProcessing falls back to JPEG when we don’t we don’t provide a format, so if we want to preserve the source format, we must explicitly specify it.

Supersedes #39984 by leaning on the variation to specify the desired destination format. This allows customizing the destination format.

Fixes #39921.
Fixes #39983.
Closes #38160.

To-do:
- [x] Decide on a MIME type database. We have four(!) available in a typical Rails app: `Mime::Type`, `Rack::Mime`, `MiniMime`, `MimeMagic`.
- [x] Add tests for the default.
- [x] Add tests for customization.