### PR TITLE
Remove `database` kwarg from `connected_to`

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -206,23 +206,6 @@ module ActiveRecord
           ENV["RAILS_ENV"] = previous_env
         end
 
-        def test_switching_connections_with_database_and_role_raises
-          error = assert_raises(ArgumentError) do
-            assert_deprecated do
-              ActiveRecord::Base.connected_to(database: :readonly, role: :writing) { }
-            end
-          end
-          assert_equal "`connected_to` cannot accept a `database` argument with any other arguments.", error.message
-        end
-
-        def test_database_argument_is_deprecated
-          assert_deprecated do
-            ActiveRecord::Base.connected_to(database: { writing: { adapter: "sqlite3", database: "test/db/primary.sqlite3" } }) { }
-          end
-        ensure
-          ActiveRecord::Base.establish_connection(:arunit)
-        end
-
         def test_switching_connections_without_database_and_role_raises
           error = assert_raises(ArgumentError) do
             ActiveRecord::Base.connected_to { }

--- a/activerecord/test/cases/connection_adapters/legacy_connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/legacy_connection_handlers_multi_db_test.rb
@@ -224,23 +224,6 @@ module ActiveRecord
           ENV["RAILS_ENV"] = previous_env
         end
 
-        def test_switching_connections_with_database_and_role_raises
-          error = assert_raises(ArgumentError) do
-            assert_deprecated do
-              ActiveRecord::Base.connected_to(database: :readonly, role: :writing) { }
-            end
-          end
-          assert_equal "`connected_to` cannot accept a `database` argument with any other arguments.", error.message
-        end
-
-        def test_database_argument_is_deprecated
-          assert_deprecated do
-            ActiveRecord::Base.connected_to(database: { writing: { adapter: "sqlite3", database: "test/db/primary.sqlite3" } }) { }
-          end
-        ensure
-          ActiveRecord::Base.establish_connection(:arunit)
-        end
-
         def test_switching_connections_without_database_and_role_raises
           error = assert_raises(ArgumentError) do
             ActiveRecord::Base.connected_to { }


### PR DESCRIPTION
The `database` kwarg was deprecated in #37874. It shouldn't be used by
apps even before the deprecation because it's kind of dangerous to use
in a request. Also it makes the `connected_to` method really ugly.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>

cc/ @rafaelfranca do we usually leave deprecations in until the release that the deprecation says they'll be removed? I'd like to remove this deprecation because it's been in the code for so long.