### PR TITLE
Support an options hash in Hash#to_query including preserve_order

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/to_query.rb
+++ b/activesupport/lib/active_support/core_ext/object/to_query.rb
@@ -59,6 +59,8 @@ class Array
 end
 
 class Hash
+  @@valid_options_for_to_query = Set[:namespace, :preserve_order].freeze
+
   # Returns a string representation of the receiver suitable for use as a URL
   # query string:
   #
@@ -70,18 +72,32 @@ class Hash
   #   {name: 'David', nationality: 'Danish'}.to_query('user')
   #   # => "user%5Bname%5D=David&user%5Bnationality%5D=Danish"
   #
-  # The string pairs "key=value" that conform the query string
-  # are sorted lexicographically in ascending order.
+  # An options hash can be passed in place of namespace,
+  # with support for the following keys:
+  #  :namespace, as described above
+  #  :preserve_order, to rely on existing hash ordering
+  #  for the string pairs "key=value"
+  #
+  # The string pairs "key=value" that form the query string
+  # are sorted lexicographically in ascending order by default.
   #
   # This method is also aliased as +to_param+.
-  def to_query(namespace = nil)
+  def to_query(options_or_namespace = nil)
+    if options_or_namespace.is_a?(Hash) && options_or_namespace.all? { |key, _value| @@valid_options_for_to_query.include?(key) }
+      # support newer contract with an options hash
+      namespace = options_or_namespace[:namespace]
+      preserve_order = options_or_namespace[:preserve_order]
+    else
+      # support older contract with a single namespace argument
+      namespace = options_or_namespace
+      preserve_order = false
+    end
     query = collect do |key, value|
       unless (value.is_a?(Hash) || value.is_a?(Array)) && value.empty?
         value.to_query(namespace ? "#{namespace}[#{key}]" : key)
       end
     end.compact
-
-    query.sort! unless namespace.to_s.include?("[]")
+    query.sort! unless preserve_order || namespace.to_s.include?("[]")
     query.join("&")
   end
 

--- a/activesupport/test/core_ext/object/to_query_test.rb
+++ b/activesupport/test/core_ext/object/to_query_test.rb
@@ -72,6 +72,11 @@ class ToQueryTest < ActiveSupport::TestCase
     assert_equal "user%5Bname%5D=Nakshay&user%5Bnationality%5D=Indian", hash.to_query("user")
   end
 
+  def test_hash_with_namespace_option
+    hash = { name: "Nakshay", nationality: "Indian" }
+    assert_equal "user%5Bname%5D=Nakshay&user%5Bnationality%5D=Indian", hash.to_query(namespace: "user")
+  end
+
   def test_hash_sorted_lexicographically
     hash = { type: "human", name: "Nakshay" }
     assert_equal "name=Nakshay&type=human", hash.to_query
@@ -89,6 +94,39 @@ class ToQueryTest < ActiveSupport::TestCase
     expected = "foo[contents][][name]=gorby&foo[contents][][id]=123&foo[contents][][name]=puff&foo[contents][][d]=true"
 
     assert_equal expected, URI.decode_www_form_component(params.to_query)
+  end
+
+  def test_hash_not_sorted_lexicographically_if_option_specified
+    hash = { type: "human", name: "Nakshay" }
+    assert_equal "type=human&name=Nakshay", hash.to_query(preserve_order: true)
+  end
+
+  def test_hash_sorted_lexicographically_if_option_specified
+    hash = { type: "human", name: "Nakshay" }
+    assert_equal "name=Nakshay&type=human", hash.to_query(preserve_order: false)
+  end
+
+  def test_hash_with_namespace_and_preserve_order_options_provided
+    hash = { type: "human", name: "Nakshay" }
+    expected = "earth[type]=human&earth[name]=Nakshay"
+    actual = hash.to_query(preserve_order: true, namespace: "earth")
+    assert_equal expected, URI.decode_www_form_component(actual)
+  end
+
+  def test_hash_as_a_namespace
+    hash = { type: "human", name: "Nakshay" }
+    hash_namespace = { weird_namespace: "yes" }
+    actual = hash.to_query(hash_namespace)
+    expected = '{:weird_namespace=>"yes"}[name]=Nakshay&{:weird_namespace=>"yes"}[type]=human'
+    assert_equal expected, CGI.unescape(actual)
+  end
+
+  def test_hash_with_hash_key
+    hash_as_key = { weird_key: "yes" }
+    main_hash = { hash_as_key => "myvalue" }
+    actual = main_hash.to_query()
+    expected = "weird_key%3Dyes=myvalue"
+    assert_equal expected, actual
   end
 
   private


### PR DESCRIPTION
Add support for an options hash to `Hash#to_query` in place of the current single `namespace` parameter, including an option to keep existing hash ordering rather than sort lexicographically.  Implemented in a manner that is nearly 100%, backwards compatible (see "Other Information" below.)

### Summary

Many Rails developers are now accustomed to hash iteration ordering being predictable and may build hashes desiring `.to_query` to preserve that ordering.  This change will allow that use, while still preserving almost total backwards compatibility.

As a bonus, a structure will now be in place to support more sophisticated optional behavior of this method in the future without breaking backwards compatibility (standard options hash approach.)

```
# old interface, still supported;
my_hash.to_query 'myNamespace'

# new interface:
my_hash.to_query namespace: 'myNamespace'
my_hash.to_query namespace: 'myNamespace', preserve_order: true
```

### Other Information

In the (unlikely?) event that any existing code is passing a Hash as the `namespace` option, this will fall back to the older behavior after testing the incoming hash keys against valid options. It should only be the rarest of cases where these changes are not backward compatible (someone is using a hash as a key which *happens* to use only the keys `:namespace` and/or `:preserve_order`.) This costs some lookup against a Set of valid options so may impact performance a bit. May need some performance-testing due diligence.
