### PR TITLE
Make `role` required when using `shard` in `connected_to`

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -160,7 +160,11 @@ module ActiveRecord
 
         with_handler(role, &blk)
       elsif shard
-        with_shard(shard, role || current_role, prevent_writes, &blk)
+        unless role
+          raise ArgumentError, "`connected_to` cannot accept a `shard` argument without a `role`."
+        end
+
+        with_shard(shard, role, prevent_writes, &blk)
       elsif role
         with_role(role, prevent_writes, &blk)
       else

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -349,14 +349,15 @@ class ApplicationRecord < ActiveRecord::Base
 end
 ```
 
-Then models can swap connections manually via the `connected_to` API:
+Then models can swap connections manually via the `connected_to` API. If
+using sharding both a `role` and `shard` must be passed:
 
 ```ruby
-ActiveRecord::Base.connected_to(shard: :default) do
+ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
   @id = Record.create! # creates a record in shard one
 end
 
-ActiveRecord::Base.connected_to(shard: :shard_one) do
+ActiveRecord::Base.connected_to(role: :writing, shard: :shard_one) do
   Record.find(@id) # can't find record, doesn't exist
 end
 ```


### PR DESCRIPTION
While working on some more indepth changes to Rails internal connection
management we noticed that it's confusing in some cases that the `role`
is implcit when using a `shard`. For example, if you passed a `shard`
and not a `role` in an un-nested block the default `role` would be
`writing`.

```
ActiveRecord::Base.connected_to(shard: :one) do
  # connected to writing
end
```

However in cases where nesting is used it could be confusing to
application authors that the role is inherited:

```
ActiveRecord::Base.connected_to(role: :reading) do
  ActiveRecord::Base.connected_to(shard: :one) do
    # will read from shard one replica, not write to primary
  end
end
```

Since this could be potentially confusing, and extremely hard to track
in complex applications, the best approach is to require `role` when
using `shard` which is what this PR does.

Note: the code for this method is...getting unweildy. Once the
`database` argument is fully deprecated we can remove most of the guards
and make `role` required by removing `nil` from the keyword argument.
Until then we need to support required arguments in this round about way.