### PR TITLE
Don't skip money's type cast for pluck and calculations

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -57,7 +57,7 @@ module ActiveRecord
               ftype = result.ftype i
               fmod  = result.fmod i
               case type = get_oid_type(ftype, fmod, fname)
-              when Type::Integer, Type::Float, Type::Decimal, Type::String, Type::DateTime, Type::Boolean
+              when Type::Integer, Type::Float, OID::Decimal, Type::String, Type::DateTime, Type::Boolean
                 # skip if a column has already been type casted by pg decoders
               else types[fname] = type
               end

--- a/activerecord/test/cases/adapters/postgresql/money_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/money_test.rb
@@ -64,6 +64,18 @@ class PostgresqlMoneyTest < ActiveRecord::PostgreSQLTestCase
     assert_equal(-2.25, type.cast(+"(2.25)"))
   end
 
+  def test_sum_with_type_cast
+    @connection.execute("INSERT INTO postgresql_moneys (id, wealth) VALUES (1, '123.45'::money)")
+
+    assert_equal BigDecimal("123.45"), PostgresqlMoney.sum("id * wealth")
+  end
+
+  def test_pluck_with_type_cast
+    @connection.execute("INSERT INTO postgresql_moneys (id, wealth) VALUES (1, '123.45'::money)")
+
+    assert_equal [BigDecimal("123.45")], PostgresqlMoney.pluck(Arel.sql("id * wealth"))
+  end
+
   def test_schema_dumping
     output = dump_table_schema("postgresql_moneys")
     assert_match %r{t\.money\s+"wealth",\s+scale: 2$}, output


### PR DESCRIPTION
Returning `OID::Money` column type is accidentally skipped in a query
result due to the type is a subclass of `Type::Decimal`.

Fixes #40860.
