### PR TITLE
Skip Spring in plugin dummy apps

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -103,6 +103,7 @@ task default: :test
       opts = options.transform_keys(&:to_sym).except(*DUMMY_IGNORE_OPTIONS)
       opts[:force] = force
       opts[:skip_bundle] = true
+      opts[:skip_spring] = true
       opts[:skip_listen] = true
       opts[:skip_git] = true
       opts[:skip_turbolinks] = true

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -539,6 +539,14 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_directory "test/dummy/.git"
   end
 
+  def test_spring_binstub_is_not_generated_in_dummy_application
+    run_generator
+    assert_no_file "test/dummy/bin/spring"
+    assert_file "test/dummy/bin/rails" do |contents|
+      assert_no_match %r/spring/, contents
+    end
+  end
+
   def test_skipping_test_files
     run_generator [destination_root, "--skip-test"]
     assert_no_directory "test"


### PR DESCRIPTION
Since #39746, the Spring binstub can be generated without having to run `bundle install` first, and thus the `skip_bundle` option does not prevent the Spring binstub from being generated.  Therefore, explicitly set the `skip_spring` option for plugin dummy apps.
