### PR TITLE
Return BigDecimal **OR** Float from "average" operations

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -448,7 +448,11 @@ module ActiveRecord
         when "sum"
           yield value || 0
         when "average"
-          value&.respond_to?(:to_d) ? value.to_d : value
+          if !value.is_a?(Numeric) && value&.respond_to?(:to_d)
+            value.to_d
+          else
+            value
+          end
         else # "minimum", "maximum"
           yield value
         end

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -59,6 +59,14 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 3, value
   end
 
+  def test_should_return_float_average_if_db_returns_such
+    NumericData.create!(temperature: 37.5)
+
+    value = NumericData.average(:temperature)
+    assert_instance_of Float, value
+    assert_equal 37.5, value
+  end
+
   def test_should_return_nil_as_average
     assert_nil NumericData.average(:bank_balance)
   end


### PR DESCRIPTION
### Summary

Databases behave differently when aggregating via `AVG`. Postgres for example should return `Float` for the column types `real` and `double precision` (`Numeric` otherwise), while SQLite3 always returns `Float` for numbers.

This change has its [roots back 12 years](https://github.com/rails/rails/commit/9599948fbcd67c1c2c5fecc2dca148e998479e33) at the time when `BigDecimal` was introduced to Ruby 1.9. I think it was wrong to switch to use **only** `BigDecimal` because other aggregation functions are a bit more carefully respecting the underlying database column.

### Practical Relevance

```ruby
# db/schema.rb (applied for Postgres)

create_table "measurements", id: :serial, force: :cascade do |t|
  t.float "temperature", null: false
  …
end
```

```ruby
# app/controllers/measurements_controller.rb

@measurements = Measurement.all.group('DATE(created_at)').reorder('DATE(created_at)')
@minimum_temperature = @measurements.minimum(:temperature)
@maximum_temperature = @measurements.maximum(:temperature)
@average_temperature = @measurements.average(:temperature)
```

```ruby
# app/views/measurements/aggregated.json.jbuilder

json.minimum_temperature @minimum_temperature
json.maximum_temperature @maximum_temperature
json.average_temperature @average_temperature
```

This generates JSON where a `double precision` typed database column is represented in aggregated form as a String (because of `BigDecimal`). My intention would be that `average_temperature` consisted of numbers instead.

```json
{
  "minimum_temperature": {
    "2020-10-04": 1.0,
    "2020-10-05": 2.0,
    "2020-10-06": 1.0
  },
  "maximum_temperature": {
    "2020-10-04": 1.0,
    "2020-10-05": 3.0,
    "2020-10-06": 1.0
  },
  "average_temperature": {
    "2020-10-04": "1.0",
    "2020-10-05": "2.5",
    "2020-10-06": "1.0"
  }
}
```
