### PR TITLE
Fix Mysql2ActiveSchemaTest test

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -119,7 +119,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_create_mysql_database_with_encoding
-    if row_format_dynamic_by_default?
+    if ActiveRecord::Base.connection.send(:row_format_dynamic_by_default?)
       assert_equal "CREATE DATABASE `matt` DEFAULT CHARACTER SET `utf8mb4`", create_database(:matt)
     else
       error = assert_raises(RuntimeError) { create_database(:matt) }


### PR DESCRIPTION
Follow-up to 0e4473ca935f7b0f7c95abf2bbe41ee2c61abcaa.

`row_format_dynamic_by_default?` is a private method.
