### PR TITLE
Split code snippets by context [ci-skip]

### DIFF
--- a/guides/source/4_2_release_notes.md
+++ b/guides/source/4_2_release_notes.md
@@ -396,15 +396,17 @@ Please refer to the [Changelog][railties] for detailed changes.
 *   Introduced `Rails::Application.config_for` to load a configuration for the
     current environment.
 
-    ```ruby
-    # config/exception_notification.yml:
+    ```yaml
+    # config/exception_notification.yml
     production:
       url: http://127.0.0.1:8080
       namespace: my_app_production
     development:
       url: http://localhost:3001
       namespace: my_app_development
+    ```
 
+    ```ruby
     # config/environments/production.rb
     Rails.application.configure do
       config.middleware.use ExceptionNotifier, config_for(:exception_notification)

--- a/guides/source/5_0_release_notes.md
+++ b/guides/source/5_0_release_notes.md
@@ -96,17 +96,20 @@ Some things that you can achieve with this:
 - Attributes do not need to be backed by a database column.
 
 ```ruby
-
 # db/schema.rb
 create_table :store_listings, force: true do |t|
   t.decimal :price_in_cents
   t.string :my_string, default: "original default"
 end
+```
 
+```ruby
 # app/models/store_listing.rb
 class StoreListing < ActiveRecord::Base
 end
+```
 
+```ruby
 store_listing = StoreListing.new(price_in_cents: '10.1')
 
 # before

--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -113,7 +113,9 @@ class InvitationsMailer < ApplicationMailer
     mail subject: "#{@inviter.name} invited you to their Basecamp (#{@account.name})"
   end
 end
+```
 
+```ruby
 InvitationsMailer.with(inviter: person_a, invitee: person_b)
                  .account_invitation.deliver_later
 ```

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -188,7 +188,9 @@ Then you would create your own channel classes. For example, you could have a
 # app/channels/chat_channel.rb
 class ChatChannel < ApplicationCable::Channel
 end
+```
 
+```ruby
 # app/channels/appearance_channel.rb
 class AppearanceChannel < ApplicationCable::Channel
 end

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -64,7 +64,9 @@ class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout 'mailer'
 end
+```
 
+```ruby
 # app/mailers/user_mailer.rb
 class UserMailer < ApplicationMailer
 end
@@ -723,7 +725,7 @@ end
 
 * You could use an `after_action` to do similar setup as a `before_action` but
   using instance variables set in your mailer action.
-  
+
 * Using an `after_action` callback also enables you to override delivery method
   settings by updating `mail.delivery_method.settings`.
 

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -196,7 +196,9 @@ module YourApp
     config.active_job.queue_name_prefix = Rails.env
   end
 end
+```
 
+```ruby
 # app/jobs/guests_cleanup_job.rb
 class GuestsCleanupJob < ApplicationJob
   queue_as :low_priority
@@ -232,7 +234,9 @@ module YourApp
     config.active_job.queue_name_delimiter = '.'
   end
 end
+```
 
+```ruby
 # app/jobs/guests_cleanup_job.rb
 class GuestsCleanupJob < ApplicationJob
   queue_as :low_priority
@@ -270,7 +274,9 @@ class ProcessVideoJob < ApplicationJob
     # Do process video
   end
 end
+```
 
+```ruby
 ProcessVideoJob.perform_later(Video.last)
 ```
 

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -37,11 +37,15 @@ that are supported by the PostgreSQL adapter.
 create_table :documents do |t|
   t.binary 'payload'
 end
+```
 
+```ruby
 # app/models/document.rb
 class Document < ApplicationRecord
 end
+```
 
+```ruby
 # Usage
 data = File.read(Rails.root + "tmp/output.pdf")
 Document.create payload: data
@@ -61,11 +65,15 @@ create_table :books do |t|
 end
 add_index :books, :tags, using: 'gin'
 add_index :books, :ratings, using: 'gin'
+```
 
+```ruby
 # app/models/book.rb
 class Book < ApplicationRecord
 end
+```
 
