### PR TITLE
Ensure the connection used in a failed rollback is discarded

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -317,25 +317,31 @@ module ActiveRecord
           end
           raise
         ensure
-          if !error && transaction
-            if Thread.current.status == "aborting"
-              rollback_transaction
+          if transaction
+            if error
+              # @connection still holds an open transaction, so we must not
+              # put it back in the pool for reuse
+              @connection.throw_away! unless transaction.state.rolledback?
             else
-              if !completed && transaction.written
-                ActiveSupport::Deprecation.warn(<<~EOW)
-                  Using `return`, `break` or `throw` to exit a transaction block is
-                  deprecated without replacement. If the `throw` came from
-                  `Timeout.timeout(duration)`, pass an exception class as a second
-                  argument so it doesn't use `throw` to abort its block. This results
-                  in the transaction being committed, but in the next release of Rails
-                  it will rollback.
-                EOW
-              end
-              begin
-                commit_transaction
-              rescue Exception
-                rollback_transaction(transaction) unless transaction.state.completed?
-                raise
+              if Thread.current.status == "aborting"
+                rollback_transaction
+              else
+                if !completed && transaction.written
+                  ActiveSupport::Deprecation.warn(<<~EOW)
+                    Using `return`, `break` or `throw` to exit a transaction block is
+                    deprecated without replacement. If the `throw` came from
+                    `Timeout.timeout(duration)`, pass an exception class as a second
+                    argument so it doesn't use `throw` to abort its block. This results
+                    in the transaction being committed, but in the next release of Rails
+                    it will rollback.
+                  EOW
+                end
+                begin
+                  commit_transaction
+                rescue Exception
+                  rollback_transaction(transaction) unless transaction.state.completed?
+                  raise
+                end
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -501,6 +501,12 @@ module ActiveRecord
         # this should be overridden by concrete adapters
       end
 
+      # Removes the connection from the pool and disconnect it.
+      def throw_away!
+        pool.remove self
+        disconnect!
+      end
+
       # Clear any caching the database adapter may be doing.
       def clear_cache!
         @lock.synchronize { @statements.clear } if @statements


### PR DESCRIPTION
### Summary

TL;DR: We identified that if a transaction that was rollbacked errors out, it can get re-added to the pool. This will cause the transaction to commit the next time it gets used.

So the connection, on which the transaction was initiated, fails to issues ROLLBACK. Also, the connection is kept alive and is returned to the connection pool. As a consequence of that, if a later transaction comes in, for the same connection, MySQL will COMMIT any pending transaction for that connection before BEGIN. When this happens, it leads to partial data in MySQL and duplicate orders for a checkout.

This can be reproduced by putting a raise inside of rollback_transaction

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
