### PR TITLE
Fix connected_to_many argument and docs

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -180,12 +180,14 @@ module ActiveRecord
     #
     # Usage:
     #
-    #   ActiveRecord::Base.connected_to(AnimalsRecord, MealsRecord], role: :reading) do
+    #   ActiveRecord::Base.connected_to_many(AnimalsRecord, MealsRecord, role: :reading) do
     #     Dog.first # Read from animals replica
     #     Dinner.first # Read from meals replica
     #     Person.first # Read from primary writer
     #   end
-    def connected_to_many(classes, role:, shard: nil, prevent_writes: false)
+    def connected_to_many(*classes, role:, shard: nil, prevent_writes: false)
+      classes = classes.flatten
+
       if legacy_connection_handling
         raise NotImplementedError, "connected_to_many is not available with legacy connection handling"
       end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1718,4 +1718,19 @@ class BasicsTest < ActiveRecord::TestCase
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
+
+  test "#connected_to_many with a single argument for classes" do
+    ActiveRecord::Base.connected_to_many(AbstractCompany, role: :reading) do
+      assert AbstractCompany.current_preventing_writes
+      assert_not ActiveRecord::Base.current_preventing_writes
+    end
+  end
+
+  test "#connected_to_many with a multiple classes without brackets works" do
+    ActiveRecord::Base.connected_to_many(AbstractCompany, FirstAbstractClass, role: :reading) do
+      assert AbstractCompany.current_preventing_writes
+      assert FirstAbstractClass.current_preventing_writes
+      assert_not ActiveRecord::Base.current_preventing_writes
+    end
+  end
 end


### PR DESCRIPTION
The docs were missing `[` open bracket. We then realized that the method
signature is misleading and doesn't indicate to the user that we are
expecting an array. To fix this we added the single splat and ensure it
is flattened before passing it to the rest of the method.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>