### PR TITLE
Document Regexp#multiline? [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/regexp.rb
+++ b/activesupport/lib/active_support/core_ext/regexp.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
-class Regexp #:nodoc:
+class Regexp
+  # Returns +true+ if the regexp has the multiline flag set.
+  #
+  #   (/./).multiline?  # => false
+  #   (/./m).multiline? # => true
+  #
+  #   Regexp.new(".").multiline?                    # => false
+  #   Regexp.new(".", Regexp::MULTILINE).multiline? # => true
   def multiline?
     options & MULTILINE == MULTILINE
   end


### PR DESCRIPTION
`Regexp#multiline?` has been publicized in the Active Support Core Extensions guide [for a while now](https://guides.rubyonrails.org/v4.0/active_support_core_extensions.html#multiline-questionmark).  This commit adds matching API docs.