### PR TITLE
Fix text_field_tag's placeholder documentation [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -167,8 +167,8 @@ module ActionView
       # * <tt>:size</tt> - The number of visible characters that will fit in the input.
       # * <tt>:maxlength</tt> - The maximum number of characters that the browser will allow the user to enter.
       # * <tt>:placeholder</tt> - The text contained in the field by default which is removed when the field receives focus.
-      #   If set to true, use a translation is found in the current I18n locale
-      #   (through helpers.placeholders.<modelname>.<attribute>).
+      #   If set to true, use the translation found in the current I18n locale
+      #   (through helpers.placeholder.<modelname>.<attribute>).
       # * Any other key creates standard HTML attributes for the tag.
       #
       # ==== Examples


### PR DESCRIPTION
### Summary

When placeholder set to true on `text_field_tag`, it will try to look up its value from the translation files.
The documentation referenced an incorrect translation key scope, it is defined in [Placeholderable][1] as `helpers.placeholder` (singular).

Followup for #37054

Also improves wording.

[1]: https://github.com/rails/rails/blob/4640cff2b2c920adc372bbb60809d2a0a9b6d62a/actionview/lib/action_view/helpers/tags/placeholderable.rb