### PR TITLE
issue with schema:load when a MySQL table definition contains partitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       http_parser.rb (>= 0.6.0)
     em-socksify (0.3.2)
       eventmachine (>= 1.0.0.beta.4)
-    erubi (1.9.0)
+    erubi (1.10.0)
     et-orbi (1.2.4)
       tzinfo
     event_emitter (0.2.6)

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -338,7 +338,7 @@
     Example global policy:
 
     ```ruby
-    Rails.application.config.feature_policy do |f|
+    Rails.application.config.permissions_policy do |f|
       f.camera      :none
       f.gyroscope   :none
       f.microphone  :none
@@ -352,7 +352,7 @@
 
     ```ruby
     class PagesController < ApplicationController
-      feature_policy do |p|
+      permissions_policy do |p|
         p.geolocation "https://example.com"
       end
     end

--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -29,7 +29,7 @@ module ActionController
     autoload :DefaultHeaders
     autoload :EtagWithTemplateDigest
     autoload :EtagWithFlash
-    autoload :FeaturePolicy
+    autoload :PermissionsPolicy
     autoload :Flash
     autoload :Head
     autoload :Helpers

--- a/actionpack/lib/action_controller/base.rb
+++ b/actionpack/lib/action_controller/base.rb
@@ -226,7 +226,7 @@ module ActionController
       FormBuilder,
       RequestForgeryProtection,
       ContentSecurityPolicy,
-      FeaturePolicy,
+      PermissionsPolicy,
       Streaming,
       DataStreaming,
       HttpAuthentication::Basic::ControllerMethods,

--- a/actionpack/lib/action_controller/metal/permissions_policy.rb
+++ b/actionpack/lib/action_controller/metal/permissions_policy.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module ActionController #:nodoc:
-  # HTTP Feature Policy is a web standard for defining a mechanism to
-  # allow and deny the use of browser features in its own context, and
+  # HTTP Permissions Policy is a web standard for defining a mechanism to
+  # allow and deny the use of browser permissions in its own context, and
   # in content within any <iframe> elements in the document.
   #
-  # Full details of HTTP Feature Policy specification and guidelines can
+  # Full details of HTTP Permissions Policy specification and guidelines can
   # be found at MDN:
   #
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
@@ -13,7 +13,7 @@ module ActionController #:nodoc:
   # Examples of usage:
   #
   #   # Global policy
-  #   Rails.application.config.feature_policy do |f|
+  #   Rails.application.config.permissions_policy do |f|
   #     f.camera      :none
   #     f.gyroscope   :none
   #     f.microphone  :none
@@ -24,20 +24,20 @@ module ActionController #:nodoc:
   #
   #   # Controller level policy
   #   class PagesController < ApplicationController
-  #     feature_policy do |p|
+  #     permissions_policy do |p|
   #       p.geolocation "https://example.com"
   #     end
   #   end
-  module FeaturePolicy
+  module PermissionsPolicy
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def feature_policy(**options, &block)
+      def permissions_policy(**options, &block)
         before_action(options) do
           if block_given?
-            policy = request.feature_policy.clone
+            policy = request.permissions_policy.clone
             yield policy
-            request.feature_policy = policy
+            request.permissions_policy = policy
           end
         end
       end

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -46,7 +46,7 @@ module ActionDispatch
   eager_autoload do
     autoload_under "http" do
       autoload :ContentSecurityPolicy
-      autoload :FeaturePolicy
+      autoload :PermissionsPolicy
       autoload :Request
       autoload :Response
     end

--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -3,10 +3,10 @@
 require "active_support/core_ext/object/deep_dup"
 
 module ActionDispatch #:nodoc:
-  class FeaturePolicy
+  class PermissionsPolicy
     class Middleware
       CONTENT_TYPE = "Content-Type"
-      POLICY       = "Feature-Policy"
+      POLICY       = "Permissions-Policy"
 
       def initialize(app)
         @app = app
@@ -19,7 +19,7 @@ module ActionDispatch #:nodoc:
         return response unless html_response?(headers)
         return response if policy_present?(headers)
 
-        if policy = request.feature_policy
+        if policy = request.permissions_policy
           headers[POLICY] = policy.build(request.controller_instance)
         end
 
@@ -47,13 +47,13 @@ module ActionDispatch #:nodoc:
     end
 
     module Request
-      POLICY = "action_dispatch.feature_policy"
+      POLICY = "action_dispatch.permissions_policy"
 
