### PR TITLE
Avoid query from exists? on contradictory relation

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -315,6 +315,7 @@ module ActiveRecord
       end
 
       relation = construct_relation_for_exists(conditions)
+      return false if relation.where_clause.contradiction?
 
       skip_query_cache_if_necessary { connection.select_rows(relation.arel, "#{name} Exists?").size == 1 }
     end

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -444,6 +444,18 @@ module ActiveRecord
       end
     end
 
+    test "no queries on empty relation exists?" do
+      assert_queries(0) do
+        Post.where(id: []).exists?(123)
+      end
+    end
+
+    test "no queries on empty condition exists?" do
+      assert_queries(0) do
+        Post.all.exists?(id: [])
+      end
+    end
+
     private
       def skip_if_sqlite3_version_includes_quoting_bug
         if sqlite3_version_includes_quoting_bug?


### PR DESCRIPTION
Previously exists would make a query even if it was passed a contradiction, like `User.where(id: []).exists?`. Unlike queries which loaded records which skip the query as of https://github.com/rails/rails/pull/37266.

@HParker and I spotted this because we had some extra queries from https://github.com/rails/rails/pull/40323 (I ❤️ this change), since that previously loaded the association but is now performing an `exists?`.

This PR makes the same improvement to `exists?` that https://github.com/rails/rails/pull/37266 did for loading records. This handles both contradictions from the original relation `exists?` is being called on as well as from the conditions passed in.

cc @georgeclaghorn @eileencodes 