### PR TITLE
Removes the unnecessary require from active_job/logging

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/string/filters"
 require "active_support/log_subscriber"
 
 module ActiveJob

--- a/activejob/lib/active_job/logging.rb
+++ b/activejob/lib/active_job/logging.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/filters"
 require "active_support/tagged_logging"
 require "active_support/logger"
 


### PR DESCRIPTION
### Summary
This PR removes `require "active_support/core_ext/string/filters"` from `activejob/lib/active_job/logging.rb` as we are not using any string extentions here.
Update:
`require "active_support/core_ext/string/filters"` is moved to `activejob/lib/active_job/log_subscriber.rb`