### PR TITLE
ActionView: FormBuilder default aria-invalid value

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -46,6 +46,7 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
+      @validator.validate!(options)
       @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { editable_value }, options.except("value"))
     end
 

--- a/actiontext/test/dummy/app/models/validated_message.rb
+++ b/actiontext/test/dummy/app/models/validated_message.rb
@@ -1,0 +1,3 @@
+class ValidatedMessage < Message
+  validates :body, presence: true
+end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -124,4 +124,20 @@ class ActionText::FormHelperTest < ActionView::TestCase
       "</form>",
       output_buffer
   end
+
+  test "form with invalid rich text area" do
+    model = ValidatedMessage.new.tap(&:validate)
+
+    form_with url: "/messages", model: model, scope: :message do |form|
+      form.rich_text_area :body
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[body]" id="message_body_trix_input_validated_message" />' \
+        '<trix-editor aria-invalid="true" id="message_body" input="message_body_trix_input_validated_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
 end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   When rendering fields for an ActiveModel-enabled form, encode the validity of
+    the field to the [aria-invalid][] attribute.
+
+    *Sean Doyle*
+
+[aria-invalid]: https://www.w3.org/TR/wai-aria-1.1/#aria-invalid
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Yield translated strings to calls of `ActionView::FormBuilder#button`

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/validator"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
@@ -18,6 +20,7 @@ module ActionView
           @skip_default_ids = options.delete(:skip_default_ids)
           @allow_method_names_outside_object = options.delete(:allow_method_names_outside_object)
           @options = options
+          @validator = Validator.new(@object, @method_name)
 
           if Regexp.last_match
             @generate_indexed_names = true

--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -13,6 +13,8 @@ module ActionView
         end
 
         def render
+          @validator.validate!(@html_options)
+
           error_wrapping(datetime_selector(@options, @html_options).public_send("select_#{select_type}").html_safe)
         end
 

--- a/actionview/lib/action_view/helpers/tags/hidden_field.rb
+++ b/actionview/lib/action_view/helpers/tags/hidden_field.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/validator"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class HiddenField < TextField # :nodoc:
+        def initialize(*)
+          super
+
+          @validator = NullValidator.new
+        end
       end
     end
   end

--- a/actionview/lib/action_view/helpers/tags/radio_button.rb
+++ b/actionview/lib/action_view/helpers/tags/radio_button.rb
@@ -17,7 +17,10 @@ module ActionView
           options = @options.stringify_keys
           options["type"]     = "radio"
           options["value"]    = @tag_value
-          options["checked"] = "checked" if input_checked?(options)
+          if input_checked?(options)
+            options["checked"] = "checked"
+            @validator.validate!(options)
+          end
           add_default_name_and_id_for_value(@tag_value, options)
           tag("input", options)
         end

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -25,6 +25,8 @@ module ActionView
             options_for_select(@choices, option_tags_options)
           end
 
+          @validator.validate!(@html_options)
+
           select_content_tag(option_tags, @options, @html_options)
         end
 

--- a/actionview/lib/action_view/helpers/tags/text_area.rb
+++ b/actionview/lib/action_view/helpers/tags/text_area.rb
@@ -16,6 +16,8 @@ module ActionView
             options["cols"], options["rows"] = size.split("x") if size.respond_to?(:split)
           end
 
+          @validator.validate!(options)
+
           content_tag("textarea", options.delete("value") { value_before_type_cast }, options)
         end
       end

--- a/actionview/lib/action_view/helpers/tags/text_field.rb
+++ b/actionview/lib/action_view/helpers/tags/text_field.rb
@@ -13,6 +13,7 @@ module ActionView
           options["size"] = options["maxlength"] unless options.key?("size")
           options["type"] ||= field_type
           options["value"] = options.fetch("value") { value_before_type_cast } unless field_type == "file"
+          @validator.validate!(options)
           add_default_name_and_id(options)
           tag("input", options)
         end

--- a/actionview/lib/action_view/helpers/tags/validator.rb
+++ b/actionview/lib/action_view/helpers/tags/validator.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Helpers
+    module Tags # :nodoc:
+      class NullValidator
+        def validate!(attributes)
+          attributes
+        end
+      end
+
+      class Validator # :nodoc:
+        def initialize(object, method_name)
+          @object = object
+          @method_name = method_name
+        end
+
+        def validate!(attributes)
+          if validatable?
+            attributes["aria-invalid"] ||= invalid? ? "true" : nil
+          end
+
+          attributes
+        end
+
+        private
+          def invalid?
+            @object.errors.include?(@method_name)
+          end
+
+          def validatable?
+            @object.respond_to?(:errors) && @object.errors.respond_to?(:include?)
+          end
+      end
+    end
+  end
+end

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -35,27 +35,27 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_text_area_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><textarea id="post_body" name="post[body]">\nBack to the hill and over it again!</textarea></div>),
+      field_error(%(<textarea id="post_body" name="post[body]" aria-invalid="true">\nBack to the hill and over it again!</textarea>)),
       text_area("post", "body")
     )
   end
 
   def test_text_field_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /></div>),
