### PR TITLE
update `ActiveSupport::TestCase#assert_not` to be ruby styleguide compliant

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -20,7 +20,7 @@ module ActiveSupport
       #   assert_not foo, 'foo should be false'
       def assert_not(object, message = nil)
         message ||= "Expected #{mu_pp(object)} to be nil or false"
-        assert !object, message
+        refute object, message
       end
 
       # Assertion that the block should not raise an exception.

--- a/activesupport/test/test_case_test.rb
+++ b/activesupport/test/test_case_test.rb
@@ -26,6 +26,9 @@ class AssertionsTest < ActiveSupport::TestCase
 
     e = assert_raises(Minitest::Assertion) { assert_not true, "custom" }
     assert_equal "custom", e.message
+
+    e = assert_raises(Minitest::Assertion) { assert_not "truthy value" }
+    assert_equal "Expected \"truthy value\" to be nil or false", e.message
   end
 
   def test_assert_no_difference_pass


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

* use `refute value`, not `assert !value`
* add additional testing for "truthy" values

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
The [general ruby style guide](https://minitest.rubystyle.guide/#refute-false) says to prefer `refute` over `assert !`

The current implementation goes directly against that under the premise that "minitest might change `refute`" ([see here](https://github.com/rails/rails/pull/27476))

1. that is not a good reason to not use refute, in my opinion.
    - Minitest is not going to randomly change one of the two *core* methods of the framework on a whim.
2. instead of going against the style guide on the *extremely slim* chance that Minitest completely rewrites their core methods I believe it's better to follow the style guide, and instead add additional testing to check that the values we want are properly accepted or rejected
    - this has the benefit of following the core ruby style guide
    - it also verifies that *if* a change is made in Minitest, our testing will notify us of that change
