### PR TITLE
Fix `read_attribute_before_type_cast` to consider attribute aliases

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `read_attribute_before_type_cast` to consider attribute aliases.
+
+    *Marcelo Lauxen*
+
 *   Support passing record to uniqueness validator `:conditions` callable:
 
     ```ruby

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -46,7 +46,10 @@ module ActiveRecord
       #   task.read_attribute_before_type_cast('completed_on') # => "2012-10-21"
       #   task.read_attribute_before_type_cast(:completed_on)  # => "2012-10-21"
       def read_attribute_before_type_cast(attr_name)
-        attribute_before_type_cast(attr_name.to_s)
+        name = attr_name.to_s
+        name = self.class.attribute_aliases[name] || name
+
+        attribute_before_type_cast(name)
       end
 
       # Returns a hash of attributes before typecasting and deserialization.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -12,6 +12,7 @@ require "models/category"
 require "models/reply"
 require "models/contact"
 require "models/keyboard"
+require "models/numeric_data"
 
 class AttributeMethodsTest < ActiveRecord::TestCase
   include InTimeZone
@@ -1085,6 +1086,11 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "generated attribute methods ancestors have correct module" do
     mod = Topic.send(:generated_attribute_methods)
     assert_equal "Topic::GeneratedAttributeMethods", mod.inspect
+  end
+
+  test "read_attribute_before_type_cast with aliased attribute" do
+    model = NumericData.new(new_bank_balance: "abcd")
+    assert_equal "abcd", model.read_attribute_before_type_cast("new_bank_balance")
   end
 
   private

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -102,4 +102,12 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
     assert_not_predicate subject, :valid?
   end
+
+  def test_aliased_attribute
+    model_class.validates_numericality_of(:new_bank_balance, greater_or_equal_than: 0)
+
+    subject = model_class.new(new_bank_balance: "abcd")
+
+    assert_not_predicate subject, :valid?
+  end
 end

--- a/activerecord/test/models/numeric_data.rb
+++ b/activerecord/test/models/numeric_data.rb
@@ -7,4 +7,6 @@ class NumericData < ActiveRecord::Base
   attribute :world_population, :big_integer
   attribute :my_house_population, :big_integer
   attribute :atoms_in_universe, :big_integer
+
+  alias_attribute :new_bank_balance, :bank_balance
 end


### PR DESCRIPTION
Numericality validations for aliased attributes are not able
to get the value of the attribute before typecast because
ActiveRecord was trying to get the attribute value using
its alias and not the original attribute name.

An example of validation which would pass even if an invalid value
would be provided

    class MyModel < ActiveRecord::Base
      validates :aliased_balance, numericality: { greater_than_or_equal_to: 0 }
    end

If we instantiate MyModel like bellow, it will be valid because
when numericality validation runs it will not be able to get the
value before typecast, so it uses the typecaste value
which will be `0.0` and the validation will succeed.

    subject = MyModel.new(aliased_balance: "abcd")
    subject.valid?

But if we declare MyModel like this:

    class MyModel < ActiveRecord::Base
      validates :balance, numericality: { greater_than_or_equal_to: 0 }
    end

and assign "abcd" value to `balance` property, when the validations
run, the model will be invalid because ActiveRecord will be able
to get the value before the typecasting.

With this change, `read_attribute_before_type_cast` will be able to
get the value before typecast even if the attr_name is an
alias_attribute.

----

Executable test case: https://gist.github.com/marcelolx/471191635daa6be1ea4408aeed8713c4

---

It's my first PR, so if I'm missing anything, please let me know.