### PR TITLE
Update message_encryptor.rb to handle if 'iv' is nil(in case of ECB mode it is NIL and throwing error)

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -191,7 +191,7 @@ module ActiveSupport
 
         cipher.decrypt
         cipher.key = @secret
-        cipher.iv  = iv
+        cipher.iv  = iv.to_s
         if aead_mode?
           cipher.auth_tag = auth_tag
           cipher.auth_data = ""


### PR DESCRIPTION
handle iv nil

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
I was about to use AES-256_ECB cipher mechanism for encryption and decryption. ECB mode generally avoid using of initial vector. So in the code 'iv' comes NIL and cipher.iv = iv is giving error. so make sure iv is not nil by making it iv.to_s

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
