### PR TITLE
ActiveStorage: Add support for per-environment configuration file

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add per-environment configuration file support.
+
+    *Younes SERRAJ*
+
 *   The Poppler PDF previewer renders a preview image using the original
     document's crop box rather than its media box, hiding print margins. This
     matches the behavior of the MuPDF previewer.

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -116,7 +116,8 @@ module ActiveStorage
       ActiveSupport.on_load(:active_storage_blob) do
         configs = Rails.configuration.active_storage.service_configurations ||=
           begin
-            config_file = Rails.root.join("config/storage.yml")
+            config_file = Rails.root.join("config/storage/#{Rails.env}.yml")
+            config_file = Rails.root.join("config/storage.yml") unless config_file.exist?
             raise("Couldn't find Active Storage configuration in #{config_file}") unless config_file.exist?
 
             ActiveSupport::ConfigurationFile.parse(config_file)

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -31,6 +31,9 @@ module ActiveStorage
   #
   #   config.active_storage.service = :local
   #
+  # If specific configuration file exists for current environment, it takes precedence, thus for +production+
+  # environment it is <tt>config/storage/production.yml</tt> that will be loaded.
+  #
   # If you are using Active Storage outside of a Ruby on Rails application, you
   # can configure the service to use like this:
   #

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -66,6 +66,8 @@ amazon:
   region: "" # e.g. 'us-east-1'
 ```
 
+NOTE: Environment-specific configuration files take precedence over `config/storage.yml`. In `production` for instance, it is `config/storage/production.yml` that will be loaded if present.
+
 Tell Active Storage which service to use by setting
 `Rails.application.config.active_storage.service`. Because each environment will
 likely use a different service, it is recommended to do this on a
@@ -132,7 +134,7 @@ amazon:
   http_open_timeout: 0
   http_read_timeout: 0
   retry_limit: 0
-  upload: 
+  upload:
     server_side_encryption: "" # 'aws:kms' or 'AES256'
 ```
 TIP: Set sensible client HTTP timeouts and retry limits for your application. In certain failure scenarios, the default AWS client configuration may cause connections to be held for up to several minutes and lead to request queuing.


### PR DESCRIPTION
### Summary

Add support for per-environment configuration files for ActiveStorage.

For instance, when on `production`, we first look for `config/storage/production.yml`. When not present, we fallback to `config/storage.yml`.

### Other Information

This PR results from the following issue: https://github.com/rails/rails/issues/40248
