### PR TITLE
Expose rack.request_method through request.raw_request_method for Logger

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -137,6 +137,8 @@ module ActionDispatch
       HTTP_METHOD_LOOKUP[method] = method.underscore.to_sym
     }
 
+    alias raw_request_method request_method # :nodoc:
+
     # Returns the HTTP \method that the application should see.
     # In the case where the \method was overridden by a middleware
     # (for instance, if a HEAD request was converted to a GET,

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Return a 405 Method Not Allowed response when a request uses an unknown HTTP method.
+
+    Fixes #38998.
+
+    *Loren Norman*
+
 *   Make railsrc file location xdg-specification compliant
 
     `rails new` will now look for the default `railsrc` file at

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -47,7 +47,7 @@ module Rails
         # Started GET "/session/new" for 127.0.0.1 at 2012-09-26 14:51:42 -0700
         def started_request_message(request) # :doc:
           'Started %s "%s" for %s at %s' % [
-            request.request_method,
+            request.raw_request_method,
             request.filtered_path,
             request.remote_ip,
             Time.now.to_default_s ]

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -46,6 +46,11 @@ module ApplicationTests
       assert_equal 404, last_response.status
     end
 
+    test "renders unknown http methods as 405" do
+      request "/", { "REQUEST_METHOD" => "NOT_AN_HTTP_METHOD" }
+      assert_equal 405, last_response.status
+    end
+
     test "uses custom exceptions app" do
       add_to_config <<-RUBY
         config.exceptions_app = lambda do |env|


### PR DESCRIPTION
### Summary

fixes #38998 

ActionDispatch::Request modifies Rack#request_method so that it raises on unrecognized HTTP methods. Logger later calls that and triggers the trap at a bad time.

This PR aliases the old request method so that Logger can call it instead, (hopefully) side-stepping the trap.
