### PR TITLE
Display exception messages using simple_format

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb
@@ -1,5 +1,7 @@
 <% if exception.respond_to?(:original_message) && exception.respond_to?(:corrections) %>
-  <h2><%= h exception.original_message %></h2>
+  <div class="exception-message">
+    <%= simple_format h(exception.original_message), { class: "message" }, wrapper_tag: "div" %>
+  </div>
   <%
     # The 'did_you_mean' gem can raise exceptions when calling #corrections on
     # the exception. If it does there are no corrections to show.
@@ -14,5 +16,7 @@
     </ul>
   <% end %>
 <% else %>
-  <h2><%= h exception.message %></h2>
+  <div class="exception-message">
+    <%= simple_format h(exception.message), { class: "message" }, wrapper_tag: "div" %>
+  </div>
 <% end %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -49,6 +49,18 @@
       line-height: 25px;
     }
 
+    .exception-message {
+      padding: 8px 0;
+    }
+
+    .exception-message .message{
+      margin-bottom: 8px;
+      line-height: 25px;
+      font-size: 1.5em;
+      font-weight: bold;
+      color: #C00;
+    }
+
     .details {
       border: 1px solid #D0D0D0;
       border-radius: 4px;

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -629,7 +629,9 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
       # Assert correct error
       assert_response 500
-      assert_select "h2", /error in framework/
+      assert_select "div.exception-message" do
+        assert_select "div", /error in framework/
+      end
 
       # assert source view line is the call to method_that_raises
       assert_select "div.source:not(.hidden)" do
@@ -637,7 +639,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       end
 
       # assert first source view (hidden) that throws the error
-      assert_select "div.source:first" do
+      assert_select "div.source" do
         assert_select "pre .line.active", /raise StandardError\.new/
       end
 
@@ -680,7 +682,9 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
       # Assert correct error
       assert_response 500
-      assert_select "h2", /Third error/
+      assert_select "div.exception-message" do
+        assert_select "div", /Third error/
+      end
 
       # assert source view line shows the last error
       assert_select "div.source:not(.hidden)" do
@@ -749,7 +753,9 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     get "/nil_annoted_source_code_error", headers: { "action_dispatch.show_exceptions" => true, "action_dispatch.logger" => logger }
 
     assert_select "header h1", /DebugExceptionsTest::Boomer::NilAnnotedSourceCodeError/
-    assert_select "#container h2", /nil annoted_source_code/
+    assert_select "#container div.exception-message" do
+      assert_select "div", /nil annoted_source_code/
+    end
   end
 
   test "debug exceptions app shows diagnostics for template errors that contain UTF-8 characters" do

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -8,6 +8,7 @@ module ApplicationTests
   class MailerPreviewsTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
     include Rack::Test::Methods
+    include ERB::Util
 
     def setup
       build_app
@@ -299,7 +300,7 @@ module ApplicationTests
       app("development")
       get "/rails/mailers/notifier"
       assert_predicate last_response, :not_found?
-      assert_match "Mailer preview &#39;notifier&#39; not found", last_response.body
+      assert_match "Mailer preview &#39;notifier&#39; not found", h(last_response.body)
     end
 
     test "mailer preview email not found" do
@@ -329,7 +330,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/bar"
       assert_predicate last_response, :not_found?
-      assert_match "Email &#39;bar&#39; not found in NotifierPreview", last_response.body
+      assert_match "Email &#39;bar&#39; not found in NotifierPreview", h(last_response.body)
     end
 
     test "mailer preview NullMail" do
@@ -385,7 +386,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo?part=text%2Fhtml"
       assert_predicate last_response, :not_found?
-      assert_match "Email part &#39;text/html&#39; not found in NotifierPreview#foo", last_response.body
+      assert_match "Email part &#39;text/html&#39; not found in NotifierPreview#foo", h(last_response.body)
     end
 
     test "message header uses full display names" do


### PR DESCRIPTION
### Summary

Currently error messages are displayed all in one line in the error pages, in the rails console/logs they appear nicely on multiple lines, making it easier to grok. With this PR I want to propose that we display error messages in the view on multiple lines making it easier for developers to read the error messages.

These changes were pulled out from https://github.com/rails/rails/pull/39723

Before:

<img width="1662" alt="Screenshot 2020-11-09 at 20 52 47" src="https://user-images.githubusercontent.com/658005/98598444-5f2a0d00-22d2-11eb-9b4e-1f99d08d89fe.png">

After:

<img width="1667" alt="Screenshot 2020-11-09 at 21 15 49" src="https://user-images.githubusercontent.com/658005/98598456-64875780-22d2-11eb-8c29-35dadafeceda.png">
