### PR TITLE
Upgrade sdoc to 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (2.0.0)
+    sdoc (2.0.2)
       rdoc (>= 5.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)


### PR DESCRIPTION
### Summary

Changes compared to 2.0.0:
* Fix arrow icons for selected panel items
* Always use only one metatag for keywords
* Use h2 instead of h1 for banner head

## Before

<img width="300" alt="image" src="https://user-images.githubusercontent.com/28561/98595001-b67dac80-22d5-11eb-9d11-0a3eb82fc9fd.png">

## After

<img width="300" alt="image" src="https://user-images.githubusercontent.com/28561/98594826-7d453c80-22d5-11eb-8bb5-125c007a0cda.png">