-      def feature_policy
+      def permissions_policy
         get_header(POLICY)
       end
 
-      def feature_policy=(policy)
+      def permissions_policy=(policy)
         set_header(POLICY, policy)
       end
     end
@@ -63,8 +63,8 @@ module ActionDispatch #:nodoc:
       none: "'none'",
     }.freeze
 
-    # List of available features can be found at
-    # https://github.com/WICG/feature-policy/blob/master/features.md#policy-controlled-features
+    # List of available permissions can be found at
+    # https://github.com/w3c/webappsec-permissions-policy/blob/master/features.md#policy-controlled-features
     DIRECTIVES = {
       accelerometer:        "accelerometer",
       ambient_light_sensor: "ambient-light-sensor",
@@ -121,14 +121,14 @@ module ActionDispatch #:nodoc:
           when String, Proc
             source
           else
-            raise ArgumentError, "Invalid HTTP feature policy source: #{source.inspect}"
+            raise ArgumentError, "Invalid HTTP permissions policy source: #{source.inspect}"
           end
         end
       end
 
       def apply_mapping(source)
         MAPPINGS.fetch(source) do
-          raise ArgumentError, "Unknown HTTP feature policy source mapping: #{source.inspect}"
+          raise ArgumentError, "Unknown HTTP permissions policy source mapping: #{source.inspect}"
         end
       end
 
@@ -156,12 +156,12 @@ module ActionDispatch #:nodoc:
           source.to_s
         when Proc
           if context.nil?
-            raise RuntimeError, "Missing context for the dynamic feature policy source: #{source.inspect}"
+            raise RuntimeError, "Missing context for the dynamic permissions policy source: #{source.inspect}"
           else
             context.instance_exec(&source)
           end
         else
-          raise RuntimeError, "Unexpected feature policy source: #{source.inspect}"
+          raise RuntimeError, "Unexpected permissions policy source: #{source.inspect}"
         end
       end
   end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -23,7 +23,7 @@ module ActionDispatch
     include ActionDispatch::Http::FilterParameters
     include ActionDispatch::Http::URL
     include ActionDispatch::ContentSecurityPolicy::Request
-    include ActionDispatch::FeaturePolicy::Request
+    include ActionDispatch::PermissionsPolicy::Request
     include Rack::Request::Env
 
     autoload :Session, "action_dispatch/request/session"

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -2,9 +2,9 @@
 
 require "abstract_unit"
 
-class FeaturePolicyTest < ActiveSupport::TestCase
+class PermissionsPolicyTest < ActiveSupport::TestCase
   def setup
-    @policy = ActionDispatch::FeaturePolicy.new
+    @policy = ActionDispatch::PermissionsPolicy.new
   end
 
   def test_mappings
@@ -37,22 +37,22 @@ class FeaturePolicyTest < ActiveSupport::TestCase
       @policy.vr [:non_existent]
     end
 
-    assert_equal "Invalid HTTP feature policy source: [:non_existent]", exception.message
+    assert_equal "Invalid HTTP permissions policy source: [:non_existent]", exception.message
   end
 end
 
-class FeaturePolicyIntegrationTest < ActionDispatch::IntegrationTest
+class PermissionsPolicyIntegrationTest < ActionDispatch::IntegrationTest
   class PolicyController < ActionController::Base
-    feature_policy only: :index do |f|
+    permissions_policy only: :index do |f|
       f.gyroscope :none
     end
 
-    feature_policy only: :sample_controller do |f|
+    permissions_policy only: :sample_controller do |f|
       f.gyroscope nil
       f.usb       :self
     end
 
-    feature_policy only: :multiple_directives do |f|
+    permissions_policy only: :multiple_directives do |f|
       f.gyroscope nil
       f.usb       :self
       f.autoplay  "https://example.com"
@@ -74,14 +74,14 @@ class FeaturePolicyIntegrationTest < ActionDispatch::IntegrationTest
 
   ROUTES = ActionDispatch::Routing::RouteSet.new
   ROUTES.draw do
-    scope module: "feature_policy_integration_test" do
+    scope module: "permissions_policy_integration_test" do
       get "/", to: "policy#index"
       get "/sample_controller", to: "policy#sample_controller"
       get "/multiple_directives", to: "policy#multiple_directives"
     end
   end
 
-  POLICY = ActionDispatch::FeaturePolicy.new do |p|
+  POLICY = ActionDispatch::PermissionsPolicy.new do |p|
     p.gyroscope :self
   end
 
@@ -91,7 +91,7 @@ class FeaturePolicyIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     def call(env)
-      env["action_dispatch.feature_policy"] = POLICY
+      env["action_dispatch.permissions_policy"] = POLICY
       env["action_dispatch.show_exceptions"] = false
 
       @app.call(env)
@@ -100,24 +100,24 @@ class FeaturePolicyIntegrationTest < ActionDispatch::IntegrationTest
 
   APP = build_app(ROUTES) do |middleware|
     middleware.use PolicyConfigMiddleware
-    middleware.use ActionDispatch::FeaturePolicy::Middleware
+    middleware.use ActionDispatch::PermissionsPolicy::Middleware
   end
 
   def app
     APP
   end
 
-  def test_generates_feature_policy_header
+  def test_generates_permissions_policy_header
     get "/"
     assert_policy "gyroscope 'none'"
   end
 
-  def test_generates_per_controller_feature_policy_header
+  def test_generates_per_controller_permissions_policy_header
     get "/sample_controller"
     assert_policy "usb 'self'"
   end
 
-  def test_generates_multiple_directives_feature_policy_header
+  def test_generates_multiple_directives_permissions_policy_header
     get "/multiple_directives"
     assert_policy "usb 'self'; autoplay https://example.com; payment https://secure.example.com"
   end
@@ -127,16 +127,16 @@ class FeaturePolicyIntegrationTest < ActionDispatch::IntegrationTest
       Rails.application.env_config
     end
 
-    def feature_policy
-      env_config["action_dispatch.feature_policy"]
+    def permissions_policy
+      env_config["action_dispatch.permissions_policy"]
     end
 
-    def feature_policy=(policy)
-      env_config["action_dispatch.feature_policy"] = policy
+    def permissions_policy=(policy)
+      env_config["action_dispatch.permissions_policy"] = policy
     end
 
     def assert_policy(expected)
       assert_response :success
-      assert_equal expected, response.headers["Feature-Policy"]
+      assert_equal expected, response.headers["Permissions-Policy"]
     end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -23,6 +23,10 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :schema_cache
+
+      def owner_name
+        nil
+      end
     end
 
     # Connection pool base class for managing Active Record database
@@ -356,7 +360,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config
+      attr_reader :db_config, :size, :reaper, :pool_config, :owner_name
 
       delegate :schema_cache, :schema_cache=, to: :pool_config
 
@@ -371,6 +375,7 @@ module ActiveRecord
 
         @pool_config = pool_config
         @db_config = pool_config.db_config
+        @owner_name = pool_config.connection_specification_name
 
         @checkout_timeout = db_config.checkout_timeout
         @idle_timeout = db_config.idle_timeout

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -45,10 +45,9 @@ module ActiveRecord
           end
 
           def add_table_options!(create_sql, o)
-            create_sql = super
             create_sql << " DEFAULT CHARSET=#{o.charset}" if o.charset
             create_sql << " COLLATE=#{o.collation}" if o.collation
-            add_sql_comment!(create_sql, o.comment)
+            add_sql_comment!(super, o.comment)
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -45,8 +45,8 @@ module ActiveRecord
           end
 
           def add_table_options!(create_sql, o)
-            create_sql = super
             create_sql << " DEFAULT CHARSET=#{o.charset}" if o.charset
+            super(create_sql, o)
             create_sql << " COLLATE=#{o.collation}" if o.collation
             add_sql_comment!(create_sql, o.comment)
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -47,8 +47,7 @@ module ActiveRecord
           def add_table_options!(create_sql, o)
             create_sql << " DEFAULT CHARSET=#{o.charset}" if o.charset
             create_sql << " COLLATE=#{o.collation}" if o.collation
-            super(create_sql, o)
-            add_sql_comment!(create_sql, o.comment)
+            add_sql_comment!(super, o.comment)
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -46,8 +46,8 @@ module ActiveRecord
 
           def add_table_options!(create_sql, o)
             create_sql << " DEFAULT CHARSET=#{o.charset}" if o.charset
-            super(create_sql, o)
             create_sql << " COLLATE=#{o.collation}" if o.collation
+            super(create_sql, o)
             add_sql_comment!(create_sql, o.comment)
           end
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -166,10 +166,18 @@ module ActiveRecord
       end
 
       def self.connection_handlers
+        unless legacy_connection_handling
+          raise NotImplementedError, "The new connection handling does not support accessing multiple connection handlers."
+        end
+
         @@connection_handlers ||= {}
       end
 
       def self.connection_handlers=(handlers)
+        unless legacy_connection_handling
+          raise NotImplementedError, "The new connection handling does not setting support multiple connection handlers."
+        end
+
         @@connection_handlers = handlers
       end
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -56,7 +56,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
       t.bigint "account_id", null: false, unsigned: true
     end
     output = dump_table_schema("mysql_table_options")
-    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(`account_id`\)\\nPARTITIONS 128 \*\/", force: :cascade/
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n(\/\*\!50100)? PARTITION BY HASH \(`account_id`\)\\nPARTITIONS 128( \*\/)?", force: :cascade/
     assert_match expected, output
   end
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -50,6 +50,16 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
     assert_match expected, output
   end
 
+  test "charset and partitioned table options" do
+    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */", force: :cascade do |t|
+      t.bigint "id", null: false, auto_increment: true
+      t.bigint "account_id", null: false, unsigned: true
+    end
+    output = dump_table_schema("mysql_table_options")
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n(\/\*\!50100)? PARTITION BY HASH \(`account_id`\)\\nPARTITIONS 128( \*\/)?", force: :cascade/
+    assert_match expected, output
+  end
+
   test "schema dump works with NO_TABLE_OPTIONS sql mode" do
     skip "As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated. It will be removed in a future version of MySQL." if @connection.database_version >= "5.7.22"
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -51,12 +51,12 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   end
 
   test "charset and partitioned table options" do
-    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (account_id)\nPARTITIONS 128 */", force: :cascade do |t|
+    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (account_id)\nPARTITIONS 128 */", force: :cascade do |t|
       t.bigint "id", null: false, auto_increment: true
       t.bigint "account_id", null: false, unsigned: true
     end
     output = dump_table_schema("mysql_table_options")
-    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4"(?:, collation: "\w+")?, options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(account_id\)\\nPARTITIONS 128 \*\/", force: :cascade/
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(account_id\)\\nPARTITIONS 128 \*\/", force: :cascade/
     assert_match expected, output
   end
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -51,12 +51,12 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
   end
 
   test "charset and partitioned table options" do
-    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (account_id)\nPARTITIONS 128 */", force: :cascade do |t|
+    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */", force: :cascade do |t|
       t.bigint "id", null: false, auto_increment: true
       t.bigint "account_id", null: false, unsigned: true
     end
     output = dump_table_schema("mysql_table_options")
-    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(?`account_id?`\)\\nPARTITIONS 128 \*\/", force: :cascade/
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(`account_id`\)\\nPARTITIONS 128 \*\/", force: :cascade/
     assert_match expected, output
   end
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -56,7 +56,7 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
       t.bigint "account_id", null: false, unsigned: true
     end
     output = dump_table_schema("mysql_table_options")
-    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(account_id\)\\nPARTITIONS 128 \*\/", force: :cascade/
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(?`account_id?`\)\\nPARTITIONS 128 \*\/", force: :cascade/
     assert_match expected, output
   end
 

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -50,6 +50,16 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
     assert_match expected, output
   end
 
+  test "charset and partitioned table options" do
+    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (account_id)\nPARTITIONS 128 */", force: :cascade do |t|
+      t.bigint "id", null: false, auto_increment: true
+      t.bigint "account_id", null: false, unsigned: true
+    end
+    output = dump_table_schema("mysql_table_options")
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4"(?:, collation: "\w+")?, options: "ENGINE=InnoDB\\n\/\*\!50100 PARTITION BY HASH \(account_id\)\\nPARTITIONS 128 \*\/", force: :cascade/
+    assert_match expected, output
+  end
+
   test "schema dump works with NO_TABLE_OPTIONS sql mode" do
     skip "As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated. It will be removed in a future version of MySQL." if @connection.database_version >= "5.7.22"
 

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_prevent_writes_test.rb
@@ -11,9 +11,7 @@ module ActiveRecord
       self.use_transactional_tests = false
 
       def setup
-        @conn = Base.sqlite3_connection database: ":memory:",
-                                        adapter: "sqlite3",
-                                        timeout: 100
+        @conn = ActiveRecord::Base.connection
       end
 
       def test_errors_when_an_insert_query_is_called_while_preventing_writes
@@ -100,9 +98,7 @@ module ActiveRecord
         @old_value = ActiveRecord::Base.legacy_connection_handling
         ActiveRecord::Base.legacy_connection_handling = true
 
-        @conn = Base.sqlite3_connection database: ":memory:",
-                                        adapter: "sqlite3",
-                                        timeout: 100
+        @conn = ActiveRecord::Base.connection
 
         @connection_handler = ActiveRecord::Base.connection_handler
       end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1521,8 +1521,8 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
     def teardown
       ActiveRecord::Base.configurations = @prev_configs
       ActiveRecord::Base.connection_handler = @old_handler
-      ActiveRecord::Base.legacy_connection_handling = false
       clean_up_legacy_connection_handlers
+      ActiveRecord::Base.legacy_connection_handling = false
     end
 
     def test_uses_writing_connection_for_fixtures

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -695,8 +695,10 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     mw.call({})
   ensure
-    clean_up_legacy_connection_handlers
-    ActiveRecord::Base.legacy_connection_handling = old_value
+    unless in_memory_db?
+      clean_up_legacy_connection_handlers
+      ActiveRecord::Base.legacy_connection_handling = old_value
+    end
   end
 
   def test_clear_query_cache_is_called_on_all_connections

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -54,10 +54,10 @@ class TestFixturesTest < ActiveRecord::TestCase
       test_result = klass.new("test_run_successfuly").run
       assert_predicate(test_result, :passed?)
     ensure
-      ActiveRecord::Base.legacy_connection_handling = old_value
-      ActiveRecord::Base.connection_handler = old_handler
       clean_up_legacy_connection_handlers
+      ActiveRecord::Base.connection_handler = old_handler
       FileUtils.rm_r(tmp_dir)
+      ActiveRecord::Base.legacy_connection_handling = old_value
     end
 
     def test_doesnt_rely_on_active_support_test_case_specific_methods

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Implement `strict_loading` on ActiveStorage associations.
+
+    *David Angulo*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Remove deprecated support to pass `:combine_options` operations to `ActiveStorage::Transformers::ImageProcessing`.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -40,7 +40,14 @@ module ActiveStorage
       #     has_one_attached :avatar, service: :s3
       #   end
       #
-      def has_one_attached(name, dependent: :purge_later, service: nil)
+      # If you need to enable +strict_loading+ to prevent lazy loading of attachment,
+      # pass the +:strict_loading+ option. You can do:
+      #
+      #   class User < ApplicationRecord
+      #     has_one_attached :avatar, strict_loading: true
+      #   end
+      #
+      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
         validate_service_configuration(name, service)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -60,8 +67,8 @@ module ActiveStorage
           end
         CODE
 
-        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy
-        has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob
+        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
+        has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
 
@@ -111,7 +118,14 @@ module ActiveStorage
       #     has_many_attached :photos, service: :s3
       #   end
       #
-      def has_many_attached(name, dependent: :purge_later, service: nil)
+      # If you need to enable +strict_loading+ to prevent lazy loading of attachments,
+      # pass the +:strict_loading+ option. You can do:
+      #
+      #   class Gallery < ApplicationRecord
+      #     has_many_attached :photos, strict_loading: true
+      #   end
+      #
+      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
         validate_service_configuration(name, service)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -138,7 +152,7 @@ module ActiveStorage
           end
         CODE
 
-        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy do
+        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading do
           def purge
             each(&:purge)
             reset
@@ -149,7 +163,7 @@ module ActiveStorage
             reset
           end
         end
-        has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob
+        has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachments": :blob) }
 

--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -28,7 +28,21 @@ module ActiveStorage
 
     private
       def draw_relevant_frame_from(file, &block)
-        draw self.class.ffmpeg_path, "-i", file.path, "-y", "-vframes", "1", "-f", "image2", "-", &block
+        ffmpeg_args = [
+          "-i", file.path,
+          "-vf",
+            # Select the first video frame, plus keyframes and frames
+            # that meet the scene change threshold.
+            'select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),' +
+            # Loop the first 1-2 selected frames in case we were only
+            # able to select 1 frame, then drop the first looped frame.
+            # This lets us use the first video frame as a fallback.
+            "loop=loop=-1:size=2,trim=start_frame=1",
+          "-frames:v", "1",
+          "-f", "image2", "-",
+        ]
+
+        draw self.class.ffmpeg_path, *ffmpeg_args, &block
       end
   end
 end

--- a/activestorage/test/models/strict_loading_test.rb
+++ b/activestorage/test/models/strict_loading_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::StrictLoadingTest < ActiveSupport::TestCase
+  class Admin < User
+    has_one_attached :image, strict_loading: true
+    has_many_attached :images, strict_loading: true
+  end
+
+  setup do
+    Admin.create!(name: "David")
+  end
+
+  test "has_one_attached raises if strict loading and lazy loading" do
+    assert_raises ActiveRecord::StrictLoadingViolationError do
+      admins = Admin.all
+      admins.as_json(include: :image)
+    end
+  end
+
+  test "has_many_attached raises if strict loading and lazy loading" do
+    assert_raises ActiveRecord::StrictLoadingViolationError do
+      admins = Admin.all
+      admins.as_json(include: :images)
+    end
+  end
+end

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -102,11 +102,11 @@ module ActiveSupport
   #
   # === Prepending concerns
   #
-  # Just like `include`, concerns also support `prepend` with a corresponding
-  # `prepended do` callback. `module ClassMethods` or `class_methods do` are
+  # Just like <tt>include</tt>, concerns also support <tt>prepend</tt> with a corresponding
+  # <tt>prepended do</tt> callback. <tt>module ClassMethods</tt> or <tt>class_methods do</tt> are
   # prepended as well.
   #
-  # `prepend` is also used for any dependencies.
+  # <tt>prepend</tt> is also used for any dependencies.
   module Concern
     class MultipleIncludedBlocks < StandardError #:nodoc:
       def initialize

--- a/activesupport/lib/active_support/core_ext/module/concerning.rb
+++ b/activesupport/lib/active_support/core_ext/module/concerning.rb
@@ -105,10 +105,10 @@ class Module
   # * clean up monolithic junk-drawer classes by separating their concerns, and
   # * stop leaning on protected/private for crude "this is internal stuff" modularity.
   #
-  # === Prepending `concerning`
+  # === Prepending concerning
   #
-  # `concerning` supports a `prepend: true` argument which will `prepend` the
-  # concern instead of using `include` for it.
+  # <tt>concerning</tt> supports a <tt>prepend: true</tt> argument which will <tt>prepend</tt> the
+  # concern instead of using <tt>include</tt> for it.
   module Concerning
     # Define a new concern and mix it in.
     def concerning(topic, prepend: false, &block)

--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -20,7 +20,11 @@ module ActiveSupport
 
     module CoreExtPrivate
       include CoreExt
-      private :fork
+
+      private
+        def fork(*)
+          super
+        end
     end
 
     @pid = Process.pid

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -559,7 +559,7 @@ the box, Active Storage supports previewing videos and PDF documents.
 </ul>
 ```
 
-WARNING: Extracting previews requires third-party applications, FFmpeg for
+WARNING: Extracting previews requires third-party applications, FFmpeg v3.4+ for
 video and muPDF for PDFs, and on macOS also XQuartz and Poppler.
 These libraries are not provided by Rails. You must install them yourself to
 use the built-in previewers. Before you install and use third-party software,

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -244,7 +244,7 @@ module Rails
 
       if yaml.exist?
         require "erb"
-        all_configs    = ActiveSupport::ConfigurationFile.parse(yaml, symbolize_names: true)
+        all_configs    = ActiveSupport::ConfigurationFile.parse(yaml).deep_symbolize_keys
         config, shared = all_configs[env.to_sym], all_configs[:shared]
 
         if config.is_a?(Hash)

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -286,7 +286,7 @@ module Rails
           "action_dispatch.content_security_policy_report_only" => config.content_security_policy_report_only,
           "action_dispatch.content_security_policy_nonce_generator" => config.content_security_policy_nonce_generator,
           "action_dispatch.content_security_policy_nonce_directives" => config.content_security_policy_nonce_directives,
-          "action_dispatch.feature_policy" => config.feature_policy,
+          "action_dispatch.permissions_policy" => config.permissions_policy,
         )
       end
     end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -73,7 +73,7 @@ module Rails
         @autoloader                              = :classic
         @disable_sandbox                         = false
         @add_autoload_paths_to_load_path         = true
-        @feature_policy                          = nil
+        @permissions_policy                      = nil
         @rake_eager_load                         = false
       end
 
@@ -325,11 +325,11 @@ module Rails
         end
       end
 
-      def feature_policy(&block)
+      def permissions_policy(&block)
         if block_given?
-          @feature_policy = ActionDispatch::FeaturePolicy.new(&block)
+          @permissions_policy = ActionDispatch::PermissionsPolicy.new(&block)
         else
-          @feature_policy
+          @permissions_policy
         end
       end
 

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -69,7 +69,7 @@ module Rails
 
           unless config.api_only
             middleware.use ::ActionDispatch::ContentSecurityPolicy::Middleware
-            middleware.use ::ActionDispatch::FeaturePolicy::Middleware
+            middleware.use ::ActionDispatch::PermissionsPolicy::Middleware
           end
 
           middleware.use ::Rack::Head

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -138,7 +138,7 @@ module Rails
       rack_cors_config_exist         = File.exist?("config/initializers/cors.rb")
       assets_config_exist            = File.exist?("config/initializers/assets.rb")
       csp_config_exist               = File.exist?("config/initializers/content_security_policy.rb")
-      feature_policy_config_exist    = File.exist?("config/initializers/feature_policy.rb")
+      permissions_policy_config_exist = File.exist?("config/initializers/permissions_policy.rb")
 
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
 
@@ -174,8 +174,8 @@ module Rails
           remove_file "config/initializers/content_security_policy.rb"
         end
 
-        unless feature_policy_config_exist
-          remove_file "config/initializers/feature_policy.rb"
+        unless permissions_policy_config_exist
+          remove_file "config/initializers/permissions_policy.rb"
         end
       end
     end
@@ -527,7 +527,7 @@ module Rails
         if options[:api]
           remove_file "config/initializers/cookies_serializer.rb"
           remove_file "config/initializers/content_security_policy.rb"
-          remove_file "config/initializers/feature_policy.rb"
+          remove_file "config/initializers/permissions_policy.rb"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/permissions_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/permissions_policy.rb.tt
@@ -1,7 +1,7 @@
-# Define an application-wide HTTP feature policy. For further
+# Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #
-# Rails.application.config.feature_policy do |f|
+# Rails.application.config.permissions_policy do |f|
 #   f.camera      :none
 #   f.gyroscope   :none
 #   f.microphone  :none

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2080,6 +2080,19 @@ module ApplicationTests
       assert_equal "unicorn", Rails.application.config.my_custom_config[:key]
     end
 
+    test "config_for handles YAML patches (like safe_yaml) that disable the symbolize_names option" do
+      app_file "config/custom.yml", <<~RUBY
+        development:
+          key: value
+      RUBY
+
+      app "development"
+
+      YAML.stub :load, { "development" => { "key" => "value" } } do
+        assert_equal({ key: "value" }, Rails.application.config_for(:custom))
+      end
+    end
+
     test "api_only is false by default" do
       app "development"
       assert_not Rails.application.config.api_only

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -46,7 +46,7 @@ module ApplicationTests
         "ActionDispatch::Session::CookieStore",
         "ActionDispatch::Flash",
         "ActionDispatch::ContentSecurityPolicy::Middleware",
-        "ActionDispatch::FeaturePolicy::Middleware",
+        "ActionDispatch::PermissionsPolicy::Middleware",
         "Rack::Head",
         "Rack::ConditionalGet",
         "Rack::ETag",

--- a/railties/test/application/permissions_policy_test.rb
+++ b/railties/test/application/permissions_policy_test.rb
@@ -4,7 +4,7 @@ require "isolation/abstract_unit"
 require "rack/test"
 
 module ApplicationTests
-  class FeaturePolicyTest < ActiveSupport::TestCase
+  class PermissionsPolicyTest < ActiveSupport::TestCase
     include ActiveSupport::Testing::Isolation
     include Rack::Test::Methods
 
@@ -16,7 +16,7 @@ module ApplicationTests
       teardown_app
     end
 
-    test "feature policy is not enabled by default" do
+    test "permissions policy is not enabled by default" do
       controller :pages, <<-RUBY
         class PagesController < ApplicationController
           def index
@@ -34,10 +34,10 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_nil last_response.headers["Feature-Policy"]
+      assert_nil last_response.headers["Permissions-Policy"]
     end
 
-    test "global feature policy in an initializer" do
+    test "global permissions policy in an initializer" do
       controller :pages, <<-RUBY
         class PagesController < ApplicationController
           def index
@@ -46,8 +46,8 @@ module ApplicationTests
         end
       RUBY
 
-      app_file "config/initializers/feature_policy.rb", <<-RUBY
-        Rails.application.config.feature_policy do |p|
+      app_file "config/initializers/permissions_policy.rb", <<-RUBY
+        Rails.application.config.permissions_policy do |p|
           p.geolocation :none
         end
       RUBY
@@ -64,10 +64,10 @@ module ApplicationTests
       assert_policy "geolocation 'none'"
     end
 
-    test "override feature policy using same directive in a controller" do
+    test "override permissions policy using same directive in a controller" do
       controller :pages, <<-RUBY
         class PagesController < ApplicationController
-          feature_policy do |p|
+          permissions_policy do |p|
             p.geolocation "https://example.com"
           end
 
@@ -77,8 +77,8 @@ module ApplicationTests
         end
       RUBY
 
-      app_file "config/initializers/feature_policy.rb", <<-RUBY
-        Rails.application.config.feature_policy do |p|
+      app_file "config/initializers/permissions_policy.rb", <<-RUBY
+        Rails.application.config.permissions_policy do |p|
           p.geolocation :none
         end
       RUBY
@@ -95,10 +95,10 @@ module ApplicationTests
       assert_policy "geolocation https://example.com"
     end
 
-    test "override feature policy by unsetting a directive in a controller" do
+    test "override permissions policy by unsetting a directive in a controller" do
       controller :pages, <<-RUBY
         class PagesController < ApplicationController
-          feature_policy do |p|
+          permissions_policy do |p|
             p.geolocation nil
           end
 
@@ -108,8 +108,8 @@ module ApplicationTests
         end
       RUBY
 
-      app_file "config/initializers/feature_policy.rb", <<-RUBY
-        Rails.application.config.feature_policy do |p|
+      app_file "config/initializers/permissions_policy.rb", <<-RUBY
+        Rails.application.config.permissions_policy do |p|
           p.geolocation :none
         end
       RUBY
@@ -124,13 +124,13 @@ module ApplicationTests
 
       get "/"
       assert_equal 200, last_response.status
-      assert_nil last_response.headers["Feature-Policy"]
+      assert_nil last_response.headers["Permissions-Policy"]
     end
 
-    test "override feature policy using different directives in a controller" do
+    test "override permissions policy using different directives in a controller" do
       controller :pages, <<-RUBY
         class PagesController < ApplicationController
-          feature_policy do |p|
+          permissions_policy do |p|
             p.geolocation nil
             p.payment     "https://secure.example.com"
             p.autoplay    :none
@@ -142,8 +142,8 @@ module ApplicationTests
         end
       RUBY
 
-      app_file "config/initializers/feature_policy.rb", <<-RUBY
-        Rails.application.config.feature_policy do |p|
+      app_file "config/initializers/permissions_policy.rb", <<-RUBY
+        Rails.application.config.permissions_policy do |p|
           p.geolocation :none
         end
       RUBY
@@ -160,9 +160,9 @@ module ApplicationTests
       assert_policy "payment https://secure.example.com; autoplay 'none'"
     end
 
-    test "global feature policy added to rack app" do
-      app_file "config/initializers/feature_policy.rb", <<-RUBY
-        Rails.application.config.feature_policy do |p|
+    test "global permissions policy added to rack app" do
+      app_file "config/initializers/permissions_policy.rb", <<-RUBY
+        Rails.application.config.permissions_policy do |p|
           p.payment :none
         end
       RUBY
@@ -185,7 +185,7 @@ module ApplicationTests
     private
       def assert_policy(expected)
         assert_equal 200, last_response.status
-        assert_equal expected, last_response.headers["Feature-Policy"]
+        assert_equal expected, last_response.headers["Permissions-Policy"]
       end
   end
 end

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -96,7 +96,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/initializers/cookies_serializer.rb"
     assert_no_file "config/initializers/assets.rb"
     assert_no_file "config/initializers/content_security_policy.rb"
-    assert_no_file "config/initializers/feature_policy.rb"
+    assert_no_file "config/initializers/permissions_policy.rb"
   end
 
   def test_app_update_does_not_generate_unnecessary_bin_files
@@ -172,7 +172,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          config/initializers/assets.rb
          config/initializers/cookies_serializer.rb
          config/initializers/content_security_policy.rb
-         config/initializers/feature_policy.rb
+         config/initializers/permissions_policy.rb
          lib/assets
          test/helpers
          tmp/cache/assets


### PR DESCRIPTION
`bundle exec rails db:schema:load` fails with a SQL error when the table definition contains partitions.