### PR TITLE
Handle when Spring is not installed

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
@@ -1,10 +1,13 @@
 if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
-  # Load Spring without loading other gems in the Gemfile, for speed.
   gem "bundler"
   require "bundler"
+
+  # Load Spring without loading other gems in the Gemfile, for speed.
   Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem "spring", spring.version
     require "spring/binstub"
+  rescue Gem::LoadError
+    # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION
Spring is not in the default `:test` gem group, and may not be installed in some testing environments, such as CI.

Fixes #40911.
