### PR TITLE
Do not allow subscribing to Base channel

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -33,7 +33,7 @@ module ActionCable
 
         subscription_klass = id_options[:channel].safe_constantize
 
-        if subscription_klass && ActionCable::Channel::Base >= subscription_klass
+        if subscription_klass && ActionCable::Channel::Base > subscription_klass
           subscription = subscription_klass.new(connection, id_key, id_options)
           subscriptions[id_key] = subscription
           subscription.subscribe_to_channel

--- a/actioncable/test/connection/subscriptions_test.rb
+++ b/actioncable/test/connection/subscriptions_test.rb
@@ -66,6 +66,17 @@ class ActionCable::Connection::SubscriptionsTest < ActionCable::TestCase
     end
   end
 
+  test "subscribe command with Base channel" do
+    run_in_eventmachine do
+      setup_connection
+
+      identifier = ActiveSupport::JSON.encode(id: 1, channel: "ActionCable::Channel::Base")
+      @subscriptions.execute_command "command" => "subscribe", "identifier" => identifier
+
+      assert_empty @subscriptions.identifiers
+    end
+  end
+
   test "unsubscribe command" do
     run_in_eventmachine do
       setup_connection


### PR DESCRIPTION
Closes #40482

Prior to this commit it was possible to subscribe with
`ActionCable::Channel::Base` as the subscription class. While it doesn't
seem possible to exploit this in away way, it also doesn't seem like
something we need to allow.

This commit swaps [Module#>=][gte] with [Module#>][gt] to prevent
subscribing to a channel when `ActionCable::Channel::Base` is the
subscription class.

[gte]: https://ruby-doc.org/core-2.5.3/Module.html#method-i-3E-3D
[gt]: https://ruby-doc.org/core-2.5.3/Module.html#method-i-3E