### PR TITLE
ActiveRecord::AttributeMethods::Query respect getter overwrites in the model

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,28 @@
+*   Makes `ActiveRecord::AttributeMethods::Query` respect the getter overrides defined in the model. 
+
+    Fixes #40771.
+
+    Before:
+
+    ```ruby
+      class User
+
+        def admin
+          false # Overriding the getter to always return false
+        end
+
+      end
+
+      user = User.first
+      user.update(admin: true)
+
+      user.admin # false (as expected, due to the getter overwrite)
+      user.admin? # true (not expected, returned the DB column value)
+
+    ```
+
+    After this commit, `user.admin?` above returns false, as expected.
+
 *   Allow delegated_type to be specified primary_key and foreign_key.
 
     Since delegated_type assumes that the foreign_key ends with `_id`,

--- a/activerecord/lib/active_record/attribute_methods/query.rb
+++ b/activerecord/lib/active_record/attribute_methods/query.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       end
 
       def query_attribute(attr_name)
-        value = self[attr_name]
+        value = self.public_send(attr_name)
 
         case value
         when true        then true

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -137,6 +137,23 @@ module ActiveRecord #:nodoc:
   #   anonymous = User.new(name: "")
   #   anonymous.name? # => false
   #
+  # Query methods will also respect any overwrites of default accessors:
+  #
+  #   class User
+  #     # Has admin boolean column
+  #     def admin
+  #       false
+  #     end
+  #   end
+  #
+  #   user.update(admin: true)
+  #
+  #   user.read_attribute(:admin)  # => true, gets the column value
+  #   user[:admin] # => true, also gets the column value
+  #
+  #   user.admin   # => false, due to the getter overwrite
+  #   user.admin?  # => false, due to the getter overwrite
+  #
   # == Accessing attributes before they have been typecasted
   #
   # Sometimes you want to be able to read the raw attribute data without having the column-determined

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -429,6 +429,16 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal "a", topic[:title]
   end
 
+  test "read overriden attribute with predicate respects override" do
+    topic = Topic.new
+
+    topic.approved = true
+
+    def topic.approved; false; end
+
+    assert_not topic.approved?, "overriden approved should be false"
+  end
+
   test "string attribute predicate" do
     [nil, "", " "].each do |value|
       assert_equal false, Topic.new(author_name: value).author_name?


### PR DESCRIPTION
### Changelog
*   Makes ActiveRecord::AttributeMethods::Query respect the getter overrides defined in the model. 

    Fixes #40771

    Before:

    ```ruby
      class User

        def admin
          false # Overriding the getter to always return false
        end

      end

      user = User.first
      user.update(admin: true)

      user.admin # false (as expected, due to the getter overwrite)
      user.admin? # true (not expected, returned the DB column value)

    ```

    After this commit, `user.admin?` above returns false, as expected.

### Summary

As discussed in #40771 , `ActiveRecord::AttributeMethods::Query` didn't respect the getter overrides defined in the model. 

Assuming the User model has boolean column named admin:

```ruby
class User

  def admin
    false # Overriding the getter to always return false
  end

end

user = User.first
user.update(admin: true)

user[:admin] # true (as expected)
user.read_attribute(:admin) # true (as expected)

user.admin # false (as expected)
user.admin? # true (not expected)

```

This commit is a one-liner that makes https://github.com/rails/rails/blob/46337faa795fa40dedb1b9b906bec1793358d7f3/activerecord/lib/active_record/attribute_methods/query.rb#L12 use `value = public_send(attr_name)` instead of `value = self[attr_name]`, so instead of going directly to the column value, it goes through the model to respect any getter overwrites.

I also updated tests and documentation. 

Pinging @rafaelfranca as we had initiated a discussion on the issue above. 
