### PR TITLE
Fix to handle missing yarn environment in bin/yarn

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -8,9 +8,11 @@ Dir.chdir(APP_ROOT) do
     normalized_path != __dir__ && File.executable?(Pathname.new(normalized_path).join('yarn'))
   end
 
-  exec File.expand_path(Pathname.new(executable_path).join('yarn')), *ARGV
-rescue Errno::ENOENT
-  $stderr.puts "Yarn executable was not detected in the system."
-  $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
-  exit 1
+  if executable_path
+    exec File.expand_path(Pathname.new(executable_path).join('yarn')), *ARGV
+  else
+    $stderr.puts "Yarn executable was not detected in the system."
+    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    exit 1
+  end
 end


### PR DESCRIPTION
### Summary
When we use `bin/yarn` without original yarn,
the following error will be occurred:
```
bin/yarn:12:in `initialize': no implicit conversion of nil into String (TypeError)
```

This means `executable_path` is `nil`.

To handle missing yarn correctly, checking `executable_path` seems good.
This is a result of my local without yarn.
```
Yarn executable was not detected in the system.
Download Yarn at https://yarnpkg.com/en/docs/install
rake aborted!
```

This PR follows up https://github.com/rails/rails/pull/40646.

### Other Information
I met this issue on rails 6.1.0.rc2.
