### PR TITLE
Arel: Add support for FILTER clause (SQL:2003)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Arel: Add support for FILTER clause (SQL:2003)
+
+    Currently supported by PostgreSQL 9.4+ and SQLite 3.30+
+
+    Example usage:
+
+        Model.all.pluck(
+          Arel.star.count.as('records_total').to_sql,
+          Arel.star.count.filter(Model.arel_table[:some_column].not_eq(nil)).as('records_filtered').to_sql,
+        )
+
+    Example result:
+
+        SELECT
+          COUNT(*) AS records_total,
+          COUNT(*) FILTER (WHERE "some_column" IS NOT NULL) AS records_filtered
+        FROM models
+
+    *Andrey Novikov*
+
 *   Two change tracking methods are added for `belongs_to` associations.
 
     The `association_changed?` method (assuming an association named `:association`) returns true

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -7,6 +7,7 @@ require "arel/factory_methods"
 
 require "arel/expressions"
 require "arel/predications"
+require "arel/filter_predications"
 require "arel/window_predications"
 require "arel/math"
 require "arel/alias_predication"

--- a/activerecord/lib/arel/filter_predications.rb
+++ b/activerecord/lib/arel/filter_predications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Arel
+  module FilterPredications
+    def filter(expr)
+      Nodes::Filter.new(self, expr)
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -28,6 +28,7 @@ require "arel/nodes/with"
 # binary
 require "arel/nodes/binary"
 require "arel/nodes/equality"
+require "arel/nodes/filter"
 require "arel/nodes/in"
 require "arel/nodes/join_source"
 require "arel/nodes/delete_statement"

--- a/activerecord/lib/arel/nodes/filter.rb
+++ b/activerecord/lib/arel/nodes/filter.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Arel
+  module Nodes
+    class Filter < Binary
+      include Arel::WindowPredications
+      include Arel::AliasPredication
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/function.rb
+++ b/activerecord/lib/arel/nodes/function.rb
@@ -4,6 +4,7 @@ module Arel # :nodoc: all
   module Nodes
     class Function < Arel::Nodes::NodeExpression
       include Arel::WindowPredications
+      include Arel::FilterPredications
       attr_accessor :expressions, :alias, :distinct
 
       def initialize(expr, aliaz = nil)

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -245,6 +245,13 @@ module Arel # :nodoc: all
           collector << ")"
         end
 
+        def visit_Arel_Nodes_Filter(o, collector)
+          visit o.left, collector
+          collector << " FILTER (WHERE "
+          visit o.right, collector
+          collector << ")"
+        end
+
         def visit_Arel_Nodes_Rows(o, collector)
           if o.expr
             collector << "ROWS "

--- a/activerecord/test/cases/arel/nodes/filter_test.rb
+++ b/activerecord/test/cases/arel/nodes/filter_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "../helper"
+
+module Arel
+  module Nodes
+    class ::FilterTest < Arel::Spec
+      describe "Filter" do
+        it "should add filter to expression" do
+          table = Arel::Table.new :users
+          _(table[:id].count.filter(table[:income].gteq(40_000)).to_sql).must_be_like %{
+              COUNT("users"."id") FILTER (WHERE "users"."income" >= 40000)
+            }
+        end
+
+        describe "as" do
+          it "should alias the expression" do
+            table = Arel::Table.new :users
+            _(table[:id].count.filter(table[:income].gteq(40_000)).as("rich_users_count").to_sql).must_be_like %{
+              COUNT("users"."id") FILTER (WHERE "users"."income" >= 40000) AS rich_users_count
+            }
+          end
+        end
+
+        describe "over" do
+          it "should reference the window definition by name" do
+            table = Arel::Table.new :users
+            window = Arel::Nodes::Window.new.partition(table[:year])
+            _(table[:id].count.filter(table[:income].gteq(40_000)).over(window).to_sql).must_be_like %{
+              COUNT("users"."id") FILTER (WHERE "users"."income" >= 40000) OVER (PARTITION BY "users"."year")
+            }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reopened from https://github.com/rails/arel/pull/518 due to the numerous requests of users (also in https://github.com/rails/arel/issues/460).

Allows to write following Ruby code:
```ruby
Model.all.pluck(
  Arel.star.count.as('records_total').to_sql,
  Arel.star.count.filter(Model.arel_table[:some_column].not_eq(nil)).as('records_filtered').to_sql,
)
```

to get following SQL:

```sql
SELECT
  COUNT(*) AS records_total  
  COUNT(*) FILTER (WHERE some_column IS NOT NULL) AS records_filtered
FROM models
```

Database support:

 1. PostgreSQL 9.4+ (december 2014, [release notes](https://www.postgresql.org/docs/9.4/release-9-4.html))
 2. SQLite 3.30+ (october 2019, [release notes](https://sqlite.org/changes.html#version_3_30_0))

See:

 - http://modern-sql.com/feature/filter
 - https://www.postgresql.org/docs/9.4/static/sql-expressions.html#SYNTAX-AGGREGATES
 - https://sqlite.org/lang_aggfunc.html#aggfilter