### PR TITLE
Fix has_many_inversing with touch: true on a belongs_to association with inverse

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -81,7 +81,7 @@ module ActiveRecord
             @updated = true
           end
 
-          replace_keys(record)
+          replace_keys(record, record_target_key(record))
 
           self.target = record
         end
@@ -109,8 +109,8 @@ module ActiveRecord
           reflection.counter_cache_column && owner.persisted?
         end
 
-        def replace_keys(record, target_key = :unset)
-          owner[reflection.foreign_key] = target_key == :unset ? record_target_key(record) : target_key
+        def replace_keys(record, target_key)
+          owner[reflection.foreign_key] = target_key
         end
 
         def record_target_key(record)

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -29,7 +29,8 @@ module ActiveRecord
       end
 
       def inversed_from(record)
-        replace_keys_if_needed(record)
+        target_key = record_target_key(record)
+        replace_keys(record, target_key) if owner[reflection.foreign_key] != target_key
         super
       end
 
@@ -80,7 +81,7 @@ module ActiveRecord
             @updated = true
           end
 
-          replace_keys(record)
+          replace_keys(record, record_target_key(record))
 
           self.target = record
         end
@@ -108,13 +109,8 @@ module ActiveRecord
           reflection.counter_cache_column && owner.persisted?
         end
 
-        def replace_keys(record)
-          owner[reflection.foreign_key] = record_target_key(record)
-        end
-
-        def replace_keys_if_needed(record)
-          target_key = record_target_key(record)
-          owner[reflection.foreign_key] = target_key if owner[reflection.foreign_key] != target_key
+        def replace_keys(record, target_key)
+          owner[reflection.foreign_key] = target_key
         end
 
         def record_target_key(record)

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -29,8 +29,7 @@ module ActiveRecord
       end
 
       def inversed_from(record)
-        target_key = record_target_key(record)
-        replace_keys(target_key) if owner[reflection.foreign_key] != target_key
+        replace_keys_if_needed(record)
         super
       end
 
@@ -81,7 +80,7 @@ module ActiveRecord
             @updated = true
           end
 
-          replace_keys(record_target_key(record))
+          replace_keys(record)
 
           self.target = record
         end
@@ -109,8 +108,13 @@ module ActiveRecord
           reflection.counter_cache_column && owner.persisted?
         end
 
-        def replace_keys(target_key)
-          owner[reflection.foreign_key] = target_key
+        def replace_keys(record)
+          owner[reflection.foreign_key] = record_target_key(record)
+        end
+
+        def replace_keys_if_needed(record)
+          target_key = record_target_key(record)
+          owner[reflection.foreign_key] = target_key if owner[reflection.foreign_key] != target_key
         end
 
         def record_target_key(record)

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -30,7 +30,7 @@ module ActiveRecord
 
       def inversed_from(record)
         target_key = record_target_key(record)
-        replace_keys(record, target_key) if owner[reflection.foreign_key] != target_key
+        replace_keys(target_key) if owner[reflection.foreign_key] != target_key
         super
       end
 
@@ -81,7 +81,7 @@ module ActiveRecord
             @updated = true
           end
 
-          replace_keys(record, record_target_key(record))
+          replace_keys(record_target_key(record))
 
           self.target = record
         end
@@ -109,7 +109,7 @@ module ActiveRecord
           reflection.counter_cache_column && owner.persisted?
         end
 
-        def replace_keys(record, target_key)
+        def replace_keys(target_key)
           owner[reflection.foreign_key] = target_key
         end
 

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -29,7 +29,7 @@ module ActiveRecord
       end
 
       def inversed_from(record)
-        replace_keys(record)
+        replace_keys(record) if owner[reflection.foreign_key] != record_target_key(record)
         super
       end
 
@@ -109,7 +109,11 @@ module ActiveRecord
         end
 
         def replace_keys(record)
