### PR TITLE
Refactor Preloader to remove AlreadyLoaded class

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -11,9 +11,16 @@ module ActiveRecord
           @preload_scope = preload_scope
           @associate     = associate_by_default || !preload_scope || preload_scope.empty_scope?
           @model         = owners.first && owners.first.class
+
+          @already_loaded = owners.all? { |o| o.association(reflection.name).loaded? }
         end
 
         def run
+          if @already_loaded
+            fetch_from_preloaded_records
+            return self
+          end
+
           records = records_by_owner
 
           owners.each do |owner|
@@ -37,6 +44,14 @@ module ActiveRecord
 
         private
           attr_reader :owners, :reflection, :preload_scope, :model, :klass
+
+          def fetch_from_preloaded_records
+            @records_by_owner = owners.index_with do |owner|
+              Array(owner.association(reflection.name).target)
+            end
+
+            @preloaded_records = records_by_owner.flat_map(&:last)
+          end
 
           def load_records
             # owners can be duplicated when a relation has a collection association join

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -4,11 +4,6 @@ module ActiveRecord
   module Associations
     class Preloader
       class ThroughAssociation < Association # :nodoc:
-        def initialize(*)
-          super
-          @already_loaded = owners.first.association(through_reflection.name).loaded?
-        end
-
         def preloaded_records
           @preloaded_records ||= source_preloaders.flat_map(&:preloaded_records)
         end
@@ -21,7 +16,7 @@ module ActiveRecord
           @records_by_owner = owners.each_with_object({}) do |owner, result|
             through_records = through_records_by_owner[owner] || []
 
-            if @already_loaded
+            if owners.first.association(through_reflection.name).loaded?
               if source_type = reflection.options[:source_type]
                 through_records = through_records.select do |record|
                   record[reflection.foreign_type] == source_type


### PR DESCRIPTION
Part 2 of ?

It felt strange to have an `AlreadyLoaded` class when we have 2 classes
for the preloaders. `ThroughAssociation` already super's to
`Association`. Instead of having a new class that provides a confusing
indirection, we can get and set all the information we need on
`Association` inside of `run`.

In addition, the `already_loaded` instance variable on
`ThroughAssociation` actually meant something different than
`already_loaded` that was checked for `AlreadyLoaded`. By pushing this
check down we can get rid of the `initialize` in `ThroughAssociation`
entirely since then all it's doing is calling `super`.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>

Part 1: https://github.com/rails/rails/pull/40776