### PR TITLE
Allows ensuring_owner_was option only with dependent as destroy_async

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_many.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:counter_cache, :join_table, :index_errors, :ensuring_owner_was]
+      valid = super + [:counter_cache, :join_table, :index_errors]
       valid += [:as, :foreign_type] if options[:as]
       valid += [:through, :source, :source_type] if options[:through]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3090,7 +3090,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_key_ensuring_owner_was_is_not_valid_without_dependent_option
     error = assert_raises(ArgumentError) do
       Class.new(ActiveRecord::Base) do
-        has_many :books, ensuring_owner_was: true
+        has_many :books, ensuring_owner_was: :destroyed?
       end
     end
 
@@ -3101,7 +3101,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     Class.new(ActiveRecord::Base) do
       self.destroy_association_async_job = Class.new
 
-      has_many :books, ensuring_owner_was: true, dependent: :destroy_async
+      has_many :books, dependent: :destroy_async, ensuring_owner_was: :destroyed?
     end
   end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -3087,6 +3087,24 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_key_ensuring_owner_was_is_not_valid_without_dependent_option
+    error = assert_raises(ArgumentError) do
+      Class.new(ActiveRecord::Base) do
+        has_many :books, ensuring_owner_was: true
+      end
+    end
+
+    assert_match(/Unknown key: :ensuring_owner_was/, error.message)
+  end
+
+  def test_key_ensuring_owner_was_is_valid_when_dependent_option_is_destroy_async
+    Class.new(ActiveRecord::Base) do
+      self.destroy_association_async_job = Class.new
+
+      has_many :books, ensuring_owner_was: true, dependent: :destroy_async
+    end
+  end
+
   private
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target


### PR DESCRIPTION
### Summary

The option `ensuring_owner_was` should be enabled only with `dependent: destroy_async`. Since this option is [always added](https://github.com/rails/rails/pull/40157/files#diff-9d03762293bfe7b5ae014d4eeef8ee6250f6a14f7a2958de43887bb3b0a39f7bR10
) in the `valid` options `Association#build` was not raising an error.