### PR TITLE
Adds the missing spec for Action Text installer warning

### DIFF
--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -29,6 +29,13 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     assert_match %r"^add .*trix@", yarn_commands
   end
 
+  test "throws warning for incomplete webpacker configuration" do
+    output = run_generator_instance
+    expected = "WARNING: Action Text can't locate your JavaScript bundle to add its package dependencies."
+
+    assert_match expected, output
+  end
+
   test "loads JavaScript dependencies in application.js" do
     application_js = Pathname("app/javascript/packs/application.js").expand_path(destination_root)
     application_js.dirname.mkpath


### PR DESCRIPTION
Action Text installer raises a warning if the webpacker configuration is missing or is not present as expected for Rails generator. We recently added specs for generator here: #40673 and decided to add the missing spec in new PR: https://github.com/rails/rails/pull/40673#issuecomment-734962864

This PR addresses the comment. cc/ @jonathanhefner 