### PR TITLE
Allow missing Action Cable config

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -30,7 +30,7 @@ module ActionCable
 
       ActiveSupport.on_load(:action_cable) do
         if (config_path = Pathname.new(app.config.paths["config/cable"].first)).exist?
-          self.cable = Rails.application.config_for(config_path).with_indifferent_access
+          self.cable = Rails.application.config_for(config_path).to_h.with_indifferent_access
         end
 
         previous_connection_class = connection_class

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2453,6 +2453,14 @@ module ApplicationTests
       assert_nil ActiveStorage.queues[:purge]
     end
 
+    test "ActionCable.server.config.cable is set when missing configuration for the current environment" do
+      quietly do
+        app "missing"
+      end
+
+      assert_kind_of ActiveSupport::HashWithIndifferentAccess, ActionCable.server.config.cable
+    end
+
     test "ActionMailbox.logger is Rails.logger by default" do
       app "development"
 


### PR DESCRIPTION
Since #37850, `config_for` returns `nil` instead of an empty Hash when a config file does not contain configuration for the specified environment.  Thus, the return value should be converted to a Hash before calling `with_indifferent_access`.

Fixes #40548.
