### PR TITLE
Always show version badge in guides, not just for edge [ci skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -768,10 +768,10 @@ code.highlight.console span.w, code.highlight.irb span.w {
   display: table-cell;
 }
 
-/* Edge Badge
+/* Version Badge
 --------------------------------------- */
 
-#edge-badge {
+#version-badge {
   position: fixed;
   right: 0;
   top: 0;

--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -764,10 +764,10 @@ div.important p, div.caution p, div.warning p, div.note p, div.info p {
   margin-bottom: 1em;
 }
 
-/* Edge Badge
+/* Version Badge
 --------------------------------------- */
 
-#edge-badge {
+#version-badge {
   position: fixed;
   right: 0px;
   top: 0px;

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -20,9 +20,9 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="guide">
-  <% if @edge %>
+  <% if badge_version = @edge ? "edge" : @version %>
   <div>
-    <div id="edge-badge">edge</div>
+    <div id="version-badge"><%= badge_version %></div>
   </div>
   <% end %>
   <div id="topNav">


### PR DESCRIPTION
### Summary

Now that we have a CSS based version banner since 1c5d9a89a724c898b71efb91437db3253a08883c
we can also show the banner for non edge versions.
Since we have guides for minor versions only, truncate the version to
the minor version: v6.0, v5.2, v5.1 etc...

<img width="747" alt="image" src="https://user-images.githubusercontent.com/28561/96490823-9f511f00-1241-11eb-85da-a6c57b226829.png">

