### PR TITLE
Move Spring machinery back to bin files

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rails.tt
@@ -1,3 +1,6 @@
+<% if spring_install? -%>
+load File.expand_path("spring", __dir__)
+<% end -%>
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative "../config/boot"
 require "rails/commands"

--- a/railties/lib/rails/generators/rails/app/templates/bin/rake.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/rake.tt
@@ -1,3 +1,6 @@
+<% if spring_install? -%>
+load File.expand_path("spring", __dir__)
+<% end -%>
 require_relative "../config/boot"
 require "rake"
 Rake.application.run

--- a/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
@@ -1,7 +1,9 @@
-# Load Spring without loading other gems in the Gemfile, for speed.
-require "bundler"
-Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
-  Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-  gem "spring", spring.version
-  require "spring/binstub"
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  # Load Spring without loading other gems in the Gemfile, for speed.
+  require "bundler"
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
+    require "spring/binstub"
+  end
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/boot.rb.tt
@@ -1,10 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-<% if spring_install? -%>
-
-if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
-  load File.expand_path("../bin/spring", __dir__)
-end
-<% end -%>
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
 <% if depend_on_bootsnap? -%>

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -862,7 +862,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_gem "spring"
     assert_file "bin/spring", %r{^\s*require "spring/binstub"}
-    assert_file "config/boot.rb", %r{^\s*load .+\bbin/spring"}
+    assert_file "bin/rails", %r{^\s*load .+"spring"}
+    assert_file "bin/rake", %r{^\s*load .+"spring"}
     assert_file("config/environments/test.rb") do |contents|
       assert_match("config.cache_classes = false", contents)
       assert_match("config.action_view.cache_template_loading = true", contents)
@@ -893,7 +894,10 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file("config/environments/test.rb") do |contents|
       assert_match("config.cache_classes = true", contents)
     end
-    assert_file "config/boot.rb" do |contents|
+    assert_file "bin/rails" do |contents|
+      assert_no_match %r{spring}, contents
+    end
+    assert_file "bin/rake" do |contents|
       assert_no_match %r{spring}, contents
     end
   end

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -510,7 +510,7 @@ Module.new do
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
 
-  sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-listen --no-rc --skip-webpack-install --quiet"
+  sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-spring --skip-listen --no-rc --skip-webpack-install --quiet"
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
     f.puts 'require "rails/all"'
   end


### PR DESCRIPTION
Follow-up to #39746.

This shifts the responsibility of loading Spring from `config/boot.rb` back to the relevant bin files.

Fixes #40518.
Closes #40521.
