### PR TITLE
Fix syntax highlighting [ci-skip]

### DIFF
--- a/guides/source/2_3_release_notes.md
+++ b/guides/source/2_3_release_notes.md
@@ -434,7 +434,7 @@ grouped_options_for_select([["Hats", ["Baseball Cap","Cowboy Hat"]]],
 
 returns
 
-```ruby
+```html
 <option value="">Choose a product...</option>
 <optgroup label="Hats">
   <option value="Baseball Cap">Baseball Cap</option>

--- a/guides/source/5_1_release_notes.md
+++ b/guides/source/5_1_release_notes.md
@@ -104,7 +104,7 @@ Secrets will be decrypted in production, using a key stored either in the
 Allows specifying common parameters used for all methods in a mailer class in
 order to share instance variables, headers, and other common setup.
 
-``` ruby
+```ruby
 class InvitationsMailer < ApplicationMailer
   before_action { @inviter, @invitee = params[:inviter], params[:invitee] }
   before_action { @account = params[:inviter].account }
@@ -127,13 +127,13 @@ InvitationsMailer.with(inviter: person_a, invitee: person_b)
 Rails 5.1 adds two new methods, `resolve` and `direct`, to the routing
 DSL. The `resolve` method allows customizing polymorphic mapping of models.
 
-``` ruby
+```ruby
 resource :basket
 
 resolve("Basket") { [:basket] }
 ```
 
-``` erb
+```erb
 <%= form_for @basket do |form| %>
   <!-- basket form -->
 <% end %>
@@ -143,7 +143,7 @@ This will generate the singular URL `/basket` instead of the usual `/baskets/:id
 
 The `direct` method allows creation of custom URL helpers.
 
-``` ruby
+```ruby
 direct(:homepage) { "http://www.rubyonrails.org" }
 
 homepage_url # => "http://www.rubyonrails.org"
@@ -153,7 +153,7 @@ The return value of the block must be a valid argument for the `url_for`
 method. So, you can pass a valid string URL, Hash, Array, an
 Active Model instance, or an Active Model class.
 
-``` ruby
+```ruby
 direct :commentable do |model|
   [ model, anchor: model.dom_id ]
 end
@@ -175,7 +175,7 @@ can generate form tags based on URLs, scopes, or models.
 
 Using just a URL:
 
-``` erb
+```erb
 <%= form_with url: posts_path do |form| %>
   <%= form.text_field :title %>
 <% end %>
@@ -189,7 +189,7 @@ Using just a URL:
 
 Adding a scope prefixes the input field names:
 
-``` erb
+```erb
 <%= form_with scope: :post, url: posts_path do |form| %>
   <%= form.text_field :title %>
 <% end %>
@@ -203,7 +203,7 @@ Adding a scope prefixes the input field names:
 
 Using a model infers both the URL and scope:
 
-``` erb
+```erb
 <%= form_with model: Post.new do |form| %>
   <%= form.text_field :title %>
 <% end %>
@@ -217,7 +217,7 @@ Using a model infers both the URL and scope:
 
 An existing model makes an update form and fills out field values:
 
-``` erb
+```erb
 <%= form_with model: Post.first do |form| %>
   <%= form.text_field :title %>
 <% end %>

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -251,43 +251,57 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
     Before:
 
-        User.where(name: "John").create do |john|
-          User.find_by(name: "David") # => nil
-        end
+    ```ruby
+    User.where(name: "John").create do |john|
+      User.find_by(name: "David") # => nil
+    end
+    ```
 
     After:
 
-        User.where(name: "John").create do |john|
-          User.find_by(name: "David") # => #<User name: "David", ...>
-        end
+    ```ruby
+    User.where(name: "John").create do |john|
+      User.find_by(name: "David") # => #<User name: "David", ...>
+    end
+    ```
 
 *   Named scope chain does no longer leak scope to class level querying methods.
 
-        class User < ActiveRecord::Base
-          scope :david, -> { User.where(name: "David") }
-        end
+    ```ruby
+    class User < ActiveRecord::Base
+      scope :david, -> { User.where(name: "David") }
+    end
+    ```
 
     Before:
 
-        User.where(name: "John").david
-        # SELECT * FROM users WHERE name = 'John' AND name = 'David'
+    ```ruby
+    User.where(name: "John").david
+    # SELECT * FROM users WHERE name = 'John' AND name = 'David'
+    ```
 
     After:
 
-        User.where(name: "John").david
-        # SELECT * FROM users WHERE name = 'David'
+    ```ruby
+    User.where(name: "John").david
+    # SELECT * FROM users WHERE name = 'David'
+    ```
 
 *   `where.not` now generates NAND predicates instead of NOR.
 
     Before:
 
-        User.where.not(name: "Jon", role: "admin")
-        # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
+    ```ruby
+    User.where.not(name: "Jon", role: "admin")
+    # SELECT * FROM users WHERE name != 'Jon' AND role != 'admin'
+    ```
 
     After:
 
-        User.where.not(name: "Jon", role: "admin")
-        # SELECT * FROM users WHERE NOT (name == 'Jon' AND role == 'admin')
+    ```ruby
+    User.where.not(name: "Jon", role: "admin")
+    # SELECT * FROM users WHERE NOT (name == 'Jon' AND role == 'admin')
+    ```
 
 *   To use the new per-database connection handling applications must change
     `legacy_connection_handling` to false and remove deprecated accessors on

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -628,7 +628,7 @@ config.asset_host = 'http://example.com'
 
 Now you can display an image inside your email.
 
-```ruby
+```html+erb
 <%= image_tag 'image.jpg' %>
 ```
 

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1177,7 +1177,7 @@ class Person < ApplicationRecord
 end
 ```
 
-```irb>
+```irb
 irb> person = Person.new(name: "John Doe")
 irb> person.valid?
 => true
@@ -1357,7 +1357,7 @@ it generates that displays the full list of errors on that model.
 Assuming we have a model that's been saved in an instance variable named
 `@article`, it looks like this:
 
-```ruby
+```html+erb
 <% if @article.errors.any? %>
   <div id="error_explanation">
     <h2><%= pluralize(@article.errors.count, "error") %> prohibited this article from being saved:</h2>

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2183,7 +2183,7 @@ The [`collection.clear`][] method removes every object from the collection by de
 
 The [`collection.empty?`][] method returns `true` if the collection does not contain any associated objects.
 
-```ruby
+```html+erb
 <% if @part.assemblies.empty? %>
   This part is not used in any assemblies
 <% end %>

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -244,7 +244,7 @@ not your engine's application controller. Ruby is able to resolve the `Applicati
 The best way to prevent this from happening is to use `require_dependency` to ensure that the engine's application
 controller is loaded. For example:
 
-``` ruby
+```ruby
 # app/controllers/blorgh/articles_controller.rb:
 require_dependency "blorgh/application_controller"
 

--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -361,13 +361,13 @@ escaped so that the generated output is valid ERB code.
 For example, the following escaped ERB tag would be needed in the template
 (note the extra `%`)...
 
-```ruby
+```erb
 <%%= stylesheet_include_tag :application %>
 ```
 
 ...to generate the following output:
 
-```ruby
+```erb
 <%= stylesheet_include_tag :application %>
 ```
 

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1089,13 +1089,13 @@ Partial templates - usually just called "partials" - are another device for brea
 
 To render a partial as part of a view, you use the [`render`][view.render] method within the view:
 
-```ruby
+```html+erb
 <%= render "menu" %>
 ```
 
 This will render a file named `_menu.html.erb` at that point within the view being rendered. Note the leading underscore character: partials are named with a leading underscore to distinguish them from regular views, even though they are referred to without the underscore. This holds true even when you're pulling in a partial from another folder:
 
-```ruby
+```html+erb
 <%= render "shared/menu" %>
 ```
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -780,7 +780,7 @@ Both the `matches?` method and the lambda gets the `request` object as an argume
 
 You can specify constraints in a block form. This is useful for when you need to apply the same rule to several routes. For example
 
-```
+```ruby
 class RestrictedListConstraint
   # ...Same as the example above
 end
@@ -795,7 +795,7 @@ end
 
 You also use a `lambda`:
 
-```
+```ruby
 Rails.application.routes.draw do
   constraints(lambda { |request| RestrictedList.retrieve_ips.include?(request.remote_ip) }) do
     get '*path', to: 'restricted_list#index',
@@ -967,13 +967,13 @@ end
 
 The [`resolve`][] method allows customizing polymorphic mapping of models. For example:
 
-``` ruby
+```ruby
 resource :basket
 
 resolve("Basket") { [:basket] }
 ```
 
-``` erb
+```erb
 <%= form_with model: @basket do |form| %>
   <!-- basket form -->
 <% end %>

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -719,7 +719,9 @@ warning about this upcoming change.
 When you are ready, you can opt into the new behavior and remove the deprecation
 warning by adding the following configuration to your `config/application.rb`:
 
-    ActiveSupport.halt_callback_chains_on_return_false = false
+```ruby
+ActiveSupport.halt_callback_chains_on_return_false = false
+```
 
 Note that this option will not affect Active Support callbacks since they never
 halted the chain when any value was returned.
@@ -811,7 +813,9 @@ parameters are already permitted, then you will not need to make any changes. If
 and other methods that depend on being able to read the hash regardless of `permitted?` you will
 need to upgrade your application to first permit and then convert to a hash.
 
-    params.permit([:proceed_to, :return_to]).to_h
+```ruby
+params.permit([:proceed_to, :return_to]).to_h
+```
 
 ### `protect_from_forgery` Now Defaults to `prepend: false`
 
@@ -915,7 +919,9 @@ This can be turned off per-association with `optional: true`.
 This default will be automatically configured in new applications. If an existing application
 wants to add this feature it will need to be turned on in an initializer:
 
-    config.active_record.belongs_to_required_by_default = true
+```ruby
+config.active_record.belongs_to_required_by_default = true
+```
 
 The configuration is by default global for all your models, but you can
 override it on a per model basis. This should help you migrate all your models to have their
@@ -943,7 +949,9 @@ Rails 5 now supports per-form CSRF tokens to mitigate against code-injection att
 created by JavaScript. With this option turned on, forms in your application will each have their
 own CSRF token that is specific to the action and method for that form.
 
-    config.action_controller.per_form_csrf_tokens = true
+```ruby
+config.action_controller.per_form_csrf_tokens = true
+```
 
 #### Forgery Protection with Origin Check
 
@@ -951,40 +959,52 @@ You can now configure your application to check if the HTTP `Origin` header shou
 against the site's origin as an additional CSRF defense. Set the following in your config to
 true:
 
-    config.action_controller.forgery_protection_origin_check = true
+```ruby
+config.action_controller.forgery_protection_origin_check = true
+```
 
 #### Allow Configuration of Action Mailer Queue Name
 
 The default mailer queue name is `mailers`. This configuration option allows you to globally change
 the queue name. Set the following in your config:
 
-    config.action_mailer.deliver_later_queue_name = :new_queue_name
+```ruby
+config.action_mailer.deliver_later_queue_name = :new_queue_name
+```
 
 #### Support Fragment Caching in Action Mailer Views
 
 Set `config.action_mailer.perform_caching` in your config to determine whether your Action Mailer views
 should support caching.
 
-    config.action_mailer.perform_caching = true
+```ruby
+config.action_mailer.perform_caching = true
+```
 
 #### Configure the Output of `db:structure:dump`
 
 If you're using `schema_search_path` or other PostgreSQL extensions, you can control how the schema is
 dumped. Set to `:all` to generate all dumps, or to `:schema_search_path` to generate from schema search path.
 
-    config.active_record.dump_schemas = :all
+```ruby
+config.active_record.dump_schemas = :all
+```
 
 #### Configure SSL Options to Enable HSTS with Subdomains
 
 Set the following in your config to enable HSTS when using subdomains:
 
-    config.ssl_options = { hsts: { subdomains: true } }
+```ruby
+config.ssl_options = { hsts: { subdomains: true } }
+```
 
 #### Preserve Timezone of the Receiver
 
 When using Ruby 2.4, you can preserve the timezone of the receiver when calling `to_time`.
 
-    ActiveSupport.to_time_preserves_timezone = false
+```ruby
+ActiveSupport.to_time_preserves_timezone = false
+```
 
 ### Changes with JSON/JSONB serialization
 
@@ -1051,7 +1071,9 @@ you are ready, you can opt into the new behavior and remove the
 deprecation warning by adding following configuration to your
 `config/application.rb`:
 
-    config.active_record.raise_in_transactional_callbacks = true
+```ruby
+config.active_record.raise_in_transactional_callbacks = true
+```
 
 See [#14488](https://github.com/rails/rails/pull/14488) and
 [#16537](https://github.com/rails/rails/pull/16537) for more details.


### PR DESCRIPTION
This fixes the syntax highlighting of several code snippets by changing the code fences to the correct language.
