### PR TITLE
Fix _decrypt method when using aes-256-ecb.

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -188,7 +188,7 @@ module ActiveSupport
 
         cipher.decrypt
         cipher.key = @secret
-        cipher.iv  = iv
+        cipher.iv  = iv if cipher.iv.present?
         if aead_mode?
           cipher.auth_tag = auth_tag
           cipher.auth_data = ""

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -95,6 +95,12 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     assert_aead_not_decrypted(encryptor, "eHdGeExnZEwvMSt3U3dKaFl1WFo0TjVvYzA0eGpjbm5WSkt5MXlsNzhpZ0ZnbWhBWFlQZTRwaXE1bVJCS2oxMDZhYVp2dVN3V0lNZUlWQ3c2eVhQbnhnVjFmeVVubmhRKzF3WnZyWHVNMDg9LS1HSisyakJVSFlPb05ISzRMaXRzcFdBPT0=--831a1d54a3cda8a0658dc668a03dedcbce13b5ca")
   end
 
+  def test_aes_256_ecb_mode_encryption
+    encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-ecb")
+    message = encryptor.encrypt_and_sign(@data)
+    assert_equal @data, encryptor.decrypt_and_verify(message)
+  end
+  
   def test_messing_with_aead_values_causes_failures
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
     text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")

--- a/activesupport/test/message_encryptor_test.rb
+++ b/activesupport/test/message_encryptor_test.rb
@@ -100,7 +100,7 @@ class MessageEncryptorTest < ActiveSupport::TestCase
     message = encryptor.encrypt_and_sign(@data)
     assert_equal @data, encryptor.decrypt_and_verify(message)
   end
-  
+
   def test_messing_with_aead_values_causes_failures
     encryptor = ActiveSupport::MessageEncryptor.new(@secret, cipher: "aes-256-gcm")
     text, iv, auth_tag = encryptor.encrypt_and_sign(@data).split("--")


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
When ECB mode cipher is used, _decrypt method is throwing error as cipher has no 'iv' and we are trying to assign value to it.
from the reference [#39276](https://github.com/rails/rails/pull/39276) I am raising MR again as I am also facing same issue.
to keep the conversation linked together. -->

### Other Information
@NZKoz reply to your message in   [#39276](https://github.com/rails/rails/pull/39276#issuecomment-629534361) , we know ecb mode is not suggestible but there must be senario where we must use this mode. and as we are already supporting this method, we should fix the issue or else we should not support ECB mode.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
