### PR TITLE
Use indentity hashes in Journey::GTG::Builder

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/builder.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/builder.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+
 require "action_dispatch/journey/gtg/transition_table"
 
 module ActionDispatch
@@ -18,8 +19,8 @@ module ActionDispatch
 
         def transition_table
           dtrans   = TransitionTable.new
-          marked   = {}
-          state_id = Hash.new { |h, k| h[k] = h.length }
+          marked   = {}.compare_by_identity
+          state_id = Hash.new { |h, k| h[k] = h.length }.compare_by_identity
           dstates  = [firstpos(root)]
 
           until dstates.empty?
@@ -124,7 +125,7 @@ module ActionDispatch
 
         private
           def build_followpos
-            table = Hash.new { |h, k| h[k] = [] }
+            table = Hash.new { |h, k| h[k] = [] }.compare_by_identity
             @ast.each do |n|
               case n
               when Nodes::Cat


### PR DESCRIPTION
While profiling our app boot, I noticed a surprising amount of time spent in `Kernel#hash`:

```
==================================
  Mode: cpu(1000)
  Samples: 44670 (17.20% miss rate)
  GC: 11404 (25.53%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
...
       514   (1.2%)         514   (1.2%)     Kernel#hash
```

Which is mostly called from `GTG::Builder`:

```
$ bundle exec stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method='Kernel#hash'
Kernel#hash (<cfunc>:1)
  samples:   514 self (1.2%)  /    514 total (1.2%)
  callers:
     331  (   64.4%)  Array#hash
      71  (   13.8%)  ActionDispatch::Journey::GTG::Builder#build_followpos
      34  (    6.6%)  ActionDispatch::Journey::GTG::Builder#transition_table
      23  (    4.5%)  ActiveRecord::ConnectionAdapters::SqlTypeMetadata#hash
...

$ bundle exec stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method='Array#hash'
Array#hash (<cfunc>:1)
  samples:    18 self (0.0%)  /    526 total (1.2%)
  callers:
     336  (   63.9%)  ActionDispatch::Journey::GTG::Builder#transition_table
      86  (   16.3%)  Hash#delete
...
```

Looking at the `GTG::Builder` code, it's not too surprising as there are multiple hashes using `Node` and `Array[Node]` instances as keys. And they're queried a lot.

But it also appear to me (and that's the main assertion to be confirmed here) that `Node` doesn't define equality, so ultimately these are identity hashes.

And actual identity hashes are much faster than regular ones:

```ruby
require 'benchmark/ips'

ARRAY = [Object.new]
# Use a hash big enough to use an actual ST table
hash = { a: 1, b: 1, c: 1, d: 1, e: 1, f: 1, g: 1, h: 1}
id_hash = hash.dup.compare_by_identity

Benchmark.ips do |x|
  x.report('regular miss') { hash[ARRAY] }
  x.report('identity miss') { id_hash[ARRAY] }
  x.compare!
end
```

```
$ ruby  /tmp/bench-identity-hash.rb 
Warming up --------------------------------------
        regular miss   217.541k i/100ms
       identity miss     1.648M i/100ms
Calculating -------------------------------------
        regular miss      2.196M (± 1.5%) i/s -     11.095M in   5.053667s
       identity miss     16.364M (± 1.6%) i/s -     82.392M in   5.036234s

Comparison:
       identity miss: 16364296.8 i/s
        regular miss:  2195826.5 i/s - 7.45x  (± 0.00) slower
```

After converting these 3 hashes to identity comparison, `Kernel#hash` is mostly gone from the profiles:

```
$ bundle exec stackprof ~/Downloads/stackprof-shopify-boot-production-cpu\ \(2\).dump --method='Kernel#hash'
Kernel#hash (<cfunc>:1)
  samples:    95 self (0.2%)  /     95 total (0.2%)
  callers:
      22  (   23.2%)  ActiveRecord::ConnectionAdapters::SqlTypeMetadata#hash
...
```

And overall the `transition_table` method is down from 1.0% of our boot time, to 0.3%, mostly by avoiding `Array#hash`:

```
$ bundle exec stackprof ~/Downloads/stackprof-shopify-boot-production-cpu.dump --method='ActionDispatch::Journey::GTG::Builder#transition_table'
ActionDispatch::Journey::GTG::Builder#transition_table (/tmp/bundle/ruby/3.0.0/bundler/gems/rails-580eefe1bc5d/actionpack/lib/action_dispatch/journey/gtg/builder.rb:19)
  samples:    15 self (0.0%)  /    444 total (1.0%)
....
  callees (429 total):
     372  (   86.7%)  Hash#each
     336  (   78.3%)  Array#hash
      34  (    7.9%)  Kernel#hash


$ bundle exec stackprof ~/Downloads/stackprof-shopify-boot-production-cpu\ \(2\).dump --method='ActionDispatch::Journey::GTG::Builder#transition_table'
ActionDispatch::Journey::GTG::Builder#transition_table (/tmp/bundle/ruby/3.0.0/bundler/gems/rails-895134bcff29/actionpack/lib/action_dispatch/journey/gtg/builder.rb:20)
  samples:    41 self (0.1%)  /    137 total (0.3%)

  callees (96 total):
      74  (   77.1%)  Hash#each
      41  (   42.7%)  Enumerable#group_by
      39  (   40.6%)  Enumerable#flat_map
...
```

cc @rafaelfranca @tenderlove I'm not 100% certain I understand the context enough to be sure it's fine to convert these hashes. Both the Rails test suite and our app test suite pass fine, but I'd love a second pair of eyes.