### PR TITLE
Upload raw email before creating pending ActionMailbox::InboundEmail

### DIFF
--- a/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
@@ -17,9 +17,8 @@ module ActionMailbox::InboundEmail::MessageId
       message_checksum = Digest::SHA1.hexdigest(source)
       message_id = extract_message_id(source) || generate_missing_message_id(message_checksum)
 
-      create! options.merge(message_id: message_id, message_checksum: message_checksum) do |inbound_email|
-        inbound_email.raw_email.attach io: StringIO.new(source), filename: "message.eml", content_type: "message/rfc822"
-      end
+      create! raw_email: create_and_upload_raw_email!(source),
+        message_id: message_id, message_checksum: message_checksum, **options
     rescue ActiveRecord::RecordNotUnique
       nil
     end
@@ -33,6 +32,10 @@ module ActionMailbox::InboundEmail::MessageId
         Mail::MessageIdField.new("<#{message_checksum}@#{::Socket.gethostname}.mail>").message_id.tap do |message_id|
           logger.warn "Message-ID couldn't be parsed or is missing. Generated a new Message-ID: #{message_id}"
         end
+      end
+
+      def create_and_upload_raw_email!(source)
+        ActiveStorage::Blob.create_and_upload! io: StringIO.new(source), filename: "message.eml", content_type: "message/rfc822"
       end
   end
 end


### PR DESCRIPTION
Fix that a storage upload error would leave behind a stuck-pending `ActionMailbox::InboundEmail` that could never be processed. The message isn't lost: the SMTP relay sees an HTTP server error and defers message delivery. We just have spurious, non-actionable `InboundEmail`s stuck pending and tripping monitoring.

This does still leave behind an unattached `ActiveStorage::Blob` with no corresponding object on the storage service, but that's less annoying.

To-do:
- [x] Test?