### PR TITLE
Allow default to be configured for serialization

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -41,6 +41,12 @@ module ActiveRecord
         # * +class_name_or_coder+ - Optional, a coder object, which responds to +.load+ and +.dump+
         #   or a class name that the object type should be equal to.
         #
+        # ==== Options
+        #
+        # +default+ The default value to use when no value is provided. If this option
+        # is not passed, the previous default value (if any) will be used.
+        # Otherwise, the default will be +nil+.
+        #
         # ==== Example
         #
         #   # Serialize a preferences attribute.
@@ -57,7 +63,7 @@ module ActiveRecord
         #   class User < ActiveRecord::Base
         #     serialize :preferences, Hash
         #   end
-        def serialize(attr_name, class_name_or_coder = Object)
+        def serialize(attr_name, class_name_or_coder = Object, **options)
           # When ::JSON is used, force it to go through the Active Support JSON encoder
           # to ensure special objects (e.g. Active Record models) are dumped correctly
           # using the #as_json hook.
@@ -69,7 +75,7 @@ module ActiveRecord
             Coders::YAMLColumn.new(attr_name, class_name_or_coder)
           end
 
-          decorate_attribute_type(attr_name.to_s) do |cast_type|
+          decorate_attribute_type(attr_name.to_s, **options) do |cast_type|
             if type_incompatible_with_serialize?(cast_type, class_name_or_coder)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -41,6 +41,27 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal(myobj, topic.content)
   end
 
+  def test_serialized_attribute_with_default
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+      serialize(:content, Hash, default: { key: "value" })
+    end
+
+    t = klass.new
+    assert_equal({ key: "value" }, t.content)
+  end
+
+  def test_serialized_attribute_on_custom_attribute_with_default
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+      attribute :content, default: { key: "value" }
+      serialize :content, Hash
+    end
+
+    t = klass.new
+    assert_equal({ key: "value" }, t.content)
+  end
+
   def test_serialized_attribute_in_base_class
     Topic.serialize("content", Hash)
 


### PR DESCRIPTION
Set the default value in the application layer for columns that can't have a default value, like MySQL's text columns.

```ruby
class Audit < ActiveRecord::Base
  serialize :content, JSON, default: []
end

Audit.new.content #=> []
```