### PR TITLE
Address "ArgumentError: missing keywords: :sql, :name" with ruby 3.0.0dev

### DIFF
--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -26,8 +26,8 @@ class ActiveSupport::TestCase
     ActiveRecord::Base.connection.materialize_transactions
 
     queries = []
-    ActiveSupport::Notifications.subscribe("sql.active_record") do |*, sql:, name:, **|
-      queries << sql unless %w[ SCHEMA TRANSACTION ].include?(name)
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      queries << payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(payload[:name])
     end
 
     yield.tap do


### PR DESCRIPTION
This pull request addresses the `ArgumentError: missing keywords: :sql, :name`,
which has been reported at https://buildkite.com/rails/rails/builds/72990#c78d1e4c-5775-4758-9010-9ba71fdb6138

Follow up #39397

```ruby
$ ruby -v
ruby 3.0.0dev (2020-11-24T22:48:19Z master 63ad55cd88) [x86_64-linux]
$ cd actiontext
$ bin/test test/unit/model_test.rb -n test_eager_loading
Run options: -n test_eager_loading --seed 16493

E

Error:
ActionText::ModelTest#test_eager_loading:
ArgumentError: missing keywords: :sql, :name
    /home/yahonda/src/github.com/rails/rails/actiontext/test/test_helper.rb:29:in `block in assert_queries'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:186:in `finish'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:63:in `block in finish'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:63:in `each'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:63:in `finish'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:45:in `finish_with_state'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:30:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:688:in `log'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:46:in `exec_query'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:536:in `select_prepared'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:67:in `select_all'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:103:in `select_all'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/querying.rb:47:in `find_by_sql'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:850:in `block in exec_queries'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:868:in `skip_query_cache_if_necessary'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:835:in `exec_queries'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:638:in `load'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:249:in `records'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation.rb:244:in `to_ary'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:553:in `find_nth_with_limit'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:538:in `find_nth'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:122:in `first'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/relation/finder_methods.rb:153:in `last'
    /home/yahonda/src/github.com/rails/rails/actiontext/test/unit/model_test.rb:93:in `block (2 levels) in <class:ModelTest>'
    /home/yahonda/src/github.com/rails/rails/actiontext/test/test_helper.rb:33:in `assert_queries'
    /home/yahonda/src/github.com/rails/rails/actiontext/test/unit/model_test.rb:93:in `block in <class:ModelTest>'

Error:
ActionText::ModelTest#test_eager_loading:
ArgumentError: missing keywords: :sql, :name
    /home/yahonda/src/github.com/rails/rails/actiontext/test/test_helper.rb:29:in `block in assert_queries'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:186:in `finish'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:63:in `block in finish'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:63:in `each'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/fanout.rb:63:in `finish'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:45:in `finish_with_state'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:30:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:688:in `log'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb:98:in `exec_rollback_db_transaction'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:378:in `rollback_db_transaction'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb:22:in `rollback_db_transaction'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:205:in `rollback'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:302:in `block in rollback_transaction'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb:300:in `rollback_transaction'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:328:in `rollback_transaction'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/test_fixtures.rb:168:in `block in teardown_fixtures'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/test_fixtures.rb:167:in `each'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/test_fixtures.rb:167:in `teardown_fixtures'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/test_fixtures.rb:16:in `after_teardown'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/setup_and_teardown.rb:51:in `after_teardown'

bin/test test/unit/model_test.rb:90

Finished in 0.117256s, 8.5284 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
