### PR TITLE
Improved parsing number from :money string

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `cast_value` for PostgreSQL column type `:money`. Now it can handle wider set of currency strings.
+
+    *Petr  Mlčoch*
+
 *   Allow double-dash comment syntax when querying read-only databases
 
     *James Adam*

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -58,10 +58,15 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     assert_equal(12345678.12, type.cast(+"$12.345.678,12"))
     assert_equal(12345678.12, type.cast(+"12,345,678.12"))
     assert_equal(12345678.12, type.cast(+"12.345.678,12"))
+
     assert_equal(-1.15, type.cast(+"-$1.15"))
     assert_equal(-2.25, type.cast(+"($2.25)"))
     assert_equal(-1.15, type.cast(+"-1.15"))
     assert_equal(-2.25, type.cast(+"(2.25)"))
+
+    assert_equal(12345678.12, type.cast(+"12 345 678.12 Kč"))
+    assert_equal(12345678.12, type.cast(+"12 345 678,12 Kč"))
+    assert_equal(12345678.12, type.cast(+"12345678.123 OMR")) # yep .003 is vanished
   end
 
   def test_schema_dumping


### PR DESCRIPTION
* Fix `cast_value` for PostgreSQL column type `:money`. Now it can handle wider set of currency strings.

### Summary

When using PostgreSQL column type `:money`, only base currency format was sucessfuly read from DB. I improved parsing number from currency string a little bit more.

It solves #31457 
