### PR TITLE
Reuse the same ActiveModel::Type::Value

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -16,7 +16,7 @@ module ActiveModel
     end
 
     module ClassMethods
-      def attribute(name, type = Type::Value.new, **options)
+      def attribute(name, type = Type.default_value, **options)
         name = name.to_s
         if type.is_a?(Symbol)
           type = ActiveModel::Type.lookup(type, **options.except(:default))


### PR DESCRIPTION
### Summary

tiny optimization.
New instance of ActiveModel::Type::Value is not necessary. Reuse ActiveModel::Type.default_value instead of.