### PR TITLE
check yarn version and run correct install command for yarn 2

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use correct install flags with Yarn 2.
+
+    *Markus Doits*
+
 *   Removed manifest.js and application.css in app/assets
     folder when --skip-sprockets option passed as flag to rails.
 

--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -8,7 +8,15 @@ namespace :yarn do
     node_env = ENV.fetch("NODE_ENV") do
       valid_node_envs.include?(Rails.env) ? Rails.env : "production"
     end
-    system({ "NODE_ENV" => node_env }, "#{Rails.root}/bin/yarn install --no-progress --frozen-lockfile")
+
+    yarn_flags =
+      if `#{Rails.root}/bin/yarn --version`.start_with?("1")
+        "--no-progress --frozen-lockfile"
+      else
+        "--immutable"
+      end
+
+    system({ "NODE_ENV" => node_env }, "#{Rails.root}/bin/yarn install #{yarn_flags}")
   end
 end
 


### PR DESCRIPTION
### Summary

Yarn 2 has different command line flags when installing dependencies. Rails now checks which yarn version is installed and uses correct flags, so it should work with either version.

### Other Information

- The guide is updated to install Yarn 2 with pnp *disabled*, so for maximum compatibility the usual node_modules folder gets created. Afaik everything should work like before with Yarn 1 with this.
- Do we need a test for this?