### PR TITLE
Increasing Puma's worker timeout in development

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt
@@ -8,6 +8,11 @@ max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
+# Specifies the `worker_timeout` threshold that Puma will use to wait before
+# terminating a worker in development environments.
+#
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
 port ENV.fetch("PORT") { 3000 }


### PR DESCRIPTION
### Summary 
After Puma's version 5, a worker timeout check was added, causing all
debugging sessions (byebug, binding.irb, ...) to be terminated after a
minute is passed.

One minute timeout is fine for production environments but not for
development, when we usually debug stuff and need more than a minute to
do so.

This PR updates Puma's config template file to include a worker timeout
of one hour, only for development environments.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
This panned out after https://github.com/puma/puma/pull/2443#issuecomment-714688496 @nateberkopec's comment. 