### PR TITLE
Fix small typos in the guides [skip ci]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -70,7 +70,7 @@ ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*a
 end
 ```
 
-You may also pass block with only one argument, it will yield an event object to the block:
+You may also pass a block that accepts only one argument, and it will receive an event object:
 
 ```ruby
 ActiveSupport::Notifications.subscribe "process_action.action_controller" do |event|

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -473,7 +473,7 @@ which contains these lines:
 */
 ```
 
-Rails create `app/assets/stylesheets/application.css` regardless of whether the
+Rails creates `app/assets/stylesheets/application.css` regardless of whether the
 `--skip-sprockets` option is used when creating a new Rails application. This is
 so you can easily add asset pipelining later if you like.
 


### PR DESCRIPTION
### Summary

This fixes two small typos in the guides.