### PR TITLE
Reduce object allocations in param wrapping

### DIFF
--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -264,9 +264,11 @@ module ActionController
       def _extract_parameters(parameters)
         if include_only = _wrapper_options.include
           parameters.slice(*include_only)
+        elsif _wrapper_options.exclude
+          exclude = _wrapper_options.exclude + EXCLUDE_PARAMETERS
+          parameters.except(*exclude)
         else
-          exclude = _wrapper_options.exclude || []
-          parameters.except(*(exclude + EXCLUDE_PARAMETERS))
+          parameters.except(*EXCLUDE_PARAMETERS)
         end
       end
 


### PR DESCRIPTION
### Summary

When wrapping parameters, `_extract_parameters` is called twice for
every request. In most cases, both the `include` and `exclude` options
will be empty. In that case, we can use a logical check to save
allocation of an empty array and another allocation of a new array
concatenating the empty array with the hard-coded `EXCLUDE_PARAMETERS`.
The result is 4 array allocations less per request when wrapping is
enabled.

### Other Information

Memory benchmark:
```ruby
EXCLUDE_PARAMETERS = %w(authenticity_token _method utf8)
parameters = {}
opt = nil # stand-in for `_wrapper_options.exclude`
Benchmark.memory do |x|
  x.report("old") do
    exclude = opt || []
    parameters.except(*(exclude + EXCLUDE_PARAMETERS))
  end
  x.report("new") do
    if opt
      exclude = opt + EXCLUDE_PARAMETERS
      parameters.except(*exclude)
    else
      parameters.except(*EXCLUDE_PARAMETERS)
    end
  end
  x.compare!
end

Calculating -------------------------------------
                 old   432.000  memsize (    40.000  retained)
                         6.000  objects (     1.000  retained)
                         0.000  strings (     0.000  retained)
                 new   352.000  memsize (     0.000  retained)
                         4.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)

Comparison:
                 new:        352 allocated
                 old:        432 allocated - 1.23x more
```

Speed benchmark (same benchmark as above only using `Benchmark.ips`):

```ruby
Warming up --------------------------------------
                 old   267.696k i/100ms
                 new   381.881k i/100ms
Calculating -------------------------------------
                 old      2.743M (± 2.8%) i/s -     13.920M in   5.079153s
                 new      3.892M (± 1.8%) i/s -     19.476M in   5.005470s

Comparison:
                 new:  3892245.1 i/s
                 old:  2742923.0 i/s - 1.42x  (± 0.00) slower

```

When setting `opt` to an array (simulating the case of `exclude`
option set) both benchmarks result in no measurable difference
between the implementations, so there is no performance degradation
in that case either.

