### PR TITLE
Add test_selector to tag_helper

### DIFF
--- a/actionmailbox/test/dummy/config/environments/development.rb
+++ b/actionmailbox/test/dummy/config/environments/development.rb
@@ -60,6 +60,9 @@ Rails.application.configure do
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -46,4 +46,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
 end

--- a/actiontext/test/dummy/config/environments/development.rb
+++ b/actiontext/test/dummy/config/environments/development.rb
@@ -60,6 +60,9 @@ Rails.application.configure do
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/actiontext/test/dummy/config/environments/test.rb
+++ b/actiontext/test/dummy/config/environments/test.rb
@@ -46,4 +46,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `test_selector` helper and tag helper option for precise targeting of DOM elements in test assertions.
+
+    *Nikka Padilla*, *Joel Hawksley*
+
 *   `ActionView::Helpers::TranslationHelper#translate` accepts a block, yielding
     the translated text and the fully resolved translation key:
 

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -165,6 +165,9 @@ module ActionView #:nodoc:
     # Annotate rendered view with file names
     cattr_accessor :annotate_rendered_view_with_filenames, default: false
 
+    # Annotate rendered view with test selectors
+    cattr_accessor :annotate_rendered_view_with_test_selectors, default: false
+
     class_attribute :_routes
     class_attribute :logger
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -43,6 +43,15 @@ class TagHelperTest < ActionView::TestCase
     assert_equal("<input value=\"123 456\" />", str)
   end
 
+  def test_tag_test_selector
+    ActionView::Base.annotate_rendered_view_with_filenames = true
+
+    str = tag("p", test_selector: "my-element")
+    assert_match(/data-test-selector="my-element"/, str)
+  ensure
+    ActionView::Base.annotate_rendered_view_with_filenames = false
+  end
+
   def test_tag_options_with_array_of_random_objects
     klass = Class.new do
       def to_s
@@ -336,6 +345,14 @@ class TagHelperTest < ActionView::TestCase
 
     str = tag.p "limelight", class: ["song", { "play>": true }], escape_attributes: false
     assert_equal "<p class=\"song play>\">limelight</p>", str
+  end
+
+  def test_test_selector_helper
+    ActionView::Base.annotate_rendered_view_with_filenames = true
+
+    assert_equal ' data-test-selector="limelight"', test_selector("limelight")
+  ensure
+    ActionView::Base.annotate_rendered_view_with_filenames = false
   end
 
   def test_class_names

--- a/activestorage/test/dummy/config/environments/development.rb
+++ b/activestorage/test/dummy/config/environments/development.rb
@@ -49,6 +49,9 @@ Rails.application.configure do
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -38,4 +38,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames
+
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -701,6 +701,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
+* `config.action_view.annotate_rendered_view_with_test_selectors` determines whether to render the output of `test_selector`. This defaults to `false`.
+
 ### Configuring Action Mailbox
 
 `config.action_mailbox` provides the following configuration options:

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -77,6 +77,9 @@ Rails.application.configure do
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
 
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   <%= '# ' unless depend_on_listen? %>config.file_watcher = ActiveSupport::EventedFileUpdateChecker

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -66,4 +66,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Annotate rendered view with test selectors
+  # config.action_view.annotate_rendered_view_with_test_selectors = true
 end


### PR DESCRIPTION
## Problem

As a developer, it can be difficult to write test assertions looking for specific DOM nodes without introducing markup specifically for tests.

## Solution

Add functionality to display a `data-test-selector` value in non-production environments for the purpose of precisely targeting DOM nodes in test assertions.

We've been using this solution for over four years in the GitHub monolith.

For example:

```erb
<%= tag.p("Hello, world!", test_selector: "greeting") %>
```

```ruby
assert_selector("[data-test-selector='greeting']")
```

## Implementation

I've implemented this functionality as both an option to `tag_helper` and as a standalone `test_selector` view helper. We use both approaches extensively at GitHub.

The behavior is controlled by the `render_test_selectors` configuration flag, which defaults to `false`. It's expected that developers will set the flag to `true` in development and test.

Co-authored-by: Nikka Padilla <nixpad@github.com>