### PR TITLE
Support delegators in query Predicate building

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Build predicate conditions with objects that delegate `#id` and primary key:
+
+    ```ruby
+    class AdminAuthor
+      delegate_missing_to :@author
+
+      def initialize(author)
+        @author = author
+      end
+    end
+
+    Post.where(author: AdminAuthor.new(author))
+    ```
+
+    *Sean Doyle*
+
 *   Allow constructors (`build_association` and `create_association`) on
     `has_one :through` associations.
 

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -59,7 +59,7 @@ module ActiveRecord
     end
 
     def build(attribute, value, operator = nil)
-      value = value.id if value.is_a?(Base)
+      value = value.id if value.respond_to?(:id)
       if operator ||= table.type(attribute.name).force_equality?(value) && :eq
         bind = build_bind_attribute(attribute.name, value)
         attribute.public_send(operator, bind)

--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -31,9 +31,8 @@ module ActiveRecord
         end
 
         def convert_to_id(value)
-          case value
-          when Base
-            value._read_attribute(primary_key)
+          if value.respond_to?(:id)
+            value.id
           else
             value
           end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -810,6 +810,26 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, authors.to_a.length
   end
 
+  def test_where_with_ar_relation
+    author = Post.last.author
+    posts = Post.all.where(author: author)
+    assert_equal 3, posts.to_a.length
+  end
+
+  def test_where_id_with_delegated_ar_object
+    decorator = Class.new(SimpleDelegator)
+    author = Author.first
+    assert_equal 1, Author.where(id: decorator.new(author)).to_a.length
+    assert_equal 1, Author.where(id: [decorator.new(author)]).to_a.length
+  end
+
+  def test_where_relation_with_delegated_ar_object
+    decorator = Class.new(SimpleDelegator)
+    author = Post.last.author
+    assert_equal 3, Post.where(author: decorator.new(author)).to_a.length
+    assert_equal 3, Post.where(author: [decorator.new(author)]).to_a.length
+  end
+
   def test_find_with_list_of_ar
     author = Author.first
     authors = Author.find([author.id])


### PR DESCRIPTION
### Summary

Prior to this commit, queries specifying objects as values like
`where(id: user)` and `where(author: user)` would only successfully
serialize to a SQL query if the value (i.e. `user` in the case of these
examples) were an instance of an `ActiveRecord::Base` descendant.

In applications that use decorators (either via `SimpleDelegator`,
`delegate_missing_to`, or other means), this required conversion can be
burdensome.

This commit modifies the `PredicateBuilder`, replacing class based
comparison conditionals with calls to `#respond_to?`.
