### PR TITLE
[6.1.0.rc1] Handle frozen conditions in validate

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -163,10 +163,10 @@ module ActiveModel
         if options.key?(:on)
           options = options.dup
           options[:on] = Array(options[:on])
-          options[:if] = Array(options[:if])
-          options[:if].unshift ->(o) {
-            !(options[:on] & Array(o.validation_context)).empty?
-          }
+          options[:if] = [
+            ->(o) { !(options[:on] & Array(o.validation_context)).empty? },
+            *options[:if]
+          ]
         end
 
         set_callback(:validate, *args, options, &block)

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -159,6 +159,12 @@ class ValidationsTest < ActiveModel::TestCase
     assert_equal ["will never be valid"], t.errors["title"]
   end
 
+  def test_validates_with_array_condition_does_not_mutate_the_array
+    opts = []
+    Topic.validate(if: opts, on: :create) { }
+    assert_empty opts
+  end
+
   def test_invalid_validator
     Topic.validate :i_dont_exist
     assert_raises(NoMethodError) do


### PR DESCRIPTION
### Summary

`validate` currently doesn't work with `with_options(on: ..., if: [])` because of [array conditions are frozen by ActiveSupport::Callbacks](https://github.com/rails/rails/pull/38323)

### Examples

```ruby
Class.new(ActiveRecord::Base) do
  with_options(on: :create, if: []) do
    validate :one # freeze array of :if
    validate :two #=> FrozenError: can't modify frozen Array
  end
end
```