### PR TITLE
Fix s3 multipart uploads when threshold is larger than the file uploaded

### DIFF
--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -16,7 +16,7 @@ module ActiveStorage
       @client = Aws::S3::Resource.new(**options)
       @bucket = @client.bucket(bucket)
 
-      @multipart_upload_threshold = upload.fetch(:multipart_threshold, 100.megabytes)
+      @multipart_upload_threshold = upload.delete(:multipart_threshold) || 100.megabytes
       @public = public
 
       @upload_options = upload

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -156,6 +156,20 @@ if SERVICE_CONFIGURATIONS[:s3]
       end
     end
 
+    test "uploading a small object with multipart_threshold configured" do
+      service = build_service(upload: { multipart_threshold: 5.megabytes })
+
+      begin
+        key  = SecureRandom.base58(24)
+        data = SecureRandom.bytes(3.megabytes)
+
+        service.upload key, StringIO.new(data), checksum: Digest::MD5.base64digest(data)
+        assert data == service.download(key)
+      ensure
+        service.delete key
+      end
+    end
+
     private
       def build_service(configuration)
         ActiveStorage::Service.configure :s3, SERVICE_CONFIGURATIONS.deep_merge(s3: configuration)


### PR DESCRIPTION
### Summary

Hello from AWS. A customer reported a bug in our repo (https://github.com/aws/aws-sdk-ruby/issues/2451) around using `:multipart_threshold` with ActiveStorage. The bug occurs when the file being uploaded has a smaller size than the multipart threshold. This happens because the `:multipart_threshold` is passed into `:put_object`, a parameter that is not understood by the s3 API. This results in a param validation failure. Please see the above issue for more details.

### Other Information

I tested this by doing the following:
* Made a new rails app (`rails new --skip-javascript`)
* Set the Gemfile to use my fork with `path:`
* Configured ActiveStorage and S3 similar to https://edgeguides.rubyonrails.org/active_storage_overview.html
* Added `multipart_threshold: <%= 10.megabytes %>` under the `:upload` and `:amazon` keys.
* Attempted to upload a file that was 38 kb, resulting in a failure (customer reproduction)
* Made the code change in my fork
* Attempted the same upload and it succeeded. I verified the object in my bucket.

As far as unit tests go, I'm not sure if you wanted an explicit test for this - I would assume it's not necessary in this case because it's a matter of what parameters are passed through to the SDK.
