### PR TITLE
Add :initial option to ActiveSupport::Cache::MemCacheStore#increment/decrement

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -102,8 +102,7 @@ module ActiveSupport
 
       # Increment a cached value. This method uses the memcached incr atomic
       # operator and can only be used on values written with the :raw option.
-      # Calling it on a value not stored with :raw will initialize that value
-      # to zero.
+      # Calling it on a value not stored with :raw will fail and returns nil.
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:increment, name, amount: amount) do
@@ -115,8 +114,7 @@ module ActiveSupport
 
       # Decrement a cached value. This method uses the memcached decr atomic
       # operator and can only be used on values written with the :raw option.
-      # Calling it on a value not stored with :raw will initialize that value
-      # to zero.
+      # Calling it on a value not stored with :raw will fail and returns nil.
       def decrement(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:decrement, name, amount: amount) do

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -102,12 +102,14 @@ module ActiveSupport
 
       # Increment a cached value. This method uses the memcached incr atomic
       # operator and can only be used on values written with the :raw option.
-      # Calling it on a value not stored with :raw will fail and returns nil.
+      # Calling it on a value not stored with :raw will fail and return nil.
+      # With the :initial option, its vlaue is used for a new counter.
+      # Otherwise, an operation to a nonexistant value will fail and return nil.
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:increment, name, amount: amount) do
           rescue_error_with nil do
-            @data.with { |c| c.incr(normalize_key(name, options), amount, options[:expires_in]) }
+            @data.with { |c| c.incr(normalize_key(name, options), amount, options[:expires_in], options[:initial]) }
           end
         end
       end
@@ -115,11 +117,13 @@ module ActiveSupport
       # Decrement a cached value. This method uses the memcached decr atomic
       # operator and can only be used on values written with the :raw option.
       # Calling it on a value not stored with :raw will fail and returns nil.
+      # With the :initial option, its vlaue is used for a new counter.
+      # Otherwise, an operation to a nonexistant value will fail and return nil.
       def decrement(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:decrement, name, amount: amount) do
           rescue_error_with nil do
-            @data.with { |c| c.decr(normalize_key(name, options), amount, options[:expires_in]) }
+            @data.with { |c| c.decr(normalize_key(name, options), amount, options[:expires_in], options[:initial]) }
           end
         end
       end

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -103,8 +103,8 @@ module ActiveSupport
       # Increment a cached value. This method uses the memcached incr atomic
       # operator and can only be used on values written with the :raw option.
       # Calling it on a value not stored with :raw will fail and return nil.
-      # With the :initial option, its vlaue is used for a new counter.
-      # Otherwise, an operation to a nonexistant value will fail and return nil.
+      # With the :initial option, its value is used for a new counter.
+      # Otherwise, an operation to a nonexistent value will fail and return nil.
       def increment(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:increment, name, amount: amount) do
@@ -116,9 +116,9 @@ module ActiveSupport
 
       # Decrement a cached value. This method uses the memcached decr atomic
       # operator and can only be used on values written with the :raw option.
-      # Calling it on a value not stored with :raw will fail and returns nil.
-      # With the :initial option, its vlaue is used for a new counter.
-      # Otherwise, an operation to a nonexistant value will fail and return nil.
+      # Calling it on a value not stored with :raw will fail and return nil.
+      # With the :initial option, its value is used for a new counter.
+      # Otherwise, an operation to a nonexistent value will fail and return nil.
       def decrement(name, amount = 1, options = nil)
         options = merged_options(options)
         instrument(:decrement, name, amount: amount) do

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -98,17 +98,17 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
-  def test_increment_expires_in
+  def test_increment_expires_in_and_initial
     cache = lookup_store(raw: true, namespace: nil)
-    assert_called_with client(cache), :incr, [ "foo", 1, 60 ] do
-      cache.increment("foo", 1, expires_in: 60)
+    assert_called_with client(cache), :incr, [ "foo", 1, 60, 1 ] do
+      cache.increment("foo", 1, expires_in: 60, initial: 1)
     end
   end
 
-  def test_decrement_expires_in
+  def test_decrement_expires_in_and_initial
     cache = lookup_store(raw: true, namespace: nil)
-    assert_called_with client(cache), :decr, [ "foo", 1, 60 ] do
-      cache.decrement("foo", 1, expires_in: 60)
+    assert_called_with client(cache), :decr, [ "foo", 1, 60, 0 ] do
+      cache.decrement("foo", 1, expires_in: 60, initial: 0)
     end
   end
 


### PR DESCRIPTION
### Summary

#### Problem description
Previously, the comments of `ActiveSupport::Cache::MemCacheStore#increment/decrement` was saying:
```
Calling it on a value not stored with :raw will initialize that value to zero.
```
However, it actually failed to update the value and just returned nil.
It behaved to a nonexsintent key in the same way.


In addition, increment/decrement takes the `expires_in` option, but it had never used, since it had never created a new counter as described above although memcached (Dalli) set the ttl only when the new counter is created.

DalliStore (which is deprecated) was using the `initial` option or the `amount` parameter as the default value for a new counter.
https://github.com/petergoldstein/dalli/blob/2.x/lib/active_support/cache/dalli_store.rb#L241
However, porting this (defaulting to `amount`) may break the application that relies on the current behaviour which returns nil.

#### Solution
To keep the compatibility with the previous behaviour, this fixes the issue by adding the `initial` option to `MemCacheStore` that is used as the initial value for the new counter. By specifying the `expires_in` with the `initial` option to a new counter key, the TTL is also set:
```
store = ActiveSupport::Cache::MemCacheStore.new
store.increment("new_key", expires_in: 10, initial: 1)
# => 1  
store.increment("new_key", expires_in: 10, initial: 1)
# => 2

# after 10 seconds from the first increment
store.increment("new_key", expires_in: 10, initial: 1)
# => 1
```
When the `initial` option is not specified, it behaves in the same way as current.