### PR TITLE
change ActiveModel::Name initialize arguments to hash and add locale

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -153,6 +153,7 @@ module ActiveModel
     # Returns a new ActiveModel::Name instance. By default, the +namespace+
     # and +name+ option will take the namespace and name of the given class
     # respectively.
+    # Use +locale+ argument for singularize and pluralize model name.
     #
     #   module Foo
     #     class Bar
@@ -161,7 +162,7 @@ module ActiveModel
     #
     #   ActiveModel::Name.new(Foo::Bar).to_s
     #   # => "Foo::Bar"
-    def initialize(klass, namespace = nil, name = nil)
+    def initialize(klass, namespace = nil, name = nil, locale = :en)
       @name = name || klass.name
 
       raise ArgumentError, "Class name cannot be blank. You need to supply a name argument when anonymous class given" if @name.blank?
@@ -169,15 +170,15 @@ module ActiveModel
       @unnamespaced = @name.delete_prefix("#{namespace.name}::") if namespace
       @klass        = klass
       @singular     = _singularize(@name)
-      @plural       = ActiveSupport::Inflector.pluralize(@singular)
+      @plural       = ActiveSupport::Inflector.pluralize(@singular, locale)
       @element      = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(@name))
       @human        = ActiveSupport::Inflector.humanize(@element)
       @collection   = ActiveSupport::Inflector.tableize(@name)
       @param_key    = (namespace ? _singularize(@unnamespaced) : @singular)
       @i18n_key     = @name.underscore.to_sym
 
-      @route_key          = (namespace ? ActiveSupport::Inflector.pluralize(@param_key) : @plural.dup)
-      @singular_route_key = ActiveSupport::Inflector.singularize(@route_key)
+      @route_key          = (namespace ? ActiveSupport::Inflector.pluralize(@param_key, locale) : @plural.dup)
+      @singular_route_key = ActiveSupport::Inflector.singularize(@route_key, locale)
       @route_key << "_index" if @plural == @singular
     end
 

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -158,6 +158,24 @@ class NamingWithSuppliedModelNameTest < ActiveModel::TestCase
   end
 end
 
+class NamingWithSuppliedLocaleTest < ActiveModel::TestCase
+  def setup
+    ActiveSupport::Inflector.inflections(:cs) do |inflect|
+      inflect.plural(/(e)l$/i, '\1lé')
+    end
+
+    @model_name = ActiveModel::Name.new(Blog::Post, nil, "Uzivatel", :cs)
+  end
+
+  def test_singular
+    assert_equal "uzivatel", @model_name.singular
+  end
+
+  def test_plural
+    assert_equal "uzivatelé", @model_name.plural
+  end
+end
+
 class NamingUsingRelativeModelNameTest < ActiveModel::TestCase
   def setup
     @model_name = Blog::Post.model_name


### PR DESCRIPTION
### Summary

For some reason I would like plural form of model name according to language. I see that `pluralize` method accept `locale` as argument, but there is no way how to pass it to initlizer of ActiveModel::Name.


### Other Information

Add `locael` as 4th argument seems to be wierd for me, especially for usage = `new(User, nil, nil, :cs)` for example ... So I decide to change regular args to hash named = Its just nice-to-have change, to decide...