### PR TITLE
Fix Getting_Started guide which provides non-functional code as an example

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2005,7 +2005,30 @@ You can use concerns in your controller or model the same way you would use any 
 
 A given blog article might have various statuses - for instance, it might be visible to everyone (i.e. `public`), or only visible to the author (i.e. `private`). It may also be hidden to all but still retrievable (i.e. `archived`). Comments may similarly be hidden or visible. This could be represented using a `status` column in each model.
 
-Within the `article` model, after running a migration to add a `status` column, you might add:
+Within the `article` and the `comment` model add a `status` column:
+
+```bash
+$ rails g migration AddStatusToModels
+```
+
+Before you migrate your database, add a status column to `comments` and `status`:
+
+```ruby
+class AddStatusToCommentsAndArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :status, :string, default: "public"
+    add_column :articles, :status, :string, default: "public"
+  end
+end
+```
+
+Above you can set the default status of new articles and comments to `default`. Now now you can migrate your database with the new columns:
+
+```bash
+$ bin/rails db:migrate
+```
+
+Now we want to add a validation process to our `Article` model.
 
 ```ruby
 class Article < ApplicationRecord
@@ -2015,7 +2038,7 @@ class Article < ApplicationRecord
 
   VALID_STATUSES = ['public', 'private', 'archived']
 
-  validates :status, in: VALID_STATUSES
+  validates :status, inclusion: { in: VALID_STATUSES }
 
   def archived?
     status == 'archived'
@@ -2031,7 +2054,7 @@ class Comment < ApplicationRecord
 
   VALID_STATUSES = ['public', 'private', 'archived']
 
-  validates :status, in: VALID_STATUSES
+  validates :status, inclusion: { in: VALID_STATUSES }
 
   def archived?
     status == 'archived'
@@ -2090,7 +2113,7 @@ module Visible
   included do
     VALID_STATUSES = ['public', 'private', 'archived']
 
-    validates :status, in: VALID_STATUSES
+    validates :status, inclusion: { in: VALID_STATUSES }
   end
 
   def archived?
@@ -2133,7 +2156,7 @@ module Visible
   VALID_STATUSES = ['public', 'private', 'archived']
 
   included do
-    validates :status, in: VALID_STATUSES
+    validates :status, inclusion: { in: VALID_STATUSES }
   end
 
   class_methods do


### PR DESCRIPTION
### Summary

This fixes two problems with the [concerns section](https://edgeguides.rubyonrails.org/getting_started.html#using-concerns) of the getting started guide. The problems are:
1. The guide assumes a strong understanding of database migrations

<img width="760" alt="Screen Shot 2020-10-03 at 3 03 04 PM" src="https://user-images.githubusercontent.com/7991933/95000823-c218dd80-0589-11eb-9bb6-ccfccae60b89.png">

2. The guide uses validation code which doesn't work (at least not with Rails 6)

<img width="1440" alt="Screen Shot 2020-10-03 at 2 49 31 PM" src="https://user-images.githubusercontent.com/7991933/95000781-7cf4ab80-0589-11eb-8fbd-a6b9ebcc3a6c.png">


### Other Information

I just did a focused study of the Getting Started guide and found errors.

This is the [first PR](https://github.com/rails/rails/pull/40326) which addresses another issue earlier in the guide.

Thanks to [tlatsas](https://github.com/tlatsas) for the _heads up_. He made me aware that the issue is being discussed [here](https://github.com/rails/rails/issues/39920) .