### PR TITLE
Load most recent version of Bundler in bin/spring

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
@@ -1,5 +1,6 @@
 if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
   # Load Spring without loading other gems in the Gemfile, for speed.
+  gem "bundler"
   require "bundler"
   Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path


### PR DESCRIPTION
Because Bundler is a default gem, `require "bundler"` by itself will load the default version of the gem, instead of the most recent version.  This can cause Rails commands to produce warnings like the following:

> Warning: the running version of Bundler (2.1.4) is older than the version that created the lockfile (2.2.2). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.2`.

Adding `gem "bundler"` allows the most recent version of the gem to be loaded.
