### PR TITLE
Make git diff aware about ruby context

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitattributes.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitattributes.tt
@@ -1,5 +1,9 @@
 # See https://git-scm.com/docs/gitattributes for more about git attribute files.
 
+*.rb diff=ruby
+*.rake diff=ruby
+*.gemspec diff=ruby
+
 <% unless options[:skip_active_record] -%>
 # Mark the database schema as having been generated.
 db/schema.rb linguist-generated


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This PR adds ruby diff patterns .gitattributes. This change enables git to maps the Ruby file extensions to the diff pattern for Ruby to show better git diff output.

Reference Blog Post: https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
