### PR TITLE
`{SchemaMigration,InternalMetadata}.create_table` ensure the table is to be created

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -43,11 +43,9 @@ module ActiveRecord
       def create_table
         return unless enabled?
 
-        unless table_exists?
-          key_options = connection.internal_string_options_for_primary_key
-
+        unless connection.table_exists?(table_name)
           connection.create_table(table_name, id: false) do |t|
-            t.string :key, **key_options
+            t.string :key, **connection.internal_string_options_for_primary_key
             t.string :value
             t.timestamps
           end

--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -23,11 +23,9 @@ module ActiveRecord
       end
 
       def create_table
-        unless table_exists?
-          version_options = connection.internal_string_options_for_primary_key
-
+        unless connection.table_exists?(table_name)
           connection.create_table(table_name, id: false) do |t|
-            t.string :version, **version_options
+            t.string :version, **connection.internal_string_options_for_primary_key
           end
         end
       end


### PR DESCRIPTION
It shouldn't be affected by the schema cache.

Fixes #40553.