-          owner[reflection.foreign_key] = record ? record._read_attribute(primary_key(record.class)) : nil
+          owner[reflection.foreign_key] = record_target_key(record)
+        end
+
+        def record_target_key(record)
+          record ? record._read_attribute(primary_key(record.class)) : nil
         end
 
         def primary_key(klass)

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -29,7 +29,8 @@ module ActiveRecord
       end
 
       def inversed_from(record)
-        replace_keys(record) if owner[reflection.foreign_key] != record_target_key(record)
+        target_key = record_target_key(record)
+        replace_keys(record, target_key) if owner[reflection.foreign_key] != target_key
         super
       end
 
@@ -108,8 +109,8 @@ module ActiveRecord
           reflection.counter_cache_column && owner.persisted?
         end
 
-        def replace_keys(record)
-          owner[reflection.foreign_key] = record_target_key(record)
+        def replace_keys(record, target_key = :unset)
+          owner[reflection.foreign_key] = target_key == :unset ? record_target_key(record) : target_key
         end
 
         def record_target_key(record)

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
       def inversed_from(record)
         target_type = record_target_type(record)
-        replace_type(record, target_type) if owner[reflection.foreign_type] != target_type
+        replace_type(target_type) if owner[reflection.foreign_type] != target_type
         super
       end
 
@@ -21,11 +21,11 @@ module ActiveRecord
 
       private
         def replace(record)
-          replace_type(record, record_target_type(record))
+          replace_type(record_target_type(record))
           super
         end
 
-        def replace_type(record, target_type)
+        def replace_type(target_type)
           owner[reflection.foreign_type] = target_type
         end
 

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -4,6 +4,12 @@ module ActiveRecord
   module Associations
     # = Active Record Belongs To Polymorphic Association
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
+      def inversed_from(record)
+        target_type = record_target_type(record)
+        replace_type(record, target_type) if owner[reflection.foreign_type] != target_type
+        super
+      end
+
       def klass
         type = owner[reflection.foreign_type]
         type.presence && owner.class.polymorphic_class_for(type)
@@ -14,9 +20,17 @@ module ActiveRecord
       end
 
       private
-        def replace_keys(record)
+        def replace(record)
+          replace_type(record, record_target_type(record))
           super
-          owner[reflection.foreign_type] = record ? record.class.polymorphic_name : nil
+        end
+
+        def replace_type(record, target_type)
+          owner[reflection.foreign_type] = target_type
+        end
+
+        def record_target_type(record)
+          record ? record.class.polymorphic_name : nil
         end
 
         def inverse_reflection_for(record)

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -14,20 +14,9 @@ module ActiveRecord
       end
 
       private
-        def replace_keys(record)
+        def replace_keys(record, _target_key)
           super
-          owner[reflection.foreign_type] = record_target_type(record)
-        end
-
-        def replace_keys_if_needed(record)
-          super
-
-          target_type = record_target_type(record)
-          owner[reflection.foreign_type] = target_type if owner[reflection.foreign_type] != target_type
-        end
-
-        def record_target_type(record)
-          record ? record.class.polymorphic_name : nil
+          owner[reflection.foreign_type] = record ? record.class.polymorphic_name : nil
         end
 
         def inverse_reflection_for(record)

--- a/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_polymorphic_association.rb
@@ -4,15 +4,6 @@ module ActiveRecord
   module Associations
     # = Active Record Belongs To Polymorphic Association
     class BelongsToPolymorphicAssociation < BelongsToAssociation #:nodoc:
-      def inversed_from(record)
-        target_key  = record_target_key(record)
-        target_type = record_target_type(record)
-        if owner[reflection.foreign_key] != target_key || owner[reflection.foreign_type] != target_type
-          replace_keys(record, target_key, target_type)
-        end
-        super
-      end
-
       def klass
         type = owner[reflection.foreign_type]
         type.presence && owner.class.polymorphic_class_for(type)
@@ -23,21 +14,16 @@ module ActiveRecord
       end
 
       private
