### PR TITLE
Fix `composed_of` with symbol mapping

### DIFF
--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -244,8 +244,8 @@ module ActiveRecord
         private
           def reader_method(name, class_name, mapping, allow_nil, constructor)
             define_method(name) do
-              if @aggregation_cache[name].nil? && (!allow_nil || mapping.any? { |key, _| !_read_attribute(key).nil? })
-                attrs = mapping.collect { |key, _| _read_attribute(key) }
+              if @aggregation_cache[name].nil? && (!allow_nil || mapping.any? { |key, _| !read_attribute(key).nil? })
+                attrs = mapping.collect { |key, _| read_attribute(key) }
                 object = constructor.respond_to?(:call) ?
                   constructor.call(*attrs) :
                   class_name.constantize.send(constructor, *attrs)
@@ -271,10 +271,10 @@ module ActiveRecord
               end
 
               if part.nil? && allow_nil
-                mapping.each { |key, _| self[key] = nil }
+                mapping.each { |key, _| write_attribute(key, nil) }
                 @aggregation_cache[name] = nil
               else
-                mapping.each { |key, value| self[key] = part.send(value) }
+                mapping.each { |key, value| write_attribute(key, part.send(value)) }
                 @aggregation_cache[name] = part.freeze
               end
             end

--- a/activerecord/test/models/customer.rb
+++ b/activerecord/test/models/customer.rb
@@ -4,7 +4,7 @@ class Customer < ActiveRecord::Base
   cattr_accessor :gps_conversion_was_run
 
   composed_of :address, mapping: [ %w(address_street street), %w(address_city city), %w(address_country country) ], allow_nil: true
-  composed_of :balance, class_name: "Money", mapping: %w(balance amount)
+  composed_of :balance, class_name: "Money", mapping: %i(balance amount)
   composed_of :gps_location, allow_nil: true
   composed_of :non_blank_gps_location, class_name: "GpsLocation", allow_nil: true, mapping: %w(gps_location gps_location),
               converter: lambda { |gps| self.gps_conversion_was_run = true; gps.blank? ? nil : GpsLocation.new(gps) }


### PR DESCRIPTION
Use `{read,write}_attribute` public API in `composed_of` because
`_read_attribute` internal API should be passed argument as a string
since 7834363bbfdb68d734143063932ccc5a8814c97f.

Fixes #40843.
