### PR TITLE
Implement granular shard swapping

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Connections can be granularly switched for abstract classes when `connected_to` is called.
+
+    This change allows `connected_to` to switch a `shard` for a single abstract class instead of all classes.
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Add `SKIP_TEST_DATABASE` environment variable to disable modifying the test database when `rails db:create` and `rails db:drop` are called.
 
     *Jason Schweier*

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1677,6 +1677,20 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "`connected_to` can only be called on ActiveRecord::Base", error.message
   end
 
+  test "cannot call connected_to with role and shard on non-abstract classes" do
+    error = assert_raises(NotImplementedError) do
+      Bird.connected_to(role: :reading, shard: :default) { }
+    end
+
+    assert_equal "calling `connected_to` with `role` and `shard` is only allowed on ActiveRecord::Base or abstract classes", error.message
+  end
+
+  test "can call connected_to with role and shard on abstract classes" do
+    AbstractCompany.connected_to(role: :reading, shard: :default) do
+      assert AbstractCompany.connected_to?(role: :reading, shard: :default)
+    end
+  end
+
   test "preventing writes applies to all connections on a handler" do
     conn1_error = assert_raises ActiveRecord::ReadOnlyError do
       ActiveRecord::Base.connection_handler.while_preventing_writes do


### PR DESCRIPTION
This changes allows granular connection swapping for shards. Previously
it was required to use `ActiveRecord::Base` with `connected_to(role:
:writing, shard: :default)` because the switch was always global - there
was no way to switch only `AnimalsBase` to `shard: :one`.

Note: This PR only implements granular connection swapping for shards
and not roles. Roles are still global. Granular role swapping is coming
soon - we wanted to pull this out of the work in progress PR since it's
useful and will reduce the size of the followup PRs.

**Implementation**

By using a `Concurrent::Array` we can build an array of the shard +
klass `connected_to` is being called on. That `shard_stack` is added to
in order of called `connected_to` block so we're able to nest
`connected_to` blocks and keep track of which block wins.

This change is backwards compatible because it considers
`ActiveRecord::Base` to be a global connection switch, therefore all
existing connections will continue working.

Previously shards could only be swapped on ActiveRecord like this:

```
ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
  # all models called within this block will lookup reading + shard one
  # connections
end
```

Now this is possible:

```
AnimalsBase.connected_to(role: :reading, shard: :shard_one) do
  # just models inheriting from AnimalsBase will lookup from the
  # reading + shard one connections
end
```

This also fixes an issue where if `ActiveRecord::Base.connected_to` was
called with a `shard` and that `shard` is only available on one abstract
class we'd end up raising an error that the connection doesn't exist.
Now if we switch only the `AnimalsBase` connection models called that
belong to `ApplicationRecord`'s connection won't raise an error, they'll
simply lookup against the default shard or last swapped shard if nested.

There is one caveat in this change. While `role` is required, `shard` is
not. Therefore in deeply nested blocks if a shard is switched, that
current shard remains the `current_shard` until either the block is
exited or another `current_shard` is set.

Example:

```ruby
ActiveRecord::Base.connected_to(role: :reading, shard: :shard_one) do
  # Person is connected to reading + shard_one
  # Dog is connected to reading + shard_one

  AnimalsBase.connected_to(role: :writing, shard: :default) do
    # Person is connected to reading + shard_one
    # Dog is connected to writing + default

    ActiveRecord::Base.connected_to(role: :writing) do
      # Person is connected to writing + shard_one
      # Dog is connected to writing + default
    end
  end
end
```

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>
