### PR TITLE
Set the inverse record on find with multiple ids from has_many association

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -69,8 +69,8 @@ module ActiveRecord
 
     private
       def relation_with(values)
-        result = Relation.create(klass, values: values)
-        result.extend(*extending_values) if extending_values.any?
+        result = spawn
+        result.instance_variable_set(:@values, values)
         result
       end
   end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -509,6 +509,24 @@ class InverseHasManyTests < ActiveRecord::TestCase
     assert_not_predicate human.interests, :loaded?
   end
 
+  def test_find_on_child_instance_with_id_should_set_inverse_instances
+    human = Human.create!
+    interest = Interest.create!(human: human)
+
+    child = human.interests.find(interest.id)
+    assert_predicate child.association(:human), :loaded?
+  end
+
+  def test_find_on_child_instances_with_ids_should_set_inverse_instances
+    human = Human.create!
+    interests = Array.new(2) { Interest.create!(human: human) }
+
+    children = human.interests.find(interests.pluck(:id))
+    children.each do |child|
+      assert_predicate child.association(:human), :loaded?
+    end
+  end
+
   def test_raise_record_not_found_error_when_invalid_ids_are_passed
     # delete all interest records to ensure that hard coded invalid_id(s)
     # are indeed invalid.


### PR DESCRIPTION
### Summary

Previously, the `find` method of the `has_many` association set the inverse record to the `belong_to` association only when called with a single id, but it didn't set it with multiple ids:

```ruby
class User < ApplicationRecord
  has_many :posts
end

class Post < ApplicationRecord
  belongs_to :user
end

user = User.create!
posts = [Post.create!(user: user), Post.create!(user: user)]

results = user.posts.find(posts.pluck(:id))
results.map(&:user) #=> loads the user 2 times
```

This was because `except(:limit, :offset)` in `find_some_ordered` had created a new relation irrelevant to the original association relation.
This commit fixes the issue by allowing the `except` and `only` methods of the association relation to maintain the association.

Co-authored-by: Ryuta Kamizono <kamipo@gmail.com>