### PR TITLE
Add `config.action_view.preload_links_header` option

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `config.action_view.preload_links_header` to allow disabling of
+    the `Link` header being added by default when using `stylesheet_link_tag`
+    and `javascript_include_tag`.
+    
+    *Andrew White*
+
 *   The `translate` helper now resolves `default` values when a `nil` key is
     specified, instead of always returning `nil`.
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -23,6 +23,7 @@ module ActionView
 
       mattr_accessor :image_loading
       mattr_accessor :image_decoding
+      mattr_accessor :preload_links_header
 
       # Returns an HTML script tag for each of the +sources+ provided.
       #
@@ -95,7 +96,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
-          unless options["defer"]
+          if preload_links_header && !options["defer"]
             preload_link = "<#{href}>; rel=preload; as=script"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
@@ -112,7 +113,9 @@ module ActionView
           content_tag("script", "", tag_options)
         }.join("\n").html_safe
 
-        send_preload_links_header(preload_links)
+        if preload_links_header
+          send_preload_links_header(preload_links)
+        end
 
         sources_tags
       end
@@ -156,11 +159,13 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
-          preload_link = "<#{href}>; rel=preload; as=style"
-          preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
-          preload_link += "; integrity=#{integrity}" unless integrity.nil?
-          preload_link += "; nopush" if nopush
-          preload_links << preload_link
+          if preload_links_header
+            preload_link = "<#{href}>; rel=preload; as=style"
+            preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
+            preload_link += "; integrity=#{integrity}" unless integrity.nil?
+            preload_link += "; nopush" if nopush
+            preload_links << preload_link
+          end
           tag_options = {
             "rel" => "stylesheet",
             "media" => "screen",
@@ -170,7 +175,9 @@ module ActionView
           tag(:link, tag_options)
         }.join("\n").html_safe
 
-        send_preload_links_header(preload_links)
+        if preload_links_header
+          send_preload_links_header(preload_links)
+        end
 
         sources_tags
       end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -42,6 +42,7 @@ module ActionView
     config.after_initialize do |app|
       ActionView::Helpers::AssetTagHelper.image_loading = app.config.action_view.delete(:image_loading)
       ActionView::Helpers::AssetTagHelper.image_decoding = app.config.action_view.delete(:image_decoding)
+      ActionView::Helpers::AssetTagHelper.preload_links_header = app.config.action_view.delete(:preload_links_header)
     end
 
     config.after_initialize do |app|

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -511,36 +511,54 @@ class AssetTagHelperTest < ActionView::TestCase
   end
 
   def test_should_set_preload_links
-    stylesheet_link_tag("http://example.com/style.css")
-    javascript_include_tag("http://example.com/all.js")
-    expected = "<http://example.com/style.css>; rel=preload; as=style; nopush,<http://example.com/all.js>; rel=preload; as=script; nopush"
-    assert_equal expected, @response.headers["Link"]
+    with_preload_links_header do
+      stylesheet_link_tag("http://example.com/style.css")
+      javascript_include_tag("http://example.com/all.js")
+      expected = "<http://example.com/style.css>; rel=preload; as=style; nopush,<http://example.com/all.js>; rel=preload; as=script; nopush"
+      assert_equal expected, @response.headers["Link"]
+    end
   end
 
   def test_should_not_preload_links_with_defer
-    javascript_include_tag("http://example.com/all.js", defer: true)
-    assert_equal "", @response.headers["Link"]
+    with_preload_links_header do
+      javascript_include_tag("http://example.com/all.js", defer: true)
+      assert_equal "", @response.headers["Link"]
+    end
   end
 
   def test_should_allow_caller_to_remove_nopush
-    stylesheet_link_tag("http://example.com/style.css", nopush: false)
-    javascript_include_tag("http://example.com/all.js", nopush: false)
-    expected = "<http://example.com/style.css>; rel=preload; as=style,<http://example.com/all.js>; rel=preload; as=script"
-    assert_equal expected, @response.headers["Link"]
+    with_preload_links_header do
+      stylesheet_link_tag("http://example.com/style.css", nopush: false)
+      javascript_include_tag("http://example.com/all.js", nopush: false)
+      expected = "<http://example.com/style.css>; rel=preload; as=style,<http://example.com/all.js>; rel=preload; as=script"
+      assert_equal expected, @response.headers["Link"]
+    end
   end
 
   def test_should_set_preload_links_with_cross_origin
-    stylesheet_link_tag("http://example.com/style.css", crossorigin: "use-credentials")
-    javascript_include_tag("http://example.com/all.js", crossorigin: true)
-    expected = "<http://example.com/style.css>; rel=preload; as=style; crossorigin=use-credentials; nopush,<http://example.com/all.js>; rel=preload; as=script; crossorigin=anonymous; nopush"
-    assert_equal expected, @response.headers["Link"]
+    with_preload_links_header do
+      stylesheet_link_tag("http://example.com/style.css", crossorigin: "use-credentials")
+      javascript_include_tag("http://example.com/all.js", crossorigin: true)
+      expected = "<http://example.com/style.css>; rel=preload; as=style; crossorigin=use-credentials; nopush,<http://example.com/all.js>; rel=preload; as=script; crossorigin=anonymous; nopush"
+      assert_equal expected, @response.headers["Link"]
+    end
   end
 
   def test_should_set_preload_links_with_integrity_hashes
