### PR TITLE
Add example usage pattern of ActiveRecord::Base.ignored_columns=

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -297,6 +297,35 @@ module ActiveRecord
 
       # Sets the columns names the model should ignore. Ignored columns won't have attribute
       # accessors defined, and won't be referenced in SQL queries.
+      #
+      # A common usage pattern for this method is to ensure all references to an attribute
+      # have been removed and deployed, before a migration to drop the column from the database
+      # has been deployed and run. Using this two step approach to dropping columns ensures there
+      # is no code that raises errors due to having a cached schema in memory at the time the
+      # schema migration is run.
+
+      # For example, given a model where you want to drop the "category" attribute, first mark it
+      # as ignored:
+      #
+      #   class Project < ActiveRecord::Base
+      #     # schema:
+      #     #   id         :bigint
+      #     #   name       :string, limit: 255
+      #     #   category   :string, limit: 255
+      #
+      #     self.ignored_columns = [:category]
+      #   end
+      #
+      # The schema still contains `category`, but now the model omits it, so any meta-driven code or
+      # schema caching will not attempt to use the column:
+      #
+      #   Project.columns_hash["category"] => nil
+      #
+      # You will get an error if accessing that attribute directly, so ensure all usages of the
+      # column are removed (automated tests can help you find any usages).
+      #
+      #   user = Project.create!(name: "First Project")
+      #   user.category # => raises NoMethodError
       def ignored_columns=(columns)
         reload_schema_from_cache
         @ignored_columns = columns.map(&:to_s).freeze


### PR DESCRIPTION
### Summary

This is a documentation change only, to provide more context and example usage to the [ActiveRecord::ModelSchema::ClassMethods#ignored_columns=](https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_columns-3D) method.

### Other Information

This started as a [feature request on the Rails forum](https://discuss.rubyonrails.org/t/feature-proposal-add-method-on-activerecord-to-safely-deprecate-attributes-before-dropping-them/76406/5?u=nburwell), but it was pointed out that this feature already exists starting in Rails 5.  Rafael suggested submitting an update to the documentation, so that hopefully others looking for this multi-step workflow to ensure zero downtime migrations will find this feature.

Thank you for your consideration.