### PR TITLE
Fix formatting issue in multiple db docs [ci-skip]

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -403,8 +403,8 @@ It's also possible to swap connections granularly for shards.
 
 ```ruby
 AnimalsRecord.connected_to(role: :reading, shard: :shard_one) do
-  Dog.first # Will read from shard_one_replica. If no connection exists for
-  shard_one_replica, a ConnectionNotEstablished error will be raised
+  Dog.first # Will read from shard_one_replica. If no connection exists for shard_one_replica,
+  # a ConnectionNotEstablished error will be raised
   Person.first # Will read from primary writer
 end
 ```


### PR DESCRIPTION
### Summary

Fix formatting with multiple db docs, it's currently:

<img width="1034" alt="Screenshot 2020-11-03 at 13 42 07" src="https://user-images.githubusercontent.com/658005/97992534-b31c8980-1dda-11eb-8bf7-6088fc986b31.png">
