### PR TITLE
Update thin to 1.8.0 to fix bundle install error with xcode 12 on MacOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,10 +78,6 @@ group :cable do
   gem "redis-namespace", github: "resque/redis-namespace"
 
   gem "websocket-client-simple", github: "matthewd/websocket-client-simple", branch: "close-race", require: false
-
-  gem "blade", require: false, platforms: [:ruby]
-  gem "blade-sauce_labs_plugin", require: false, platforms: [:ruby]
-  gem "sprockets-export", require: false
 end
 
 # Active Storage
@@ -100,6 +96,12 @@ gem "webmock"
 group :ujs do
   gem "qunit-selenium"
   gem "webdrivers"
+end
+
+# Action View
+group :view do
+  gem "blade", require: false, platforms: [:ruby]
+  gem "sprockets-export", require: false
 end
 
 # Add your own local bundler stuff.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,7 +497,7 @@ GEM
     stackprof (0.2.16)
     sucker_punch (2.1.2)
       concurrent-ruby (~> 1.0)
-    thin (1.7.2)
+    thin (1.8.0)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,10 +177,6 @@ GEM
       thor (>= 0.19.1)
       useragent (~> 0.16.7)
     blade-qunit_adapter (2.0.1)
-    blade-sauce_labs_plugin (0.7.3)
-      childprocess
-      faraday
-      selenium-webdriver
     bootsnap (1.5.0)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -564,7 +560,6 @@ DEPENDENCIES
   bcrypt (~> 3.1.11)
   benchmark-ips
   blade
-  blade-sauce_labs_plugin
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)


### PR DESCRIPTION
### Summary

When I attempt to `bundle install` a fresh set of Rails dependencies, `thin` (a dependency of `blade`) fails to build with native extensions. It looks like I'm hitting the issue described in https://github.com/macournoyer/thin/issues/372. The root cause seems to be a change in how Clang 12 treats a specific compiler warning. Updating `thin` to 1.8.0 fixes the issue, thanks to [this change](https://github.com/macournoyer/thin/pull/364). The 1.7.2 to 1.8.0 [diff is non-trivial](https://github.com/macournoyer/thin/compare/v1.7.2...v1.8.0), but the vast majority of the changes are to specs.

One thing I am a bit confused about: the `blade` dependency is listed under ActionCable in the Gemfile, but from grepping around it's only used by ActionView. Am I right that it's only used in the ActionView tests? I'm not super familiar with the Rails codebase. I did see the `assets:compile` ActionView rake task, but since `blade` isn't included with the packaged gem, it seems like any non-development code that tried to use it would fail.

### Other Information

Worth noting if anybody else runs into this issue that there's a temporary fix described in the [PR](https://github.com/macournoyer/thin/pull/364) to thin which worked for me. Would nice to get a vanilla `bundle install` working, though!