### PR TITLE
Allow for proxy-revalidate in cache-control header

### DIFF
--- a/actionpack/lib/action_dispatch/http/cache.rb
+++ b/actionpack/lib/action_dispatch/http/cache.rb
@@ -125,7 +125,7 @@ module ActionDispatch
       private
         DATE          = "Date"
         LAST_MODIFIED = "Last-Modified"
-        SPECIAL_KEYS  = Set.new(%w[extras no-store no-cache max-age public private must-revalidate])
+        SPECIAL_KEYS  = Set.new(%w[extras no-store no-cache max-age public private must-revalidate proxy-revalidate])
 
         def generate_weak_etag(validators)
           "W/#{generate_strong_etag(validators)}"
@@ -171,6 +171,7 @@ module ActionDispatch
         PUBLIC                = "public"
         PRIVATE               = "private"
         MUST_REVALIDATE       = "must-revalidate"
+        PROXY_REVALIDATE      = "proxy-revalidate"
 
         def handle_conditional_get!
           # Normally default cache control setting is handled by ETag
@@ -214,6 +215,7 @@ module ActionDispatch
             options << "max-age=#{max_age.to_i}" if max_age
             options << (control[:public] ? PUBLIC : PRIVATE)
             options << MUST_REVALIDATE if control[:must_revalidate]
+            options << PROXY_REVALIDATE if control[:proxy_revalidate]
             options << "stale-while-revalidate=#{stale_while_revalidate.to_i}" if stale_while_revalidate
             options << "stale-if-error=#{stale_if_error.to_i}" if stale_if_error
             options.concat(extras) if extras

--- a/actionpack/test/dispatch/live_response_test.rb
+++ b/actionpack/test/dispatch/live_response_test.rb
@@ -68,6 +68,12 @@ module ActionController
         assert_equal "no-store", @response.headers["Cache-Control"]
       end
 
+      def test_cache_control_proxy_revalidate_is_respected
+        @response.set_header("Cache-Control", "proxy-revalidate")
+        @response.stream.write "omg"
+        assert_equal "private, proxy-revalidate", @response.headers["Cache-Control"]
+      end
+
       def test_content_length_is_removed
         @response.headers["Content-Length"] = "1234"
         @response.stream.write "omg"

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -306,6 +306,16 @@ class ResponseTest < ActiveSupport::TestCase
     assert_equal("no-store", resp.headers["Cache-Control"])
   end
 
+  test "respect proxy-revalidate cache-control" do
+    resp = ActionDispatch::Response.new.tap { |response|
+      response.cache_control[:proxy_revalidate] = true
+      response.body = "Hello"
+    }
+    resp.to_a
+
+    assert_equal("private, proxy-revalidate", resp.headers["Cache-Control"])
+  end
+
   test "read content type with default charset utf-8" do
     resp = ActionDispatch::Response.new(200, "Content-Type" => "text/xml")
     assert_equal("utf-8", resp.charset)


### PR DESCRIPTION
### Summary
I have an Nginx reverse proxy on the same machine as my origin server. I want the proxy to cache dynamic content from the origin, but when a client revalidates a resource, I want the proxy to revalidate the public content with the origin too, and not the private authenticated responses. I found currently Nginx never revalidates with the origin server. It just gets a new copy of the resource whenever it thinks it needs one.

What appears to be the most immediate way of doing so is to modify the configuration in config/application.rb like so:

```ruby
config.action_dispatch.default_headers.merge!('Cache-Control' => 'proxy-revalidate')
```
The proxy-revalidate in the cached response should be enough for nginx to trigger a revalidate when receiving a request. Proxy-revalidate header can be used on a response to an authenticated request to permit the user's cache to store and later return the response without needing to revalidate it, since it has already been authenticated once by that user, while still requiring proxies that service many users to revalidate each time in order to make sure that each user has been authenticated. Note that such authenticated responses also need the public cache control directive in order to allow them to be cached at all.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
