### PR TITLE
Transform Hash into HTML atrributes for ERB interpolation

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Transforms a Hash into HTML Attributes, ready to be interpolated into ERB.
+
+        <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %> >
+        # => <input type="text" aria-label="Search">
+
+    *Sean Doyle*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Yield translated strings to calls of `ActionView::FormBuilder#button`

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -48,6 +48,15 @@ module ActionView
           @view_context = view_context
         end
 
+        # Transforms a Hash into HTML Attributes, ready to be interpolated into
+        # ERB.
+        #
+        #   <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %> >
+        #   # => <input type="text" aria-label="Search">
+        def attributes(attributes)
+          tag_options(attributes.to_h).to_s.strip.html_safe
+        end
+
         def p(*arguments, **options, &block)
           tag_string(:p, *arguments, **options, &block)
         end

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -391,6 +391,30 @@ class TagHelperTest < ActionView::TestCase
     assert_equal " &#X27; &#x27; &#x03BB; &#X03bb; &quot; &#39; &lt; &gt; ", escape_once(" &#X27; &#x27; &#x03BB; &#X03bb; \" ' < > ")
   end
 
+  def test_tag_attributes_inlines_html_attributes
+    expected_output = <<~HTML.strip
+      <input type="text" name="name" aria-hidden="false" aria-label="label" data-input-value="data" required="required">
+    HTML
+
+    assert_equal expected_output, render_erb(<<~HTML.strip)
+      <input type="text" <%= tag.attributes value: nil, name: "name", "aria-hidden": false, aria: { label: "label" }, data: { input_value: "data" }, required: true %>>
+    HTML
+  end
+
+  def test_tag_attributes_escapes_values
+    assert_not_includes "<script>alert()</script>", render_erb(<<~HTML.strip)
+      <input type="text" <%= tag.attributes xss: '"><script>alert()</script>' %>>
+    HTML
+  end
+
+  def test_tag_attributes_nil
+    assert_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes nil %>>))
+  end
+
+  def test_tag_attributes_empty
+    assert_equal %(<input type="text" >), render_erb(%(<input type="text" <%= tag.attributes({}) %>>))
+  end
+
   def test_tag_honors_html_safe_for_param_values
     ["1&amp;2", "1 &lt; 2", "&#8220;test&#8220;"].each do |escaped|
       assert_equal %(<a href="#{escaped}" />), tag("a", href: escaped.html_safe)


### PR DESCRIPTION
### Summary

Transforms a Hash into HTML Attributes, ready to be interpolated into
ERB.

```html+erb
<input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
<%# => <input type="text" aria-label="Search"> %>
```

Utilizes the `ActionView::Helpers::TagHelper#tag_options` implementation
to enable combining ERB with attribute transformation, without requiring
templates to replace HTML strings with `tag` or `content_tag`
invocations.