-        def replace(record)
-          if record
-            raise_on_type_mismatch!(record)
-            set_inverse_instance(record)
-            @updated = true
-          end
-
-          replace_keys(record_target_key(record), record_target_type(record))
-
-          self.target = record
+        def replace_keys(record)
+          super
+          owner[reflection.foreign_type] = record_target_type(record)
         end
 
-        def replace_keys(target_key, target_type)
-          super(target_key)
-          owner[reflection.foreign_type] = target_type
+        def replace_keys_if_needed(record)
+          super
+
+          target_type = record_target_type(record)
+          owner[reflection.foreign_type] = target_type if owner[reflection.foreign_type] != target_type
         end
 
         def record_target_type(record)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1372,6 +1372,21 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal toy, sponsor.reload.sponsorable
   end
 
+  class SponsorWithTouchInverse < Sponsor
+    belongs_to :sponsorable, polymorphic: true, inverse_of: :sponsors, touch: true
+  end
+
+  def test_destroying_polymorphic_child_with_unloaded_parent_and_touch_is_possible_with_has_many_inversing
+    with_has_many_inversing do
+      toy     = Toy.create!
+      sponsor = toy.sponsors.create!
+
+      assert_difference "Sponsor.count", -1 do
+        SponsorWithTouchInverse.find(sponsor.id).destroy
+      end
+    end
+  end
+
   def test_polymorphic_with_false
     assert_nothing_raised do
       Class.new(ActiveRecord::Base) do

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -25,6 +25,8 @@ require "models/admin/user"
 require "models/ship"
 require "models/treasure"
 require "models/parrot"
+require "models/book"
+require "models/citation"
 
 class BelongsToAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :topics,
@@ -1175,6 +1177,17 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_predicate firm_with_condition_proxy, :stale_target?
     assert_equal companies(:another_firm), client.firm
     assert_equal companies(:another_firm), client.firm_with_condition
+  end
+
+  def test_destroying_child_with_unloaded_parent_and_foreign_key_and_touch_is_possible_with_has_many_inversing
+    with_has_many_inversing do
+      book     = Book.create!
+      citation = book.citations.create!
+
+      assert_difference "Citation.count", -1 do
+        Citation.find(citation.id).destroy
+      end
+    end
   end
 
   def test_polymorphic_reassignment_of_associated_id_updates_the_object

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -3,7 +3,7 @@
 class Book < ActiveRecord::Base
   belongs_to :author
 
-  has_many :citations, foreign_key: "book1_id"
+  has_many :citations, foreign_key: "book1_id", inverse_of: :book
   has_many :references, -> { distinct }, through: :citations, source: :reference_of
 
   has_many :subscriptions

--- a/activerecord/test/models/citation.rb
+++ b/activerecord/test/models/citation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Citation < ActiveRecord::Base
+  belongs_to :book, foreign_key: :book1_id, inverse_of: :citations, touch: true
   belongs_to :reference_of, class_name: "Book", foreign_key: :book2_id
   has_many :citations
 end

--- a/activerecord/test/models/toy.rb
+++ b/activerecord/test/models/toy.rb
@@ -4,5 +4,7 @@ class Toy < ActiveRecord::Base
   self.primary_key = :toy_id
   belongs_to :pet
 
+  has_many :sponsors, as: :sponsorable, inverse_of: :sponsorable
+
   scope :with_pet, -> { joins(:pet) }
 end


### PR DESCRIPTION
### Summary

`has_many_inversing` adds records to a has_many association. It does so with destroyed records, too. So if a child was destroyed with a `belongs_to :parent, touch: true` association *and* the parent was not loaded, it tried to load the parent to touch it. While loading the parent it added the child record to the parent's has_many association. The logic doing this always set the child's parent id – even if it was correct/the same already. But since the child is destroyed, it resulted in a `FrozenError`.

This commit prevents doing the unnecessary setting of the identical id and therefore fixes this error.

Fixes #40943