### PR TITLE
Fix: TimeWithzone bug

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -47,7 +47,9 @@ class Time
       # Time.at can be called with a time or numerical value
       time_or_number = args.first
 
-      if time_or_number.is_a?(ActiveSupport::TimeWithZone) || time_or_number.is_a?(DateTime)
+      if time_or_number.is_a?(ActiveSupport::TimeWithZone)
+        at_without_coercion(time_or_number.to_r).getlocal
+      elsif time_or_number.is_a?(DateTime)
         at_without_coercion(time_or_number.to_f).getlocal
       else
         at_without_coercion(time_or_number)

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1162,6 +1162,15 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     assert_equal ActiveSupport::TimeZone["Alaska"], Time.zone
   end
 
+  def test_end_of_period_timezone_equality_with_DateTime
+    Time.use_zone "UTC" do
+      without_time_zone = "2019-01-01 00:00:00Z".to_time.end_of_month
+      zoned = without_time_zone.in_time_zone
+
+      assert_equal(Time.zone.at(without_time_zone), Time.zone.at(zoned))
+    end
+  end
+
   def test_time_zone_getter_and_setter
     Time.zone = ActiveSupport::TimeZone["Alaska"]
     assert_equal ActiveSupport::TimeZone["Alaska"], Time.zone


### PR DESCRIPTION
### Summary

### What was the problem?
There was a rounding off issue here when we were comparing TimeWithZone times with DateTime raised in #40413. I have written a failing test and made it pass.

### How did we fix it?
The problem was that when we using time_instance.to_f  - this was not accurate enough in certain cases. I have attempted to solve it by ensuring that we use Rationals when creating Time instances time_instance.to_r . (there is a slight performance cost to this, but the benefit is accuracy). 


Thanks for reviewing and I hope this helps.

rgds,
Ben

