### PR TITLE
Replace 'ws' occurrences in favour of 'wss'

### DIFF
--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -9,7 +9,7 @@ import Subscriptions from "./subscriptions"
 // The following example shows how this can be set up:
 //
 //   App = {}
-//   App.cable = ActionCable.createConsumer("ws://example.com/accounts/1")
+//   App.cable = ActionCable.createConsumer("wss://example.com/accounts/1")
 //   App.appearance = App.cable.subscriptions.create("AppearanceChannel")
 //
 // For more details on how you'd configure an actual channel subscription, see ActionCable.Subscription.

--- a/actioncable/app/javascript/action_cable/subscriptions.js
+++ b/actioncable/app/javascript/action_cable/subscriptions.js
@@ -5,7 +5,7 @@ import Subscription from "./subscription"
 // and it should be called through the consumer like so:
 //
 //   App = {}
-//   App.cable = ActionCable.createConsumer("ws://example.com/accounts/1")
+//   App.cable = ActionCable.createConsumer("wss://example.com/accounts/1")
 //   App.appearance = App.cable.subscriptions.create("AppearanceChannel")
 //
 // For more details on how you'd configure an actual channel subscription, see ActionCable.Subscription.

--- a/actioncable/lib/action_cable/helpers/action_cable_helper.rb
+++ b/actioncable/lib/action_cable/helpers/action_cable_helper.rb
@@ -26,9 +26,9 @@ module ActionCable
       #   <%= action_cable_meta_tag %> would render:
       #   => <meta name="action-cable-url" content="/cable123" />
       #
-      #   config.action_cable.url = "ws://actioncable.com"
+      #   config.action_cable.url = "wss://actioncable.com"
       #   <%= action_cable_meta_tag %> would render:
-      #   => <meta name="action-cable-url" content="ws://actioncable.com" />
+      #   => <meta name="action-cable-url" content="wss://actioncable.com" />
       #
       def action_cable_meta_tag
         tag "meta", name: "action-cable-url", content: (

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -594,7 +594,7 @@ consumer.subscriptions.create("AppearanceChannel", {
 ##### Client-Server Interaction
 
 1. **Client** connects to the **Server** via `App.cable =
-ActionCable.createConsumer("ws://cable.example.com")`. (`cable.js`). The
+ActionCable.createConsumer("wss://cable.example.com")`. (`cable.js`). The
 **Server** identifies this connection by `current_user`.
 
 2. **Client** subscribes to the appearance channel via


### PR DESCRIPTION
### Replace 'ws' occurrences in favour of 'wss'

In the current documentation of **ActionCable**, there are some URLs that follow the format `ws://` when they should be following the format `wss://` in favour of secure connections.

Given the fact that Rails uses `https` in the documentation, this can help with consistency.

