### PR TITLE
Replace create/update in on option comment [ci skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -827,10 +827,10 @@ is updated.
 
 ```ruby
 class Person < ApplicationRecord
-  # it will be possible to update email with a duplicated value
+  # it will be possible to create email with a duplicated value
   validates :email, uniqueness: true, on: :create
 
-  # it will be possible to create the record with a non-numerical age
+  # it will be possible to update the record with a non-numerical age
   validates :age, numericality: true, on: :update
 
   # the default (validates on both create and update)


### PR DESCRIPTION
### Summary

Shouldn't `create` and `update` in comment are reversed?