### PR TITLE
Save model attachment on reload

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -206,7 +206,7 @@ module ActiveStorage
     end
 
     def reload(*) #:nodoc:
-      super.tap { @attachment_changes = nil }
+      super
     end
   end
 end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -570,12 +570,12 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_not_predicate @user, :changed_for_autosave?
   end
 
-  test "clearing change on reload" do
+  test "keeping change on reload" do
     @user.highlights = [ create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg") ]
     assert @user.highlights.attached?
 
     @user.reload
-    assert_not @user.highlights.attached?
+    assert @user.highlights.attached?
   end
 
   test "overriding attached reader" do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -554,12 +554,12 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_not_predicate @user, :changed_for_autosave?
   end
 
-  test "clearing change on reload" do
+  test "keeping change on reload" do
     @user.avatar = create_blob(filename: "funky.jpg")
     assert @user.avatar.attached?
 
     @user.reload
-    assert_not @user.avatar.attached?
+    assert @user.avatar.attached?
   end
 
   test "overriding attached reader" do


### PR DESCRIPTION
### Summary
Fixes https://github.com/rails/rails/issues/40630, Save uploaded model attachments when reloading the model within a transaction.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
