### PR TITLE
Use official sdoc gem instead of fork [skip ci]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", github: "p8/sdoc", branch: "without-frames"
+  gem "sdoc", "~> 2.0"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,14 +29,6 @@ GIT
       websocket
 
 GIT
-  remote: https://github.com/p8/sdoc.git
-  revision: a5e95cafdebf8a76ea21f2237e6349223f9ecac5
-  branch: without-frames
-  specs:
-    sdoc (1.1.0)
-      rdoc (>= 5.0)
-
-GIT
   remote: https://github.com/resque/redis-namespace.git
   revision: c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e
   specs:
@@ -470,6 +462,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sdoc (2.0.0)
+      rdoc (>= 5.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -619,7 +613,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails
-  sdoc!
+  sdoc (~> 2.0)
   selenium-webdriver (>= 3.141.592)
   sequel
   sidekiq


### PR DESCRIPTION
Sdoc 2.0.0 has been released, replacing frames with css.
