### PR TITLE
Fix retrieving default value for text column for MariaDB

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -167,6 +167,9 @@ module ActiveRecord
             elsif type_metadata.extra == "DEFAULT_GENERATED"
               default = +"(#{default})" unless default.start_with?("(")
               default, default_function = nil, default
+            elsif type_metadata.type == :text && default
+              # strip and unescape quotes
+              default = default[1...-1].gsub("\\'", "'")
             end
 
             MySQL::Column.new(

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -83,6 +83,33 @@ class DefaultStringsTest < ActiveRecord::TestCase
   end
 end
 
+if supports_text_column_with_default?
+  class DefaultTextTest < ActiveRecord::TestCase
+    class DefaultText < ActiveRecord::Base; end
+
+    setup do
+      @connection = ActiveRecord::Base.connection
+      @connection.create_table :default_texts do |t|
+        t.text :text_col, default: "Smith"
+        t.text :text_col_with_quotes, default: "O'Connor"
+      end
+      DefaultText.reset_column_information
+    end
+
+    def test_default_texts
+      assert_equal "Smith", DefaultText.new.text_col
+    end
+
+    def test_default_texts_containing_single_quotes
+      assert_equal "O'Connor", DefaultText.new.text_col_with_quotes
+    end
+
+    teardown do
+      @connection.drop_table :default_texts
+    end
+  end
+end
+
 if current_adapter?(:PostgreSQLAdapter)
   class PostgresqlDefaultExpressionTest < ActiveRecord::TestCase
     include SchemaDumpingHelper

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -63,6 +63,15 @@ def supports_non_unique_constraint_name?
   end
 end
 
+def supports_text_column_with_default?
+  if current_adapter?(:Mysql2Adapter)
+    conn = ActiveRecord::Base.connection
+    conn.mariadb? && conn.database_version >= "10.2.1"
+  else
+    true
+  end
+end
+
 %w[
   supports_savepoints?
   supports_partial_index?

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -814,6 +814,7 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
       t.datetime :datetime_with_default, default: "2014-06-05 07:17:04"
       t.time     :time_with_default,     default: "07:17:04"
       t.decimal  :decimal_with_default,  default: "1234567890.0123456789", precision: 20, scale: 10
+      t.text :text_with_default, default: "John' Doe" if supports_text_column_with_default?
     end
 
     if current_adapter?(:PostgreSQLAdapter)
@@ -841,6 +842,12 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     assert_match %r{t\.time\s+"time_with_default",\s+default: "2000-01-01 07:17:04"}, output
     assert_match %r{t\.decimal\s+"decimal_with_default",\s+precision: 20,\s+scale: 10,\s+default: "1234567890.0123456789"}, output
   end
+
+  def test_schema_dump_with_text_column
+    output = dump_table_schema("dump_defaults")
+
+    assert_match %r{t\.text\s+"text_with_default",.*?default: "John' Doe"}, output
+  end if supports_text_column_with_default?
 
   def test_schema_dump_with_column_infinity_default
     skip unless current_adapter?(:PostgreSQLAdapter)


### PR DESCRIPTION
Fixes #38218
Fixes #41240

All adapters support `text` columns with defaults, except MySQL (but MariaDB >= 10.2.1 [supports](https://mariadb.com/kb/en/create-table/#default-column-option)).