### PR TITLE
Use `IPAddr#prefix` for postgres cidr type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/cidr.rb
@@ -12,19 +12,17 @@ module ActiveRecord
           end
 
           def type_cast_for_schema(value)
-            subnet_mask = value.instance_variable_get(:@mask_addr)
-
             # If the subnet mask is equal to /32, don't output it
-            if subnet_mask == (2**32 - 1)
+            if value.prefix == 32
               "\"#{value}\""
             else
-              "\"#{value}/#{subnet_mask.to_s(2).count('1')}\""
+              "\"#{value}/#{value.prefix}\""
             end
           end
 
           def serialize(value)
             if IPAddr === value
-              "#{value}/#{value.instance_variable_get(:@mask_addr).to_s(2).count('1')}"
+              "#{value}/#{value.prefix}"
             else
               value
             end


### PR DESCRIPTION
`IPAddr#prefix` was added in https://github.com/ruby/ipaddr/commit/293ad5ac6ed704f91d418ecaf24ae58156a5
and imported into Ruby 2.5 in https://github.com/ruby/ruby/commit/c2db917b3db09e3738529d5a45315b77d12ae4c3

Since Rails now uses Ruby >= 2.5 we can safely rely on `IPAddr#prefix`
instead of reaching into instance variables.