### PR TITLE
Fix resources being fetched twice when crossorigin attribute is used

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -88,16 +88,20 @@ module ActionView
         path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
         preload_links = []
         nopush = options["nopush"].nil? ? true : options.delete("nopush")
+        crossorigin = options.delete("crossorigin")
+        crossorigin = "anonymous" if crossorigin == true
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
           unless options["defer"]
             preload_link = "<#{href}>; rel=preload; as=script"
+            preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; nopush" if nopush
             preload_links << preload_link
           end
           tag_options = {
-            "src" => href
+            "src" => href,
+            "crossorigin" => crossorigin
           }.merge!(options)
           if tag_options["nonce"] == true
             tag_options["nonce"] = content_security_policy_nonce
@@ -142,16 +146,20 @@ module ActionView
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "host", "skip_pipeline").symbolize_keys
         preload_links = []
+        crossorigin = options.delete("crossorigin")
+        crossorigin = "anonymous" if crossorigin == true
         nopush = options["nopush"].nil? ? true : options.delete("nopush")
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
           preload_link = "<#{href}>; rel=preload; as=style"
+          preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
           preload_link += "; nopush" if nopush
           preload_links << preload_link
           tag_options = {
             "rel" => "stylesheet",
             "media" => "screen",
+            "crossorigin" => crossorigin,
             "href" => href
           }.merge!(options)
           tag(:link, tag_options)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -528,6 +528,13 @@ class AssetTagHelperTest < ActionView::TestCase
     assert_equal expected, @response.headers["Link"]
   end
 
+  def test_should_set_preload_links_with_cross_origin
+    stylesheet_link_tag("http://example.com/style.css", crossorigin: "use-credentials")
+    javascript_include_tag("http://example.com/all.js", crossorigin: true)
+    expected = "<http://example.com/style.css>; rel=preload; as=style; crossorigin=use-credentials; nopush,<http://example.com/all.js>; rel=preload; as=script; crossorigin=anonymous; nopush"
+    assert_equal expected, @response.headers["Link"]
+  end
+
   def test_image_path
     ImagePathToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end


### PR DESCRIPTION
### Summary

When you load a script or css (by using  `javascript_include_tag` or `stylesheet_link_tag` respectively) with[ `crossorigin` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) applied, rails currently causes some browsers to fetch these resources twice. That is because `crossorigin` in the `link` header[ preload ](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content)directive and on the resource itself need to match in order for browsers to re-use a resource.

For example if you use this tag in a view:

```erb
<%= javascript_include_tag("[...snip]react.production.min.js", crossorigin: "anonymous") %>
```

`javascript_include_tag` pushes that resource to the link http header, but currently ignores the `crossorigin` attribute.

Which leads to the above-mentioned double fetches:
<img width="1618" alt="double fetches in network tab chrome" src="https://user-images.githubusercontent.com/474248/96795533-778ec200-13cd-11eb-9f11-b543a81aea85.png">

Chrome even provides a warning for these cases:
<img width="1613" alt="chrome warning" src="https://user-images.githubusercontent.com/474248/96795717-81b0c080-13cd-11eb-898e-af142e75aae6.png">

> A preload for 'https://cdnjs.cloudflare.com/ajax/libs/react/17.0.0/umd/react.production.min.js' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.

This PR changes it so that the link header directives include the same `crossorigin` values as those that have been passed to the resources themselves, which allows browsers to reuse the preloaded resource. 

<img width="1616" alt="double fetches fixed chrome network tab" src="https://user-images.githubusercontent.com/474248/96795590-7a89b280-13cd-11eb-8f61-cd13f9412c9a.png">


`crossorigin: true` producing  `anonymous` has already been done [in the existing `https://github.com/rails/rails/blob/57dd21ef65f8c4ff8f847b04133b17c5f01d6ed7/actionview/lib/action_view/helpers/asset_tag_helper.rb#L281`](https://github.com/rails/rails/blob/57dd21ef65f8c4ff8f847b04133b17c5f01d6ed7/actionview/lib/action_view/helpers/asset_tag_helper.rb#L281) helper, so I replicated this behavior here, too.

