### PR TITLE
Use non-memoized route helper modules at namespace boundaries.

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -476,8 +476,10 @@ module ActionDispatch
         RUBY
       end
 
-      def url_helpers(supports_path = true)
-        if supports_path
+      def url_helpers(supports_path = true, fresh_module = false)
+        if fresh_module
+          generate_url_helpers(supports_path)
+        elsif supports_path
           @url_helpers_with_paths ||= generate_url_helpers(true)
         else
           @url_helpers_without_paths ||= generate_url_helpers(false)

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -405,7 +405,7 @@ module Rails
             end
 
             unless mod.respond_to?(:railtie_routes_url_helpers)
-              define_method(:railtie_routes_url_helpers) { |include_path_helpers = true| railtie.routes.url_helpers(include_path_helpers) }
+              define_method(:railtie_routes_url_helpers) { |include_path_helpers = true, fresh_module = false| railtie.routes.url_helpers(include_path_helpers, fresh_module) }
             end
           end
         end


### PR DESCRIPTION
### Summary

A possible fix for the failing test in #40263, hopefully without throwing out the gains of #37927.

If we're switching namespace in a controller subclass (especially due to an isolated engine controller appearing in the ancestors) then we may need a fresh route-helper module to "mask" that of the previous namespace.

### Discussion

The idea here is, at the point where a module would be included, ask the ancestors what their namespace was, and if ours is different then assume a fresh module is required rather than a memoized one.

If not, then do not ask for a fresh module, to avoid trampling on the intentions of #37927.  It looks like validating benchmarks were run at the time, it might be helpful to run them against this change to avoid performance regression.

This approach relies on the ancestors for any given controller class being essentially invariant (which isn't perfectly guaranteed but may be true enough); and, permission to add an additional parameter to ActionDispatch::Routing::RouteSet#url_helpers, which needs review from someone more familiar than me with the routing engine.
