### PR TITLE
`connected_to` shouldn't be called on abstract class that not established connection

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -141,6 +141,10 @@ module ActiveRecord
         if self != Base && !abstract_class
           raise NotImplementedError, "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes."
         end
+
+        if name != connection_specification_name
+          raise NotImplementedError, "calling `connected_to` is only allowed on the abstract class that established the connection."
+        end
       end
 
       unless role || shard

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -35,6 +35,10 @@ end
 class SecondAbstractClass < FirstAbstractClass
   self.abstract_class = true
 end
+class ThirdAbstractClass < FirstAbstractClass
+  self.abstract_class = true
+  connects_to(database: { writing: :arunit, reading: :arunit })
+end
 class Photo < SecondAbstractClass; end
 class Smarts < ActiveRecord::Base; end
 class CreditCard < ActiveRecord::Base
@@ -1646,9 +1650,17 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes.", error.message
   end
 
+  test "cannot call connected_to on the abstract class that established the connection" do
+    error = assert_raises(NotImplementedError) do
+      SecondAbstractClass.connected_to(role: :reading) { }
+    end
+
+    assert_equal "calling `connected_to` is only allowed on the abstract class that established the connection.", error.message
+  end
+
   test "can call connected_to with role and shard on abstract classes" do
-    AbstractCompany.connected_to(role: :reading, shard: :default) do
-      assert AbstractCompany.connected_to?(role: :reading, shard: :default)
+    ThirdAbstractClass.connected_to(role: :reading, shard: :default) do
+      assert ThirdAbstractClass.connected_to?(role: :reading, shard: :default)
     end
   end
 


### PR DESCRIPTION
### Summary

Fixed: https://github.com/rails/rails/issues/40559#issuecomment-752056106

When abstract class hasn't own connections, calling `AbstractClass.connection` returns parent class's connection. We call `AbstractClass.connection.preventing_writes?` expecting abstract class's state to be returned, but actually it is parent's one.

I think that it isn't expected behavior so I prevents call `connected_to` on abstract
class that not established the connection.

~In addition, `connected_to_many` didn't check for passed classes, so now it checks for them as well as `connected_to`.~  This change is a not same concern, so I'll separate PR.

### Other Information

[bug report template gist](https://gist.github.com/alpaca-tc/f4335960b312e026808712a7f43a7947)