### PR TITLE
Add destroy_async

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -37,6 +37,7 @@ module ActiveJob
 
       ActiveSupport.on_load(:active_record) do
         self.destroy_association_async_job = ActiveRecord::DestroyAssociationAsyncJob
+        self.destroy_async_job = ActiveRecord::DestroyAsyncJob
       end
     end
 

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -77,6 +77,7 @@ module ActiveRecord
   autoload :Validations
   autoload :SecureToken
   autoload :DestroyAssociationAsyncJob
+  autoload :DestroyAsyncJob
 
   eager_autoload do
     autoload :ConnectionAdapters

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -39,6 +39,12 @@ module ActiveRecord
       class_attribute :destroy_association_async_job, instance_writer: false, instance_predicate: false, default: false
 
       ##
+      # :singleton-method:
+      #
+      # Specifies the job used to destroy a record in the background
+      class_attribute :destroy_async_job, instance_writer: false, instance_predicate: false, default: false
+
+      ##
       # Contains the database configuration - as is typically stored in config/database.yml -
       # as an ActiveRecord::DatabaseConfigurations object.
       #

--- a/activerecord/lib/active_record/destroy_async_job.rb
+++ b/activerecord/lib/active_record/destroy_async_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class DestroyAsyncError < StandardError
+  end
+
+  # Job to destroy  a record  in background.
+  class DestroyAsyncJob < ActiveJob::Base
+    queue_as { ActiveRecord::Base.queues[:destroy] }
+
+    discard_on ActiveJob::DeserializationError
+
+    def perform(
+      model_name: nil, id: nil
+    )
+      model = model_name.constantize
+      begin
+        model.find(id).destroy
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -552,6 +552,16 @@ module ActiveRecord
       freeze
     end
 
+    # Enqueues a job that will handle the deletion of this object. The stanadard job
+    # calls destroy so all callbacks will be executed in the job.
+    def destroy_async
+      raise ActiveRecord::ActiveJobRequiredError unless self.class.destroy_async_job
+      _raise_readonly_record_error if readonly?
+      raise ActiveRecord::DestroyAsyncError unless persisted?
+      self.class.destroy_async_job&.perform_later(model_name: self.class.to_s, id: self.id)
+    end
+
+
     # Deletes the record in the database and freezes this instance to reflect
     # that no changes should be made (since they can't be persisted).
     #

--- a/activerecord/test/activejob/destroy_async_test.rb
+++ b/activerecord/test/activejob/destroy_async_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "activejob/helper"
+
+require "models/tag"
+require "models/minivan"
+require "models/bulb"
+
+class UnusedDestroyAsync < ActiveRecord::Base
+  self.destroy_async_job = nil
+end
+
+
+class DestroyAsyncTest < ActiveRecord::TestCase
+  include ActiveJob::TestHelper
+
+  test "running the job destroys the object" do
+    tag = Tag.create!(name: "Der be treasure")
+    tag.destroy_async
+    assert_difference -> { Tag.count }, -1 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyAsyncJob
+    end
+  end
+
+  test "destroy runs all callbacks" do
+    funky = FunkyBulb.create!
+    funky.destroy_async
+    # The funky destroy throws a Runtime error in its before destroy
+    assert_raises RuntimeError do
+      perform_enqueued_jobs only: ActiveRecord::DestroyAsyncJob
+    end
+  end
+
+  test "non-persisted objects cannot be enqueued" do
+    tag = Tag.new(name: "Der be treasure")
+
+    assert_raises ActiveRecord::DestroyAsyncError do
+      tag.destroy_async
+    end
+  end
+
+  test "cannot enqueue on a read only db" do
+    van = Minivan.create!(name: "Der be treasure")
+    van.destroy_async
+  end
+
+  test "destroying an all ready destroyed object in a job just passes" do
+    tag = Tag.create!(name: "Der be treasure")
+    tag.destroy_async
+    tag.delete
+    perform_enqueued_jobs only: ActiveRecord::DestroyAsyncJob
+  end
+
+  test "ActiveJob not present error" do
+    record = UnusedDestroyAsync.create!
+    assert_raises ActiveRecord::ActiveJobRequiredError do
+      record.destroy_async
+    end
+  end
+end

--- a/activerecord/test/activejob/helper.rb
+++ b/activerecord/test/activejob/helper.rb
@@ -13,3 +13,4 @@ ActiveJob::Base.logger = ActiveSupport::Logger.new(nil)
 require_relative "../../../tools/test_common"
 
 ActiveRecord::Base.destroy_association_async_job = ActiveRecord::DestroyAssociationAsyncJob
+ActiveRecord::Base.destroy_async_job = ActiveRecord::DestroyAsyncJob


### PR DESCRIPTION
Motivation:
  - Now that destroy_async is an option on association, a natural next
    step seems to be adding this method to standard objects for a more
    consistent offering.

Related Issues:
  - #40157
  - #36912

Changes:
  - Add a destroy_async method to persistence.
  - Add a rail tie to setup the active job configs.
  - Add a default destroy async job.
  - Test


