### PR TITLE
Fix `or` to raise structurally incompatible error for single values

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1530,7 +1530,7 @@ module ActiveRecord
             v1 = v1.uniq
             v2 = v2.uniq
           end
-          v1 == v2 || (!v1 || v1.empty?) && (!v2 || v2.empty?)
+          v1 == v2
         end
       end
   end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -61,7 +61,15 @@ module ActiveRecord
       assert_equal expected, Post.order("body asc").where("id = 1").or(Post.order("body asc").where(id: [2, 3])).to_a
     end
 
-    def test_or_with_incompatible_relations
+    def test_or_with_incompatible_single_value_relations
+      error = assert_raises ArgumentError do
+        Post.distinct.where("id = 1").or(Post.where(id: [2, 3])).to_a
+      end
+
+      assert_equal "Relation passed to #or must be structurally compatible. Incompatible values: [:distinct]", error.message
+    end
+
+    def test_or_with_incompatible_multi_value_relations
       error = assert_raises ArgumentError do
         Post.order("body asc").where("id = 1").or(Post.order("id desc").where(id: [2, 3])).to_a
       end


### PR DESCRIPTION
It is a regression for f854b46, to match empty values greedy.
But that it not important part, so I've removed that to fix #40723.
