### PR TITLE
Use LoadError#original_message if available in depend_on

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -375,7 +375,12 @@ module ActiveSupport #:nodoc:
       require_or_load(path || file_name)
     rescue LoadError => load_error
       if file_name = load_error.message[/ -- (.*?)(\.rb)?$/, 1]
-        load_error.message.replace(message % file_name)
+        load_error_message = if load_error.respond_to?(:original_message)
+          load_error.original_message
+        else
+          load_error.message
+        end
+        load_error_message.replace(message % file_name)
         load_error.copy_blame!(load_error)
       end
       raise

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -42,6 +42,13 @@ class DependenciesTest < ActiveSupport::TestCase
     assert_equal expected.path, e.path
   end
 
+  def test_depend_on_message
+    e = assert_raises(LoadError) do
+      ActiveSupport::Dependencies.depend_on "omgwtfbbq"
+    end
+    assert_equal "No such file to load -- omgwtfbbq.rb", e.message
+  end
+
   def test_require_dependency_accepts_an_object_which_implements_to_path
     o = Object.new
     def o.to_path; "dependencies/service_one"; end


### PR DESCRIPTION
did_you_mean 1.5.0 will add suggestions to `LoadError` (previously: https://github.com/rails/rails/pull/39743). This means that `LoadError#message` will now return a new string on each invocation, and mutating the result will no longer modify the error's message.

The only test covering this behaviour was an Action View / Action Pack integration test which no longer exists on master, but can be seen failing on 6-0-stable here:

https://buildkite.com/rails/rails/builds/72495#d743d7e6-4e76-4c81-b4cf-7b3e8966f06d/976-996