### PR TITLE
Remove keys from local_cache in RedisCacheStore#delete_matched

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove entries from local cache on `RedisCacheStore#delete_matched`
+
+    Fixes #38627
+
+    *ojab*
+
 *   Speed up `ActiveSupport::SecurityUtils.fixed_length_secure_compare` by using
     `OpenSSL.fixed_length_secure_compare`, if available.
 

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -107,6 +107,12 @@ module ActiveSupport
           super
         end
 
+        def delete_matched(matcher, options = nil) # :nodoc:
+          return super unless cache = local_cache
+          cache.clear
+          super
+        end
+
         def increment(name, amount = 1, **options) # :nodoc:
           return super unless local_cache
           value = bypass_local_cache { super }

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -102,6 +102,24 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_delete_matched
+    begin
+      @cache.delete_matched("*")
+    rescue NotImplementedError
+      skip
+    end
+
+    @cache.with_local_cache do
+      @cache.write("foo", "bar")
+      @cache.write("fop", "bar")
+      @cache.write("bar", "foo")
+      @cache.delete_matched("fo*")
+      assert_not @cache.exist?("foo")
+      assert_not @cache.exist?("fop")
+      assert_equal "foo", @cache.read("bar")
+    end
+  end
+
   def test_local_cache_of_exist
     @cache.with_local_cache do
       @cache.write("foo", "bar")


### PR DESCRIPTION
### Summary

Right now we're not deleting keys from local cache. Fixes #38627
