### PR TITLE
Fix `where` with custom primary key for belongs_to association

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -31,8 +31,8 @@ module ActiveRecord
         end
 
         def convert_to_id(value)
-          if value.respond_to?(:id)
-            value.id
+          if value.respond_to?(primary_key)
+            value.public_send(primary_key)
           else
             value
           end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -29,7 +29,7 @@ require "models/parrot"
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
            :developers_projects, :computers, :authors, :author_addresses,
-           :posts, :tags, :taggings, :comments, :sponsors, :members
+           :essays, :posts, :tags, :taggings, :comments, :sponsors, :members
 
   def test_belongs_to
     client = Client.find(3)
@@ -38,6 +38,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
       assert_equal first_firm, client.firm
       assert_equal first_firm.name, client.firm.name
     end
+  end
+
+  def test_where_with_custom_primary_key
+    assert_equal [authors(:david)], Author.where(owned_essay: essays(:david_modest_proposal))
   end
 
   def test_assigning_belongs_to_on_destroyed_object


### PR DESCRIPTION
It is a regression for #40554.

Fixes #40809.