### PR TITLE
Allow access to CurrentAttributes in test teardown

### DIFF
--- a/activesupport/lib/active_support/current_attributes/test_helper.rb
+++ b/activesupport/lib/active_support/current_attributes/test_helper.rb
@@ -6,8 +6,8 @@ module ActiveSupport::CurrentAttributes::TestHelper # :nodoc:
     super
   end
 
-  def before_teardown
-    ActiveSupport::CurrentAttributes.reset_all
+  def after_teardown
     super
+    ActiveSupport::CurrentAttributes.reset_all
   end
 end

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -126,6 +126,14 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     assert_equal "account/1", Current.account
   end
 
+  setup { @testing_teardown = false }
+  teardown { assert_equal 42, Session.current if @testing_teardown }
+
+  test "accessing attributes in teardown" do
+    Session.current = 42
+    @testing_teardown = true
+  end
+
   test "delegation" do
     Current.person = Person.new(42, "David", "Central Time (US & Canada)")
     assert_equal "Central Time (US & Canada)", Current.time_zone


### PR DESCRIPTION
### Summary

When using CurrentAttributes in tests, they get reset before teardown.
It's annoying when you use multiple setup/teardown in different places and expect to be able to use CurrentAttributes.

For example:
```
AccountTestHelper
  setup: Current.account = Account.first
```
```
SomeTest
  setup: Redis.current.set("account:#{Current.account.id}", Current.account.data)
  teardown: Redis.current.del("account:#{Current.account.id}") # Current.account has already been reset
```

Since the test helper helps to prevent leaks, it can call `reset_all` at the very end of teardown, in `after_teardown`, after the call to `super`.

@rafaelfranca
cc @byroot 