### PR TITLE
Add option for `default_scope` to run on all queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add option to run `default_scope` on all queries.
+
+    Previously, a `default_scope` would only run on select or insert queries. In some cases, like non-Rails tenant sharding solutions, it may be desirable to run `default_scope` on all queries in order to ensure queries are including a foreign key for the shard (ie `blog_id`).
+
+    Now applications can add an option to run on all queries including select, insert, delete, and update by adding an `all_queries` option to the default scope definition.
+
+    ```ruby
+    class Article < ApplicationRecord
+      default_scope -> { where(blog_id: Current.blog.id) }, all_queries: true
+    end
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Add `where.associated` to check for the presence of an association.
 
     ```ruby

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -378,6 +378,10 @@ module ActiveRecord
       def _update_record(values, constraints) # :nodoc:
         constraints = _substitute_values(constraints).map { |attr, bind| attr.eq(bind) }
 
+        if default_scopes.any? && !default_scoped(all_queries: true).where_clause.empty?
+          constraints << default_scoped(all_queries: true).where_clause.ast
+        end
+
         um = arel_table.where(
           constraints.reduce(&:and)
         ).compile_update(_substitute_values(values), primary_key)
@@ -387,6 +391,10 @@ module ActiveRecord
 
       def _delete_record(constraints) # :nodoc:
         constraints = _substitute_values(constraints).map { |attr, bind| attr.eq(bind) }
+
+        if default_scopes.any? && !default_scoped(all_queries: true).where_clause.empty?
+          constraints << default_scoped(all_queries: true).where_clause.ast
+        end
 
         dm = Arel::DeleteManager.new
         dm.from(arel_table)

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -42,8 +42,8 @@ module ActiveRecord
         end
 
         # Returns a scope for the model with default scopes.
-        def default_scoped(scope = relation)
-          build_default_scope(scope) || scope
+        def default_scoped(scope = relation, all_queries: nil)
+          build_default_scope(scope, all_queries: all_queries) || scope
         end
 
         def default_extensions # :nodoc:

--- a/activerecord/test/cases/associations/nested_through_associations_test.rb
+++ b/activerecord/test/cases/associations/nested_through_associations_test.rb
@@ -378,7 +378,7 @@ class NestedThroughAssociationsTest < ActiveRecord::TestCase
     prev_default_scope = Club.default_scopes
 
     [:includes, :preload, :joins, :eager_load].each do |q|
-      Club.default_scopes = [proc { Club.public_send(q, :category) }]
+      Club.default_scopes = [ActiveRecord::Scoping::DefaultScope.new(proc { Club.public_send(q, :category) })]
       assert_equal categories(:general), members(:groucho).reload.club_category
     end
   ensure

--- a/activerecord/test/cases/dup_test.rb
+++ b/activerecord/test/cases/dup_test.rb
@@ -145,7 +145,7 @@ module ActiveRecord
 
     def test_dup_with_default_scope
       prev_default_scopes = Topic.default_scopes
-      Topic.default_scopes = [proc { Topic.where(approved: true) }]
+      Topic.default_scopes = [ActiveRecord::Scoping::DefaultScope.new(proc { Topic.where(approved: true) })]
       topic = Topic.new(approved: false)
       assert_not topic.dup.approved?, "should not be overridden by default scopes"
     ensure

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -7,6 +7,7 @@ require "models/developer"
 require "models/project"
 require "models/computer"
 require "models/cat"
+require "models/mentor"
 require "concurrent/atomic/cyclic_barrier"
 
 class DefaultScopingTest < ActiveRecord::TestCase
@@ -77,6 +78,84 @@ class DefaultScopingTest < ActiveRecord::TestCase
     wheres = MultiplePoorDeveloperCalledJamis.all.where_values_hash
     assert_equal "Jamis", wheres["name"]
     assert_equal 50000,   wheres["salary"]
