### PR TITLE
Use application time zone in `travel_to` when it gets time as String.

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -156,6 +156,8 @@ module ActiveSupport
 
         if date_or_time.is_a?(Date) && !date_or_time.is_a?(DateTime)
           now = date_or_time.midnight.to_time
+        elsif date_or_time.is_a?(String)
+          now = Time.zone.parse(date_or_time)
         else
           now = date_or_time.to_time.change(usec: 0)
         end

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -3,6 +3,7 @@
 require_relative "abstract_unit"
 require "active_support/core_ext/date_time"
 require "active_support/core_ext/numeric/time"
+require "active_support/core_ext/string/conversions"
 require_relative "time_zone_test_helpers"
 
 class TimeTravelTest < ActiveSupport::TestCase
@@ -77,6 +78,20 @@ class TimeTravelTest < ActiveSupport::TestCase
           expected_time = 5.minutes.ago
 
           travel_to 5.minutes.ago do
+            assert_equal expected_time.to_s(:db), Time.zone.now.to_s(:db)
+          end
+        end
+      end
+    end
+  end
+
+  def test_time_helper_travel_to_with_string_for_time_zone
+    with_env_tz "US/Eastern" do
+      with_tz_default ActiveSupport::TimeZone["UTC"] do
+        Time.stub(:now, Time.now) do
+          expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+
+          travel_to "2004-11-24 01:04:44" do
             assert_equal expected_time.to_s(:db), Time.zone.now.to_s(:db)
           end
         end


### PR DESCRIPTION
### Summary

It looks like a bug but we have not had this functionality in docs.

`travel_to` can get a string argument like "2004-11-24 01:04:44" but the method `to_time` what is additionally defined for String loses the application time zone and sets it to local.

**Now:**
```ruby
travel_to "2004-11-24 01:04:44" do
  Time.zone.now.to_s(:db) # => "2004-11-24 06:04:44" 
end 
```

**Expected:**
```ruby
travel_to "2004-11-24 01:04:44" do
  Time.zone.now.to_s(:db) # => "2004-11-24 01:04:44"  
end 
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
