### PR TITLE
Add gitattributes for vendored and generated files [ci-skip]

### DIFF
--- a/actioncable/app/assets/javascripts/.gitattributes
+++ b/actioncable/app/assets/javascripts/.gitattributes
@@ -1,0 +1,1 @@
+action_cable.js linguist-generated

--- a/activestorage/app/assets/javascripts/.gitattributes
+++ b/activestorage/app/assets/javascripts/.gitattributes
@@ -1,0 +1,1 @@
+activestorage.js linguist-generated

--- a/guides/assets/javascripts/.gitattributes
+++ b/guides/assets/javascripts/.gitattributes
@@ -1,0 +1,2 @@
+clipboard.js linguist-vendored
+turbolinks.js linguist-vendored


### PR DESCRIPTION
The `linguist-vendored` attribute excludes the specified file from the project's language stats on GitHub.  The `linguist-generated` attribute does the same, and also suppresses that file in diffs on GitHub.

See https://github.com/github/linguist for more information.

---

Inspired by #40278.
