### PR TITLE
Fix rename_index removing old index with symbols

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -890,6 +890,8 @@ module ActiveRecord
       #   rename_index :people, 'index_people_on_last_name', 'index_users_on_last_name'
       #
       def rename_index(table_name, old_name, new_name)
+        old_name = old_name.to_s
+        new_name = new_name.to_s
         validate_index_length!(table_name, new_name)
 
         # this is a naive implementation; some DBs may support this more efficiently (PostgreSQL, for instance)

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -37,6 +37,15 @@ module ActiveRecord
         assert connection.index_name_exists?(table_name, "new_idx")
       end
 
+      def test_rename_index_with_symbol
+        # keep the names short to make Oracle and similar behave
+        connection.add_index(table_name, [:foo], name: :old_idx)
+        connection.rename_index(table_name, :old_idx, :new_idx)
+
+        assert_not connection.index_name_exists?(table_name, "old_idx")
+        assert connection.index_name_exists?(table_name, "new_idx")
+      end
+
       def test_rename_index_too_long
         too_long_index_name = good_index_name + "x"
         # keep the names short to make Oracle and similar behave


### PR DESCRIPTION
### Summary

Some adapters (sqlite3 and older mysql/mariadb) do not support to rename an index directly.
That causes rename_index cannot find an old index to remove.