### PR TITLE
Remove obsolete comment [skip ci]

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -91,7 +91,6 @@ module ActionDispatch
         else
           expected_path = "/#{expected_path}" unless expected_path.start_with?("/")
         end
-        # Load routes.rb if it hasn't been loaded.
 
         options = options.clone
         generated_path, query_string_keys = @routes.generate_extras(options, defaults)


### PR DESCRIPTION
### Summary

I found a meaningless comment since https://github.com/rails/rails/commit/5f8e48cbd297aca4add4b48efa2136ba6ac851b1#diff-14047d50c33a89d0c4441fbbfed1e603R81 and just removed it.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Nothing.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
