### PR TITLE
Added option  to specify cache expiration time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Added option `expires_in_at` to specify cache expiration time:
+
+        Rails.cache.fetch('cache_key', expires_in_at: '00:00') do
+           do somethink ...
+        end
+
+        or
+
+        Rails.cache.write('cache_key', expires_in_at: '00:00')
+
+
+    *Maxim Aleynikov*
+
 *   `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
 
     *Nathaniel Woodthorpe*

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -12,5 +12,22 @@ class CacheEntryTest < ActiveSupport::TestCase
     Time.stub(:now, Time.now + 61) do
       assert entry.expired?, "entry is expired"
     end
+    Time.stub(:now, Time.strptime("00:00", "%H:%M")) do
+      entry = ActiveSupport::Cache::Entry.new("value", expires_in_at: "00:05")
+      assert_not entry.expired?, "entry not expired"
+    end
+
+    entry = ActiveSupport::Cache::Entry.new("value", expires_in_at: "00:05")
+    Time.stub(:now, Time.strptime("00:06", "%H:%M") + 86_400) do
+      assert entry.expired?, "entry is expired"
+    end
+
+    assert_raises ArgumentError do
+      entry = ActiveSupport::Cache::Entry.new("value", expires_in_at: "00:05", expires_in: 60)
+    end
+
+    assert_raises ArgumentError do
+      entry = ActiveSupport::Cache::Entry.new("value", expires_in_at: "wrong format")
+    end
   end
 end


### PR DESCRIPTION
### Summary
Added option `expires_in_at` to specify cache expiration time:
```ruby
        Rails.cache.fetch('cache_key', expires_in_at: '00:00') do
           do somethink ...
        end
```
        or
```ruby
        Rails.cache.write('cache_key', expires_in_at: '00:00')
```

