### PR TITLE
Validates using proc with instance variable for minimum

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -65,7 +65,7 @@ module ActiveModel
 
       private
         def skip_nil_check?(key)
-          key == :maximum && options[:allow_nil].nil? && options[:allow_blank].nil?
+          %i(maximum minimum).include?(key) && options[key] != 0 && options[:allow_nil].nil? && options[:allow_blank].nil?
         end
     end
 

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -385,7 +385,7 @@ class LengthValidationTest < ActiveModel::TestCase
     assert_predicate t, :invalid?
   end
 
-  def test_validates_length_of_using_minimum_0_should_not_allow_nil
+  def test_validates_length_of_using_minimum_0_should_allow_nil
     Topic.validates_length_of :title, minimum: 0
     t = Topic.new
     assert_predicate t, :invalid?
@@ -455,5 +455,23 @@ class LengthValidationTest < ActiveModel::TestCase
 
     t.title = ""
     assert_predicate t, :valid?
+  end
+
+  def test_validates_length_of_using_proc_as_minimum_nil_with_instance_variable
+    Topic.define_method(:min_title_length) { 5 }
+    Topic.validates_length_of :title, minimum: Proc.new(&:min_title_length)
+
+    t = Topic.new("title" => "valid", "content" => "whatever")
+    assert_predicate t, :valid?
+
+    t.title = "not"
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too short (minimum is 5 characters)"], t.errors[:title]
+
+    t.title = nil
+    assert_predicate t, :invalid?
+    assert_predicate t.errors[:title], :any?
+    assert_equal ["is too short (minimum is 5 characters)"], t.errors[:title]
   end
 end


### PR DESCRIPTION
### Summary
Fixes https://github.com/rails/rails/issues/40642, allow_nil only works with maximum. This PR enables allow_nil to work with other attributes. For example, if allow_nil is set with minimum, then it will skip validation check of minimum.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
