### PR TITLE
Raise if connection_handlers is called in legacy_connection_handling

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -166,10 +166,18 @@ module ActiveRecord
       end
 
       def self.connection_handlers
+        unless legacy_connection_handling
+          raise NotImplementedError, "The new connection handling does not support accessing multiple connection handlers."
+        end
+
         @@connection_handlers ||= {}
       end
 
       def self.connection_handlers=(handlers)
+        unless legacy_connection_handling
+          raise NotImplementedError, "The new connection handling does not setting support multiple connection handlers."
+        end
+
         @@connection_handlers = handlers
       end
 

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1521,8 +1521,8 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
     def teardown
       ActiveRecord::Base.configurations = @prev_configs
       ActiveRecord::Base.connection_handler = @old_handler
-      ActiveRecord::Base.legacy_connection_handling = false
       clean_up_legacy_connection_handlers
+      ActiveRecord::Base.legacy_connection_handling = false
     end
 
     def test_uses_writing_connection_for_fixtures

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -695,8 +695,10 @@ class QueryCacheTest < ActiveRecord::TestCase
 
     mw.call({})
   ensure
-    clean_up_legacy_connection_handlers
-    ActiveRecord::Base.legacy_connection_handling = old_value
+    unless in_memory_db?
+      clean_up_legacy_connection_handlers
+      ActiveRecord::Base.legacy_connection_handling = old_value
+    end
   end
 
   def test_clear_query_cache_is_called_on_all_connections

--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -54,10 +54,10 @@ class TestFixturesTest < ActiveRecord::TestCase
       test_result = klass.new("test_run_successfuly").run
       assert_predicate(test_result, :passed?)
     ensure
-      ActiveRecord::Base.legacy_connection_handling = old_value
-      ActiveRecord::Base.connection_handler = old_handler
       clean_up_legacy_connection_handlers
+      ActiveRecord::Base.connection_handler = old_handler
       FileUtils.rm_r(tmp_dir)
+      ActiveRecord::Base.legacy_connection_handling = old_value
     end
 
     def test_doesnt_rely_on_active_support_test_case_specific_methods


### PR DESCRIPTION
While we didn't need to deprecate any behavior when implementing
granular connection swapping it's not 100% clear to the person upgrading
that this needs to change when you switch off
`legacy_connection_handling`. The new version doesn't support
multiple handlers but before it wasn't raising an exception so it was
possible applications were still using it and hitting confusing errors.
This change ensures that if an application is using the new handling
that `connection_handlers` and `connection_handlers=` an exception will
be raised.