### PR TITLE
make validating params encoding in action_dispatch/http/request configurable

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -25,6 +25,7 @@ module ActionDispatch
     config.action_dispatch.perform_deep_munge = true
     config.action_dispatch.request_id_header = "X-Request-Id"
     config.action_dispatch.return_only_request_media_type_on_content_type = true
+    config.action_dispatch.validate_params_encoding = true
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -46,6 +47,7 @@ module ActionDispatch
       ActiveSupport.on_load(:action_dispatch_request) do
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_request_media_type_on_content_type
+        self.validate_params_encoding = app.config.action_dispatch.validate_params_encoding
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
       end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -607,6 +607,22 @@ class IntegrationProcessTest < ActionDispatch::IntegrationTest
     ActionDispatch::Request.ignore_accept_header = original_ignore_accept_header
   end
 
+  def test_with_false_validate_params_encoding
+    ActionDispatch::Request.stub(:validate_params_encoding, false) do
+      with_routing do |routes|
+        routes.draw do
+          ActiveSupport::Deprecation.silence do
+            post ":action" => FooController
+          end
+        end
+
+        post "/post", params: { foo: "%81E" }
+
+        assert_equal "%81E", request.filtered_parameters["foo"]
+      end
+    end
+  end
+
   private
     def with_default_headers(headers)
       original = ActionDispatch::Response.default_headers

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1133,6 +1133,28 @@ class RequestParameters < BaseRequestTest
     end
   end
 
+  test "validate_params_encoding_get" do
+    ActionDispatch::Request.stub(:validate_params_encoding, false) do
+      request = stub_request("QUERY_STRING" => "foo=%81E")
+
+      assert_equal request.parameters["foo"], "\x81E"
+    end
+  end
+
+  test "validate_params_encoding_post" do
+    ActionDispatch::Request.stub(:validate_params_encoding, false) do
+      data = "foo=%81E"
+
+      request = stub_request(
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_LENGTH" => data.length,
+        "CONTENT_TYPE" => "application/x-www-form-urlencoded; charset=utf-8",
+        "rack.input" => StringIO.new(data)
+      )
+      assert_equal request.body.read, "foo=%81E"
+    end
+  end
+
   test "parameters not accessible after rack parse error 1" do
     request = stub_request(
       "REQUEST_METHOD" => "POST",


### PR DESCRIPTION
Rails 6.1 started raising exceptions for GET and POST requests that do no not have valid encodings in the parameters (refer this PR - https://github.com/rails/rails/pull/40124). Until 6.0, rails would let the application handle these - which should be the ideal behaviour from a framework's POV. I have made this behaviour configurable. i.e. applications can choose whether they want ActionDispatch#Request to raise exceptions on invalidly encoded params or not. Since rails 6.1 currently enables this by default, I am setting this configuration option as true by default too, which can be disabled for applications which require custom handling.

For eg, we receive requests from various sources(both automated tools and user driven ones) and often, these requests contain non-utf8 characters. We however, do not want to miss processing these requests and neither do we want to do a runtime detection / force_encoding of these params. We simply `scrub!` what is invalid and carry on with the request processing - writing to the message bus, database etc.