### PR TITLE
Test Action Text install generator

### DIFF
--- a/railties/test/fixtures/Rakefile
+++ b/railties/test/fixtures/Rakefile
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.load_tasks

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "generators/generators_test_helper"
+require "generators/action_text/install/install_generator"
+
+class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
+  include GeneratorsTestHelper
+
+  setup do
+    Rails.application = Rails.application.class
+    Rails.application.config.root = Pathname(destination_root)
+  end
+
+  teardown do
+    Rails.application = Rails.application.instance
+  end
+
+  test "creates bin/yarn" do
+    run_generator_instance
+
+    assert_file "bin/yarn"
+  end
+
+  test "installs JavaScript dependencies" do
+    run_generator_instance
+    yarn_commands = @yarn_commands.join("\n")
+
+    assert_match %r"^add .*@rails/actiontext@", yarn_commands
+    assert_match %r"^add .*trix@", yarn_commands
+  end
+
+  test "loads JavaScript dependencies in application.js" do
+    application_js = Pathname("app/javascript/packs/application.js").expand_path(destination_root)
+    application_js.dirname.mkpath
+    application_js.write("\n")
+    run_generator_instance
+
+    assert_file application_js do |content|
+      assert_match %r"^#{Regexp.escape 'require("@rails/actiontext")'}", content
+      assert_match %r"^#{Regexp.escape 'require("trix")'}", content
+    end
+  end
+
+  test "creates Action Text stylesheet" do
+    run_generator_instance
+
+    assert_file "app/assets/stylesheets/actiontext.scss"
+  end
+
+  test "creates Active Storage view partial" do
+    run_generator_instance
+
+    assert_file "app/views/active_storage/blobs/_blob.html.erb"
+  end
+
+  test "creates migrations" do
+    run_generator_instance
+
+    assert_migration "db/migrate/create_active_storage_tables.active_storage.rb"
+    assert_migration "db/migrate/create_action_text_tables.action_text.rb"
+  end
+
+  private
+    def run_generator_instance
+      @yarn_commands = []
+      yarn_command_stub = -> (command, *) { @yarn_commands << command }
+
+      generator.stub :yarn_command, yarn_command_stub do
+        with_database_configuration { super }
+      end
+    end
+end

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -1,22 +1,12 @@
 # frozen_string_literal: true
 
 require "abstract_unit"
-require "active_support/core_ext/module/remove_method"
 require "active_support/testing/stream"
 require "active_support/testing/method_call_assertions"
 require "rails/generators"
 require "rails/generators/test_case"
 
-module Rails
-  class << self
-    remove_possible_method :root
-    def root
-      @root ||= Pathname.new(File.expand_path("../fixtures", __dir__))
-    end
-  end
-end
-Rails.application.config.root = Rails.root
-Rails.application.config.generators.templates = [File.join(Rails.root, "lib", "templates")]
+Rails.application.config.generators.templates = [File.expand_path("../fixtures/lib/templates", __dir__)]
 
 # Call configure to load the settings from
 # Rails.application.config.generators to Rails::Generators
@@ -38,8 +28,13 @@ module GeneratorsTestHelper
 
   def self.included(base)
     base.class_eval do
-      destination File.join(Rails.root, "tmp")
+      destination File.expand_path("../fixtures/tmp", __dir__)
       setup :prepare_destination
+
+      setup { Rails.application.config.root = Pathname("../fixtures").expand_path(__dir__) }
+
+      setup { @original_rakeopt, ENV["RAKEOPT"] = ENV["RAKEOPT"], "--silent" }
+      teardown { ENV["RAKEOPT"] = @original_rakeopt }
 
       begin
         base.tests Rails::Generators.const_get(base.name.delete_suffix("Test"))

--- a/railties/test/generators/generators_test_helper.rb
+++ b/railties/test/generators/generators_test_helper.rb
@@ -48,6 +48,12 @@ module GeneratorsTestHelper
     end
   end
 
