### PR TITLE
Option to mute multiple database yml error

### DIFF
--- a/actionmailbox/test/dummy/config/environments/development.rb
+++ b/actionmailbox/test/dummy/config/environments/development.rb
@@ -46,6 +46,10 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Show a warning when Rails couldn't parse your database.yml
+  # for multiple databases.
+  config.active_record.suppress_multiple_database_warning = false
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/actiontext/test/dummy/config/environments/development.rb
+++ b/actiontext/test/dummy/config/environments/development.rb
@@ -46,6 +46,10 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Show a warning when Rails couldn't parse your database.yml
+  # for multiple databases.
+  config.active_record.suppress_multiple_database_warning = false
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allow users to silence the "Rails couldn't infer whether you are using multiple databases..."
+    message using `config.active_record.suppress_multiple_database_warning`.
+
+    *Omri Gabay*
+
 *   Add `values_at` method.
 
     Returns an array containing the values associated with the given methods.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -131,6 +131,12 @@ module ActiveRecord
       # potentially cause memory bloat.
       mattr_accessor :warn_on_records_fetched_greater_than, instance_writer: false
 
+      ##
+      # :singleton-method:
+      # Show a warning when Rails couldn't parse your database.yml
+      # for multiple databases.
+      mattr_accessor :suppress_multiple_database_warning, instance_writer: false, default: false
+
       mattr_accessor :maintain_test_schema, instance_accessor: false
 
       class_attribute :belongs_to_required_by_default, instance_accessor: false

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -154,7 +154,9 @@ module ActiveRecord
         begin
           Rails.application.config.load_database_yaml
         rescue
-          $stderr.puts "Rails couldn't infer whether you are using multiple databases from your database.yml and can't generate the tasks for the non-primary databases. If you'd like to use this feature, please simplify your ERB."
+          unless ActiveRecord::Base.suppress_multiple_database_warning
+            $stderr.puts "Rails couldn't infer whether you are using multiple databases from your database.yml and can't generate the tasks for the non-primary databases. If you'd like to use this feature, please simplify your ERB."
+          end
 
           {}
         end


### PR DESCRIPTION
### Summary

This merge request allows users to suppress the warning shown by `        ActiveRecord::Tasks::DatabaseTasks.setup_initial_database_yaml`.

### Other Information

@eileencodes mentioned that this would be merged, if someone built it: https://github.com/rails/rails/pull/36560#issuecomment-559180204
