### PR TITLE
Let AS::SafeBuffer#[] and * return value be an instance of SafeBuffer in Ruby 3.0

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -152,12 +152,12 @@ module ActiveSupport #:nodoc:
 
     def [](*args)
       if html_safe?
-        new_safe_buffer = super
+        new_string = super
 
-        if new_safe_buffer
-          new_safe_buffer.instance_variable_set :@html_safe, true
-        end
+        return unless new_string
 
+        new_safe_buffer = new_string.is_a?(SafeBuffer) ? new_string : SafeBuffer.new(new_string)
+        new_safe_buffer.instance_variable_set :@html_safe, true
         new_safe_buffer
       else
         to_str[*args]
@@ -213,7 +213,8 @@ module ActiveSupport #:nodoc:
     end
 
     def *(*)
-      new_safe_buffer = super
+      new_string = super
+      new_safe_buffer = new_string.is_a?(SafeBuffer) ? new_string : SafeBuffer.new(new_string)
       new_safe_buffer.instance_variable_set(:@html_safe, @html_safe)
       new_safe_buffer
     end


### PR DESCRIPTION
### Summary

Ruby 3 introduces an incompatibility that all String methods return String instances when called on a subclass instance.
https://bugs.ruby-lang.org/issues/10845
https://github.com/ruby/ruby/pull/3701

This slightly affects our ActiveSupport::SafeBuffer that subclasses String, and here's a patch for `SafeBuffer#[]` and `SafeBuffer#*` to preserve Ruby 2 behavior (= return another SafeBuffer instance) in Ruby 3.

Note that almost all other methods that were changed in Ruby 3.0 were overridden on SafeBuffer to return a String already, so only two methods here were needed to be patched for the tests to pass.