### PR TITLE
Mention `rails dev:cache` in Caching with Rails guide [ci skip] [docs]

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -34,17 +34,12 @@ fragment caching. By default Rails provides fragment caching. In order to use
 page and action caching you will need to add `actionpack-page_caching` and
 `actionpack-action_caching` to your `Gemfile`.
 
-By default, caching is only enabled in your production environment. To play
-around with caching locally you'll want to enable caching in your local
-environment by setting `config.action_controller.perform_caching` to `true` in
-the relevant `config/environments/*.rb` file:
-
-```ruby
-config.action_controller.perform_caching = true
-```
+By default, caching is only enabled in your production environment. You can play
+around with caching locally by running `rails dev:cache`, or by setting
+`config.action_controller.perform_caching` to `true` in `config/environments/development.rb`.
 
 NOTE: Changing the value of `config.action_controller.perform_caching` will
-only have an effect on the caching provided by the Action Controller component.
+only have an effect on the caching provided by Action Controller.
 For instance, it will not impact low-level caching, that we address
 [below](#low-level-caching).
 


### PR DESCRIPTION
On a new Rails app, [`config/development.rb`](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt#L19) is set up to support [`rails dev:cache`](https://github.com/rails/rails/pull/20961).

This PR explains how to enable caching in development in https://guides.rubyonrails.org/caching_with_rails.html, replacing the old advice that looks like it came before https://github.com/rails/rails/pull/20961.
