### PR TITLE
Fix regression with scope with optional path, defaults and route with dynamic segment

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -77,7 +77,7 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
-          route.groupped_optional_parts.each do |group|
+          route.grouped_optional_parts.each do |group|
             group.reverse_each do |key|
               break if defaults[key].nil? && parameterized_parts[key].present?
               break if parameterized_parts[key].to_s != defaults[key].to_s

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -77,12 +77,14 @@ module ActionDispatch
           defaults       = route.defaults
           required_parts = route.required_parts
 
-          route.parts.reverse_each do |key|
-            break if defaults[key].nil? && parameterized_parts[key].present?
-            next if parameterized_parts[key].to_s != defaults[key].to_s
-            break if required_parts.include?(key)
+          route.groupped_optional_parts.each do |group|
+            group.reverse_each do |key|
+              break if defaults[key].nil? && parameterized_parts[key].present?
+              break if parameterized_parts[key].to_s != defaults[key].to_s
+              break if required_parts.include?(key)
 
-            parameterized_parts.delete(key)
+              parameterized_parts.delete(key)
+            end
           end
 
           return RouteWithParams.new(route, parameterized_parts, params)

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -53,7 +53,7 @@ module ActionDispatch
           }.map(&:name).uniq
         end
 
-        def groupped_optional_names
+        def grouped_optional_names
           last_added_group = nil
           spec.each_with_object([]) do |node, memo|
             next unless node.group?

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -53,6 +53,18 @@ module ActionDispatch
           }.map(&:name).uniq
         end
 
+        def groupped_optional_names
+          last_added_group = nil
+          spec.each_with_object([]) do |node, memo|
+            next unless node.group?
+
+            if !last_added_group || last_added_group.exclude?(node)
+              last_added_group = node
+              memo << node.find_all(&:symbol?).map(&:name)
+            end
+          end
+        end
+
         class AnchoredRegexp < Journey::Visitors::Visitor # :nodoc:
           def initialize(separator, matchers)
             @separator = separator

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -141,8 +141,8 @@ module ActionDispatch
         end
       end
 
-      def groupped_optional_parts
-        @groupped_optional_parts ||= path.groupped_optional_names.map do |group|
+      def grouped_optional_parts
+        @grouped_optional_parts ||= path.grouped_optional_names.map do |group|
           group.map(&:to_sym)
         end
       end

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -141,6 +141,12 @@ module ActionDispatch
         end
       end
 
+      def groupped_optional_parts
+        @groupped_optional_parts ||= path.groupped_optional_names.map do |group|
+          group.map(&:to_sym)
+        end
+      end
+
       def glob?
         path.spec.any?(Nodes::Star)
       end

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -509,12 +509,54 @@ module AbstractController
                 param1: /\d*/,
                 param2: /\d+/
               }
+            get "(:param1)/test2(/:param2)" => "index#index2",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
+            get "(:param1)/test3/:param2" => "index#index3",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
+            get "test4/(:param1)/(:param2)" => "index#index4",
+              defaults: {
+                param1: 1
+              },
+              constraints: {
+                param1: /\d*/,
+                param2: /\d+/
+              }
           end
 
           kls = Class.new { include set.url_helpers }
           kls.default_url_options[:host] = "www.basecamphq.com"
 
+          assert_equal "http://www.basecamphq.com/test", kls.new.url_for(controller: "index")
           assert_equal "http://www.basecamphq.com/test", kls.new.url_for(controller: "index", param1: "1")
