### PR TITLE
Use image/jpeg instead of non-standard image/jpg

### DIFF
--- a/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/ingresses/mandrill/inbound_emails_controller_test.rb
@@ -19,7 +19,7 @@ class ActionMailbox::Ingresses::Mandrill::InboundEmailsControllerTest < ActionDi
   test "receiving an inbound email from Mandrill" do
     assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
       post rails_mandrill_inbound_emails_url,
-        headers: { "X-Mandrill-Signature" => "gldscd2tAb/G+DmpiLcwukkLrC4=" }, params: { mandrill_events: @events }
+        headers: { "X-Mandrill-Signature" => "1bNbyqkMFL4VYIT5+RQCrPs/mRY=" }, params: { mandrill_events: @events }
     end
 
     assert_response :ok

--- a/actionmailbox/test/fixtures/files/welcome.eml
+++ b/actionmailbox/test/fixtures/files/welcome.eml
@@ -27,7 +27,7 @@ Content-Type: multipart/related;
 Content-Transfer-Encoding: base64
 Content-Disposition: inline;
   filename=avatar1.jpeg
-Content-Type: image/jpg;
+Content-Type: image/jpeg;
   name="avatar1.jpeg"
 Content-Id: <7AAEB353-2341-4D46-A054-5CA5CB2363B7>
 
@@ -397,7 +397,7 @@ mk8VWW5WRGJGAOaAP//Z
 Content-Transfer-Encoding: base64
 Content-Disposition: inline;
   filename=avatar2.jpg
-Content-Type: image/jpg;
+Content-Type: image/jpeg;
   x-unix-mode=0700;
   name="avatar2.jpg"
 Content-Id: <4594E827-6E69-4329-8691-6BC35E3E73A0>

--- a/actionpack/lib/action_controller/metal/mime_responds.rb
+++ b/actionpack/lib/action_controller/metal/mime_responds.rb
@@ -103,7 +103,7 @@ module ActionController #:nodoc:
     # If you need to use a MIME type which isn't supported by default, you can register your own handlers in
     # +config/initializers/mime_types.rb+ as follows.
     #
-    #   Mime::Type.register "image/jpg", :jpg
+    #   Mime::Type.register "image/jpeg", :jpg
     #
     # +respond_to+ also allows you to specify a common block for different formats by using +any+:
     #

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1229,7 +1229,7 @@ class IntegrationFileUploadTest < ActionDispatch::IntegrationTest
   def test_fixture_file_upload
     post "/test_file_upload",
       params: {
-        file: fixture_file_upload("/ruby_on_rails.jpg", "image/jpg")
+        file: fixture_file_upload("/ruby_on_rails.jpg", "image/jpeg")
       }
     assert_equal "45142", @response.body
   end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -909,7 +909,7 @@ XML
   def test_fixture_file_upload_with_binary
     filename = "ruby_on_rails.jpg"
     path = "#{FILES_DIR}/#{filename}"
-    content_type = "image/jpg"
+    content_type = "image/jpeg"
 
     binary_file_upload = fixture_file_upload(path, content_type, :binary)
     assert_equal File.open(path, READ_BINARY).read, binary_file_upload.read
@@ -919,14 +919,14 @@ XML
   end
 
   def test_fixture_file_upload_should_be_able_access_to_tempfile
-    file = fixture_file_upload(FILES_DIR + "/ruby_on_rails.jpg", "image/jpg")
+    file = fixture_file_upload(FILES_DIR + "/ruby_on_rails.jpg", "image/jpeg")
     assert_respond_to file, :tempfile
   end
 
   def test_fixture_file_upload
     post :test_file_upload,
       params: {
-        file: fixture_file_upload(FILES_DIR + "/ruby_on_rails.jpg", "image/jpg")
+        file: fixture_file_upload(FILES_DIR + "/ruby_on_rails.jpg", "image/jpeg")
       }
     assert_equal "45142", @response.body
   end
@@ -935,7 +935,7 @@ XML
     TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
       TestCaseTest.stub :file_fixture_path, nil do
         assert_deprecated(/In Rails 7.0, the path needs to be relative to `file_fixture_path`/) do
-          fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpg")
+          fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpeg")
         end
       end
     end
@@ -944,7 +944,7 @@ XML
   def test_fixture_file_upload_does_not_output_deprecation_when_file_fixture_path_is_set
     TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
       assert_not_deprecated do
-        fixture_file_upload("ruby_on_rails.jpg", "image/jpg")
+        fixture_file_upload("ruby_on_rails.jpg", "image/jpeg")
       end
     end
   end
@@ -954,7 +954,7 @@ XML
       expected = "`fixture_file_upload(\"multipart/ruby_on_rails.jpg\")` to `fixture_file_upload(\"ruby_on_rails.jpg\")`"
 
       assert_deprecated(expected) do
-        uploaded_file = fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpg")
+        uploaded_file = fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpeg")
         assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
       end
     end
@@ -975,13 +975,13 @@ XML
 
   def test_fixture_file_upload_ignores_fixture_path_given_full_path
     TestCaseTest.stub :fixture_path, __dir__ do
