### PR TITLE
Revert 'sleep 1' workarounds since Ruby issue 17220 has been addressed

### DIFF
--- a/activejob/test/support/integration/adapters/resque.rb
+++ b/activejob/test/support/integration/adapters/resque.rb
@@ -19,7 +19,6 @@ module ResqueJobsManager
   end
 
   def start_workers
-    sleep 1
     @resque_thread = Thread.new do
       w = Resque::Worker.new("integration_tests")
       w.term_child = true

--- a/activejob/test/support/integration/adapters/sidekiq.rb
+++ b/activejob/test/support/integration/adapters/sidekiq.rb
@@ -24,7 +24,6 @@ module SidekiqJobsManager
     continue_read, continue_write = IO.pipe
     death_read, death_write = IO.pipe
 
-    sleep 1
     @pid = fork do
       continue_read.close
       death_write.close

--- a/activejob/test/support/integration/adapters/sneakers.rb
+++ b/activejob/test/support/integration/adapters/sneakers.rb
@@ -28,7 +28,6 @@ module SneakersJobsManager
   end
 
   def start_workers
-    sleep 1
     @pid = fork do
       queues = %w(integration_tests)
       workers = queues.map do |q|


### PR DESCRIPTION
### Summary

Revert 'sleep 1' workarounds for Active Job integration tests since [Ruby issue 17220](https://bugs.ruby-lang.org/issues/17220) has been addressed via https://github.com/ruby/ruby/commit/94d49ed31c39002335eeee65d42463139f561954

* Commands to revert

```ruby
$ git revert -m 1 1fddc80
[revert_workarounds_for_ruby_17220 fa3d47018b] Revert "Merge pull request #40453 from yahonda/resque_start_workers"
 1 file changed, 1 deletion(-)
$ git revert -m 1 3b9807f
[revert_workarounds_for_ruby_17220 8ae1738a14] Revert "Merge pull request #40451 from yahonda/sneakers"
 1 file changed, 1 deletion(-)
$ git revert 7cf8e30902119b22c5f9fa1f4d80185ba3f3a5f7
[revert_workarounds_for_ruby_17220 aa026ee105] Revert "Work around getaddrinfo deadlock in forked process"
 1 file changed, 1 deletion(-)
```

* References
https://bugs.ruby-lang.org/issues/17220
#40451
#40453

### Other Information

Rails master branch CI against ruby-head has been failing because of the 15 min timeout since https://buildkite.com/rails/rails/builds/73169#e71e570a-1acd-4ddc-b10a-ba7ed94c069c, will take a look at if CI for this pull request gets a timeout.
