### PR TITLE
Model#find with hash should not raise NoMethodError

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -336,7 +336,7 @@ module ActiveRecord
         error = +"Couldn't find #{name}"
         error << " with#{conditions}" if conditions
         raise RecordNotFound.new(error, name, key)
-      elsif Array(ids).size == 1
+      elsif Array.wrap(ids).size == 1
         error = "Couldn't find #{name} with '#{key}'=#{ids}#{conditions}"
         raise RecordNotFound.new(error, name, key, ids)
       else

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -44,6 +44,11 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal(topics(:first).title, Topic.find(1).title)
   end
 
+  def test_find_with_hash_parameter
+    assert_raises(ActiveRecord::RecordNotFound) { Post.find(foo: "bar") }
+    assert_raises(ActiveRecord::RecordNotFound) { Post.find(foo: "bar", bar: "baz") }
+  end
+
   def test_find_with_proc_parameter_and_block
     exception = assert_raises(RuntimeError) do
       Topic.all.find(-> { raise "should happen" }) { |e| e.title == "non-existing-title" }


### PR DESCRIPTION
### Summary

`Person.find(foo: "bar", bar: "baz")` is a wrong usage, but it will raise `NoMethodError` made people hard to realize the problem

e.g

```
Loading development environment (Rails 6.1.0.alpha)
2.7.1 :001 > Project.find identifier: "abc"
  Project Load (0.3ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", nil], ["LIMIT", 1]]
Traceback (most recent call last):
       16: from rails (99a0254effde) railties/lib/rails/commands.rb:18:in `<main>'
       15: from rails (99a0254effde) railties/lib/rails/command.rb:50:in `invoke'
       14: from rails (99a0254effde) railties/lib/rails/command/base.rb:69:in `perform'
       13: from thor (1.0.1) lib/thor.rb:392:in `dispatch'
       12: from thor (1.0.1) lib/thor/invocation.rb:127:in `invoke_command'
       11: from thor (1.0.1) lib/thor/command.rb:27:in `run'
       10: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:102:in `perform'
        9: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:19:in `start'
        8: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:70:in `start'
        7: from (irb):1
        6: from rails (99a0254effde) activerecord/lib/active_record/core.rb:187:in `find'
        5: from rails (99a0254effde) activerecord/lib/active_record/querying.rb:22:in `find'
        4: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:69:in `find'
        3: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:442:in `find_with_ids'
        2: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:460:in `find_one'
        1: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:341:in `raise_record_not_found_exception!'
ActiveRecord::RecordNotFound (Couldn't find Project with 'id'={:identifier=>"abc"})
2.7.1 :002 > Project.find identifier: "abc", platform: "123"
  Project Load (0.3ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", nil], ["LIMIT", 1]]
Traceback (most recent call last):
       16: from rails (99a0254effde) railties/lib/rails/command.rb:50:in `invoke'
       15: from rails (99a0254effde) railties/lib/rails/command/base.rb:69:in `perform'
       14: from thor (1.0.1) lib/thor.rb:392:in `dispatch'
       13: from thor (1.0.1) lib/thor/invocation.rb:127:in `invoke_command'
       12: from thor (1.0.1) lib/thor/command.rb:27:in `run'
       11: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:102:in `perform'
       10: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:19:in `start'
        9: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:70:in `start'
        8: from (irb):1
        7: from (irb):2:in `rescue in irb_binding'
        6: from rails (99a0254effde) activerecord/lib/active_record/core.rb:187:in `find'
        5: from rails (99a0254effde) activerecord/lib/active_record/querying.rb:22:in `find'
        4: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:69:in `find'
        3: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:442:in `find_with_ids'
        2: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:460:in `find_one'
        1: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:344:in `raise_record_not_found_exception!'
NoMethodError (undefined method `join' for {:identifier=>"abc", :platform=>"123"}:Hash)
```

With this fix, it should be

```
2.7.1 :001 > Project.find identifier: "abc", platform: "123"
  Project Load (0.4ms)  SELECT "projects".* FROM "projects" WHERE "projects"."id" = $1 LIMIT $2  [["id", nil], ["LIMIT", 1]]
Traceback (most recent call last):
       16: from rails (99a0254effde) railties/lib/rails/commands.rb:18:in `<main>'
       15: from rails (99a0254effde) railties/lib/rails/command.rb:50:in `invoke'
       14: from rails (99a0254effde) railties/lib/rails/command/base.rb:69:in `perform'
       13: from thor (1.0.1) lib/thor.rb:392:in `dispatch'
       12: from thor (1.0.1) lib/thor/invocation.rb:127:in `invoke_command'
       11: from thor (1.0.1) lib/thor/command.rb:27:in `run'
       10: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:102:in `perform'
        9: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:19:in `start'
        8: from rails (99a0254effde) railties/lib/rails/commands/console/console_command.rb:70:in `start'
        7: from (irb):1
        6: from rails (99a0254effde) activerecord/lib/active_record/core.rb:187:in `find'
        5: from rails (99a0254effde) activerecord/lib/active_record/querying.rb:22:in `find'
        4: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:69:in `find'
        3: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:442:in `find_with_ids'
        2: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:460:in `find_one'
        1: from rails (99a0254effde) activerecord/lib/active_record/relation/finder_methods.rb:346:in `raise_record_not_found_exception!'
ActiveRecord::RecordNotFound (Couldn't find all Projects with 'id': ({:identifier=>"abc", :platform=>"123"}) (found 0 results, but was looking for 1).)
```

### Other Information

This PR isn't fix the root cause because I think well check args may introducing extra performance overhead, so I just prevent `raise_record_not_found_exception!` crash
