### PR TITLE
Use Feature-Policy header name for now

### DIFF
--- a/actionpack/lib/action_dispatch/http/permissions_policy.rb
+++ b/actionpack/lib/action_dispatch/http/permissions_policy.rb
@@ -6,7 +6,12 @@ module ActionDispatch #:nodoc:
   class PermissionsPolicy
     class Middleware
       CONTENT_TYPE = "Content-Type"
-      POLICY       = "Permissions-Policy"
+      # The Feature-Policy header has been renamed to Permissions-Policy.
+      # The Permissions-Policy requires a different implementation and isn't
+      # yet supported by all browsers. To avoid having to rename this
+      # middleware in the future we use the new name for the middleware but
+      # keep the old header name and implementation for now.
+      POLICY       = "Feature-Policy"
 
       def initialize(app)
         @app = app

--- a/actionpack/test/dispatch/permissions_policy_test.rb
+++ b/actionpack/test/dispatch/permissions_policy_test.rb
@@ -137,6 +137,6 @@ class PermissionsPolicyIntegrationTest < ActionDispatch::IntegrationTest
 
     def assert_policy(expected)
       assert_response :success
-      assert_equal expected, response.headers["Permissions-Policy"]
+      assert_equal expected, response.headers["Feature-Policy"]
     end
 end

--- a/railties/test/application/permissions_policy_test.rb
+++ b/railties/test/application/permissions_policy_test.rb
@@ -34,7 +34,7 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_nil last_response.headers["Permissions-Policy"]
+      assert_nil last_response.headers["Feature-Policy"]
     end
 
     test "global permissions policy in an initializer" do
@@ -124,7 +124,7 @@ module ApplicationTests
 
       get "/"
       assert_equal 200, last_response.status
-      assert_nil last_response.headers["Permissions-Policy"]
+      assert_nil last_response.headers["Feature-Policy"]
     end
 
     test "override permissions policy using different directives in a controller" do
@@ -185,7 +185,7 @@ module ApplicationTests
     private
       def assert_policy(expected)
         assert_equal 200, last_response.status
-        assert_equal expected, last_response.headers["Permissions-Policy"]
+        assert_equal expected, last_response.headers["Feature-Policy"]
       end
   end
 end


### PR DESCRIPTION
### Summary

In 90e710d7672b928ce6bb3ec05f8f2c05338be6c9 the FeaturePolicy middleware was renamed
to PermissionsPolicy as this will be new name of the header as used by browsers.
The Permissions-Policy header requires a different implementation and
isn't yet supported by all browsers. To avoid having to rename the
middleware in the future, we keep the new name for the Middleware, but
use the old implementation and header name.

### Other Information

The permissions-policy changed the format of the data to a structured header:
w3c/webappsec-permissions-policy#383

So the following:
```
 "usb 'self'; autoplay https://example.com; payment https://secure.example.com" 
```
Would need to change to
```
   "usb=(self), autoplay=(https://example.com), payment=(https://secure.example.com)" 
```