### PR TITLE
Deprecate assigning single `trusted_proxies` value

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+*   Deprecate the ability to assign a single value to `config.action_dispatch.trusted_proxies`
+    as `RemoteIp` middleware behaves inconsistently depending on whether this is configured
+    with a single value or an enumerable.
+
+    Fixes #40772
+
+    *Christian Sutter*
+
 *   Add `redirect_back_or_to(fallback_location, **)` as a more aesthetically pleasing version of `redirect_back fallback_location:, **`.
     The old method name is retained without explicit deprecation.
 

--- a/actionpack/lib/action_dispatch/middleware/remote_ip.rb
+++ b/actionpack/lib/action_dispatch/middleware/remote_ip.rb
@@ -51,10 +51,8 @@ module ActionDispatch
     # clients (like WAP devices), or behind proxies that set headers in an
     # incorrect or confusing way (like AWS ELB).
     #
-    # The +custom_proxies+ argument can take an Array of string, IPAddr, or
-    # Regexp objects which will be used instead of +TRUSTED_PROXIES+. If a
-    # single string, IPAddr, or Regexp object is provided, it will be used in
-    # addition to +TRUSTED_PROXIES+. Any proxy setup will put the value you
+    # The +custom_proxies+ argument can take an enumerable which will be used
+    # instead of +TRUSTED_PROXIES+. Any proxy setup will put the value you
     # want in the middle (or at the beginning) of the X-Forwarded-For list,
     # with your proxy servers after it. If your proxies aren't removed, pass
     # them in via the +custom_proxies+ parameter. That way, the middleware will
@@ -67,6 +65,20 @@ module ActionDispatch
       elsif custom_proxies.respond_to?(:any?)
         custom_proxies
       else
+        ActiveSupport::Deprecation.warn(<<~EOM)
+          Setting config.action_dispatch.trusted_proxies to a single value has
+          been deprecated. Please set this to an enumerable instead. For
+          example, instead of:
+
+          config.action_dispatch.trusted_proxies = IPAddr.new("10.0.0.0/8")
+
+          Wrap the value in an Array:
+
+          config.action_dispatch.trusted_proxies = [IPAddr.new("10.0.0.0/8")]
+
+          Note that unlike passing a single argument, passing an enumerable
+          will *replace* the default set of trusted proxies.
+        EOM
         Array(custom_proxies) + TRUSTED_PROXIES
       end
     end


### PR DESCRIPTION
### Summary

Fixes #40772 

- Deprecate ability to assign a single value to `trusted_proxies` in `RemoteIp` middleware
- Add an explicit test for the setting overriding the default list of trusted proxies

The `RemoteIp` middleware currently behaves inconsistently depending on whether `config.action_dispatch.trusted_proxies` is configured with a single value or an enumerable. This is surprising behaviour and can lead to frustration when e.g. moving from having one single trusted proxy specified to needing multiple (and vice versa).

For example, the following two settings behave differently:

```ruby
# Adds 4.2.42.0/24 to default list of trusted proxies
app.config.action_dispatch.trusted_proxies = IPAddr.new("4.2.42.0/24")

# Replaces default list of trusted proxies with 4.2.42.0/24
app.config.action_dispatch.trusted_proxies = [IPAddr.new("4.2.42.0/24")]
```