### PR TITLE
Test find_signed/! on Relation

### DIFF
--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -22,6 +22,12 @@ class SignedIdTest < ActiveRecord::TestCase
     assert_equal @account, Account.find_signed(@account.signed_id)
   end
 
+  test "find signed record on relation" do
+    assert_equal @account, Account.where("1=1").find_signed(@account.signed_id)
+
+    assert_nil Account.where("1=0").find_signed(@account.signed_id)
+  end
+
   test "find signed record with custom primary key" do
     assert_equal @toy, Toy.find_signed(@toy.signed_id)
   end
@@ -39,6 +45,14 @@ class SignedIdTest < ActiveRecord::TestCase
 
   test "find signed record with a bang" do
     assert_equal @account, Account.find_signed!(@account.signed_id)
+  end
+
+  test "find signed record with a bang on relation" do
+    assert_equal @account, Account.where("1=1").find_signed!(@account.signed_id)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      Account.where("1=0").find_signed!(@account.signed_id)
+    end
   end
 
   test "fail to find record from broken signed id" do


### PR DESCRIPTION
Want to make sure that those methods work on relation and return
expected result when retation has or doesn't have any records.

Those methods are delegated by
https://github.com/rails/rails/blob/7cb451346618811796efce1f8a2bf576b8e4999c/activerecord/lib/active_record/relation/delegation.rb#L21,
https://github.com/rails/rails/blob/7cb451346618811796efce1f8a2bf576b8e4999c/activerecord/lib/active_record/relation/delegation.rb#L95-L114,
https://github.com/rails/rails/blob/7cb451346618811796efce1f8a2bf576b8e4999c/activerecord/lib/active_record/relation/delegation.rb#L56-L78
as I understand.

Related to https://github.com/rails/rails/pull/39313