### PR TITLE
Fix web-console version for Rails 6.1

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -49,7 +49,7 @@ group :development do
   <%- if options.dev? || options.edge? || options.master? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
-  gem 'web-console', '>= 4.0.3'
+  gem 'web-console', '>= 4.1.0'
   <%- end -%>
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -787,7 +787,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console', '>= 4\.0\.3'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 4\.1\.0'\z/, content)
     end
   end
 
@@ -796,7 +796,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console', '>= 4\.0\.3'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 4\.1\.0'\z/, content)
     end
   end
 
@@ -805,7 +805,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
-      assert_no_match(/\Agem 'web-console', '>= 4\.0\.3'\z/, content)
+      assert_no_match(/\Agem 'web-console', '>= 4\.1\.0'\z/, content)
     end
   end
 


### PR DESCRIPTION
### Summary
Bump web-console version to 4.1.0. There is an incompatibility between web-console and Rails 6.1.0.rc1 described here: https://github.com/rails/rails/issues/40532.
The problem occurred due to ActionView::Base#initialize arguments be required now (https://github.com/rails/rails/commit/cd0c99c991ecbdb60b87cf648a6fddb0a50a13ad). 
This [pull request](https://github.com/rails/web-console/pull/304) to https://github.com/rails/web-console fixed the problem.