### PR TITLE
Fix exact and fuzzy search match highlighting in dark mode

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -55,6 +55,12 @@
       background: #333;
     }
 
+    #route_table tbody.exact_matches tr,
+    #route_table tbody.fuzzy_matches tr {
+      background: none;
+      border-bottom: none;
+    }
+
     #route_table tbody.exact_matches,
     #route_table tbody.fuzzy_matches {
       color: #333;

--- a/railties/lib/rails/templates/layouts/application.html.erb
+++ b/railties/lib/rails/templates/layouts/application.html.erb
@@ -4,7 +4,14 @@
   <meta charset="utf-8" />
   <title><%= @page_title %></title>
   <style>
-    body { background-color: #fff; color: #333; }
+    body {
+      background-color: #FAFAFA;
+      color: #333;
+      color-scheme: light dark;
+      supported-color-schemes: light dark;
+      margin: 0;
+      padding: 1.5em;
+    }
 
     body, p, ol, ul, td {
       font-family: helvetica, verdana, arial, sans-serif;
@@ -13,17 +20,23 @@
     }
 
     pre {
-      background-color: #eee;
-      padding: 10px;
       font-size: 11px;
       white-space: pre-wrap;
     }
 
-    a { color: #000; }
+    a { color: #980905; }
     a:visited { color: #666; }
-    a:hover { color: #fff; background-color:#000; }
+    a:hover { color: #C00; }
 
-    h2 { padding-left: 10px; }
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #222;
+        color: #ECECEC;
+      }
+
+      a { color: #C00; }
+      a:hover { color: #E9382B; }
+    }
 
     <%= yield :style %>
   </style>


### PR DESCRIPTION
### Summary

This PR improves legibility of the dark version of the Rescues and Routes Info pages regarding their fuzzy and exact search match highlighting, from this:

<img width="1552" alt="Screen Shot 2020-12-21 at 00 41 47" src="https://user-images.githubusercontent.com/3188392/102727391-ac63ba80-4325-11eb-8122-533e9c522604.png">

… to this.

<img width="1552" alt="Screen Shot 2020-12-21 at 00 38 46" src="https://user-images.githubusercontent.com/3188392/102727407-c1404e00-4325-11eb-96ea-471225bf25d4.png">

Which also is more consistent with the light theme:

<img width="1552" alt="Screen Shot 2020-12-21 at 00 42 01" src="https://user-images.githubusercontent.com/3188392/102727423-d87f3b80-4325-11eb-8c56-7f373eb6d493.png">

Same goes for the separate Info page about the Routes:

<img width="1552" alt="Screen Shot 2020-12-21 at 00 38 18" src="https://user-images.githubusercontent.com/3188392/102727465-12e8d880-4326-11eb-9567-413271c5fed6.png">

The CSS for the layout of the Info pages also is slightly changed to be more consistent with the Rescues layout.