### PR TITLE
Allow config.hosts proc to receive request object

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Pass request object to `Proc` used for `ActionDispatch::HostAuthorization`
+
+    If a `Proc` is provided to `config.hosts`, it can receive two arguments: the host value and the full request
+    object. This allows bypassing the host authorization check based on other aspects of a request, such as the path
+    or headers.
+    
+    *Andrew Weinstein*
+
 *   Added support for exclusive no-store Cache-Control header.
 
     If `no-store` is set on Cache-Control header it is exclusive (all other cache directives are dropped).

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -19,9 +19,9 @@ module ActionDispatch
         @hosts.empty?
       end
 
-      def allows?(host)
+      def allows?(host, request = nil)
         @hosts.any? do |allowed|
-          allowed === host
+          allowed === (allowed.is_a?(Proc) && allowed.arity > 1 ? [host, request] : host)
         rescue
           # IPAddr#=== raises an error if you give it a hostname instead of
           # IP. Treat similar errors as blocked access.
@@ -90,8 +90,8 @@ module ActionDispatch
         origin_host = request.get_header("HTTP_HOST").to_s.sub(/:\d+\z/, "")
         forwarded_host = request.x_forwarded_host.to_s.split(/,\s?/).last.to_s.sub(/:\d+\z/, "")
 
-        @permissions.allows?(origin_host) &&
-          (forwarded_host.blank? || @permissions.allows?(forwarded_host))
+        @permissions.allows?(origin_host, request) &&
+          (forwarded_host.blank? || @permissions.allows?(forwarded_host, request))
       end
 
       def mark_as_authorized(request)

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -71,6 +71,19 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal "Success", body
   end
 
+  test "proc host can accept both host and request" do
+    host_proc = proc { |host, req| host == "example.com" || req.path == "/skip" }
+    @app = ActionDispatch::HostAuthorization.new(App, host_proc)
+
+    get "/skip", env: {
+      "HOST" => "forbidden",
+      "X-Forwarded-Host" => "forbidden"
+    }
+
+    assert_response :ok
+    assert_equal "Success", body
+  end
+
   test "mark the host when authorized" do
     @app = ActionDispatch::HostAuthorization.new(App, ".example.com")
 


### PR DESCRIPTION
Didn't get much feedback from the [core mailing list](https://discuss.rubyonrails.org/t/feature-proposal-list-of-paths-to-skip-when-checking-host-authorization/76246/6), but what I did get was encouraging.

### Summary

I wanted a way to skip the host authorization check - which I want to use in production as protection against host header poisoning - for a specific endpoint. With my application set up behind a load balancer on AWS, the host that the application sees on the health check is the IP address of the load balancer, which can change and therefore can't be hard-coded into my application. There is nothing sensitive at the health check endpoint, and I'd like to just skip the check there.

In a Rails 5 app, I just implemented the host filtering stuff in my own custom middleware. I guess I could keep doing that on Rails 6, but since Rails now has its own middleware for this, it seems like all of that functionality should be kept in one place if possible.

ActionDispatch::HostAuthorization accepts a list of allowed values via config.hosts. An item in this list can be anything that responds to ===, which includes a Proc. Passing the entire request object - in addition to the host value - to such a Proc allows for customization like skipping the host authorization check on a particular endpoint, e.g. a health check.

### Usage

```ruby
Rails.application.configure do
  config.hosts += [
    'myapp.com',
    proc { |_host, req| req.path == '/healthcheck' }
  ]
end
```

Or just

```ruby
Rails.application.configure do
  config.hosts << proc { |host, req| host == 'myapp.com' || req.path  == '/healthcheck' }
end
```

### Questions and concerns

- Is passing the request object back into the Proc on every request too unwieldy?
- Would it be clearer to do `allowed.call` instead of trying to keep using `===` for everything?