### PR TITLE
Normalize code indentation [ci-skip]

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -147,9 +147,9 @@ that the `products` table was created using an SQL (or one of its extensions) st
 
 ```sql
 CREATE TABLE products (
-   id int(11) NOT NULL auto_increment,
-   name varchar(255),
-   PRIMARY KEY  (id)
+  id int(11) NOT NULL auto_increment,
+  name varchar(255),
+  PRIMARY KEY  (id)
 );
 ```
 

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -218,11 +218,11 @@ CREATE TYPE full_address AS
 ```ruby
 # db/migrate/20140207133952_create_contacts.rb
 execute <<-SQL
- CREATE TYPE full_address AS
- (
-   city VARCHAR(90),
-   street VARCHAR(90)
- );
+  CREATE TYPE full_address AS
+  (
+    city VARCHAR(90),
+    street VARCHAR(90)
+  );
 SQL
 create_table :contacts do |t|
   t.column :address, :full_address

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1789,7 +1789,8 @@ WHERE (reviews.created_at > '2019-01-08')
 ### Retrieving specific data from multiple tables
 
 ```ruby
-Book.select('books.id, books.title, authors.first_name')
+Book
+  .select('books.id, books.title, authors.first_name')
   .joins(:author)
   .find_by(title: 'Abstraction and Specification in Program Development')
 ```
@@ -1800,7 +1801,7 @@ The above should generate:
 SELECT books.id, books.title, authors.first_name
 FROM books
 INNER JOIN authors
- ON authors.id = books.author_id
+  ON authors.id = books.author_id
 WHERE books.title = $1 [["title", "Abstraction and Specification in Program Development"]]
 LIMIT 1
 ```

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -468,9 +468,9 @@ which contains these lines:
 
 ```css
 /* ...
-*= require_self
-*= require_tree .
-*/
+ *= require_self
+ *= require_tree .
+ */
 ```
 
 Rails creates `app/assets/stylesheets/application.css` regardless of whether the
@@ -501,10 +501,10 @@ might concatenate three CSS files together this way:
 
 ```js
 /* ...
-*= require reset
-*= require layout
-*= require chrome
-*/
+ *= require reset
+ *= require layout
+ *= require chrome
+ */
 ```
 
 ### Preprocessing

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -889,7 +889,7 @@ The `build_association` method returns a new object of the associated type. This
 
 ```ruby
 @author = @book.build_author(author_number: 123,
-                                  author_name: "John Doe")
+                             author_name: "John Doe")
 ```
 
 ##### `create_association(attributes = {})`
@@ -898,7 +898,7 @@ The `create_association` method returns a new object of the associated type. Thi
 
 ```ruby
 @author = @book.create_author(author_number: 123,
-                                   author_name: "John Doe")
+                              author_name: "John Doe")
 ```
 
 ##### `create_association!(attributes = {})`
@@ -1011,7 +1011,7 @@ By convention, Rails assumes that the column used to hold the foreign key on thi
 ```ruby
 class Book < ApplicationRecord
   belongs_to :author, class_name: "Patron",
-                        foreign_key: "patron_id"
+                      foreign_key: "patron_id"
 end
 ```
 
