### PR TITLE
Refactor ActiveRecord::Associations::Preloader class

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -4,8 +4,6 @@ module ActiveRecord
   module Associations
     class Preloader
       class ThroughAssociation < Association # :nodoc:
-        PRELOADER = ActiveRecord::Associations::Preloader.new(associate_by_default: false)
-
         def initialize(*)
           super
           @already_loaded = owners.first.association(through_reflection.name).loaded?
@@ -44,7 +42,7 @@ module ActiveRecord
 
         private
           def source_preloaders
-            @source_preloaders ||= PRELOADER.preload(middle_records, source_reflection.name, scope)
+            @source_preloaders ||= ActiveRecord::Associations::Preloader.new(records: middle_records, associations: source_reflection.name, scope: scope, associate_by_default: false).call
           end
 
           def middle_records
@@ -52,7 +50,7 @@ module ActiveRecord
           end
 
           def through_preloaders
-            @through_preloaders ||= PRELOADER.preload(owners, through_reflection.name, through_scope)
+            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false).call
           end
 
           def through_reflection

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -763,11 +763,9 @@ module ActiveRecord
     def preload_associations(records) # :nodoc:
       preload = preload_values
       preload += includes_values unless eager_loading?
-      preloader = nil
       scope = strict_loading_value ? StrictLoadingScope : nil
       preload.each do |associations|
-        preloader ||= build_preloader
-        preloader.preload records, associations, scope
+        ActiveRecord::Associations::Preloader.new(records: records, associations: associations, scope: scope).call
       end
     end
 
@@ -867,10 +865,6 @@ module ActiveRecord
         else
           yield
         end
-      end
-
-      def build_preloader
-        ActiveRecord::Associations::Preloader.new
       end
 
       def references_eager_loaded_tables?

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -1530,10 +1530,10 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   test "preload with invalid argument" do
-    exception = assert_raises(ArgumentError) do
+    exception = assert_raises(ActiveRecord::AssociationNotFoundError) do
       Author.preload(10).to_a
     end
-    assert_equal("10 was not recognized for preload", exception.message)
+    assert_match(/Association named '10' was not found on Author; perhaps you misspelled it\?/, exception.message)
   end
 
   test "associations with extensions are not instance dependent" do

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -361,8 +361,20 @@ class PreloaderTest < ActiveRecord::TestCase
   def test_preload_with_scope
     post = posts(:welcome)
 
-    preloader = ActiveRecord::Associations::Preloader.new
-    preloader.preload([post], :comments, Comment.where(body: "Thank you for the welcome"))
+    preloader = ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments, scope: Comment.where(body: "Thank you for the welcome"))
+    preloader.call
+
+    assert_predicate post.comments, :loaded?
+    assert_equal [comments(:greetings)], post.comments
+  end
+
+  def test_legacy_preload_with_scope
+    post = posts(:welcome)
+
+    assert_deprecated do
+      preloader = ActiveRecord::Associations::Preloader.new
+      preloader.preload([post], :comments, Comment.where(body: "Thank you for the welcome"))
+    end
 
     assert_predicate post.comments, :loaded?
     assert_equal [comments(:greetings)], post.comments


### PR DESCRIPTION
Part 1 of ?

The `ActiveRecord::Associations::Preloader` class was passing around
many of the same arguments to methods and was difficult to follow.

This PR does a few things:

1) Move arguments for the `Preloader` to the initializer instead of
`preload`
2) Merges the `preloaders_for_one` and `preloaders_for_hash` methods
into one `build_preloaders` method that takes no arguments. This new
method is responsible for looping through all the passed associations.
3) If there are nested associations passed, the class will build a new
`Preloader` object for each `child` in `build_child_preloader`.
4) The above changes allowed for removing most of the arguments being
passed down.

Next steps:

1) Continue refactoring this class and shared classes as they make more
sense. There's a lot of `flat_map`'s in here that feel overused.
2) Once the API is more reasonable revive older Preloader PRs (ie #32136)
3) Expose a usable public API so that apps can build their own
preloaders when necessary (we do this a lot at GitHub) without
interacting with private methods.

While this API is private and undocumented I know that it is used a lot
in applications. Since it's private we don't need a deprecation cycle
but if we find it to be disruptive or too extensive I can build separate
opt-in classes for a new, public preloader.

---

I know we've talked about exposing the preloader in the past, but I don't know if anyone had specific plans for it. If this isn't going in the desired direction let me know.

cc/ @tenderlove @rafaelfranca @jhawthorn @dinahshi @matthewd 