### PR TITLE
allow passing false to :polymorphic option of belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Restore possibility of passing `false` to :polymorphic option of `belongs_to`.
+
+    Previously, passing `false` would trigger the option validation logic
+    to throw an error saying :polymorphic would not be a valid option.
+
+    *glaszig*
+
 *   Remove deprecated `database` kwarg from `connected_to`.
 
     *Eileen M. Uchitelle*, *John Crepezzi*

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -7,8 +7,8 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:counter_cache, :optional, :default]
-      valid += [:polymorphic, :foreign_type] if options[:polymorphic]
+      valid = super + [:polymorphic, :counter_cache, :optional, :default]
+      valid += [:foreign_type] if options[:polymorphic]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
       valid
     end

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1354,6 +1354,15 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal toy, sponsor.reload.sponsorable
   end
 
+  def test_polymorphic_with_false
+    assert_nothing_raised do
+      Class.new(ActiveRecord::Base) do
+        def self.name; "Post"; end
+        belongs_to :category, polymorphic: false
+      end
+    end
+  end
+
   test "stale tracking doesn't care about the type" do
     apple = Firm.create("name" => "Apple")
     citibank = Account.create("credit_limit" => 10)


### PR DESCRIPTION
### Summary

AR 6.1 will raise the following error because a condition would disregard the option `:polymorphic` entirely if false was passed.

```
ArgumentError: Unknown key: :polymorphic. Valid keys are:
:class_name, :anonymous_class, :primary_key, :foreign_key,
:dependent, :validate, :inverse_of, :strict_loading, :autosave,
:required, :touch, :counter_cache, :optional, :default
```


### Other Information

i stumbled upon this using the awesome_nested_set gem.
it has options to configure polymorphism and always passes this option (with the default of `false`).

possibly related to #40830.

i added a test case. it's kind of weird though. please advise.