### PR TITLE
Update outdated has_secure_password documentation

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -446,28 +446,7 @@ User Management
 
 NOTE: _Almost every web application has to deal with authorization and authentication. Instead of rolling your own, it is advisable to use common plug-ins. But keep them up-to-date, too. A few additional precautions can make your application even more secure._
 
-There are a number of authentication plug-ins for Rails available. Good ones, such as the popular [devise](https://github.com/plataformatec/devise) and [authlogic](https://github.com/binarylogic/authlogic), store only encrypted passwords, not plain-text passwords. In Rails 3.1 you can use the built-in `has_secure_password` method which has similar features.
-
-Every new user gets an activation code to activate their account when they get an e-mail with a link in it. After activating the account, the activation_code columns will be set to NULL in the database. If someone requested a URL like these, they would be logged in as the first activated user found in the database (and chances are that this is the administrator):
-
-```
-http://localhost:3006/user/activate
-http://localhost:3006/user/activate?id=
-```
-
-This is possible because on some servers, this way the parameter id, as in params[:id], would be nil. However, here is the finder from the activation action:
-
-```ruby
-User.find_by_activation_code(params[:id])
-```
-
-If the parameter was nil, the resulting SQL query will be
-
-```sql
-SELECT * FROM users WHERE (users.activation_code IS NULL) LIMIT 1
-```
-
-And thus it found the first user in the database, returned it, and logged them in. You can find out more about it in [this blog post](http://www.rorsecurity.info/2007/10/28/restful_authentication-login-security/). _It is advisable to update your plug-ins from time to time_. Moreover, you can review your application to find more flaws like this.
+There are a number of authentication plug-ins for Rails available. Good ones, such as the popular [devise](https://github.com/heartcombo/devise) and [authlogic](https://github.com/binarylogic/authlogic), store only encrypted passwords, not plain-text passwords. Since Rails 3.1 you can also use the built-in [`has_secure_password`](https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password) method which supports password encryption, confirmation, and recovery mechanisms.
 
 ### Brute-Forcing Accounts
 


### PR DESCRIPTION
### Summary

In the Securing Rails Applications guide, we still reference a feature of `has_secure_password` which doesn't exist and would confuse readers.

### Details 

There's no `activation_code` column used by `has_secure_password` (anymore?) and unlike what the documentation suggests "every user"doesn't get one. Instead you *can choose to use* `has_secure_password` on second column (`recovery_password` is [suggested in the `ActiveMode::SecurePassword` docs][1] [since 2018][2]) and disable validations so it can be null by default until a user asks for recovery password at which point your own application logic will need to generate at least the plain text version of that recovery password before SecurePassword creates a bcrypt digest.

There was also an disingenuous suggestion in the paragraph that `has_secure_password` has "similar features" to Devise and Auth Logic. That's just not true. It's definitely simpler and lighter weight, so I cut down the unnecessarily long activation code example, explained what basic features `has_secure_password` *does* support, and linked to the API documentation for `has_secure_password` to avoid making the guide excessively dependent on the current API of the module.

[1]: https://github.com/olivierlacan/rails/blob/533c5c3a532a01ca5ae6ddd3f04137b13e9271ab/activemodel/lib/active_model/secure_password.rb#L44
[2]: https://github.com/rails/rails/commit/e62e68e25bb7b1281e20e228db66f7deace4330f