### PR TITLE
Allow spaces in path to Yarn binstub and only run on precompile if needed

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -17,6 +17,10 @@ namespace :yarn do
       end
 
     system({ "NODE_ENV" => node_env }, "\"#{Rails.root}/bin/yarn\" install #{yarn_flags}")
+  rescue Errno::ENOENT
+    $stderr.puts "bin/yarn was not found."
+    $stderr.puts "Please run `bundle exec rails app:update:bin` to create it."
+    exit 1
   end
 end
 

--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -10,13 +10,13 @@ namespace :yarn do
     end
 
     yarn_flags =
-      if `#{Rails.root}/bin/yarn --version`.start_with?("1")
+      if `"#{Rails.root}/bin/yarn" --version`.start_with?("1")
         "--no-progress --frozen-lockfile"
       else
         "--immutable"
       end
 
-    system({ "NODE_ENV" => node_env }, "#{Rails.root}/bin/yarn install #{yarn_flags}")
+    system({ "NODE_ENV" => node_env }, "\"#{Rails.root}/bin/yarn\" install #{yarn_flags}")
   end
 end
 

--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -25,6 +25,6 @@ namespace :yarn do
 end
 
 # Run Yarn prior to Sprockets assets precompilation, so dependencies are available for use.
-if Rake::Task.task_defined?("assets:precompile")
+if Rake::Task.task_defined?("assets:precompile") && File.exist?(Rails.root.join("bin", "yarn"))
   Rake::Task["assets:precompile"].enhance [ "yarn:install" ]
 end


### PR DESCRIPTION
### Summary

Fixes #40783, #40795

Before the version check was introduced in https://github.com/rails/rails/commit/bd4d8fdfce9bbc160752d1b15db2f358d005fd24, the `system` call right below it failed silently in such cases and did nothing. Now the version check call raises `Errno::ENOENT` and acutally exposes the missing binary.

```ruby
system("not present")
# => nil

`not present`
# Traceback (most recent call last):
#        2: from (irb):4
#        1: from (irb):4:in ``'
# Errno::ENOENT (No such file or directory - not)
```