### PR TITLE
Update security guide section on session expirity [ci skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -220,7 +220,7 @@ class Session < ApplicationRecord
       time = time.split.inject { |count, unit| count.to_i.send(unit) }
     end
 
-    delete_all "updated_at < '#{time.ago.to_s(:db)}'"
+    where("updated_at < ?", time.ago.to_s(:db)).delete_all
   end
 end
 ```
@@ -228,8 +228,7 @@ end
 The section about session fixation introduced the problem of maintained sessions. An attacker maintaining a session every five minutes can keep the session alive forever, although you are expiring sessions. A simple solution for this would be to add a `created_at` column to the sessions table. Now you can delete sessions that were created a long time ago. Use this line in the sweep method above:
 
 ```ruby
-delete_all "updated_at < '#{time.ago.to_s(:db)}' OR
-  created_at < '#{2.days.ago.to_s(:db)}'"
+where("updated_at < ? OR created_at < ?", time.ago.to_s(:db), 2.days.ago.to_s(:db)).delete_all
 ```
 
 Cross-Site Request Forgery (CSRF)


### PR DESCRIPTION
### Summary

Updates only documentation, part of security guide dealing with session expirity:
* Avoid string interpolation in methods describing database access
* `delete_all` no longer takes condition param since Rails 5.1