### PR TITLE
Add `primary_key` option to `has_one_attachment` and `has_many_attachments` in ActiveStorage

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,4 +1,20 @@
+*   Add `:primary_key` option to the
+    `ActiveStorage::Attached::Model::has_one_attachment` and
+    `ActiveStorage::Attached::Model::has_many_attachments`
+    methods. This is used to specify the method to use as the primary key for
+    the relation.
+    
+    For example:
 
+    ```ruby
+    class Message < ApplicationRecord
+      # ...
+      has_one_attached :file, primary_key: "bigint_id"
+      # ...
+    end
+    ``` 
+
+    *John Isom*
 
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -47,7 +47,14 @@ module ActiveStorage
       #     has_one_attached :avatar, strict_loading: true
       #   end
       #
-      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      # If you need to specify the method that returns the primary key for the association,
+      # pass the +:primary_key+ option. For example:
+      #
+      #   class User < ApplicationRecord
+      #     has_one_attached :avatar, primary_key: "uuid"
+      #   end
+      #
+      def has_one_attached(name, dependent: :purge_later, service: nil, strict_loading: false, primary_key: "id")
         validate_service_configuration(name, service)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -67,7 +74,7 @@ module ActiveStorage
           end
         CODE
 
-        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
+        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", primary_key: primary_key, as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
         has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
@@ -125,7 +132,14 @@ module ActiveStorage
       #     has_many_attached :photos, strict_loading: true
       #   end
       #
-      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false)
+      # If you need to specify the method that returns the primary key for the association,
+      # pass the +:primary_key+ option. For example:
+      #
+      #   class User < ApplicationRecord
+      #     has_many_attached :avatar, primary_key: "uuid"
+      #   end
+      #
+      def has_many_attached(name, dependent: :purge_later, service: nil, strict_loading: false, primary_key: "id")
         validate_service_configuration(name, service)
 
         generated_association_methods.class_eval <<-CODE, __FILE__, __LINE__ + 1
@@ -152,7 +166,7 @@ module ActiveStorage
           end
         CODE
 
-        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading do
+        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", primary_key: primary_key, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading do
           def purge
             each(&:purge)
             reset

--- a/activestorage/test/database/create_messages_migration.rb
+++ b/activestorage/test/database/create_messages_migration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ActiveStorageCreateMessages < ActiveRecord::Migration[6.2]
+  def change
+    create_table :messages, primary_key: :integer_id do |t|
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/activestorage/test/database/setup.rb
+++ b/activestorage/test/database/setup.rb
@@ -2,8 +2,10 @@
 
 require_relative "create_users_migration"
 require_relative "create_groups_migration"
+require_relative "create_messages_migration"
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.connection.migration_context.migrate
 ActiveStorageCreateUsers.migrate(:up)
 ActiveStorageCreateGroups.migrate(:up)
+ActiveStorageCreateMessages.migrate(:up)

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -609,4 +609,24 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
     assert_match(/Cannot configure service :unknown for User#featured_photo/, error.message)
   end
+
+  test "attaching a new blob from a hash with a custom primary_key" do
+    message = Message.create!(body: <<~BODY)
+      This is the body of a message that will soon have a banner_img attached to it.
+    BODY
+
+    message.banner_img.attach io: StringIO.new("STUFF"), filename: "image.jpg", content_type: "image/jpeg"
+
+    assert_equal "image.jpg", message.banner_img.filename.to_s
+  end
+
+  test "attaching a new blob from an uploaded file with a custom primary_key" do
+    message = Message.create!(body: <<~BODY)
+      This is the body of a message that will soon have a banner_img attached to it.
+    BODY
+
+    message.banner_img.attach fixture_file_upload("racecar.jpg")
+
+    assert_equal "racecar.jpg", message.banner_img.filename.to_s
+  end
 end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -128,4 +128,9 @@ class Group < ActiveRecord::Base
   accepts_nested_attributes_for :users
 end
 
+class Message < ActiveRecord::Base
+  has_one_attached :banner_img, primary_key: "integer_id"
+  has_many_attached :attachments, primary_key: "integer_id"
+end
+
 require_relative "../../tools/test_common"


### PR DESCRIPTION
### Summary

As it currently stands, there is no way to specify the primary key column
to use when adding `ActiveStorage` attachments to `ActiveRecord` models. For
some situations, this is undesirable, as the "primary key" of a specific
model may be different than `id` or one may wish to use a different column
as the primary key for the relation.

To illustrate, imagine a model `Message` and a model `DataExport`. `Message`
has a primary key `id` of type `uuid`, while `DataExport` has a primary
key `id` of type `bigint`. `Message` also has a `bigint_id` column of type
`bigint`.

If we just put `has_one_attached :file` in both `Message` and `DataExport`,
it obviously wouldn't work because `Message` uses a `uuid` whereas `DataExport`
uses a `bigint`. The solution then is to specify that the primary key column
to use for `Message`'s attachments should be `bigint_id` (assuming it's
unique and not null), but that's not possible without monkey-patching.
This proposal gives the user more fine-grained control while still
defaulting to the convention of `id` as the primary key column.

Example usage is as follows:

``` ruby
class DataExport < ApplicationRecord
  # ...
  has_one_attached :file
  # ...
end
class Message < ApplicationRecord
  # ...
  has_one_attached :file, primary_key: "bigint_id"
  # ...
end
```
 
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

- Since this change is minor, I'm not sure it merits a change in the CHANGELOG or it's own tests. I'll defer to the reviewers on this one.
- At @reamaze, we ran in to this problem out in the wild, so this is based on a real-world use case.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