-      uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpg")
+      uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpeg")
       assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
     end
   end
 
   def test_fixture_file_upload_ignores_nil_fixture_path
-    uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpg")
+    uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpeg")
     assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
   end
 
@@ -989,7 +989,7 @@ XML
     filename = "ruby_on_rails.jpg"
     path = "#{FILES_DIR}/#{filename}"
     post :test_file_upload, params: {
-      file: Rack::Test::UploadedFile.new(path, "image/jpg", true)
+      file: Rack::Test::UploadedFile.new(path, "image/jpeg", true)
     }
     assert_equal "45142", @response.body
   end

--- a/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/multipart_params_parsing_test.rb
@@ -157,7 +157,7 @@ class MultipartParamsParsingTest < ActionDispatch::IntegrationTest
   test "uploads and reads binary file" do
     with_test_routing do
       fixture = FIXTURE_PATH + "/ruby_on_rails.jpg"
-      params = { uploaded_data: fixture_file_upload(fixture, "image/jpg") }
+      params = { uploaded_data: fixture_file_upload(fixture, "image/jpeg") }
       post "/read", params: params
     end
   end

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -66,6 +66,6 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     end
 
     def attachable
-      @attachment ||= create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+      @attachment ||= create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     end
 end

--- a/actiontext/test/unit/content_test.rb
+++ b/actiontext/test/unit/content_test.rb
@@ -28,7 +28,7 @@ class ActionText::ContentTest < ActiveSupport::TestCase
   end
 
   test "extracts attachables" do
-    attachable = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    attachable = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{attachable.attachable_sgid}" caption="Captioned"></action-text-attachment>)
 
     content = content_from_html(html)
@@ -56,7 +56,7 @@ class ActionText::ContentTest < ActiveSupport::TestCase
   end
 
   test "identifies destroyed attachables as missing" do
-    attachable = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    attachable = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     html = %Q(<action-text-attachment sgid="#{attachable.attachable_sgid}"></action-text-attachment>)
     attachable.destroy!
     content = content_from_html(html)

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -32,14 +32,14 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   end
 
   test "embed extraction" do
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     message = Message.create!(subject: "Greetings", content: ActionText::Content.new("Hello world").append_attachables(blob))
     assert_equal "racecar.jpg", message.content.embeds.first.filename.to_s
   end
 
   test "embed extraction only extracts file attachments" do
     remote_image_html = '<action-text-attachment content-type="image" url="http://example.com/cat.jpg"></action-text-attachment>'
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     content = ActionText::Content.new(remote_image_html).append_attachables(blob)
     message = Message.create!(subject: "Greetings", content: content)
     assert_equal [ActionText::Attachables::RemoteImage, ActiveStorage::Blob], message.content.body.attachables.map(&:class)
@@ -47,7 +47,7 @@ class ActionText::ModelTest < ActiveSupport::TestCase
   end
 
   test "embed extraction deduplicates file attachments" do
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     content = ActionText::Content.new("Hello world").append_attachables([ blob, blob ])
 
     assert_nothing_raised do

--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -32,7 +32,7 @@ class User < ApplicationRecord
 end
 
 # Attach an avatar to the user.
-user.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
+user.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
 
 # Does the user have an avatar?
 user.avatar.attached? # => true

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -25,7 +25,7 @@ module ActiveStorage
     #
     #   document.images.attach(params[:images]) # Array of ActionDispatch::Http::UploadedFile objects
     #   document.images.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
-    #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpg")
+    #   document.images.attach(io: File.open("/path/to/racecar.jpg"), filename: "racecar.jpg", content_type: "image/jpeg")
     #   document.images.attach([ first_blob, second_blob ])
     def attach(*attachables)
       if record.persisted? && !record.changed?

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -25,7 +25,7 @@ module ActiveStorage
     #
     #   person.avatar.attach(params[:avatar]) # ActionDispatch::Http::UploadedFile object
     #   person.avatar.attach(params[:signed_blob_id]) # Signed reference to blob from direct upload
-    #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpg")
+    #   person.avatar.attach(io: File.open("/path/to/face.jpg"), filename: "face.jpg", content_type: "image/jpeg")
     #   person.avatar.attach(avatar_blob) # ActiveStorage::Blob object
     def attach(attachable)
       if record.persisted? && !record.changed?

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -5,12 +5,12 @@ require "database/setup"
 
 class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
   test "showing blob inline" do
-    blob = create_blob(filename: "hello.jpg", content_type: "image/jpg")
+    blob = create_blob(filename: "hello.jpg", content_type: "image/jpeg")
 
     get blob.url
     assert_response :ok
     assert_equal "inline; filename=\"hello.jpg\"; filename*=UTF-8''hello.jpg", response.headers["Content-Disposition"]
-    assert_equal "image/jpg", response.headers["Content-Type"]
+    assert_equal "image/jpeg", response.headers["Content-Type"]
     assert_equal "Hello world!", response.body
   end
 
@@ -46,11 +46,11 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
 
   test "showing public blob" do
     with_service("local_public") do
