### PR TITLE
Add missing `LIMIT 1` to `find_by` doc

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1719,6 +1719,7 @@ FROM books
 INNER JOIN authors
  ON authors.id = books.author_id
 WHERE books.title = $1 [["title", "Abstraction and Specification in Program Development"]]
+LIMIT 1
 ```
 
 NOTE: Note that if a query matches multiple records, `find_by` will


### PR DESCRIPTION
https://edgeguides.rubyonrails.org/active_record_querying.html#retrieving-specific-data-from-multiple-tables

![image](https://user-images.githubusercontent.com/509837/95249612-8e82c100-07de-11eb-83b1-1541188e6766.png)

The yellow box says to see the "`LIMIT 1` statement above", but it's missing from the generated SQL. It looks like it was accidentally removed [here](https://github.com/rails/rails/commit/536a7e5bddce9bb583b32f598d8d0c7b7b3f0ed9#diff-a8f3fba05ae44c884b78bea618781883L1650) so this PR just adds it back.