### PR TITLE
Ignore strict loading violations on instances loaded through fixtures

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -773,9 +773,12 @@ module ActiveRecord
 
     def find
       raise FixtureClassNotFound, "No class attached to find." unless model_class
-      model_class.unscoped do
+      object = model_class.unscoped do
         model_class.find(fixture[model_class.primary_key])
       end
+      # Fixtures can't be eagerly loaded
+      object.instance_variable_set(:@strict_loading, false)
+      object
     end
   end
 end

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -6,6 +6,8 @@ require "models/computer"
 require "models/mentor"
 require "models/project"
 require "models/ship"
+require "models/strict_zine"
+require "models/interest"
 
 class StrictLoadingTest < ActiveRecord::TestCase
   fixtures :developers
@@ -416,4 +418,21 @@ class StrictLoadingTest < ActiveRecord::TestCase
         ActiveRecord::Base.logger = old_logger
       end
     end
+end
+
+class StrictLoadingFixturesTest < ActiveRecord::TestCase
+  fixtures :strict_zines
+
+  test "strict loading violations are ignored on fixtures" do
+    ActiveRecord::FixtureSet.reset_cache
+    create_fixtures("strict_zines")
+
+    assert_nothing_raised do
+      strict_zines(:going_out).interests.to_a
+    end
+
+    assert_raises(ActiveRecord::StrictLoadingViolationError) do
+      StrictZine.first.interests.to_a
+    end
+  end
 end

--- a/activerecord/test/fixtures/strict_zines.yml
+++ b/activerecord/test/fixtures/strict_zines.yml
@@ -1,0 +1,2 @@
+going_out:
+  title: Hello

--- a/activerecord/test/models/strict_zine.rb
+++ b/activerecord/test/models/strict_zine.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "models/zine"
+
+class StrictZine < Zine
+  self.strict_loading_by_default = true
+end

--- a/activerecord/test/models/zine.rb
+++ b/activerecord/test/models/zine.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Zine < ActiveRecord::Base
-  has_many :interests, inverse_of: :zine
+  has_many :interests, inverse_of: :zine, foreign_key: "zine_id"
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1101,6 +1101,10 @@ ActiveRecord::Schema.define do
     t.string :title
   end
 
+  create_table :strict_zines, force: true do |t|
+    t.string :title
+  end
+
   create_table :wheels, force: true do |t|
     t.integer :size
     t.references :wheelable, polymorphic: true


### PR DESCRIPTION
Fixes an issue reported here: https://discuss.rubyonrails.org/t/how-to-eager-load-fixture-associations-in-rails-6-1/76645
