### PR TITLE
Fix preventing_writes for granular swapping

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -23,6 +23,10 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :schema_cache
+
+      def owner_name
+        nil
+      end
     end
 
     # Connection pool base class for managing Active Record database
@@ -356,7 +360,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config
+      attr_reader :db_config, :size, :reaper, :pool_config, :owner_name
 
       delegate :schema_cache, :schema_cache=, to: :pool_config
 
@@ -371,6 +375,7 @@ module ActiveRecord
 
         @pool_config = pool_config
         @db_config = pool_config.db_config
+        @owner_name = pool_config.connection_specification_name
 
         @checkout_timeout = db_config.checkout_timeout
         @idle_timeout = db_config.idle_timeout

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
@@ -11,9 +11,7 @@ module ActiveRecord
       self.use_transactional_tests = false
 
       def setup
-        @conn = Base.sqlite3_connection database: ":memory:",
-                                        adapter: "sqlite3",
-                                        timeout: 100
+        @conn = ActiveRecord::Base.connection
       end
 
       def test_errors_when_an_insert_query_is_called_while_preventing_writes
@@ -100,9 +98,7 @@ module ActiveRecord
         @old_value = ActiveRecord::Base.legacy_connection_handling
         ActiveRecord::Base.legacy_connection_handling = true
 
-        @conn = Base.sqlite3_connection database: ":memory:",
-                                        adapter: "sqlite3",
-                                        timeout: 100
+        @conn = ActiveRecord::Base.connection
 
         @connection_handler = ActiveRecord::Base.connection_handler
       end


### PR DESCRIPTION
When we implemented granular connection swapping we treated
`prevent_writes` similarly to `role` and `shard`. However, it's a little
different. `prevent_writes` is a feature of a conneciton whereas `role`
and `shared` are used to lookup a connection. A writing connection that
wants to prevent writes doesn't get stored in the pool as such,
`prevent_writes` is added as a way to change behavior of a connection.

Because of this when `preventing_writes?` calls
`ActiveRecord::Base.current_preventing_writes` the lookup is on the
wrong class if we're using granular swapping. Instead we need to lookup
the `prevent_writes` from the class that called `connected_to` rather
than `ActiveRecord::Base`. To do that I've done the following:

1) Added access to the `connection_specification_name` as `owner_name`
on the pool so the connection can access it.
2) Call `safe_constantize` on the `owner_name` since the
`connected_to_stack` stores the class as a class and not a string.
3) Now we can call `safe_constantize` on the klass that we got out of
the pool to be able to look up the correct `prevent_writes` from the
stack.

I benchmarked this and the two versions were pretty close, although this
is a little bit slower.

I tried a few other ways of fixing this. I first tried adding
`prevent_writes` to the connection in `retrieve_connection` based on the
`current_preventing_writes` but then that behavior only worked correctly
for ActiveRecord connections. If we already had a connection and
`retrieve_connection` isn't called then the tests testing that behavior
would fail. This was the best way to not introduce confusing differences
between global and granular connections.

Fixes #40559

cc/ @seejohnrun 