### PR TITLE
removed sprocket related files

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removed manifest.js and application.css in app/assets
+    folder when --skip-sprockets option passed as flag to rails.
+
+    *Cindy Gao*
+
 *   Add support for stylesheets and ERB views to `rails stats`.
 
     *Joel Hawksley*

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -137,7 +137,9 @@ module Rails
       active_storage_config_exist    = File.exist?("config/storage.yml")
       rack_cors_config_exist         = File.exist?("config/initializers/cors.rb")
       assets_config_exist            = File.exist?("config/initializers/assets.rb")
-      csp_config_exist               = File.exist?("config/initializers/content_security_policy.rb")
+      asset_manifest_exist          = File.exist?("app/assets/config/manifest.js")
+      asset_app_stylesheet_exist    = File.exist?("app/assets/stylesheets/application.css")
+      csp_config_exist = File.exist?("config/initializers/content_security_policy.rb")
       permissions_policy_config_exist = File.exist?("config/initializers/permissions_policy.rb")
 
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
@@ -159,6 +161,14 @@ module Rails
 
       if options[:skip_sprockets] && !assets_config_exist
         remove_file "config/initializers/assets.rb"
+      end
+
+      if options[:skip_sprockets] && !asset_manifest_exist
+        remove_file "app/assets/config/manifest.js"
+      end
+
+      if options[:skip_sprockets] && !asset_app_stylesheet_exist
+        remove_file "app/assets/stylesheets/application.css"
       end
 
       unless rack_cors_config_exist
@@ -491,6 +501,8 @@ module Rails
       def delete_assets_initializer_skipping_sprockets
         if options[:skip_sprockets]
           remove_file "config/initializers/assets.rb"
+          remove_file "app/assets/config/manifest.js"
+          remove_file "app/assets/stylesheets/application.css"
         end
       end
 

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -125,8 +125,11 @@ task default: :test
       end
     end
 
-    def test_dummy_assets
+    def test_dummy_webpacker_assets
       template "rails/javascripts.js",    "#{dummy_path}/app/javascript/packs/application.js", force: true
+    end
+
+    def test_dummy_sprocket_assets
       template "rails/stylesheets.css",   "#{dummy_path}/app/assets/stylesheets/application.css", force: true
       template "rails/dummy_manifest.js", "#{dummy_path}/app/assets/config/manifest.js", force: true
     end
@@ -290,7 +293,8 @@ task default: :test
         mute do
           build(:generate_test_dummy)
           build(:test_dummy_config)
-          build(:test_dummy_assets)
+          build(:test_dummy_webpacker_assets)
+          build(:test_dummy_sprocket_assets) unless options[:skip_sprockets]
           build(:test_dummy_clean)
           # ensure that bin/rails has proper dummy_path
           build(:bin, true)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -325,6 +325,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
       quietly { generator.update_config_files }
 
       assert_no_file "#{app_root}/config/initializers/assets.rb"
+      assert_no_file "#{app_root}/app/assets/config/manifest.js"
+      assert_no_file "#{app_root}/app/assets/stylesheets/application.css"
     end
   end
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -320,6 +320,8 @@ module SharedGeneratorTests
     run_generator [destination_root, "--skip-sprockets"]
 
     assert_no_file "#{application_path}/config/initializers/assets.rb"
+    assert_no_file "#{application_path}/app/assets/config/manifest.js"
+    assert_no_file "#{application_path}/app/assets/stylesheets/application.css"
 
     assert_file "#{application_path}/config/application.rb", /#\s+require\s+["']sprockets\/railtie["']/
 


### PR DESCRIPTION
### Summary

Removed sprocket related files `/app/assets/config/manifest.js` and `/app/assets/stylesheets/application.css` from generated rails app when --skip-sprockets flag passed into rails new and app:update. These files were used for the asset pipeline but not removed when rails disables asset pipelines via the --skip-sprocket flag.

In addition in plugin_generator.rb we broke out the `PluginGenerator#test_dummy_assets` method into two methods: one to force webpacker files to exist and one to force sprocket files to exist. We also changed the dummy test generation in PluginGenerator so that sprocket files were only forced to exist if --skip-sprocket flag is not passed.
