### PR TITLE
Fix to indicate the the example is below the text in ActionView 3.2.3

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -224,7 +224,7 @@ Here, the `_ad_banner.html.erb` and `_footer.html.erb` partials could contain co
 
 #### `render` without `partial` and `locals` options
 
-In the above example, `render` takes 2 options: `partial` and `locals`. But if
+In the example below, `render` takes 2 options: `partial` and `locals`. But if
 these are the only options you want to pass, you can skip using these options.
 For example, instead of:
 


### PR DESCRIPTION
### Summary

The text indicated the example with `partial` and `locals` was above, but it is in fact below. This change fixes that.
