### PR TITLE
Annotation for `Relation#inspect` query

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -1092,6 +1092,11 @@ module ActiveRecord
         self
       end
 
+      def inspect # :nodoc:
+        load_target if find_from_target?
+        super
+      end
+
       delegate_methods = [
         QueryMethods,
         SpawnMethods,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -732,7 +732,7 @@ module ActiveRecord
     end
 
     def inspect
-      subject = loaded? ? records : self
+      subject = loaded? ? records : annotate("loading for inspect")
       entries = subject.take([limit_value, 11].compact.min).map!(&:inspect)
 
       entries[10] = "..." if entries.size == 11

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -185,6 +185,7 @@ class AssociationProxyTest < ActiveRecord::TestCase
     andreas = Developer.new name: "Andreas", log: "new developer added"
     assert_not_predicate andreas.audit_logs, :loaded?
     assert_match(/message: "new developer added"/, andreas.audit_logs.inspect)
+    assert_predicate andreas.audit_logs, :loaded?
   end
 
   def test_save_on_parent_saves_children

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1942,6 +1942,12 @@ class RelationTest < ActiveRecord::TestCase
     end
   end
 
+  test "loading query is annotated in #inspect" do
+    assert_sql(%r(/\* loading for inspect \*/)) do
+      Post.all.inspect
+    end
+  end
+
   test "already-loaded relations don't perform a new query in #inspect" do
     relation = Post.limit(2)
     relation.to_a


### PR DESCRIPTION
Related #40415, #40208, #39778, #32810, #30497, #29570.

We had been reported lots of issues about `Relation#inspect` query.

I think that annotation for `Relation#inspect` query makes it easier for
people to understand why the query is being executed.
