### PR TITLE
Allow for ActionMailbox to store emails across different services

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,4 +1,5 @@
+Allow for ActionMailbox to use a different storage service rather than ActiveStorage's defaults.
 
-
+*Matt*
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -29,7 +29,7 @@ module ActionMailbox
 
     include Incineratable, MessageId, Routable
 
-    has_one_attached :raw_email
+    has_one_attached :raw_email, service: ActionMailbox.storage_service
     enum status: %i[ pending processing delivered failed bounced ]
 
     def mail

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -14,4 +14,5 @@ module ActionMailbox
   mattr_accessor :incinerate, default: true
   mattr_accessor :incinerate_after, default: 30.days
   mattr_accessor :queues, default: {}
+  mattr_accessor :storage_service
 end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -27,6 +27,7 @@ module ActionMailbox
         ActionMailbox.incinerate_after = app.config.action_mailbox.incinerate_after || 30.days
         ActionMailbox.queues = app.config.action_mailbox.queues || {}
         ActionMailbox.ingress = app.config.action_mailbox.ingress
+        ActionMailbox.storage_service = app.config.action_mailbox.storage_service || app.config.active_storage.service
       end
     end
   end

--- a/actionmailbox/test/unit/storage_test.rb
+++ b/actionmailbox/test/unit/storage_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+Rails.application.config.active_storage.service = :test
+Rails.application.config.action_mailbox.storage_service = :local
+
+module ActionMailbox
+  class StorageTest < ActiveSupport::TestCase
+    setup do
+      @inbound_email = create_inbound_email_from_mail(
+        to: "To <test@case.com>",
+        from: "Sender from TestCase <sender@test.case.com>",
+        subject: "Hello, Testing Case!",
+        body: "Hello!"
+      )
+      @blob         = @inbound_email.raw_email.blob
+    end
+
+    test "allow for inbound emails to have different storage services" do
+      assert_not @blob.service_name == ActiveStorage::Blob.service.name, "Should be able to differ"
+    end
+
+    test "assert storage service is set" do
+      assert_equal @blob.service_name, ActionMailbox.storage_service.to_s
+      assert_equal ActiveStorage::Blob.service.name, :test
+      assert_instance_of ActiveStorage::Service::DiskService, @inbound_email.raw_email.blob.service
+    end
+
+    test "assert storage service is not nil" do
+      assert_not @blob.service_name == nil
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Optionally use a different service rather than Active Storage defaults for storage services. Previously, you would set 
```ruby
# production.rb
config.active_storage.service = :amazon
```
And ActionMailbox would pick it up from there storing emails as specified. However, now you could also do a:
```ruby
# production.rb
config.action_mailbox.storage_service = :google
```
And for each new email blob created, it'll have a different service than Active Storage's service being able to be accessed at
```ruby
# 1. Enter rails console with rails c
# 2. For each instance of ActionMailbox::InboundEmail, inspect the service used for the blob and allow for it to be set differently.
inbound_email.raw_email.blob.service_name # => :google
```