### PR TITLE
Improve config.active_support.use_sha1_digests deprecation message

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -60,6 +60,12 @@
 
     *Adrianna Chang*
 
+*   Allow the digest class used to generate non-sensitive digests to be configured with `config.active_support.hash_digest_class`.
+
+    `config.active_support.use_sha1_digests` is deprecated in favour of `config.active_support.hash_digest_class = ::Digest::SHA1`.
+
+    *Dirkjan Bussink*
+
 *   Fix bug to make memcached write_entry expire correctly with unless_exist
 
     *Jye Lee*

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -87,8 +87,8 @@ module ActiveSupport
         if app.config.active_support.use_sha1_digests
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             config.active_support.use_sha1_digests is deprecated and will
-            be removed from Rails 6.2. Use config.active_support.hash_digest_class
-            instead.
+            be removed from Rails 6.2. Use
+            config.active_support.hash_digest_class = ::Digest::SHA1 instead.
           MSG
           ActiveSupport::Digest.hash_digest_class = ::Digest::SHA1
         end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1067,7 +1067,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_record.collection_cache_versioning`: `false`
 - `config.active_record.has_many_inversing`: `false`
 - `config.active_support.use_authenticated_message_encryption`: `false`
-- `config.active_support.use_sha1_digests`: `false`
+- `config.active_support.hash_digest_class`: `::Digest::MD5`
 - `ActiveSupport.utc_to_local_returns_utc_offset_times`: `false`
 
 ### Configuring a Database

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -15,12 +15,6 @@
 
     *Nick Wolf*
 
-*   Deprecate `config.active_support.use_sha1_digests`
-
-    `config.active_support.use_sha1_digests` is deprecated. It is replaced with `config.active_support.hash_digest_class` which allows setting the desired Digest instead. The Rails version defaults have been updated to use this new method as well so the behavior there is unchanged.
-
-    *Dirkjan Bussink*
-
 *   Change the default logging level from :debug to :info to avoid inadvertent exposure of personally
     identifiable information (PII) in production environments.
 


### PR DESCRIPTION
This setting was a new framework default for Rails 5.2, which means that any application that followed the upgrade guide and ran the `app:update` task will have it set.

Deprecating a setting that we added to users' applications in favour of a different setting that does the same thing is unreasonably fussy. We should maintain support for the old spelling to avoid the hassle.

This was discussed on the original PR (https://github.com/rails/rails/pull/40213#discussion_r488912038), and the deprecation was added to avoid confusion between the two overlapping settings - but in practice I think it will cause more confusion than it will prevent. Removing all documentation for `use_sha1_digests` and documenting `hash_digest_class` instead should be sufficient.

/cc @jeremy since you were involved in the original discussion.