### PR TITLE
fix issue with schema:load when table definition contains partitions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -45,10 +45,9 @@ module ActiveRecord
           end
 
           def add_table_options!(create_sql, o)
-            create_sql = super
             create_sql << " DEFAULT CHARSET=#{o.charset}" if o.charset
             create_sql << " COLLATE=#{o.collation}" if o.collation
-            add_sql_comment!(create_sql, o.comment)
+            add_sql_comment!(super, o.comment)
           end
 
           def add_column_options!(sql, options)

--- a/activerecord/test/cases/adapters/mysql2/table_options_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/table_options_test.rb
@@ -50,6 +50,16 @@ class Mysql2TableOptionsTest < ActiveRecord::Mysql2TestCase
     assert_match expected, output
   end
 
+  test "charset and partitioned table options" do
+    @connection.create_table "mysql_table_options", primary_key: ["id", "account_id"], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\n/*!50100 PARTITION BY HASH (`account_id`)\nPARTITIONS 128 */", force: :cascade do |t|
+      t.bigint "id", null: false, auto_increment: true
+      t.bigint "account_id", null: false, unsigned: true
+    end
+    output = dump_table_schema("mysql_table_options")
+    expected = /create_table "mysql_table_options", primary_key: \["id", "account_id"\], charset: "utf8mb4", collation: "utf8mb4_bin", options: "ENGINE=InnoDB\\n(\/\*\!50100)? PARTITION BY HASH \(`account_id`\)\\nPARTITIONS 128( \*\/)?", force: :cascade/
+    assert_match expected, output
+  end
+
   test "schema dump works with NO_TABLE_OPTIONS sql mode" do
     skip "As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated. It will be removed in a future version of MySQL." if @connection.database_version >= "5.7.22"
 


### PR DESCRIPTION
`bundle exec rails db:schema:load` fails with a SQL error when the table definition contains partitions.