### PR TITLE
Show open in editor link on the debug exception page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -17,11 +17,12 @@ module ActionDispatch
       interceptors << interceptor
     end
 
-    def initialize(app, routes_app = nil, response_format = :default, interceptors = self.class.interceptors)
+    def initialize(app, routes_app = nil, response_format = :default, interceptors = self.class.interceptors, editor_url = nil)
       @app             = app
       @routes_app      = routes_app
       @response_format = response_format
       @interceptors    = interceptors
+      @editor_url      = editor_url
     end
 
     def call(env)
@@ -54,7 +55,7 @@ module ActionDispatch
 
       def render_exception(request, exception)
         backtrace_cleaner = request.get_header("action_dispatch.backtrace_cleaner")
-        wrapper = ExceptionWrapper.new(backtrace_cleaner, exception)
+        wrapper = ExceptionWrapper.new(backtrace_cleaner, exception, @editor_url)
         log_error(request, wrapper)
 
         if request.get_header("action_dispatch.show_detailed_exceptions")

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -43,11 +43,12 @@ module ActionDispatch
 
     attr_reader :backtrace_cleaner, :exception, :wrapped_causes, :line_number, :file
 
-    def initialize(backtrace_cleaner, exception)
+    def initialize(backtrace_cleaner, exception, editor_url = nil)
       @backtrace_cleaner = backtrace_cleaner
       @exception = exception
       @exception_class_name = @exception.class.name
       @wrapped_causes = wrapped_causes_for(exception, backtrace_cleaner)
+      @editor_url = editor_url
 
       expand_backtrace if exception.is_a?(SyntaxError) || exception.cause.is_a?(SyntaxError)
     end
@@ -121,10 +122,15 @@ module ActionDispatch
     def source_extracts
       backtrace.map do |trace|
         file, line_number = extract_file_and_line_number(trace)
+        editor_url = @editor_url && @editor_url % {
+          file: URI.encode_www_form_component(file),
+          line: line_number
+        }
 
         {
           code: source_fragment(file, line_number),
-          line_number: line_number
+          line_number: line_number,
+          editor_url: editor_url
         }
       end
     end

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_source.html.erb
@@ -4,6 +4,9 @@
   <% if source_extract[:code] %>
     <div class="source <%= "hidden" if show_source_idx != index %>" id="frame-source-<%= error_index %>-<%= index %>">
       <div class="info">
+        <% if source_extract[:editor_url] %>
+          <a class="editor_url" href="<%= source_extract[:editor_url] %>">Open in editor</a>
+        <% end %>
         Extracted source (around line <strong>#<%= source_extract[:line_number] %></strong>):
       </div>
       <div class="data">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -100,6 +100,10 @@
       padding: 0.5em;
     }
 
