### PR TITLE
Remove duplicate assertion in test file

### DIFF
--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -53,7 +53,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_correct_file_in_lib_folder_of_hyphenated_plugin_name
     run_generator [File.join(destination_root, "hyphenated-name")]
     assert_no_file "hyphenated-name/lib/hyphenated-name.rb"
-    assert_no_file "hyphenated-name/lib/hyphenated_name.rb"
     assert_file "hyphenated-name/lib/hyphenated/name.rb", /module Hyphenated\n  module Name\n    # Your code goes here\.\.\.\n  end\nend/
   end
 


### PR DESCRIPTION
### Summary

The assertion `assert_no_file "hyphenated-name/lib/hyphenated_name.rb"` is present twice.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