+          assert_equal "http://www.basecamphq.com/2/test", kls.new.url_for(controller: "index", param1: "2")
+          assert_equal "http://www.basecamphq.com/test/3", kls.new.url_for(controller: "index", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test2", kls.new.url_for(controller: "index", param1: "1", action: "index2")
+          assert_equal "http://www.basecamphq.com/2/test2", kls.new.url_for(controller: "index", param1: "2", action: "index2")
+          assert_equal "http://www.basecamphq.com/test2/3", kls.new.url_for(controller: "index", action: "index2", param2: "3")
+          assert_equal "http://www.basecamphq.com/2/test2/3", kls.new.url_for(controller: "index", param1: "2", action: "index2", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test3/3", kls.new.url_for(controller: "index", action: "index3", param2: "3")
+          assert_equal "http://www.basecamphq.com/test3/3", kls.new.url_for(controller: "index", param1: "1", action: "index3", param2: "3")
+          assert_equal "http://www.basecamphq.com/2/test3/3", kls.new.url_for(controller: "index", param1: "2", action: "index3", param2: "3")
+
+          assert_equal "http://www.basecamphq.com/test4", kls.new.url_for(controller: "index", action: "index4")
+          assert_equal "http://www.basecamphq.com/test4/2", kls.new.url_for(controller: "index", param1: "2", action: "index4")
+          assert_equal "http://www.basecamphq.com/test4/2/3", kls.new.url_for(controller: "index", param1: "2", action: "index4", param2: "3")
+          # Doesn't make sense due to ambiguity, but is consistent with both rails4 and rails5 routing behavior:
+          assert_equal "http://www.basecamphq.com/test4/3", kls.new.url_for(controller: "index", action: "index4", param2: "3")
         end
       end
 

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -115,7 +115,7 @@ module ActionDispatch
             ["/:foo/:bar", []],
             ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
           ].each do |pattern, list|
-            path = Pattern.from_string pattern
+            path = path_from_string pattern
             assert_equal list, path.grouped_optional_names
           end
         end

--- a/actionpack/test/journey/path/pattern_test.rb
+++ b/actionpack/test/journey/path/pattern_test.rb
@@ -110,6 +110,16 @@ module ActionDispatch
           end
         end
 
+        def test_grouped_optional_names
+          [
+            ["/:foo/:bar", []],
+            ["(/:lol)/:foo(/:bar(/:baz))", [["lol"], ["bar", "baz"]]],
+          ].each do |pattern, list|
+            path = Pattern.from_string pattern
+            assert_equal list, path.grouped_optional_names
+          end
+        end
+
         def test_to_regexp_match_non_optional
           path = build_path(
             "/:name",


### PR DESCRIPTION
### Summary

This PR is basically just a simpler version of https://github.com/rails/rails/pull/32382
The regression still exists in rails master so it is another attempt to fix it 
[The refactoring part](https://github.com/rails/rails/pull/32382/commits/dce6e63e8fc8aac8a5b58828f6a1697172cca149) has been removed because it [slowed down things a bit](https://github.com/rails/rails/pull/32382#issuecomment-380816534)

The PR addresses an issue when an optional scope param with the defaults is always included in the resulted URL even when the default value is passed.
Looks like it was introduced in https://github.com/rails/rails/commit/8ca8a2d773b942c4ea76baabe2df502a339d05b1#diff-f263f30232edae53a59ca3fc0e853e2fR36

So if there is a route with an optional scope param
```ruby
scope "(:market)", market: /gb|ua/, defaults: { market: :ua } do
  get "/product/:id" => "products#index", as: :product
end
```

Before https://github.com/rails/rails/commit/8ca8a2d773b942c4ea76baabe2df502a339d05b1
```
product_path(id: 1) # /product/1
product_path(id: 1, market: :ua) # /product/1
product_path(id: 1, market: :gb) # /gb/product/1
```

After https://github.com/rails/rails/commit/8ca8a2d773b942c4ea76baabe2df502a339d05b1
```
product_path(id: 1) # /product/1
product_path(id: 1, market: :ua) # /ua/product/1
product_path(id: 1, market: :gb) # /gb/product/1
```

In the example above `product_path(id: 1, market: :ua)` should generate `/product/1`, because `market: :ua` is part of the `defaults`

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
