### PR TITLE
Add note for ActionText models that use UUID's [ci skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -47,6 +47,8 @@ happens after every keystroke, and avoids the need to use execCommand at all.
 
 Run `bin/rails action_text:install` to add the Yarn package and copy over the necessary migration. Also, you need to set up Active Storage for embedded images and other attachments. Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
 
+NOTE: ActionText uses polymorphic relationships with the `action_text_rich_texts` table so that it can be shared with all models that have rich text attributes. If your models with ActionText content use UUID values for identifiers, all models that use ActionText attributes will need to use UUID values for their unique identifiers. The generated migration for ActionText will also need to be updated to specify `type: :uuid` for the `:record` `references` line.
+
 After the installation is complete, a Rails app using Webpacker should have the following changes:
 
 1. Both `trix` and `@rails/actiontext` should be required in your JavaScript pack.


### PR DESCRIPTION
I ran into an issue where I failed to specify `type: :uuid` for the ActionText migration since the migration was automatically generated. The result was that even after updating the fixtures, my tests were failing due to `nil`  values for the `body` of any rich text attributes. It took a little time to connect the dots, so hopefully this (or something like it) could help save others some time investigating.

Separately, this also made me realize that the polymorphic nature of the `action_text_rich_texts` table means that all models that need rich text attributes would have to use the same approach, either UUID's or integer ID's. This note may be trying to do too much as a result. Very much open to better approaches on how to clarify this to save anyone else some spelunking.

### Summary

Adds a note to the ActionText guides documnetation drawing attention to the impact of UUID's on models that have rich text attributes.


