### PR TITLE
Eagerly establish test transactions for shards

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1040,6 +1040,7 @@ module ActiveRecord
         payload = {}
         if pool_config
           payload[:spec_name] = pool_config.connection_specification_name
+          payload[:shard] = shard
           payload[:config] = db_config.configuration_hash
         end
 

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -131,11 +131,12 @@ module ActiveRecord
         # When connections are established in the future, begin a transaction too
         @connection_subscriber = ActiveSupport::Notifications.subscribe("!connection.active_record") do |_, _, _, _, payload|
           spec_name = payload[:spec_name] if payload.key?(:spec_name)
+          shard = payload[:shard] if payload.key?(:shard)
           setup_shared_connection_pool
 
           if spec_name
             begin
-              connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name)
+              connection = ActiveRecord::Base.connection_handler.retrieve_connection(spec_name, shard: shard)
             rescue ConnectionNotEstablished
               connection = nil
             end


### PR DESCRIPTION
Previously when a sharded model was autoloaded during a test, every shard's test transaction was opened on the default shard's connection, which meant that other shards' data leaked into subsequent tests.