### PR TITLE
Add missing TLD to api links in AR queries guide [skip ci]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -130,34 +130,34 @@ The primary operation of `Model.find(options)` can be summarized as:
 * Instantiate the equivalent Ruby object of the appropriate model for every resulting row.
 * Run `after_find` and then `after_initialize` callbacks, if any.
 
-[`ActiveRecord::Relation`]: https://api.rubyonrails/classes/ActiveRecord/Relation.html
-[`annotate`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-annotate
-[`create_with`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-create_with
-[`distinct`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-distinct
-[`eager_load`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-eager_load
-[`extending`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-extending
-[`extract_associated`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-extract_associated
-[`find`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-find
-[`from`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-from
-[`group`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-group
-[`having`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-having
-[`includes`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-includes
-[`joins`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-joins
-[`left_outer_joins`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-left_outer_joins
-[`limit`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-limit
-[`lock`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-lock
-[`none`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-none
-[`offset`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-offset
-[`optimizer_hints`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-optimizer_hints
-[`order`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-order
-[`preload`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-preload
-[`readonly`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-readonly
-[`references`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-references
-[`reorder`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-reorder
-[`reselect`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-reselect
-[`reverse_order`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-reverse_order
-[`select`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-select
-[`where`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-where
+[`ActiveRecord::Relation`]: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html
+[`annotate`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-annotate
+[`create_with`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-create_with
+[`distinct`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-distinct
+[`eager_load`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-eager_load
+[`extending`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-extending
+[`extract_associated`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-extract_associated
+[`find`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find
+[`from`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-from
+[`group`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-group
+[`having`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-having
+[`includes`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-includes
+[`joins`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-joins
+[`left_outer_joins`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-left_outer_joins
+[`limit`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-limit
+[`lock`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-lock
+[`none`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-none
+[`offset`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-offset
+[`optimizer_hints`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-optimizer_hints
+[`order`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-order
+[`preload`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-preload
+[`readonly`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-readonly
+[`references`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-references
+[`reorder`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-reorder
+[`reselect`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-reselect
+[`reverse_order`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-reverse_order
+[`select`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-select
+[`where`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-where
 
 ### Retrieving a Single Object
 
@@ -231,8 +231,8 @@ The [`take!`][] method behaves exactly like `take`, except that it will raise `A
 
 TIP: The retrieved record may vary depending on the database engine.
 
-[`take`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-take
-[`take!`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-take-21
+[`take`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-take
+[`take!`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-take-21
 
 #### `first`
 
@@ -281,8 +281,8 @@ SELECT * FROM customers ORDER BY customers.first_name ASC LIMIT 1
 
 The [`first!`][] method behaves exactly like `first`, except that it will raise `ActiveRecord::RecordNotFound` if no matching record is found.
 
-[`first`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-first
-[`first!`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-first-21
+[`first`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-first
+[`first!`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-first-21
 
 #### `last`
 
@@ -331,8 +331,8 @@ SELECT * FROM customers ORDER BY customers.first_name DESC LIMIT 1
 
 The [`last!`][] method behaves exactly like `last`, except that it will raise `ActiveRecord::RecordNotFound` if no matching record is found.
 
-[`last`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-last
-[`last!`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-last-21
+[`last`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-last
+[`last!`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-last-21
 
 #### `find_by`
 
@@ -371,8 +371,8 @@ This is equivalent to writing:
 Customer.where(first_name: 'does not exist').take!
 ```
 
-[`find_by`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-find_by
-[`find_by!`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-find_by-21
+[`find_by`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find_by
+[`find_by!`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find_by-21
 
 ### Retrieving Multiple Objects in Batches
 
@@ -422,7 +422,7 @@ raised, otherwise the order is ignored and a warning issued, which is the
 default. This can be overridden with the option `:error_on_ignore`, explained
 below.
 
-[`find_each`]: https://api.rubyonrails/classes/ActiveRecord/Batches.html#method-i-find_each
+[`find_each`]: https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_each
 
 ##### Options for `find_each`
 
@@ -493,7 +493,7 @@ end
 as long as they have no ordering, since the method needs to force an order
 internally to iterate.
 
-[`find_in_batches`]: https://api.rubyonrails/classes/ActiveRecord/Batches.html#method-i-find_in_batches
+[`find_in_batches`]: https://api.rubyonrails.org/classes/ActiveRecord/Batches.html#method-i-find_in_batches
 
 ##### Options for `find_in_batches`
 
@@ -663,7 +663,7 @@ In other words, this query can be generated by calling `where` with no argument,
 SELECT * FROM customers WHERE (customers.orders_count NOT IN (1,3,5))
 ```
 
-[`where.not`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-not
+[`where.not`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods/WhereChain.html#method-i-not
 
 ### OR Conditions
 
@@ -678,7 +678,7 @@ Customer.where(last_name: 'Smith').or(Customer.where(orders_count: [1,3,5]))
 SELECT * FROM customers WHERE (customers.last_name = 'Smith' OR customers.orders_count IN (1,3,5))
 ```
 
-[`or`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-or
+[`or`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-or
 
 Ordering
 --------
@@ -844,7 +844,7 @@ FROM orders
 GROUP BY status
 ```
 
-[`count`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-count
+[`count`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-count
 
 Having
 ------
@@ -915,7 +915,7 @@ Book.order('id desc').merge(Book.unscope(:order))
 # SELECT books.* FROM books
 ```
 
-[`unscope`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-unscope
+[`unscope`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-unscope
 
 ### `only`
 
@@ -935,7 +935,7 @@ SELECT * FROM books WHERE id > 10 ORDER BY id DESC LIMIT 20
 
 ```
 
-[`only`]: https://api.rubyonrails/classes/ActiveRecord/SpawnMethods.html#method-i-only
+[`only`]: https://api.rubyonrails.org/classes/ActiveRecord/SpawnMethods.html#method-i-only
 
 ### `reselect`
 
@@ -1053,7 +1053,7 @@ the SQL executed would be:
 SELECT * FROM books WHERE `out_of_print` = 1 AND `out_of_print` = 0
 ```
 
-[`rewhere`]: https://api.rubyonrails/classes/ActiveRecord/QueryMethods.html#method-i-rewhere
+[`rewhere`]: https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-rewhere
 
 Null Relation
 -------------
@@ -1455,7 +1455,7 @@ class Book < ApplicationRecord
 end
 ```
 
-[`scope`]: https://api.rubyonrails/classes/ActiveRecord/Scoping/Named/ClassMethods.html#method-i-scope
+[`scope`]: https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Named/ClassMethods.html#method-i-scope
 
 ### Passing in arguments
 
@@ -1571,7 +1571,7 @@ irb> Book.new
 => #<Book id: nil, out_of_print: nil>
 ```
 
-[`default_scope`]: https://api.rubyonrails/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-default_scope
+[`default_scope`]: https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-default_scope
 
 ### Merging of scopes
 
@@ -1634,7 +1634,7 @@ SELECT books.* FROM books WHERE (year_published >= 1969) AND (price > 50)
 As you can see above the `default_scope` is being merged in both
 `scope` and `where` conditions.
 
-[`merge`]: https://api.rubyonrails/classes/ActiveRecord/SpawnMethods.html#method-i-merge
+[`merge`]: https://api.rubyonrails.org/classes/ActiveRecord/SpawnMethods.html#method-i-merge
 
 ### Removing All Scoping
 
@@ -1663,7 +1663,7 @@ irb> Book.unscoped { Book.out_of_print }
 SELECT books.* FROM books WHERE books.out_of_print
 ```
 
-[`unscoped`]: https://api.rubyonrails/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-unscoped
+[`unscoped`]: https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Default/ClassMethods.html#method-i-unscoped
 
 Dynamic Finders
 ---------------
@@ -1731,7 +1731,7 @@ UPDATE "orders" SET "status" = ?, "updated_at" = ? WHERE "orders"."id" = ?  [["s
 
 Full documentation about enums can be found [here](https://api.rubyonrails.org/classes/ActiveRecord/Enum.html).
 
-[`enum`]: https://api.rubyonrails/classes/ActiveRecord/Enum.html#method-i-enum
+[`enum`]: https://api.rubyonrails.org/classes/ActiveRecord/Enum.html#method-i-enum
 
 Understanding Method Chaining
 -----------------------------
@@ -1841,7 +1841,7 @@ end
 The block will only be executed if the customer is being created. The
 second time we run this code, the block will be ignored.
 
-[`find_or_create_by`]: https://api.rubyonrails/classes/ActiveRecord/Relation.html#method-i-find_or_create_by
+[`find_or_create_by`]: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by
 
 ### `find_or_create_by!`
 
@@ -1858,7 +1858,7 @@ irb> Customer.find_or_create_by!(first_name: 'Andy')
 ActiveRecord::RecordInvalid: Validation failed: Orders count can't be blank
 ```
 
-[`find_or_create_by!`]: https://api.rubyonrails/classes/ActiveRecord/Relation.html#method-i-find_or_create_by-21
+[`find_or_create_by!`]: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by-21
 
 ### `find_or_initialize_by`
 
@@ -1892,7 +1892,7 @@ irb> nina.save
 => true
 ```
 
-[`find_or_initialize_by`]: https://api.rubyonrails/classes/ActiveRecord/Relation.html#method-i-find_or_initialize_by
+[`find_or_initialize_by`]: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_initialize_by
 
 Finding by SQL
 --------------
@@ -1906,7 +1906,7 @@ irb> Customer.find_by_sql("SELECT * FROM customers INNER JOIN orders ON customer
 
 `find_by_sql` provides you with a simple way of making custom calls to the database and retrieving instantiated objects.
 
-[`find_by_sql`]: https://api.rubyonrails/classes/ActiveRecord/Querying.html#method-i-find_by_sql
+[`find_by_sql`]: https://api.rubyonrails.org/classes/ActiveRecord/Querying.html#method-i-find_by_sql
 
 ### `select_all`
 
@@ -1920,7 +1920,7 @@ irb> Customer.connection.select_all("SELECT first_name, created_at FROM customer
 => [{"first_name"=>"Rafael", "created_at"=>"2012-11-10 23:23:45.281189"}, {"first_name"=>"Eileen", "created_at"=>"2013-12-09 11:22:35.221282"}]
 ```
 
-[`connection.select_all`]: https://api.rubyonrails/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-select_all
+[`connection.select_all`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-select_all
 
 ### `pluck`
 
@@ -2011,7 +2011,7 @@ One way to avoid this is to `unscope` the includes:
 irb> assoc.unscope(:includes).pluck(:id)
 ```
 
-[`pluck`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-pluck
+[`pluck`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-pluck
 
 ### `ids`
 
@@ -2033,7 +2033,7 @@ irb> Customer.ids
 SELECT customer_id FROM customers
 ```
 
-[`ids`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-ids
+[`ids`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-ids
 
 Existence of Objects
 --------------------
@@ -2090,7 +2090,7 @@ Customer.first.orders.any?
 Customer.first.orders.many?
 ```
 
-[`exists?`]: https://api.rubyonrails/classes/ActiveRecord/FinderMethods.html#method-i-exists-3F
+[`exists?`]: https://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-exists-3F
 
 Calculations
 ------------
@@ -2145,7 +2145,7 @@ This will return a number (possibly a floating point number such as 3.14159265) 
 
 For options, please see the parent section, [Calculations](#calculations).
 
-[`average`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-average
+[`average`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-average
 
 ### Minimum
 
@@ -2157,7 +2157,7 @@ Order.minimum("subtotal")
 
 For options, please see the parent section, [Calculations](#calculations).
 
-[`minimum`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-minimum
+[`minimum`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-minimum
 
 ### Maximum
 
@@ -2169,7 +2169,7 @@ Order.maximum("subtotal")
 
 For options, please see the parent section, [Calculations](#calculations).
 
-[`maximum`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-maximum
+[`maximum`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-maximum
 
 ### Sum
 
@@ -2181,7 +2181,7 @@ Order.sum("subtotal")
 
 For options, please see the parent section, [Calculations](#calculations).
 
-[`sum`]: https://api.rubyonrails/classes/ActiveRecord/Calculations.html#method-i-sum
+[`sum`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-sum
 
 Running EXPLAIN
 ---------------
@@ -2288,7 +2288,7 @@ and may yield this for PostgreSQL:
 (2 rows)
 ```
 
-[`explain`]: https://api.rubyonrails/classes/ActiveRecord/Relation.html#method-i-explain
+[`explain`]: https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-explain
 
 ### Interpreting EXPLAIN
 


### PR DESCRIPTION
### Summary

840c1913e0717f356586107be8c300ccd1bbd0e3 added links to the api, but the
TLD was missing in the url.