@@ -1671,7 +1671,7 @@ The [`collection.build`][] method returns a single or array of new objects of th
 
 ```ruby
 @book = @author.books.build(published_at: Time.now,
-                                book_number: "A12345")
+                            book_number: "A12345")
 
 @books = @author.books.build([
   { published_at: Time.now, book_number: "A12346" },
@@ -1685,7 +1685,7 @@ The [`collection.create`][] method returns a single or array of new objects of t
 
 ```ruby
 @book = @author.books.create(published_at: Time.now,
-                                 book_number: "A12345")
+                             book_number: "A12345")
 
 @books = @author.books.create([
   { published_at: Time.now, book_number: "A12346" },
@@ -1878,7 +1878,7 @@ You can also set conditions via a hash:
 ```ruby
 class Author < ApplicationRecord
   has_many :confirmed_books, -> { where confirmed: true },
-                              class_name: "Book"
+    class_name: "Book"
 end
 ```
 

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -667,8 +667,8 @@ response body.
 Weak ETags have a leading `W/` to differentiate them from strong ETags.
 
 ```
-  W/"618bbc92e2d35ea1945008b42799b0e7" → Weak ETag
-  "618bbc92e2d35ea1945008b42799b0e7" → Strong ETag
+W/"618bbc92e2d35ea1945008b42799b0e7" → Weak ETag
+"618bbc92e2d35ea1945008b42799b0e7" → Strong ETag
 ```
 
 Unlike weak ETag, strong ETag implies that response should be exactly the same
@@ -677,18 +677,18 @@ large video or PDF file. Some CDNs support only strong ETags, like Akamai.
 If you absolutely need to generate a strong ETag, it can be done as follows.
 
 ```ruby
-  class ProductsController < ApplicationController
-    def show
-      @product = Product.find(params[:id])
-      fresh_when last_modified: @product.published_at.utc, strong_etag: @product
-    end
+class ProductsController < ApplicationController
+  def show
+    @product = Product.find(params[:id])
+    fresh_when last_modified: @product.published_at.utc, strong_etag: @product
   end
+end
 ```
 
 You can also set the strong ETag directly on the response.
 
 ```ruby
-  response.strong_etag = response.body # => "618bbc92e2d35ea1945008b42799b0e7"
+response.strong_etag = response.body # => "618bbc92e2d35ea1945008b42799b0e7"
 ```
 
 Caching in Development

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1698,72 +1698,73 @@ The key difference between these two is that you should be using `config.x` if y
 are defining _nested_ configuration (ex: `config.x.nested.hi`), and just
 `config` for _single level_ configuration (ex: `config.hello`).
 
-  ```ruby
-  config.x.payment_processing.schedule = :daily
-  config.x.payment_processing.retries  = 3
-  config.super_debugger = true
-  ```
+```ruby
+config.x.payment_processing.schedule = :daily
+config.x.payment_processing.retries  = 3
+config.super_debugger = true
+```
 
 These configuration points are then available through the configuration object:
 
-  ```ruby
-  Rails.configuration.x.payment_processing.schedule # => :daily
-  Rails.configuration.x.payment_processing.retries  # => 3
-  Rails.configuration.x.payment_processing.not_set  # => nil
-  Rails.configuration.super_debugger                # => true
-  ```
+```ruby
+Rails.configuration.x.payment_processing.schedule # => :daily
+Rails.configuration.x.payment_processing.retries  # => 3
+Rails.configuration.x.payment_processing.not_set  # => nil
+Rails.configuration.super_debugger                # => true
+```
 
 You can also use `Rails::Application.config_for` to load whole configuration files:
 
-  ```yaml
-  # config/payment.yml
-  production:
-    environment: production
-    merchant_id: production_merchant_id
-    public_key:  production_public_key
-    private_key: production_private_key
+```yaml
+# config/payment.yml
+production:
+  environment: production
+  merchant_id: production_merchant_id
+  public_key:  production_public_key
+  private_key: production_private_key
 
-  development:
-    environment: sandbox
-    merchant_id: development_merchant_id
-    public_key:  development_public_key
-    private_key: development_private_key
-  ```
+development:
+  environment: sandbox
+  merchant_id: development_merchant_id
+  public_key:  development_public_key
+  private_key: development_private_key
+```
 
-  ```ruby
-  # config/application.rb
-  module MyApp
-    class Application < Rails::Application
-      config.payment = config_for(:payment)
-    end
+```ruby
+# config/application.rb
+module MyApp
+  class Application < Rails::Application
+    config.payment = config_for(:payment)
   end
-  ```
+end
+```
 
-  ```ruby
-  Rails.configuration.payment['merchant_id'] # => production_merchant_id or development_merchant_id
-  ```
+```ruby
+Rails.configuration.payment['merchant_id'] # => production_merchant_id or development_merchant_id
+```
+
 `Rails::Application.config_for` supports a `shared` configuration to group common
 configurations. The shared configuration will be merged into the environment
 configuration.
 
-  ```yaml
-  # config/example.yml
-  shared:
-    foo:
-      bar:
-        baz: 1
+```yaml
+# config/example.yml
+shared:
+  foo:
+    bar:
+      baz: 1
 
-  development:
-    foo:
-      bar:
-        qux: 2
-  ```
+development:
+  foo:
+    bar:
+      qux: 2
+```
 
 
-  ```ruby
-  # development environment
-  Rails.application.config_for(:example)[:foo][:bar] #=> { baz: 1, qux: 2 }
-  ```
+```ruby
+# development environment
+Rails.application.config_for(:example)[:foo][:bar] #=> { baz: 1, qux: 2 }
+```
 
 Search Engines Indexing
 -----------------------

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1341,7 +1341,7 @@ Pipeline require statements in processed files:
 ```css
 /*
  *= require blorgh/style
-*/
+ */
 ```
 
 INFO. Remember that in order to use languages like Sass or CoffeeScript, you

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1711,10 +1711,10 @@ Concerns are a way to make large controllers or models easier to understand and 
 
 You can use concerns in your controller or model the same way you would use any module. When you first created your app with `rails new blog`, two folders were created within `app/` along with the rest:
 
- ```
- app/controllers/concerns
- app/models/concerns
- ```
+```
+app/controllers/concerns
+app/models/concerns
+```
 
 A given blog article might have various statuses - for instance, it might be visible to everyone (i.e. `public`), or only visible to the author (i.e. `private`). It may also be hidden to all but still retrievable (i.e. `archived`). Comments may similarly be hidden or visible. This could be represented using a `status` column in each model.
 
@@ -1938,8 +1938,8 @@ So first, let's add the delete link in the
 
 <p>
   <%= link_to 'Destroy Comment', [comment.article, comment],
-               method: :delete,
-               data: { confirm: "Are you sure?" } %>
+              method: :delete,
+              data: { confirm: "Are you sure?" } %>
 </p>
 ```
 

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -116,8 +116,8 @@ NOTE: The backend lazy-loads these translations when a translation is looked up 
 You can change the default locale as well as configure the translations load paths in `config/application.rb` as follows:
 
 ```ruby
-  config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
-  config.i18n.default_locale = :de
+config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}')]
+config.i18n.default_locale = :de
 ```
 
 The load path must be specified before any translations are looked up. To change the default locale from an initializer instead of `config/application.rb`:
@@ -590,9 +590,8 @@ This way, you can separate model and model attribute names from text inside view
 NOTE: The default locale loading mechanism in Rails does not load locale files in nested dictionaries, like we have here. So, for this to work, we must explicitly tell Rails to look further:
 
 ```ruby
-  # config/application.rb
-  config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-
+# config/application.rb
+config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 ```
 
 Overview of the I18n API Features

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -113,13 +113,15 @@ The Content-Type will now be based on the given block rather than the request's 
 Example:
 
 ```ruby
-  def my_action
-    respond_to do |format|
-      format.any { render(json: { foo: 'bar' }) }
-    end
+def my_action
+  respond_to do |format|
+    format.any { render(json: { foo: 'bar' }) }
   end
+end
+```
 
-  get('my_action.csv')
+```ruby
+get('my_action.csv')
 ```
 
 Previous behaviour was returning a `text/csv` response's Content-Type which is inaccurate since a JSON response is being rendered.
@@ -129,7 +131,7 @@ If your application relies on the previous incorrect behaviour, you are encourag
 which formats your action accepts, i.e.
 
 ```ruby
-  format.any(:xml, :json) { render request.format.to_sym => @people }
+format.any(:xml, :json) { render request.format.to_sym => @people }
 ```
 
 ### `ActiveSupport::Callbacks#halted_callback_hook` now receive a second argument
@@ -142,14 +144,14 @@ change without a prior deprecation cycle (for performance reasons).
 Example:
 
 ```ruby
-  class Book < ApplicationRecord
-    before_save { throw(:abort) }
-    before_create { throw(:abort) }
+class Book < ApplicationRecord
+  before_save { throw(:abort) }
+  before_create { throw(:abort) }
 
-    def halted_callback_hook(filter, callback_name) # => This method now accepts 2 arguments instead of 1
-      Rails.logger.info("Book couldn't be #{callback_name}d")
-    end
+  def halted_callback_hook(filter, callback_name) # => This method now accepts 2 arguments instead of 1
+    Rails.logger.info("Book couldn't be #{callback_name}d")
   end
+end
 ```
 
 ### The `helper` class method in controllers uses `String#constantize`


### PR DESCRIPTION
This removes unnecessary indentation of several code snippets, and otherwise normalizes indentation of a handful more.
