### PR TITLE
Create unit test to use to_time for timestamp in string

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/string/conversions.rb
@@ -18,6 +18,7 @@ class String
   #   "2012-12-13T06:12".to_time         # => 2012-12-13 06:12:00 +0100
   #   "2012-12-13T06:12".to_time(:utc)   # => 2012-12-13 06:12:00 UTC
   #   "12/13/2012".to_time               # => ArgumentError: argument out of range
+  #   "1604326192".to_time               # => ArgumentError: argument out of range
   def to_time(form = :local)
     parts = Date._parse(self, false)
     used_keys = %i(year mon mday hour min sec sec_fraction offset)

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -573,6 +573,14 @@ class StringConversionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_timestamp_string_to_time
+    exception = assert_raises(ArgumentError) do
+      "1604326192".to_time
+    end
+
+    assert_equal "argument out of range", exception.message
+  end
+
   def test_string_to_time_utc_offset
     with_env_tz "US/Eastern" do
       if ActiveSupport.to_time_preserves_timezone


### PR DESCRIPTION
### Summary
While working with `to_time`, I expected that timestamp in string will be converted to date. But it's not. I have added document for timestamp and also added a unit test for timestamp with `to_time`.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
