### PR TITLE
Fix ActiveRecord::Relation#include? in case where offset is provided

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -325,7 +325,7 @@ module ActiveRecord
     # compared to the records in memory. If the relation is unloaded, an
     # efficient existence query is performed, as in #exists?.
     def include?(record)
-      if loaded?
+      if loaded? || offset_value
         records.include?(record)
       else
         record.is_a?(klass) && exists?(record.id)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -405,6 +405,12 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_include_on_unloaded_relation_with_offset
+    assert_sql(/ORDER BY name ASC/) do
+      assert_equal true, Customer.offset(1).order("name ASC").include?(customers(:mary))
+    end
+  end
+
   def test_include_on_loaded_relation_without_match
     customers = Customer.where(name: "David").load
     mary      = customers(:mary)
@@ -450,6 +456,12 @@ class FinderTest < ActiveRecord::TestCase
 
     assert_no_queries do
       assert_equal false, customers.member?(mary)
+    end
+  end
+
+  def test_member_on_unloaded_relation_with_offset
+    assert_sql(/ORDER BY name ASC/) do
+      assert_equal true, Customer.offset(1).order("name ASC").member?(customers(:mary))
     end
   end
 


### PR DESCRIPTION
### Summary

[This PR](https://github.com/rails/rails/pull/40323) shipped an optimization to `ActiveRecord::Relation#include?` to perform an efficient existence query if the relation is unloaded. `exists?(record.id)` fails if an offset is provided to the relation, because the single row with the matching id is skipped by the offset.

To fix this, we should load the entire relation to check for inclusion if there is an `offset_value`.