### PR TITLE
Convert translation key to string as necessary

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -69,6 +69,7 @@ module ActionView
       #
       def translate(key, **options)
         return key.map { |k| translate(k, **options) } if key.is_a?(Array)
+        key = key.to_s unless key.is_a?(Symbol)
 
         alternatives = if options.key?(:default)
           options[:default].is_a?(Array) ? options.delete(:default).compact : [options.delete(:default)]

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -71,6 +71,12 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal "Tue, 08 Jul 2008 12:18:38 +0000", localize(@time, locale: "en")
   end
 
+  def test_converts_key_to_string_as_necessary
+    key = Struct.new(:to_s).new("translations.foo")
+    assert_equal "Foo", translate(key)
+    assert_equal key, translate(:"translations.missing", default: key)
+  end
+
   def test_returns_missing_translation_message_without_span_wrap
     old_value = ActionView::Base.debug_missing_translation
     ActionView::Base.debug_missing_translation = false


### PR DESCRIPTION
Follow-up to #39989.

`I18n.translate` converts the initial key (but not `default` keys) to a string before performing a lookup.  For parity, we should do the same.

Fixes https://github.com/rails/rails/commit/d81926fdacbeb384d211e22cff66195c1a753eb5#r44945299.