### PR TITLE
Update documentation for Persistence#reload

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -776,7 +776,7 @@ module ActiveRecord
     #
     # The optional <tt>:lock</tt> flag option allows you to lock the reloaded record:
     #
-    #   reload(lock: true) # reload with pessimistic locking
+    #   reload({lock: true}) # reload with pessimistic locking
     #
     # Reloading is commonly used in test suites to test something is actually
     # written to the database, or when some action modifies the corresponding


### PR DESCRIPTION
- Updated rdoc comment to show that an options hash is expected, instead
  of keyword arguments

### Summary

[The method signature of `#reload` takes only one option (`options`)](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/persistence.rb#L806), and does not accept any keyword arguments.  This PR only corrects the RDoc comment to properly illustrate the correct method signature.
