### PR TITLE
Interpreting leading characters in str as an integer

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -64,10 +64,10 @@ class String
   #   'And they found that many people were sleeping better.'.truncate(25, omission: '... (continued)')
   #   # => "And they f... (continued)"
   def truncate(truncate_at, options = {})
-    return dup unless length > truncate_at
+    return dup unless length > truncate_at.to_i
 
     omission = options[:omission] || "..."
-    length_with_room_for_omission = truncate_at - omission.length
+    length_with_room_for_omission = truncate_at.to_i - omission.length
     stop = \
       if options[:separator]
         rindex(options[:separator], length_with_room_for_omission) || length_with_room_for_omission


### PR DESCRIPTION
### Summary
I got these below error while running `'Once upon a time in a world far far away'.truncate('27')`,
`comparison of Integer with String failed`.
This PR fixes it.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
