### PR TITLE
Handle port-less `$MEMCACHE_SERVERS` in `MemCacheStore` tests

### DIFF
--- a/actionpack/test/dispatch/session/mem_cache_store_test.rb
+++ b/actionpack/test/dispatch/session/mem_cache_store_test.rb
@@ -40,7 +40,7 @@ class MemCacheStoreTest < ActionDispatch::IntegrationTest
     require "dalli"
     servers = ENV["MEMCACHE_SERVERS"] || "localhost:11211"
     ss = Dalli::Client.new(servers).stats
-    raise Dalli::DalliError unless ss[servers]
+    raise Dalli::DalliError unless ss[servers] || ss[servers + ":11211"]
 
     def test_setting_and_getting_session_value
       with_test_route_set do

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -27,7 +27,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   begin
     servers = ENV["MEMCACHE_SERVERS"] || "localhost:11211"
     ss = Dalli::Client.new(servers).stats
-    raise Dalli::DalliError unless ss[servers]
+    raise Dalli::DalliError unless ss[servers] || ss[servers + ":11211"]
 
     MEMCACHE_UP = true
   rescue Dalli::DalliError


### PR DESCRIPTION
### Summary

When running tests, we check the `stats` payload returned by the `Dalli::Client` to see if it includes the server's address as a key. The key always includes the port, even if the client was created without specifying it.

Devs may be running tests on a machine which provides `$MEMCACHE_SERVERS` without a trailing port. We should allow for this when checking if Memcache is working.

