### PR TITLE
[v6.1.0.rc1] Fix regression for select tag helper with array

### DIFF
--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -15,7 +15,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value || value.to_s },
+            selected: @options.fetch(:selected) { value.nil? ? "" : value },
             disabled: @options[:disabled]
           }
 

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -15,7 +15,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value.to_s },
+            selected: @options.fetch(:selected) { value || value.to_s },
             disabled: @options[:disabled]
           }
 

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -851,6 +851,15 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_array
+    @continent = Continent.new
+    @continent.countries = ["Africa", "Europe"]
+    assert_dom_equal(
+      %(<select name="continent[countries]" id="continent_countries"><option selected="selected" value="Africa">Africa</option>\n<option selected="selected" value="Europe">Europe</option>\n<option value="America">America</option></select>),
+      select("continent", "countries", %W(Africa Europe America), { multiple: true })
+    )
+  end
+
   def test_required_select
     assert_dom_equal(
       %(<select id="post_category" name="post[category]" required="required"><option value="" label=" "></option>\n<option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),


### PR DESCRIPTION
v6.1.0.rc1 does not generate DOM with the selected attribute when the object's method returns an array.
This is because it has been changed by #34809 to always convert to a string.

This commit fixes the issue.

## Steps to reproduce

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", ENV["RAILS_VERSION"]
end

require "action_view"
require "minitest/autorun"

class BugTest < ActionView::TestCase
  Post = Struct.new("Post", :tags)

  def test_stuff
    @post = Post.new
    @post.tags = ["foo", "bar"]
    expected = <<~DOM.strip
      <select name="post[tags]" id="post_tags"><option selected="selected" value="foo">foo</option>
      <option selected="selected" value="bar">bar</option>
      <option value="buz">buz</option></select>
    DOM

    assert_dom_equal(expected, select("post", "tags", %W(foo bar buz), { multiple: true }))
  end
end
```

The test succeeds on v6.0.3.4, but the test fails on v6.1.0.rc1.

```
# Running:

F

Failure:
BugTest#test_stuff [issue.rb:28]:
Expected: <select name="post[tags]" id="post_tags"><option selected="selected" value="foo">foo</option>
<option selected="selected" value="bar">bar</option>
<option value="buz">buz</option></select>
Actual: <select name="post[tags]" id="post_tags"><option value="foo">foo</option>
<option value="bar">bar</option>
<option value="buz">buz</option></select>
```