### PR TITLE
Add assert_required_keys to complement assert_valid_keys

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -53,6 +53,20 @@ class Hash
       end
     end
   end
+  
+  # Validates that no required keys in a hash are missing from <tt>*required_keys</tt>, raising
+  # +ArgumentError+ for any missing keys.
+  #
+  # Note that keys are treated differently than HashWithIndifferentAccess,
+  # meaning that string and symbol keys will not match.
+  #
+  #   { name: 'Rob', age: '28' }.assert_required_keys('name', 'age') # => raises "ArgumentError: Missing required option(s): 'name', 'age'"
+  #   { name: 'Rob', years: '28' }.assert_required_keys(:name, :age) # => raises "ArgumentError: Missing required option(s): :age"
+  #   { name: 'Rob', age: '28' }.assert_required_keys(:name, :age)   # => passes, raises nothing
+  def assert_required_keys(*required_keys)
+    missing_keys = required_keys.reject { |key| key?(key) }
+    raise ArgumentError.new("Missing required option(s): #{missing_keys.join(", ")}") unless missing_keys.empty?
+  end
 
   # Returns a new hash with all keys converted by the block operation.
   # This includes the keys from the root hash and from all

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -64,7 +64,7 @@ class Hash
   #   { name: 'Rob', years: '28' }.assert_required_keys(:name, :age) # => raises "ArgumentError: Missing required option(s): :age"
   #   { name: 'Rob', age: '28' }.assert_required_keys(:name, :age)   # => passes, raises nothing
   def assert_required_keys(*required_keys)
-    missing_keys = required_keys.reject { |key| key?(key) }
+    missing_keys = required_keys.flatten.reject { |key| key?(key) }
     raise ArgumentError.new("Missing required option(s): #{missing_keys.join(", ")}") unless missing_keys.empty?
   end
 

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -53,7 +53,7 @@ class Hash
       end
     end
   end
-  
+
   # Validates that no required keys in a hash are missing from <tt>*required_keys</tt>, raising
   # +ArgumentError+ for any missing keys.
   #

--- a/activesupport/lib/active_support/core_ext/hash/keys.rb
+++ b/activesupport/lib/active_support/core_ext/hash/keys.rb
@@ -65,7 +65,7 @@ class Hash
   #   { name: 'Rob', age: '28' }.assert_required_keys(:name, :age)   # => passes, raises nothing
   def assert_required_keys(*required_keys)
     missing_keys = required_keys.flatten.reject { |key| key?(key) }
-    raise ArgumentError.new("Missing required option(s): #{missing_keys.join(", ")}") unless missing_keys.empty?
+    raise ArgumentError.new("Missing required option(s): #{missing_keys.map(&:inspect).join(", ")}") unless missing_keys.empty?
   end
 
   # Returns a new hash with all keys converted by the block operation.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -270,6 +270,38 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal "Unknown key: :failore. Valid keys are: :failure", exception.message
   end
 
+  def test_assert_required_keys
+    assert_nothing_raised do
+      { failure: "stuff", funny: "business" }.assert_required_keys([ :failure, :funny ])
+      { failure: "stuff", funny: "business" }.assert_required_keys(:failure, :funny)
+    end
+    # keys that are not required may be present
+    assert_nothing_raised do
+      { failure: "stuff", funny: "business", sunny: "day" }.assert_required_keys([ :failure, :funny ])
+      { failure: "stuff", funny: "business", sunny: "day" }.assert_required_keys(:failure, :funny)
+    end
+
+    exception = assert_raise ArgumentError do
+      { failore: "stuff", funny: "business" }.assert_required_keys([ :failure, :funny ])
+    end
+    assert_equal "Missing required option(s): :failure", exception.message
+
+    exception = assert_raise ArgumentError do
+      { failore: "stuff", funny: "business" }.assert_required_keys(:failure, :funny)
+    end
+    assert_equal "Missing required option(s): :failure", exception.message
+
+    exception = assert_raise ArgumentError do
+      { failore: "stuff", funny: "business" }.assert_required_keys([ :failure ])
+    end
+    assert_equal "Missing required option(s): :failure", exception.message
+
+    exception = assert_raise ArgumentError do
+      { failore: "stuff", funny: "business" }.assert_required_keys(:failure)
+    end
+    assert_equal "Missing required option(s): :failure", exception.message
+  end
+
   def test_deep_merge
     hash_1 = { a: "a", b: "b", c: { c1: "c1", c2: "c2", c3: { d1: "d1" } } }
     hash_2 = { a: 1, c: { c1: 2, c3: { d2: "d2" } } }

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -3041,6 +3041,19 @@ NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
 
 [Hash#assert_valid_keys]: https://api.rubyonrails.org/classes/Hash.html#method-i-assert_valid_keys
 
+#### `assert_required_keys`
+
+The method [`assert_required_keys`][Hash#assert_required_keys] receives an arbitrary number of arguments, and checks whether the receiver is missing any keys in the list. If any are missing, `ArgumentError` is raised.
+
+```ruby
+{a: 1}.assert_required_keys(:a)  # passes
+{"a" => 1}.assert_required_keys(:a) # ArgumentError
+```
+
+NOTE: Defined in `active_support/core_ext/hash/keys.rb`.
+
+[Hash#assert_valid_keys]: https://api.rubyonrails.org/classes/Hash.html#method-i-assert_valid_keys
+
 ### Working with Values
 
 #### `deep_transform_values` and `deep_transform_values!`


### PR DESCRIPTION
### Summary
Adds a public method to `Hash` that can be used to ensure all required parameters are present before doing further work (e.g. during validations or at the beginning of an asynchronous job)

While `assert_valid_keys` ensures that no unexpected keys are present, this provides the complementary behavior, to ensure that no required keys are missing. 

Provides a helpful list of missing keys when the error is triggered. 

#### History
Attempts to implement in Rails
https://github.com/rails/rails/pull/10718/files
Attempts to implement outside of Rails:
https://github.com/laserlemon/figaro/commit/9f54872dfc1a972b4a971211706272f0f38495f4

#### Performance
TODO: add comparisons in approaches based on size of args * size of Hash object being operated on

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->


TODO: 
Add to Changelog, like so: https://github.com/rails/rails/commit/62a20c2a642a2ae6ac7c265af1fe8fdf33114bf4#diff-69e4fa602a1f47160db003903d0de0671658b11a05dfe2883afe2988d429a032
