### PR TITLE
Add `prepend_order` as a new query method to prepend the specified order onto any existing order

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `prepend_order` as a new query method to prepend the specified order onto any existing order.
+
+    ```ruby
+    class User < ApplicationRecord
+      scope :recent, -> { order(name: :asc) }
+    end
+
+    most_popular_then_recent = User.recent.prepend_order(popularity: :desc) # generated SQL has `ORDER BY popularity DESC, name ASC`
+    ```
+
+    *Alex Robbin*
+
 *   Add a load hook for `ActiveRecord::ConnectionAdapters::Mysql2Adapter`
     (named `active_record_mysql2adapter`) to allow for overriding aspects of the
     `ActiveRecord::ConnectionAdapters::Mysql2Adapter` class. This makes `Mysql2Adapter`

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       :create_or_find_by, :create_or_find_by!,
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
-      :select, :reselect, :order, :regroup, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
+      :select, :reselect, :order, :regroup, :in_order_of, :prepend_order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -647,6 +647,25 @@ module ActiveRecord
       self
     end
 
+    # Prepends to any existing order defined on the relation with the specified order. For example:
+    #
+    #   User.order('email ASC').prepend_order('id DESC')
+    #
+    # generates a query with `ORDER BY id DESC, email ASC`. This is useful if you are using a scope that has an order that you want use as a fallback.
+    def prepend_order(*args)
+      check_if_method_has_arguments!(:prepend_order, args) do
+        sanitize_order_arguments(args)
+      end
+      spawn.prepend_order!(*args)
+    end
+
+    # Same as #prepend_order but operates on relation in-place instead of copying.
+    def prepend_order!(*args)
+      preprocess_order_args(args) unless args.empty?
+      self.order_values = args | order_values
+      self
+    end
+
     VALID_UNSCOPING_VALUES = Set.new([:where, :select, :group, :order, :lock,
                                      :limit, :offset, :joins, :left_outer_joins, :annotate,
                                      :includes, :eager_load, :preload, :from, :readonly,

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -86,6 +86,13 @@ module ActiveRecord
       assert_equal "posts", node.expr.relation.name
     end
 
+    test "#prepend_order!" do
+      @relation = relation.order("foo")
+
+      assert relation.prepend_order!("bar").equal?(relation)
+      assert_equal ["bar", "foo"], relation.order_values
+    end
+
     test "reverse_order!" do
       @relation = Post.order("title ASC, comments_count DESC")
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -432,6 +432,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal ["The First Topic", "The Second Topic of the day", "The Third Topic of the day", "The Fourth Topic of the day", "The Fifth Topic of the day"], topics_titles
   end
 
+  def test_finding_with_prepend_order
+    topics = Topic.order("author_name").prepend_order("title").to_a
+    topics_titles = topics.map(&:title)
+    assert_equal ["The Fifth Topic of the day", "The First Topic", "The Fourth Topic of the day", "The Second Topic of the day", "The Third Topic of the day"], topics_titles
+  end
+
+  def test_finding_with_prepend_order_and_no_existing_order
+    topics = Topic.prepend_order("title").to_a
+    topics_titles = topics.map(&:title)
+    assert_equal ["The Fifth Topic of the day", "The First Topic", "The Fourth Topic of the day", "The Second Topic of the day", "The Third Topic of the day"], topics_titles
+  end
+
   def test_reorder_deduplication
     topics = Topic.reorder("id desc", "id desc")
     assert_equal ["id desc"], topics.order_values


### PR DESCRIPTION
### Summary

I recently ran into a situation where it would've been great to *prepend* a new `ORDER BY` clause to a query. In our case, it was when using a `scope` that itself had something to the effect of:

```ruby
class Profile < ApplicationRecord
  belongs_to :user

  scope :recently_updated, -> { where(arel_table[:updated_at].gteq(7.days.ago)).order(updated_at: :desc) }
end

class User < ApplicationRecord
  has_one :profile

  scope :recently_updated, -> { joins(:profile).merge(Profile.recently_updated) }
end
```

We wanted to use `User.recently_updated`, but needed to put a specific group of users at the top of the list. The only way to do that without something like `prepend_order` would be to reimplement the `recently_updated` scopes defined on the model.

With `prepend_order`, we can simply call `User.recently_updated.prepend_order('...')`, and we're done!

Another way we could use this would be in conjunction with [`ActiveRecord::FinderMethods#ordered_relation`](https://github.com/rails/rails/blob/d83ee61dc6b5e73dd2853c5af9681e71c0150e30/activerecord/lib/active_record/relation/finder_methods.rb#L578-L588):

```ruby
class CustomerLegalEntity < ApplicationRecord
  scope :ordered, -> { ordered_relation.prepend_order(default: :desc) }
end
```