### PR TITLE
Make `ActiveSupport::Inflector#clear` also clear acronyms

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -3,6 +3,10 @@
 
     *Vipul A M*
 
+*   `ActiveSupport::Inflector#clear` now clears acronyms, and `inflector.clear(:acronyms)` is now supported.
+
+    *Alex Ghiculescu*
+
 *   `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
 
     *Nathaniel Woodthorpe*

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -76,8 +76,7 @@ module ActiveSupport
       attr_reader :acronyms_camelize_regex, :acronyms_underscore_regex # :nodoc:
 
       def initialize
-        @plurals, @singulars, @uncountables, @humans, @acronyms = [], [], Uncountables.new, [], {}
-        define_acronym_regex_patterns
+        clear(:all)
       end
 
       # Private, for the test suite.
@@ -222,17 +221,25 @@ module ActiveSupport
       # Clears the loaded inflections within a given scope (default is
       # <tt>:all</tt>). Give the scope as a symbol of the inflection type, the
       # options are: <tt>:plurals</tt>, <tt>:singulars</tt>, <tt>:uncountables</tt>,
-      # <tt>:humans</tt>.
+      # <tt>:humans</tt>, <tt>:acronyms</tt>.
       #
       #   clear :all
       #   clear :plurals
       def clear(scope = :all)
-        case scope
-        when :all
-          @plurals, @singulars, @uncountables, @humans = [], [], Uncountables.new, []
+        if scope == :all
+          @plurals, @singulars, @uncountables, @humans, @acronyms = [], [], Uncountables.new, [], {}
         else
-          instance_variable_set "@#{scope}", []
+          value = case scope
+                  when :plurals, :singulars, :humans
+                    []
+                  when :uncountables
+                    Uncountables.new
+                  when :acronyms
+                    {}
+          end
+          instance_variable_set "@#{scope}", value
         end
+        define_acronym_regex_patterns if [:all, :acronyms].include?(scope)
       end
 
       private

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -477,6 +477,7 @@ class InflectorTest < ActiveSupport::TestCase
   def test_clear_all
     ActiveSupport::Inflector.inflections do |inflect|
       # ensure any data is present
+      inflect.acronym("HTTP")
       inflect.plural(/(quiz)$/i, '\1zes')
       inflect.singular(/(database)s$/i, '\1')
       inflect.uncountable("series")
@@ -484,6 +485,7 @@ class InflectorTest < ActiveSupport::TestCase
 
       inflect.clear :all
 
+      assert_empty inflect.acronyms
       assert_empty inflect.plurals
       assert_empty inflect.singulars
       assert_empty inflect.uncountables
@@ -494,6 +496,7 @@ class InflectorTest < ActiveSupport::TestCase
   def test_clear_with_default
     ActiveSupport::Inflector.inflections do |inflect|
       # ensure any data is present
+      inflect.acronym("HTTP")
       inflect.plural(/(quiz)$/i, '\1zes')
       inflect.singular(/(database)s$/i, '\1')
       inflect.uncountable("series")
@@ -501,10 +504,26 @@ class InflectorTest < ActiveSupport::TestCase
 
       inflect.clear
 
+      assert_empty inflect.acronyms
       assert_empty inflect.plurals
       assert_empty inflect.singulars
       assert_empty inflect.uncountables
       assert_empty inflect.humans
+    end
+  end
+
+  def test_clear_all_rests_camelize_and_underscore_regexes
+    ActiveSupport::Inflector.inflections do |inflect|
+      # ensure any data is present
+      inflect.acronym("HTTP")
+      assert_equal "http_s", "HTTPS".underscore
+      assert_equal "Https", "https".camelize
+
+      inflect.clear :all
+
+      assert_empty inflect.acronyms
+      assert_equal "https", "HTTPS".underscore
+      assert_equal "Https", "https".camelize
     end
   end
 
@@ -561,13 +580,21 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
-  %w(plurals singulars uncountables humans acronyms).each do |scope|
+  %w(plurals singulars uncountables humans).each do |scope|
     define_method("test_clear_inflections_with_#{scope}") do
       # clear the inflections
       ActiveSupport::Inflector.inflections do |inflect|
-        inflect.clear(scope)
+        inflect.clear(scope.to_sym)
         assert_equal [], inflect.public_send(scope)
       end
+    end
+  end
+
+  def test_clear_inflections_with_acronyms
+    # clear the inflections
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.clear(:acronyms)
+      assert_equal({}, inflect.acronyms)
     end
   end
 end


### PR DESCRIPTION
Currently `ActiveSupport::Inflector#clear` clears all inflector contents *except* acronyms. So it clears plurals, singulars, uncountables, and "humans". This feels like an oversight. The `clear` method existed when acronyms were added (https://github.com/rails/rails/pull/1648), so I'm guessing the author just forgot to update this method.

This PR makes `clear(:all)` and `clear` reset the acronyms hash (and corresponding regexes), and adds support for `clear(:acronyms)`.