### PR TITLE
Support grouped collection for collection_select

### DIFF
--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/try"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
@@ -19,11 +21,22 @@ module ActionView
             disabled: @options[:disabled]
           }
 
-          select_content_tag(
-            options_from_collection_for_select(@collection, @value_method, @text_method, option_tags_options),
-            @options, @html_options
-          )
+          option_tags = if grouped_collection?
+            option_groups_from_collection_for_select(@collection, :last, :first, @value_method, @text_method, option_tags_options)
+          else
+            options_from_collection_for_select(@collection, @value_method, @text_method, option_tags_options)
+          end
+
+          select_content_tag(option_tags, @options, @html_options)
         end
+
+        private
+          def grouped_collection?
+            case @collection
+            when Hash, Array
+              @collection.first&.try(:last).is_a?(Array)
+            end
+          end
       end
     end
   end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1003,6 +1003,26 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_select_with_grouped_collection_as_nested_array
+    @post = Post.new
+    @post.origin = "dk"
+
+    assert_dom_equal(
+      %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
+      collection_select("post", "origin", dummy_continents.pluck(:continent_name, :countries), :country_id, :country_name)
+    )
+  end
+
+  def test_collection_select_with_grouped_collection_as_hash
+    @post = Post.new
+    @post.origin = "dk"
+
+    assert_dom_equal(
+      %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
+      collection_select("post", "origin", dummy_continents.pluck(:continent_name, :countries).to_h, :country_id, :country_name)
+    )
+  end
+
   def test_collection_select_under_fields_for
     @post = Post.new
     @post.author_name = "Babe"


### PR DESCRIPTION
This adds support for grouped collections to the `collection_select` helper, much like the `select` helper:

```ruby
collection_select :country_id, @countries.group_by(&:continent_name), :id, :name
```

This differs from `grouped_collection_select` in that it does not require a secondary model to group options:

```ruby
grouped_collection_select :country_id, @continents, :countries, :name, :id, :name
```

Of course, a secondary model can be used as well:

```ruby
collection_select :country_id, @countries.group_by { |country| country.continent.name }, :id, :name
```

---

TODO:
- [x] documentation
