### PR TITLE
Handle frozen payloads in AR::Type::Serialized

### DIFF
--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -63,7 +63,8 @@ module ActiveRecord
         def encoded(value)
           return if default_value?(value)
           payload = coder.dump(value)
-          if payload && binary?
+          if payload && binary? && payload.encoding != Encoding::BINARY
+            payload = payload.dup if payload.frozen?
             payload.force_encoding(Encoding::BINARY)
           end
           payload

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -330,6 +330,24 @@ class SerializedAttributeTest < ActiveRecord::TestCase
       model.normal_blob = value
       assert_not_predicate model, :normal_blob_changed?
     end
+
+    class FrozenBinaryField < BinaryField
+      class FrozenCoder < ActiveRecord::Coders::YAMLColumn
+        def dump(obj)
+          super&.freeze
+        end
+      end
+      serialize :normal_blob, FrozenCoder.new(:normal_blob, Array)
+    end
+
+    def test_is_not_changed_when_stored_in_mysql_blob_frozen_payload
+      value = %w(Fée)
+      model = FrozenBinaryField.create!(normal_blob: value, normal_text: value)
+      model.reload
+
+      model.normal_blob = value
+      assert_not_predicate model, :normal_blob_changed?
+    end
   end
 
   def test_values_cast_from_nil_are_persisted_as_nil


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/40383

I didn't think about payload potentially being frozen. One of our serializers looked like:

```ruby
  def self.dump(*args)
    "#{self::VERSION_LINE}#{dump_safely(*args)}"
  end
```

So the returned payload was frozen causing the `.force_encoding` to blow up.

I also added a check to not do anything if the encoding is already properly set, as to avoid needless dup.

cc @rafaelfranca @lucasuyezu @jbourassa 