### PR TITLE
Speed up `ActiveSupport::SecurityUtils.fixed_length_secure_compare`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Speed up `ActiveSupport::SecurityUtils.fixed_length_secure_compare` by using
+    `OpenSSL.fixed_length_secure_compare`, if available.
+
+    *Nate Matykiewicz*
+
 *   `ActiveSupport::Cache::MemCacheStore` now checks `ENV["MEMCACHE_SERVERS"]` before falling back to `"localhost:11211"` if configured without any addresses.
 
     ```ruby

--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -6,14 +6,21 @@ module ActiveSupport
     #
     # The values compared should be of fixed length, such as strings
     # that have already been processed by HMAC. Raises in case of length mismatch.
-    def fixed_length_secure_compare(a, b)
-      raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize
 
-      l = a.unpack "C#{a.bytesize}"
+    if defined?(OpenSSL.fixed_length_secure_compare)
+      def fixed_length_secure_compare(a, b)
+        OpenSSL.fixed_length_secure_compare(a, b)
+      end
+    else
+      def fixed_length_secure_compare(a, b)
+        raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize
 
-      res = 0
-      b.each_byte { |byte| res |= byte ^ l.shift }
-      res == 0
+        l = a.unpack "C#{a.bytesize}"
+
+        res = 0
+        b.each_byte { |byte| res |= byte ^ l.shift }
+        res == 0
+      end
     end
     module_function :fixed_length_secure_compare
 


### PR DESCRIPTION
### Summary

Speed up `ActiveSupport::SecurityUtils.fixed_length_secure_compare` by using `OpenSSL.fixed_length_secure_compare`, if available. OpenSSL's version is a C method, which is faster.

### Other Information

```ruby
# frozen_string_literal: true

require 'openssl'
require 'benchmark/ips'

string = '1234567890'

def slow(a, b)
  raise ArgumentError, "string length mismatch." unless a.bytesize == b.bytesize

  l = a.unpack "C#{a.bytesize}"

  res = 0
  b.each_byte { |byte| res |= byte ^ l.shift }
  res == 0
end

def fast(a, b)
  OpenSSL.fixed_length_secure_compare(a, b)
end

Benchmark.ips do |x|
  x.report('slow') { slow(string, string) }
  x.report('fast') { fast(string, string) }
  x.compare!
end
```

```
Warming up --------------------------------------
                slow    69.393k i/100ms
                fast     1.302M i/100ms
Calculating -------------------------------------
                slow    638.026k (± 5.3%) i/s -      3.192M in   5.018762s
                fast     12.416M (± 5.4%) i/s -     62.517M in   5.050475s

Comparison:
                fast: 12415792.1 i/s
                slow:   638026.5 i/s - 19.46x  (± 0.00) slower
```

There is one minor difference between the two methods. While both raise an `ArgumentError` if the strings are not equal length, OpenSSL's error message is `inputs must be of equal length` (https://github.com/ruby/openssl/blob/master/ext/openssl/ossl.c#L627), while ActiveSupport's is `string length mismatch.`.

Since the ArgumentError is not really expected, I figured it doesn't matter that the messages are different. If anyone is actually rescuing this error, they should probably just be using `ActiveSupport::SecurityUtils.secure_compare` which doesn't raise in the first place.