### PR TITLE
Rack responses may be frozen

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -23,7 +23,24 @@ module ActionDispatch
     def call(env)
       req = ActionDispatch::Request.new env
       req.request_id = make_request_id(req.headers[@header])
-      @app.call(env).tap { |_status, headers, _body| headers[@header] = req.request_id }
+
+      response = @app.call(env)
+
+      status, headers, body = response
+
+      if headers.frozen?
+        headers = headers.dup
+
+        if response.frozen?
+          response = [status, headers, body]
+        else
+          response[1] = headers
+        end
+      end
+
+      headers[@header] = req.request_id
+
+      response
     end
 
     private


### PR DESCRIPTION
### Summary

We are getting errors like this in our production rails app from this middleware:

     FrozenError: can't modify frozen Hash
     .../actionpack-6.0.3.4/lib/action_dispatch/middleware/request_id.rb:27:in `block in call'

I'm not sure where the frozen response is coming from, but it seems like a thing which can happen -- even within rails, in [ActionDispatch::Http::Response#before_sending](https://github.com/rails/rails/blob/a750b0cf8fe362ef762f34972e2d1ec302795174/actionpack/lib/action_dispatch/http/response.rb#L467):

    def before_sending
      # Normally we've already committed by now, but it's possible
      # (e.g., if the controller action tries to read back its own
      # response) to get here before that. In that case, we must force
      # an "early" commit: we're about to freeze the headers, so this is
      # our last chance.
      commit! unless committed?

      headers.freeze
      request.commit_cookie_jar! unless committed?
    end

This middleware seems to take pains to avoid too much object churn, so the spirit has been followed here to only duplicate what is required to insert the header.