+    .info .editor_url {
+      float: right;
+    }
+
     .source .data .line_numbers {
       background-color: #ECECEC;
       color: #AAA;

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -29,7 +29,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(nil, exception)
 
       assert_called_with(wrapper, :source_fragment, ["lib/file.rb", 42], returns: "foo") do
-        assert_equal [ code: "foo", line_number: 42 ], wrapper.source_extracts
+        assert_equal [ code: "foo", line_number: 42, editor_url: nil ], wrapper.source_extracts
       end
     end
 
@@ -39,7 +39,7 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(nil, exc)
 
       assert_called_with(wrapper, :source_fragment, ["c:/path/to/rails/app/controller.rb", 27], returns: "nothing") do
-        assert_equal [ code: "nothing", line_number: 27 ], wrapper.source_extracts
+        assert_equal [ code: "nothing", line_number: 27, editor_url: nil ], wrapper.source_extracts
       end
     end
 
@@ -49,7 +49,16 @@ module ActionDispatch
       wrapper = ExceptionWrapper.new(nil, exc)
 
       assert_called_with(wrapper, :source_fragment, ["invalid", 0], returns: "nothing") do
-        assert_equal [ code: "nothing", line_number: 0 ], wrapper.source_extracts
+        assert_equal [ code: "nothing", line_number: 0, editor_url: nil ], wrapper.source_extracts
+      end
+    end
+
+    test "#source_extracts add editor_url if such option passed" do
+      exception = TestError.new("lib/file.rb:42:in `index'")
+      wrapper = ExceptionWrapper.new(nil, exception, "editor_url_file=%{file},editor_url_line=%{line}")
+
+      assert_called_with(wrapper, :source_fragment, ["lib/file.rb", 42], returns: "foo") do
+        assert_equal [ code: "foo", line_number: 42, editor_url: "editor_url_file=lib%2Ffile.rb,editor_url_line=42" ], wrapper.source_extracts
       end
     end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -24,7 +24,7 @@ module Rails
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
                     :rake_eager_load
 
-      attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
+      attr_reader :encoding, :api_only, :loaded_config_version, :autoloader, :debug_exception_editor_url
 
       def initialize(*)
         super
@@ -74,6 +74,7 @@ module Rails
         @add_autoload_paths_to_load_path         = true
         @feature_policy                          = nil
         @rake_eager_load                         = false
+        @debug_exception_editor_url              = nil
       end
 
       # Loads default configurations. See {the result of the method for each version}[https://guides.rubyonrails.org/configuring.html#results-of-config-load-defaults].
@@ -358,6 +359,14 @@ module Rails
         f.binmode
         f.sync = autoflush_log # if true make sure every write flushes
         f
+      end
+
+      def debug_exception_editor_url=(url)
+        @debug_exception_editor_url =
+          case url
+          when Symbol then "#{url}://open?url=file://%{file}&line=%{line}"
+          when String then url
+          end
       end
 
       class Custom #:nodoc:

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -49,7 +49,13 @@ module Rails
 
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
-          middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
+          middleware.use(
+            ::ActionDispatch::DebugExceptions,
+            app,
+            config.debug_exception_response_format,
+            ::ActionDispatch::DebugExceptions.interceptors,
+            config.debug_exception_editor_url
+          )
           middleware.use ::ActionDispatch::ActionableExceptions
 
           unless config.cache_classes

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2693,6 +2693,26 @@ module ApplicationTests
       assert_equal false, Rails.application.config.assets.unknown_asset_fallback
     end
 
+    test "debug_exception_editor_url can be specified" do
+      add_to_config <<-RUBY
+        config.debug_exception_editor_url = '_some_editor_url_'
+      RUBY
+
+      app "development"
+
+      assert_equal "_some_editor_url_", Rails.configuration.debug_exception_editor_url
+    end
+
+    test "debug_exception_editor_url can be specified via shortcut" do
+      add_to_config <<-RUBY
+        config.debug_exception_editor_url = :txmt
+      RUBY
+
+      app "development"
+
+      assert_equal "txmt://open?url=file://%{file}&line=%{line}", Rails.configuration.debug_exception_editor_url
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
### Summary

Both macOS and iOS support custom URL-schemes. Most editors allow opening a file via the URL-scheme (usually it is `<editor_shortcut>://open?url=file://<path_to_file>&line=<line>`)
This PR adds the ability to inspect the source of the raised exception in a selected editor by rendering a link following the format from the configuration

If the URL pattern is a string that it will be used as it is, if it is a symbol that it will be converted to `#{editor_shortcut}://open?url=file://%{file}&line=%{line}`

``` ruby
Rails.application.configure do |config|
  config.debug_exception_editor_url = 'vscode://file/%{file}:%{line}'
  # config.debug_exception_editor_url = :textmate
  # config.debug_exception_editor_url = :emacs
  # config.debug_exception_editor_url = :sublime
end
```

![open_in_editor](https://cloud.githubusercontent.com/assets/471335/14376381/c44bc9d4-fd71-11e5-9233-76f937d7f365.png)

![open-in-editor](https://user-images.githubusercontent.com/471335/97441824-d1453e00-1931-11eb-8215-f7b54ed62270.gif)

I submitted the same PR a few years ago https://github.com/rails/rails/pull/24463 but it has never been really reviewed 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
