### PR TITLE
Ensure DB Directory Is Created

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -378,6 +378,7 @@ module ActiveRecord
         filename = dump_filename(db_config.name, format)
         connection = ActiveRecord::Base.connection
 
+        FileUtils.mkdir_p(db_dir)
         case format
         when :ruby
           File.open(filename, "w:utf-8") do |file|

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -283,6 +283,26 @@ module ActiveRecord
     end
   end
 
+  class DatabaseTasksDumpSchemaTest < ActiveRecord::TestCase
+    def test_ensure_db_dir
+      Dir.mktmpdir do |dir|
+        ActiveRecord::Tasks::DatabaseTasks.stub(:db_dir, dir) do
+          db_config = OpenStruct.new(name: "fake_db_config")
+          path = "#{dir}/fake_db_config_schema.rb"
+
+          FileUtils.rm_rf(dir)
+          assert_not File.file?(path)
+
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+
+          assert File.file?(path)
+        end
+      end
+    ensure
+      ActiveRecord::Base.clear_cache!
+    end
+  end
+
   class DatabaseTasksCreateAllTest < ActiveRecord::TestCase
     def setup
       @configurations = { "development" => { "database" => "my-db" } }


### PR DESCRIPTION
I have experienced the following issue. The task `db:migrate` fails if the directory `db/` is missing. This can happen if the app doesn’t have a DB, for example when initially created with `--skip-active-record`. 

I can think of two possible solutions here:
1. Ensure the db directory exists by always creating it at the start of loading the module `DatabaseTasks`
2. Show a warning if the directory is missing, so that the user knows where the failure is.

For this PR, I’m just doing a quick patch that creates the directory during the `db:schema:dump` task. Probably should be changed to one of the two options above. Thoughts?