### PR TITLE
[ActionText] Add a warning to avoid silently failing uploads

### DIFF
--- a/actiontext/app/javascript/actiontext/attachment_upload.js
+++ b/actiontext/app/javascript/actiontext/attachment_upload.js
@@ -36,7 +36,11 @@ export class AttachmentUpload {
   }
 
   get directUploadUrl() {
-    return this.element.dataset.directUploadUrl
+    const uploadUrl = this.element.dataset.directUploadUrl
+    if (!uploadUrl) {
+      throw new Error(`The field (${this.element}) is missing a directUploadUrl data value. Did you use a Rails helper to create this field?`)
+    }
+    return uploadUrl
   }
 
   get blobUrlTemplate() {


### PR DESCRIPTION
### Summary

If you use actiontext with a rich text field then you expect image uploads to "just work". However if you neglect to use the Rails helper and use `<trix-editor ...>` yourself, then you're missing some required data attributes that facilitate uploads.

This is particularly confusing because dragging in images into the Trix editor _appears_ to work. You see the preview immediately, but the upload fails in the background. Saving still works, but your image will be gone.

If you open the console you can see...

> POST /your/action/undefined

But it's unclear where this is coming from or why.

To avoid having developers spin their wheels trying to track this down, I think it should fail earlier.

This change adds an error if the `directUploadUrl` data value is missing on the element so the error becomes more obvious.

### Other Information

In my case I had to change this:

```erb
<%= f.hidden_field field.attribute, id: field.attribute %>
<trix-editor input="<%= field.attribute %>">
```

To this:

```erb
<%= f.hidden_field field.attribute, id: field.attribute %>
<%= f.rich_text_area field.attribute %>
```

Had I seen a helpful message like the one that this PR suggests, then it would have been a 5-minute fix, rather than (I don't want to say how long I spent tracking this down lol).
