### PR TITLE
[ci skip] use ApplicationRecord as parent class on guides

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -129,7 +129,7 @@
 
 *   Named scope chain does no longer leak scope to class level querying methods.
 
-        class User < ActiveRecord::Base
+        class User < ApplicationRecord
           scope :david, -> { User.where(name: "David") }
         end
 
@@ -299,7 +299,7 @@
 *   Allow associations supporting the `dependent:` key to take `dependent: :destroy_async`.
 
     ```ruby
-    class Account < ActiveRecord::Base
+    class Account < ApplicationRecord
         belongs_to :supplier, dependent: :destroy_async
     end
     ```
@@ -341,7 +341,7 @@
 *   Allow `where` references association names as joined table name aliases.
 
     ```ruby
-    class Comment < ActiveRecord::Base
+    class Comment < ApplicationRecord
       enum label: [:default, :child]
       has_many :children, class_name: "Comment", foreign_key: :parent_id
     end
@@ -390,7 +390,7 @@
 *   Allow attribute's default to be configured but keeping its own type.
 
     ```ruby
-    class Post < ActiveRecord::Base
+    class Post < ApplicationRecord
       attribute :written_at, default: -> { Time.now.utc }
     end
 
@@ -406,7 +406,7 @@
 *   Allow default to be configured for Enum.
 
     ```ruby
-    class Book < ActiveRecord::Base
+    class Book < ApplicationRecord
       enum status: [:proposed, :written, :published], _default: :published
     end
 

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -104,7 +104,7 @@ create_table :store_listings, force: true do |t|
 end
 
 # app/models/store_listing.rb
-class StoreListing < ActiveRecord::Base
+class StoreListing < ApplicationRecord
 end
 
 store_listing = StoreListing.new(price_in_cents: '10.1')
@@ -113,7 +113,7 @@ store_listing = StoreListing.new(price_in_cents: '10.1')
 store_listing.price_in_cents # => BigDecimal.new(10.1)
 StoreListing.new.my_string # => "original default"
 
-class StoreListing < ActiveRecord::Base
+class StoreListing < ApplicationRecord
   attribute :price_in_cents, :integer # custom type
   attribute :my_string, :string, default: "new default" # default value
   attribute :my_default_proc, :datetime, default: -> { Time.now } # default value

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -257,7 +257,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   Named scope chain does no longer leak scope to class level querying methods.
 
-        class User < ActiveRecord::Base
+        class User < ApplicationRecord
           scope :david, -> { User.where(name: "David") }
         end
 


### PR DESCRIPTION
### Summary

Change ActiveRecord::Base by ApplicationRecord