+  end
+
+  def test_default_scope_runs_on_create
+    Mentor.create!
+    create_sql = capture_sql { DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen") }.first
+
+    assert_match(/mentor_id/, create_sql)
+  end
+
+  def test_default_scope_with_all_queries_runs_on_create
+    Mentor.create!
+    create_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen") }.first
+
+    assert_match(/mentor_id/, create_sql)
+  end
+
+  def test_default_scope_runs_on_select
+    Mentor.create!
+    DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
+    select_sql = capture_sql { DeveloperwithDefaultMentorScopeNot.find_by(name: "Eileen") }.first
+
+    assert_match(/mentor_id/, select_sql)
+  end
+
+  def test_default_scope_with_all_queries_runs_on_select
+    Mentor.create!
+    DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    select_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.find_by(name: "Eileen") }.first
+
+    assert_match(/mentor_id/, select_sql)
+  end
+
+  def test_default_scope_doesnt_run_on_update
+    Mentor.create!
+    dev = DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
+    update_sql = capture_sql { dev.update!(name: "Not Eileen") }.first
+
+    assert_no_match(/mentor_id/, update_sql)
+  end
+
+  def test_default_scope_with_all_queries_runs_on_update
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    update_sql = capture_sql { dev.update!(name: "Not Eileen") }.first
+
+    assert_match(/mentor_id/, update_sql)
+  end
+
+  def test_default_scope_doesnt_run_on_update_columns
+    Mentor.create!
+    dev = DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
+    update_sql = capture_sql { dev.update_columns(name: "Not Eileen") }.first
+
+    assert_no_match(/mentor_id/, update_sql)
+  end
+
+  def test_default_scope_with_all_queries_runs_on_update_columns
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    update_sql = capture_sql { dev.update_columns(name: "Not Eileen") }.first
+
+    assert_match(/mentor_id/, update_sql)
+  end
+
+  def test_default_scope_doesnt_run_on_destroy
+    Mentor.create!
+    dev = DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
+    destroy_sql = capture_sql { dev.destroy }.first
+
+    assert_no_match(/mentor_id/, destroy_sql)
+  end
+
+  def test_default_scope_with_all_queries_runs_on_destroy
+    Mentor.create!
+    dev = DeveloperWithDefaultMentorScopeAllQueries.create!(name: "Eileen")
+    destroy_sql = capture_sql { dev.destroy }.first
+
+    assert_match(/mentor_id/, destroy_sql)
   end
 
   def test_scope_overwrites_default

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -140,6 +140,16 @@ class DeveloperWithSelect < ActiveRecord::Base
   default_scope { select("name") }
 end
 
+class DeveloperwithDefaultMentorScopeNot < ActiveRecord::Base
+  self.table_name = "developers"
+  default_scope -> { where(mentor_id: 1) }
+end
+
+class DeveloperWithDefaultMentorScopeAllQueries < ActiveRecord::Base
+  self.table_name = "developers"
+  default_scope -> { where(mentor_id: 1) }, all_queries: true
+end
+
 class DeveloperWithIncludes < ActiveRecord::Base
   self.table_name = "developers"
   has_many :audit_logs, foreign_key: :developer_id


### PR DESCRIPTION
I'm open to other ways of achieving a set default scope / foreign key that gets applied to all queries for a model. In talking to @tenderlove this seemed to be the most straight forward way to achieve this since default scope already works for select/insert. We need this (or something like this) to use at GitHub for Vitess sharding (ie we want to add `repository_id` to sharded models for the primary vindex). I also talked to the Vitess folks over at planet scale and their monkey patch they've used for other Rails customers was very similar to extending default scope to include update/delete.

---

This change allows for applications to optionally run a `default_scope`
on `update` and `delete` queries. Default scopes already ran on select
and insert queries.

Applications can now run a set default scope on all queries for a model
by setting a `all_queries` option:

```ruby
class Article < ApplicationRecord
  default_scope -> { where(blog_id: 1) }, all_queries: true
end
```

Using the default scope in this way is useful for applications that need
to query by more than the primary key by default. An example of this
would be in an application using a sharding strategy like Vitess.
For Rails sharding, we route connections first and then query the
database. However, Vitess and other solutions use a parameter in the
query to figure out how to route the queries. By extending
`default_scope` to apply to all queries we can allow applications to
optionally apply additional constraints to all queries. Note that this
only works with `where` queries as it does not make sense to select a
record by primary key with an order. With this change we're allowing
apps to select with a primary key and an additional foreign key.

To make this change dynamic for routing queries in a tenant sharding
strategy applications can use the `Current` API or parameters in a
request to route queries:

```ruby
class Article < ApplicationRecord
  default_scope -> { where(blog_id: Current.blog.id) }, all_queries: true
end
```

In order to achieve this I created a new object when default scopes are
created. This allows us to store both the scope itself and whether we
should run this on all queries. I chose not to implement an `on:` option
that takes an array of actions because there is no simple or clear way
to turn off the default scope for create/select. It also doesn't really
make sense to only have a default scope for delete queries. The decision
to use `all_queries` here allows for the implementation to be more
flexible than it was without creating a mess in an application.

cc/ @rafaelfranca @tenderlove  - I was wondering if this would benefit you at all Shopify with your sharding strategies.
cc/ @jhawthorn