### PR TITLE
Handle nil translation key

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   The `translate` helper now resolves `default` values when a `nil` key is
+    specified, instead of always returning `nil`.
+
+    *Jonathan Hefner*
+
 *   Add `config.action_view.image_loading` to configure the default value of
     the `image_tag` `:loading` option.
 

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -69,7 +69,7 @@ module ActionView
       #
       def translate(key, **options)
         return key.map { |k| translate(k, **options) } if key.is_a?(Array)
-        key = key.to_s unless key.is_a?(Symbol)
+        key = key&.to_s unless key.is_a?(Symbol)
 
         alternatives = if options.key?(:default)
           options[:default].is_a?(Array) ? options.delete(:default).compact : [options.delete(:default)]
@@ -78,13 +78,12 @@ module ActionView
         options[:raise] = true if options[:raise].nil? && ActionView::Base.raise_on_missing_translations
         default = MISSING_TRANSLATION
 
-        translation = while key
+        translation = while key || alternatives.present?
           if alternatives.blank? && !options[:raise].nil?
             default = NO_DEFAULT # let I18n handle missing translation
           end
 
           key = scope_key_by_partial(key)
-          first_key ||= key
 
           if html_safe_translation_key?(key)
             html_safe_options ||= html_escape_translation_options(options)
@@ -97,10 +96,11 @@ module ActionView
 
           break alternatives.first if alternatives.present? && !alternatives.first.is_a?(Symbol)
 
+          first_key ||= key
           key = alternatives&.shift
         end
 
-        if key.nil?
+        if key.nil? && !first_key.nil?
           translation = missing_translation(first_key, options)
           key = first_key
         end
@@ -130,7 +130,7 @@ module ActionView
         end
 
         def scope_key_by_partial(key)
-          if key.start_with?(".")
+          if key&.start_with?(".")
             if @current_template&.virtual_path
               @_scope_key_by_partial_cache ||= {}
               @_scope_key_by_partial_cache[@current_template.virtual_path] ||= @current_template.virtual_path.gsub(%r{/_?}, ".")

--- a/actionview/test/template/translation_helper_test.rb
+++ b/actionview/test/template/translation_helper_test.rb
@@ -77,6 +77,16 @@ class TranslationHelperTest < ActiveSupport::TestCase
     assert_equal key, translate(:"translations.missing", default: key)
   end
 
+  def test_returns_nil_for_nil_key_without_default
+    assert_nil translate(nil)
+  end
+
+  def test_returns_default_for_nil_key_with_default
+    assert_equal "Foo", translate(nil, default: "Foo")
+    assert_equal "Foo", translate(nil, default: :"translations.foo")
+    assert_predicate translate(nil, default: :"translations.html"), :html_safe?
+  end
+
   def test_returns_missing_translation_message_without_span_wrap
     old_value = ActionView::Base.debug_missing_translation
     ActionView::Base.debug_missing_translation = false


### PR DESCRIPTION
`I18n.translate` returns `nil` when given a `nil` key, *unless* a `default` is also specified.  If a `default` is specified, the `nil` key is treated as a missing key.

In Rails 6.0, the `translate` helper always returned `nil` when given a `nil` key.  After #40773, the `translate` helper always raised an `I18n::ArgumentError` when given a `nil` key.  This commit fixes the `translate` helper to mirror the `I18n.translate` behavior when given a `nil` key, with and without a `default`.

Fixes https://github.com/rails/rails/pull/40773#issuecomment-742553083.

---

Since this changes the behavior of the `translate` helper when both a `nil` key and a `default` are specified, I've added a CHANGELOG entry.  If we do not want to change this for 6.1.1, I can create a separate PR against `6-1-stable` that restores the Rails 6.0 behavior for `nil` keys.
