### PR TITLE
Fix RDoc code formatting for Railtie [ci skip]

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -120,11 +120,11 @@ module Rails
   # this less confusing for everyone.
   # It can be used like this:
   #
-  # class MyRailtie < Rails::Railtie
-  #   server do
-  #     WebpackServer.start
+  #   class MyRailtie < Rails::Railtie
+  #     server do
+  #       WebpackServer.start
+  #     end
   #   end
-  # end
   #
   # == Application and Engine
   #


### PR DESCRIPTION
### Summary

Fixes an indention issue which results in ill-formatted RDoc code rendering on https://api.rubyonrails.org/classes/Rails/Railtie.html.

#### Before
<img width="439" alt="Screen Shot 2020-12-19 at 2 19 51 PM" src="https://user-images.githubusercontent.com/574871/102697628-44b64e00-4205-11eb-82dd-43de5c66d6cb.png">

#### After
<img width="439" alt="Screen Shot 2020-12-19 at 2 20 45 PM" src="https://user-images.githubusercontent.com/574871/102697647-64e60d00-4205-11eb-8d60-309e029ec5e4.png">