-    stylesheet_link_tag("http://example.com/style.css", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
-    javascript_include_tag("http://example.com/all.js", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
-    expected = "<http://example.com/style.css>; rel=preload; as=style; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush,<http://example.com/all.js>; rel=preload; as=script; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush"
-    assert_equal expected, @response.headers["Link"]
+    with_preload_links_header do
+      stylesheet_link_tag("http://example.com/style.css", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
+      javascript_include_tag("http://example.com/all.js", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
+      expected = "<http://example.com/style.css>; rel=preload; as=style; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush,<http://example.com/all.js>; rel=preload; as=script; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush"
+      assert_equal expected, @response.headers["Link"]
+    end
+  end
+
+  def test_should_not_preload_links_when_disabled
+    with_preload_links_header(false) do
+      stylesheet_link_tag("http://example.com/style.css")
+      javascript_include_tag("http://example.com/all.js")
+      assert_nil @response.headers["Link"]
+    end
   end
 
   def test_image_path
@@ -725,6 +743,16 @@ class AssetTagHelperTest < ActionView::TestCase
       assert_equal "http://localhost/images/xml.png", image_path("xml.png")
     end
   end
+
+  private
+    def with_preload_links_header(new_preload_links_header = true)
+      original_preload_links_header = ActionView::Helpers::AssetTagHelper.preload_links_header
+      ActionView::Helpers::AssetTagHelper.preload_links_header = new_preload_links_header
+
+      yield
+    ensure
+      ActionView::Helpers::AssetTagHelper.preload_links_header = original_preload_links_header
+    end
 end
 
 class AssetTagHelperNonVhostTest < ActionView::TestCase

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -176,6 +176,8 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 *   Make `locals` argument required on `ActionView::Template#initialize`.
 
+*   The `javascript_include_tag` and `stylesheet_link_tag` asset helpers generate a `Link` header that gives hints to modern browsers about preloading assets. This can be disabled by setting `config.action_view.preload_links_header` to `false`.
+
 Action Mailer
 -------------
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -715,6 +715,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
+* `config.action_view.preload_links_header` determines whether `javascript_include_tag` and `stylesheet_link_tag` will generate a `Link` header that preload assets. This defaults to `true`.
+
 ### Configuring Action Mailbox
 
 `config.action_mailbox` provides the following configuration options:

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -183,6 +183,7 @@ module Rails
 
           if respond_to?(:action_view)
             action_view.form_with_generates_remote_forms = false
+            action_view.preload_links_header = true
           end
 
           if respond_to?(:active_storage)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2379,6 +2379,119 @@ module ApplicationTests
       assert_equal "async", ActionView::Helpers::AssetTagHelper.image_decoding
     end
 
+    test "ActionView::Helpers::AssetTagHelper.preload_links_header is true by default" do
+      app "development"
+      assert_equal true, ActionView::Helpers::AssetTagHelper.preload_links_header
+    end
+
+    test "ActionView::Helpers::AssetTagHelper.preload_links_header can be configured via config.action_view.preload_links_header" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_view.preload_links_header = false
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActionView::Helpers::AssetTagHelper.preload_links_header
+    end
+
+    test "stylesheet_link_tag sets the Link header by default" do
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+      class PagesController < ApplicationController
+        def index
+          render inline: "<%= stylesheet_link_tag '/application.css' %>"
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          root to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/"
+      assert_match %r[<link rel="stylesheet" media="screen" href="/application.css" />], last_response.body
+      assert_equal "</application.css>; rel=preload; as=style; nopush", last_response.headers["Link"]
+    end
+
+    test "stylesheet_link_tag doesn't set the Link header when disabled" do
+      app_file "config/initializers/action_view.rb", <<-RUBY
+        Rails.application.config.action_view.preload_links_header = false
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+      class PagesController < ApplicationController
+        def index
+          render inline: "<%= stylesheet_link_tag '/application.css' %>"
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          root to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/"
+      assert_match %r[<link rel="stylesheet" media="screen" href="/application.css" />], last_response.body
+      assert_nil last_response.headers["Link"]
+    end
+
+    test "javascript_include_tag sets the Link header by default" do
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+      class PagesController < ApplicationController
+        def index
+          render inline: "<%= javascript_include_tag '/application.js' %>"
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          root to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/"
+      assert_match %r[<script src="/application.js"></script>], last_response.body
+      assert_equal "</application.js>; rel=preload; as=script; nopush", last_response.headers["Link"]
+    end
+
+    test "javascript_include_tag doesn't set the Link header when disabled" do
+      app_file "config/initializers/action_view.rb", <<-RUBY
+        Rails.application.config.action_view.preload_links_header = false
+      RUBY
+
+      app_file "app/controllers/pages_controller.rb", <<-RUBY
+      class PagesController < ApplicationController
+        def index
+          render inline: "<%= javascript_include_tag '/application.js' %>"
+        end
+      end
+      RUBY
+
+      add_to_config <<-RUBY
+        routes.prepend do
+          root to: "pages#index"
+        end
+      RUBY
+
+      app "development"
+
+      get "/"
+      assert_match %r[<script src="/application.js"></script>], last_response.body
+      assert_nil last_response.headers["Link"]
+    end
+
     test "ActiveJob::Base.retry_jitter is 0.15 by default for new apps" do
       app "development"
 


### PR DESCRIPTION
PR #39939 added support for the `Link` header being generated automatically when using `stylesheet_link_tag` and
`javascript_include_tag`. However not everything should be preloaded, e.g. a link to a legacy IE stylesheet has no need to be preloaded because IE doesn't support the header and in some browsers it will trigger the preload even though it's not used since it's inside an IE conditional comment. This leads to increased bandwith costs and slower application performance.

To allow more flexibility for sites that may have complex needs for the `Link` header this commit adds a configuration option that disables it completely and leaves it up to the application to decide how to handle generating a `Link` header.

NOTE: The intention is to backport this to 6-1-stable and add a new entry to `new_framework_defaults_6_1.rb` so that upgrading applications can opt into the default option of it being enabled since they're the most likely to be affected by the legacy IE issue.