### PR TITLE
Incorrect default for `config.autoload_paths` [ci skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -62,7 +62,7 @@ These configuration methods are to be called on a `Rails::Railtie` object, such 
 
 * `config.autoload_once_paths` accepts an array of paths from which Rails will autoload constants that won't be wiped per request. Relevant if `config.cache_classes` is `false`, which is the default in the development environment. Otherwise, all autoloading happens only once. All elements of this array must also be in `autoload_paths`. Default is an empty array.
 
-* `config.autoload_paths` accepts an array of paths from which Rails will autoload constants. Default is all directories under `app`. It is no longer recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#autoload-paths)
+* `config.autoload_paths` accepts an array of paths from which Rails will autoload constants. Default is an empty array. Since [Rails 6](upgrading_ruby_on_rails.html#autoloading), it is not recommended to adjust this. See [Autoloading and Reloading Constants](autoloading_and_reloading_constants.html#autoload-paths).
 
 * `config.add_autoload_paths_to_load_path` says whether autoload paths have to be added to `$LOAD_PATH`. This flag is `true` by default, but it is recommended to be set to `false` in `:zeitwerk` mode early, in `config/application.rb`. Zeitwerk uses absolute paths internally, and applications running in `:zeitwerk` mode do not need `require_dependency`, so models, controllers, jobs, etc. do not need to be in `$LOAD_PATH`. Setting this to `false` saves Ruby from checking these directories when resolving `require` calls with relative paths, and saves Bootsnap work and RAM, since it does not need to build an index for them.
 


### PR DESCRIPTION
The docs implied that the default for `config.autoload_paths` was the output of `Dir.glob("app/*")`. In reality, on a new Rails app the default is `[]`.

Internally, Rails sets `ActiveSupport::Dependencies.autoload_paths` based on the union of [several configs](https://github.com/rails/rails/blob/v6.0.3.4/railties/lib/rails/engine.rb#L707), which is how `app` ends up being autoloaded (it is in `config.eager_load_paths` [by default](https://github.com/rails/rails/blob/v6.0.3.4/railties/lib/rails/engine/configuration.rb#L42)).

I think this is worth clarifying, because the current docs implies code like this will do something:

```ruby
config.autoload_paths -= ["#{config.root}/app/middleware"]
```

In reality it does nothing. This style of code is [discouraged](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#globs-in-config-autoload-paths) but that doesn't mean it's not out there :) :(

This is a docs only change.