### PR TITLE
Avoid making query from find_by on contradictory relation

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -78,6 +78,7 @@ module ActiveRecord
     #   Post.find_by name: 'Spartacus', rating: 4
     #   Post.find_by "published_at < ?", 2.weeks.ago
     def find_by(arg, *args)
+      return false if where_clause.contradiction?
       where(arg, *args).take
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -456,6 +456,18 @@ module ActiveRecord
       end
     end
 
+    test "no queries on empty relation find_by" do
+      assert_queries(0) do
+        Post.find_by(id: [])
+      end
+    end
+
+    test "no queries on empty condition find_by" do
+      assert_queries(0) do
+        Post.all.find_by(id: [])
+      end
+    end
+
     private
       def skip_if_sqlite3_version_includes_quoting_bug
         if sqlite3_version_includes_quoting_bug?


### PR DESCRIPTION
### Summary

Previously find_by would make a query even if it was passed a contradiction, like User.find_by(id: []). Unlike queries which loaded records which skip the query as of #37266 and #40387.

cc @jhawthorn
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
