### PR TITLE
Always render Action Text HTML with :html format

### DIFF
--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -84,7 +84,7 @@ module ActionText
     end
 
     def to_rendered_html_with_layout
-      render partial: "action_text/content/layout", locals: { content: self }
+      render partial: "action_text/content/layout", formats: :html, locals: { content: self }
     end
 
     def to_s

--- a/actiontext/test/dummy/app/views/messages/show.json.erb
+++ b/actiontext/test/dummy/app/views/messages/show.json.erb
@@ -1,0 +1,5 @@
+{
+  "id": <%= @message.id %>,
+  "subject": "<%= j @message.subject %>",
+  "content": "<%= j @message.content %>"
+}

--- a/actiontext/test/integration/controller_render_test.rb
+++ b/actiontext/test/integration/controller_render_test.rb
@@ -14,6 +14,16 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "renders as HTML when the request format is not HTML" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    message = Message.create!(content: ActionText::Content.new.append_attachables(blob))
+
+    host! "loocalhoost"
+    get message_path(message, format: :json)
+    content = Nokogiri::HTML::DocumentFragment.parse(response.parsed_body["content"])
+    assert_select content, "img:match('src', ?)", %r"//loocalhoost/.+/racecar"
+  end
+
   test "resolves partials when controller is namespaced" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
     message = Message.create!(content: ActionText::Content.new.append_attachables(blob))


### PR DESCRIPTION
Since #40222, Action Text HTML is rendered in the context of the current request.  This causes the Action Text template format to default to the request format, which prevents the template from being resolved when the request format is not `:html` (e.g. `:json`).  Therefore, override the template format to always be `:html`.

Fixes #40695.
