### PR TITLE
Lock rails/webpacker npm package version to 5

### DIFF
--- a/railties/test/isolation/assets/package.json
+++ b/railties/test/isolation/assets/package.json
@@ -5,7 +5,7 @@
     "@rails/actioncable": "file:../../../../actioncable",
     "@rails/activestorage": "file:../../../../activestorage",
     "@rails/ujs": "file:../../../../actionview",
-    "@rails/webpacker": "https://github.com/rails/webpacker.git",
+    "@rails/webpacker": "^5.2.1",
     "turbolinks": "^5.2.0"
   }
 }


### PR DESCRIPTION
### Summary

This pull request locks `rails/webpacker` npm package version to 5.

railties CI failures are reported at https://buildkite.com/rails/rails/builds/73586 .

It looks like Rails unit test does not support `rails/webpacker` 6 yet.
because `rails/webpacker` 6.0.0-pre.1 has been released recently, which
triggers these errors.

https://www.npmjs.com/package/@rails/webpacker/v/6.0.0-pre.1

This pull request addresses these errors.

```ruby
$ cd railties
$ bin/test test/application/asset_debugging_test.rb -n test_assets_are_concatenated_when_debug_is_off_and_compile_is_off_either_if_debug_assets_param_is_provided
Run options: -n test_assets_are_concatenated_when_debug_is_off_and_compile_is_off_either_if_debug_assets_param_is_provided --seed 62457

E

Error:
ApplicationTests::AssetDebuggingTest#test_assets_are_concatenated_when_debug_is_off_and_compile_is_off_either_if_debug_assets_param_is_provided:
RuntimeError: rails command failed (1): bin/rails assets:precompile --trace 2>&1
... snip ...
Compilation failed:
[webpack-cli] TypeError: Cannot read property 'toWebpackConfig' of undefined
    at Object.<anonymous> (/home/yahonda/src/github.com/rails/rails/tmp/d20201222-730245-pstvl8/app/config/webpack/production.js:3:30)
    at Module._compile (/home/yahonda/src/github.com/rails/rails/railties/test/isolation/assets/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (/home/yahonda/src/github.com/rails/rails/railties/test/isolation/assets/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at requireConfig (/home/yahonda/src/github.com/rails/rails/railties/test/isolation/assets/node_modules/webpack-cli/lib/groups/resolveConfig.js:73:18)
    at /home/yahonda/src/github.com/rails/rails/railties/test/isolation/assets/node_modules/webpack-cli/lib/groups/resolveConfig.js:99:36
    at Array.map (<anonymous>)

    /home/yahonda/src/github.com/rails/rails/railties/test/isolation/abstract_unit.rb:373:in `rails'
    /home/yahonda/src/github.com/rails/rails/railties/test/application/asset_debugging_test.rb:44:in `block in <class:AssetDebuggingTest>'

bin/test test/application/asset_debugging_test.rb:41

Finished in 3.836355s, 0.2607 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

### Other Information

This pull request aims to lock rails/webpacker version to 5 temporarily.  
