### PR TITLE
Fix system test scaffold generator for vowels

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -864,7 +864,7 @@ You can also run `bin/rails test:all` to run all tests, including system tests.
 Now let's test the flow for creating a new article in our blog.
 
 ```ruby
-test "creating an article" do
+test "should create Article" do
   visit articles_path
 
   click_on "New Article"

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Modified scaffold generator template so that running
+    `rails g scaffold Author` no longer generates tests called "creating
+    a Author", "updating a Author", and "destroying a Author"
+
+    Fixes #40744.
+
+    *Michael Duchemin*
+
 *   Add benchmark method that can be called from anywhere.
 
     This method is used as a quick way to measure & log the speed of some code.

--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
@@ -11,7 +11,7 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
     assert_selector "h1", text: "<%= class_name.pluralize.titleize %>"
   end
 
-  test "creating a <%= human_name %>" do
+  test "should create <%= human_name %>" do
     visit <%= plural_table_name %>_url
     click_on "New <%= class_name.titleize %>"
 
@@ -28,7 +28,7 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
     click_on "Back"
   end
 
-  test "updating a <%= human_name %>" do
+  test "should update <%= human_name %>" do
     visit <%= plural_table_name %>_url
     click_on "Edit", match: :first
 
@@ -45,7 +45,7 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
     click_on "Back"
   end
 
-  test "destroying a <%= human_name %>" do
+  test "should destroy <%= human_name %>" do
     visit <%= plural_table_name %>_url
     page.accept_confirm do
       click_on "Destroy", match: :first


### PR DESCRIPTION
Fix issue where running "rails g scaffold Author" will create system
test names like "creating a Author" and "updating a Author" so that
there are not grammatical errors. Now running "rails g scaffold Author"
will generate "should create Author", "should update Author", and
"should destroy Author" which works around the article vowel-sound
agreement issues.

Fixes #40744

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
Also needed to update the testing guide.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
