### PR TITLE
Fix the documentation for use_cookies_with_metadata

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -602,7 +602,7 @@ Defaults to `'signed cookie'`.
   the older AES-256-CBC cipher. It defaults to `true`.
 
 * `config.action_dispatch.use_cookies_with_metadata` enables writing
-  cookies with the purpose and expiry metadata embedded. It defaults to `true`.
+  cookies with the purpose metadata embedded. It defaults to `true`.
 
 * `config.action_dispatch.perform_deep_munge` configures whether `deep_munge`
   method should be performed on the parameters. See [Security Guide](security.html#unsafe-query-generation)


### PR DESCRIPTION
The `use_cookies_with_metadata` option was created in https://github.com/rails/rails/pull/32937 and documented in https://github.com/rails/rails/pull/33757. At the time, the option controlled both purpose and expiry metadata. Later https://github.com/rails/rails/pull/35134 changed the option to control only the purpose metadata, but the documentation was not updated. I've done that here.

@assain @bogdanvlviv @Edouard-chin 