### PR TITLE
Do not alias table if it occurs inside join in sub query

### DIFF
--- a/activerecord/test/cases/associations/left_outer_join_association_test.rb
+++ b/activerecord/test/cases/associations/left_outer_join_association_test.rb
@@ -80,7 +80,19 @@ class LeftOuterJoinAssociationTest < ActiveRecord::TestCase
   end
 
   def test_left_outer_joins_with_string_join
-    assert_equal 16, Author.left_outer_joins(:posts).joins("LEFT OUTER JOIN comments ON comments.post_id = posts.id").count
+    assert_equal 16, Author.left_outer_joins(:posts).joins("LEFT OUTER JOIN comments ON comments.post_id = posts.id").where.not(posts: { title: nil }).count
+  end
+
+  def test_left_outer_joins_with_sub_query_string_join
+    assert_equal 16, Author.left_outer_joins(:posts).joins("LEFT OUTER JOIN (SELECT * FROM comments LEFT OUTER JOIN posts ON comments.post_id = posts.id) c ON c.post_id = posts.id").where.not(posts: { title: nil }).count
+  end
+
+  def test_left_outer_joins_with_sub_query_with_join_string_join
+    assert_equal 16, Author.left_outer_joins(:posts).joins("LEFT OUTER JOIN (#{Comment.joins(:post).to_sql}) c ON c.post_id = posts.id").count
+  end
+
+  def test_left_outer_joins_with_sub_query_with_join_string_join_with_root_condition
+    assert_equal 16, Author.left_outer_joins(:posts).joins("LEFT OUTER JOIN (#{Comment.joins(:post).to_sql}) c ON c.post_id = posts.id").where.not(posts: { title: nil }).count
   end
 
   def test_left_outer_joins_with_arel_join


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/issues/40737

The patch submitted does not attempt to solve the second issue with conditions not respecting aliases. It only changes how alias collisions are detected in string joins and omits matches inside parentheses which I suspect is not the only way to invoke the bug. Due to the limitations of the patch it might need to be followed up with a change that makes more robust changes after guidance has been provided on the expected behaviour.
