### PR TITLE
Add support to MemoryStore to clear specific namespaces.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -3,6 +3,10 @@
 
     *Max Gurewitz*
 
+*   Add support to clear specific namespaces in `MemoryStore` using `.clear(namespace:)`
+
+    *Doug Edey
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Calling `iso8601` on negative durations retains the negative sign on individual

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -62,8 +62,12 @@ module ActiveSupport
       # Delete all data stored in a given cache store.
       def clear(options = nil)
         synchronize do
-          @data.clear
-          @cache_size = 0
+          if options && options[:namespace]
+            delete_matched(//, options)
+          else
+            @data.clear
+            @cache_size = 0
+          end
         end
       end
 

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -27,6 +27,26 @@ class MemoryStoreTest < ActiveSupport::TestCase
   def test_large_object_with_default_compression_settings
     assert_uncompressed(LARGE_OBJECT)
   end
+
+  def test_clear_responds_to_namespace_option
+    @cache.write("key_name", "a", namespace: "a")
+    @cache.write("key_name", "b", namespace: "b")
+
+    @cache.clear(namespace: "a")
+
+    assert_not @cache.exist?("key_name", namespace: "a")
+    assert @cache.exist?("key_name", namespace: "b")
+  end
+
+  def test_clear_clears_all_namespaces
+    @cache.write("key_name", "a", namespace: "a")
+    @cache.write("key_name", "b", namespace: "b")
+
+    @cache.clear
+
+    assert_not @cache.exist?("key_name", namespace: "a")
+    assert_not @cache.exist?("key_name", namespace: "b")
+  end
 end
 
 class MemoryStorePruningTest < ActiveSupport::TestCase


### PR DESCRIPTION
### Summary

I was implementing some namespace based caching and found that the `ActiveSupport::Cache::MemoryStore` that I used in tests behaved differently to the `RedisCacheStore` (used in development/production) when calling `.clear`, while adding and deleting based on namespace behaves the same, the Memory store just clears everything.

I originally went with a loop over the raw `@data.keys`, because `delete_matched` is instrumented, but then I realized that 

(1) `RedisCacheStore.clear(namespace:)` uses `delete_matched`
(2) We probably want to expose this instrumentation if developers want it.

### Other Information

This was fixed in `RedisCacheStore` a while ago: https://github.com/rails/rails/pull/32573

