### PR TITLE
Add support for sqlcmd instead of sqsh on sql server

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -73,17 +73,17 @@ module Rails
       when "sqlserver"
         args = []
 
-        args += ["-D", "#{db_config.database}"] if db_config.database
+        args += ["-d", "#{db_config.database}"] if db_config.database
         args += ["-U", "#{config[:username]}"] if config[:username]
         args += ["-P", "#{config[:password]}"] if config[:password]
 
         if config[:host]
-          host_arg = +"#{config[:host]}"
-          host_arg << ":#{config[:port]}" if config[:port]
+          host_arg = +"tcp:#{config[:host]}"
+          host_arg << ",#{config[:port]}" if config[:port]
           args += ["-S", host_arg]
         end
 
-        find_cmd_and_exec("sqsh", *args)
+        find_cmd_and_exec("sqlcmd", *args)
 
       else
         abort "Unknown command-line client for #{db_config.database}."

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -194,7 +194,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   def test_sqlserver
     start(adapter: "sqlserver", database: "db", username: "user", password: "secret", host: "localhost", port: 1433)
     assert_not aborted
-    assert_equal ["sqsh", "-D", "db", "-U", "user", "-P", "secret", "-S", "localhost:1433"], dbconsole.find_cmd_and_exec_args
+    assert_equal ["sqlcmd", "-d", "db", "-U", "user", "-P", "secret", "-S", "tcp:localhost,1433"], dbconsole.find_cmd_and_exec_args
   end
 
   def test_unknown_command_line_client


### PR DESCRIPTION
### Summary
Fixes for #40611 to suggest that Rails move from sqsh to sqlcmd, which Microsoft offers on Windows, Mac, and Linux.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
