### PR TITLE
Update Action Mailer guide on delivery methods in callbacks

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -689,12 +689,12 @@ Action Mailer allows for you to specify a [`before_action`][], [`after_action`][
 * Filters can be specified with a block or a symbol to a method in the mailer
   class similar to controllers.
 
-* You could use a `before_action` to populate the mail object with defaults,
-  delivery_method_options or insert default headers and attachments.
+* You could use a `before_action` to set instance variables, populate the mail
+  object with defaults, or insert default headers and attachments.
 
 ```ruby
 class InvitationsMailer < ApplicationMailer
-  before_action { @inviter, @invitee = params[:inviter], params[:invitee] }
+  before_action :set_inviter_and_invitee
   before_action { @account = params[:inviter].account }
 
   default to:       -> { @invitee.email_address },
@@ -711,11 +711,21 @@ class InvitationsMailer < ApplicationMailer
 
     mail subject: "#{@inviter.name.familiar} added you to a project in Basecamp (#{@account.name})"
   end
+
+  private
+
+  def set_inviter_and_invitee
+    @inviter = params[:inviter]
+    @invitee = params[:invitee]
+  end
 end
 ```
 
 * You could use an `after_action` to do similar setup as a `before_action` but
   using instance variables set in your mailer action.
+  
+* Using an `after_action` callback also enables you to override delivery method
+  settings by updating `mail.delivery_method.settings`.
 
 ```ruby
 class UserMailer < ApplicationMailer


### PR DESCRIPTION
### Summary

The Action Mailer Basics guide is misleading in its current version. It mentions that delivery method options can be defined during a `before callback`:

> You could use a `before_action` to populate the mail object with defaults, **delivery_method_options** or insert default headers and attachments.

However, there seems to be no way to define delivery method options before the call to `mail` has been made. As of today, delivery method options can only be set in two contexts:

* when calling the `mail` method, passing `:delivery_method` and `:delivery_method_options` parameters
* in a `after_callback`, by modifying the value of `mail.delivery_method.settings`

I updated the guide so it would indicate this instead of misleadingly mentioning `delivery_method_options` in `before_action`.

While I was there, I also added an example of named callback, since the guide mentions them but gives no example.

Note: I realized I was not the only person to be confused by this when I stumbled on [this StackOverflow question](https://stackoverflow.com/questions/60983685).

### Other Information

I spent a good amount of time trying to provide a way to set delivery method options in a `before_action` callback, but it proved difficult since the `mail` method needed to be changed so I would not override the value set in `before_action`.

I decided not add complexity for a change that would only provide syntactic sugar but no substantial feature improvement.

**I also thought about documenting the `wrap_delivery_behavior!` and mentioning it in the guide, but there probably is a reason why it is kept internal. I would love some insights on this.**

PS : This is my first request, so feel free to tell me what I could have done better! :upside_down_face: 