### PR TITLE
Add benchmark method that can be called from anywhere

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add benchmark method that can be called from anywhere.
+
+    This method is used as a quick way to measure & log the speed of some code.
+    However, it was previously available only in specific contexts, mainly views and controllers.
+    The new Rails.benchmark can be used in the rest of your app: services, API wrappers, models, etc.
+
+        def test
+          Rails.benchmark("test") { ... }
+        end
+
+    *Simon Perepelitsa*
+
 *   Removed manifest.js and application.css in app/assets
     folder when --skip-sprockets option passed as flag to rails.
 

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -25,6 +25,7 @@ end
 
 module Rails
   extend ActiveSupport::Autoload
+  extend ActiveSupport::Benchmarkable
 
   autoload :Info
   autoload :InfoController


### PR DESCRIPTION
In Rails we have a convenient "benchmark" method to quickly measure & log the speed of some code. However, it is only available in specific contexts, mainly views and controllers. If I want to use it in my own objects, such as services, API wrappers, or even models, the usage becomes cumbersome - I must first include its module and make sure to have a "logger" attribute. This looks like an overkill for a quick benchmark that you might want to run just once & remove right away.

```ruby
mattr_accessor :logger, default: Rails.logger
extend ActiveSupport::Benchmarkable
include ActiveSupport::Benchmarkable

def self.test
  benchmark("test") { ... }
end

def test
  benchmark("test") { ... }
end
```

I'm proposing to add a universal method that would use the default logger. Since the default logger is defined by Rails.logger, I thought it would be most appropriate to place the benchmark method right alongside:

```ruby
Rails.benchmark("test") { ... }
```

What do you think?
