### PR TITLE
Fix `rails new` and `rails app:update` hanging on master bug.

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -1,6 +1,14 @@
+require 'pathname'
+
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  exec "yarn", *ARGV
+  executable_path = ENV["PATH"].split(File::PATH_SEPARATOR).find do |path|
+    normalized_path = File.expand_path(path)
+
+    normalized_path != __dir__ && File.executable?(Pathname.new(normalized_path).join('yarn'))
+  end
+
+  exec File.expand_path(Pathname.new(executable_path).join('yarn')), *ARGV
 rescue Errno::ENOENT
   $stderr.puts "Yarn executable was not detected in the system."
   $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"


### PR DESCRIPTION
### Summary

Filter PATH environment variable so script doesn't loop on itself.

Fixes: #38666 
Related: #39619

When updating a rails application to the master branch, and running rails app:update, if you have bin in your PATH you would get thrown into an infinite loop.

This excludes bin from the PATH variable, so when bin/yarn is called, it does not loop on itself when calling exec "yarn".

Related Issue: #38666
Also briefly mentioned here: #39282 (comment)

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
