### PR TITLE
Raise helpful error when request object does not exist due to asset_url helper called outside of views

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Raise error when asset_url is used outside of views.
+
+    Instead of getting the error `NoMethodError: undefined method 'protocol' for nil:NilClass` when
+    ActionController::Base.helpers.asset_url(IMAGE_NAME) is called somewhere other than a view (where
+    request object cannot be accessed), this ensures that an informative error message is raised.
+
+    *Fai Wong*
+
 *   `ActionView::Helpers::TranslationHelper#translate` accepts a block, yielding
     the translated text and the fully resolved translation key:
 

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -300,6 +300,7 @@ module ActionView
           when :relative
             "//#{host}"
           when :request
+            raise "Protocol undefined for request" unless request
             "#{request.protocol}#{host}"
           else
             "#{protocol}://#{host}"


### PR DESCRIPTION
### Summary

When using `ActionController::Base.helpers.asset_url(IMAGE_NAME)` somewhere other than a view, the user sees the error `NoMethodError: undefined method 'protocol' for nil:NilClass`. This is because the request object does not exist. 

This raises an error with a more informative message that will hint to the user that request object is not present.

cc: @rafaelfranca @kamipo 
