### PR TITLE
Resolves constants from partial names

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,57 @@
+*   Add `ActiveSupport::ConstantResolver` module to resolve partial constant names.
+
+    Ruby doesn't resolve partial constant names by default. So in order to make this work, the `ConstantResolver`
+    module overrides `#const_missing` and gets prepended in both `Class` and `Module`.
+
+    Without the `ConstantResolver` :
+
+        module Ace
+          module Base
+            class Case
+              class Dice
+              end
+            end
+            class Fase < Case
+            end
+          end
+          class Gas
+            include Base
+          end
+
+        end
+
+        class Object
+          module AddtlGlobalConstants
+            class Case
+              class Dice
+              end
+            end
+          end
+          include AddtlGlobalConstants
+        end
+
+        p Ace::Dice
+        # => NameError: uninitialized constant Ace::Dice
+
+    With the `ConstantResolver` :
+
+        require "active_support"
+        require "active_support/constant_resolver"
+
+        p Ace::Dice
+        # => Ace::Base::Case::Dice
+
+    This allows the `#constantize` method to resolve partial names :
+
+        require "active_support/inflector"
+
+        p "Ace::Dice".constantize
+        # => Ace::Base::Case::Dice
+
+    Note that the `Inflector` tests still passes when we require the `ConstantResolver` in `test/inflector_test.rb`.
+
+    *Mansa Keïta (mansakondo)*
+
 *   Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
     invalid.
 

--- a/activesupport/lib/active_support/constant_resolver.rb
+++ b/activesupport/lib/active_support/constant_resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ConstantResolver
+  def const_missing(name)
+    return super if constants.empty? || self == Object
+
+    constants.each do |const_name|
+      const = const_get const_name
+
+      begin
+        return const.const_get name, false
+      rescue
+        next const
+      end
+    end
+
+    super
+  end
+end
+
+class Class
+  prepend ConstantResolver
+end
+
+class Module
+  prepend ConstantResolver
+end

--- a/activesupport/test/constant_resolver_test.rb
+++ b/activesupport/test/constant_resolver_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/constant_resolver"
+
+module WhereAreMyKeys
+  module School
+    class Classroom
+      # ...
+    end
+
+    class Cafeteria
+      # ...
+    end
+  end
+
+  module Club
+    # ...
+  end
+
+  module Home
+    class Kitchen
+      # ...
+    end
+
+    class Basement
+      # ...
+
+      class Keys
+        def self.found?
+          true
+        end
+      end
+    end
+  end
+end
+
+module Empty
+end
+
+class ConstantResolverTest < ActiveSupport::TestCase
+  def test_should_be_prepended
+    class_ancestors = Class.ancestors
+    module_ancestors = Module.ancestors
+
+    assert_equal ConstantResolver, class_ancestors.first
+    assert_equal ConstantResolver, module_ancestors.first
+  end
+
+  def test_should_resolve_a_partial_constant_name
+    assert_equal WhereAreMyKeys::Home::Basement::Keys, WhereAreMyKeys::Keys
+    assert WhereAreMyKeys::Keys.found?
+  end
+
+  def test_should_preserve_the_default_behaviour_if_self_is_object_class
+    assert_raise(NameError) { yield Object::Keys }
+    assert Object::NameError
+  end
+
+  def test_should_raise_a_name_error_if_constants_is_empty
+    assert_raises(NameError) { yield Empty::Keys }
+  end
+end


### PR DESCRIPTION
## Summary
Ruby doesn't resolve partial constant names by default. So in order to make this work, the `ConstantResolver` module overrides `#const_missing` and gets prepended in both `Class` and `Module`.

## Example
Without the `ConstantResolver` :
```ruby
module Ace
  module Base
    class Case
      class Dice
      end
    end
    class Fase < Case
    end
  end
  class Gas
    include Base
  end
end

class Object
  module AddtlGlobalConstants
    class Case
      class Dice
      end
    end
  end
  include AddtlGlobalConstants
end

p Ace::Dice
# => NameError: uninitialized constant Ace::Dice
```
With the `ConstantResolver` :
```ruby
require "active_support"
require "active_support/constant_resolver"

p Ace::Dice
# => Ace::Base::Case::Dice
```
This allows the `#constantize` method to resolve partial names :
```ruby
require "active_support/inflector"

p "Ace::Dice".constantize
# => Ace::Base::Case::Dice
```
Note that the `Inflector` tests still passes when we require the `ConstantResolver` in `test/inflector_test.rb.`