### PR TITLE
Fix Rails Version in Guides Index

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -10,12 +10,14 @@
 </p>
 <% else %>
 <p>
-  These are the new guides for Rails 6.0 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
+  These are the new guides for Rails 6.2 based on <a href="https://github.com/rails/rails/tree/<%= @version %>"><%= @version %></a>.
   These guides are designed to make you immediately productive with Rails, and to help you understand how all of the pieces fit together.
 </p>
 <% end %>
 <p>
 The guides for earlier releases:
+<a href="https://guides.rubyonrails.org/v6.1/">Rails 6.1</a>,
+<a href="https://guides.rubyonrails.org/v6.0/">Rails 6.0</a>,
 <a href="https://guides.rubyonrails.org/v5.2/">Rails 5.2</a>,
 <a href="https://guides.rubyonrails.org/v5.1/">Rails 5.1</a>,
 <a href="https://guides.rubyonrails.org/v5.0/">Rails 5.0</a>,


### PR DESCRIPTION
See https://github.com/rails/rails/pull/40813 for the related PR for 6-1-stable.