### PR TITLE
Allow configuration of the digest class used in the key generator

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -98,5 +98,13 @@ module ActiveSupport
         end
       end
     end
+
+    initializer "active_support.set_key_generator_hash_digest_class" do |app|
+      config.after_initialize do
+        if klass = app.config.active_support.key_generator_hash_digest_class
+          ActiveSupport::KeyGenerator.hash_digest_class = klass
+        end
+      end
+    end
   end
 end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -10,6 +10,8 @@ rescue LoadError, NameError
 else
 
   class KeyGeneratorTest < ActiveSupport::TestCase
+    class InvalidDigest; end
+
     def setup
       @secret    = SecureRandom.hex(64)
       @generator = ActiveSupport::KeyGenerator.new(@secret, iterations: 2)
@@ -40,6 +42,22 @@ else
 
       expected = "cbea7f7f47df705967dc508f4e446fd99e7797b1d70011c6899cd39bbe62907b8508337d678505a7dc8184e037f1003ba3d19fc5d829454668e91d2518692eae"
       assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64, iterations: 2).generate_key("some_salt").unpack1("H*")
+    end
+
+    test "With custom hash digest class" do
+      original_hash_digest_class = ActiveSupport::KeyGenerator.hash_digest_class
+
+      ActiveSupport::KeyGenerator.hash_digest_class = ::OpenSSL::Digest::SHA256
+
+      expected = "c92322ad55ee691520e8e0f279b53e7a5cc9c1f8efca98295ae252b04cc6e2274c3aaf75ef53b260a6dc548f3e5fbb8af0edf10e7663cf7054c35bcc12835fc0"
+      assert_equal expected, ActiveSupport::KeyGenerator.new("0" * 64).generate_key("some_salt").unpack1("H*")
+    ensure
+      ActiveSupport::KeyGenerator.hash_digest_class = original_hash_digest_class
+    end
+
+    test "Raises if given a non digest instance" do
+      assert_raises(ArgumentError) { ActiveSupport::KeyGenerator.hash_digest_class = InvalidDigest }
+      assert_raises(ArgumentError) { ActiveSupport::KeyGenerator.hash_digest_class = InvalidDigest.new }
     end
   end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -853,6 +853,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.hash_digest_class` allows configuring the digest class to use to generate non-sensitive digests, such as the ETag header.
 
+* `config.active_support.key_generator_hash_digest_class` allows configuring the digest class to use to derive secrets from the configured secret base, such as for encrypted cookies.
+
 * `config.active_support.use_authenticated_message_encryption` specifies whether to use AES-256-GCM authenticated encryption as the default cipher for encrypting messages instead of AES-256-CBC.
 
 * `ActiveSupport::Logger.silencer` is set to `false` to disable the ability to silence logging in a block. The default is `true`.
@@ -1037,6 +1039,9 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 `config.load_defaults` sets new defaults up to and including the version passed. Such that passing, say, `6.0` also gets the new defaults from every version before it.
 
+#### For '6.2', defaults from previous versions below and:
+- `config.active_support.key_generator_hash_digest_class`: `OpenSSL::Digest::SHA256`
+
 #### For '6.1', defaults from previous versions below and:
 
 - `config.active_record.has_many_inversing`: `true`
@@ -1106,6 +1111,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_record.legacy_connection_handling`: `true`
 - `config.active_support.use_authenticated_message_encryption`: `false`
 - `config.active_support.hash_digest_class`: `::Digest::MD5`
+- `config.active_support.key_generator_hash_digest_class`: `OpenSSL::Digest::SHA1`
 - `ActiveSupport.utc_to_local_returns_utc_offset_times`: `false`
 
 ### Configuring a Database

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -207,6 +207,10 @@ module Rails
           if respond_to?(:action_view)
             action_view.button_to_generates_button_tag = true
           end
+
+          if respond_to?(:active_support)
+            active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2295,6 +2295,32 @@ module ApplicationTests
       assert_equal Digest::SHA256, ActiveSupport::Digest.hash_digest_class
     end
 
+    test "ActiveSupport::KeyGenerator.hash_digest_class is OpenSSL::Digest::SHA256 by default for new apps" do
+      app "development"
+
+      assert_equal OpenSSL::Digest::SHA256, ActiveSupport::KeyGenerator.hash_digest_class
+    end
+
+    test "ActiveSupport::KeyGenerator.hash_digest_class is OpenSSL::Digest::SHA1 by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal OpenSSL::Digest::SHA1, ActiveSupport::KeyGenerator.hash_digest_class
+    end
+
+    test "ActiveSupport::KeyGenerator.hash_digest_class can be configured via config.active_support.key_generator_hash_digest_class" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/custom_key_generator_digest_class.rb", <<-RUBY
+        Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+      RUBY
+
+      app "development"
+
+      assert_equal OpenSSL::Digest::SHA256, ActiveSupport::KeyGenerator.hash_digest_class
+    end
+
     test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do
       class ::DummySerializer < ActiveJob::Serializers::ObjectSerializer; end
 

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -246,7 +246,7 @@ module ApplicationTests
       controller :foo, <<-RUBY
         class FooController < ActionController::Base
           def write_raw_session
-            # AES-256-CBC with SHA1 HMAC
+            # AES-256-CBC with SHA1 HMAC & SHA1 key derivation
             # {"session_id"=>"1965d95720fffc123941bdfb7d2e6870", "foo"=>1}
             cookies[:_myapp_session] = "TlgrdS85aUpDd1R2cDlPWlR6K0FJeGExckwySjZ2Z0pkR3d2QnRObGxZT25aalJWYWVvbFVLcHF4d0VQVDdSaFF2QjFPbG9MVjJzeWp3YjcyRUlKUUU2ZlR4bXlSNG9ZUkJPRUtld0E3dVU9LS0xNDZXbGpRZ3NjdW43N2haUEZJSUNRPT0=--3639b5ce54c09495cfeaae928cd5634e0c4b2e96"
             head :ok
@@ -277,6 +277,9 @@ module ApplicationTests
 
         # Enable AEAD cookies
         config.action_dispatch.use_authenticated_cookie_encryption = true
+
+        # Use SHA1 key derivation
+        config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
       RUBY
 
       begin


### PR DESCRIPTION
### Summary

This change allows for configuration of the hash digest that is used in the key generator for key derivation.


SHA1 is an outdated algorithm and security auditors tend to frown on its usage. By allowing this to be configured, it becomes possible to move to a more up to date hash mechanism.

While I don't think this has any current relevant security implications, especially not with a proper random secret base, moving away from SHA1 makes conversations with auditors and FIPS compliance checks easier since the best answer is always that an approved algorithm is used.

A rotation can be built using this change with an approach like the following for encrypted cookies:

```ruby
Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256

Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
  salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
  secret_key_base = Rails.application.secrets.secret_key_base

  key_generator = ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1)
  key_len = ActiveSupport::MessageEncryptor.key_len
  secret = key_generator.generate_key(salt, key_len)

  cookies.rotate :encrypted, secret
end
```

This turns the default into using SHA256 but also still accepts secrets
derived using SHA1.

### Other Information

This is similar in spirit as https://github.com/rails/rails/pull/40213 where the generic Digest class could be configured for similar reasons. 