### PR TITLE
55% speedup for HashWithIndifferentAccess.new when no args provided

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -64,7 +64,7 @@ module ActiveSupport
       self
     end
 
-    def initialize(constructor = {})
+    def initialize(constructor = nil)
       if constructor.respond_to?(:to_hash)
         super()
         update(constructor)
@@ -72,6 +72,8 @@ module ActiveSupport
         hash = constructor.is_a?(Hash) ? constructor : constructor.to_hash
         self.default = hash.default if hash.default
         self.default_proc = hash.default_proc if hash.default_proc
+      elsif constructor.nil?
+        super()
       else
         super(constructor)
       end


### PR DESCRIPTION
### Summary

In working on #40703 we noticed `HashWithIndifferentAccess.new` with no args was slower than expected. This PR optimizes the method by skipping the costly `#update` call which does nothing when no args are provided resulting in a 55% speedup.

Before the fix, initializing 500_000 indifferent hashes yielded this flamegraph which shows `#update` taking the bulk of initialization time. Checking `#default` and `#default_proc` are also on the same line.

<img width="1073" alt="Screen Shot 2020-12-01 at 11 55 54 AM" src="https://user-images.githubusercontent.com/30920216/100771283-3e823e00-33cc-11eb-9226-9fa813e922fd.png">

### Other Information

Benchmark below. The last two reports are most important, but I found the `Hash` and `HashSubclass` benchmarks useful as a target for an empty `HashWithIndifferentAccess`.

```
require "benchmark"

n = 5_000_000

class HashSubclass < Hash
  def initialize(foo = {})
    super(foo)
  end
end

hash = { a: { b: 1 } }

Benchmark.bmbm do |benchmark|
  benchmark.report("Hash") do
    n.times { Hash.new }
  end

  benchmark.report("HashSubclass") do
    n.times { HashSubclass.new }
  end

  benchmark.report("HashWithIndifferentAccess") do
    n.times { HashWithIndifferentAccess.new }
  end

  benchmark.report("Non-empty HashWithIndifferentAccess") do
    n.times { HashWithIndifferentAccess.new(hash) }
  end
end
```

**Results BEFORE fix**
```
Rehearsal -----------------------------------------------------------------------
Hash                                  0.869645   0.008317   0.877962 (  0.879695)
HashSubclass                          1.396459   0.000000   1.396459 (  1.397598)
HashWithIndifferentAccess             3.154455   0.000000   3.154455 (  3.156963)
Non-empty HashWithIndifferentAccess  10.447288   0.009722  10.457010 ( 10.464025)
------------------------------------------------------------- total: 15.885886sec

                                          user     system      total        real
Hash                                  0.764372   0.000000   0.764372 (  0.764661)
HashSubclass                          1.232905   0.000000   1.232905 (  1.233245)
HashWithIndifferentAccess             2.965751   0.000000   2.965751 (  2.966891)
Non-empty HashWithIndifferentAccess  10.416107   0.000000  10.416107 ( 10.421967)
```

**Results AFTER fix**
```
Rehearsal -----------------------------------------------------------------------
Hash                                  0.788410   0.001709   0.790119 (  0.791016)
HashSubclass                          1.572995   0.000000   1.572995 (  1.574531)
HashWithIndifferentAccess             1.354520   0.000000   1.354520 (  1.355104)
Non-empty HashWithIndifferentAccess  10.445823   0.000633  10.446456 ( 10.452897)
------------------------------------------------------------- total: 14.164090sec

                                          user     system      total        real
Hash                                  0.859961   0.000000   0.859961 (  0.861648)
HashSubclass                          1.333123   0.000000   1.333123 (  1.335666)
HashWithIndifferentAccess             1.329057   0.000000   1.329057 (  1.330119)
Non-empty HashWithIndifferentAccess  10.308272   0.000000  10.308272 ( 10.324237)
```

Empty `HashWithIndifferentAccess` went from 2.966 to 1.330,  so a **55% decrease in execution time**.

No tests or changelogs with this one since behaviour did not change.