### PR TITLE
Refactor code to use index_with instead of map.

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -462,7 +462,7 @@ module ActiveRecord
         end
 
         def copy_table_contents(from, to, columns, rename = {})
-          column_mappings = Hash[columns.map { |name| [name, name] }]
+          column_mappings = columns.index_with { |name| name }
           rename.each { |a| column_mappings[a.last] = a.first }
           from_columns = columns(from).collect(&:name)
           columns = columns.find_all { |col| from_columns.include?(column_mappings[col]) }


### PR DESCRIPTION
### Summary
This PR uses index_with instead of map. This avoids allocating a two-element array on each iteration.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
