### PR TITLE
Satisfy Rubocop

### DIFF
--- a/activesupport/lib/active_support/xml_mini/rexml.rb
+++ b/activesupport/lib/active_support/xml_mini/rexml.rb
@@ -38,7 +38,6 @@ module ActiveSupport
     end
 
     private
-
       def require_rexml
         silence_warnings { require "rexml/document" }
       rescue LoadError => e


### PR DESCRIPTION
Fixes offense:

```
activesupport/lib/active_support/xml_mini/rexml.rb:40:5: C: Layout/EmptyLinesAroundAccessModifier: Remove a blank line after private.
    private
    ^^^^^^^
```
