### PR TITLE
CI against erubi 1.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       http_parser.rb (>= 0.6.0)
     em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
-    erubi (1.9.0)
+    erubi (1.10.0)
     et-orbi (1.2.4)
       tzinfo
     event_emitter (0.2.6)


### PR DESCRIPTION
A new version of Erubi was released: https://rubygems.org/gems/erubi

This release includes [an internal refactoring](https://github.com/jeremyevans/erubi/commit/4dc81c21) that once introduced an incompatibility for Action View that was [two months later reverted back](https://github.com/jeremyevans/erubi/commit/16ca175) because the maintainer luckily discovered the breakage while pareparing for the release.

I know it's only a week since we [upgraded everything](fc73becc3cbfa574af9d7f8359d060728375d186), but now that the gem has been released, and it'd be bundled on Rails 6.1 users' apps, we'd better CI against this version.

Thank you @jeremyevans for letting me know about this release.