### PR TITLE
Add support for `rails console --sandbox` for multiple database applications

### DIFF
--- a/activerecord/lib/active_record/railties/console_sandbox.rb
+++ b/activerecord/lib/active_record/railties/console_sandbox.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-ActiveRecord::Base.connection.begin_transaction(joinable: false)
-
-at_exit do
-  ActiveRecord::Base.connection.rollback_transaction
+ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback(:checkout, :after) do
+  begin_transaction(joinable: false)
 end


### PR DESCRIPTION
### Summary

With a multiple database application `rails console --sandbox` becomes problematic. We can't rollback any modifications for every non-primary database because we can't open transaction for the connections that haven't yet been loaded.

```ruby
class UserDefinedBaseClass < ActiveRecord::Base
  # sandbox console can't handle new connection like the followings.
  establish_connection(...)
  connects_to(database: { ... })
end
```

To solve this I handled that if the database is connected then it will open transaction. This way can handle all connections.