### PR TITLE
Fix the status inclusion validation in Getting started: Using Concerns [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1729,7 +1729,7 @@ class Article < ApplicationRecord
 
   VALID_STATUSES = ['public', 'private', 'archived']
 
-  validates :status, in: VALID_STATUSES
+  validates :status, inclusion: { in: VALID_STATUSES }
 
   def archived?
     status == 'archived'
@@ -1745,7 +1745,7 @@ class Comment < ApplicationRecord
 
   VALID_STATUSES = ['public', 'private', 'archived']
 
-  validates :status, in: VALID_STATUSES
+  validates :status, inclusion: { in: VALID_STATUSES }
 
   def archived?
     status == 'archived'
@@ -1794,7 +1794,7 @@ module Visible
   included do
     VALID_STATUSES = ['public', 'private', 'archived']
 
-    validates :status, in: VALID_STATUSES
+    validates :status, inclusion: { in: VALID_STATUSES }
   end
 
   def archived?
@@ -1836,7 +1836,7 @@ module Visible
   VALID_STATUSES = ['public', 'private', 'archived']
 
   included do
-    validates :status, in: VALID_STATUSES
+    validates :status, inclusion: { in: VALID_STATUSES }
   end
 
   class_methods do


### PR DESCRIPTION
### Summary

Following the Getting started guidelines, in the [Using Concerns](https://guides.rubyonrails.org/getting_started.html#using-concerns) chapter, `validates :status, in: VALID_STATUSES` in the `Visible` module (`app/models/concerns/visible.rb`) raises `ArgumentError (Unknown validator: 'InValidator'):` in the `ArticleController#index` method.

Adding the `inclusion` helper as specified in the [Active Record Validations' guidelines](https://guides.rubyonrails.org/v6.1/active_record_validations.html#inclusion) fixes this issue.

### Other Information

```shell
➜ ruby --version
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
➜ rails --version
Rails 6.1.0
```