### PR TITLE
Comparison of record in shard

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -470,10 +470,17 @@ module ActiveRecord
     # Note also that destroying a record preserves its ID in the model instance, so deleted
     # models are still comparable.
     def ==(comparison_object)
-      super ||
-        comparison_object.instance_of?(self.class) &&
-        !id.nil? &&
-        comparison_object.id == id
+      if !self.class.current_shard.nil?
+        super ||
+          comparison_object.instance_of?(self.class) &&
+          !id.nil? &&
+          comparison_object.id == id && comparison_object.class.current_shard == self.class.current_shard
+      else
+        super ||
+          comparison_object.instance_of?(self.class) &&
+          !id.nil? &&
+          comparison_object.id == id
+      end
     end
     alias :eql? :==
 


### PR DESCRIPTION
### Summary

This PR address issue https://github.com/rails/rails/issues/40358.
Now ActiveRecord::Core.== will return false on comparing records in the different shards, which store independent data. Note that, records in the different roles and the same shard should be equal, becuase they are concidered as replicated.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
