### PR TITLE
Replace frames-based api docs with css implementation and Turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", "~> 1.1"
+  gem "sdoc", github: "p8/sdoc", branch: "without-frames"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,14 @@ GIT
       websocket
 
 GIT
+  remote: https://github.com/p8/sdoc.git
+  revision: a5e95cafdebf8a76ea21f2237e6349223f9ecac5
+  branch: without-frames
+  specs:
+    sdoc (1.1.0)
+      rdoc (>= 5.0)
+
+GIT
   remote: https://github.com/resque/redis-namespace.git
   revision: c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e
   specs:
@@ -461,8 +469,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (1.1.0)
-      rdoc (>= 5.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -612,7 +618,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails
-  sdoc (~> 1.1)
+  sdoc!
   selenium-webdriver (>= 3.141.592)
   sequel
   sidekiq


### PR DESCRIPTION
### Summary

The current Rails documentation has a frames based implementation.
This prevents deep linking to documentation and removes navigation if the page
is opened without frames.

We can keep the same layout with a css based implementation.

Turbolinks is used to persisted the navigation/search bar across
requests.

### Other Information

A demo can be seen here:
https://sdoc.deheus.net/
