### PR TITLE
Fix ForkTracker on ruby <= 2.5.3

### DIFF
--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -20,7 +20,11 @@ module ActiveSupport
 
     module CoreExtPrivate
       include CoreExt
-      private :fork
+
+      private
+        def fork(*)
+          super
+        end
     end
 
     @pid = Process.pid


### PR DESCRIPTION
### Summary

Making the fork method private by calling `private :fork` raises a
"no superclass method `fork'" error when calling super in a subclass on
ruby <= 2.5.3. The error doesn't occur on ruby 2.5.4 and higher.
Making the method private by redefining doesn't raise the error.

### Other Information

The possible fix on 2.5.4 is https://github.com/ruby/ruby/commit/75aba10d7ae24126b0f9aa561855020bdfcd8c9d

The error can be reproduced with the following script on ruby 2.5.3:
```
class Cluster
  def start
    fork { puts "forked!" }
  end
end

module CoreExt
  def fork(*)
    super
  end
end

module CoreExtPrivate
  include CoreExt
  private :fork
end

::Object.prepend(CoreExtPrivate)
Cluster.new.start
```

Fixes #40603
