### PR TITLE
Populate ARGV for app template

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -110,8 +110,9 @@ module Rails
                                            desc: "Show this help message and quit"
       end
 
-      def initialize(*args)
-        @gem_filter    = lambda { |gem| true }
+      def initialize(positional_argv, option_argv, *)
+        @argv = [*positional_argv, *option_argv]
+        @gem_filter = lambda { |gem| true }
         super
       end
 
@@ -148,9 +149,14 @@ module Rails
       end
 
       def apply_rails_template # :doc:
+        original_argv = ARGV.dup
+        ARGV.replace(@argv)
+
         apply rails_template if rails_template
       rescue Thor::Error, LoadError, Errno::ENOENT => e
         raise Error, "The template [#{rails_template}] could not be loaded. Error: #{e}"
+      ensure
+        ARGV.replace(original_argv)
       end
 
       def set_default_accessors! # :doc:

--- a/railties/test/fixtures/lib/template.rb
+++ b/railties/test/fixtures/lib/template.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 say "It works from file!"
+say "With ARGV! #{ARGV.join(" ")}"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -731,6 +731,13 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
+  def test_argv_is_populated_for_template
+    FileUtils.cd(Rails.root)
+    argv = [destination_root, "-m", "lib/template.rb"]
+
+    assert_match %r/With ARGV! #{Regexp.escape argv.join(" ")}/, run_generator(argv)
+  end
+
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc


### PR DESCRIPTION
In #38495, `ARGV` was isolated to prevent commands from depending on its contents, which might be indeterminate.  However, app templates may depend on `ARGV`, so populate it before evaluating them.

Fixes #40945.
