### PR TITLE
Add reflected association methods to relations

### DIFF
--- a/activerecord/test/cases/relation/reflection_methods_test.rb
+++ b/activerecord/test/cases/relation/reflection_methods_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+require "models/comment"
+require "models/rating"
+
+module ActiveRecord
+  class ReflectionMethodsTest < ActiveRecord::TestCase
+    fixtures :posts, :comments, :ratings
+
+    test "Post -> Comment" do
+      assert_equal_ids Comment.all.ids, Post.all.comments.ids
+    end
+
+    test "Comment -> Post" do
+      assert_equal_ids Post.joins(:comments).distinct.pluck(:id),
+                       Comment.all.post.ids.uniq
+    end
+
+    test "Post -> Comment -> Rating" do
+      assert_equal_ids Rating.all.ids, Post.all.comments.ratings.ids
+    end
+
+    test "Rating -> Comment -> Post" do
+      assert_equal_ids Post.joins(comments: :ratings).distinct.pluck(:id),
+                       Rating.all.comment.post.ids.uniq
+    end
+
+    private
+      def assert_equal_ids(expected, actual)
+        assert_equal expected.sort, actual.sort
+      end
+  end
+end

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -11,7 +11,7 @@ class Comment < ActiveRecord::Base
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }
   scope :created, -> { all }
 
-  belongs_to :post, counter_cache: true
+  belongs_to :post, inverse_of: :comments, counter_cache: true
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
 

--- a/activerecord/test/models/rating.rb
+++ b/activerecord/test/models/rating.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Rating < ActiveRecord::Base
-  belongs_to :comment
+  belongs_to :comment, inverse_of: :ratings
   has_many :taggings, as: :taggable
   has_many :taggings_without_tag, -> { left_joins(:tag).where("tags.id": [nil, 0]) }, as: :taggable, class_name: "Tagging"
   has_many :taggings_with_no_tag, -> { joins("LEFT OUTER JOIN tags ON tags.id = taggings.tag_id").where("tags.id": nil) }, as: :taggable, class_name: "Tagging"


### PR DESCRIPTION
I'm reopening #37938 here which is an implementation of the first half of #37875. In the spirit of simplifying this PR and trying to get it merged, I've changed this PR to just be the association side of things, and moved the attributes work into another one that I'll open shortly. We're down to this PR just being this API:

```ruby
class Blog < ActiveRecord::Base
  has_many :categories

  scope :large_id, -> { where(arel_table[:id].gt(100)) }
end

class Category < ActiveRecord::Base
  belongs_to :blog
  has_many :posts

  scope :small_id, -> { where(arel_table[:id].lt(100)) }
end

class Post < ActiveRecord::Base
  belongs_to :category
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end
```

Now you can call:

```ruby
Blog.large_id.categories.small_id.posts.comments 
```

which gives you:

```sql
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" IN (
  SELECT "posts"."id" FROM "posts" WHERE "posts"."category_id" IN (
    SELECT "categories"."id" FROM "categories" WHERE "categories"."blog_id" IN (
      SELECT "blogs"."id" FROM "blogs" WHERE "blogs"."id" > 100
    ) AND "categories"."id" < 100
  )
)
```

Please take a look and let me know what y'all think about the proposed API. Happy to change/improve anything.