### PR TITLE
Using write with unless_exist + expires_in should unlock after the gi…

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix bug to make memcached write_entry expire correctly with unless_exist
+
+    *Jye Lee*
+
 *   Add `ActiveSupport::Duration` conversion methods
 
     `in_seconds`, `in_minutes`, `in_hours`, `in_days`, `in_weeks`, `in_months`, and `in_years` return the respective duration covered.

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -144,7 +144,7 @@ module ActiveSupport
           method = options[:unless_exist] ? :add : :set
           value = options[:raw] ? entry.value.to_s : entry
           expires_in = options[:expires_in].to_i
-          if expires_in > 0 && !options[:raw]
+          if options[:race_condition_ttl] && expires_in > 0 && !options[:raw]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
             expires_in += 5.minutes
           end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -161,6 +161,20 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_unless_exist_expires_when_configured
+    cache = ActiveSupport::Cache.lookup_store(:mem_cache_store)
+    called = nil
+    server = Class.new do
+      define_method(:add) { |*args| called = args }
+      def with
+        yield self
+      end
+    end
+    cache.instance_variable_set(:@data, server.new)
+    assert cache.write("foo", "bar", expires_in: 1, unless_exist: true)
+    assert_equal 1, called[2]
+  end
+
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -163,16 +163,9 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
   def test_unless_exist_expires_when_configured
     cache = ActiveSupport::Cache.lookup_store(:mem_cache_store)
-    called = nil
-    server = Class.new do
-      define_method(:add) { |*args| called = args }
-      def with
-        yield self
-      end
+    assert_called_with cache.instance_variable_get(:@data), :add, [ "foo", ActiveSupport::Cache::Entry, 1, Hash ] do
+      cache.write("foo", "bar", expires_in: 1, unless_exist: true)
     end
-    cache.instance_variable_set(:@data, server.new)
-    assert cache.write("foo", "bar", expires_in: 1, unless_exist: true)
-    assert_equal 1, called[2]
   end
 
   private


### PR DESCRIPTION
…ven expires_in and not 5 minutes later

Reproduce by using Rails.cache.write('foo', unless_exist: true, expires_in: 1) and then wait 2 seconds
to call it again ... it should not return false

fixed version for https://github.com/rails/rails/pull/34026

@eugeneius