### PR TITLE
Change Anchor Text which Invites Contributors to View Team

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 * Please read [Contributing to the Rails Documentation](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation).
 
-Ruby on Rails is a volunteer effort. We encourage you to pitch in and [join the team](https://contributors.rubyonrails.org)!
+Ruby on Rails is a volunteer effort. We encourage you to pitch in and join [the team](https://contributors.rubyonrails.org)!
 
 Thanks! :heart: :heart: :heart:
 


### PR DESCRIPTION
### Summary

In [the documentation](https://github.com/rails/rails/pull/40257/files#diff-6a3371457528722a734f3c51d9238c13), there is an anchor link which could be tightened up. It reads as follows:

**Existing:**
We encourage you to pitch in and [join the team](https://contributors.rubyonrails.org/)
**Proposed:**
We encourage you to pitch in and join [the team](https://contributors.rubyonrails.org/)

**Reasoning:**

This link points to the team roster.

If the link pointed to a sign up process, _join_ would make more sense.

**I hope this isn't annoying:**
Sorry, I'm just getting back into Rails. I hope this isn't too silly to merge. If it is, please feel free to disregard and sorry for wasting your time.