### PR TITLE
Gitignore Brewfile.lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /dist/
 /doc/
 /guides/output/
+Brewfile.lock.json
 debug.log
 node_modules/
 package-lock.json


### PR DESCRIPTION
### Summary

Similar files are included in `.gitignore` so I thought `Brewfile.lock.json` also could.
The file got generated when running `brew bundle` as noted in the docs.