### PR TITLE
Ruby 3 does not have webrick by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,9 @@ gem "libxml-ruby", platforms: :ruby
 gem "connection_pool", require: false
 gem "rexml", require: false
 
-# for railties app_generator_test
+# for railties
 gem "bootsnap", ">= 1.4.4", require: false
+gem "webrick", require: false
 
 # Active Job
 group :job do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,6 +533,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    webrick (1.7.0)
     websocket (1.2.8)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
@@ -620,6 +621,7 @@ DEPENDENCIES
   webdrivers
   webmock
   webpacker (~> 5.0)
+  webrick
   websocket-client-simple!
 
 BUNDLED WITH


### PR DESCRIPTION
### Summary

Railties CI against Ruby 3.0.0-dev has been failing
since https://buildkite.com/rails/rails/builds/73338#51165eef-b631-4f9c-8e98-fc210e71e6d1

This pull request addresses the following error.

```ruby
$ ruby -v
ruby 3.0.0dev (2020-12-13T04:39:57Z master c7530f0d56) [x86_64-linux]
$ ruby -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/commands/server_test.rb
... snip ...
Run options: --seed 54404

.E

Error:
Rails::Command::ServerCommandTest#test_served_url:
LoadError: cannot load such file -- webrick
    test/commands/server_test.rb:292:in `test_served_url'

rails test test/commands/server_test.rb:289

........................

Finished in 0.303746s, 85.5977 runs/s, 177.7799 assertions/s.
26 runs, 54 assertions, 0 failures, 1 errors, 0 skips
$
```

Related to
https://github.com/ruby/ruby/pull/3729
https://bugs.ruby-lang.org/issues/17303

