### PR TITLE
Build token list with RecordIdentifier#dom_ids

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Extend `ActionView::RecordIdentifier#dom_id` to accept variable arguments and
+    keyword arguments to build an identifier list.
+
+    For example, reference multiple elements from within an aria-labelledby
+    attribute:
+
+        tag.button "Edit", aria: { labelledby: dom_id(@post, [:edit, {custom: true}, :title] }
+        # => <button aria-labelledby="edit_post_1 custom_post_1 title_post_1">Edit</button>
+
+    *Sean Doyle*
+
 ## Rails 6.1.0.rc1 (November 02, 2020) ##
 
 *   Yield translated strings to calls of `ActionView::FormBuilder#button`

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,11 +1,11 @@
-*   Extend `ActionView::RecordIdentifier#dom_id` to accept variable arguments and
-    keyword arguments to build an identifier list.
+*   Declare `ActionView::RecordIdentifier#dom_ids` to accept variable arguments
+    and keyword arguments to build an identifier list.
 
     For example, reference multiple elements from within an aria-labelledby
     attribute:
 
-        tag.button "Edit", aria: { labelledby: dom_id(@post, [:edit, {custom: true}, :title] }
-        # => <button aria-labelledby="edit_post_1 custom_post_1 title_post_1">Edit</button>
+        tag.button "Edit", id: dom_id(@post, :edit), aria: { labelledby: dom_ids(@post, [:edit, {custom: true}, :title] }
+        # => <button id="edit_post_1" aria-labelledby="edit_post_1 custom_post_1 title_post_1">Edit</button>
 
     *Sean Doyle*
 

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -87,38 +87,44 @@ module ActionView
     #
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
     #   dom_id(Post.new, :custom)    # => "custom_post"
-    #
+    def dom_id(record, prefix = nil)
+      if record_id = record_key_for_dom_id(record)
+        "#{dom_class(record, prefix)}#{JOIN}#{record_id}"
+      else
+        dom_class(record, prefix || NEW)
+      end
+    end
+
     # If you need to prepend multiple prefixes at a time, pass them as an Array
     # or as arguments:
     #
-    #   dom_id(Post.find(45), :edit, custom: true)                # => "edit_post_45 custom_post_45"
-    #   dom_id(Post.new, :edit, custom: true)                     # => "edit_post custom_post"
+    #   dom_ids(Post.find(45), :edit, custom: true)                # => "edit_post_45 custom_post_45"
+    #   dom_ids(Post.new, :edit, custom: true)                     # => "edit_post custom_post"
     #
-    #   dom_id(Post.find(45), [:edit, { custom: true }, :title])  # => "edit_post_45 custom_post_45 title_post_45"
-    #   dom_id(Post.new, [:edit, { custom: true }, :title])       # => "edit_post custom_post title_post"
+    #   dom_ids(Post.find(45), [:edit, { custom: true }, :title])  # => "edit_post_45 custom_post_45 title_post_45"
+    #   dom_ids(Post.new, [:edit, { custom: true }, :title])       # => "edit_post custom_post title_post"
     #
     # For example, reference multiple elements from within an aria-labelledby
     # attribute:
     #
-    #   tag.button "Edit", aria: { labelledby: dom_id(@post, [:edit, { custom: true }, :title] }
-    #   # => <button aria-labelledby="edit_post_1 custom_post_1 title_post_1">Edit</button>
-    #
-    def dom_id(record, *prefixes, **conditional_prefixes)
+    #   tag.button "Edit", id: dom_id(@post, :edit), aria: { labelledby: dom_ids(@post, [:edit, { custom: true }, :title] }
+    #   # => <button id="edit_post_1" aria-labelledby="edit_post_1 custom_post_1 title_post_1">Edit</button>
+    def dom_ids(record, *prefixes, **conditional_prefixes)
       prefixes = (Array.wrap(prefixes) + [conditional_prefixes].compact_blank).flatten
 
       if prefixes.any?
         identifiers = prefixes.map do |prefix|
           case prefix
           when Hash
-            prefix.transform_keys { |key| _dom_id(record, key) }
+            prefix.transform_keys { |key| dom_id(record, key) }
           else
-            _dom_id(record, prefix.presence)
+            dom_id(record, prefix.presence)
           end
         end
 
         ActionView::Helpers::TagHelper.build_tag_values(identifiers).join(LIST)
       else
-        _dom_id(record)
+        dom_id(record)
       end
     end
 
@@ -134,14 +140,6 @@ module ActionView
     def record_key_for_dom_id(record) # :doc:
       key = convert_to_model(record).to_key
       key ? key.join(JOIN) : key
-    end
-
-    def _dom_id(record, prefix = nil)
-      if record_id = record_key_for_dom_id(record)
-        "#{dom_class(record, prefix)}#{JOIN}#{record_id}"
-      else
-        dom_class(record, prefix || NEW)
-      end
     end
   end
 end

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -61,6 +61,7 @@ module ActionView
 
     JOIN = "_"
     NEW = "new"
+    LIST = " "
 
     # The DOM class convention is to use the singular form of an object or class.
     #
@@ -86,11 +87,38 @@ module ActionView
     #
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
     #   dom_id(Post.new, :custom)    # => "custom_post"
-    def dom_id(record, prefix = nil)
-      if record_id = record_key_for_dom_id(record)
-        "#{dom_class(record, prefix)}#{JOIN}#{record_id}"
+    #
+    # If you need to prepend multiple prefixes at a time, pass them as an Array
+    # or as arguments:
+    #
+    #   dom_id(Post.find(45), :edit, custom: true)                # => "edit_post_45 custom_post_45"
+    #   dom_id(Post.new, :edit, custom: true)                     # => "edit_post custom_post"
+    #
+    #   dom_id(Post.find(45), [:edit, { custom: true }, :title])  # => "edit_post_45 custom_post_45 title_post_45"
+    #   dom_id(Post.new, [:edit, { custom: true }, :title])       # => "edit_post custom_post title_post"
+    #
+    # For example, reference multiple elements from within an aria-labelledby
+    # attribute:
+    #
+    #   tag.button "Edit", aria: { labelledby: dom_id(@post, [:edit, { custom: true }, :title] }
+    #   # => <button aria-labelledby="edit_post_1 custom_post_1 title_post_1">Edit</button>
+    #
+    def dom_id(record, *prefixes, **conditional_prefixes)
+      prefixes = (Array.wrap(prefixes) + [conditional_prefixes].compact_blank).flatten
+
+      if prefixes.any?
+        identifiers = prefixes.map do |prefix|
+          case prefix
+          when Hash
+            prefix.transform_keys { |key| _dom_id(record, key) }
+          else
+            _dom_id(record, prefix.presence)
+          end
+        end
+
+        ActionView::Helpers::TagHelper.build_tag_values(identifiers).join(LIST)
       else
-        dom_class(record, prefix || NEW)
+        _dom_id(record)
       end
     end
 
@@ -106,6 +134,14 @@ module ActionView
     def record_key_for_dom_id(record) # :doc:
       key = convert_to_model(record).to_key
       key ? key.join(JOIN) : key
+    end
+
+    def _dom_id(record, prefix = nil)
+      if record_id = record_key_for_dom_id(record)
+        "#{dom_class(record, prefix)}#{JOIN}#{record_id}"
+      else
+        dom_class(record, prefix || NEW)
+      end
     end
   end
 end

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -31,6 +31,16 @@ class RecordIdentifierTest < ActiveSupport::TestCase
     assert_equal "edit_#{@singular}_1", dom_id(@record, :edit)
   end
 
+  def test_dom_id_with_argument_prefixes
+    @record.save
+    assert_equal "#{@singular}_1 edit_#{@singular}_1 delete_#{@singular}_1", dom_id(@record, nil, :edit, :delete, new: !@record.persisted?)
+  end
+
+  def test_dom_id_with_array_prefixes
+    @record.save
+    assert_equal "#{@singular}_1 edit_#{@singular}_1 delete_#{@singular}_1", dom_id(@record, [nil, :edit, { new: !@record.persisted? }, :delete])
+  end
+
   def test_dom_class
     assert_equal @singular, dom_class(@record)
   end
@@ -72,6 +82,16 @@ class RecordIdentifierWithoutActiveModelTest < ActiveSupport::TestCase
   def test_dom_id_with_prefix
     @record.save
     assert_equal "edit_airplane_1", dom_id(@record, :edit)
+  end
+
+  def test_dom_id_with_argument_prefixes
+    @record.save
+    assert_equal "airplane_1 custom_airplane_1 edit_airplane_1", dom_id(@record, nil, :custom, :edit, new: false)
+  end
+
+  def test_dom_id_with_array_prefixes
+    @record.save
+    assert_equal "airplane_1 custom_airplane_1 edit_airplane_1", dom_id(@record, nil, [:custom, { new: false }, :edit])
   end
 
   def test_dom_class

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -31,14 +31,14 @@ class RecordIdentifierTest < ActiveSupport::TestCase
     assert_equal "edit_#{@singular}_1", dom_id(@record, :edit)
   end
 
-  def test_dom_id_with_argument_prefixes
+  def test_dom_ids_with_argument_prefixes
     @record.save
-    assert_equal "#{@singular}_1 edit_#{@singular}_1 delete_#{@singular}_1", dom_id(@record, nil, :edit, :delete, new: !@record.persisted?)
+    assert_equal "#{@singular}_1 edit_#{@singular}_1 delete_#{@singular}_1", dom_ids(@record, nil, :edit, :delete, new: !@record.persisted?)
   end
 
-  def test_dom_id_with_array_prefixes
+  def test_dom_ids_with_array_prefixes
     @record.save
-    assert_equal "#{@singular}_1 edit_#{@singular}_1 delete_#{@singular}_1", dom_id(@record, [nil, :edit, { new: !@record.persisted? }, :delete])
+    assert_equal "#{@singular}_1 edit_#{@singular}_1 delete_#{@singular}_1", dom_ids(@record, [nil, :edit, { new: !@record.persisted? }, :delete])
   end
 
   def test_dom_class
@@ -84,14 +84,14 @@ class RecordIdentifierWithoutActiveModelTest < ActiveSupport::TestCase
     assert_equal "edit_airplane_1", dom_id(@record, :edit)
   end
 
-  def test_dom_id_with_argument_prefixes
+  def test_dom_ids_with_argument_prefixes
     @record.save
-    assert_equal "airplane_1 custom_airplane_1 edit_airplane_1", dom_id(@record, nil, :custom, :edit, new: false)
+    assert_equal "airplane_1 custom_airplane_1 edit_airplane_1", dom_ids(@record, nil, :custom, :edit, new: false)
   end
 
-  def test_dom_id_with_array_prefixes
+  def test_dom_ids_with_array_prefixes
     @record.save
-    assert_equal "airplane_1 custom_airplane_1 edit_airplane_1", dom_id(@record, nil, [:custom, { new: false }, :edit])
+    assert_equal "airplane_1 custom_airplane_1 edit_airplane_1", dom_ids(@record, nil, [:custom, { new: false }, :edit])
   end
 
   def test_dom_class


### PR DESCRIPTION
### Summary

Declare `ActionView::RecordIdentifier#dom_ids` to accept variable arguments and
keyword arguments to build an identifier list.

For example, reference multiple elements from within an aria-labelledby
attribute:

```ruby
tag.button "Edit", id: dom_id(@post, :edit), aria: { labelledby: dom_ids(@post, [:edit, {custom: true}, :title] }
```
