### PR TITLE
Clone to keep extended Logger methods for tagged logger

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -79,7 +79,7 @@ module ActiveSupport
     end
 
     def self.new(logger)
-      logger = logger.dup
+      logger = logger.clone
 
       if logger.formatter
         logger.formatter = logger.formatter.dup

--- a/activesupport/test/tagged_logging_test.rb
+++ b/activesupport/test/tagged_logging_test.rb
@@ -214,4 +214,16 @@ class TaggedLoggingWithoutBlockTest < ActiveSupport::TestCase
 
     assert_equal "[BCX] [Jason] Funky time\n[BCX] Junky time!\n", @output.string
   end
+
+  test "keeps broadcasting functionality" do
+    broadcast_output = StringIO.new
+    broadcast_logger = ActiveSupport::TaggedLogging.new(Logger.new(broadcast_output))
+    @logger.extend(ActiveSupport::Logger.broadcast(broadcast_logger))
+
+    tagged_logger = @logger.tagged("OMG")
+    tagged_logger.info "Broadcasting..."
+
+    assert_equal "[OMG] Broadcasting...\n", @output.string
+    assert_equal "[OMG] Broadcasting...\n", broadcast_output.string
+  end
 end


### PR DESCRIPTION
### Summary

`#dup` resets the extended Logger methods that could come from enabling broadcasting. That would mean if we create a tagged logger from a Logger with broadcasting enabled (usually to stdout), the new tagged logger will not perform broadcasting.

### Other Information

I'm not sure if the current behavior is as expected, but it seemed surprising to me. If your Logger has broadcasting enabled, it feels like the derived tagged loggers should also broadcast. Happy to hear what you think.

Relates to https://github.com/rails/rails/pull/27792 and https://github.com/rails/rails/pull/38850