### PR TITLE
Clarify use of rescue_from [ci skip]

### DIFF
--- a/activesupport/lib/active_support/rescuable.rb
+++ b/activesupport/lib/active_support/rescuable.rb
@@ -14,12 +14,12 @@ module ActiveSupport
     end
 
     module ClassMethods
-      # Rescue exceptions raised in controller actions.
+      # Registers exception classes with a handler to be called by <tt>rescue_with_handler</tt>.
       #
       # <tt>rescue_from</tt> receives a series of exception classes or class
-      # names, and a trailing <tt>:with</tt> option with the name of a method
-      # or a Proc object to be called to handle them. Alternatively a block can
-      # be given.
+      # names, and an exception handler specified by a trailing <tt>:with</tt>
+      # option containing the name of a method or a Proc object. Alternatively, a block
+      # can be given as the handler.
       #
       # Handlers that take one argument will be called with the exception, so
       # that the exception can be inspected when dealing with it.


### PR DESCRIPTION
### Summary
`rescue_from` works for rescuing exceptions in controller actions, but it's not specific to ActionController.

This change updates the docs to clarify the specifics of how `rescue_from` is used and that its use goes beyond controller actions.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
Note: I believe the original addition of this documentation was added as part of the move from [`ActionController::Rescue` to `ActiveSupport::Rescuable`](https://github.com/rails/rails/commit/259a7a844b53b7d508145cc61fed9e11581e5409#diff-2276a3674b84e1262c94cc36346f9fbd8d00e0a4542bb991a8846c06d86335b1R12)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
