### PR TITLE
Always recommend `config.asset_host` in guides, examples, and docs

### DIFF
--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -621,7 +621,7 @@ As the `:asset_host` usually is consistent across the application you can
 configure it globally in `config/application.rb`:
 
 ```ruby
-config.action_mailer.asset_host = 'http://example.com'
+config.asset_host = 'http://example.com'
 ```
 
 Now you can display an image inside your email.

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -23,11 +23,11 @@ The following is only a brief overview summary of the helpers available in Actio
 
 This module provides methods for generating HTML that links views to assets such as images, JavaScript files, stylesheets, and feeds.
 
-By default, Rails links to these assets on the current host in the public folder, but you can direct Rails to link to assets from a dedicated assets server by setting `config.action_controller.asset_host` in the application configuration, typically in `config/environments/production.rb`. For example, let's say your asset host is `assets.example.com`:
+By default, Rails links to these assets on the current host in the public folder, but you can direct Rails to link to assets from a dedicated assets server by setting `config.asset_host` in the application configuration, typically in `config/environments/production.rb`. For example, let's say your asset host is `assets.example.com`:
 
 ```ruby
-config.action_controller.asset_host = "assets.example.com"
-image_tag("rails.png") 
+config.asset_host = "assets.example.com"
+image_tag("rails.png")
 # => <img src="http://assets.example.com/images/rails.png" />
 ```
 
@@ -36,7 +36,7 @@ image_tag("rails.png")
 Returns a link tag that browsers and feed readers can use to auto-detect an RSS, Atom, or JSON feed.
 
 ```ruby
-auto_discovery_link_tag(:rss, "http://www.example.com/feed.rss", { title: "RSS Feed" }) 
+auto_discovery_link_tag(:rss, "http://www.example.com/feed.rss", { title: "RSS Feed" })
 # => <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="http://www.example.com/feed.rss" />
 ```
 
@@ -51,7 +51,7 @@ image_path("edit.png") # => /assets/edit.png
 Fingerprint will be added to the filename if config.assets.digest is set to true.
 
 ```ruby
-image_path("edit.png") 
+image_path("edit.png")
 # => /assets/edit-2d1a2db63fc738690021fedb5a65b68e.png
 ```
 
@@ -76,7 +76,7 @@ image_tag("icon.png") # => <img src="/assets/icon.png" />
 Returns an HTML script tag for each of the sources provided. You can pass in the filename (`.js` extension is optional) of JavaScript files that exist in your `app/assets/javascripts` directory for inclusion into the current page or you can pass the full path relative to your document root.
 
 ```ruby
-javascript_include_tag "common" 
+javascript_include_tag "common"
 # => <script src="/assets/common.js"></script>
 ```
 
@@ -93,7 +93,7 @@ javascript_path "common" # => /assets/common.js
 Computes the URL to a JavaScript asset in the `app/assets/javascripts` directory. This will call `javascript_path` internally and merge with your current host or your asset host.
 
 ```ruby
-javascript_url "common" 
+javascript_url "common"
 # => http://www.example.com/assets/common.js
 ```
 
@@ -102,7 +102,7 @@ javascript_url "common"
 Returns a stylesheet link tag for the sources specified as arguments. If you don't specify an extension, `.css` will be appended automatically.
 
 ```ruby
-stylesheet_link_tag "application" 
+stylesheet_link_tag "application"
 # => <link href="/assets/application.css" media="screen" rel="stylesheet" />
 ```
 
@@ -119,7 +119,7 @@ stylesheet_path "application" # => /assets/application.css
 Computes the URL to a stylesheet asset in the `app/assets/stylesheets` directory. This will call `stylesheet_path` internally and merge with your current host or your asset host.
 
 ```ruby
-stylesheet_url "application" 
+stylesheet_url "application"
 # => http://www.example.com/assets/application.css
 ```
 
