### PR TITLE
Fixed typo for rdoc

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -177,7 +177,7 @@ module ActionView
       #   # => <a href="/searches?query=ruby+on+rails">Ruby on Rails search</a>
       #
       #   link_to "Nonsense search", searches_path(foo: "bar", baz: "quux")
-      #   # => <a href="/searches?foo=bar&amp;baz=quux">Nonsense search</a>
+      #   # => <a href="/searches?foo=bar&baz=quux">Nonsense search</a>
       #
       # The only option specific to +link_to+ (<tt>:method</tt>) is used as follows:
       #


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This is a very minor patch to correct the description of the following URL. It could be a cosmetic change, but I think escaping `&` could be misinterpreted, so I fixed it!

https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to

<img width="977" alt="スクリーンショット 2020-10-26 11 17 21" src="https://user-images.githubusercontent.com/701242/97130056-b5039e80-1783-11eb-84cb-af7fd46b991f.png">

If you don't need it, please close this.

### Other Information

The output using rdoc is as follows. 

```ruby
rdoc  actionview/lib/action_view/helpers/url_helper.rb
```
<img width="683" alt="スクリーンショット 2020-10-26 12 00 35" src="https://user-images.githubusercontent.com/701242/97130096-cc428c00-1783-11eb-9e60-03a2b4df74bd.png">


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
