### PR TITLE
Optimized Cache::Entry serialization

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -88,6 +88,14 @@ module ActiveSupport
 
   cattr_accessor :test_order # :nodoc:
 
+  def self.optimized_cache_entry_format
+    Cache.optimized_cache_entry_format
+  end
+
+  def self.optimized_cache_entry_format=(value)
+    Cache.optimized_cache_entry_format = value
+  end
+
   def self.to_time_preserves_timezone
     DateAndTime::Compatibility.preserve_timezone
   end

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -26,8 +26,6 @@ module ActiveSupport
     # MemCacheStore implements the Strategy::LocalCache strategy which implements
     # an in-memory cache inside of a block.
     class MemCacheStore < Store
-      DEFAULT_CODER = NullCoder # Dalli automatically Marshal values
-
       # Provide support for raw values in the local cache strategy.
       module LocalCacheWithRaw # :nodoc:
         private
@@ -136,6 +134,10 @@ module ActiveSupport
       end
 
       private
+        def default_coder
+          NullCoder
+        end
+
         # Read an entry from the cache.
         def read_entry(key, **options)
           rescue_error_with(nil) { deserialize_entry(@data.with { |c| c.get(key, options) }) }

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -33,8 +33,6 @@ module ActiveSupport
         end
       end
 
-      DEFAULT_CODER = DupCoder
-
       def initialize(options = nil)
         options ||= {}
         super(options)
@@ -130,6 +128,10 @@ module ActiveSupport
 
       private
         PER_ENTRY_OVERHEAD = 240
+
+        def default_coder
+          DupCoder
+        end
 
         def cached_size(key, payload)
           key.to_s.bytesize + payload.bytesize + PER_ENTRY_OVERHEAD

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -169,7 +169,7 @@ module ActiveSupport
       # Race condition TTL is not set by default. This can be used to avoid
       # "thundering herd" cache writes when hot cache entries are expired.
       # See <tt>ActiveSupport::Cache::Store#fetch</tt> for more.
-      def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: DEFAULT_CODER, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
+      def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: default_coder, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
         @redis_options = redis_options
 
         @max_key_bytesize = MAX_KEY_BYTESIZE

--- a/activesupport/test/cache/coder_test.rb
+++ b/activesupport/test/cache/coder_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/cache"
+
+class CacheCoderTest < ActiveSupport::TestCase
+  def test_new_coder_can_read_legacy_payloads
+    entry = ActiveSupport::Cache::Entry.new("foobar", expires_in: 1.hour, version: "v42")
+    deserialized_entry = ActiveSupport::Cache::EntryCoder.load(ActiveSupport::Cache::LegacyCoder.dump(entry))
+
+    assert_equal entry.value, deserialized_entry.value
+    assert_equal entry.version, deserialized_entry.version
+    assert_equal entry.expires_at, deserialized_entry.expires_at
+  end
+
+  def test_legacy_coder_can_read_new_payloads
+    entry = ActiveSupport::Cache::Entry.new("foobar", expires_in: 1.hour, version: "v42")
+    deserialized_entry = ActiveSupport::Cache::LegacyCoder.load(ActiveSupport::Cache::EntryCoder.dump(entry))
+
+    assert_equal entry.value, deserialized_entry.value
+    assert_equal entry.version, deserialized_entry.version
+    assert_equal entry.expires_at, deserialized_entry.expires_at
+  end
+end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -145,3 +145,15 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
   end
 end
+
+class OptimizedFileStoreTest < FileStoreTest
+  def setup
+    ActiveSupport::Cache.optimized_cache_entry_format = true
+    super
+  end
+
+  def teardown
+    super
+    ActiveSupport::Cache.optimized_cache_entry_format = nil
+  end
+end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -202,6 +202,19 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
   end
 
+  class OptimizedRedisCacheStoreCommonBehaviorTest < RedisCacheStoreCommonBehaviorTest
+    def setup
+      ActiveSupport::Cache.optimized_cache_entry_format = true
+      super
+    end
+
+    def teardown
+      super
+      ActiveSupport::Cache.optimized_cache_entry_format = nil
+    end
+  end
+
+
   class ConnectionPoolBehaviourTest < StoreTest
     include ConnectionPoolBehavior
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -162,6 +162,10 @@ module Rails
 
           self.autoloader = :zeitwerk if %w[ruby truffleruby].include?(RUBY_ENGINE)
 
+          if respond_to?(:active_support)
+            active_support.optimized_cache_entry_format = true
+          end
+
           if respond_to?(:active_record)
             active_record.has_many_inversing = true
           end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -6,6 +6,10 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
+# Turns on the new ActiveSupport::Cache serialization format, that is both
+# more compact an faster.
+# Rails.application.config.active_support.optimized_cache_entry_format = true
+
 # Support for inversing belongs_to -> has_many Active Record associations.
 # Rails.application.config.active_record.has_many_inversing = true
 


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/39770

### Reminder:

>   - The minimum entry overhead is quite ridiculous: `Marshal.dump(ActiveSupport::Cache::Entry.new("")).bytesize # => 107`. This could be largely reduced, the compression flag could be just one byte for instance.
>  - If you `MemCacheStore` with the default config, values are serialized and compressed several times `ZLib.deflate(Marshal.Dump(Entry.new(ZLib.deflate(Marshal.dump(actual_value)))))`, that is just wasted compute.
>  - I found and read https://github.com/rails/rails/issues/9494, apparently there was an attempt to improve things a few years ago, but it was reverted to preserve backward / forward compatibility.

### Performance

[As shown by this benchmark](https://gist.github.com/casperisfine/2b67492c83c259d5a1160cc2b74dd91b), the minimum entry size is down from `112B` to `23B`.

The deserialization of an empty payload is `~1.64x` faster, and serialization `~1.88x` faster.

Of course that advantage quickly drop as the entry gets bigger, and the deserialization of the payload dwarfs the deserialization of the enveloppe. But deserialization stay slightly faster (`~1.12x`), likely because we avoid the "marshal in marshal" issue.

### Backward compatibility

Now that the coders are swappable, we can keep the old behavior just fine, until you use `load_defaults '6.1'` or set the configuration field individually.

Also both the `LegacyCoder` and the `EntryCoder` are able to detect payloads serialized with Marshal, hence the transition can be done without flushing the cache stores.

cc @eugeneius as you reviewed the previous parts
cc @rafaelfranca @etiennebarrie 
