### PR TITLE
Don't consider ApplicationRecord the same as ActiveRecord::Base

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -269,10 +269,6 @@ module ActiveRecord
       @connection_specification_name
     end
 
-    def primary_class? # :nodoc:
-      self == Base || defined?(ApplicationRecord) && self == ApplicationRecord
-    end
-
     # Returns the configuration of the associated connection as a hash:
     #
     #  ActiveRecord::Base.connection_config
@@ -337,11 +333,10 @@ module ActiveRecord
       def resolve_config_for_connection(config_or_env)
         raise "Anonymous class is not allowed." unless name
 
-        owner_name = primary_class? ? Base.name : name
-        self.connection_specification_name = owner_name
+        self.connection_specification_name = name
 
         db_config = Base.configurations.resolve(config_or_env)
-        [db_config, owner_name]
+        [db_config, name]
       end
 
       def with_handler(handler_key, &blk)


### PR DESCRIPTION
### Summary

Fixed: https://github.com/rails/rails/issues/40559

When calling `connects_to` from `ApplicationRecord`, `owner_name` will be
`ActiveRecord::Base` instead of `ApplicationRecord`. It is unexpected behavior.

It means `ApplicationRecord.connection` can't resolve correct `owner_name`
and can't fetch own `preventing_writes?`.

### Other Information

This behavior introduced by rails/rails#36394
But, I think that the new established connection is completely independent connection.
If we want to consider the same as the `ActiveRecord::Base`, we can call
`ActiveRecord::Base.connects_to` instead of.