### PR TITLE
Dash comments should match read query regexp

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow double-dash comment syntax when querying read-only databases
+
+    *James Adam*
+
 *   Add support for PostgreSQL `interval` data type with conversion to
     `ActiveSupport::Duration` when loading records from database and
     serialization to ISO 8601 formatted duration string on save.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -37,7 +37,7 @@ module ActiveRecord
       include Savepoints
 
       SIMPLE_INT = /\A\d+\z/
-      COMMENT_REGEX = %r{/\*(?:[^\*]|\*[^/])*\*/}m
+      COMMENT_REGEX = %r{(?:\-\-.*\n)*|/\*(?:[^\*]|\*[^/])*\*/}m
 
       attr_accessor :pool
       attr_reader :visitor, :owner, :logger, :lock


### PR DESCRIPTION
### Summary

When checking if a query is suitable for a read-only database connection, as well as allowing queries of the form

```sql
/* some comment */
SELECT ...
```

we should also allow queries of the form

```sql
-- some comment
-- some other comment
SELECT ...
```

Additionally, I've added tests for both comment forms into the general adapter test case, along with some additional checks to ensure that the regexp does not return a false-positive match if the read query signifier keyword is actually a part of the comment.

This expands on the change already implemented in 12b964c50f108f6668d1af2e22939059a217f28a (#37184)

### Other Information

I'd also like to add support for `# comment` in MySQL, but it's non-trivial to add database-specific comment syntax support at this time. I also suspect there's increasingly limited value, since the main source of queries being checked are those generated by Rails itself.