### PR TITLE
    ActiveStorage/DirectUpload: Allow DirectUpload to Receive Callback as Delegate on Instantiation 

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -512,6 +512,9 @@
     var elements = root.querySelectorAll(selector);
     return toArray$1(elements);
   }
+  function isFunc(func) {
+    return func && {}.toString.call(func) === "[object Function]";
+  }
   function findElement(root, selector) {
     if (typeof root == "string") {
       selector = root;
@@ -688,7 +691,7 @@
             return;
           }
           var blob = new BlobRecord(_this.file, checksum, _this.url);
-          notify(_this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr);
+          notify(_this.delegate, "directUploadWillStoreFileWithXHR", blob.xhr);
           blob.create(function(error) {
             if (error) {
               callback(error);
@@ -709,12 +712,21 @@
     } ]);
     return DirectUpload;
   }();
-  function notify(object, methodName) {
-    if (object && typeof object[methodName] == "function") {
-      for (var _len = arguments.length, messages = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
-        messages[_key - 2] = arguments[_key];
-      }
-      return object[methodName].apply(object, messages);
+  var notifyError = function notifyError() {
+    throw new Error("Delgate must either be a callback or a class or object that implements directUploadWillStoreFileWithXHR.");
+  };
+  function notify(obj, methodName) {
+    if (obj === undefined || typeof obj === "string" || Array.isArray(obj) || typeof obj === "boolean" || obj === null) {
+      notifyError();
+    }
+    for (var _len = arguments.length, messages = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+      messages[_key - 2] = arguments[_key];
+    }
+    if (typeof obj[methodName] === "function") {
+      return obj[methodName].apply(obj, messages);
+    }
+    if (isFunc(obj)) {
+      return obj.apply(undefined, messages);
     }
   }
   var DirectUploadController = function() {

--- a/activestorage/app/javascript/activestorage/direct_upload.js
+++ b/activestorage/app/javascript/activestorage/direct_upload.js
@@ -1,6 +1,9 @@
 import { FileChecksum } from "./file_checksum"
 import { BlobRecord } from "./blob_record"
 import { BlobUpload } from "./blob_upload"
+import {
+  isFunc,
+} from "../../javascript/activestorage/helpers"
 
 let id = 0
 
@@ -20,7 +23,7 @@ export class DirectUpload {
       }
 
       const blob = new BlobRecord(this.file, checksum, this.url)
-      notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr)
+      notify(this.delegate, "directUploadWillStoreFileWithXHR", blob.xhr)
 
       blob.create(error => {
         if (error) {
@@ -41,8 +44,26 @@ export class DirectUpload {
   }
 }
 
-function notify(object, methodName, ...messages) {
-  if (object && typeof object[methodName] == "function") {
-    return object[methodName](...messages)
+const notifyError = () => {
+  throw new Error(
+    "Delgate must either be a callback or a class or object that implements directUploadWillStoreFileWithXHR."
+  )
+}
+
+function notify(obj, methodName, ...messages) {
+  if (
+    obj === undefined ||
+    typeof obj === "string" ||
+    Array.isArray(obj) ||
+    typeof obj === "boolean" || obj === null
+
+  ) {
+    notifyError()
+  }
+  if (typeof obj[methodName] === "function") {
+    return obj[methodName](...messages)
+  }
+  if (isFunc(obj)) {
+    return obj(...messages)
   }
 }

--- a/activestorage/app/javascript/activestorage/helpers.js
+++ b/activestorage/app/javascript/activestorage/helpers.js
@@ -14,6 +14,10 @@ export function findElements(root, selector) {
   return toArray(elements)
 }
 
+export function isFunc(func) {
+  return func && {}.toString.call(func) === "[object Function]"
+}
+
 export function findElement(root, selector) {
   if (typeof root == "string") {
     selector = root

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -839,10 +839,7 @@ const uploadFile = (file) => {
 }
 ```
 
-If you need to track the progress of the file upload, you can pass a third
-parameter to the `DirectUpload` constructor. During the upload, DirectUpload
-will call the object's `directUploadWillStoreFileWithXHR` method. You can then
-bind your own progress handler on the XHR.
+If you need to track the progress of the file upload, you can pass a third parameter to the `DirectUpload` constructor. The third parameter can either be a callback or an object/class that implements `directUploadWillStoreFileWithXHR`. During the upload, DirectUpload will either call the object's/class' `directUploadWillStoreFileWithXHR` method or the provided callback. You can then bind your own progress handler on the XHR.
 
 ```js
 import { DirectUpload } from "@rails/activestorage"
@@ -872,6 +869,25 @@ class Uploader {
     // Use event.loaded and event.total to update the progress bar
   }
 }
+```
+
+Or using a callback
+
+```js
+const file = new File([""], "filename");
+const url = `https://localhost:3000/rails/active_storage/direct_uploads`
+const callback = (request) => 	request.upload.addEventListener("progress", event => console.log('uploading', event))
+
+const upload = new DirectUpload(file, url, callback);
+
+upload.create((error, blob) => {
+  if (error) {
+    // Handle the error
+  } else {
+    // do something else
+    //
+  }
+})
 ```
 
 Discarding Files Stored During System Tests


### PR DESCRIPTION
### Summary
Currently, DirectUpload can only accept a class or an object as a third parameter that implements `directUploadWillStoreFileWithXHR`. This limits being notified about an upload's progress exclusively to object like structures. This PR allows DirectUpload to receive a callback or a class/object implementing `directUploadWillStoreFileWithXHR`. 

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
