### PR TITLE
Fixed odd behavior of inverse_of with multiple belongs_to to same class 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix odd behavior of inverse_of with multiple belongs_to to same class.
+
+    Fixes #35204.
+
+    *Tomoyuki Kai*
+
 *   Build predicate conditions with objects that delegate `#id` and primary key:
 
     ```ruby

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -623,6 +623,7 @@ module ActiveRecord
         # with the current reflection's klass name.
         def valid_inverse_reflection?(reflection)
           reflection &&
+            foreign_key == reflection.foreign_key &&
             klass <= reflection.active_record &&
             can_find_inverse_of_automatically?(reflection)
         end

--- a/activerecord/test/models/room.rb
+++ b/activerecord/test/models/room.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Room < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :owner, class_name: "User"
+end

--- a/activerecord/test/models/user.rb
+++ b/activerecord/test/models/user.rb
@@ -10,6 +10,8 @@ class User < ActiveRecord::Base
     class_name: "Job",
     join_table: "jobs_pool"
 
+  has_one :room
+  has_one :owned_room, class_name: "Room", foreign_key: "owner_id"
   has_one :family_tree, -> { where(token: nil) }, foreign_key: "member_id"
   has_one :family, through: :family_tree
   has_many :family_members, through: :family, source: :members

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -873,6 +873,11 @@ ActiveRecord::Schema.define do
     t.integer :lock_version, default: 0
   end
 
+  create_table :rooms, force: true do |t|
+    t.references :user
+    t.references :owner
+  end
+
   disable_referential_integrity do
     create_table :seminars, force: :cascade do |t|
       t.string :name


### PR DESCRIPTION
Fix: #35204.

This PR added validation to `automatic_inverse_of` that foreign_keys are the same.

If class has multiple `belongs_to` to same class, `automatic_inverse_of` can find the wrong `inverse_name`.

```ruby
class Room < ActiveRecord::Base
  belongs_to :user
  belongs_to :owner, class_name: "User"
end

class User < ActiveRecord::Base
  has_one :room
  has_one :owned_room, class_name: "Room", foreign_key: "owner_id"
end

user = User.create!
owned_room = Room.create!(owner: user)

p user.room
```

The current `automatic_inverse_of` validates the `reflection` that found from associations.
However, its validation does not validate that foreign keys are the same.

so this issue can be fixed by adding a validation of foreign keys.