### PR TITLE
Fix nil translation key lookup in controllers

### DIFF
--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -15,7 +15,7 @@ module AbstractController
     # to translate many keys within the same controller / action and gives you a
     # simple framework for scoping them consistently.
     def translate(key, **options)
-      if key.start_with?(".")
+      if key&.start_with?(".")
         path = controller_path.tr("/", ".")
         defaults = [:"#{path}#{key}"]
         defaults << options[:default] if options[:default]

--- a/actionpack/test/abstract/translation_test.rb
+++ b/actionpack/test/abstract/translation_test.rb
@@ -65,6 +65,11 @@ module AbstractController
         end
       end
 
+      def test_nil_key_lookup
+        default = "foo"
+        assert_equal default, @controller.t(nil, default: default)
+      end
+
       def test_lazy_lookup_with_symbol
         @controller.stub :action_name, :index do
           assert_equal "bar", @controller.t(:'.foo')


### PR DESCRIPTION
There are scenarios where a user constructs translation key dynamically, providing a fallback if the key can't be built:

```ruby
 t(my_key, default: 'foo')
```

This is an approach that works with `nil` values in `I18n` but not when calling `t`/`translate` from within a controller.

This PR adds handling of `nil` case and a corresponding spec.

