### PR TITLE
Fix triple-click-to-select for IRB code examples [ci-skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -763,8 +763,8 @@ div.important p, div.caution p, div.warning p, div.note p, div.info p {
   margin-bottom: 1em;
 }
 
-/* When triple-clicking shell code, select only the command, not the prompt */
-code.highlight.console span.w {
+/* When triple-clicking console code, select only the command, not the prompt */
+code.highlight.console span.w, code.highlight.irb span.w {
   display: table-cell;
 }
 


### PR DESCRIPTION
Previously, both the IRB prompt and the line of code were selected on triple-click.  This commit causes only the line of code to be selected.