### PR TITLE
Grammer correction on ActiveSupport en.yml

### DIFF
--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -55,7 +55,7 @@ en:
     # Used in NumberHelper.number_to_currency()
     currency:
       format:
-        # Where is the currency sign? %u is the currency unit, %n the number (default: $5.00)
+        # Where is the currency sign? %u is the currency unit, %n is the number (default: $5.00)
         format: "%u%n"
         unit: "$"
         # These six are to override number.format and are optional


### PR DESCRIPTION
### Summary

A minor grammar correction on the ActiveSupport locale/en.yml. Making it uniform with others in the same file.
