### PR TITLE
cleanup WhereClauseFactory

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1534,11 +1534,4 @@ module ActiveRecord
         end
       end
   end
-
-  class Relation # :nodoc:
-    # No-op WhereClauseFactory to work Mashal.load(File.read("legacy_relation.dump")).
-    # TODO: Remove the class once Rails 6.1 has released.
-    class WhereClauseFactory # :nodoc:
-    end
-  end
 end


### PR DESCRIPTION
with 6.1 released, we can clean up the no-op `WhereClauseFactory` added in https://github.com/rails/rails/commit/550ce69f8adcd19542453ae03ac837a9ac8adf4b