### PR TITLE
Fix initializing STI from abstract class

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       # and if the inheritance column is attr accessible, it initializes an
       # instance of the given subclass instead of the base class.
       def new(attributes = nil, &block)
-        if abstract_class? || self == Base
+        if self == Base
           raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
 
@@ -67,10 +67,14 @@ module ActiveRecord
         end
 
         if subclass && subclass != self
-          subclass.new(attributes, &block)
-        else
-          super
+          return subclass.new(attributes, &block)
         end
+
+        if abstract_class?
+          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
+        end
+
+        super
       end
 
       # Returns +true+ if this does not need STI type condition. Returns

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         end
 
         if abstract_class?
-          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
+          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated without setting the '#{inheritance_column}' attribute."
         end
 
         super

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -71,7 +71,7 @@ module ActiveRecord
         end
 
         if abstract_class?
-          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
+          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated without setting the '#{inheritance_column}' attribute."
         end
 
       end

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -71,10 +71,9 @@ module ActiveRecord
         end
 
         if abstract_class?
-          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated without setting the '#{inheritance_column}' attribute."
+          raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated."
         end
 
-        super
       end
 
       # Returns +true+ if this does not need STI type condition. Returns

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -74,6 +74,7 @@ module ActiveRecord
           raise NotImplementedError, "#{self} is an abstract class and cannot be instantiated without setting the '#{inheritance_column}' attribute."
         end
 
+        super
       end
 
       # Returns +true+ if this does not need STI type condition. Returns

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1133,7 +1133,7 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   def test_abstract_class_table_name
-    assert_nil AbstractCompany.table_name
+    assert_equal AbstractCompany.table_name, "companies"
   end
 
   def test_find_on_abstract_base_class_doesnt_use_type_condition

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -320,7 +320,6 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_new_with_abstract_class
     e = assert_raises(NotImplementedError) do
-
       AbstractCompany.new
     end
     assert_equal("AbstractCompany is an abstract class and cannot be instantiated.", e.message)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -320,6 +320,7 @@ class InheritanceTest < ActiveRecord::TestCase
 
   def test_new_with_abstract_class
     e = assert_raises(NotImplementedError) do
+
       AbstractCompany.new
     end
     assert_equal("AbstractCompany is an abstract class and cannot be instantiated.", e.message)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -298,6 +298,11 @@ class InheritanceTest < ActiveRecord::TestCase
     assert_equal Firm, firm.class
   end
 
+  def test_inheritance_new_with_abstract_class
+    firm = AbstractCompany.new(type: "Firm")
+    assert_equal Firm, firm.class
+  end
+
   def test_where_new_with_subclass
     firm = Company.where(type: "Firm").new
     assert_equal Firm, firm.class

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -2,6 +2,7 @@
 
 class AbstractCompany < ActiveRecord::Base
   self.abstract_class = true
+  self.table_name = :companies
 end
 
 class Company < AbstractCompany


### PR DESCRIPTION
### Summary

It should be possible to call `.new` on the abstract class and return
the subclass instantiated properly just like it would with a base class.

Given the following example:

```
class AbstractCompany < ActiveRecord::Base
  self.abstract_class = true
end

class Company < AbstractCompany
end

class Acme < Company
end
```

It is possible to calls `Company.new(type: "Acme")` and it will return
an instance of Acme.

However, if someone would call `AbstractCompany.new(type: "Acme")`, it
would raise a `NotImplementedError`.

This fixes it so that calling new on the abstract class behaves the
same.

### Other Information

I'm happy to provide more information and more test. I didn't know what else to add besides the small unit test I added. It's been a while since I contributed here, so my apologies if there are things that are missing. I will gladly provide any additional information requested.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
