### PR TITLE
Allow `reload` to be `default_scoped`

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -52,6 +52,17 @@ module ActiveRecord
           self.current_scope = nil
         end
 
+        # Checks if the model has any default scopes. If all_queries
+        # is set to true, the method will check if there are any
+        # default_scopes for the model  where `all_queries` is true.
+        def default_scopes?(all_queries: false)
+          if all_queries
+            self.default_scopes.map(&:all_queries).include?(true)
+          else
+            self.default_scopes.any?
+          end
+        end
+
         private
           # Use this macro in your model to set a default scope for all operations on
           # the model.


### PR DESCRIPTION
`reload` is not `default_scoped` by default because you could be
creating a record that does not match your default scope and therefore
`reload` wouldn't find the record.

However, in the case of sharding an application you may want `reload` to
support `default_scope` because you'll always have the correct scope
set. To accomplish this I added a new method that checks if there are
any default scopes defined that are set to run for `all_queries`. If
there are then don't `unscope` the find methods.

If there is a case where you do want the default scope to apply to all
queries but be able to turn that off, I've added a `unscoped` option to
`reload`. This would use the original behavior regardless of whether the
`default_scope` was used for all queries.

Additionally, this exposes a new public method `default_scopes?` that
returns true if there are default scopes. If `all_queries` is passed to
`default_scopes?` the method will only return true if there is a default
scope for the model that has `all_queries` set to true. If there are no
default scopes with `all_queries` then it will return false.