### PR TITLE
Decouple instrumentation from logging

### DIFF
--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -64,6 +64,7 @@ module ActionDispatch
     autoload :ExceptionWrapper
     autoload :Executor
     autoload :Flash
+    autoload :Instrumentation
     autoload :PublicExceptions
     autoload :Reloader
     autoload :RemoteIp

--- a/actionpack/lib/action_dispatch/middleware/instrumentation.rb
+++ b/actionpack/lib/action_dispatch/middleware/instrumentation.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "action_dispatch/http/request"
+
+module ActionDispatch
+  # This middleware is responsible for instrumenting the request
+  class Instrumentation
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = ActionDispatch::Request.new(env)
+
+      instrumenter = ActiveSupport::Notifications.instrumenter
+      instrumenter.start("request.action_dispatch", request: request)
+
+      status, headers, body = @app.call(env)
+      body = ::Rack::BodyProxy.new(body) { finish(request) }
+      [status, headers, body]
+    rescue Exception
+      finish(request)
+      raise
+    end
+
+    private
+      def finish(request)
+        instrumenter = ActiveSupport::Notifications.instrumenter
+        instrumenter.finish("request.action_dispatch", request: request)
+      end
+  end
+end

--- a/actionpack/test/dispatch/instrumentation_test.rb
+++ b/actionpack/test/dispatch/instrumentation_test.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class InstrumentationTest < ActionDispatch::IntegrationTest
+  Subscriber = Struct.new(:starts, :finishes) do
+    def initialize(starts = [], finishes = [])
+      super
+    end
+
+    def start(name, id, payload)
+      starts << [name, id, payload]
+    end
+
+    def finish(name, id, payload)
+      finishes << [name, id, payload]
+    end
+  end
+
+  attr_reader :subscriber, :notifier
+
+  def setup
+    @subscriber = Subscriber.new
+    @notifier = ActiveSupport::Notifications.notifier
+    @subscription = notifier.subscribe "request.action_dispatch", subscriber
+  end
+
+  def teardown
+    notifier.unsubscribe @subscription
+  end
+
+  def test_notification
+    @app = ActionDispatch::Instrumentation.new(->(env) { [200, {}, %w(Success)] })
+
+    assert_difference("subscriber.starts.length") do
+      assert_difference("subscriber.finishes.length") do
+        get "/"
+      end
+    end
+  end
+
+  def test_notification_on_raise
+    @app = ActionDispatch::Instrumentation.new(->(env) {
+      # using an exception class that is not a StandardError subclass on purpose
+      raise NotImplementedError
+    })
+
+    assert_difference("subscriber.starts.length") do
+      assert_difference("subscriber.finishes.length") do
+        assert_raises(NotImplementedError) do
+          get "/"
+        end
+      end
+    end
+  end
+end

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -48,6 +48,7 @@ module Rails
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
           middleware.use ::Rails::Rack::Logger, config.log_tags
+          middleware.use ::ActionDispatch::Instrumentation
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
           middleware.use ::ActionDispatch::ActionableExceptions

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -31,15 +31,8 @@ module Rails
 
       private
         def call_app(request, env) # :doc:
-          instrumenter = ActiveSupport::Notifications.instrumenter
-          instrumenter.start "request.action_dispatch", request: request
           logger.info { started_request_message(request) }
-          status, headers, body = @app.call(env)
-          body = ::Rack::BodyProxy.new(body) { finish(request) }
-          [status, headers, body]
-        rescue Exception
-          finish(request)
-          raise
+          @app.call(env)
         ensure
           ActiveSupport::LogSubscriber.flush_all!
         end
@@ -64,11 +57,6 @@ module Rails
               tag
             end
           end
-        end
-
-        def finish(request)
-          instrumenter = ActiveSupport::Notifications.instrumenter
-          instrumenter.finish "request.action_dispatch", request: request
         end
 
         def logger

--- a/railties/test/rack_logger_test.rb
+++ b/railties/test/rack_logger_test.rb
@@ -29,57 +29,6 @@ module Rails
         end
       end
 
-      Subscriber = Struct.new(:starts, :finishes) do
-        def initialize(starts = [], finishes = [])
-          super
-        end
-
-        def start(name, id, payload)
-          starts << [name, id, payload]
-        end
-
-        def finish(name, id, payload)
-          finishes << [name, id, payload]
-        end
-      end
-
-      attr_reader :subscriber, :notifier
-
-      def setup
-        @subscriber = Subscriber.new
-        @notifier = ActiveSupport::Notifications.notifier
-        @subscription = notifier.subscribe "request.action_dispatch", subscriber
-      end
-
-      def teardown
-        notifier.unsubscribe @subscription
-      end
-
-      def test_notification
-        logger = TestLogger.new { }
-
-        assert_difference("subscriber.starts.length") do
-          assert_difference("subscriber.finishes.length") do
-            logger.call("REQUEST_METHOD" => "GET").last.close
-          end
-        end
-      end
-
-      def test_notification_on_raise
-        logger = TestLogger.new do
-          # using an exception class that is not a StandardError subclass on purpose
-          raise NotImplementedError
-        end
-
-        assert_difference("subscriber.starts.length") do
-          assert_difference("subscriber.finishes.length") do
-            assert_raises(NotImplementedError) do
-              logger.call "REQUEST_METHOD" => "GET"
-            end
-          end
-        end
-      end
-
       def test_logger_does_not_mutate_app_return
         response = [].freeze
         app = TestApp.new(response)


### PR DESCRIPTION
`Rails::Rack::Logger` has been responsible for two things: logging the request (`Started GET ...`) and instrumenting it (aka firing `request.action_dispatch` on `AS::Notifications`).

Depending on the app and logging setup, you may not want `Started GET ...` appended to your Rails log, while `request.action_dispatch` event is still useful.

Since "rack logger" things don't have much in common with AS Notifications, I'd like to use this as a change to decouple those two. I've done that by introducing a new middleware, `ActionDispatch::Instrumentation`. I thought that would be more clean compared to having configuration for `Rails::Rack::Logger`.

Now, those who would like to opt out from logging could remove `Rails::Rack::Logger` from their middleware stack.

cc @rafaelfranca @georgeclaghorn 