### PR TITLE
Implement 'no_store' HTTP cache directive

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   New `ActionController::ConditionalGet#no_store` method to set HTTP cache control `no-store` directive.
+
+    *Tadas Sasnauskas*
+
 *   Drop support for the `SERVER_ADDR` header
 
     Following up https://github.com/rack/rack/pull/1573 and https://github.com/rails/rails/pull/42349

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -115,6 +115,7 @@ module ActionController
     #   before_action { fresh_when @article, template: 'widgets/show' }
     #
     def fresh_when(object = nil, etag: nil, weak_etag: nil, strong_etag: nil, last_modified: nil, public: false, cache_control: {}, template: nil)
+      response.cache_control.delete(:no_store)
       weak_etag ||= etag || object unless strong_etag
       last_modified ||= object.try(:updated_at) || object.try(:maximum, :updated_at)
 
@@ -273,6 +274,7 @@ module ActionController
     #
     # The method will also ensure an HTTP Date header for client compatibility.
     def expires_in(seconds, options = {})
+      response.cache_control.delete(:no_store)
       response.cache_control.merge!(
         max_age: seconds,
         public: options.delete(:public),
@@ -307,6 +309,12 @@ module ActionController
       yield if stale?(etag: request.fullpath,
                       last_modified: Time.new(2011, 1, 1).utc,
                       public: public)
+    end
+
+    # Sets an HTTP 1.1 Cache-Control header of <tt>no-store</tt>. This means the
+    # resource may not be stored in any cache.
+    def no_store
+      response.cache_control.replace(no_store: true)
     end
 
     private

--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -187,13 +187,20 @@ module ActionDispatch
 
           return if control.empty? && cache_control.empty?  # Let middleware handle default behavior
 
-          if extras = control.delete(:extras)
-            cache_control[:extras] ||= []
-            cache_control[:extras] += extras
-            cache_control[:extras].uniq!
-          end
+          if cache_control.any?
+            # Any caching directive coming from a controller overrides
+            # no-cache/no-store in the default Cache-Control header.
+            control.delete(:no_cache)
+            control.delete(:no_store)
 
-          control.merge! cache_control
+            if extras = control.delete(:extras)
+              cache_control[:extras] ||= []
+              cache_control[:extras] += extras
+              cache_control[:extras].uniq!
+            end
+
+            control.merge! cache_control
+          end
 
           options = []
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -290,6 +290,24 @@ class TestController < ActionController::Base
     end
   end
 
+  def cache_control_default_header_with_extras_partially_overridden_by_expires_in
+    response.headers["Cache-Control"] = "max-age=120, public, s-maxage=60, proxy-revalidate"
+    expires_in 300.seconds, public: true
+    render action: "hello_world"
+  end
+
+  def cache_control_no_store_overridden_by_expires_in
+    response.headers["Cache-Control"] = "no-store"
+    expires_in 60.seconds, public: true
+    render action: "hello_world"
+  end
+
+  def cache_control_no_store_overridden_by_expires_now
+    response.headers["Cache-Control"] = "no-store"
+    expires_now
+    render action: "hello_world"
+  end
+
   private
     def set_variable_for_layout
       @variable_for_layout = nil
@@ -462,6 +480,21 @@ class ExpiresInRenderTest < ActionController::TestCase
       get :conditional_hello_with_expires_in
       assert_equal Time.now.httpdate, @response.headers["Date"]
     end
+  end
+
+  def test_cache_control_default_header_with_extras_partially_overridden_by_expires_in
+    get :cache_control_default_header_with_extras_partially_overridden_by_expires_in
+    assert_equal "max-age=300, public, s-maxage=60, proxy-revalidate", @response.headers["Cache-Control"]
+  end
+
+  def test_cache_control_no_store_overridden_by_expires_in
+    get :cache_control_no_store_overridden_by_expires_in
+    assert_equal "max-age=60, public", @response.headers["Cache-Control"]
+  end
+
+  def test_cache_control_no_store_overridden_by_expires_now
+    get :cache_control_no_store_overridden_by_expires_now
+    assert_equal "no-cache", @response.headers["Cache-Control"]
   end
 end
 
@@ -987,5 +1020,109 @@ class HttpCacheForeverTest < ActionController::TestCase
     @request.if_none_match = @response.etag
     get :cache_me_forever
     assert_response :not_modified
+  end
+end
+
+class HttpCacheNoStoreTest < ActionController::TestCase
+  class HttpCacheNoStoreController < ActionController::Base
+    def standalone_no_store_call
+      no_store
+      render plain: "hello world"
+    end
+
+    before_action(only: :no_store_overridden_by_expires_in) { no_store }
+    def no_store_overridden_by_expires_in
+      expires_in 30.seconds
+      render plain: "hello world"
+    end
+
+    before_action(only: :expires_in_overridden_by_no_store) { expires_in 30.seconds }
+    def expires_in_overridden_by_no_store
+      no_store
+      render plain: "hello world"
+    end
+
+    before_action(only: :no_store_overridden_by_fresh_when) { no_store }
+    def no_store_overridden_by_fresh_when
+      fresh_when(etag: "123abc")
+      render plain: "hello world"
+    end
+
+    before_action(only: :fresh_when_overridden_by_no_store) { fresh_when etag: "abc123" }
+    def fresh_when_overridden_by_no_store
+      no_store
+      render plain: "hello world"
+    end
+
+    before_action(only: :expires_now_overridden_by_no_store) { expires_now }
+    def expires_now_overridden_by_no_store
+      no_store
+      render plain: "hello world"
+    end
+
+    before_action(only: :no_store_overridden_by_expires_now) { no_store }
+    def no_store_overridden_by_expires_now
+      expires_now
+      render plain: "hello world"
+    end
+
+    def cache_control_no_cache_overridden_by_no_store
+      response.headers["Cache-Control"] = "no-cache"
+      no_store
+      render plain: "hello world"
+    end
+
+    def cache_control_public_with_max_age_overridden_by_no_store
+      response.headers["Cache-Control"] = "public, max-age=604800"
+      no_store
+      render plain: "hello world"
+    end
+  end
+
+  tests HttpCacheNoStoreController
+
+  def test_standalone_no_store_call
+    get :standalone_no_store_call
+    assert_equal "no-store", @response.headers["Cache-Control"]
+  end
+
+  def test_no_store_overridden_by_expires_in
+    get :no_store_overridden_by_expires_in
+    assert_equal "max-age=30, private", @response.headers["Cache-Control"]
+  end
+
+  def test_expires_in_overridden_by_no_store
+    get :expires_in_overridden_by_no_store
+    assert_equal "no-store", @response.headers["Cache-Control"]
+  end
+
+  def test_no_store_overridden_by_fresh_when
+    get :no_store_overridden_by_fresh_when
+    assert_equal "max-age=0, private, must-revalidate", @response.headers["Cache-Control"]
+  end
+
+  def test_fresh_when_overridden_by_no_store
+    get :fresh_when_overridden_by_no_store
+    assert_equal "no-store", @response.headers["Cache-Control"]
+  end
+
+  def test_expires_now_overridden_by_no_store
+    get :expires_now_overridden_by_no_store
+    assert_equal "no-store", @response.headers["Cache-Control"]
+  end
+
+  def test_no_store_overridden_by_expires_now
+    get :no_store_overridden_by_expires_now
+    assert_equal "no-cache", @response.headers["Cache-Control"]
+  end
+
+  def test_cache_control_no_cache_header_can_be_overridden_by_no_store
+    get :cache_control_no_cache_overridden_by_no_store
+    assert_equal "no-store", @response.headers["Cache-Control"]
+  end
+
+  def test_cache_control_public_with_expiration_header_can_be_overridden_by_no_store
+    get :cache_control_public_with_max_age_overridden_by_no_store
+    assert_equal "no-store", @response.headers["Cache-Control"]
   end
 end


### PR DESCRIPTION
I tried starting conversation in [rubyonrails-core](https://discuss.rubyonrails.org/t/feature-proposal-method-to-set-cache-control-no-store-header/76281) but haven't really got much feedback from there.

Summary
=======

Currently there is no way to set `Cache-Control: no-store` header using
built-in cache control methods (`expires_now`/`expires_in`/etc..). One of
the [top StackOverflow][1] answers currently suggests putting it directly
into header set.

Unfortunately, it cannot later be overridden in specific/individual actions by
calling say `expires_in 5.minutes`. Resulting header in that case is
stays the same, i.e. `Cache-Control: no-store`.

This:
 1. Adds the `no_store` method to set `Cache-Control: no-store` header.
 2. Changes cache control "merge and normalize" code so default `no-store`
    directive can be overridden using built in cache control methods mentioned
    above.

What's the use of it
--------------------

Couple examples:

* To [prevent rendering stale content][3] if browser return button is used
(`expires_now` does not help).
* To prevent browser disk cache being used. In some situations it's considered
a [privacy/security risk][4].

Naming it
=======
I'm open for ideas. Couple random suggestions:

* `no_store`
* `http_cache_no_store`

Other Information
=================

* Mozilla developer docs for [Cache-Control][2] header.
* A related ~open~ merged PR #39461 

[1]: https://stackoverflow.com/questions/10744169/rails-set-no-cache-method-cannot-disable-browser-caching-in-safari-and-opera
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
[3]: https://engineering.mixmax.com/blog/chrome-back-button-cache-no-store/
[4]: https://portswigger.net/kb/issues/00700100_cacheable-https-response