### PR TITLE
Improve query used in `test_with_advisory_lock_closes_connection`. 

### DIFF
--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -942,10 +942,9 @@ class MigrationTest < ActiveRecord::TestCase
         }.new
 
         migrator = ActiveRecord::Migrator.new(:up, [migration], @schema_migration, 100)
+        query = "SELECT query FROM pg_stat_activity WHERE datname = '#{ActiveRecord::Base.connection_db_config.database}' AND state = 'idle'"
 
-        query = "SELECT COUNT(*) FROM pg_stat_activity WHERE datname = '#{ActiveRecord::Base.connection_db_config.database}'"
-
-        assert_no_changes -> { ActiveRecord::Base.connection.exec_query(query).rows.flatten.first } do
+        assert_no_changes -> { ActiveRecord::Base.connection.exec_query(query).rows.flatten } do
           migrator.migrate
         end
       end


### PR DESCRIPTION
The test is flaky and I can't reproduce it locally. Using the count does
not provide any useful information on failure so we select the queries
instead.
