### PR TITLE
Create a gitattributes file for templated apps

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -66,6 +66,10 @@ module Rails
       template "gitignore", ".gitignore"
     end
 
+    def gitattributes
+      template "gitattributes", ".gitattributes"
+    end
+
     def version_control
       if !options[:skip_git] && !options[:pretend]
         run "git init", capture: options[:quiet], abort_on_failure: false
@@ -331,8 +335,13 @@ module Rails
         build(:rakefile)
         build(:ruby_version)
         build(:configru)
-        build(:gitignore)   unless options[:skip_git]
-        build(:gemfile)     unless options[:skip_gemfile]
+
+        unless options[:skip_git]
+          build(:gitignore)
+          build(:gitattributes)
+        end
+
+        build(:gemfile) unless options[:skip_gemfile]
         build(:version_control)
         build(:package_json) unless options[:skip_javascript]
       end

--- a/railties/lib/rails/generators/rails/app/templates/gitattributes.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitattributes.tt
@@ -1,0 +1,14 @@
+# See https://git-scm.com/docs/gitattributes for more about git attribute files.
+
+<% unless options[:skip_active_record] -%>
+# Mark the database schema as having been generated.
+db/schema.rb linguist-generated
+<% end -%>
+
+<% unless options[:skip_javascript] -%>
+# Mark the yarn lockfile as having been generated.
+yarn.lock linguist-generated
+<% end -%>
+
+# Mark any vendored files as having been vendored.
+vendor/* linguist-vendored

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -126,7 +126,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
   test "diff enroll diffing" do
     assert_match("successfully enrolled", run_diff_command(enroll: true))
 
-    assert_equal <<~EOM, File.read(app_path(".gitattributes"))
+    assert_includes File.read(app_path(".gitattributes")), <<~EOM
       config/credentials/*.yml.enc diff=rails_credentials
       config/credentials.yml.enc diff=rails_credentials
     EOM

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -5,6 +5,7 @@ require "rails/generators/rails/app/app_generator"
 require "generators/shared_generator_tests"
 
 DEFAULT_APP_FILES = %w(
+  .gitattributes
   .gitignore
   .ruby-version
   README.md
@@ -915,6 +916,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "spring"
   end
 
+  def test_skip_active_record_option
+    run_generator [destination_root, "--skip-active-record"]
+
+    assert_file ".gitattributes" do |content|
+      assert_no_match(/schema.rb/, content)
+    end
+  end
+
   def test_skip_javascript_option
     command_check = -> command, *_ do
       if command == "webpacker:install"
@@ -931,6 +940,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "webpacker"
     assert_file "config/initializers/content_security_policy.rb" do |content|
       assert_no_match(/policy\.connect_src/, content)
+    end
+
+    assert_file ".gitattributes" do |content|
+      assert_no_match(/yarn\.lock/, content)
     end
   end
 


### PR DESCRIPTION
### Summary

`.gitattributes` files are a useful way to mark certain metadata about paths in a git repository (https://git-scm.com/docs/gitattributes). This can include all kinds of information, but one of the more useful ones is that linguist (https://github.com/github/linguist, the tool that powers the language statistics/diff view of GitHub) respects certain attributes. For example:

* `linguist-vendored` paths will not be counted toward the language statistics
* `linguist-generated` paths will not have their diff shown by default

These little niceties can be really helpful over time, so we should add it to the default app generator.