+      field_error(%(<input id="post_author_name" name="post[author_name]" type="text" value="" aria-invalid="true" />)),
       text_field("post", "author_name")
     )
   end
 
   def test_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><select name="post[author_name]" id="post_author_name"><option value="a">a</option>\n<option value="b">b</option></select></div>),
+      field_error(%(<select name="post[author_name]" id="post_author_name" aria-invalid="true"><option value="a">a</option>\n<option value="b">b</option></select>)),
       select("post", "author_name", [:a, :b])
     )
   end
 
   def test_select_with_errors_and_blank_option
-    expected_dom = %(<div class="field_with_errors"><select name="post[author_name]" id="post_author_name"><option value="">Choose one...</option>\n<option value="a">a</option>\n<option value="b">b</option></select></div>)
+    expected_dom = field_error %(<select name="post[author_name]" id="post_author_name" aria-invalid="true"><option value="">Choose one...</option>\n<option value="a">a</option>\n<option value="b">b</option></select>)
     assert_dom_equal(expected_dom, select("post", "author_name", [:a, :b], include_blank: "Choose one..."))
     assert_dom_equal(expected_dom, select("post", "author_name", [:a, :b], prompt: "Choose one..."))
   end
@@ -67,35 +67,35 @@ class ActiveModelHelperTest < ActionView::TestCase
     ]
 
     assert_dom_equal(
-      %(<div class="field_with_errors"><select name="post[category]" id="post_category"><optgroup label="A"><option value="A1">A1</option>\n<option value="A2">A2</option></optgroup><optgroup label="B"><option value="B1">B1</option>\n<option value="B2">B2</option></optgroup></select></div>),
+      field_error(%(<select name="post[category]" id="post_category" aria-invalid="true"><optgroup label="A"><option value="A1">A1</option>\n<option value="A2">A2</option></optgroup><optgroup label="B"><option value="B1">B1</option>\n<option value="B2">B2</option></optgroup></select>)),
       select("post", "category", grouped_options)
     )
   end
 
   def test_collection_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><select name="post[author_name]" id="post_author_name"><option value="a">a</option>\n<option value="b">b</option></select></div>),
+      field_error(%(<select name="post[author_name]" id="post_author_name"><option value="a">a</option>\n<option value="b">b</option></select>)),
       collection_select("post", "author_name", [:a, :b], :to_s, :to_s)
     )
   end
 
   def test_date_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><select id="post_updated_at_1i" name="post[updated_at(1i)]">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" />\n</div>),
+      field_error(%(<select id="post_updated_at_1i" name="post[updated_at(1i)]" aria-invalid="true">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" />\n)),
       date_select("post", "updated_at", discard_month: true, discard_day: true, start_year: 2004, end_year: 2005)
     )
   end
 
   def test_datetime_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      field_error(%(<input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]" aria-invalid="true">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]" aria-invalid="true">\n<option selected="selected" value="00">00</option>\n</select>\n)),
       datetime_select("post", "updated_at", discard_year: true, discard_month: true, discard_day: true, minute_step: 60)
     )
   end
 
   def test_time_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      field_error(%(<input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]" aria-invalid="true">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]" aria-invalid="true">\n<option selected="selected" value="00">00</option>\n</select>\n)),
       time_select("post", "updated_at", minute_step: 60)
     )
   end
@@ -123,14 +123,14 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_radio_button_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails" /></div>),
+      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails" aria-invalid="true" /></div>),
       radio_button("post", "category", "rails")
     )
   end
 
   def test_radio_buttons_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails" /></div><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java" /></div>),
+      %(<div class="field_with_errors"><input type="radio" value="rails" checked="checked" name="post[category]" id="post_category_rails" aria-invalid="true" /></div><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java" /></div>),
       radio_button("post", "category", "rails") + radio_button("post", "category", "java")
     )
   end
@@ -163,10 +163,15 @@ class ActiveModelHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" /> <span class="error">can't be empty</span></div>),
+      %(<div class="field_with_errors"><input id="post_author_name" name="post[author_name]" type="text" value="" aria-invalid="true" /> <span class="error">can't be empty</span></div>),
       text_field("post", "author_name")
     )
   ensure
     ActionView::Base.field_error_proc = old_proc if old_proc
   end
+
+  private
+    def field_error(content)
+      ActionView::Base.field_error_proc.call(content)
+    end
 end


### PR DESCRIPTION
When rendering fields for an ActiveModel-enabled form, encode the
validity of the field to the [aria-invalid][] attribute.

Encode the validity for `<input type="text">` descendants (with the
exception of `type="hidden"` and `type="checkbox"`), `<select>`
elements, `<textarea>` elements, and `<trix-editor>` elements.

When rendering an `<input type="radio">`, _only_ render
`[aria-invalid="true"]` for the element marked as `[checked]`.

[aria-invalid]: https://www.w3.org/TR/wai-aria-1.1/#aria-invalid

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
