### PR TITLE
Only replace existing pools in transactional tests

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -214,6 +214,7 @@ module ActiveRecord
             pool_manager.shard_names.each do |shard_name|
               writing_pool_config = pool_manager.get_pool_config(ActiveRecord::Base.writing_role, shard_name)
               pool_manager.role_names.each do |role|
+                next unless pool_manager.get_pool_config(role, shard_name)
                 pool_manager.set_pool_config(role, shard_name, writing_pool_config)
               end
             end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1453,6 +1453,21 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
       assert_equal rw_conn, ro_conn
     end
 
+    def test_only_existing_connections_are_replaced
+      ActiveRecord::Base.connects_to shards: {
+        default: { writing: :default, reading: :readonly },
+        two: { writing: :default }
+      }
+
+      setup_shared_connection_pool
+
+      assert_raises(ActiveRecord::ConnectionNotEstablished) do
+        ActiveRecord::Base.connected_to(role: :reading, shard: :two) do
+          ActiveRecord::Base.retrieve_connection
+        end
+      end
+    end
+
     private
       def config
         { "default" => default_config, "readonly" => readonly_config }
@@ -1514,6 +1529,21 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
       ro_conn = reading.connection_pool_list.first.connection
 
       assert_equal rw_conn, ro_conn
+    end
+
+    def test_only_existing_connections_are_replaced
+      ActiveRecord::Base.connects_to shards: {
+        default: { writing: :default, reading: :readonly },
+        two: { writing: :default }
+      }
+
+      setup_shared_connection_pool
+
+      assert_raises(ActiveRecord::ConnectionNotEstablished) do
+        ActiveRecord::Base.connected_to(role: :reading, shard: :two) do
+          ActiveRecord::Base.retrieve_connection
+        end
+      end
     end
 
     private


### PR DESCRIPTION
`setup_shared_connection_pool` replaces reading connection pools with writing ones, so that replica reads work as they would in production.

If a shard doesn't have a reading connection we should skip it, since adding one could lead to code that only works in the test environment.