### PR TITLE
`allow_nil` should work for casted value in `NumericalityValidator`

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -109,7 +109,9 @@ module ActiveModel
       end
 
       def read_attribute_for_validation(record, attr_name)
-        return super if record_attribute_changed_in_place?(record, attr_name)
+        value = super
+
+        return value if record_attribute_changed_in_place?(record, attr_name)
 
         came_from_user = :"#{attr_name}_came_from_user?"
 
@@ -126,7 +128,7 @@ module ActiveModel
           end
         end
 
-        raw_value || super
+        raw_value || value
       end
 
       def record_attribute_changed_in_place?(record, attr_name)

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -108,9 +108,7 @@ module ActiveModel
         end
       end
 
-      def read_attribute_for_validation(record, attr_name)
-        value = super
-
+      def read_attribute_for_validation(record, attr_name, value)
         return value if record_attribute_changed_in_place?(record, attr_name)
 
         came_from_user = :"#{attr_name}_came_from_user?"

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -147,9 +147,10 @@ module ActiveModel
     # override +validate_each+ with validation logic.
     def validate(record)
       attributes.each do |attribute|
-        value = read_attribute_for_validation(record, attribute)
-        next if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
-        validate_each(record, attribute, value)
+        catch(:allowed) do
+          value = read_attribute_for_validation(record, attribute)
+          validate_each(record, attribute, value)
+        end
       end
     end
 
@@ -167,7 +168,9 @@ module ActiveModel
 
     private
       def read_attribute_for_validation(record, attr_name)
-        record.read_attribute_for_validation(attr_name)
+        value = record.read_attribute_for_validation(attr_name)
+        throw(:allowed) if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
+        value
       end
   end
 

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -147,10 +147,10 @@ module ActiveModel
     # override +validate_each+ with validation logic.
     def validate(record)
       attributes.each do |attribute|
-        catch(:allowed) do
-          value = read_attribute_for_validation(record, attribute)
-          validate_each(record, attribute, value)
-        end
+        value = record.read_attribute_for_validation(attribute)
+        next if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
+        value = read_attribute_for_validation(record, attribute, value)
+        validate_each(record, attribute, value)
       end
     end
 
@@ -167,9 +167,7 @@ module ActiveModel
     end
 
     private
-      def read_attribute_for_validation(record, attr_name)
-        value = record.read_attribute_for_validation(attr_name)
-        throw(:allowed) if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
+      def read_attribute_for_validation(record, attr_name, value)
         value
       end
   end

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -110,4 +110,12 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
     assert_not_predicate subject, :valid?
   end
+
+  def test_allow_nil_works_for_casted_value
+    model_class.validates_numericality_of(:bank_balance, greater_than: 0, allow_nil: true)
+
+    subject = model_class.new(bank_balance: "")
+
+    assert_predicate subject, :valid?
+  end
 end


### PR DESCRIPTION
It is a regression for 4cc438a1df75e4c230f19cafe9258dbab969cd27.

`NumericalityValidator` basically takes the value before typecasting,
but `allow_nil` should work for the typecasted value for the
compatibility.

Fixes #40750.
