### PR TITLE
Make exclusive endless ranges produce `gt` queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Make exclusive endless ranges produce `gt` queries:
+
+    Currently, `where` with exclusive, endless ranges produces the same, `gteq`,
+    queries as `where` with inclusive, endless ranges:
+    
+    ```
+    irb(main):001:0> Thing.where(id: 42..::Float::INFINITY).count
+       (0.2ms)  SELECT COUNT(*) FROM "things" WHERE "things"."id" >= ?  [["age", 18]]
+    => 2
+    irb(main):002:0> Thing.where(id: 42...::Float::INFINITY).count
+       (0.2ms)  SELECT COUNT(*) FROM "things" WHERE "things"."id" >= ?  [["age", 18]]
+    => 2
+    ```
+
+    After this change, `where` with exclusive, endless ranges produces `gt` queries:
+
+    ```
+    irb(main):001:0> Thing.where(id: 42..::Float::INFINITY).count
+       (0.2ms)  SELECT COUNT(*) FROM "things" WHERE "things"."id" >= ?  [["age", 18]]
+    => 2
+    irb(main):002:0> Thing.where(id: 42...::Float::INFINITY).count
+       (0.2ms)  SELECT COUNT(*) FROM "things" WHERE "things"."id" > ?  [["age", 18]]
+    => 1
+    ```
+
+    *Raghu Betina*
+
 *   Build predicate conditions with objects that delegate `#id` and primary key:
 
     ```ruby

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -37,16 +37,20 @@ module Arel # :nodoc: all
     def between(other)
       if unboundable?(other.begin) == 1 || unboundable?(other.end) == -1
         self.in([])
+      elsif open_ended?(other.begin) && open_ended?(other.end)
+        not_in([])
       elsif open_ended?(other.begin)
-        if open_ended?(other.end)
-          not_in([])
-        elsif other.exclude_end?
+        if other.exclude_end?
           lt(other.end)
         else
           lteq(other.end)
         end
       elsif open_ended?(other.end)
-        gteq(other.begin)
+        if other.exclude_end?
+          gt(other.begin)
+        else
+          gteq(other.begin)
+        end
       elsif other.exclude_end?
         gteq(other.begin).and(lt(other.end))
       else

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -638,12 +638,52 @@ module Arel
           )
         end
 
+        it "can be constructed with a quoted range ending at Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(quoted_range(0, ::Float::INFINITY, false))
+
+          _(node).must_equal Nodes::GreaterThanOrEqual.new(
+            attribute,
+            Nodes::Quoted.new(0)
+          )
+        end
+
+        it "can be constructed with an exclusive range ending at Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(0...::Float::INFINITY)
+
+          _(node).must_equal Nodes::GreaterThan.new(
+            attribute,
+            Nodes::Casted.new(0, attribute)
+          )
+        end
+
+        it "can be constructed with a quoted exclusive range ending at Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(quoted_range(0, ::Float::INFINITY, true))
+
+          _(node).must_equal Nodes::GreaterThan.new(
+            attribute,
+            Nodes::Quoted.new(0)
+          )
+        end
+
         if RUBY_VERSION >= "2.7"
           it "can be constructed with a range implicitly starting at Infinity" do
             attribute = Attribute.new nil, nil
             node = attribute.between(eval("..0")) # eval for backwards compatibility
 
             _(node).must_equal Nodes::LessThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            )
+          end
+
+          it "can be constructed with an exclusive range implicitly starting at Infinity" do
+            attribute = Attribute.new nil, nil
+            node = attribute.between(eval("...0")) # eval for backwards compatibility
+
+            _(node).must_equal Nodes::LessThan.new(
               attribute,
               Nodes::Casted.new(0, attribute)
             )
@@ -656,6 +696,16 @@ module Arel
             node = attribute.between(eval("0..")) # Use eval for compatibility with Ruby < 2.6 parser
 
             _(node).must_equal Nodes::GreaterThanOrEqual.new(
+              attribute,
+              Nodes::Casted.new(0, attribute)
+            )
+          end
+
+          it "can be constructed with an exclusive range implicitly ending at Infinity" do
+            attribute = Attribute.new nil, nil
+            node = attribute.between(eval("(0...)")) # Use eval for compatibility with Ruby < 2.6 parser
+
+            _(node).must_equal Nodes::GreaterThan.new(
               attribute,
               Nodes::Casted.new(0, attribute)
             )

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1062,8 +1062,20 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal [1, 2, 6, 7, 8], Comment.where(id: [1..2, 6..8]).to_a.map(&:id).sort
   end
 
-  def test_find_on_hash_conditions_with_open_ended_range
+  def test_find_on_hash_conditions_with_beginless_range
     assert_equal [1, 2, 3], Comment.where(id: Float::INFINITY..3).to_a.map(&:id).sort
+  end
+
+  def test_find_on_hash_conditions_with_exclusive_beginless_range
+    assert_equal [1, 2], Comment.where(id: Float::INFINITY...3).to_a.map(&:id).sort
+  end
+
+  def test_find_on_hash_conditions_with_endless_range
+    assert_equal [10, 11, 12], Comment.where(id: 10..Float::INFINITY).to_a.map(&:id).sort
+  end
+
+  def test_find_on_hash_conditions_with_exclusive_endless_range
+    assert_equal [11, 12], Comment.where(id: 10...Float::INFINITY).to_a.map(&:id).sort
   end
 
   def test_find_on_hash_conditions_with_numeric_range_for_string


### PR DESCRIPTION
Before this patch, a `where` with an **exclusive**, **endless** `Range`
argument:

```ruby
Thing.where(id: 42...::Float::INFINITY)
```

Produced:

```sql
SELECT COUNT(*) FROM "things" WHERE "things"."id" >= ?  [["id", 42]]
```

I expected that using an exclusive endless `Range` would produce a `>`
query, equivalent to:

```ruby
Thing.where(Thing.arel_table[:id].gt(42))
```

Instead, it does the same thing as an _inclusive_ endless `Range`,
producing a `>=` query.

By comparison (using Ruby 2.6 and 2.7s implicit beginless and endless
syntax):

 - `Thing.where(id: ..42)` (inclusive, beginless) produces `<=`:

    ```sql
    SELECT COUNT(*) FROM "things" WHERE "things"."id" <= ?  [["id", 42]]
    ```
 - `Thing.where(id: ...42)` (exclusive, beginless) produces `<`:

    ```sql
    SELECT COUNT(*) FROM "photos" WHERE "photos"."id" < ?  [["id", 42]]
    ```
 - `Thing.where(id: 42..)` (inclusive, endless) produces `>=`:

    ```sql
    SELECT COUNT(*) FROM "photos" WHERE "photos"."id" >= ?  [["id", 42]]
    ```

It seems least-surprising that `Thing.where(id: 42...)` (exclusive, endless)
would produce `>`, symmetrically to the beginless exclusive behavior.

A counterargument is that `Range`s are inclusive or exclusive of their
_ending_, and not their beginning; so `42..::Float::INFINITY` and
`42...::Float::INFINITY` are the same. So it's reasonable that they
produce the same query when used as arguments to `where`.

However, I believe it's worth breaking with mathematical purity here to
complete the inequalities available without dropping down to Arel;
especially as the style becomes more popular with Ruby 2.6 and 2.7's
implicit endless and beginless `Range` syntax.

Therefore, this patch differentiates between _exclusive_ and _inclusive_
endless `Range`s when building predicates, and makes the former produce
`gt` queries instead of `gteq`.

Resolves #40627.
