### PR TITLE
Extract {ActiveStorage,ActionText,ActionMailbox}::Record

### DIFF
--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -24,7 +24,7 @@ module ActionMailbox
   #
   #   inbound_email.mail.from # => 'david@loudthinking.com'
   #   inbound_email.source # Returns the full rfc822 source of the email as text
-  class InboundEmail < ActiveRecord::Base
+  class InboundEmail < Record
     self.table_name = "action_mailbox_inbound_emails"
 
     include Incineratable, MessageId, Routable

--- a/actionmailbox/app/models/action_mailbox/record.rb
+++ b/actionmailbox/app/models/action_mailbox/record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActionMailbox
+  class Record < ActiveRecord::Base #:nodoc:
+    self.abstract_class = true
+  end
+end
+
+ActiveSupport.run_load_hooks :action_mailbox_record, ActionMailbox::Record

--- a/actiontext/app/models/action_text/record.rb
+++ b/actiontext/app/models/action_text/record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ActionText
+  class Record < ActiveRecord::Base #:nodoc:
+    self.abstract_class = true
+  end
+end
+
+ActiveSupport.run_load_hooks :action_text_record, ActionText::Record

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -5,7 +5,7 @@ module ActionText
   # It also holds all the references to the embedded files, which are stored using Active Storage.
   # This record is then associated with the Active Record model the application desires to have
   # rich text content using the +has_rich_text+ class method.
-  class RichText < ActiveRecord::Base
+  class RichText < Record
     self.table_name = "action_text_rich_texts"
 
     serialize :body, ActionText::Content

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -7,7 +7,7 @@ require "active_support/core_ext/module/delegation"
 # on the attachments table prevents blobs from being purged if they’re still attached to any records.
 #
 # Attachments also have access to all methods from {ActiveStorage::Blob}[rdoc-ref:ActiveStorage::Blob].
-class ActiveStorage::Attachment < ActiveRecord::Base
+class ActiveStorage::Attachment < ActiveStorage::Record
   self.table_name = "active_storage_attachments"
 
   belongs_to :record, polymorphic: true, touch: true

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -14,7 +14,7 @@
 # Blobs are intended to be immutable in as-so-far as their reference to a specific file goes. You're allowed to
 # update a blob's metadata on a subsequent pass, but you should not update the key or change the uploaded file.
 # If you need to create a derivative or otherwise change the blob, simply create a new blob and purge the old one.
-class ActiveStorage::Blob < ActiveRecord::Base
+class ActiveStorage::Blob < ActiveStorage::Record
   # We use constant paths in the following include calls to avoid a gotcha of
   # classic mode: If the parent application defines a top-level Analyzable, for
   # example, and ActiveStorage::Blob::Analyzable is not yet loaded, a bare

--- a/activestorage/app/models/active_storage/record.rb
+++ b/activestorage/app/models/active_storage/record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ActiveStorage::Record < ActiveRecord::Base #:nodoc:
+  self.abstract_class = true
+end
+
+ActiveSupport.run_load_hooks :active_storage_record, ActiveStorage::Record

--- a/activestorage/app/models/active_storage/variant_record.rb
+++ b/activestorage/app/models/active_storage/variant_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActiveStorage::VariantRecord < ActiveRecord::Base
+class ActiveStorage::VariantRecord < ActiveStorage::Record
   self.table_name = "active_storage_variant_records"
 
   belongs_to :blob

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -133,7 +133,11 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
     setup_ar!
 
-    initial = [ActiveStorage::Blob, ActiveStorage::Attachment, ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord].collect(&:to_s).sort
+    initial = [
+      ActiveStorage::Record, ActiveStorage::Blob, ActiveStorage::Attachment,
+      ActiveRecord::SchemaMigration, ActiveRecord::InternalMetadata, ApplicationRecord
+    ].collect(&:to_s).sort
+
     assert_equal initial, ActiveRecord::Base.descendants.collect(&:to_s).sort.uniq
     get "/load"
     assert_equal [Post].collect(&:to_s).sort, ActiveRecord::Base.descendants.collect(&:to_s).sort - initial


### PR DESCRIPTION
Permit applications to hack in custom databases for Active Storage/Action Text/ActionMailbox models until they offer first-class multi-DB support:

```ruby
# config/initializers/active_storage.rb
ActiveSupport.on_load(:active_storage_record) do
  connects_to reading: :active_storage_replica, writing: :active_storage_primary
end
```

These models will also be needed when we do implement multi-DB support for ASt/AT/AMb.