### PR TITLE
Make OpenStruct#as_json behavior less surprising

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -65,6 +65,12 @@ class Struct #:nodoc:
   end
 end
 
+class OpenStruct #:nodoc:
+  def as_json(options = nil)
+    to_h.as_json(options)
+  end
+end
+
 class TrueClass
   def as_json(options = nil) #:nodoc:
     self

--- a/activesupport/test/json/encoding_test.rb
+++ b/activesupport/test/json/encoding_test.rb
@@ -164,6 +164,28 @@ class TestJSONEncoding < ActiveSupport::TestCase
     assert_equal({ "foo" => { "foo" => "hello" } }, JSON.parse(json))
   end
 
+  def test_open_struct_to_json_without_options
+    open_struct = OpenStruct.new(foo: "hello", bar: "world")
+    json = open_struct.to_json
+
+    assert_equal({ "foo" => "hello", "bar" => "world" }, JSON.parse(json))
+  end
+
+  def test_open_struct_to_json_with_options
+    open_struct = OpenStruct.new(foo: "hello", bar: "world")
+    json = open_struct.to_json only: [:foo]
+
+    assert_equal({ "foo" => "hello" }, JSON.parse(json))
+  end
+
+  def test_open_struct_to_json_with_options_nested
+    nested_open_struct = OpenStruct.new(foo: "hello", bar: "world")
+    open_struct = OpenStruct.new(foo: nested_open_struct)
+    json = open_struct.to_json only: [:foo]
+
+    assert_equal({ "foo" => { "foo" => "hello" } }, JSON.parse(json))
+  end
+
   def test_hash_should_pass_encoding_options_to_children_in_as_json
     person = {
       name: "John",


### PR DESCRIPTION
### Summary

Because OpenStruct uses an instance variable `@table` internally,
the implementation of `Object#as_json` results in serializing an
OpenStruct as json having a surprising "table" key that maps to
the hash you'd expect.

Hiding this implementation detail seems reasonable and omitting
the `table` key seems less surprising... to me. 😄 

### Other Information

I think another option for solving this could be adding `OpenStruct#to_hash`.
Not sure if that's better or worse.
