### PR TITLE
Guides: update description of `to_prepare` event in the Configuration section

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1454,7 +1454,7 @@ Rails has 5 initialization events which can be hooked into (listed in the order 
 
 * `before_initialize`: This is run directly before the initialization process of the application occurs with the `:bootstrap_hook` initializer near the beginning of the Rails initialization process.
 
-* `to_prepare`: Run after the initializers are run for all Railties (including the application itself), but before eager loading and the middleware stack is built. More importantly, will run upon every request in `development`, but only once (during boot-up) in `production` and `test`.
+* `to_prepare`: Run after the initializers are run for all Railties (including the application itself), but before eager loading and the middleware stack is built. More importantly, will run upon every code reload in `development`, but only once (during boot-up) in `production` and `test`.
 
 * `before_eager_load`: This is run directly before eager loading occurs, which is the default behavior for the `production` environment and not for the `development` environment.
 


### PR DESCRIPTION
### Summary

The description of `to_prepare` events says that provided callback is executed on every request during `development` which I believe is no longer accurate.

### Other Information

Callbacks provided to `Railtie::Configuration.to_prepare` are eventually passed to `ActiveSupport::Reloader.to_prepare` in the [Application::Finisher initializer](https://github.com/rails/rails/blob/v6.0.3.4/railties/lib/rails/application/finisher.rb#L104). Those callbacks are executed once at application startup but also before a work run that is reloading (according to [`ActiveSupport::Reloader` comments](https://github.com/rails/rails/blob/v6.0.3.4/activesupport/lib/active_support/reloader.rb#L10))
