### PR TITLE
Add symbol to string association cache for reflections

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -9,6 +9,7 @@ module ActiveRecord
 
     included do
       class_attribute :_reflections, instance_writer: false, default: {}
+      class_attribute :_reflection_symbol_to_string, instance_writer: false, default: {}
       class_attribute :aggregate_reflections, instance_writer: false, default: {}
     end
 
@@ -22,6 +23,7 @@ module ActiveRecord
         ar.clear_reflections_cache
         name = -name.to_s
         ar._reflections = ar._reflections.except(name).merge!(name => reflection)
+        ar._reflection_symbol_to_string[name.to_sym] = name
       end
 
       def add_aggregate_reflection(ar, name, reflection)
@@ -112,11 +114,13 @@ module ActiveRecord
       #   Invoice.reflect_on_association(:line_items).macro  # returns :has_many
       #
       def reflect_on_association(association)
-        reflections[association.to_s]
+        key = _reflection_symbol_to_string[association] || association
+        reflections[key]
       end
 
       def _reflect_on_association(association) #:nodoc:
-        _reflections[association.to_s]
+        key = _reflection_symbol_to_string[association] || association
+        _reflections[key]
       end
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.


### PR DESCRIPTION
### Summary

Reduce string allocations when reflecting on associations by creating a hash of symbol to string similar to https://github.com/rails/rails/commit/f45267bc423017109e442e5c35a5765dc482b12b#diff-6c8fd220c92c2b25aa29891b59d00c04.

### Other Information

Benchmarking gist

```
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # gem "rails", github: "rails/rails"
  gem "rails", path: './'
  gem "sqlite3"
  gem "memory_profiler"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
# ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :poster_id
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
    t.integer :commenter_id
  end

  create_table :users, force: true do |t|
  end
end

class User < ActiveRecord::Base
end

class Post < ActiveRecord::Base
  has_many :comments
  belongs_to :poster, class_name: 'User'
end

class Comment < ActiveRecord::Base
  belongs_to :post
  belongs_to :commenter, class_name: 'User'
end

class BugTest < Minitest::Test
  def test_association_stuff
    user1 = User.create!
    post1 = Post.create!(poster: user1)
    post1.comments << Comment.create!(commenter: user1)

    user2 = User.create!
    post2 = Post.create!(poster: user2)
    post2.comments << Comment.create!(commenter: user2)

    posts = Array.new(25) do
      user = User.create!
      post = Post.create!(poster: user)
      post.comments << Comment.create!(commenter: user)
      post
    end
    post_ids = posts.map(&:id)

    # assert_equal 1, post.comments.count
    # assert_equal 1, Comment.count
    # assert_equal post.id, Comment.first.post.id

    # Work out the memory loads from first time use
    Post.where(id: post_ids).includes(:comments).each { |post| post }

    MemoryProfiler.report do
      Post.where(id: post_ids).includes(:comments).each { |post| post }
    end.pretty_print
  end
end
```

Allocations without changes
```
Total allocated: 103888 bytes (880 objects)
```

Allocations with changes
```
Total allocated: 100888 bytes (805 objects)
```

