### PR TITLE
Regression in controller inheritance from isolated engines

### DIFF
--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -644,7 +644,7 @@ en:
       assert_equal Rails.application.routes, env["action_dispatch.routes"]
     end
 
-    test "isolated engine should include only its own routes and helpers" do
+    test "isolated engine routes and helpers are isolated to that engine" do
       @plugin.write "lib/bukkits.rb", <<-RUBY
         module Bukkits
           class Engine < ::Rails::Engine
@@ -729,6 +729,30 @@ en:
         end
       RUBY
 
+      @plugin.write "app/controllers/bukkits/session_controller.rb", <<-RUBY
+        module Bukkits
+          class SessionController < ApplicationController
+            def index
+              render plain: default_path
+            end
+
+            private
+              def default_path
+                foo_path
+              end
+          end
+        end
+      RUBY
+
+      controller "bar", <<-RUBY
+        class BarController < Bukkits::SessionController
+          private
+            def default_path
+              bar_path
+            end
+        end
+      RUBY
+
       @plugin.write "app/mailers/bukkits/my_mailer.rb", <<-RUBY
         module Bukkits
           class MyMailer < ActionMailer::Base
@@ -745,6 +769,9 @@ en:
       assert_equal Bukkits.railtie_namespace, Bukkits::Engine
       assert ::Bukkits::MyMailer.method_defined?(:foo_url)
       assert_not ::Bukkits::MyMailer.method_defined?(:bar_url)
+
+      get("/bar")
+      assert_equal "/bar", last_response.body
 
       get("/bukkits/from_app")
       assert_equal "false", last_response.body


### PR DESCRIPTION
### Summary

This PR contains a **failing test case** to illustrate a regression due to https://github.com/rails/rails/pull/37927. There's a possible fix in https://github.com/rails/rails/pull/40264.

In essence, when an application subclasses an isolated engine controller, and both share a common ancestor of e.g. ApplicationController, it'll get the wrong route helpers. 

The underlying cause is Ruby ignoring the include in the child class, since the memoized route-helper module is already in the ancestors list; unfortunately, the isolated engine's route-helper module is _also_ in the ancestors list but now sits ahead, rather than behind, the route-helpers for the main application.

This arrangement of classes occurs in the wild (e.g. with some configurations of devise) and was observed with real code when tested against Rails master.

_(edit: moved patch into separate PR)_