### PR TITLE
Update sdoc to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", "~> 2.0"
+  gem "sdoc", ">= 2.0.3"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,7 +453,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (2.0.2)
+    sdoc (2.0.3)
       rdoc (>= 5.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -603,7 +603,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails
-  sdoc (~> 2.0)
+  sdoc (>= 2.0.3)
   selenium-webdriver (>= 3.141.592)
   sequel
   sidekiq


### PR DESCRIPTION
### Summary
This fixes the title tag on the index page.
It also add the ability to run the docs locally with rack but that is for development only.

https://my.diffend.io/gems/sdoc/2.0.2/2.0.3