### PR TITLE
Add `utc_to_local_returns_utc_offset_times` default value into guide [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -850,7 +850,7 @@ There are a few configuration options available in Active Support:
 
 * `ActiveSupport.utc_to_local_returns_utc_offset_times` configures
   `ActiveSupport::TimeZone.utc_to_local` to return a time with a UTC offset
-  instead of a UTC time incorporating that offset.
+  instead of a UTC time incorporating that offset. The default is `false`.
 
 ### Configuring Active Job
 


### PR DESCRIPTION
### Summary
The setting `ActiveSupport.utc_to_local_returns_utc_offset_times` added by https://github.com/rails/rails/commit/bf34c808f9936ecb160914cace45c655ec0924c7, but the default value is not described in the guide. I added this.

The default values ​​are set below.
https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/date_and_time/compatibility.rb#L29

See: https://edgeguides.rubyonrails.org/configuring.html
