### PR TITLE
Add where.associated to check association presence

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `where.associated` to check for the presence of an association.
+
+    ```ruby
+    # Before:
+    account.users.joins(:contact).where.not(contact_id: nil)
+
+    # After:
+    account.users.where.associated(:contact)
+    ```
+
+    Also mirrors `where.missing`.
+
+    *Kasper Timm Hansen*
+
 *   Fix odd behavior of inverse_of with multiple belongs_to to same class.
 
     Fixes #35204.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -66,12 +66,11 @@ module ActiveRecord
       #    # LEFT OUTER JOIN "authors" ON "authors"."id" = "posts"."author_id"
       #    # LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id"
       #    # WHERE "authors"."id" IS NULL AND "comments"."id" IS NULL
-      def missing(*args)
-        args.each do |arg|
-          reflection = @scope.klass._reflect_on_association(arg)
-          opts = { reflection.table_name => { reflection.association_primary_key => nil } }
-          @scope.left_outer_joins!(arg)
-          @scope.where!(opts)
+      def missing(*associations)
+        associations.each do |association|
+          reflection = @scope.klass._reflect_on_association(association)
+          @scope.left_outer_joins!(association)
+          @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
         end
 
         @scope

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -12,6 +12,22 @@ module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
     fixtures :posts, :comments, :authors, :humans, :essays
 
+    def test_associated_with_association
+      Post.where.associated(:author).tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_includes     relation, posts(:sti_habtm)
+        assert_not_includes relation, posts(:authorless)
+      end
+    end
+
+    def test_associated_with_multiple_associations
+      Post.where.associated(:author, :comments).tap do |relation|
+        assert_includes     relation, posts(:welcome)
+        assert_not_includes relation, posts(:sti_habtm)
+        assert_not_includes relation, posts(:authorless)
+      end
+    end
+
     def test_missing_with_association
       assert posts(:authorless).author.blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a


### PR DESCRIPTION
Extracted from an app where we had this:

```ruby
class Account < ApplicationRecord
  has_many :users, -> { joins(:contact).where.not(contact_id: nil) }
end
```

Here `user` is a `contactable` delegated type of `contact`, so replacing the `contactable` and deleting a `user` in the background is a common pattern. This check prevents rendering users currently being deleted, giving the appearance of an immediate delete without needing to track a deleted status.

So this has more syntactic noise when you just want to communicate the presence of the association, so this is now:

```ruby
class Account < ApplicationRecord
  has_many :users, -> { where.associated(:contact) }
end
```

Mirroring `where.missing` added in https://github.com/rails/rails/pull/34727