### PR TITLE
Raise more specific exception for invalid mime type from user-agent

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -7,6 +7,8 @@ module ActionDispatch
     module MimeNegotiation
       extend ActiveSupport::Concern
 
+      class InvalidType < ::Mime::Type::InvalidMimeType; end
+
       RESCUABLE_MIME_FORMAT_ERRORS = [
         ActionController::BadRequest,
         ActionDispatch::Http::Parameters::ParseError,
@@ -25,6 +27,8 @@ module ActionDispatch
             nil
           end
           set_header k, v
+        rescue ::Mime::Type::InvalidMimeType => e
+          raise InvalidType, e.message
         end
       end
 
@@ -47,6 +51,8 @@ module ActionDispatch
             Mime::Type.parse(header)
           end
           set_header k, v
+        rescue ::Mime::Type::InvalidMimeType => e
+          raise InvalidType, e.message
         end
       end
 

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -60,7 +60,7 @@ module ActionDispatch
         if request.get_header("action_dispatch.show_detailed_exceptions")
           begin
             content_type = request.formats.first
-          rescue Mime::Type::InvalidMimeType
+          rescue ActionDispatch::Http::MimeNegotiation::InvalidType
             content_type = Mime[:text]
           end
 

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -12,7 +12,7 @@ module ActionDispatch
       "ActionController::UnknownHttpMethod"          => :method_not_allowed,
       "ActionController::NotImplemented"             => :not_implemented,
       "ActionController::UnknownFormat"              => :not_acceptable,
-      "Mime::Type::InvalidMimeType"                  => :not_acceptable,
+      "ActionDispatch::Http::MimeNegotiation::InvalidType" => :not_acceptable,
       "ActionController::MissingExactTemplate"       => :not_acceptable,
       "ActionController::InvalidAuthenticityToken"   => :unprocessable_entity,
       "ActionController::InvalidCrossOriginRequest"  => :unprocessable_entity,

--- a/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/public_exceptions.rb
@@ -23,7 +23,7 @@ module ActionDispatch
       status       = request.path_info[1..-1].to_i
       begin
         content_type = request.formats.first
-      rescue Mime::Type::InvalidMimeType
+      rescue ActionDispatch::Http::MimeNegotiation::InvalidType
         content_type = Mime[:text]
       end
       body = { status: status, error: Rack::Utils::HTTP_STATUS_CODES.fetch(status, Rack::Utils::HTTP_STATUS_CODES[500]) }

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -88,7 +88,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       when "/unprocessable_entity"
         raise ActionController::InvalidAuthenticityToken
       when "/invalid_mimetype"
-        raise Mime::Type::InvalidMimeType
+        raise ActionDispatch::Http::MimeNegotiation::InvalidType
       when "/not_found_original_exception"
         begin
           raise AbstractController::ActionNotFound.new
@@ -230,7 +230,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     get "/invalid_mimetype", headers: { "Accept" => "text/html,*", "action_dispatch.show_exceptions" => true }
     assert_response 406
     assert_match(/<body>/, body)
-    assert_match(/Mime::Type::InvalidMimeType/, body)
+    assert_match(/ActionDispatch::Http::MimeNegotiation::InvalidType/, body)
   end
 
   test "rescue with text error for xhr request" do
@@ -327,7 +327,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_response 406
     assert_no_match(/<body>/, body)
     assert_equal "application/json", response.media_type
-    assert_match(/Mime::Type::InvalidMimeType/, body)
+    assert_match(/ActionDispatch::Http::MimeNegotiation::InvalidType/, body)
   end
 
   if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)

--- a/actionpack/test/dispatch/show_exceptions_test.rb
+++ b/actionpack/test/dispatch/show_exceptions_test.rb
@@ -10,7 +10,7 @@ class ShowExceptionsTest < ActionDispatch::IntegrationTest
       when "/not_found"
         raise AbstractController::ActionNotFound
       when "/invalid_mimetype"
-        raise Mime::Type::InvalidMimeType
+        raise ActionDispatch::Http::MimeNegotiation::InvalidType
       when "/bad_params", "/bad_params.json"
         begin
           raise StandardError.new


### PR DESCRIPTION
### Summary

This allows distinguishing from other kinds of `Mime::Type::InvalidMimeType` that may be raised by user or third-party code. It's only failure in parsing client-supplied content-types in ActionDispatch::Http::MimeNegotiation that should result in special handling from Rails. 

### Other Information

This also allows third-party error handling/tracking code to specifically target the new `ActionDispatch::Http::MimeNegotiation::InvalidType` for ignoring or other special handling, separate from  `Mime::Type::InvalidMimeType`

This is a revision of #35753 in response to #37620 and discussion with @eugeneius