### PR TITLE
Only execute route reloads once on boot for development environment

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only execute route reloads once on boot for development environment
+
+    *Louis Cloutier*
+
 *   Removed manifest.js and application.css in app/assets
     folder when --skip-sprockets option passed as flag to rails.
 

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -173,6 +173,22 @@ module Rails
         end
       end
 
+      initializer :add_internal_routes do |app|
+        if Rails.env.development?
+          app.routes.prepend do
+            get "/rails/info/properties" => "rails/info#properties", internal: true
+            get "/rails/info/routes"     => "rails/info#routes",     internal: true
+            get "/rails/info"            => "rails/info#index",      internal: true
+          end
+
+          routes_reloader.after_load_paths = -> do
+            app.routes.append do
+              get "/" => "rails/welcome#index", internal: true
+            end
+          end
+        end
+      end
+
       # Set routes reload after the finisher hook to ensure routes added in
       # the hook are taken into account.
       initializer :set_routes_reloader_hook do |app|
@@ -192,22 +208,6 @@ module Rails
           # some sort of reloaders dependency support, to be added.
           require_unload_lock!
           reloader.execute
-        end
-      end
-
-      initializer :add_builtin_route do |app|
-        if Rails.env.development?
-          app.routes.prepend do
-            get "/rails/info/properties" => "rails/info#properties", internal: true
-            get "/rails/info/routes"     => "rails/info#routes", internal: true
-            get "/rails/info"            => "rails/info#index", internal: true
-          end
-
-          app.routes.append do
-            get "/"                      => "rails/welcome#index", internal: true
-          end
-
-          routes_reloader.execute
         end
       end
 

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -283,12 +283,36 @@ class LoadingTest < ActiveSupport::TestCase
     require "#{rails_root}/config/environment"
 
     get "/c"
-    assert_equal "5", last_response.body
+    assert_equal "3", last_response.body
 
     app_file "db/schema.rb", ""
 
     get "/c"
-    assert_equal "11", last_response.body
+    assert_equal "7", last_response.body
+  end
+
+  test "routes are only loaded once on boot" do
+    add_to_config <<-RUBY
+      config.cache_classes = false
+    RUBY
+
+    app_file "config/routes.rb", <<-RUBY
+      $counter ||= 0
+      $counter += 1
+      Rails.application.routes.draw do
+        get '/c', to: lambda { |env| [200, {"Content-Type" => "text/plain"}, [$counter.to_s]] }
+      end
+    RUBY
+
+    boot_app "development"
+
+    require "rack/test"
+    extend Rack::Test::Methods
+
+    require "#{rails_root}/config/environment"
+
+    get "/c"
+    assert_equal "1", last_response.body
   end
 
   test "columns migrations also trigger reloading" do


### PR DESCRIPTION
Signed-off-by: Louis Cloutier <louis.cloutier@shopify.com>

### Summary

In https://github.com/rails/rails/pull/39980 a new supported use case was added to allow overriding of the welcome route in an app via `get '/'`. Unfortunately, this introduced a double `routes_reloader.execute` in the development environment. For apps with lots of routes and/or lots of routes files, this creates a significant expense when booting in development environments.

This PR aims to allow for that use case while only executing the routes reloader a single time. To do this, I've introduced a new callback that can be set via Proc on the routes reloader, and will be called after `load_paths`.

You can see that the number of items is decreased in the `LoadingTest`, back to its original number, and the existing tests should continue to pass (and support overriding of the welcome route via both `root` and `get '/'` route definitions).

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

I've gone ahead and updated the changelog already, but please let me know if I should remove that or alter the text in any way.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
