### PR TITLE
Prevent adding the same record twice on build when using source record in attribute when using has_many_inversing  #40378

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -105,7 +105,7 @@ module ActiveRecord
         if attributes.is_a?(Array)
           attributes.collect { |attr| build(attr, &block) }
         else
-          add_to_target(build_record(attributes, &block))
+          add_to_target(build_record(attributes, &block), replace: true)
         end
       end
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -639,6 +639,18 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
+  def test_with_has_many_inversing_should_have_single_record_when_setting_record_through_attribute_in_build_method
+    with_has_many_inversing do
+      human = Human.create!
+      human.interests.build(
+        human: human
+      )
+      assert_equal 1, human.interests.size
+      human.save!
+      assert_equal 1, human.interests.size
+    end
+  end
+
   def test_with_has_many_inversing_does_not_trigger_association_callbacks_on_set_when_the_inverse_is_a_has_many
     with_has_many_inversing do
       human = interests(:trainspotting).human_with_callbacks


### PR DESCRIPTION
Prevent adding the same record twice on build when using source record in attribute when using has_many_inversing 

Record should be replaced via add_to_target, not added as a separate record to an array.

More details on this issue: #40378