### PR TITLE
add ability to set per param encoding

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -135,7 +135,7 @@ module ActionController
       end
     end
 
-    def self.binary_params_for?(action) # :nodoc:
+    def self.custom_encoding_for(action, param) # :nodoc:
       false
     end
 

--- a/actionpack/lib/action_controller/metal/parameter_encoding.rb
+++ b/actionpack/lib/action_controller/metal/parameter_encoding.rb
@@ -12,11 +12,11 @@ module ActionController
       end
 
       def setup_param_encode # :nodoc:
-        @_parameter_encodings = {}
+        @_parameter_encodings = Hash.new { |h, k| h[k] = {} }
       end
 
-      def binary_params_for?(action) # :nodoc:
-        @_parameter_encodings[action.to_s]
+      def custom_encoding_for(action, param) # :nodoc:
+        @_parameter_encodings[action.to_s][param.to_s]
       end
 
       # Specify that a given action's parameters should all be encoded as
@@ -44,7 +44,35 @@ module ActionController
       # encoded as ASCII-8BIT. This is useful in the case where an application
       # must handle data but encoding of the data is unknown, like file system data.
       def skip_parameter_encoding(action)
-        @_parameter_encodings[action.to_s] = true
+        @_parameter_encodings[action.to_s] = Hash.new { Encoding::ASCII_8BIT }
+      end
+
+      # Specify the encoding for a a parameter on an action
+      # ASCII-8BIT (it "skips" the encoding default of UTF-8).
+      #
+      # For example, a controller would use it like this:
+      #
+      #   class RepositoryController < ActionController::Base
+      #     param_encoding :show, :file_path, Encoding::ASCII_8BIT
+      #
+      #     def show
+      #       @repo = Repository.find_by_filesystem_path params[:file_path]
+      #
+      #       # `repo_name` is guaranteed to be UTF-8, but was ASCII-8BIT, so
+      #       # tag it as such
+      #       @repo_name = params[:repo_name].force_encoding 'UTF-8'
+      #     end
+      #
+      #     def index
+      #       @repositories = Repository.all
+      #     end
+      #   end
+      #
+      # The file_path parameter on the show action would be encoded as ASCII-8BIT.
+      # This is useful in the case where an application must handle data
+      # but encoding of the data is unknown, like file system data.
+      def param_encoding(action, param, encoding)
+        @_parameter_encodings[action.to_s][param.to_s] = encoding
       end
     end
   end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -76,7 +76,7 @@ module ActionDispatch
     PASS_NOT_FOUND = Class.new { # :nodoc:
       def self.action(_); self; end
       def self.call(_); [404, { "X-Cascade" => "pass" }, []]; end
-      def self.binary_params_for?(action); false; end
+      def self.custom_encoding_for(action, param); nil; end
     }
 
     def controller_class

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -4,12 +4,10 @@ require "abstract_unit"
 
 class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
+    skip_parameter_encoding("parse_binary")
+
     class << self
       attr_accessor :last_request_parameters, :last_parameters
-
-      def binary_params_for?(action)
-        action == "parse_binary"
-      end
     end
 
     def parse_binary

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4559,9 +4559,7 @@ end
 
 class TestInvalidUrls < ActionDispatch::IntegrationTest
   class FooController < ActionController::Base
-    def self.binary_params_for?(action)
-      action == "show"
-    end
+    param_encoding :show, :id, Encoding::ASCII_8BIT
 
     def show
       render plain: "foo#show"
@@ -4595,7 +4593,7 @@ class TestInvalidUrls < ActionDispatch::IntegrationTest
     end
   end
 
-  test "params encoded with binary_params_for? are treated as ASCII 8bit" do
+  test "params param_encoding uses ASCII 8bit" do
     with_routing do |set|
       set.draw do
         get "/foo/show(/:id)", to: "test_invalid_urls/foo#show"


### PR DESCRIPTION
previously you could skip encoding which would encode all parameters on an action as ASCII_8BIT
After this change you can specify the `param_encoding` for any one parameter on an action

This supports how we handle parameter encoding at GitHub to work with how catching incorrect encoding changed with https://github.com/rails/rails/pull/40124 (which is a great change)
We now need to also consider post body params which may be different from request URL params

cc @adrianna-chang-shopify @jhawthorn 