### PR TITLE
Use method_defined? if possible in define_non_cyclic_method

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -155,8 +155,23 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       private
+        if Module.method(:method_defined?).arity == 1 # MRI 2.5 and older
+          using Module.new {
+            refine Module do
+              def method_defined?(method, inherit = true)
+                if inherit
+                  super(method)
+                else
+                  instance_methods(false).include?(method.to_sym)
+                end
+              end
+            end
+          }
+        end
+
         def define_non_cyclic_method(name, &block)
-          return if instance_methods(false).include?(name)
+          return if method_defined?(name, false)
+
           define_method(name) do |*args|
             result = true; @_already_called ||= {}
             # Loop prevention for validation of associations


### PR DESCRIPTION
Ruby 2.6 added a second parameter to `method_defined?` exactly for this use case. It avoid allocating an Array and then doing a linear search.

It's a small but noticeable chunk of boot time (`0.4%` for us):

```
$ bundle exec stackprof .....dump --method='ActiveRecord::AutosaveAssociation::ClassMethods#define_non_cyclic_method'
ActiveRecord::AutosaveAssociation::ClassMethods#define_non_cyclic_method (/tmp/bundle/ruby/3.0.0/bundler/gems/rails-1b2879404fd7/activerecord/lib/active_record/autosave_association.rb:158)
  samples:     2 self (0.0%)  /    208 total (0.4%)
  callers:
     127  (   61.1%)  ActiveRecord::AutosaveAssociation::ClassMethods#add_autosave_association_callbacks
      81  (   38.9%)  ActiveRecord::AutosaveAssociation::ClassMethods#define_autosave_validation_callbacks
  callees (206 total):
     186  (   90.3%)  Module#instance_methods
      10  (    4.9%)  Module#define_method
      10  (    4.9%)  Array#include?
```

cc @rafaelfranca @tenderlove 