+```ruby
 # Usage
 Book.create title: "Brave New World",
             tags: ["fantasy", "fiction"],
@@ -348,12 +356,16 @@ create_table :comments, id: :uuid do |t|
   # t.belongs_to :post, type: :uuid
   t.references :post, type: :uuid
 end
+```
 
+```ruby
 # app/models/post.rb
 class Post < ApplicationRecord
   has_many :comments
 end
+```
 
+```ruby
 # app/models/comment.rb
 class Comment < ApplicationRecord
   belongs_to :post
@@ -502,11 +514,15 @@ create_table :documents do |t|
 end
 
 add_index :documents, "to_tsvector('english', title || ' ' || body)", using: :gin, name: 'documents_idx'
+```
 
+```ruby
 # app/models/document.rb
 class Document < ApplicationRecord
 end
+```
 
+```ruby
 # Usage
 Document.create(title: "Cats and Dogs", body: "are nice!")
 

--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -290,11 +290,15 @@ require "sti_preload"
 class Shape < ApplicationRecord
   include StiPreload # Only in the root class.
 end
+```
 
+```ruby
 # app/models/polygon.rb
 class Polygon < Shape
 end
+```
 
+```ruby
 # app/models/triangle.rb
 class Triangle < Polygon
 end

--- a/guides/source/autoloading_and_reloading_constants_classic_mode.md
+++ b/guides/source/autoloading_and_reloading_constants_classic_mode.md
@@ -909,7 +909,9 @@ module Blog
     "blog_"
   end
 end
+```
 
+```ruby
 # app/models/blog/post.rb
 module Blog
   class Post < ApplicationRecord
@@ -949,11 +951,15 @@ these classes:
 # app/models/polygon.rb
 class Polygon < ApplicationRecord
 end
+```
 
+```ruby
 # app/models/triangle.rb
 class Triangle < Polygon
 end
+```
 
+```ruby
 # app/models/rectangle.rb
 class Rectangle < Polygon
 end
@@ -1157,7 +1163,9 @@ module BellX1
   class FlightModel < FlightModel
   end
 end
+```
 
+```ruby
 # app/models/bell_x1/aircraft.rb
 module BellX1
   class Aircraft
@@ -1211,11 +1219,15 @@ Given
 # app/models/hotel.rb
 class Hotel
 end
+```
 
+```ruby
 # app/models/image.rb
 class Image
 end
+```
 
+```ruby
 # app/models/hotel/image.rb
 class Hotel
   class Image < Image
@@ -1267,7 +1279,9 @@ module Hotel
   class Services
   end
 end
+```
 
+```ruby
 # app/models/hotel/geo_location.rb
 module Hotel
   class GeoLocation

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1697,7 +1697,7 @@ These configuration points are then available through the configuration object:
 You can also use `Rails::Application.config_for` to load whole configuration files:
 
   ```yaml
-  # config/payment.yml:
+  # config/payment.yml
   production:
     environment: production
     merchant_id: production_merchant_id
@@ -1709,7 +1709,9 @@ You can also use `Rails::Application.config_for` to load whole configuration fil
     merchant_id: development_merchant_id
     public_key:  development_public_key
     private_key: development_private_key
+  ```
 
+  ```ruby
   # config/application.rb
   module MyApp
     class Application < Rails::Application

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -404,7 +404,9 @@ Add the missing translations into the translation dictionary files:
 en:
   hello_world: Hello world!
   hello_flash: Hello flash!
+```
 
+```yaml
 # config/locales/pirate.yml
 pirate:
   hello_world: Ahoy World
@@ -472,7 +474,9 @@ provides a `number_to_currency` helper to handle the following case.
 # config/locales/en.yml
 en:
   currency: "$"
+```
 
+```yaml
 # config/locales/es.yml
 es:
   currency: "€"
@@ -496,7 +500,9 @@ Proper abstraction is shown in the following example:
 # config/locales/en.yml
 en:
   product_price: "$%{price}"
