### PR TITLE
Mark Reaper thread as fork-safe w/thread-local variable

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -319,7 +319,7 @@ module ActiveRecord
               Thread.new(frequency) do |t|
                 # Advise multi-threaded app servers to ignore this thread for
                 # the purposes of fork safety warnings
-                Thread.current[:fork_safe] = true
+                Thread.current.thread_variable_set(:fork_safe, true)
                 running = true
                 while running
                   sleep t

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -317,6 +317,9 @@ module ActiveRecord
           private
             def spawn_thread(frequency)
               Thread.new(frequency) do |t|
+                # Advise multi-threaded app servers to ignore this thread for
+                # the purposes of fork safety warnings
+                Thread.current[:fork_safe] = true
                 running = true
                 while running
                   sleep t


### PR DESCRIPTION
Re: https://github.com/rails/rails/issues/37066#issuecomment-709403972

### Summary

Puma (and some other multi-threaded application servers) may check the `Thread` list before and after forking to look for any threads that may have been running during a call to `fork`. Threads running during a `fork` can leave memory and resources open and potentially cause leaks or deadlocks.

However, the Reaper thread in ActiveRecord cannot orphan any resources or memory, and will be cleaned up after forking. 

Setting this thread local variable allows Puma and other application servers to ignore this thread for the purpose of displaying warnings to users about threads present and running during `fork`.

### Other Information

I'm open to a different name. I just picked the first one that came out of the ether.

Because Rails doesn't consume this thread-local, I did not add a test.
