### PR TITLE
Use digest class from configuration

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -290,5 +290,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
         self.signed_id_verifier_secret ||= -> { Rails.application.key_generator.generate_key("active_record/signed_id") }
       end
     end
+
+    initializer "active_record.set_signed_id_digest" do
+      ActiveSupport.on_load(:active_record) do
+        self.signed_id_digest ||= -> { Rails.application.config.active_support.hash_digest_class || Digest::SHA256 }
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       # :singleton-method:
       # Set the secret used for the signed id verifier instance when using Active Record outside of Rails.
       # Within Rails, this is automatically set using the Rails application key generator.
-      mattr_accessor :signed_id_verifier_secret, instance_writer: false
+      mattr_accessor :signed_id_verifier_secret, :signed_id_digest, instance_writer: false
     end
 
     module ClassMethods
@@ -76,7 +76,7 @@ module ActiveRecord
           if secret.nil?
             raise ArgumentError, "You must set ActiveRecord::Base.signed_id_verifier_secret to use signed ids"
           else
-            ActiveSupport::MessageVerifier.new secret, digest: "SHA256", serializer: JSON
+            ActiveSupport::MessageVerifier.new secret, digest: signed_id_digest, serializer: JSON
           end
         end
       end


### PR DESCRIPTION
### Summary
This PR uses `config.active_support.hash_digest_class` which allows setting the desired Digest instead.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
