### PR TITLE
Identical type for primary key and reference on sqlite3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -284,7 +284,7 @@ module ActiveRecord
       end
 
       def add_reference(table_name, ref_name, **options) # :nodoc:
-        super(table_name, ref_name, type: :integer, **options)
+        super(table_name, ref_name, type: :bigint, **options)
       end
       alias :add_belongs_to :add_reference
 


### PR DESCRIPTION
### Summary
While working on issue https://github.com/rails/rails/issues/40583, I found that after this https://github.com/rails/rails/commit/b92ae610699f991e4616409815fa1e7f134dacc5 change, we need to use identical type for primary_key and reference on sqlite3. It was done for mysql2 and postgresql on https://github.com/rails/rails/commit/14db455156cf822f1af738f24528200ae19efc1c; This PR updates reference type to `:bigint` for sqlite3.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