-      blob = create_blob(content_type: "image/jpg")
+      blob = create_blob(content_type: "image/jpeg")
 
       get blob.url
       assert_response :ok
-      assert_equal "image/jpg", response.headers["Content-Type"]
+      assert_equal "image/jpeg", response.headers["Content-Type"]
       assert_equal "Hello world!", response.body
     end
   end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -31,7 +31,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching new blobs from Hashes to an existing record" do
     @user.highlights.attach(
-      { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpg" },
+      { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpeg" },
       { io: StringIO.new("THINGS"), filename: "town.jpg", content_type: "image/jpeg" })
 
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
@@ -81,7 +81,7 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert @user.changed?
 
     @user.highlights.attach(
-      { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpg" },
+      { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpeg" },
       { io: StringIO.new("THINGS"), filename: "town.jpg", content_type: "image/jpeg" })
 
     assert_equal "funky.jpg", @user.highlights.first.filename.to_s
@@ -337,8 +337,8 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
   test "attaching new blobs from Hashes to a new record" do
     User.new(name: "Jason").tap do |user|
       user.highlights.attach(
-        { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpg" },
-        { io: StringIO.new("THINGS"), filename: "town.jpg", content_type: "image/jpg" })
+        { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpeg" },
+        { io: StringIO.new("THINGS"), filename: "town.jpg", content_type: "image/jpeg" })
 
       assert user.new_record?
       assert user.highlights.first.new_record?
@@ -600,8 +600,8 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "attaching a new blob from a Hash with a custom service" do
     with_service("mirror") do
-      @user.highlights.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
-      @user.vlogs.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
+      @user.highlights.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
+      @user.vlogs.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
 
       assert_instance_of ActiveStorage::Service::MirrorService, @user.highlights.first.service
       assert_instance_of ActiveStorage::Service::DiskService, @user.vlogs.first.service

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -38,12 +38,12 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   end
 
   test "attaching a new blob from a Hash to an existing record" do
-    @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
+    @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
     assert_equal "town.jpg", @user.avatar.filename.to_s
   end
 
   test "attaching a new blob from a Hash to an existing record passes record" do
-    hash = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" }
+    hash = { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" }
     blob = ActiveStorage::Blob.build_after_unfurling(**hash)
     arguments = [hash.merge(record: @user, service_name: nil)]
     assert_called_with(ActiveStorage::Blob, :build_after_unfurling, arguments, returns: blob) do
@@ -98,7 +98,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     @user.name = "Tina"
     assert @user.changed?
 
-    @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
+    @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
     assert_equal "town.jpg", @user.avatar.filename.to_s
     assert_not @user.avatar.persisted?
     assert @user.will_save_change_to_name?
@@ -320,7 +320,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
   end
 
   test "creating an attachment as part of an autosave association through nested attributes" do
-    group = Group.create!(users_attributes: [{ name: "John", avatar: { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg" } }])
+    group = Group.create!(users_attributes: [{ name: "John", avatar: { io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg" } }])
     group.save!
     new_user = User.find_by(name: "John")
     assert new_user.avatar.attached?
@@ -358,7 +358,7 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching a new blob from a Hash to a new record" do
     User.new(name: "Jason").tap do |user|
-      user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
+      user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
       assert user.new_record?
       assert user.avatar.attachment.new_record?
       assert user.avatar.blob.new_record?
@@ -582,8 +582,8 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
   test "attaching a new blob from a Hash with a custom service" do
     with_service("mirror") do
-      @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
-      @user.cover_photo.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpg"
+      @user.avatar.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
+      @user.cover_photo.attach io: StringIO.new("STUFF"), filename: "town.jpg", content_type: "image/jpeg"
 
       assert_instance_of ActiveStorage::Service::MirrorService, @user.avatar.service
       assert_instance_of ActiveStorage::Service::DiskService, @user.cover_photo.service

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -50,7 +50,7 @@ module ActiveStorage::Service::SharedServiceTests
         StringIO.new(data),
         checksum: Digest::MD5.base64digest(data),
         filename: "racecar.jpg",
-        content_type: "image/jpg"
+        content_type: "image/jpeg"
       )
 
       assert_equal data, @service.download(key)

--- a/guides/source/kindle/rails_guides.opf.erb
+++ b/guides/source/kindle/rails_guides.opf.erb
@@ -32,7 +32,7 @@
 
   <item id="toc" media-type="application/x-dtbncx+xml" href="toc.ncx" />
 
-  <item id="cover" media-type="image/jpg" href="images/rails_guides_kindle_cover.jpg"/>
+  <item id="cover" media-type="image/jpeg" href="images/rails_guides_kindle_cover.jpg"/>
 </manifest>
 
 <spine toc="toc">


### PR DESCRIPTION
### Summary

`image/jpg` is [not a valid content type](https://stackoverflow.com/questions/33692835/is-the-mime-type-image-jpg-the-same-as-image-jpeg). Using this in examples and default configuration will mislead developers into using this instead of the proper `image/jpeg`.