### PR TITLE
Add `attribute_for_database` attribute method

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       included do
-        attribute_method_suffix "_before_type_cast"
+        attribute_method_suffix "_before_type_cast", "_for_database"
         attribute_method_suffix "_came_from_user?"
       end
 
@@ -70,6 +70,10 @@ module ActiveRecord
         # Dispatch target for <tt>*_before_type_cast</tt> attribute methods.
         def attribute_before_type_cast(attr_name)
           @attributes[attr_name].value_before_type_cast
+        end
+
+        def attribute_for_database(attr_name)
+          @attributes[attr_name].value_for_database
         end
 
         def attribute_came_from_user?(attr_name)

--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -54,7 +54,7 @@ module ActiveRecord
         end
 
         module ClassMethods
-          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database).to_set
+          ID_ATTRIBUTE_METHODS = %w(id id= id? id_before_type_cast id_was id_in_database id_for_database).to_set
 
           def instance_method_already_implemented?(method_name)
             super || primary_key && ID_ATTRIBUTE_METHODS.include?(method_name)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -290,13 +290,23 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate Book.illustrator_visibility_invisible.create, :illustrator_visibility_invisible?
   end
 
-  test "_before_type_cast" do
+  test "attribute_before_type_cast" do
     assert_equal 2, @book.status_before_type_cast
     assert_equal "published", @book.status
 
     @book.status = "published"
 
     assert_equal "published", @book.status_before_type_cast
+    assert_equal "published", @book.status
+  end
+
+  test "attribute_for_database" do
+    assert_equal 2, @book.status_for_database
+    assert_equal "published", @book.status
+
+    @book.status = "published"
+
+    assert_equal 2, @book.status_for_database
     assert_equal "published", @book.status
   end
 


### PR DESCRIPTION
I've been reported an issue on enum from friends, they want a way to get
mapped value, but currently there is no reliable way to get that value.

If a record is loaded from database, `attribute_before_type_cast` works
for that. but the attribute is changed by user, the attribute method
won't work for that.

```ruby
book = Book.new(status: "published")

# returns "published", but what we really want is 2.
book.status_before_type_cast
```

So I propose to add `attribute_for_database` attribute method, it
consistently returns mapped value for enum.

~~Originally `attribute_before_type_cast` on enum returned mapped value,
but it was changed in Rails 5.0 (c51f9b6) to return user supplied raw
value.~~

~~I've been reported this issue from friends, they want a way to get
mapped value, but currently that way remains lost.~~

~~So I propose to add `attribute_for_database` attribute method, it
behaves the same way as the previous `attribute_before_type_cast` for
enum.~~
