### PR TITLE
Add additional time zone mappings to ActiveSupport::TimeZone

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -90,6 +90,7 @@ module ActiveSupport
       "Bern"                         => "Europe/Zurich",
       "Zurich"                       => "Europe/Zurich",
       "Rome"                         => "Europe/Rome",
+      "Oslo"                         => "Europe/Oslo",
       "Stockholm"                    => "Europe/Stockholm",
       "Vienna"                       => "Europe/Vienna",
       "West Central Africa"          => "Africa/Algiers",

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -65,6 +65,7 @@ module ActiveSupport
       "Mid-Atlantic"                 => "Atlantic/South_Georgia",
       "Azores"                       => "Atlantic/Azores",
       "Cape Verde Is."               => "Atlantic/Cape_Verde",
+      "Reykjavik"                    => "Atlantic/Reykjavik",
       "Dublin"                       => "Europe/Dublin",
       "Edinburgh"                    => "Europe/London",
       "Lisbon"                       => "Europe/Lisbon",


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I have been on a recent deep dive into time zones and read most of the documentation on [IANA](http://www.iana.org/time-zones) about time zones.

In my application I'm detecting the user's time zone with [jstz.js](https://github.com/pellepim/jstimezonedetect) and my users painfully experienced that _ActiveSupport::TimeZone::MAPPING_ does not contain some key European capitals (Oslo and Reykjavik).

I understand that ActiveSupport::TimeZone tries to limit the number of sensible time zones to keep the file size small (>500 time zones in IANA is a bit much I agree). However, I believe we should consider including Oslo and Reykjavik in the mapping if we have Copenhagen and two Swiss locations 👍



### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
