### PR TITLE
Fix spelling

### DIFF
--- a/activerecord/test/cases/test_fixtures_test.rb
+++ b/activerecord/test/cases/test_fixtures_test.rb
@@ -40,7 +40,7 @@ class TestFixturesTest < ActiveRecord::TestCase
 
         fixtures :all
 
-        def test_run_successfuly
+        def test_run_successfully
           assert_equal("Hello", Zine.first.title)
           assert_equal("Hello", zines(:going_out).title)
         end
@@ -51,7 +51,7 @@ class TestFixturesTest < ActiveRecord::TestCase
       ActiveRecord::Base.connection_handlers = {}
       ActiveRecord::Base.establish_connection(:arunit)
 
-      test_result = klass.new("test_run_successfuly").run
+      test_result = klass.new("test_run_successfully").run
       assert_predicate(test_result, :passed?)
     ensure
       clean_up_legacy_connection_handlers
@@ -75,7 +75,7 @@ class TestFixturesTest < ActiveRecord::TestCase
 
         fixtures :all
 
-        def test_run_successfuly
+        def test_run_successfully
           assert_equal("Hello", Zine.first.title)
           assert_equal("Hello", zines(:going_out).title)
         end
@@ -85,7 +85,7 @@ class TestFixturesTest < ActiveRecord::TestCase
       ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
       ActiveRecord::Base.establish_connection(:arunit)
 
-      test_result = klass.new("test_run_successfuly").run
+      test_result = klass.new("test_run_successfully").run
       assert_predicate(test_result, :passed?)
     ensure
       ActiveRecord::Base.connection_handler = old_handler

--- a/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
@@ -21,7 +21,7 @@ module CacheStoreCoderBehavior
     end
   end
 
-  def test_coder_recieve_the_entry_on_write
+  def test_coder_receive_the_entry_on_write
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
     @store.write("foo", "bar")
@@ -31,7 +31,7 @@ module CacheStoreCoderBehavior
     assert_equal "bar", entry.value
   end
 
-  def test_coder_recieve_the_entry_on_read
+  def test_coder_receive_the_entry_on_read
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
     @store.write("foo", "bar")
@@ -42,7 +42,7 @@ module CacheStoreCoderBehavior
     assert_equal "bar", entry.value
   end
 
-  def test_coder_recieve_the_entry_on_read_multi
+  def test_coder_receive_the_entry_on_read_multi
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
     @store.write_multi({ "foo" => "bar", "egg" => "spam" })
@@ -57,7 +57,7 @@ module CacheStoreCoderBehavior
     assert_equal "spam", entry.value
   end
 
-  def test_coder_recieve_the_entry_on_write_multi
+  def test_coder_receive_the_entry_on_write_multi
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
     @store.write_multi({ "foo" => "bar", "egg" => "spam" })
@@ -71,7 +71,7 @@ module CacheStoreCoderBehavior
     assert_equal "spam", entry.value
   end
 
-  def test_coder_does_not_recieve_the_entry_on_read_miss
+  def test_coder_does_not_receive_the_entry_on_read_miss
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
     @store.read("foo")


### PR DESCRIPTION
### Summary

Fixed spelling in Ruby files.  Function names and strings.
