### PR TITLE
Don't replace connections without a writing role

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -202,6 +202,8 @@ module ActiveRecord
                 pool_manager = handler.send(:owner_to_pool_manager)[name]
                 pool_manager.shard_names.each do |shard_name|
                   writing_pool_config = writing_pool_manager.get_pool_config(nil, shard_name)
+                  next unless writing_pool_config
+
                   pool_manager.set_pool_config(nil, shard_name, writing_pool_config)
                 end
               end
@@ -214,6 +216,8 @@ module ActiveRecord
             pool_manager = handler.send(:owner_to_pool_manager)[name]
             pool_manager.shard_names.each do |shard_name|
               writing_pool_config = pool_manager.get_pool_config(ActiveRecord::Base.writing_role, shard_name)
+              next unless writing_pool_config
+
               pool_manager.role_names.each do |role|
                 next unless pool_manager.get_pool_config(role, shard_name)
                 pool_manager.set_pool_config(role, shard_name, writing_pool_config)

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1482,6 +1482,14 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
       end
     end
 
+    def test_connections_with_no_writing_role_are_skipped
+      AbstractCompany.connects_to(database: { reading: :readonly })
+      handler = ActiveRecord::Base.connection_handler
+      assert_not_nil handler.retrieve_connection_pool("AbstractCompany", role: :reading)
+    ensure
+      AbstractCompany.connected_to(role: :reading) { AbstractCompany.remove_connection }
+    end
+
     private
       def config
         { "default" => default_config, "readonly" => readonly_config }
@@ -1573,6 +1581,14 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
           ActiveRecord::Base.retrieve_connection
         end
       end
+    end
+
+    def test_connections_with_no_writing_role_are_skipped
+      AbstractCompany.connects_to(database: { reading: :readonly })
+      reading_handler = ActiveRecord::Base.connection_handlers[:reading]
+      assert_not_nil reading_handler.retrieve_connection_pool("AbstractCompany")
+    ensure
+      ActiveRecord::Base.connected_to(role: :reading) { AbstractCompany.remove_connection }
     end
 
     private


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/40368, https://github.com/rails/rails/pull/40487, https://github.com/rails/rails/pull/40488; ultimately trying to unblock https://github.com/rails/rails/pull/40384.

If there's no corresponding writing connection, we currently overwrite the pool anyway, removing the connection. We should skip it instead.