### PR TITLE
Fix bad return value of `HashWithIndifferentAccess#deep_transform_keys`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
+
+    *Nathaniel Woodthorpe*
+
 *   Ensure `MemoryStore` disables compression by default. Reverts behavior of
     `MemoryStore` to its prior rails `5.1` behavior.
 

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -116,7 +116,7 @@ class Hash
     def _deep_transform_keys_in_object(object, &block)
       case object
       when Hash
-        object.each_with_object({}) do |(key, value), result|
+        object.each_with_object(self.class.new) do |(key, value), result|
           result[yield(key)] = _deep_transform_keys_in_object(value, &block)
         end
       when Array

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -433,6 +433,19 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
+  def test_indifferent_deep_transform_keys
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings).deep_transform_keys { |k| k * 2 }
+
+    assert_equal({ "aa" => { "bb" => { "cc" => 3 } } }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings).deep_transform_keys { |k| k.to_sym }
+
+    assert_equal(3, hash[:a][:b][:c])
+    assert_equal(3, hash["a"]["b"]["c"])
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
   def test_indifferent_transform_keys_bang
     indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
     indifferent_strings.transform_keys! { |k| k * 2 }
@@ -446,6 +459,21 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(1, indifferent_strings[:a])
     assert_equal(1, indifferent_strings["a"])
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
+  def test_indifferent_deep_transform_keys_bang
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings)
+    hash.deep_transform_keys! { |k| k * 2 }
+
+    assert_equal({ "aa" => { "bb" => { "cc" => 3 } } }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings)
+    hash.deep_transform_keys! { |k| k.to_sym }
+
+    assert_equal(3, hash[:a][:b][:c])
+    assert_equal(3, hash["a"]["b"]["c"])
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
   def test_indifferent_transform_values


### PR DESCRIPTION
### Summary

`HashWithIndifferentAccess#deep_transform_keys` currently returns a ` Hash` object, while other Hash methods retain the indifferent access when called on an indifferent hash. We'd expect that `HashWithIndifferentAccess#deep_transform_keys` should return a `HashWithIndifferentAccess`. Example:

```ruby
irb(main):001:0> {a: {b: 1}}.with_indifferent_access.class
=> ActiveSupport::HashWithIndifferentAccess

irb(main):002:0> {a: {b: 1}}.with_indifferent_access.deep_transform_keys(&:upcase).class
=> Hash

irb(main):003:0> {a: {b: 1}}.with_indifferent_access.deep_transform_keys(&:upcase)[:A]
=> nil
```

I tracked it down to the `Hash#_deep_transform_keys_in_object` helper method building the new hash using `each_with_object({}) ...`. Changing `{}` to `self.class.new` here properly sets the value for subclasses of Hash, including `HashWithIndifferentAccess`.

I don't love changing the base class to fix a bug in the subclass, but I figured changing the base class here allows all other subclasses of `Hash` to reap the same benefits. Alternatively, we could port over the logic needed for `deep_transform_keys` to `hash_with_indifferent_access.rb`.

`HashWithIndifferentAccess#deep_transform_keys!` wasn't broken, but I figured I'd add a test while I was in the file.

Running the test before applying my fix:

```
vagrant@rails-dev-box:/vagrant/rails/activesupport$ bundle exec ruby -w -Itest test/hash_with_indifferent_access_test.rb
Run options: --seed 2799

# Running:

..........................F

Failure:
HashWithIndifferentAccessTest#test_indifferent_deep_transform_keys [test/hash_with_indifferent_access_test.rb:440]:
Expected {"aa"=>{"bb"=>{"cc"=>3}}} to be an instance of ActiveSupport::HashWithIndifferentAccess, not Hash.


rails test test/hash_with_indifferent_access_test.rb:436

................................................................

Finished in 0.206536s, 440.6008 runs/s, 1408.9544 assertions/s.
91 runs, 291 assertions, 1 failures, 0 errors, 0 skips
```


### Other Information

I created a quick benchmark just to make sure there's no significant regression here. I measured about 10% slowdown on a regular `Hash`, and ~2.2x slowdown on a `HashWithIndifferentAccess`. Considering the `HashWithIndifferentAccess` result was incorrect before, I'm not too concerned there. 

```ruby
n = 500_000

hash = { a: { b: { c: 1 } } }
indifferent_hash = { a: { b: { c: 1 } } }.with_indifferent_access

Benchmark.bmbm do |benchmark|
  benchmark.report("Old code - Hash") do
    n.times do
      hash.deep_transform_keys(&:upcase)
    end
  end

  benchmark.report("New code - Hash") do
    n.times do
      hash.deep_transform_keys_new(&:upcase)
    end
  end

  benchmark.report("Old code - HashWithIndifferentAccess") do
    n.times do
      indifferent_hash.deep_transform_keys(&:upcase)
    end 
  end

  benchmark.report("New code - HashWithIndifferentAccess") do
    n.times do
      indifferent_hash.deep_transform_keys_new(&:upcase)
    end
  end
end
```

```
Rehearsal ------------------------------------------------------------------------
Old code - Hash                        1.097369   0.001783   1.099152 (  1.101797)
New code - Hash                        1.244988   0.000000   1.244988 (  1.248460)
Old code - HashWithIndifferentAccess   1.074657   0.002124   1.076781 (  1.078943)
New code - HashWithIndifferentAccess   2.381132   0.007455   2.388587 (  2.394352)
--------------------------------------------------------------- total: 5.809508sec

                                           user     system      total        real
Old code - Hash                        1.076133   0.007201   1.083334 (  1.086161)
New code - Hash                        1.275316   0.000000   1.275316 (  1.277547)
Old code - HashWithIndifferentAccess   1.092973   0.000293   1.093266 (  1.095658)
New code - HashWithIndifferentAccess   2.395096   0.006006   2.401102 (  2.408000)
```

If the slowdown on `Hash#deep_transform_keys` is too significant, we can duplicate some logic over to `hash_with_indifferent_access.rb`, or I can dig into alternative ways to solve this.
