### PR TITLE
Don't mangle callable enum names

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -202,7 +202,7 @@ module ActiveRecord
               suffix = "_#{enum_suffix}"
             end
 
-            method_friendly_label = label.to_s.gsub(/\W+/, "_")
+            method_friendly_label = label.to_s.gsub(/[\W&&[:ascii:]]+/, "_")
             value_method_name = "#{prefix}#{method_friendly_label}#{suffix}"
             value_method_names << value_method_name
             enum_values[label] = value

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -646,6 +646,17 @@ class EnumTest < ActiveRecord::TestCase
     assert_not_predicate computer, :extendedGold?
   end
 
+  test "unicode characters for enum names" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum language: [:🇺🇸, :🇪🇸, :🇫🇷]
+    end
+
+    book = klass.🇺🇸.build
+    assert_predicate book, :🇺🇸?
+    assert_not_predicate book, :🇪🇸?
+  end
+
   test "enum logs a warning if auto-generated negative scopes would clash with other enum names" do
     old_logger = ActiveRecord::Base.logger
     logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new


### PR DESCRIPTION
Related #39677, #39700, https://github.com/rails/rails/issues/40804#issuecomment-751440989.

The intent of #39700 is to mangle non-callable enum names to avoid
`public_send`, but `\W` (non-word) character class includes Unicode
characters which are valid for callable method name in Ruby.

It should be limited to mangle enum names only for non-word *ASCII*
characters.