### PR TITLE
Raise error on absent attribute during validation

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -403,7 +403,7 @@ module ActiveModel
       raise AbsentAttributeError.new(self, attr) unless self.respond_to?(attr)
       send(attr)
     end
-    
+
   private
     def run_validations!
       _run_validate_callbacks

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -462,4 +462,11 @@ class ValidationsTest < ActiveModel::TestCase
     assert_predicate t, :invalid?
     assert_equal ["Title is missing. You have failed me for the last time, Admiral."], t.errors[:title]
   end
+
+  def test_absent_attribute
+    Topic.validates :i_dont_exist, presence: true
+    assert_raises(ActiveModel::AbsentAttributeError) do
+      Topic.new.valid?
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Take the following:

```
class Person < ApplicationRecord
  validate :custom_validation

  private

  def custom_validation
    errors.add(:i_dont_exist, :presence)
  end
end
```

Then: 

```
person = Person.new

person.valid?
```

The problem

When `valid?` is called, methods are executed down to [`generate_message`](https://github.com/rails/rails/blob/af91d9a1c54d93ac4d725aada801cdc02c281eff/activemodel/lib/active_model/error.rb#L64), which is called on the [Error](https://github.com/rails/rails/blob/af91d9a1c54d93ac4d725aada801cdc02c281eff/activemodel/lib/active_model/error.rb) class to build the validation messages. 

[`generate_message`](https://github.com/rails/rails/blob/af91d9a1c54d93ac4d725aada801cdc02c281eff/activemodel/lib/active_model/error.rb#L64) tries to fetch the attribute value for the attribute key provided to `errors.add` by calling [`read_attribute_for_validation`](https://github.com/rails/rails/blob/8642c564dab37366c2ca8950b428d1aec84eb10d/activemodel/lib/active_model/validations.rb#L402) on the base object being validated in case the attribute key passed is not `:base`. 

```
activemodel/lib/active_model/error.rb

module ActiveModel
  ...
  class Error
    ...
    def self.generate_message(attribute, type, base, options) # :nodoc:
      ...
      value = (attribute != :base ? base.read_attribute_for_validation(attribute) : nil)
      ...
    end
    ...
  end
end
```

The [`read_attribute_for_validation`](https://github.com/rails/rails/blob/8642c564dab37366c2ca8950b428d1aec84eb10d/activemodel/lib/active_model/validations.rb#L402) is currently just an alias to `send`.

```
activemodel/lib/active_model/validations.rb

module ActiveModel
  module Validations
    extend ActiveSupport::Concern
    ...
    module ClassMethods
        ...
	alias :read_attribute_for_validation :send
    end   
  end
end
```

Currently if a non-existent attribute key is passed to `errors.add`, a `NoMethodError` is raised during the [`generate_message`](https://github.com/rails/rails/blob/af91d9a1c54d93ac4d725aada801cdc02c281eff/activemodel/lib/active_model/error.rb#L64) call (raised by `send` under the hood), _which does not hint at the fact that there's a validation being run for an attribute that is not there_.

The fix

By overriding  [`read_attribute_for_validation`](https://github.com/rails/rails/blob/8642c564dab37366c2ca8950b428d1aec84eb10d/activemodel/lib/active_model/validations.rb#L402) as follows and checking if the object being validated does _not_ respond to a given attribute being validated it's possible to raise an error that actually points the developer to what's going on. 

```
activemodel/lib/active_model/validations.rb
module ActiveModel
  module Validations
    extend ActiveSupport::Concern
    ...
    module ClassMethods
        ...
      def read_attribute_for_validation(attr)
        raise AbsentAttributeError.new(self, attr) unless self.respond_to?(attr)
        send(attr)
      end
    end   
  end
  ...
  class AbsentAttributeError < StandardError
    attr_reader :record, :attribute

    def initialize(record, attribute)
      @attribute = attribute
      super("Attribute #{attribute} does not exist for #{record.class}.")
    end
  end
end
```