### PR TITLE
Specify default locale for the root HTML tag

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= locale %>">
   <head>
     <title><%= camelized %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
HTML spec recommends specifying it and emits a warning if it's not present.