### PR TITLE
Unit test find_signed on join and find_by_sql

### DIFF
--- a/activerecord/test/cases/signed_id_test.rb
+++ b/activerecord/test/cases/signed_id_test.rb
@@ -29,15 +29,13 @@ class SignedIdTest < ActiveRecord::TestCase
   end
 
   test "find signed record on join with find_by_sql" do
-    account = Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first
-    signed_id = account.signed_id expires_in: 15.minutes, purpose: :password_reset
-    assert_equal account, account.find_signed(signed_id)
+    signed_id = Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first.signed_id expires_in: 15.minutes, purpose: :password_reset
+    assert_equal Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first, Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first.find_signed(signed_id)
   end
 
   test "find signed record on join" do
-    firm = Firm.joins(:account).where(accounts: { credit_limit: 50 }).first
-    signed_id = firm.signed_id expires_in: 15.minutes, purpose: :password_reset
-    assert_equal firm, firm.find_signed(signed_id)
+    signed_id = Firm.joins(:account).where(accounts: { credit_limit: 50 }).first.signed_id expires_in: 15.minutes, purpose: :password_reset
+    assert_equal Firm.joins(:account).where(accounts: { credit_limit: 50 }).first, Firm.joins(:account).where(accounts: { credit_limit: 50 }).first.find_signed(signed_id)
   end
 
   test "find signed record with custom primary key" do
@@ -68,15 +66,13 @@ class SignedIdTest < ActiveRecord::TestCase
   end
 
   test "find signed record with a bang on join with find_by_sql" do
-    account = Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first
-    signed_id = account.signed_id expires_in: 15.minutes, purpose: :password_reset
-    assert_equal account, account.find_signed!(signed_id)
+    signed_id = Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first.signed_id expires_in: 15.minutes, purpose: :password_reset
+    assert_equal Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first, Account.find_by_sql("SELECT * FROM accounts INNER JOIN companies ON companies.id = accounts.firm_id").first.find_signed!(signed_id)
   end
 
   test "find signed record with a bang on join" do
-    firm = Firm.joins(:account).where(accounts: { credit_limit: 50 }).first
-    signed_id = firm.signed_id expires_in: 15.minutes, purpose: :password_reset
-    assert_equal firm, firm.find_signed!(signed_id)
+    signed_id = Firm.joins(:account).where(accounts: { credit_limit: 50 }).first.signed_id expires_in: 15.minutes, purpose: :password_reset
+    assert_equal Firm.joins(:account).where(accounts: { credit_limit: 50 }).first, Firm.joins(:account).where(accounts: { credit_limit: 50 }).first.find_signed!(signed_id)
   end
 
   test "fail to find record from broken signed id" do


### PR DESCRIPTION
### Summary
I have worked on a scenario of Company table has many Users. Users table has the password and email verification. So, I need to make a join relation between Company and User table. I need to make signed_id on that join relation.  In our case calling find_signed/! on relation could simplify the implementation of accepting invites to handle the case when a user tries to accept the invitation for the second time . Want to make sure that those methods work on join relation and return
expected result when join relation has or doesn't have any records. I have created also find_by_sql unit test.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
