### PR TITLE
Don't bother checking if strings respond to string methods

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -261,32 +261,30 @@ module ActiveSupport #:nodoc:
     end
 
     UNSAFE_STRING_METHODS_WITH_BACKREF.each do |unsafe_method|
-      if unsafe_method.respond_to?(unsafe_method)
-        class_eval <<-EOT, __FILE__, __LINE__ + 1
-          def #{unsafe_method}(*args, &block)             # def gsub(*args, &block)
-            if block                                      #   if block
-              to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|
-                set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
-                block.call(*params)                       #       block.call(*params)
-              }                                           #     }
-            else                                          #   else
-              to_str.#{unsafe_method}(*args)              #     to_str.gsub(*args)
-            end                                           #   end
-          end                                             # end
+      class_eval <<-EOT, __FILE__, __LINE__ + 1
+        def #{unsafe_method}(*args, &block)             # def gsub(*args, &block)
+          if block                                      #   if block
+            to_str.#{unsafe_method}(*args) { |*params|  #     to_str.gsub(*args) { |*params|
+              set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
+              block.call(*params)                       #       block.call(*params)
+            }                                           #     }
+          else                                          #   else
+            to_str.#{unsafe_method}(*args)              #     to_str.gsub(*args)
+          end                                           #   end
+        end                                             # end
 
-          def #{unsafe_method}!(*args, &block)            # def gsub!(*args, &block)
-            @html_safe = false                            #   @html_safe = false
-            if block                                      #   if block
-              super(*args) { |*params|                    #     super(*args) { |*params|
-                set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
-                block.call(*params)                       #       block.call(*params)
-              }                                           #     }
-            else                                          #   else
-              super                                       #     super
-            end                                           #   end
-          end                                             # end
-        EOT
-      end
+        def #{unsafe_method}!(*args, &block)            # def gsub!(*args, &block)
+          @html_safe = false                            #   @html_safe = false
+          if block                                      #   if block
+            super(*args) { |*params|                    #     super(*args) { |*params|
+              set_block_back_references(block, $~)      #       set_block_back_references(block, $~)
+              block.call(*params)                       #       block.call(*params)
+            }                                           #     }
+          else                                          #   else
+            super                                       #     super
+          end                                           #   end
+        end                                             # end
+      EOT
     end
 
     private


### PR DESCRIPTION
Digression from #40389 

### Summary

The `respond_to?` calls here (`if unsafe_method.respond_to?(unsafe_method)`) are checking if the unsafe method names, in this case the strings `"gsub"` and `"sub"`, respond to those same method names. This is nonsensical and unnecessary - the result will always be `true`.

Or am I misunderstanding something? :thinking: 