+```
 
+```yaml
 # config/locales/es.yml
 es:
   product_price: "%{price} €"

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -590,15 +590,19 @@ In this application:
 Similar to the Layout Inheritance logic, if a template or partial is not found in the conventional path, the controller will look for a template or partial to render in its inheritance chain. For example:
 
 ```ruby
-# in app/controllers/application_controller
+# app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
 end
+```
 
-# in app/controllers/admin_controller
+```ruby
+# app/controllers/admin_controller.rb
 class AdminController < ApplicationController
 end
+```
 
-# in app/controllers/admin/products_controller
+```ruby
+# app/controllers/admin/products_controller.rb
 class Admin::ProductsController < AdminController
   def index
   end

--- a/guides/source/plugins.md
+++ b/guides/source/plugins.md
@@ -261,7 +261,9 @@ like yaffles.
 class Hickwall < ApplicationRecord
   acts_as_yaffle
 end
+```
 
+```ruby
 # test/dummy/app/models/wickwall.rb
 
 class Wickwall < ApplicationRecord
@@ -284,7 +286,9 @@ module Yaffle
     end
   end
 end
+```
 
+```ruby
 # test/dummy/app/models/application_record.rb
 
 class ApplicationRecord < ActiveRecord::Base
@@ -340,7 +344,9 @@ module Yaffle
     end
   end
 end
+```
 
+```ruby
 # test/dummy/app/models/application_record.rb
 
 class ApplicationRecord < ActiveRecord::Base
@@ -413,7 +419,9 @@ module Yaffle
     end
   end
 end
+```
 
+```ruby
 # test/dummy/app/models/application_record.rb
 
 class ApplicationRecord < ActiveRecord::Base

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1226,7 +1226,9 @@ class Video < ApplicationRecord
     identifier
   end
 end
+```
 
+```ruby
 video = Video.find_by(identifier: "Roman-Holiday")
 edit_video_path(video) # => "/videos/Roman-Holiday/edit"
 ```
@@ -1247,7 +1249,9 @@ Rails.application.routes.draw do
 
   draw(:admin) # Will load another route file located in `config/routes/admin.rb`
 end
+```
 
+```ruby
 # config/routes/admin.rb
 
 namespace :admin do

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -634,11 +634,13 @@ define a reference node between two different fixtures. Here's an example with
 a `belongs_to`/`has_many` association:
 
 ```yaml
-# In fixtures/categories.yml
+# fixtures/categories.yml
 about:
   name: About
+```
 
-# In fixtures/articles.yml
+```yaml
+# fixtures/articles.yml
 first:
   title: Welcome to Rails!
   body: Hello world!
@@ -1884,7 +1886,9 @@ class ChatRelayJob < ApplicationJob
     ChatChannel.broadcast_to room, text: message
   end
 end
+```
 
+```ruby
 # test/jobs/chat_relay_job_test.rb
 require "test_helper"
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1176,7 +1176,9 @@ class Notifier < ActionMailer::Base
     mail(to: user.email, ...)
   end
 end
+```
 
+```ruby
 mail = Notifier.notify(user, ...) # Notifier#notify is not yet called at this point
 mail = mail.deliver_now           # Prints "Called"
 ```
@@ -1701,7 +1703,7 @@ such format is [JSON Patch](https://tools.ietf.org/html/rfc6902). While Rails
 does not support JSON Patch natively, it's easy enough to add support:
 
 ```ruby
-# in your controller
+# in your controller:
 def update
   respond_to do |format|
     format.json do
@@ -1714,8 +1716,10 @@ def update
     end
   end
 end
+```
 
-# In config/initializers/json_patch.rb:
+```ruby
+# config/initializers/json_patch.rb
 Mime::Type.register 'application/json-patch+json', :json_patch
 ```
 


### PR DESCRIPTION
This provides a stronger visual cue that the code in these snippets belongs in different contexts (e.g. separate files).

**Before (example)**

![guides-split-code-before](https://user-images.githubusercontent.com/771968/103043566-f4135d80-4542-11eb-99c6-6b1bc20b5f4c.png)

**After (example)**

![guides-split-code-after](https://user-images.githubusercontent.com/771968/103043577-fd9cc580-4542-11eb-81e7-d823770df5f8.png)
