### PR TITLE
Small doc formatting fixes [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -182,7 +182,7 @@ module ActionController
     #
     # You can also pass an object that responds to +maximum+, such as a
     # collection of active records. In this case +last_modified+ will be set by
-    # calling +maximum(:updated_at)+ on the collection (the timestamp of the
+    # calling <tt>maximum(:updated_at)</tt> on the collection (the timestamp of the
     # most recently updated record) and the +etag+ by passing the object itself.
     #
     #   def index

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -69,9 +69,8 @@ module ActiveRecord
         #
         # * +attr_name+ - The field name that should be serialized.
         # * +class_name_or_coder+ - Optional, may be be +Array+ or +Hash+ or
-        #                           +JSON+ or a custom coder class or module
-        #                           which responds to +.load+ and
-        #                           +.dump+. See table above.
+        #   +JSON+ or a custom coder class or module which responds to +.load+
+        #   and +.dump+. See table above.
         #
         # ==== Options
         #

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -50,9 +50,9 @@ module ActiveRecord
         #
         # ==== Custom coders
         # A custom coder class or module may be given. This must have +self.load+
-        # and +self.dump+ class/module methods. +self.dump(object)+ will be called
+        # and +self.dump+ class/module methods. <tt>self.dump(object)</tt> will be called
         # to serialize an object and should return the serialized value to be
-        # stored in the database (+nil+ to store as +NULL+). +self.load(string)+
+        # stored in the database (+nil+ to store as +NULL+). <tt>self.load(string)</tt>
         # will be called to reverse the process and load (unserialize) from the
         # database.
         #

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -84,7 +84,7 @@ class ERB
     # use inside HTML attributes.
     #
     # If your JSON is being used downstream for insertion into the DOM, be aware of
-    # whether or not it is being inserted via +html()+. Most jQuery plugins do this.
+    # whether or not it is being inserted via <tt>html()</tt>. Most jQuery plugins do this.
     # If that is the case, be sure to +html_escape+ or +sanitize+ any user-generated
     # content returned by your JSON.
     #


### PR DESCRIPTION
Docs only:

* The `+` is insufficient for the parens inside — needs the full `<tt>` treatment.
* Indenting this far in the plaintext makes these lines [incorrectly render as a code block](https://user-images.githubusercontent.com/308724/102240173-8ec9c780-3ec5-11eb-954e-5de67a85d883.png).
