### PR TITLE
nil check should pass both for :minimum and :maximum

### DIFF
--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -65,7 +65,7 @@ module ActiveModel
 
       private
         def skip_nil_check?(key)
-          key == :maximum && options[:allow_nil].nil? && options[:allow_blank].nil?
+          %i(maximum minimum).include?(key) && options[:allow_nil].nil? && options[:allow_blank].nil?
         end
     end
 


### PR DESCRIPTION
### Summary
Fixes #40642, allow_nil currently only works with :maximum, this PR makes it work for both :maximum and :minimum

