### PR TITLE
Add docs and guards to `while_preventing_writes`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1009,6 +1009,10 @@ module ActiveRecord
       # See `READ_QUERY` for the queries that are blocked by this
       # method.
       def while_preventing_writes(enabled = true)
+        unless ActiveRecord::Base.legacy_connection_handling
+          raise NotImplementedError, "`while_preventing_writes` is only available on the connection_handler with legacy_connection_handling"
+        end
+
         original, self.prevent_writes = self.prevent_writes, enabled
         yield
       ensure

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -189,8 +189,23 @@ module ActiveRecord
       self.connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klass: self }
     end
 
+    # Prevent writing to the database regardless of role.
+    #
+    # In some cases you may want to prevent writes to the database
+    # even if you are on a database that can write. `while_preventing_writes`
+    # will prevent writes to the database for the duration of the block.
+    #
+    # This method does not provide the same protection as a readonly
+    # user and is meant to be a safeguard against accidental writes.
+    #
+    # See `READ_QUERY` for the queries that are blocked by this
+    # method.
     def while_preventing_writes(enabled = true, &block)
-      connected_to(role: current_role, prevent_writes: enabled, &block)
+      if legacy_connection_handling
+        connection_handler.while_preventing_writes(enabled)
+      else
+        connected_to(role: current_role, prevent_writes: enabled, &block)
+      end
     end
 
     # Returns true if role is the current connected role.


### PR DESCRIPTION
In Rails 6.1 `while_preventing_writes `moved to be called on `Base`
since we no longer have multiple connection_handlers. This change guards
against calling `while_preventing_writes` on the `connection_handler` if
we're not in legacy mode. For the new `while_preventing_writes` we can
call out to the `connection_handler` from there if in legacy mode. We
could do this on the legacy version but I'd like to use this raise as a
kind of hard deprecation. I've also documented the new method to match
docs from the previous method.