### PR TITLE
Set sidekiq retry default to 3

### DIFF
--- a/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb
@@ -23,7 +23,8 @@ module ActiveJob
           "class"   => JobWrapper,
           "wrapped" => job.class,
           "queue"   => job.queue_name,
-          "args"    => [ job.serialize ]
+          "args"    => [ job.serialize ],
+          "retry"   => 3
       end
 
       def enqueue_at(job, timestamp) #:nodoc:
@@ -32,7 +33,8 @@ module ActiveJob
           "wrapped" => job.class,
           "queue"   => job.queue_name,
           "args"    => [ job.serialize ],
-          "at"      => timestamp
+          "at"      => timestamp,
+          "retry"   => 3
       end
 
       class JobWrapper #:nodoc:


### PR DESCRIPTION
### Summary
Sidekiq uses `retry:true` as default.  Simply 'true' means Sidekiq retries 25 times. Its a long time to wait. Sidekiq will retry failures with an exponential backoff using the formula (retry_count ** 4) + 15 + (rand(30) * (retry_count + 1)) (i.e. 15, 16, 31, 96, 271, ... seconds + a random amount of time). It will perform 25 retries over approximately 21 days. This PR set the default retry to 3. So, Sidekiq will be retried 3 times before giving up.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
