### PR TITLE
Adds assertion assert_not_redirected_to

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/response.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/response.rb
@@ -61,6 +61,30 @@ module ActionDispatch
         assert_operator redirect_expected, :===, redirect_is, message
       end
 
+      # Asserts that the response is a redirect but not to the URL matching in the given options.
+      #
+      #   # Asserts that the redirection was not to the "index" action on the WeblogController
+      #   assert_not_redirected_to controller: "weblog", action: "index"
+      #
+      #   # Asserts that the redirection was not to the named route login_url
+      #   assert_not_redirected_to login_url
+      #
+      #   # Asserts that the redirection was not to the URL for @customer
+      #   assert_not_redirected_to @customer
+      #
+      #   # Asserts that the redirection does not match the regular expression
+      #   assert_not_redirected_to %r(\Ahttp://example.org)
+      def assert_not_redirected_to(options = {}, message = nil)
+        assert_response(:redirect, message)
+        return true unless options === @response.location
+
+        redirect_is       = normalize_argument_to_redirection(@response.location)
+        redirect_expected = normalize_argument_to_redirection(options)
+
+        message ||= "Expected response not to be redirected to <#{redirect_expected}> but was redirected to <#{redirect_is}>"
+        assert_not_operator redirect_expected, :===, redirect_is, message
+      end
+
       private
         # Proxy to to_param if the object will respond to it.
         def parameterize(value)

--- a/actionpack/test/controller/action_pack_assertions_test.rb
+++ b/actionpack/test/controller/action_pack_assertions_test.rb
@@ -286,6 +286,28 @@ class ActionPackAssertionsControllerTest < ActionController::TestCase
     )
   end
 
+  def test_assert_not_redirected_to_path
+    process :redirect_to_path
+    assert_not_redirected_to "http://test.host/route_two"
+  end
+
+  def test_assert_not_redirected_to_with_options
+    @controller = ActionPackAssertionsController.new
+
+    with_routing do |set|
+      set.draw do
+        get "nothing", to: "action_pack_assertions#nothing"
+        get "flash_me", to: "elsewhere#flash_me"
+        get "redirect_to_controller", to: "action_pack_assertions#redirect_to_controller"
+      end
+
+      process :redirect_to_controller
+      assert_not_redirected_to controller: "action_pack_assertions", action: "nothing"
+      assert_not_redirected_to "http://test.host/nothing"
+      assert_not_redirected_to %r(/nothing)
+    end
+  end
+
   def test_template_objects_exist
     process :assign_this
     assert_not @controller.instance_variable_defined?(:"@hi")


### PR DESCRIPTION
FIXES #40975 


### Summary

Adds a new assertion `assert_not_redirected_to`

This will work:
```
assert_not_redirected_to controller: "home", action: "index"
assert_not_redirected_to "http://localhost:3000/dashboard"
assert_not_redirected_to %r(/dashboard)
```