### PR TITLE
Convert HTML entities to their applicable characters.

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -40,6 +40,16 @@ class ERB
     end
     module_function :unwrapped_html_escape
 
+    # A utility method for unescaping HTML tag characters.
+    #
+    #   puts html_unescape('is a &gt; 0 &amp; a &lt; 10?')
+    #   # => is a > 0 & a < 10?
+    def html_unescape(s) # :nodoc:
+      s = s.to_s
+      CGI.unescapeHTML(ActiveSupport::Multibyte::Unicode.tidy_bytes(s))
+    end
+    module_function :html_unescape
+
     # A utility method for escaping HTML without affecting existing escaped entities.
     #
     #   html_escape_once('1 < 2 &amp; 3')


### PR DESCRIPTION
### Summary
While converting from HTML entities to their application characters, I found we have html_escape(), but we don't have the other counter part of html_unescape. This PR adds html_unescape.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
