### PR TITLE
Add config.action_view.image_decoding

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -22,6 +22,7 @@ module ActionView
       include TagHelper
 
       mattr_accessor :image_loading
+      mattr_accessor :image_decoding
 
       # Returns an HTML script tag for each of the +sources+ provided.
       #
@@ -369,6 +370,7 @@ module ActionView
         options[:width], options[:height] = extract_dimensions(options.delete(:size)) if options[:size]
 
         options[:loading] ||= image_loading if image_loading
+        options[:decoding] ||= image_decoding if image_decoding
 
         tag("img", options)
       end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -11,6 +11,7 @@ module ActionView
     config.action_view.debug_missing_translation = true
     config.action_view.default_enforce_utf8 = nil
     config.action_view.image_loading = nil
+    config.action_view.image_decoding = nil
 
     config.eager_load_namespaces << ActionView
 
@@ -40,6 +41,7 @@ module ActionView
 
     config.after_initialize do |app|
       ActionView::Helpers::AssetTagHelper.image_loading = app.config.action_view.delete(:image_loading)
+      ActionView::Helpers::AssetTagHelper.image_decoding = app.config.action_view.delete(:image_decoding)
     end
 
     config.after_initialize do |app|

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -579,6 +579,16 @@ class AssetTagHelperTest < ActionView::TestCase
     ActionView::Helpers::AssetTagHelper.image_loading = original_image_loading
   end
 
+  def test_image_tag_decoding_attribute_default_value
+    original_image_decoding = ActionView::Helpers::AssetTagHelper.image_decoding
+    ActionView::Helpers::AssetTagHelper.image_decoding = "async"
+
+    assert_dom_equal %(<img src="" decoding="async" />), image_tag("")
+    assert_dom_equal %(<img src="" decoding="sync" />), image_tag("", decoding: "sync")
+  ensure
+    ActionView::Helpers::AssetTagHelper.image_decoding = original_image_decoding
+  end
+
   def test_favicon_link_tag
     FaviconLinkToTag.each { |method, tag| assert_dom_equal(tag, eval(method)) }
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -708,6 +708,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.image_loading` specifies a default value for the `loading` attribute of `<img>` tags rendered by the `image_tag` helper. For example, when set to `"lazy"`, `<img>` tags rendered by `image_tag` will include `loading="lazy"`, which [instructs the browser to wait until an image is near the viewport to load it](https://html.spec.whatwg.org/#lazy-loading-attributes). (This value can still be overridden per image by passing e.g. `loading: "eager"` to `image_tag`.) Defaults to `nil`.
 
+* `config.action_view.image_decoding` specifies a default value for the `decoding` attribute of `<img>` tags rendered by the `image_tag` helper. Defaults to `nil`.
+
 * `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
 ### Configuring Action Mailbox

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2362,6 +2362,23 @@ module ApplicationTests
       assert_equal "lazy", ActionView::Helpers::AssetTagHelper.image_loading
     end
 
+    test "ActionView::Helpers::AssetTagHelper.image_decoding is nil by default" do
+      app "development"
+      assert_nil ActionView::Helpers::AssetTagHelper.image_decoding
+    end
+
+    test "ActionView::Helpers::AssetTagHelper.image_decoding can be configured via config.action_view.image_decoding" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_view.image_decoding = "async"
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal "async", ActionView::Helpers::AssetTagHelper.image_decoding
+    end
+
     test "raises when unknown configuration option is set for ActiveJob" do
       add_to_config <<-RUBY
         config.active_job.unknown = "test"


### PR DESCRIPTION
This adds `Rails.application.config.action_view.image_decoding` to configure the default value of the `image_tag` `:decoding` option.

---

/cc @kaspth Since you expressed interest in this.