### PR TITLE
ActiveStorage Direct Upload docs improvements [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -618,10 +618,16 @@ directly from the client to the cloud.
     ActiveStorage.start()
     ```
 
-2. Annotate file inputs with the direct upload URL.
+2. Add `direct_upload: true` to your [`file_field`](form_helpers.html#uploading-files).
 
     ```erb
     <%= form.file_field :attachments, multiple: true, direct_upload: true %>
+    ```
+    
+    If you aren't using a [FormBuilder](form_helpers.html#customizing-form-builders), add the data attribute directly:
+
+    ```erb
+    <input type=file data-direct-upload-url="<%= rails_direct_uploads_url %>" />
     ```
 
 3. Configure CORS on third-party storage services to allow direct upload requests.


### PR DESCRIPTION
Docs only change.

- Clarifies the wording of step 2 of https://edgeguides.rubyonrails.org/active_storage_overview.html#usage to better reflect what you should do, and to match the code sample immediately after it.
- Adds a note about how to use Direct Upload without a FormBuilder.
