### PR TITLE
Fix intermittent NameError: uninitialized constant ActiveStorage::Blob::Representable::MimeMagic

### DIFF
--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "mimemagic"
+
 module ActiveStorage::Blob::Representable
   extend ActiveSupport::Concern
 

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "mimemagic"
+
 # A set of transformations that can be applied to a blob to create a variant. This class is exposed via
 # the ActiveStorage::Blob#variant method and should rarely be used directly.
 #


### PR DESCRIPTION
### Summary

#40226 added direct use of MimeMagic but didn't add requires for the gem. This sort of works because Marcel triggers a load of MimeMagic when it is first used, but it does so through autoload, so it needs to be used first. However, if the code hits a use of MimeMagic first, it fails with an error like `NameError: uninitialized constant ActiveStorage::Blob::Representable::MimeMagic`. In our particular case, this was being triggered at 
`ActiveStorage::Blob::Representable#format`.

I added the requires direct to the files that use MimeMagic so it only gets pulled in if it is likely to be used. Initially I had the require after `require "marcel"` but MimeMagic is a much larger require by comparison.