@@ -256,9 +256,9 @@ For example, let's say we have a standard application layout, but also a special
 Reports the approximate distance in time between two Time or Date objects or integers as seconds. Set `include_seconds` to true if you want more detailed approximations.
 
 ```ruby
-distance_of_time_in_words(Time.now, Time.now + 15.seconds) 
+distance_of_time_in_words(Time.now, Time.now + 15.seconds)
 # => less than a minute
-distance_of_time_in_words(Time.now, Time.now + 15.seconds, include_seconds: true) 
+distance_of_time_in_words(Time.now, Time.now + 15.seconds, include_seconds: true)
 # => less than 20 seconds
 ```
 

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -882,11 +882,11 @@ valid CDN provider at the time of this writing). Now that you have configured
 your CDN server, you need to tell browsers to use your CDN to grab assets
 instead of your Rails server directly. You can do this by configuring Rails to
 set your CDN as the asset host instead of using a relative path. To set your
-asset host in Rails, you need to set `config.action_controller.asset_host` in
+asset host in Rails, you need to set `config.asset_host` in
 `config/environments/production.rb`:
 
 ```ruby
-config.action_controller.asset_host = 'mycdnsubdomain.fictional-cdn.com'
+config.asset_host = 'mycdnsubdomain.fictional-cdn.com'
 ```
 
 NOTE: You only need to provide the "host", this is the subdomain and root
@@ -899,7 +899,7 @@ variable](https://en.wikipedia.org/wiki/Environment_variable) to make running a
 staging copy of your site easier:
 
 ```ruby
-config.action_controller.asset_host = ENV['CDN_HOST']
+config.asset_host = ENV['CDN_HOST']
 ```
 
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -501,7 +501,7 @@ The schema dumper adds two additional configuration options:
 
 `config.action_controller` includes a number of configuration settings:
 
-* `config.action_controller.asset_host` sets the host for the assets. Useful when CDNs are used for hosting assets rather than the application server itself.
+* `config.action_controller.asset_host` sets the host for the assets. Useful when CDNs are used for hosting assets rather than the application server itself. You should only use this if you have a different configuration for Action Mailer, otherwise use `config.asset_host`.
 
 * `config.action_controller.perform_caching` configures whether the application should perform the caching features provided by the Action Controller component or not. Set to `false` in the development environment, `true` in production. If it's not specified, the default will be `true`.
 
@@ -733,6 +733,8 @@ Defaults to `'signed cookie'`.
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:
+
+* `config.action_mailer.asset_host` sets the host for the assets. Useful when CDNs are used for hosting assets rather than the application server itself. You should only use this if you have a different configuration for Action Controller, otherwise use `config.asset_host`.
 
 * `config.action_mailer.logger` accepts a logger conforming to the interface of Log4r or the default Ruby Logger class, which is then used to log information from Action Mailer. Set to `nil` to disable logging.
 

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -111,11 +111,11 @@ module Rails
       # file in <tt>config/environments</tt>.
       #
       #   environment do
-      #     "config.action_controller.asset_host = 'cdn.provider.com'"
+      #     "config.asset_host = 'cdn.provider.com'"
       #   end
       #
       #   environment(nil, env: "development") do
-      #     "config.action_controller.asset_host = 'localhost:3000'"
+      #     "config.asset_host = 'localhost:3000'"
       #   end
       def environment(data = nil, options = {})
         sentinel = "class Application < Rails::Application\n"

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   <%- end -%>
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
### Summary

[`config.asset_host`](https://guides.rubyonrails.org/configuring.html#rails-general-configuration) allows you to tell Rails where assets are hosted. This is used for things like `image_tag` in views.

[`config.action_controller.asset_host`](https://guides.rubyonrails.org/configuring.html#configuring-action-controller) exists too, as does `config.action_mailer.asset_host` (not documented). If these can be used to override `config.asset_host`. You can see Rails falling back to `config.asset_host` if these are not provided [here](https://github.com/rails/rails/blob/v6.0.3.4/actionpack/lib/action_controller/railtie.rb#L50) and [here](https://github.com/rails/rails/blob/v6.0.3.4/actionmailer/lib/action_mailer/railtie.rb#L37).

The current docs are confusing as in most cases they recommend using `config.action_controller.asset_host`. If you only set this, then your Action Mailer views won't have an asset host. This results in confusion, eg https://github.com/rails/rails/issues/39456 https://github.com/rails/rails/issues/34223.

A better solution would be to always recommend `config.asset_host` be used, except in the (rare?) case that Action Mailer and Action Controller should use different asset hosts. This PR changes all examples to use `config.asset_host`.

### Other Information

Most of the changes are in code comments / guides, but I did also change the commented example in the [new app generator](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L38).