### PR TITLE
 Support aliases to expires_in for cache stores

### DIFF
--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -406,6 +406,40 @@ module CacheStoreBehavior
     end
   end
 
+  def test_expire_in_is_alias_for_expires_in
+    time = Time.local(2008, 4, 24)
+
+    Time.stub(:now, time) do
+      @cache.write("foo", "bar", expire_in: 20)
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 10) do
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 21) do
+      assert_nil @cache.read("foo")
+    end
+  end
+
+  def test_expired_in_is_alias_for_expires_in
+    time = Time.local(2008, 4, 24)
+
+    Time.stub(:now, time) do
+      @cache.write("foo", "bar", expired_in: 20)
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 10) do
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 21) do
+      assert_nil @cache.read("foo")
+    end
+  end
+
   def test_race_condition_protection_skipped_if_not_defined
     @cache.write("foo", "bar")
     time = @cache.send(:read_entry, @cache.send(:normalize_key, "foo", {}), **{}).expires_at


### PR DESCRIPTION
The `expires_in` option is easy to misremember or mistype as `expire_in`
or `expired_in`, with potentially harmful results. If a developer wants
to cache a value for only 2 seconds but mistakenly types
`expire_in: 2.seconds`, that value will instead be cached for the
default time, likely 6 hours, meaning that users of the site will see
the same data for much longer than they should, and the only recovery
(short of waiting for the 6 hours to elapse) is to manually expire all
relevant keys. This commit allows cache stores to recognize these common
typos as aliases by normalizing them before consuming the options.

In general, we should be careful about adding too many aliases for
options to the cache stores, since each option key used by the base
Cache::Store class is one fewer key that each cache implementation can
customize for itself. This case was approved because of the similarity
of the aliases to the root key and the potential damage caused by
mistaking them.

Fixes #39850.