### PR TITLE
Fix when duplicate params are accumulated

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -696,7 +696,7 @@ will result in the `params` hash being
 {'person' => {'address' => {'city' => 'New York'}}}
 ```
 
-Normally Rails ignores duplicate parameter names. If the parameter name contains an empty set of square brackets `[]` then they will be accumulated in an array. If you wanted users to be able to input multiple phone numbers, you could place this in the form:
+Normally Rails ignores duplicate parameter names. If the parameter name ends with an empty set of square brackets `[]` then they will be accumulated in an array. If you wanted users to be able to input multiple phone numbers, you could place this in the form:
 
 ```html
 <input name="person[phone_number][]" type="text"/>


### PR DESCRIPTION
### Summary

**Fix when duplicate params are accumulated**

The previous statement was not strictly true all of the time.
For example, an input named `person[phone_number[]]` does
not get automatically accumulated. Updated this to a statement
that is always true (even if it may not fully describe all possible
cases, such as perhaps nested forms).
