### PR TITLE
Don't over protect the MySQL users on insert_all

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -69,6 +69,8 @@ module ActiveRecord
       attr_reader :scope_attributes
 
       def find_unique_index_for(unique_by)
+        return unique_by if !connection.supports_insert_conflict_target?
+
         name_or_columns = unique_by || model.primary_key
         match = Array(name_or_columns).map(&:to_s)
 

--- a/activerecord/test/models/cart.rb
+++ b/activerecord/test/models/cart.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Cart < ActiveRecord::Base
+  self.primary_key = :id
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -152,6 +152,16 @@ ActiveRecord::Schema.define do
 
   create_table :carriers, force: true
 
+  create_table :carts, force: true, primary_key: [:shop_id, :id] do |t|
+    if current_adapter?(:Mysql2Adapter)
+      t.bigint :id, index: true, auto_increment: true, null: false
+    else
+      t.bigint :id, index: true, null: false
+    end
+    t.bigint :shop_id
+    t.string :title
+  end
+
   create_table :categories, force: true do |t|
     t.string :name, null: false
     t.string :type


### PR DESCRIPTION
MySQL don't support conflict target on insert_all so we can't pass the `:unique_by` option. But, if you don't check if the index exists MySQL will successfully inset the data.

If there is a conflict in an index like the primary key the database will raise an error. We should let the database decide if the data is acceptable or not.

The test added on this commit exercise a table that has composite primary keys, but, in order to keep all the Rails behavior working (given Rails doesn't officially support composite primary keys) we set the primary key to an auto increment `:id` column.