### PR TITLE
rexml is no longer default gem in Ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ gem "dalli"
 gem "listen", "~> 3.2", require: false, github: "guard/listen"
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
-gem "rexml", require: false
 
 # for railties app_generator_test
 gem "bootsnap", ">= 1.4.4", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ PATH
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      rexml
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     rails (6.1.0.alpha)
@@ -606,7 +607,6 @@ DEPENDENCIES
   redis-namespace!
   resque
   resque-scheduler
-  rexml
   rouge
   rubocop (>= 0.90)
   rubocop-packaging

--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |s|
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "zeitwerk",        "~> 2.3"
   s.add_dependency "minitest",        ">= 5.1"
+  s.add_dependency "rexml"
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16485
https://github.com/ruby/ruby/pull/2832

Unless adding `s.add_dependency "rexml"` in the gemspec,
`ActiveSupport::XmlMini` with default engine (REXML) won't work.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "activesupport", github: "rails/rails"
end

require "active_support"
require "active_support/xml_mini"
require "minitest/autorun"

class BugTest < Minitest::Test
  def test_stuff
    xml_string = "<root></root>"
    assert_equal({ "root" => {} }, ActiveSupport::XmlMini.parse(xml_string))
  end
end
```

```
% ruby xml_mini.rb
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/............
Fetching gem metadata from https://rubygems.org/............
Resolving dependencies...
Using bundler 2.2.0.dev
Using concurrent-ruby 1.1.7
Using minitest 5.14.2
Using zeitwerk 2.4.0
Using i18n 1.8.5
Using tzinfo 2.0.2
Using activesupport 6.1.0.alpha from source at `..`
Run options: --seed 20428

# Running:

E

Finished in 0.002034s, 491.6421 runs/s, 0.0000 assertions/s.

  1) Error:
BugTest#test_stuff:
LoadError: cannot load such file -- rexml/document
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/xml_mini/rexml.rb:28:in `require'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/xml_mini/rexml.rb:28:in `block in parse'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:15:in `block in silence_warnings'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:28:in `with_warnings'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/kernel/reporting.rb:15:in `silence_warnings'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/xml_mini/rexml.rb:28:in `parse'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/xml_mini.rb:94:in `parse'
    xml_mini.rb:23:in `test_stuff'

1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
```

Follow up of 0399be70766d7c6bf46d727ef2e337ff40f242b4.
