### PR TITLE
Set default digest to SHA256 for message verifier

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -106,7 +106,7 @@ module ActiveSupport
     def initialize(secret, digest: nil, serializer: nil)
       raise ArgumentError, "Secret should not be nil." unless secret
       @secret = secret
-      @digest = digest || "SHA1"
+      @digest = digest || "SHA256"
       @serializer = serializer || Marshal
     end
 


### PR DESCRIPTION
### Summary
Set default digest to SHA256 for message verifier
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
