### PR TITLE
Simple Action Cable Thundering Herd Protection

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Action Cable has been updated to include protections against thundering herd of reconenctions:
+
+    * On connection loss the inital interval is a random number of seconds between the min and max poll internal. 
+    * Successive reconnections will use the logrythmic backoff. 
+
+    *John Williams*
 
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Action Cable has been updated to include protections against thundering herd of reconenctions:
 
-    * On connection loss the inital interval is a random number of seconds between the min and max poll internal. 
-    * Successive reconnections will use the logrythmic backoff. 
+    * On connection loss the inital interval is a random number of seconds between the min and max poll interval. 
+    * Successive reconnections will use the logarithmic backoff. 
 
     *John Williams*
 

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -110,7 +110,13 @@
     ConnectionMonitor.prototype.getPollInterval = function getPollInterval() {
       var _constructor$pollInte = this.constructor.pollInterval, min = _constructor$pollInte.min, max = _constructor$pollInte.max, multiplier = _constructor$pollInte.multiplier;
       var interval = multiplier * Math.log(this.reconnectAttempts + 1);
-      return Math.round(clamp(interval, min, max) * 1e3);
+      var seconds = void 0;
+      if (this.reconnectAttempts === 0) {
+        seconds = Math.random() * (max - min) + min;
+      } else {
+        seconds = clamp(interval, min, max);
+      }
+      return Math.round(seconds * 1e3);
     };
     ConnectionMonitor.prototype.reconnectIfStale = function reconnectIfStale() {
       if (this.connectionIsStale()) {

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -77,7 +77,14 @@ class ConnectionMonitor {
   getPollInterval() {
     const {min, max, multiplier} = this.constructor.pollInterval
     const interval = multiplier * Math.log(this.reconnectAttempts + 1)
-    return Math.round(clamp(interval, min, max) * 1000)
+    let seconds
+    
+    if (this.reconnectAttempts === 0){
+      seconds = Math.random() * (max - min) + min
+    } else {
+      seconds = clamp(interval, min, max)
+    }
+    return Math.round(seconds * 1000)
   }
 
   reconnectIfStale() {


### PR DESCRIPTION
This PR adds protections against a thundering herd of reconnections. 
* On connection loss the initial interval is a random number of seconds between the min and max poll interval.
* Successive reconnections will use the logarithmic backoff.
* These two combined should evenly spread reconnections if the cable server is down for any extended period of time.

I thought I would submit this PR to offer a different approach to the one that @jonathanhefner took in https://github.com/rails/rails/pull/40229. We had no issues with the logarithmic backoff so I saw no reason to change it to exponential. I also saw the need to increase the hold down for the initial reconnection on apps that have high numbers of connections.