### PR TITLE
Fix Rails Version in Guides Index

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -10,12 +10,13 @@
 </p>
 <% else %>
 <p>
-  These are the new guides for Rails 6.0 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
+  These are the new guides for Rails 6.1 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
 </p>
 <% end %>
 <p>
 The guides for earlier releases:
+<a href="https://guides.rubyonrails.org/v6.0/">Rails 6.0</a>,
 <a href="https://guides.rubyonrails.org/v5.2/">Rails 5.2</a>,
 <a href="https://guides.rubyonrails.org/v5.1/">Rails 5.1</a>,
 <a href="https://guides.rubyonrails.org/v5.0/">Rails 5.0</a>,


### PR DESCRIPTION
The version listed on the Rails Guides index is updated from 6.0 to 6.1.

Also, adds a missing link to get back to the 6.0 documentation.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
