### PR TITLE
Follow npm/JS standard for package name

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/package.json.tt
+++ b/railties/lib/rails/generators/rails/app/templates/package.json.tt
@@ -1,5 +1,5 @@
 {
-  "name": "<%= app_name %>",
+  "name": "<%= app_name.underscore.dasherize %>",
   "private": true,
   "dependencies": {
     "@rails/ujs": "^6.0.0"<% unless options[:skip_turbolinks] %>,


### PR DESCRIPTION
### Summary

Currently when a new rails app is created it uses the app name as it and puts
it in the package.json name. According to npm and JS standards package names
do not have capital letters and should not be using the PascalCase that is
used in Rails app name. This change is to convert app name to using snake case
but with dashes

Recommendation provided by NPM https://docs.npmjs.com/files/package.json#name
VSCode complaining as well about the package name
![image](https://user-images.githubusercontent.com/498669/95677719-71ab0c80-0b95-11eb-923c-409db0f6c2b9.png)

### Other Information

To reproduce this issue you can create a new app using rails command and if you use a PascalName then it copies that name over to the package.json `name` attribute.