### PR TITLE
Tweak generated default filter_parameters

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt
@@ -2,5 +2,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
-  :password, :secret, :token, :_key, :auth, :crypt, :salt, :certificate, :otp, :access, :private, :protected, :ssn
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]


### PR DESCRIPTION
Follow-up to #34218.

This removes some filters that could filter innocuous fields such as `author_name`.  Filtering such fields might be surprising, especially to people generating their first Rails app.

This commit also changes the `:password` filter to `:passw` so that it can also filter fields such as `passwd`.

---

/cc @eliotsykes

I wanted to revisit this before Rails 6.1.  I do like the idea of providing better / safer defaults.  I looked through several apps in https://github.com/eliotsykes/real-world-rails/tree/master/apps (great resource, by the way! :+1:), and I think the filters in this PR still cover most of the common cases.  For example, fields like `auth_token` are still covered by `:token`.  Are there any particularly common cases that wouldn't be covered by the remaining filters?
