### PR TITLE
Read all records at once when using update with an array

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -280,8 +280,8 @@ module ActiveRecord
       #   people.update(group: "masters")
       #
       # Note: Updating a large number of records will run an UPDATE
-      # query for each record(duplicates will be merged together first),
-      # which may cause a performance issue.
+      # query for each record which may cause a performance issue.
+      # Duplicate ids will only be updated once, by merging all attributes.
       # When running callbacks is not needed for each record update,
       # it is preferred to use {update_all}[rdoc-ref:Relation#update_all]
       # for updating all records in a single query.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -287,8 +287,11 @@ module ActiveRecord
       # for updating all records in a single query.
       def update(id = :all, attributes)
         if id.is_a?(Array)
-          raise(ArgumentError, "the list of ids and the list of attributes do not have " \
-                "the same length.  id: #{id.size} attributes: #{attributes.size}") if id.size != attributes.size
+          if id.size != attributes.size
+            raise ArgumentError,
+                  "the list of ids and the list of attributes do not have " \
+                  "the same length. id: #{id.size} attributes: #{attributes.size}"
+          end
 
           merged_attributes = Hash.new { |hash, key| hash[key] = {} }
           id.size.times { |i| merged_attributes[id[i]].merge!(attributes[i]) }

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -53,6 +53,14 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_equal "2 updated", Topic.find(2).content
   end
 
+  def test_update_with_different_size_arrays
+    topic_keys = [1, 2, 999]
+    topic_value = [{ "content" => "1 updated" }, { "content" => "2 updated" }]
+    assert_raise(ArgumentError) do
+      Topic.update(topic_keys, topic_value)
+    end
+  end
+
   def test_class_level_update_without_ids
     topics = Topic.all
     assert_equal 5, topics.length


### PR DESCRIPTION
### Summary

Prior to this change records were loaded one by one and then updated one
by one.

Now records are loaded upfront and updated mostly one by one.  When there are duplicate id's
attributes are merged together ahead of time.  The method
still returns duplicates in the order it was given, meaning:

```ruby
Model.update [1,1,3], [...]
```

will still return 3 Model objects in that order.

There are a number of tradeoffs to consider for this PR:

1. Attributes are merged together upfront (so duplicated id's will only
yield one update).  To me this seems better but it is a change to call out
2. We have to rebuild the ordered list with duplicates since
find(ids) removes duplicates
3. We're adding some memory overhead to make O(1) lookups happen
