### PR TITLE
Don't use explicit references for join aliases

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -84,7 +84,7 @@ module ActiveRecord
         @references = {}
 
         references.each do |table_name|
-          @references[table_name.to_sym] = table_name if table_name.is_a?(String)
+          @references[table_name.to_sym] = table_name if table_name.is_a?(Arel::Nodes::SqlLiteral)
         end unless references.empty?
 
         joins = make_join_constraints(join_root, join_type)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -32,9 +32,9 @@ module ActiveRecord
     def self.references(attributes)
       attributes.each_with_object([]) do |(key, value), result|
         if value.is_a?(Hash)
-          result << key
+          result << Arel.sql(key)
         elsif key.include?(".")
-          result << key.split(".").first
+          result << Arel.sql(key.split(".").first)
         end
       end
     end

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -663,10 +663,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_with_has_many_and_limit_and_conditions_array_on_the_eagers
-    posts = Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", "David")
+    posts = Post.includes(:author, :comments).limit(2).references("author").where("authors.name = ?", "David")
     assert_equal 2, posts.size
 
-    count = Post.includes(:author, :comments).limit(2).references(:author).where("authors.name = ?", "David").count
+    count = Post.includes(:author, :comments).limit(2).references("author").where("authors.name = ?", "David").count
     assert_equal posts.size, count
   end
 


### PR DESCRIPTION
As the API doc shows, `references` should be given table names.

https://api.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-references

However, people (and test cases in the our codebase) sometimes give
association names for `references`.

Since the API example and all test cases in the codebase use symbols as
arguments, so I regarded symbols as user given values in #40106.

But as #40743 indicates, people also use string association names, it
would have unexpected side-effect especially if singular association
names given.

As much as possible to avoid to use user given values, mark internal
references for `where` and use only them for join aliases.

Fixes #40743.
