### PR TITLE
Resolves constants with partial names by overriding #const_missing

### DIFF
--- a/activesupport/lib/active_support/constant_resolver.rb
+++ b/activesupport/lib/active_support/constant_resolver.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ConstantResolver
+  def const_missing(name)
+    return super if constants.empty?
+
+    constants.each do |const_name|
+      const = const_get const_name
+
+      begin
+        return const.const_get name
+      rescue
+        begin
+          next
+        rescue
+          return super
+        end
+      end
+    end
+
+    super
+  end
+end
+
+class Class
+  prepend ConstantResolver
+end
+
+class Module
+  prepend ConstantResolver
+end

--- a/activesupport/test/constant_resolver_test.rb
+++ b/activesupport/test/constant_resolver_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/constant_resolver"
+
+module WhereAreMyKeys
+  module School
+    class Classroom
+      # ...
+    end
+
+    class Cafetaria
+      # ...
+    end
+  end
+
+  module Home
+    class Kitchen
+      # ...
+    end
+
+    class Basement
+      # ...
+
+      class Keys
+        def self.found?
+          true
+        end
+      end
+    end
+  end
+
+  module Club
+    # ...
+  end
+end
+
+class ConstantResolverTest < ActiveSupport::TestCase
+  def test_constant_resolver_should_be_prepended
+    class_ancestors = Class.ancestors
+    module_ancestors = Module.ancestors
+
+    assert_equal ConstantResolver, class_ancestors.first
+    assert_equal ConstantResolver, module_ancestors.first
+  end
+
+  def test_should_resolve_a_partial_constant_name
+    assert_equal WhereAreMyKeys::Home::Basement::Keys, WhereAreMyKeys::Keys
+    assert_equal true, WhereAreMyKeys::Keys.found?
+  end
+end


### PR DESCRIPTION
### Summary
Let's say that the code below should help us find our keys :
```ruby
module WhereAreMyKeys
  module School
    class Classroom
      #...
    end

    class Cafetaria
      #...
    end
  end

  module Home
    class Kitchen
      #...
    end

    class Basement
      #...
      class Keys
        def self.found?
          true
        end
      end
    end
  end

  module Club
    #...
  end
end

p WhereAreMyKeys::Keys # => raise a NameError
```
After requiring the ConstantResolver, Ruby will be able to resolve the constant with a partial name :
```ruby
require "active_support/constant_resolver"

...

p WhereAreMyKeys::Keys # => WhereAreMyKeys::Home::Basement::Keys
p WhereAreMyKeys::Keys.found? # => true
```