### PR TITLE
Fix boolean negation in documentation

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -228,7 +228,7 @@ module ActiveRecord
       # If the collection has been loaded
       # it is equivalent to <tt>collection.size.zero?</tt>. If the
       # collection has not been loaded, it is equivalent to
-      # <tt>collection.exists?</tt>. If the collection has not already been
+      # <tt>!collection.exists?</tt>. If the collection has not already been
       # loaded and you are going to fetch the records anyway it is better to
       # check <tt>collection.length.zero?</tt>.
       def empty?

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -181,7 +181,7 @@ An example with a predicate:
 # If the collection has been loaded
 # it is equivalent to <tt>collection.size.zero?</tt>. If the
 # collection has not been loaded, it is equivalent to
-# <tt>collection.exists?</tt>. If the collection has not already been
+# <tt>!collection.exists?</tt>. If the collection has not already been
 # loaded and you are going to fetch the records anyway it is better to
 # check <tt>collection.length.zero?</tt>.
 def empty?


### PR DESCRIPTION
See a similar fix in 68d35960f336d5be3c5e35c88e6c8bdebcbcf500. Reading e1e17a55d246d485f546766606580e8e4919442b I'm not exactly sure whether it's intentional or not, but I tend to think it's a typo.

[ci skip]