### PR TITLE
Ensure `tag.with_options({}).p` builds a `<p>`

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -47,6 +47,10 @@ module ActionView
           @view_context = view_context
         end
 
+        def p(*arguments, **options, &block)
+          tag_string(:p, *arguments, **options, &block)
+        end
+
         def tag_string(name, content = nil, escape_attributes: true, **options, &block)
           content = @view_context.capture(self, &block) if block_given?
           if VOID_ELEMENTS.include?(name) && content.nil?

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -97,6 +97,12 @@ class TagHelperTest < ActionView::TestCase
       tag.p(disabled: true, itemscope: true, multiple: true, readonly: true, allowfullscreen: true, seamless: true, typemustmatch: true, sortable: true, default: true, inert: true, truespeed: true, allowpaymentrequest: true, nomodule: true, playsinline: true)
   end
 
+  def test_tag_builder_with_options_builds_p_elements
+    html = tag.with_options(id: "with-options") { |t| t.p("content") }
+
+    assert_dom_equal '<p id="with-options">content</p>', html
+  end
+
   def test_tag_builder_do_not_modify_html_safe_options
     html_safe_str = '"'.html_safe
     assert_equal "<p value=\"&quot;\" />", tag("p", value: html_safe_str)


### PR DESCRIPTION
Prior to this change, the following call raises:

```ruby
with_options(id: "with-options") { |t| t.p "content" }

Error:
    TagHelperTest#test_tag_builder_chained_off_with_options_builds_p_elements:
    NoMethodError: private method `p' called for "<{:id=>\"with-options\"} />":ActiveSupport::SafeBuffer
```

The `ActionView::Helpers::TagHelper::TagBuilder` implementation relies
on `method_missing` to dispatch calls to `tag_string` where the missing
method name is the resulting element's tagName. Unfortunately,
[`Kernel#p` already exists][Kernel#p] and is invoked before
`method_missing` can intervene.

This commit rectifies this by declaring `TagBuilder#p` and overriding
the existent `#p` instance method.

[Kernel#p]: https://ruby-doc.org/core-2.7.2/Kernel.html#method-i-p

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
