### PR TITLE
Remove sass-rails in favour of sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "capybara", ">= 3.26"
 gem "selenium-webdriver", ">= 3.141.592"
 
 gem "rack-cache", "~> 1.2"
-gem "sass-rails"
+gem "sassc-rails", "~> 2.1", ">= 2.1.1"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0", require: ENV["SKIP_REQUIRE_WEBPACKER"] != "true"
 # require: false so bcrypt is loaded only when has_secure_password is used.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,8 +443,6 @@ GEM
     rubyzip (2.3.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc (2.4.0-x64-mingw32)
@@ -605,7 +603,7 @@ DEPENDENCIES
   rubocop-packaging
   rubocop-performance
   rubocop-rails
-  sass-rails
+  sassc-rails (~> 2.1, >= 2.1.1)
   sdoc (~> 2.0)
   selenium-webdriver (>= 3.141.592)
   sequel

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -33,12 +33,12 @@ passing the `--skip-sprockets` option.
 $ rails new appname --skip-sprockets
 ```
 
-Rails automatically adds the [`sass-rails`](https://github.com/rails/sass-rails)
+Rails automatically adds the [`sassc-rails`](https://github.com/sass/sassc-rails)
 gem to your `Gemfile`, which is used by Sprockets for
 [Sass](https://sass-lang.com) compilation:
 
 ```ruby
-gem 'sass-rails'
+gem 'sassc-rails'
 ```
 
 Using the `--skip-sprockets` option will prevent Rails from adding
@@ -62,7 +62,7 @@ config.assets.css_compressor = :yui
 config.assets.js_compressor = :uglifier
 ```
 
-NOTE: The `sass-rails` gem is automatically used for CSS compression if included
+NOTE: The `sassc-rails` gem is automatically used for CSS compression if included
 in the `Gemfile` and no `config.assets.css_compressor` option is set.
 
 
@@ -176,9 +176,9 @@ in `app/assets` are never served directly in production.
 ### Controller Specific Assets
 
 When you generate a scaffold or a controller, Rails also generates a
-Cascading Style Sheet file (or SCSS file if `sass-rails` is in the `Gemfile`)
+Cascading Style Sheet file (or SCSS file if `sassc-rails` is in the `Gemfile`)
 for that controller. Additionally, when generating a scaffold, Rails generates
-the file `scaffolds.css` (or `scaffolds.scss` if `sass-rails` is in the
+the file `scaffolds.css` (or `scaffolds.scss` if `sassc-rails` is in the
 `Gemfile`.)
 
 For example, if you generate a `ProjectsController`, Rails will also add a new
@@ -389,7 +389,7 @@ Note that the closing tag cannot be of the style `-%>`.
 #### CSS and Sass
 
 When using the asset pipeline, paths to assets must be re-written and
-`sass-rails` provides `-url` and `-path` helpers (hyphenated in Sass,
+`sassc-rails` provides `-url` and `-path` helpers (hyphenated in Sass,
 underscored in Ruby) for the following asset classes: image, font, video, audio,
 JavaScript and stylesheet.
 
@@ -489,7 +489,17 @@ NOTE. If you want to use multiple Sass files, you should generally use the [Sass
 instead of these Sprockets directives. When using Sprockets directives, Sass files exist within
 their own scope, making variables or mixins only available within the document they were defined in.
 
-You can do file globbing as well using `@import "*"`, and `@import "**/*"` to add the whole tree which is equivalent to how `require_tree` works. Check the [sass-rails documentation](https://github.com/rails/sass-rails#features) for more info and important caveats.
+There is a special import syntax that allows you to glob imports relative to
+the folder of the stylesheet that is doing the importing.
+
+* `@import "*"` will import all the files in the folder.
+* `@import "**/*"` will import all the files in the tree, equivalent to how `require_tree` works.
+
+Any valid ruby glob may be used. The imports are sorted alphabetically.
+
+NOTE: It is recommended that you only use file globbing when importing pure library
+files (containing mixins and variables) because it is difficult to control the
+cascade ordering for imports that contain styles using this approach.
 
 You can have as many manifest files as you need. For example, the `admin.css`
 and `admin.js` manifest could contain the JS and CSS files that are used for the
@@ -516,7 +526,7 @@ was a controller called "projects", which generated an
 `app/assets/stylesheets/projects.scss` file.
 
 In development mode, or if the asset pipeline is disabled, when this file is
-requested it is processed by the processor provided by the `sass-rails` gem and
+requested it is processed by the processor provided by the `sassc-rails` gem and
 then sent back to the browser as CSS. When asset pipelining is enabled, this
 file is preprocessed and placed in the `public/assets` directory for serving by
 either the Rails app or web server.
@@ -1064,7 +1074,7 @@ gem.
 ```ruby
 config.assets.css_compressor = :yui
 ```
-The other option for compressing CSS if you have the sass-rails gem installed is
+The other option for compressing CSS if you have the sassc-rails gem installed is
 
 ```ruby
 config.assets.css_compressor = :sass

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -171,7 +171,7 @@ numbers. It also filters out sensitive values of database columns when call `#in
 * `config.assets.enabled` a flag that controls whether the asset
 pipeline is enabled. It is set to `true` by default.
 
-* `config.assets.css_compressor` defines the CSS compressor to use. It is set by default by `sass-rails`. The unique alternative value at the moment is `:yui`, which uses the `yui-compressor` gem.
+* `config.assets.css_compressor` defines the CSS compressor to use. It is set by default by `sassc-rails`. The unique alternative value at the moment is `:yui`, which uses the `yui-compressor` gem.
 
 * `config.assets.js_compressor` defines the JavaScript compressor to use. Possible values are `:closure`, `:uglifier` and `:yui` which require the use of the `closure-compiler`, `uglifier` or `yui-compressor` gems respectively.
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -324,7 +324,7 @@ module Rails
       def assets_gemfile_entry
         return [] if options[:skip_sprockets]
 
-        GemfileEntry.version("sass-rails", ">= 6", "Use SCSS for stylesheets")
+        GemfileEntry.version("sassc-rails", "'~> 2.1', '>= 2.1.1'", "Use SCSS for stylesheets")
       end
 
       def webpacker_gemfile_entry

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -40,7 +40,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_file "Gemfile" do |content|
-      assert_no_match(/gem 'sass-rails'/, content)
+      assert_no_match(/gem 'sassc-rails'/, content)
       assert_no_match(/gem 'web-console'/, content)
       assert_no_match(/gem 'capybara'/, content)
       assert_no_match(/gem 'selenium-webdriver'/, content)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -601,7 +601,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_generator_has_assets_gems
     run_generator
 
-    assert_gem "sass-rails"
+    assert_gem "sassc-rails"
   end
 
   def test_action_cable_redis_gems

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -325,7 +325,7 @@ module SharedGeneratorTests
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']sprockets\/railtie["']/
 
     assert_file "Gemfile" do |content|
-      assert_no_match(/sass-rails/, content)
+      assert_no_match(/sassc-rails/, content)
     end
 
     assert_file "#{application_path}/config/environments/development.rb" do |content|


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

The `sass-rails` 6.0 release moved the rails sass implementation to `sassc-rails`, and is now only a wrapper around it. This was done to make transition to Rails 6 easier. No further development will be done on `sass-rails` and the recommended dependency for new rails apps is `sassc-rails`. 
This PR changes the default for rails generators to be the recommended `sassc-rails` rather than the wrapper `sass-rails`.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
