### PR TITLE
Add link to GlobalID repo in active_job_basics.md [ci-skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -386,7 +386,7 @@ ActiveJob supports the following types of arguments by default:
 
 ### GlobalID
 
-Active Job supports GlobalID for parameters. This makes it possible to pass live
+Active Job supports [GlobalID](https://github.com/rails/globalid/blob/master/README.md) for parameters. This makes it possible to pass live
 Active Record objects to your job instead of class/id pairs, which you then have
 to manually deserialize. Before, jobs would look like this:
 


### PR DESCRIPTION
### Summary

Added a link to the GlobalID gem repo in the ActiveJob basics guide.

### Other Information

While reading the ActiveJob Basics guide for the first time, I wasn't sure if GlobalID was a Rails concept or something else. Linking to the gem repo would provide context for that and other questions.
