### PR TITLE
use listen v3.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 
 # Active Support
 gem "dalli"
-gem "listen", "~> 3.3", require: false
+gem "listen", "~> 3.3", ">= 3.3.1", require: false
 gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
 gem "rexml", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
       mustache
       nokogiri
     libxml-ruby (3.2.0)
-    listen (3.3.0)
+    listen (3.3.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.7.0)
@@ -578,7 +578,7 @@ DEPENDENCIES
   json (>= 2.0.0)
   kindlerb (~> 1.2.0)
   libxml-ruby
-  listen (~> 3.3)
+  listen (~> 3.3, >= 3.3.1)
   minitest-bisect
   minitest-reporters
   minitest-retry


### PR DESCRIPTION
### Summary

We discovered a race condition in `listen` v3.3.0 where if code ever calls `listener.stop` before `listener.start`, an exception is raised. This is fixed in `listen` [v3.3.1](https://github.com/guard/listen/releases/tag/v3.3.1).
- Bumps `listen` gem to v3.3.1.
