### PR TITLE
[skip ci]  Fix examples for has_{one,many} :through :source and :source_type

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1340,9 +1340,14 @@ The `:source` option specifies the source association name for a `has_one :throu
 The `:source_type` option specifies the source association type for a `has_one :through` association that proceeds through a polymorphic association.
 
 ```ruby
+class Author < ApplicationRecord
+  has_one :book
+  has_one :hardback, through: :book, source: :format, source_type: "Hardback"
+  has_one :dust_jacket, through: :hardback
+end
+
 class Book < ApplicationRecord
-  has_one :format, polymorphic: true
-  has_one :dust_jacket, through: :format, source: :dust_jacket, source_type: "Hardback"
+  belongs_to :format, polymorphic: true
 end
 
 class Paperback < ApplicationRecord; end
@@ -1795,7 +1800,7 @@ class Author < ApplicationRecord
 end
 
 class Book < ApplicationRecord
-  has_one :format, polymorphic: true
+  belongs_to :format, polymorphic: true
 end
 
 class Hardback < ApplicationRecord; end


### PR DESCRIPTION
### Summary

This is the first Pull Request which update  examples for #35612 

The syntax for `has_one :plymophic`  is not supported 

### Other Information

#### The problem of example-for-has-many-source-type

[4.3.2.10 :source_type](https://guides.rubyonrails.org/association_basics.html#options-for-has-many-source-type)

##### Steps to reproduce

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "activerecord", "6.0.0"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do

  create_table :authors, force: true do |t|
  end

  create_table :hardbacks, force: true do |t|
  end

  create_table :paperbacks, force: true do |t|
  end

  create_table :books, force: true do |t|
    t.string :author_id
    t.string :format_type
    t.integer :format_id
  end

end

class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true
end

class Author < ApplicationRecord
  has_many :books
  has_many :paperbacks, through: :books, source: :format, source_type: "Paperback"
end

class Book < ApplicationRecord
  has_one :format, polymorphic: true
end

class Hardback < ApplicationRecord; end
class Paperback < ApplicationRecord; end

class AuthorTest < Minitest::Test
  def test_association
    author = Author.create!
    paperback = Paperback.create!
    book = Book.new
    book.format = paperback
    book.author_id = author.id
    book.save!

    author.reload
    assert_equal paperback, author.paperbacks.first
  end
end

```
##### Actual behavior

```bash
$ ruby has_many_polymorphic_association_failure.rb
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Using concurrent-ruby 1.1.7
Using i18n 1.8.5
Using minitest 5.14.2
Using thread_safe 0.3.6
Using tzinfo 1.2.7
Using zeitwerk 2.4.0
Using activesupport 6.0.0
Using activemodel 6.0.0
Using activerecord 6.0.0
Using bundler 2.1.4
Using sqlite3 1.4.2
-- create_table(:authors, {:force=>true})
D, [2020-10-02T23:54:20.140981 #13635] DEBUG -- :    (0.8ms)  SELECT sqlite_version(*)
D, [2020-10-02T23:54:20.141363 #13635] DEBUG -- :    (0.1ms)  DROP TABLE IF EXISTS "authors"
D, [2020-10-02T23:54:20.141736 #13635] DEBUG -- :    (0.3ms)  CREATE TABLE "authors" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0046s
-- create_table(:hardbacks, {:force=>true})
D, [2020-10-02T23:54:20.141947 #13635] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "hardbacks"
D, [2020-10-02T23:54:20.142117 #13635] DEBUG -- :    (0.1ms)  CREATE TABLE "hardbacks" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0003s
-- create_table(:paperbacks, {:force=>true})
D, [2020-10-02T23:54:20.142297 #13635] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "paperbacks"
D, [2020-10-02T23:54:20.142462 #13635] DEBUG -- :    (0.1ms)  CREATE TABLE "paperbacks" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0003s
-- create_table(:books, {:force=>true})
D, [2020-10-02T23:54:20.142642 #13635] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "books"
D, [2020-10-02T23:54:20.142879 #13635] DEBUG -- :    (0.1ms)  CREATE TABLE "books" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "author_id" varchar, "format_type" varchar, "format_id" integer)
   -> 0.0004s
D, [2020-10-02T23:54:20.170632 #13635] DEBUG -- :    (0.2ms)  CREATE TABLE "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL)
D, [2020-10-02T23:54:20.187638 #13635] DEBUG -- :   ActiveRecord::InternalMetadata Load (2.0ms)  SELECT "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = ? LIMIT ?  [["key", "environment"], ["LIMIT", 1]]
D, [2020-10-02T23:54:20.191447 #13635] DEBUG -- :    (0.1ms)  begin transaction
D, [2020-10-02T23:54:20.191722 #13635] DEBUG -- :   ActiveRecord::InternalMetadata Create (0.1ms)  INSERT INTO "ar_internal_metadata" ("key", "value", "created_at", "updated_at") VALUES (?, ?, ?, ?)  [["key", "environment"], ["value", "default_env"], ["created_at", "2020-10-02 14:54:20.191083"], ["updated_at", "2020-10-02 14:54:20.191083"]]
D, [2020-10-02T23:54:20.191894 #13635] DEBUG -- :    (0.0ms)  commit transaction
Traceback (most recent call last):
	8: from has_many_polymorphic_association_failure.rb:51:in `<main>'
	7: from has_many_polymorphic_association_failure.rb:52:in `<class:Book>'
	6: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations.rb:1511:in `has_one'
	5: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations/builder/association.rb:30:in `build'
	4: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations/builder/association.rb:40:in `create_reflection'
	3: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations/builder/association.rb:67:in `validate_options'
	2: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/hash/keys.rb:50:in `assert_valid_keys'
	1: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/hash/keys.rb:50:in `each_key'
/Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/hash/keys.rb:52:in `block in assert_valid_keys': Unknown key: :polymorphic. Valid keys are: :class_name, :anonymous_class, :foreign_key, :validate, :autosave, :foreign_type, :dependent, :primary_key, :inverse_of, :required, :as, :touch (ArgumentError)
```


#### The problem of example-for-has-one-source-type

[4.2.2.9 :source_type](https://guides.rubyonrails.org/association_basics.html#options-for-has-one-source-type)

##### Steps to reproduce

```rb
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  gem "activerecord", "6.0.0"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do

  create_table :authors, force: true do |t|
  end

  create_table :hardbacks, force: true do |t|
  end

  create_table :paperbacks, force: true do |t|
  end

  create_table :books, force: true do |t|
    t.string :author_id
    t.string :format_type
    t.integer :format_id
  end

  create_table :dust_jackets, force: true do |t|
    t.string :hardback_id
  end
end

class ApplicationRecord < ActiveRecord::Base
  self.abstract_class = true
end

class Author < ApplicationRecord
  has_one :book
  has_one :hardback, through: :book, source: :format, source_type: "Hardback"
  has_one :dust_jacket, through: :hardback
end

class Book < ApplicationRecord
  has_one :format, polymorphic: true
end

class Paperback < ApplicationRecord; end

class Hardback < ApplicationRecord
  has_one :dust_jacket
end

class DustJacket < ApplicationRecord; end

class AuthorTest < Minitest::Test
  def test_association
    author = Author.create!
    dust_jacket = DustJacket.new
    hardback = Hardback.create!
    hardback.dust_jacket = dust_jacket
    book = Book.new
    book.format = hardback
    book.author_id = author.id
    book.save!

    author.reload
    assert_equal dust_jacket, author.dust_jacket
  end
end

```

##### Actual behavior

```bash
$ ruby has_one_polymorphic_association_failure.rb
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
Using concurrent-ruby 1.1.7
Using i18n 1.8.5
Using minitest 5.14.2
Using thread_safe 0.3.6
Using tzinfo 1.2.7
Using zeitwerk 2.4.0
Using activesupport 6.0.0
Using activemodel 6.0.0
Using activerecord 6.0.0
Using bundler 2.1.4
Using sqlite3 1.4.2
-- create_table(:authors, {:force=>true})
D, [2020-10-02T23:51:26.479832 #13529] DEBUG -- :    (1.8ms)  SELECT sqlite_version(*)
D, [2020-10-02T23:51:26.480490 #13529] DEBUG -- :    (0.1ms)  DROP TABLE IF EXISTS "authors"
D, [2020-10-02T23:51:26.480900 #13529] DEBUG -- :    (0.3ms)  CREATE TABLE "authors" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0124s
-- create_table(:hardbacks, {:force=>true})
D, [2020-10-02T23:51:26.481160 #13529] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "hardbacks"
D, [2020-10-02T23:51:26.481348 #13529] DEBUG -- :    (0.1ms)  CREATE TABLE "hardbacks" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0004s
-- create_table(:paperbacks, {:force=>true})
D, [2020-10-02T23:51:26.481572 #13529] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "paperbacks"
D, [2020-10-02T23:51:26.481814 #13529] DEBUG -- :    (0.1ms)  CREATE TABLE "paperbacks" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL)
   -> 0.0004s
-- create_table(:books, {:force=>true})
D, [2020-10-02T23:51:26.482095 #13529] DEBUG -- :    (0.1ms)  DROP TABLE IF EXISTS "books"
D, [2020-10-02T23:51:26.482315 #13529] DEBUG -- :    (0.1ms)  CREATE TABLE "books" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "author_id" varchar, "format_type" varchar, "format_id" integer)
   -> 0.0005s
-- create_table(:dust_jackets, {:force=>true})
D, [2020-10-02T23:51:26.482510 #13529] DEBUG -- :    (0.0ms)  DROP TABLE IF EXISTS "dust_jackets"
D, [2020-10-02T23:51:26.482696 #13529] DEBUG -- :    (0.1ms)  CREATE TABLE "dust_jackets" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "hardback_id" varchar)
   -> 0.0004s
D, [2020-10-02T23:51:26.527559 #13529] DEBUG -- :    (0.1ms)  CREATE TABLE "ar_internal_metadata" ("key" varchar NOT NULL PRIMARY KEY, "value" varchar, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL)
D, [2020-10-02T23:51:26.548122 #13529] DEBUG -- :   ActiveRecord::InternalMetadata Load (3.3ms)  SELECT "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = ? LIMIT ?  [["key", "environment"], ["LIMIT", 1]]
D, [2020-10-02T23:51:26.551712 #13529] DEBUG -- :    (0.1ms)  begin transaction
D, [2020-10-02T23:51:26.552067 #13529] DEBUG -- :   ActiveRecord::InternalMetadata Create (0.1ms)  INSERT INTO "ar_internal_metadata" ("key", "value", "created_at", "updated_at") VALUES (?, ?, ?, ?)  [["key", "environment"], ["value", "default_env"], ["created_at", "2020-10-02 14:51:26.551381"], ["updated_at", "2020-10-02 14:51:26.551381"]]
D, [2020-10-02T23:51:26.552271 #13529] DEBUG -- :    (0.0ms)  commit transaction
Traceback (most recent call last):
	8: from has_one_polymorphic_association_failure.rb:55:in `<main>'
	7: from has_one_polymorphic_association_failure.rb:56:in `<class:Book>'
	6: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations.rb:1511:in `has_one'
	5: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations/builder/association.rb:30:in `build'
	4: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations/builder/association.rb:40:in `create_reflection'
	3: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-6.0.0/lib/active_record/associations/builder/association.rb:67:in `validate_options'
	2: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/hash/keys.rb:50:in `assert_valid_keys'
	1: from /Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/hash/keys.rb:50:in `each_key'
/Users/mh/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/hash/keys.rb:52:in `block in assert_valid_keys': Unknown key: :polymorphic. Valid keys are: :class_name, :anonymous_class, :foreign_key, :validate, :autosave, :foreign_type, :dependent, :primary_key, :inverse_of, :required, :as, :touch (ArgumentError)
```


