### PR TITLE
ActiveStorage upgrade command

### DIFF
--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -308,7 +308,7 @@ Please refer to the [Changelog][active-storage] for detailed changes.
 *   Add `Blob.create_and_upload` to create a new blob and upload the given `io`
     to the service.
     ([Pull Request](https://github.com/rails/rails/pull/34827))
-*   ActiveStorage::Blob#service_name column was added, ( `bin/rails app:update` required ).
+*   `ActiveStorage::Blob#service_name` column was added. It is required that a migration is run after the upgrade. Run `bin/rails app:update` to generate that migration.
 
 Active Model
 ------------

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -308,7 +308,7 @@ Please refer to the [Changelog][active-storage] for detailed changes.
 *   Add `Blob.create_and_upload` to create a new blob and upload the given `io`
     to the service.
     ([Pull Request](https://github.com/rails/rails/pull/34827))
-*   ActiveStorage::Blob#service_name column added, activestorage upgrade migration needed, `rails active_storage:update`
+*   ActiveStorage::Blob#service_name column was added, ( `bin/rails app:update` required ).
 
 Active Model
 ------------

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -308,6 +308,7 @@ Please refer to the [Changelog][active-storage] for detailed changes.
 *   Add `Blob.create_and_upload` to create a new blob and upload the given `io`
     to the service.
     ([Pull Request](https://github.com/rails/rails/pull/34827))
+*   ActiveStorage::Blob#service_name column added, activestorage upgrade migration needed, `rails active_storage:update`
 
 Active Model
 ------------


### PR DESCRIPTION
### Summary

ActiveStorage::Blob is generating error when upgrading from rails 6.0.3.4 to 6.1 without the proper migration
https://github.com/rails/rails/pull/34935#issuecomment-742715565