### PR TITLE
ARIA attributes: serialize empty Hash and Array as nil

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -84,7 +84,15 @@ module ActionView
               value.each_pair do |k, v|
                 next if v.nil?
 
-                v = (v.is_a?(Array) || v.is_a?(Hash)) ? safe_join(TagHelper.build_tag_values(v), " ") : v.to_s
+                case v
+                when Array, Hash
+                  tokens = TagHelper.build_tag_values(v)
+                  next if tokens.none?
+
+                  v = safe_join(tokens, " ")
+                else
+                  v = v.to_s
+                end
 
                 output << sep
                 output << prefix_tag_option(key, k, v, escape)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -449,11 +449,11 @@ class TagHelperTest < ActionView::TestCase
   def test_aria_attributes
     ["aria", :aria].each { |aria|
       assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
-        tag("a", aria => { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { a: true, b: "truthy", falsey: false, nil: nil }, tokens: ["a", { b: true, c: false }], string_with_quotes: 'double"quote"party"' })
+        tag("a", aria => { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })
     }
 
     assert_dom_equal '<a aria-a-float="3.14" aria-a-big-decimal="-123.456" aria-a-number="1" aria-truthy="true" aria-falsey="false" aria-array="1 2 3" aria-hash="a b" aria-tokens="a b" aria-string-with-quotes="double&quot;quote&quot;party&quot;" aria-string="hello" aria-symbol="foo" />',
-    tag.a(aria: { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], hash: { a: true, b: "truthy", falsey: false, nil: nil }, tokens: ["a", { b: true, c: false }], string_with_quotes: 'double"quote"party"' })
+    tag.a(aria: { nil: nil, a_float: 3.14, a_big_decimal: BigDecimal("-123.456"), a_number: 1, truthy: true, falsey: false, string: "hello", symbol: :foo, array: [1, 2, 3], empty_array: [], hash: { a: true, b: "truthy", falsey: false, nil: nil }, empty_hash: {}, tokens: ["a", { b: true, c: false }], empty_tokens: [{ a: false }], string_with_quotes: 'double"quote"party"' })
   end
 
   def test_link_to_data_nil_equal


### PR DESCRIPTION
### Summary

As a follow-up to [rails/rails#40479][], ensure that empty Hash and
Array arguments are treated as `nil`.

For example, when conditionally rendering an [aria-describedby][]
attribute to associate an input with a related validation error, treat
an empty Array as `nil`, an omit the attribute entirely:

```html+erb
<% post = Post.new %>

<%= form_with model: post do |form| %>
  <%= form.text_field :title, aria: { describedby: { post_title_error: post.errors[:title].any? } } %>
  <%= tag.span(post.errors[:title].to_sentence, id: :post_title_error) if post.errors[:title].any? %>
<% end %>
```

In this example, when there are no errors, the desired outcome is for
the `<input type="text" name="post[title]">` element to _omit_ the
`[aria-describedby="post_title_error"]` attribute, and to only include
it when there are errors on the `title` attribute.

Without this change, the desired outcome can be achieved with a
combination of a `#token_list` and `#presence` call:

```diff
<% post = Post.new %>

<%= form_with model: post do |form| %>
-  <%= form.text_field :title, aria: { describedby: {post_title_error: post.errors[:title].any?} }
+  <%= form.text_field :title, aria: { describedby: token_list(post_title_error: post.errors[:title].any?).presence } %>
  <%= tag.span(post.errors[:title].to_sentence, id: :post_title_error) if post.errors[:title].any? %>
<% end %>
```

[rails/rails#40479]: https://github.com/rails/rails/pull/40479
[aria-describedby]: https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA21#example-2-identifying-errors-in-data-format

