### PR TITLE
Set default for datetime precision on sqlite3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -545,6 +545,14 @@ module ActiveRecord
           execute("PRAGMA foreign_keys = ON", "SCHEMA")
         end
 
+        def extract_precision(sql_type)
+          if /\A(?:date)?time(?:stamp)?\b/.match?(sql_type)
+            super || 0
+          else
+            super
+          end
+        end
+
         class SQLite3Integer < Type::Integer # :nodoc:
           private
             def _limit

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -45,7 +45,7 @@ if supports_datetime_with_precision?
       assert_equal 123456000, foo.updated_at.nsec
     end
 
-    unless current_adapter?(:Mysql2Adapter)
+    unless current_adapter?(:Mysql2Adapter, :SQLite3Adapter)
       def test_no_datetime_precision_isnt_truncated_on_assignment
         @connection.create_table(:foos, force: true)
         @connection.add_column :foos, :created_at, :datetime

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -337,7 +337,7 @@ module ActiveRecord
 
       private
         def precision_implicit_default
-          if current_adapter?(:Mysql2Adapter)
+          if current_adapter?(:Mysql2Adapter, :SQLite3Adapter)
             { precision: 0 }
           else
             { precision: nil }

--- a/activerecord/test/cases/time_precision_test.rb
+++ b/activerecord/test/cases/time_precision_test.rb
@@ -45,7 +45,7 @@ if supports_datetime_with_precision?
       assert_equal 123456000, foo.finish.nsec
     end
 
-    unless current_adapter?(:Mysql2Adapter)
+    unless current_adapter?(:Mysql2Adapter, :SQLite3Adapter)
       def test_no_time_precision_isnt_truncated_on_assignment
         @connection.create_table(:foos, force: true)
         @connection.add_column :foos, :start,  :time


### PR DESCRIPTION
### Summary
Fixes https://github.com/rails/rails/issues/40647. It sets default for datetime precision on sqlite3.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
