### PR TITLE
Fixes the route table CSS for dark mode

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -51,8 +51,17 @@
   }
 
   @media (prefers-color-scheme: dark) {
+    body {
+      background-color: #222;
+      color: #ECECEC;
+    }
+
     #route_table tbody tr:nth-child(odd) {
       background: #333;
+    }
+
+    #route_table tbody tr:nth-child(even) {
+      background: #444;
     }
 
     #route_table tbody.exact_matches,


### PR DESCRIPTION
Tried to fixes #40956

Screenshot: 
<img width="1791" alt="Routes 2020-12-28 09-51-29" src="https://user-images.githubusercontent.com/7736232/103233727-a4da7d80-48f2-11eb-8767-736a75a15999.png">
