### PR TITLE
Eliminate `fixture_file_upload` related deprecation warnings in actionmailbox/test

### DIFF
--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -60,7 +60,7 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
             to: "Replies <replies@example.com>",
             subject: "Let's debate some attachments",
             body: "Let's talk about these images:",
-            attachments: [ fixture_file_upload("files/avatar1.jpeg"), fixture_file_upload("files/avatar2.jpeg") ]
+            attachments: [ fixture_file_upload("avatar1.jpeg"), fixture_file_upload("avatar2.jpeg") ]
           }
         }
       end


### PR DESCRIPTION
https://buildkite.com/rails/rails/builds/71675#2b9c36e5-5504-4a8e-8c4d-af774e96ea16/954-982
https://buildkite.com/rails/rails/builds/71675#2b9c36e5-5504-4a8e-8c4d-af774e96ea16/954-988

```bash
.................DEPRECATION WARNING: Passing a path to `fixture_file_upload`
relative to `fixture_path` is deprecated.
In Rails 6.2, the path needs to be relative to `file_fixture_path`.

Please modify the call from
`fixture_file_upload("files/avatar1.jpeg")` to `fixture_file_upload("avatar1.jpeg")`.
DEPRECATION WARNING: Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
In Rails 6.2, the path needs to be relative to `file_fixture_path`.

Please modify the call from
`fixture_file_upload("files/avatar2.jpeg")` to `fixture_file_upload("avatar2.jpeg")`.
........................................................................
```

`fixture_file_upload` now uses path relative to `file_fixture_path`, see
https://github.com/rails/rails/pull/39086,
https://github.com/rails/rails/blob/61c4be477706b721688e36a3168f86aabc625658/actionmailbox/test/test_helper.rb#L21