### PR TITLE
Include file path in invisible space warning

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -33,7 +33,7 @@ module ActiveSupport
 
         File.read(content_path).tap do |content|
           if content.include?("\u00A0")
-            warn "File contains invisible non-breaking spaces, you may want to remove those"
+            warn "#{content_path} contains invisible non-breaking spaces, you may want to remove those"
           end
         end
       end


### PR DESCRIPTION
While the warning is useful in itself, it doesn't tell you what file is
specifically causing the issue which can make resolving it harder than
it should be. As we've got the path already, we can simply include the
location of the problematic file in the warning message.