### PR TITLE
Changed naming in HABTM middle_reflection

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -61,7 +61,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def middle_reflection(join_model)
-      middle_name = [lhs_model.name.downcase.pluralize,
+      middle_name = [lhs_model.name.underscore.pluralize,
                      association_name.to_s].sort.join("_").gsub("::", "_").to_sym
       middle_options = middle_options join_model
 


### PR DESCRIPTION
### Summary

Hello ! I encountered an issue where I had a HABTM association between, let's say, `FooBar::Test` and `Tag`.

```
class FooBar::Test
  has_and_belongs_to_many :tags
end

class Tag
  has_and_belongs_to_many :foo_bar_tests, class_name: 'FooBar::Test'
end
```

But somewhere in the code, there was written a `left_joins` on the join table name (`foo_bar_tests_tags`) instead of the association name (`tags`) -> `FooBar::Test.left_joins(:foo_bar_tests_tags)`.

For other models, it worked because the middle_reflection takes the same name as the table per convention (sorted underscored model names joined by an underscore). But in this situation, it failed!

I tracked the issue to the middle_reflection method that called `downcase` on the model_name instead of `underscore`, giving for `FooBar::Test` : `foobar::test` instead of `foo_bar_test`. And with the following methods, finished with the association name `foobar_tests_tags` instead of `foo_bar_tests_tags`.

I think calling `downcase` on model names is a mistake but I'm open to any explanations if I'm wrong. 😊

I hope I'm clear enough in my description, it's my first PR here! Thank you very much!
