### PR TITLE
Reset has_one association scope in autosave callback

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -464,11 +464,16 @@ module ActiveRecord
                 record[reflection.foreign_key] = key
                 if inverse_reflection = reflection.inverse_of
                   record.association(inverse_reflection.name).inversed_from(self)
+                  record.association(inverse_reflection.name).reset_scope
+                  record.association(inverse_reflection.name).loaded!
                 end
               end
 
               saved = record.save(validate: !autosave)
               raise ActiveRecord::Rollback if !saved && autosave
+
+              association(reflection.name).reset_scope
+
               saved
             end
           end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1364,6 +1364,20 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
     assert_not_predicate ship, :valid?
   end
+
+  def test_should_reset_scope
+    ship = Ship.new(name: "Princess Olga")
+    ship.build_pirate(catchphrase: "Arr")
+    ship.save!
+
+    assert_equal ship.association(:pirate).scope.where_values_hash, { "id" => ship.pirate.id }
+
+    pirate = Pirate.new(catchphrase: "Arr")
+    pirate.build_ship(name: "Princess Olga")
+    pirate.save!
+
+    assert_equal pirate.association(:ship).scope.where_values_hash, { "pirate_id" => pirate.id }
+  end
 end
 
 class TestAutosaveAssociationOnAHasOneThroughAssociation < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

Right now scope is not reset which leads to some issues in https://github.com/rails/rails/pull/40385
Scope should be updated on save.