### PR TITLE
Fix performance issue on back reference with safe buffer by using yie…

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -263,23 +263,23 @@ module ActiveSupport #:nodoc:
     UNSAFE_STRING_METHODS_WITH_BACKREF.each do |unsafe_method|
       if unsafe_method.respond_to?(unsafe_method)
         class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)             # def gsub(*args, &block)
-            if block                                      #   if block
+          def #{unsafe_method}(*args)             # def gsub(*args, &block)
+            if block_given?                                      #   if block
               to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|
-                set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
-                block.call(*params)                       #       block.call(*params)
+                Proc.new { |m| $~ = m }.call($~)      #       set_block_back_references(block, $~)
+                yield(*params)                            #       yield *params
               }                                           #     }
             else                                          #   else
               to_str.#{unsafe_method}(*args)              #     to_str.gsub(*args)
             end                                           #   end
           end                                             # end
 
-          def #{unsafe_method}!(*args, &block)            # def gsub!(*args, &block)
+          def #{unsafe_method}!(*args)            # def gsub!(*args, &block)
             @html_safe = false                            #   @html_safe = false
-            if block                                      #   if block
+            if block_given?                                      #   if block
               super(*args) { |*params|                    #     super(*args) { |*params|
-                set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
-                block.call(*params)                       #       block.call(*params)
+                Proc.new { |m| $~ = m }.call($~)      #       set_block_back_references(block, $~)
+                yield(*params)                             #       yield *params
               }                                           #     }
             else                                          #   else
               super                                       #     super


### PR DESCRIPTION
…ld instead of block.call

### Summary

fixes https://github.com/rails/rails/issues/40389. yield is 2x faster than block.call. I think the reason for this should be obvious because Ruby is forced to construct a Proc for each invocation.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
