### PR TITLE
Fixes rdoc formatting [ci skip]

### DIFF
--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -102,11 +102,11 @@ module ActiveSupport
   #
   # === Prepending concerns
   #
-  # Just like `include`, concerns also support `prepend` with a corresponding
-  # `prepended do` callback. `module ClassMethods` or `class_methods do` are
+  # Just like <tt>include</tt>, concerns also support <tt>prepend</tt> with a corresponding
+  # <tt>prepended do</tt> callback. <tt>module ClassMethods</tt> or <tt>class_methods do</tt> are
   # prepended as well.
   #
-  # `prepend` is also used for any dependencies.
+  # <tt>prepend</tt> is also used for any dependencies.
   module Concern
     class MultipleIncludedBlocks < StandardError #:nodoc:
       def initialize

--- a/activesupport/lib/active_support/core_ext/module/concerning.rb
+++ b/activesupport/lib/active_support/core_ext/module/concerning.rb
@@ -105,10 +105,10 @@ class Module
   # * clean up monolithic junk-drawer classes by separating their concerns, and
   # * stop leaning on protected/private for crude "this is internal stuff" modularity.
   #
-  # === Prepending `concerning`
+  # === Prepending concerning
   #
-  # `concerning` supports a `prepend: true` argument which will `prepend` the
-  # concern instead of using `include` for it.
+  # <tt>concerning</tt> supports a <tt>prepend: true</tt> argument which will <tt>prepend</tt> the
+  # concern instead of using <tt>include</tt> for it.
   module Concerning
     # Define a new concern and mix it in.
     def concerning(topic, prepend: false, &block)


### PR DESCRIPTION
### Summary
This PR fixes the Rdoc formatting.

Before:
![image](https://user-images.githubusercontent.com/13457494/99395119-fbbd6200-2905-11eb-80d8-ce20d4ebdfd8.png)
![image](https://user-images.githubusercontent.com/13457494/99394972-cc0e5a00-2905-11eb-92d1-8c5877366757.png)

After:
![image](https://user-images.githubusercontent.com/13457494/99394825-83ef3780-2905-11eb-8321-17a080d9f3c0.png)
![After 2](https://user-images.githubusercontent.com/13457494/99394706-51ddd580-2905-11eb-9502-37e46e7dca06.png)
