### PR TITLE
Backport `config.action_view.preload_links_header` option

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `config.action_view.preload_links_header` to allow disabling of
+    the `Link` header being added by default when using `stylesheet_link_tag`
+    and `javascript_include_tag`.
+    
+    *Andrew White*
+
 *   The `translate` helper now resolves `default` values when a `nil` key is
     specified, instead of always returning `nil`.
 

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -23,6 +23,8 @@ module ActionView
       include AssetUrlHelper
       include TagHelper
 
+      mattr_accessor :preload_links_header
+
       # Returns an HTML script tag for each of the +sources+ provided.
       #
       # Sources may be paths to JavaScript files. Relative paths are assumed to be relative
@@ -94,7 +96,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
-          unless options["defer"]
+          if preload_links_header && !options["defer"]
             preload_link = "<#{href}>; rel=preload; as=script"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
@@ -111,7 +113,9 @@ module ActionView
           content_tag("script", "", tag_options)
         }.join("\n").html_safe
 
-        send_preload_links_header(preload_links)
+        if preload_links_header
+          send_preload_links_header(preload_links)
+        end
 
         sources_tags
       end
@@ -155,11 +159,13 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
-          preload_link = "<#{href}>; rel=preload; as=style"
-          preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
-          preload_link += "; integrity=#{integrity}" unless integrity.nil?
-          preload_link += "; nopush" if nopush
-          preload_links << preload_link
+          if preload_links_header
+            preload_link = "<#{href}>; rel=preload; as=style"
+            preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
+            preload_link += "; integrity=#{integrity}" unless integrity.nil?
+            preload_link += "; nopush" if nopush
+            preload_links << preload_link
+          end
           tag_options = {
             "rel" => "stylesheet",
             "media" => "screen",
@@ -169,7 +175,9 @@ module ActionView
           tag(:link, tag_options)
         }.join("\n").html_safe
 
-        send_preload_links_header(preload_links)
+        if preload_links_header
+          send_preload_links_header(preload_links)
+        end
 
         sources_tags
       end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -38,6 +38,10 @@ module ActionView
     end
 
     config.after_initialize do |app|
+      ActionView::Helpers::AssetTagHelper.preload_links_header = app.config.action_view.delete(:preload_links_header)
+    end
+
+    config.after_initialize do |app|
       ActiveSupport.on_load(:action_view) do
         app.config.action_view.each do |k, v|
           if k == :raise_on_missing_translations

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -176,6 +176,8 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 *   Make `locals` argument required on `ActionView::Template#initialize`.
 
+*   The `javascript_include_tag` and `stylesheet_link_tag` asset helpers generate a `Link` header that gives hints to modern browsers about preloading assets. This can be disabled by setting `config.action_view.preload_links_header` to `false`.
+
 Action Mailer
 -------------
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -711,6 +711,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
+* `config.action_view.preload_links_header` determines whether `javascript_include_tag` and `stylesheet_link_tag` will generate a `Link` header that preload assets. This defaults to `true`.
+
 ### Configuring Action Mailbox
 
 `config.action_mailbox` provides the following configuration options:

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -183,6 +183,7 @@ module Rails
 
           if respond_to?(:action_view)
             action_view.form_with_generates_remote_forms = false
+            action_view.preload_links_header = true
           end
 
           if respond_to?(:active_storage)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -61,3 +61,7 @@
 
 # Set the default queue name for the mail deliver job to the queue adapter default.
 # Rails.application.config.action_mailer.deliver_later_queue_name = nil
+
+# Generate a `Link` header that gives a hint to modern browsers about
+# preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
+# Rails.application.config.action_view.preload_links_header = true


### PR DESCRIPTION
PR #39939 added support for the `Link` header being generated automatically when using `stylesheet_link_tag` and `javascript_include_tag`. However not everything should be preloaded, e.g. a link to a legacy IE stylesheet has no need to be preloaded because IE doesn't support the header and in some browsers it will trigger the preload even though it's not used since it's inside an IE conditional comment. This leads to increased bandwith costs and slower application performance.

To allow more flexibility for sites that may have complex needs for the `Link` header this commit adds a configuration option that disables it completely and leaves it up to the application to decide how to handle generating a `Link` header.

NOTE: This is a backport of #40882 with the config added to `new_framework_defaults_6_1.rb` plus additional tests to ensure that the header isn't set when an application is being upgraded.