### PR TITLE
Only invalidate query caches for peer connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -30,6 +30,7 @@ module ActiveRecord
 
     class NullPool # :nodoc:
       include ConnectionAdapters::AbstractPool
+      include QueryCache::NullConnectionPoolConfiguration
 
       attr_accessor :schema_cache
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -18,11 +18,16 @@ module ActiveRecord
           method_names.each do |method_name|
             base.class_eval <<-end_code, __FILE__, __LINE__ + 1
               def #{method_name}(*)
-                ActiveRecord::Base.clear_query_caches_for_current_thread
+                pool.clear_query_caches_for_peer_connections
                 super
               end
             end_code
           end
+        end
+      end
+
+      module NullConnectionPoolConfiguration
+        def clear_query_caches_for_peer_connections
         end
       end
 
@@ -44,6 +49,10 @@ module ActiveRecord
 
         def query_cache_enabled
           @query_cache_enabled[connection_cache_key(current_thread)]
+        end
+
+        def clear_query_caches_for_peer_connections
+          ActiveRecord::Base.clear_query_caches_for_peer_connections(pool_config.connection_specification_name)
         end
       end
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -244,6 +244,10 @@ module ActiveRecord
       clear_on_handler(ActiveRecord::Base.connection_handler)
     end
 
+    def clear_query_caches_for_peer_connections(owner) # :nodoc:
+      clear_on_handler(ActiveRecord::Base.connection_handler, owner)
+    end
+
     # Returns the connection currently associated with the class. This can
     # also be used to "borrow" the connection to do database work unrelated
     # to any of the specific Active Records.
@@ -309,8 +313,9 @@ module ActiveRecord
       :clear_all_connections!, :flush_idle_connections!, to: :connection_handler
 
     private
-      def clear_on_handler(handler)
+      def clear_on_handler(handler, owner = nil)
         handler.all_connection_pools.each do |pool|
+          next if owner && pool.pool_config.connection_specification_name != owner
           pool.connection.clear_query_cache if pool.active_connection?
         end
       end


### PR DESCRIPTION
As suggested by @matthewd in https://github.com/rails/rails/pull/35089#discussion_r252103555:

> Along that line, I think I'd actually go further, and limit this to only the current-thread-owned connection _in the peer pools_ -- the corresponding same-named pool in other handlers -- not all pools.

Currently writes invalidate the query cache for all connections that are owned by the current thread, but this causes unnecessary cache misses when reading from one database and writing to another.

We only need to ensure that writes can be read from their corresponding reading connections, so only clearing the cache for connections with the same `connection_specification_name` is sufficient.