### PR TITLE
Share connection pools for non-default shards

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/legacy_pool_manager.rb
+++ b/activerecord/lib/active_record/connection_adapters/legacy_pool_manager.rb
@@ -7,6 +7,10 @@ module ActiveRecord
         @name_to_pool_config = {}
       end
 
+      def shard_names
+        @name_to_pool_config.keys
+      end
+
       def pool_configs(_ = nil)
         @name_to_pool_config.values
       end

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -199,10 +199,11 @@ module ActiveRecord
                 writing_pool_manager = writing_handler.send(:owner_to_pool_manager)[name]
                 return unless writing_pool_manager
 
-                writing_pool_config = writing_pool_manager.get_pool_config(nil, :default)
-
                 pool_manager = handler.send(:owner_to_pool_manager)[name]
-                pool_manager.set_pool_config(nil, :default, writing_pool_config)
+                pool_manager.shard_names.each do |shard_name|
+                  writing_pool_config = writing_pool_manager.get_pool_config(nil, shard_name)
+                  pool_manager.set_pool_config(nil, shard_name, writing_pool_config)
+                end
               end
             end
           end


### PR DESCRIPTION
Unless `legacy_connection_handling` was set to `false`, only the default shard's connection pools were shared during transactional tests.