### PR TITLE
Uncomments bin/yarn in bin/setup for webpacker

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
 <% unless options.skip_javascript? -%>
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
+  system! 'bin/yarn'
 <% end -%>
 <% unless options.skip_active_record? -%>
 

--- a/railties/test/application/bin_setup_test.rb
+++ b/railties/test/application/bin_setup_test.rb
@@ -41,12 +41,20 @@ module ApplicationTests
         output.sub!(/^Resolving dependencies\.\.\.\n/, "")
         # Suppress Bundler platform warnings from output
         output.gsub!(/^The dependency .* will be unused .*\.\n/, "")
+        # Ignores dynamic data by yarn
+        output.sub!(/^yarn install v.*?$/, "yarn install")
+        output.sub!(/^\[.*?\] Resolving packages\.\.\.$/, "[1/4] Resolving packages...")
+        output.sub!(/^Done in \d+\.\d+s\.\n/, "Done in 0.00s.\n")
         # Ignore warnings such as `Psych.safe_load is deprecated`
         output.gsub!(/^warning:\s.*\n/, "")
 
         assert_equal(<<~OUTPUT, output)
           == Installing dependencies ==
           The Gemfile's dependencies are satisfied
+          yarn install
+          [1/4] Resolving packages...
+          success Already up-to-date.
+          Done in 0.00s.
 
           == Preparing database ==
           Created database 'app_development'

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -295,6 +295,17 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_adds_bin_yarn_into_setup_script
+    run_generator
+
+    assert_file "bin/yarn"
+
+    assert_file "bin/setup" do |content|
+      # Does not comment yarn install
+      assert_match(/(?=[^#]*?) system! 'bin\/yarn'/, content)
+    end
+  end
+
   def test_app_update_does_not_generate_yarn_contents_when_bin_yarn_is_not_used
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "--skip-javascript"]
@@ -307,7 +318,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_no_file "#{app_root}/bin/yarn"
 
       assert_file "#{app_root}/bin/setup" do |content|
-        assert_no_match(/system\('bin\/yarn'\)/, content)
+        assert_no_match(/system! 'bin\/yarn'/, content)
       end
     end
   end


### PR DESCRIPTION
### Summary

By adding the default requiring of webpacker, `bin/setup` requires a manual update in order to do the cold setup on a new instance.

### Other Information

If users do not use `bin/yarn` to install packages, then they still require to delete `bin/yarn` line in order to remove redundant code.

If we already add `bin/yarn`, then run it on `bin/setup` should not increase any confusion.
And at the same time, we reduce confusion when we run `bin/setup` without `node_modules` will not setup valid application.

### Cosmetic Changes

There is some cosmetic change which makes code consistent: `system('bin/yarn')` => `system! 'bin/yarn'`