### PR TITLE
Allow applications to change the behavior for a strict loading violation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add option to raise or log for `ActiveRecord::StrictLoadingViolationError`.
+
+    Some applications may not want to raise an error in production if using `strict_loading`. This would allow an application to set strict loading to log for the production environment while still raising in development and test environments.
+
+    Set `config.active_record.action_on_strict_loading_violation` to `:log` errors instead of raising.
+
+    *Eileen M. Uchitelle*
+
 *   Allow the inverse of a `has_one` association that was previously autosaved to be loaded.
 
     Fixes #34255.

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -208,11 +208,11 @@ module ActiveRecord
       private
         def find_target
           if owner.strict_loading?
-            raise StrictLoadingViolationError, "#{owner.class} is marked as strict_loading and #{klass} cannot be lazily loaded."
+            Base.strict_loading_violation!(owner: owner.class, association: klass)
           end
 
           if reflection.strict_loading?
-            raise StrictLoadingViolationError, "The #{reflection.name} association is marked as strict_loading and cannot be lazily loaded."
+            Base.strict_loading_violation!(owner: owner.class, association: reflection.name)
           end
 
           scope = self.scope

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -19,6 +19,15 @@ module ActiveRecord
       rt
     end
 
+    def strict_loading_violation(event)
+      debug do
+        owner = event.payload[:owner]
+        association = event.payload[:association]
+
+        color("Strict loading violation: #{association} lazily loaded on #{owner}.", RED)
+      end
+    end
+
     def sql(event)
       self.class.runtime += event.duration
       return unless logger.debug?

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -436,6 +436,11 @@ in controllers and views. This defaults to `false`.
   controls whether a record fails validation if `belongs_to` association is not
   present.
 
+* `config.active_record.action_on_strict_loading_violation` enables raising or
+  logging an exception if strict_loading is set on an association. The default
+  value is `:raise` in all environments. It can be changed to `:log` to send
+  violations to the logger instead of raising.
+
 * `config.active_record.strict_loading_by_default` is a boolean value
   that either enables or disables strict_loading mode by default.
   Defaults to `false`.


### PR DESCRIPTION
Originally strict loading violations would always raise an error if
turned on for an association. This change allows for an application to
optionally log instead of raise. The behavior here is similar to how
strong parameters work. By default all environments will raise. An
application may want to use log in production while working on finding
all lazily loaded associations.

Set `config.active_record.action_on_strict_loading_violation` to `:log`
in your application to log instead of raise.

Thanks to @cheshire137 for the feature request.