### PR TITLE
Incorrect comment regarding template error backtrace [ci-skip]

### DIFF
--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -53,7 +53,7 @@ module ActionView
 
   class Template
     # The Template::Error exception is raised when the compilation or rendering of the template
-    # fails. This exception then gathers a bunch of intimate details and uses it to report a
+    # fails. This exception then gathers a list of the function calls that were active in the thread and uses it to report a
     # precise exception message.
     class Error < ActionViewError #:nodoc:
       SOURCE_CODE_RADIUS = 3


### PR DESCRIPTION
### Summary
This PR fixes incorrect comment regarding template error backtrace.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
