### PR TITLE
Issue 40234 add Asia/Manila

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -150,6 +150,7 @@ module ActiveSupport
       "Singapore"                    => "Asia/Singapore",
       "Taipei"                       => "Asia/Taipei",
       "Perth"                        => "Australia/Perth",
+      "Manila"                       => "Asia/Manila",
       "Irkutsk"                      => "Asia/Irkutsk",
       "Ulaanbaatar"                  => "Asia/Ulaanbaatar",
       "Seoul"                        => "Asia/Seoul",


### PR DESCRIPTION
### Summary

adding Asia/Manila to time_zone.rb

https://github.com/rails/rails/issues/40234

