### PR TITLE
Skip building join queries for min/max over same table

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -136,7 +136,7 @@ module ActiveRecord
     #        ...
     #      end
     def calculate(operation, column_name)
-      if has_include?(column_name)
+      if has_include?(column_name) && !free_from_join_dependency?(operation, column_name)
         relation = apply_join_dependency
 
         if operation.to_s.downcase == "count"
@@ -250,6 +250,10 @@ module ActiveRecord
 
       def has_include?(column_name)
         eager_loading? || (includes_values.present? && column_name && column_name != :all)
+      end
+
+      def free_from_join_dependency?(operation, column_name)
+        %w[ minimum maximum ].include?(operation.to_s.downcase) && joins_values.blank? && references_values.blank? && @klass.attribute_names.include?(column_name.to_s)
       end
 
       def perform_calculation(operation, column_name)

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -720,10 +720,30 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 7, Company.includes(:contracts).maximum(:developer_id)
   end
 
+  def test_maximum_with_auto_table_name_prefix_skip_join_includes
+    Company.create!(name: "test", rating: 9999)
+
+    queries = capture_sql do
+      assert_equal 9999, Company.includes(:contracts).maximum(:rating)
+    end
+    assert_equal 1, queries.length
+    assert_no_match(/JOIN/, queries.first)
+  end
+
   def test_minimum_with_not_auto_table_name_prefix_if_column_included
     Company.create!(name: "test", contracts: [Contract.new(developer_id: 7)])
 
     assert_equal 7, Company.includes(:contracts).minimum(:developer_id)
+  end
+
+  def test_minimum_with_auto_table_name_prefix_skip_join_includes
+    Company.create!(name: "test", rating: -9999)
+
+    queries = capture_sql do
+      assert_equal (-9999), Company.includes(:contracts).minimum(:rating)
+    end
+    assert_equal 1, queries.length
+    assert_no_match(/JOIN/, queries.first)
   end
 
   def test_sum_with_not_auto_table_name_prefix_if_column_included


### PR DESCRIPTION
### Summary

While calling `.minimum` or `.maximum` on a relation, `LEFT JOIN`s cannot change the result.

### Other Information

Usually `MIN` / `MAX` over a single table (given this column is indexed) is a very quick index-only scan.
Same aggregation inside a query with `LEFT JOIN` changes plan dramatically bad, but result is guaranteed the same. 

<details>
<summary>e.g. PostgreSQL's analyzer cannot unfortunately deduct useless join</summary>

```
CREATE TABLE x (x integer);
INSERT INTO x SELECT generate_series(100,150);
CREATE INDEX x_idx on x(x);
CREATE TABLE y (y integer);
INSERT INTO y SELECT generate_series(10,1500);
CREATE INDEX y_idx on y(y);
```

now `EXPLAIN ANALYZE SELECT min(x) from x;`:
```
                                                          QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------
 Result  (cost=0.39..0.40 rows=1 width=4) (actual time=0.044..0.047 rows=1 loops=1)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.14..0.39 rows=1 width=4) (actual time=0.037..0.039 rows=1 loops=1)
           ->  Index Only Scan using x_idx on x  (cost=0.14..13.03 rows=51 width=4) (actual time=0.014..0.015 rows=1 loops=1)
                 Index Cond: (x IS NOT NULL)
                 Heap Fetches: 1
 Planning Time: 0.156 ms
 Execution Time: 0.085 ms
```

and `EXPLAIN ANALYZE SELECT min(x) from x left join y on y.y = x.x;`:

```
                                                  QUERY PLAN
---------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=34.40..34.41 rows=1 width=4) (actual time=0.297..0.298 rows=1 loops=1)
   ->  Hash Right Join  (cost=2.15..33.45 rows=380 width=4) (actual time=0.068..0.292 rows=51 loops=1)
         Hash Cond: (y.y = x.x)
         ->  Seq Scan on y  (cost=0.00..21.91 rows=1491 width=4) (actual time=0.005..0.121 rows=1491 loops=1)
         ->  Hash  (cost=1.51..1.51 rows=51 width=4) (actual time=0.038..0.038 rows=51 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 10kB
               ->  Seq Scan on x  (cost=0.00..1.51 rows=51 width=4) (actual time=0.009..0.012 rows=51 loops=1)
 Planning Time: 0.114 ms
 Execution Time: 0.328 ms
```

note execution times
</details>