### PR TITLE
Fix `SELECT COUNT` queries when rendering ActiveRecord collections

### DIFF
--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -47,6 +47,10 @@ module ActionView
       def size
         @collection.size
       end
+
+      def length
+        @collection.respond_to?(:length) ? @collection.length : size
+      end
     end
 
     class SameCollectionIterator < CollectionIterator # :nodoc:
@@ -144,7 +148,7 @@ module ActionView
           "render_collection.action_view",
           identifier: identifier,
           layout: layout && layout.virtual_path,
-          count: collection.to_a.size
+          count: collection.length
         ) do |payload|
           spacer = if @options.key?(:spacer_template)
             spacer_template = find_template(@options[:spacer_template], @locals.keys)

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -144,7 +144,7 @@ module ActionView
           "render_collection.action_view",
           identifier: identifier,
           layout: layout && layout.virtual_path,
-          count: collection.size
+          count: collection.to_a.size
         ) do |payload|
           spacer = if @options.key?(:spacer_template)
             spacer_template = find_template(@options[:spacer_template], @locals.keys)

--- a/actionview/test/activerecord/partial_rendering_query_test.rb
+++ b/actionview/test/activerecord/partial_rendering_query_test.rb
@@ -10,9 +10,13 @@ class PartialRenderingQueryTest < ActiveRecordTestCase
 
     @queries = []
 
-    ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+    @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
       @queries << payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(payload[:name])
     end
+  end
+
+  def teardown
+    ActiveSupport::Notifications.unsubscribe(@subscriber)
   end
 
   def test_render_with_relation_collection

--- a/actionview/test/activerecord/partial_rendering_query_test.rb
+++ b/actionview/test/activerecord/partial_rendering_query_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_record_unit"
+
+class PartialRenderingQueryTest < ActiveRecordTestCase
+  def setup
+    @view = ActionView::Base
+      .with_empty_template_cache
+      .with_view_paths(ActionController::Base.view_paths, {})
+
+    @queries = []
+
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      @queries << payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(payload[:name])
+    end
+  end
+
+  def test_render_with_relation_collection
+    @view.render partial: "topics/topic", collection: Topic.all
+
+    assert_equal 1, @queries.size
+    assert_equal 'SELECT "topics".* FROM "topics"', @queries[0]
+  end
+end


### PR DESCRIPTION
Fixes #40837

When rendering collections, calling `size` when the collection is an
ActiveRecord relation causes unwanted `SELECT COUNT(*)` queries. This
change ensures the collection is loaded before getting the size.