### PR TITLE
[6.1.0.rc1] ActiveModel::Attributes can be frozen again

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -115,7 +115,7 @@ module ActiveModel
     end
 
     def freeze
-      @attributes = @attributes.clone.freeze
+      @attributes = @attributes.clone.freeze unless frozen?
       super
     end
 

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -129,5 +129,11 @@ module ActiveModel
       assert data.frozen?
       assert_raise(FrozenError) { data.integer_field = 1 }
     end
+
+    test "attributes can be frozen again" do
+      data = ModelForAttributesTest.new
+      data.freeze
+      assert_nothing_raised { data.freeze }
+    end
   end
 end


### PR DESCRIPTION
`#freeze` currently can't be called again because it try to modify instance variable of frozen instance.

```ruby
instance = klass.new
instance.freeze
instance.freeze #=> FrozenError: can't modify frozen
```