+  def run_generator_instance
+    capture(:stdout) do
+      generator.invoke_all
+    end
+  end
+
   def with_database_configuration(database_name = "secondary")
     original_configurations = ActiveRecord::Base.configurations
     ActiveRecord::Base.configurations = {

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -23,7 +23,7 @@ DEFAULT_PLUGIN_FILES = %w(
 
 class PluginGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
-  destination File.join(Rails.root, "tmp/bukkits")
+  destination File.join(destination_root, "bukkits")
   arguments [destination_root]
 
   def application_path

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -205,22 +205,34 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_generation_runs_bundle_install
-    assert_generates_without_bundler
+    generator([destination_root])
+    run_generator_instance
+
+    assert_empty @bundle_commands
   end
 
   def test_dev_option
-    assert_generates_without_bundler(dev: true)
+    generator([destination_root], dev: true)
+    run_generator_instance
+
+    assert_empty @bundle_commands
     rails_path = File.expand_path("../../..", Rails.root)
     assert_file "Gemfile", /^gem\s+["']rails["'],\s+path:\s+["']#{Regexp.escape(rails_path)}["']$/
   end
 
   def test_edge_option
-    assert_generates_without_bundler(edge: true)
+    generator([destination_root], edge: true)
+    run_generator_instance
+
+    assert_empty @bundle_commands
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["']$}
   end
 
   def test_generation_does_not_run_bundle_install_with_full_and_mountable
-    assert_generates_without_bundler(mountable: true, full: true, dev: true)
+    generator([destination_root], mountable: true, full: true, dev: true)
+    run_generator_instance
+
+    assert_empty @bundle_commands
     assert_no_file "#{destination_root}/Gemfile.lock"
   end
 
@@ -779,20 +791,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
         assert_match(/group :development do\n  gem 'activerecord-jdbcsqlite3-adapter'\nend/, contents)
       else
         assert_match(/group :development do\n  gem 'sqlite3'\nend/, contents)
-      end
-    end
-
-    def assert_generates_without_bundler(options = {})
-      generator([destination_root], options)
-
-      command_check = -> command do
-        if command == "install"
-          flunk "`install` expected to not be called."
-        end
-      end
-
-      generator.stub :bundle_command, command_check do
-        quietly { generator.invoke_all }
       end
     end
 end

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -92,17 +92,16 @@ module SharedGeneratorTests
     end
 
     generator([destination_root], template: path, skip_webpack_install: true).stub(:open, check_open, template) do
-      generator.stub :bundle_command, nil do
-        quietly { assert_match(/It works!/, capture(:stdout) { generator.invoke_all }) }
-      end
+      assert_match(/It works!/, run_generator_instance)
     end
   end
 
   def test_skip_gemfile
-    assert_not_called(generator([destination_root], skip_gemfile: true, skip_webpack_install: true), :bundle_command) do
-      quietly { generator.invoke_all }
-      assert_no_file "Gemfile"
-    end
+    generator([destination_root], skip_gemfile: true, skip_webpack_install: true)
+    run_generator_instance
+
+    assert_empty @bundle_commands
+    assert_no_file "Gemfile"
   end
 
   def test_skip_git
@@ -356,4 +355,14 @@ module SharedGeneratorTests
       assert_no_match(/node_modules/, content)
     end
   end
+
+  private
+    def run_generator_instance
+      @bundle_commands = []
+      bundle_command_stub = -> (command, *) { @bundle_commands << command }
+
+      generator.stub(:bundle_command, bundle_command_stub) do
+        super
+      end
+    end
 end


### PR DESCRIPTION
There are two commits in this PR.  The first commit is a minor refactoring of several generator tests.  The second commit adds tests for the Action Text install generator.  I've bundled them together because the second commit provides some extra motivation for the first, but I can split them into separate PRs if desired.

/cc @abhaynikam I've added you as a co-author since you were exploring Action Text install generator tests in #39317.
