### PR TITLE
Fix ActiveRecord::Base.connection_specification_name= on multi-db apps

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -355,11 +355,11 @@ module ActiveRecord
       def resolve_config_for_connection(config_or_env)
         raise "Anonymous class is not allowed." unless name
 
-        owner_name = primary_class? ? Base.name : name
-        self.connection_specification_name = owner_name
+        owner = primary_class? ? Base : self
+        owner.connection_specification_name = owner.name
 
         db_config = Base.configurations.resolve(config_or_env)
-        [db_config, owner_name]
+        [db_config, owner.name]
       end
 
       def with_handler(handler_key, &blk)


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/36930, which fixed this same problem for applications that don't use `connects_to`.

Calling `ApplicationRecord.connects_to` currently sets its `connection_specification_name`, which prevents changes to ActiveRecord::Base's `connection_specification_name` from applying to subclasses of ApplicationRecord. Before Rails 6.0, setting ActiveRecord::Base's `connection_specification_name` always affected all models without their own connection.