### PR TITLE
Only use ActionDispatch::ActionableExceptions middleware if local env

### DIFF
--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -50,7 +50,10 @@ module Rails
           middleware.use ::Rails::Rack::Logger, config.log_tags
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
-          middleware.use ::ActionDispatch::ActionableExceptions
+
+          if config.consider_all_requests_local
+            middleware.use ::ActionDispatch::ActionableExceptions
+          end
 
           unless config.cache_classes
             middleware.use ::ActionDispatch::Reloader, app.reloader

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -38,6 +38,41 @@ module ApplicationTests
         "Rails::Rack::Logger",
         "ActionDispatch::ShowExceptions",
         "ActionDispatch::DebugExceptions",
+        "ActionDispatch::Reloader",
+        "ActionDispatch::Callbacks",
+        "ActiveRecord::Migration::CheckPending",
+        "ActionDispatch::Cookies",
+        "ActionDispatch::Session::CookieStore",
+        "ActionDispatch::Flash",
+        "ActionDispatch::ContentSecurityPolicy::Middleware",
+        "ActionDispatch::PermissionsPolicy::Middleware",
+        "Rack::Head",
+        "Rack::ConditionalGet",
+        "Rack::ETag",
+        "Rack::TempfileReaper"
+      ], middleware
+    end
+
+    test "default middleware stack when requests are local" do
+      add_to_config "config.consider_all_requests_local = true"
+      add_to_config "config.active_record.migration_error = :page_load"
+
+      boot!
+
+      assert_equal [
+        "Webpacker::DevServerProxy",
+        "ActionDispatch::HostAuthorization",
+        "Rack::Sendfile",
+        "ActionDispatch::Static",
+        "ActionDispatch::Executor",
+        "ActiveSupport::Cache::Strategy::LocalCache",
+        "Rack::Runtime",
+        "Rack::MethodOverride",
+        "ActionDispatch::RequestId",
+        "ActionDispatch::RemoteIp",
+        "Rails::Rack::Logger",
+        "ActionDispatch::ShowExceptions",
+        "ActionDispatch::DebugExceptions",
         "ActionDispatch::ActionableExceptions",
         "ActionDispatch::Reloader",
         "ActionDispatch::Callbacks",
@@ -72,7 +107,6 @@ module ApplicationTests
         "Rails::Rack::Logger",
         "ActionDispatch::ShowExceptions",
         "ActionDispatch::DebugExceptions",
-        "ActionDispatch::ActionableExceptions",
         "ActionDispatch::Reloader",
         "ActionDispatch::Callbacks",
         "Rack::Head",


### PR DESCRIPTION
### Summary

When building the default middleware stack, the `ActionDispatch::ActionableExceptions`
middleware should only be used if the configuration has `:consider_all_requests_local`
set to true.

There is an existing check `#actionable_request?` in ActionableExceptions
that will prevent actionable exceptions from being dispatched in the case where the "action_dispatch.show_detailed_exceptions" header is
set to false. This check should remain in place as a second line of defense
in case the ActionableExceptions middleware is added back to the application.

However, we can go ahead and remove the middleware from the default stack
when the environment is not local.
