### PR TITLE
require "time" where we depend on Time#xmlschema

### DIFF
--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).each do |path|
+Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).sort.each do |path|
   require path
 end

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "time"
 require "active_support/inflector/methods"
 require "active_support/values/time_zone"
 


### PR DESCRIPTION
The docs for Time#xmlschema note "You must require 'time' to use this
method." -- see
https://ruby-doc.org/stdlib-2.7.2/libdoc/time/rdoc/Time.html#method-i-xmlschema

Apparently in most cases, by the time `core_ext/time/conversions.rb` is
loaded, "time" has already been required, however that is not a
guarantee. If it isn't, you'll get a "NameError (undefined method
`xmlschema' for class `Time')". A simple repro is to launch `irb` and
do:

    > require 'active_support'
    > require 'active_support/core_ext/date_time'

This can even happen on some systems with just a:

    > require 'active_support'
    > require 'active_support/core_ext'

That is because `active_support/core_ext.rb` uses `Dir.glob` to
enumerate and then require all ruby files in the `core_ext` directory,
but "the order in which the results are returned [from Dir.glob]
depends on your system" -- see
https://ruby-doc.org/core-2.7.2/Dir.html#method-c-glob

Therefore this commit also sorts those results to make the load order
deterministic and system-agnostic.
