### PR TITLE
Add a note to the docs about existing apps for ActiveStorage public access

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -291,6 +291,8 @@ public_gcs:
 
 Make sure your buckets are properly configured for public access. See docs on how to enable public read permissions for [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/block-public-access-bucket.html), [Google Cloud Storage](https://cloud.google.com/storage/docs/access-control/making-data-public#buckets), and [Microsoft Azure](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources#set-container-public-access-level-in-the-azure-portal) storage services.
 
+When converting an existing application to use `public: true`, make sure to update every individual file in the bucket to be publicly-readable before switching over.
+
 Attaching Files to Records
 --------------------------
 


### PR DESCRIPTION
### Summary

Every existing file needs to be individually updated to have a publicly-readable ACL (at least, this is true of S3 and DigitalOcean Spaces), otherwise the files will fail to load.

This bit me when I was trying to introduce `public: true` in my production Rails app.

I realize the docs already mention consulting the cloud service docs to ensure that your bucket is "properly configured for public access", but that's rather vague and I didn't really understand the potential issues with individual files' public read permissions from the S3 docs.

Just trying to prevent someone else from having the same problem I did :)