### PR TITLE
Set payload name for calculation queries

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -197,7 +197,7 @@ module ActiveRecord
           if where_clause.contradiction?
             ActiveRecord::Result.new([], [])
           else
-            klass.connection.select_all(relation.arel, nil)
+            klass.connection.select_all(relation.arel, "#{klass.name} Pluck")
           end
         end
         type_cast_pluck_values(result, columns)
@@ -305,7 +305,7 @@ module ActiveRecord
           query_builder = relation.arel
         end
 
-        result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder) }
+        result = skip_query_cache_if_necessary { @klass.connection.select_all(query_builder, "#{@klass.name} #{operation.capitalize}") }
 
         type_cast_calculated_value(result.cast_values.first, operation) do |value|
           type = column.try(:type_caster) ||
@@ -360,7 +360,7 @@ module ActiveRecord
         relation.group_values  = group_fields
         relation.select_values = select_values
 
-        calculated_data = skip_query_cache_if_necessary { @klass.connection.select_all(relation.arel, nil) }
+        calculated_data = skip_query_cache_if_necessary { @klass.connection.select_all(relation.arel, "#{@klass.name} #{operation.capitalize}") }
 
         if association
           key_ids     = calculated_data.collect { |row| row[group_aliases.first] }

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -73,6 +73,42 @@ module ActiveRecord
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
+    def test_payload_name_on_pluck
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        if event.payload[:sql].match "SELECT"
+          assert_equal "Book Pluck", event.payload[:name]
+        end
+      end
+      Book.pluck(:name)
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_name_on_count
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        if event.payload[:sql].match "SELECT"
+          assert_equal "Book Count", event.payload[:name]
+        end
+      end
+      Book.count
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    def test_payload_name_on_grouped_count
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        if event.payload[:sql].match "SELECT"
+          assert_equal "Book Count", event.payload[:name]
+        end
+      end
+      Book.group(:status).count
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
     def test_payload_connection_with_query_cache_disabled
       connection = Book.connection
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/30619.

This makes the logging for pluck, count, average, minimum, maximum, and sum queries more descriptive.

### Before:

    irb(main):001:0> Post.count
       (0.1ms)  SELECT COUNT(*) FROM "posts"

### After:

    irb(main):001:0> Post.count
      Post Count (0.1ms)  SELECT COUNT(*) FROM "posts"