### PR TITLE
Treat data- prefixed attributes as data: nested attributes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Treat `data-` prefixed attributes as if they were declared in `data: {}`
+    attributes Hashes:
+
+        tag.div "data-json-value": { key: "value" }
+        # => <div data-json-value=\"{&quot;key&quot;:&quot;value&quot;}\"></div>
+
+    *Sean Doyle*
+
 *   `ActionView::Helpers::TranslationHelper#translate` accepts a block, yielding
     the translated text and the fully resolved translation key:
 

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -94,8 +94,12 @@ module ActionView
         def tag_option(key, value, escape)
           case value
           when Array, Hash
-            value = TagHelper.build_tag_values(value) if key.to_s == "class"
-            value = escape ? safe_join(value, " ") : value.join(" ")
+            if key.to_s.start_with?("data-")
+              value = value.to_json
+            else
+              value = TagHelper.build_tag_values(value) if key.to_s == "class"
+              value = escape ? safe_join(value, " ") : value.join(" ")
+            end
           else
             value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
           end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -353,11 +353,15 @@ class TagHelperTest < ActionView::TestCase
   def test_content_tag_with_data_attributes
     assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
       content_tag("p", "limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })
+    assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
+      content_tag("p", "limelight", "data-number": 1, "data-string": "hello", "data-string-with-quotes": 'double"quote"party"')
   end
 
   def test_tag_builder_with_data_attributes
     assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
       tag.p("limelight", data: { number: 1, string: "hello", string_with_quotes: 'double"quote"party"' })
+    assert_dom_equal '<p data-number="1" data-string="hello" data-string-with-quotes="double&quot;quote&quot;party&quot;">limelight</p>',
+      tag.p("limelight", "data-number": 1, "data-string": "hello", "data-string-with-quotes": 'double"quote"party"')
   end
 
   def test_cdata_section
@@ -425,6 +429,11 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_data_attributes
+    assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
+      tag("a", "data-a-float": 3.14, "data-a-big-decimal": BigDecimal("-123.456"), "data-a-number": 1, "data-string": "hello", "data-symbol": :foo, "data-array": [1, 2, 3], "data-hash": { key: "value" }, "data-string-with-quotes": 'double"quote"party"')
+    assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
+      tag.a("data-a-float": 3.14, "data-a-big-decimal": BigDecimal("-123.456"), "data-a-number": 1, "data-string": "hello", "data-symbol": :foo, "data-array": [1, 2, 3], "data-hash": { key: "value" }, "data-string-with-quotes": 'double"quote"party"')
+
     ["data", :data].each { |data|
       assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',
         tag("a", data => { a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { key: "value" }, string_with_quotes: 'double"quote"party"' })


### PR DESCRIPTION
Treat `data-` prefixed attributes as if they were declared in `data: {}`
attributes Hashes:

```ruby
tag.div "data-json-value": { key: "value" }
```

Inspired by [GitHub's ESLint rule to prefer
`element.getAttribute("data-json-value")` instead of
`element.dataset.jsonValue`][github-eslint], add support for JSON
detection when specifying a fully-qualified `data-` key name instead of
the less grep-friendly `data: {}` nested variation (in the case of this
example: `data: { json_value: { key: "value" } }`).

[github-eslint]: https://github.com/github/eslint-plugin-github/blob/5a39768d972e8b3cd7443ab4e369528bdf0399c7/docs/rules/no-dataset.md

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
