### PR TITLE
Instrument cache store name

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -715,7 +715,7 @@ module ActiveSupport
             logger.debug "Cache #{operation}: #{normalize_key(key, options)}#{options.blank? ? "" : " (#{options.inspect})"}"
           end
 
-          payload = { key: key }
+          payload = { key: key, store: self.class.name }
           payload.merge!(options) if options.is_a?(Hash)
           ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload) { yield(payload) }
         end

--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -32,6 +32,7 @@ module CacheInstrumentationBehavior
     assert_equal :fetch_multi, events[0].payload[:super_operation]
     assert_equal ["a", "b"], events[0].payload[:key]
     assert_equal ["b"], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
   end
 
   def test_instrumentation_empty_fetch_multi
@@ -43,6 +44,7 @@ module CacheInstrumentationBehavior
     assert_equal :fetch_multi, events[0].payload[:super_operation]
     assert_equal [], events[0].payload[:key]
     assert_equal [], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
   end
 
   def test_read_multi_instrumentation
@@ -55,6 +57,7 @@ module CacheInstrumentationBehavior
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
     assert_equal ["a", "b"], events[0].payload[:key]
     assert_equal ["b"], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
   end
 
   def test_empty_read_multi_instrumentation
@@ -65,6 +68,7 @@ module CacheInstrumentationBehavior
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
     assert_equal [], events[0].payload[:key]
     assert_equal [], events[0].payload[:hits]
+    assert_equal @cache.class.name, events[0].payload[:store]
   end
 
   private


### PR DESCRIPTION
In a large app, it's typical to have many cache backends, all wrapped by `AS::Cache`. When all of them are instrumented through `ActiveSupport::Notifications.subscribe(/cache_.*\.active_support/) do ...` you can see all calls to `AS::Cache`, but it's impossible to know what store backs a cache operation. Was it a file cache or a redis cache? Or in-memory cache?

I'd like to get that solved by including an extra parameter in the instrumentation payload that represents the class of a cache store.

cc @rafaelfranca @byroot @csfrancis