### PR TITLE
Allow delegated_type to be specified primary_key and foreign_key

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow delegated_type to be specified primary_key and foreign_key.
+
+    Since delegated_type assumes that the foreign_key ends with `_id`,
+    `singular_id` defined by it does not work when the foreign_key does
+    not end with `id`. This change fixes it by taking into account
+    `primary_key` and `foreign_key` in the options.
+
+    *Ryota Egusa*
+
 *   Restore possibility of passing `false` to :polymorphic option of `belongs_to`.
 
     Previously, passing `false` would trigger the option validation logic

--- a/activerecord/test/models/uuid_comment.rb
+++ b/activerecord/test/models/uuid_comment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UuidComment < ActiveRecord::Base
+  has_one :uuid_entry, as: :entryable
+end

--- a/activerecord/test/models/uuid_entry.rb
+++ b/activerecord/test/models/uuid_entry.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UuidEntry < ActiveRecord::Base
+  delegated_type :entryable, types: %w[ UuidMessage UuidComment ], primary_key: :uuid, foreign_key: :entryable_uuid
+end

--- a/activerecord/test/models/uuid_message.rb
+++ b/activerecord/test/models/uuid_message.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UuidMessage < ActiveRecord::Base
+  has_one :uuid_entry, as: :entryable
+end

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -104,9 +104,25 @@ _SQL
     t.decimal :decimal_array_default, array: true, default: [1.23, 3.45]
   end
 
+  create_table :uuid_comments, force: true, id: false do |t|
+    t.uuid :uuid, primary_key: true, **uuid_default
+    t.string :content
+  end
+
+  create_table :uuid_entries, force: true, id: false do |t|
+    t.uuid :uuid, primary_key: true, **uuid_default
+    t.string :entryable_type, null: false
+    t.uuid :entryable_uuid, null: false
+  end
+
   create_table :uuid_items, force: true, id: false do |t|
     t.uuid :uuid, primary_key: true, **uuid_default
     t.string :title
+  end
+
+  create_table :uuid_messages, force: true, id: false do |t|
+    t.uuid :uuid, primary_key: true, **uuid_default
+    t.string :subject
   end
 
   if supports_partitioned_indexes?


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Since delegated_type assumes that the foreign_key ends with `_id`, `singular_id` defined by it does not work when the foreign_key does not end with `id`.
This PR fixes it by taking into account `primary_key` and `foreign_key` in the options.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
