### PR TITLE
Stable sorting for DatabaseConfigurations#find_db_config

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -80,7 +80,7 @@ module ActiveRecord
     # the first DatabaseConfig for the environment.
     def find_db_config(env)
       configurations
-        .sort_by { |db_config| db_config.for_current_env? ? 0 : 1 }
+        .sort_by.with_index { |db_config, i| db_config.for_current_env? ? [0, i] : [1, i] }
         .find do |db_config|
           db_config.env_name == env.to_s ||
             (db_config.for_current_env? && db_config.name == env.to_s)

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -54,6 +54,24 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     ENV["RAILS_ENV"] = original_rails_env
   end
 
+  def test_find_db_config_returns_first_config_for_env
+    config = ActiveRecord::DatabaseConfigurations.new({
+        "test" => {
+          "config_1"=> {
+            "database" => "db"
+          },
+          "config_2"=> {
+            "database" => "db"
+          },
+          "config_3"=> {
+            "database" => "db"
+          },
+        }
+      })
+
+    assert_equal "config_1", config.find_db_config("test").name
+  end
+
   def test_find_db_config_returns_a_db_config_object_for_the_given_env
     config = ActiveRecord::Base.configurations.find_db_config("arunit2")
 


### PR DESCRIPTION
### Summary
`DatabaseConfigurations#find_db_config` returns the database configuration for a requested environment. To sort the configurations by environments, `sort_by` is used.

`sort_by` results are [not guaranteed to be stable](https://ruby-doc.org/core-2.7.1/Enumerable.html#method-i-sort_by):
> The result is not guaranteed to be stable. When two keys are equal, the order of the corresponding elements is unpredictable.

### Expected behavior
`DatabaseConfigurations#find_db_config` always returns the same configuration for a given environment.

### Actual behavior
In the current implementation, the keys used are `0` for the current environment and `1` for the other environments. As a side effect of the instability of `sort_by`, adding a new configuration for an environment might change the order of the results returned by `sort_by`, and therefore return a different environment, and not the first one defined in `database.yml`.

### Fix
By adding `with_index` and using it as a key for sorting, we can guarantee that configurations will maintain the order even after inserting a new one, and the first configuration for a requested environment will always be returned. This change ensures the stability of the sorting algorithm.

### Other Information
Given the nature of unstable algorithms, I did not add a new test. Adding a new test for these changes might result in a flaky test in some environments or Ruby implementations. I'm open to ideas on how to test this properly.