### PR TITLE
Document ActionController::Cookies#cookies [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/cookies.rb
+++ b/actionpack/lib/action_controller/metal/cookies.rb
@@ -9,7 +9,9 @@ module ActionController #:nodoc:
     end
 
     private
-      def cookies
+      # The cookies for the current request. See ActionDispatch::Cookies for
+      # more information.
+      def cookies # :doc:
         request.cookie_jar
       end
   end


### PR DESCRIPTION
There are several `cookies` methods that appear when searching the API documentation, but none of them are the method commonly used in controllers.

This makes Action Controller's `cookies` method appear in the search results, and makes the accompanying `ActionDispatch::Cookies` documentation more discoverable.
