### PR TITLE
removed unnecessary duplicated require.

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -20,7 +20,6 @@ require "models/developer"
 require "models/company"
 require "models/project"
 require "models/author"
-require "models/post"
 
 class AutomaticInverseFindingTests < ActiveRecord::TestCase
   fixtures :ratings, :comments, :cars


### PR DESCRIPTION
### Summary

I happened to discover that the `require "models/post"` was a duplicate, and I was convinced that this duplicate code was an unnecessary process.
i fixed very easy careless miss.

"models/post" is required on line 11, so i removed it as it is useless to have a similar process on line 23.