### PR TITLE
Add missing ActiveSupport require in ActiveModel::Serialization

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/enumerable"
+
 module ActiveModel
   # == Active \Model \Serialization
   #


### PR DESCRIPTION
serializable_attributes is using index_with from active_support/core_ext/enumerable

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I maintain a Rubygem that depends heavily on ActiveModel and only selectively requires from ActiveSupport and my rails-head CI job is failing because of this missing require.
