### PR TITLE
Document transform.active_storage event [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -686,6 +686,8 @@ INFO. The only ActiveStorage service that provides this hook so far is GCS.
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 
+### transform.active_storage
+
 Railties
 --------
 


### PR DESCRIPTION
### Summary

Add `transform.active_storage` event to the active support instrumentation guide.

https://github.com/rails/rails/blob/5699122abf7613465c62f2e50e3af017e95cb609/activestorage/app/models/active_storage/variation.rb#L55