### PR TITLE
Hash to query with flexible options hash

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -70,18 +70,32 @@ class Hash
   #   {name: 'David', nationality: 'Danish'}.to_query('user')
   #   # => "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
   #
-  # The string pairs "key=value" that conform the query string
-  # are sorted lexicographically in ascending order.
+  # An options hash can be passed instead of namespace,
+  # with support for the following keys:
+  #  :namespace, as described above
+  #  :preserve_order, to rely on existing hash ordering
+  #  for the string pairs "key=value"
+  #
+  # The string pairs "key=value" that form the query string
+  # are sorted lexicographically in ascending order by default.
   #
   # This method is also aliased as +to_param+.
-  def to_query(namespace = nil)
+  def to_query(options = {})
+    if options.is_a?(Hash)
+      # support newer contract with an options hash
+      namespace = options[:namespace]
+      preserve_order = options[:preserve_order]
+    else
+      # support older contract with a single namespace argument
+      namespace = options
+    end
     query = collect do |key, value|
       unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end
     end.compact
 
-    query.sort! unless namespace.to_s.include?("[]")
+    query.sort! unless namespace.to_s.include?("[]") || preserve_order
     query.join("&")
   end
 

--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -81,7 +81,8 @@ class Hash
   #
   # This method is also aliased as +to_param+.
   def to_query(options = {})
-    if options.is_a?(Hash)
+    valid_options = Set[:namespace, :preserve_order].freeze
+    if options.is_a?(Hash) && options.all? { |key, _value| valid_options.include?(key) }
       # support newer contract with an options hash
       namespace = options[:namespace]
       preserve_order = options[:preserve_order]

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -113,6 +113,13 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_equal expected, URI.decode_www_form_component(actual)
   end
 
+  def test_hash_as_a_key
+    inner = { weird_key: 'yes' }
+    weird_hash = { inner => 'my weird value' }
+    expected = "weird_key%3Dyes=my+weird+value"
+    assert_equal expected, weird_hash.to_query
+  end
+
   private
     def assert_query_equal(expected, actual)
       assert_equal expected.split("&"), actual.to_query.split("&")

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -114,8 +114,8 @@ class ToQueryTest < ActiveSupport::TestCase
   end
 
   def test_hash_as_a_key
-    inner = { weird_key: 'yes' }
-    weird_hash = { inner => 'my weird value' }
+    inner = { weird_key: "yes" }
+    weird_hash = { inner => "my weird value" }
     expected = "weird_key%3Dyes=my+weird+value"
     assert_equal expected, weird_hash.to_query
   end

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -72,6 +72,11 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_equal "user%5Bname%5D=Nakshay&user%5Bnationality%5D=Indian", hash.to_query("user")
   end
 
+  def test_hash_with_namespace_option
+    hash = { name: "Nakshay", nationality: "Indian" }
+    assert_equal "user%5Bname%5D=Nakshay&user%5Bnationality%5D=Indian", hash.to_query(namespace: "user")
+  end
+
   def test_hash_sorted_lexicographically
     hash = { type: "human", name: "Nakshay" }
     assert_equal "name=Nakshay&type=human", hash.to_query
@@ -89,6 +94,23 @@ class ToQueryTest < ActiveSupport::TestCase
     expected = "foo[contents][][name]=gorby&foo[contents][][id]=123&foo[contents][][name]=puff&foo[contents][][d]=true"
 
     assert_equal expected, URI.decode_www_form_component(params.to_query)
+  end
+
+  def test_hash_not_sorted_lexicographically_if_option_specified
+    hash={type: "human", name: "Nakshay"}
+    assert_equal "type=human&name=Nakshay", hash.to_query(preserve_order: true)
+  end
+
+  def test_hash_sorted_lexicographically_if_option_specified
+    hash = { type: "human", name: "Nakshay" }
+    assert_equal "name=Nakshay&type=human", hash.to_query(preserve_order: false)
+  end
+
+  def test_hash_with_namespace_and_preserve_order_options_provided
+    hash={type: "human", name: "Nakshay"}
+    expected = "earth[type]=human&earth[name]=Nakshay"
+    actual = hash.to_query(preserve_order: true, namespace: "earth")
+    assert_equal expected, URI.decode_www_form_component(actual)
   end
 
   private

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -97,7 +97,7 @@ class ToQueryTest < ActiveSupport::TestCase
   end
 
   def test_hash_not_sorted_lexicographically_if_option_specified
-    hash={type: "human", name: "Nakshay"}
+    hash = { type: "human", name: "Nakshay" }
     assert_equal "type=human&name=Nakshay", hash.to_query(preserve_order: true)
   end
 
@@ -107,7 +107,7 @@ class ToQueryTest < ActiveSupport::TestCase
   end
 
   def test_hash_with_namespace_and_preserve_order_options_provided
-    hash={type: "human", name: "Nakshay"}
+    hash = { type: "human", name: "Nakshay" }
     expected = "earth[type]=human&earth[name]=Nakshay"
     actual = hash.to_query(preserve_order: true, namespace: "earth")
     assert_equal expected, URI.decode_www_form_component(actual)


### PR DESCRIPTION
Add support for an options hash to `Hash#to_query` in place of the current single `namespace` parameter, including an option to keep existing hash ordering rather than sort lexicographically.  Implemented in a manner that is mostly, but not 100%, backwards compatible (see "Other Information" below.)

### Summary

Many Rails developers are now used to hash iteration ordering being predictable and may build hashes desiring `.to_query` to preserve that ordering.  This change will allow that use, while largely preserving backwards compatibility.

As a bonus, a structure will now be in place to support more sophisticated optional behavior of this method in the future without breaking backwards compatibility.

### Other Information

In the (unlikely?) event that any existing code is passing a Hash as the `namespace` option, this will fall back to the older behavior after testing the incoming hash keys against valid options. It should only be the rarest of cases where these changes are not backward compatible (someone is using a hash as a key which *happens* to use only the keys `:namespace` and/or `:preserve_order`.) This costs some lookup against a Set of valid options so may impact performance a bit. May need some performance-testing due diligence.

See related Pull Request without this options-checking (less new code, but introduces breaking changes for hashes that themselves use hashes as their keys) here: https://github.com/rails/rails/pull/40494