### PR TITLE
Avoid making query from find_by on contradictory relation

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -78,6 +78,7 @@ module ActiveRecord
     #   Post.find_by name: 'Spartacus', rating: 4
     #   Post.find_by "published_at < ?", 2.weeks.ago
     def find_by(arg, *args)
+      return false if where_clause.contradiction?
       where(arg, *args).take
     end
 

--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -456,6 +456,18 @@ module ActiveRecord
       end
     end
 
+    test "no queries on empty relation find_by" do
+      assert_queries(0) do
+        Post.find_by(id: [])
+      end
+    end
+
+    test "no queries on empty condition find_by" do
+      assert_queries(0) do
+        Post.all.find_by(id: [])
+      end
+    end
+
     private
       def skip_if_sqlite3_version_includes_quoting_bug
         if sqlite3_version_includes_quoting_bug?


### PR DESCRIPTION
### Summary
Previously find_by would make a query even if it was passed a contradiction, like User.find_by(id: []). Unlike queries which loaded records which skip the query as of #37266 and #40387.

cc @jhawthorn @jonathanhefner

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem "rails"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :title
  end
end

class Post < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_hasone_target_not_queried_on_autosave_when_reset
    post = Post.create!
    assert_queries(0) { Post.find_by(id: []) }
  end

  private

  def assert_queries(num = 1, options = {})
    ignore_none = options.fetch(:ignore_none) { num == :any }
    
    SQLCounter.clear_log
    x = yield
    the_log = ignore_none ? SQLCounter.log_all : SQLCounter.log
    if num == :any
      assert_operator the_log.size, :>=, 1, "1 or more queries expected, but none were executed."
    else
      mesg = "#{the_log.size} instead of #{num} queries were executed.#{the_log.size == 0 ? '' : "\nQueries:\n#{the_log.join("\n")}"}"
      assert_equal num, the_log.size, mesg
    end
    x
  end
end

class SQLCounter
  class << self
    attr_accessor :log
    def clear_log; self.log = []; end
  end

  clear_log

  def call(name, start, finish, message_id, values)
    return if values[:cached]

    sql = values[:sql]
    self.class.log << sql unless ["SCHEMA", "TRANSACTION"].include? values[:name]
  end
end

ActiveSupport::Notifications.subscribe("sql.active_record", SQLCounter.new)
```
gives the below output
```
F

Failure:
BugTest#test_hasone_target_not_queried_on_autosave_when_reset [find.rb:31]:
1 instead of 0 queries were executed.
Queries:
SELECT "posts".* FROM "posts" WHERE 1=0 LIMIT ?.
Expected: 0
  Actual: 1
```
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
