### PR TITLE
Fix #40518 by avoiding setting APP_PATH if already defined

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -40,7 +40,10 @@ This file is as follows:
 
 ```ruby
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../config/application', __dir__)
+unless defined?(APP_PATH)
+  APP_PATH = File.expand_path('../config/application', __dir__)
+end
+
 require_relative "../config/boot"
 require "rails/commands"
 ```

--- a/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
@@ -1,3 +1,6 @@
-APP_PATH = File.expand_path('../config/application', __dir__)
+unless defined?(APP_PATH)
+  APP_PATH = File.expand_path('../config/application', __dir__)
+end
+
 require_relative "../config/boot"
 require "rails/commands"


### PR DESCRIPTION
### Summary

Resolves #40518

I was able to confirm that this is caused by `spring`. The `bin/rails` binstub is getting called twice when using `spring`, and the second time it is called, the `already initialized constant` warning is triggered.

![image](https://user-images.githubusercontent.com/6373536/97955152-47a7cd00-1d84-11eb-9989-a9c5db431100.png)

Without spring
![image](https://user-images.githubusercontent.com/6373536/97955242-7d4cb600-1d84-11eb-96f6-d6d1767bd27c.png)

