### PR TITLE
add ActiveSupport::Cache::RedisCacheStore#info

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -6,5 +6,9 @@
 
     *Ritikesh G*
 
+*   add `RedisCacheStore#stats` method similar to `MemCacheStore#stats`. Calls `redis#info` internally.
+
+    *Ritikesh G*
+
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -319,6 +319,11 @@ module ActiveSupport
         end
       end
 
+      # Get info from redis servers.
+      def stats
+        redis.with { |c| c.info }
+      end
+
       def mget_capable? #:nodoc:
         set_redis_capabilities unless defined? @mget_capable
         @mget_capable


### PR DESCRIPTION
Added a `info` method to `RedisCacheStore` similar to its counterpart's `MemCacheStore#stats`