### PR TITLE
 [ci skip] instruct to change active_storage_variant_records.id column type to U…

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -43,7 +43,7 @@ tables. Use `bin/rails db:migrate` to run the migration.
 
 WARNING: `active_storage_attachments` is a polymorphic join table that stores your model's class name. If your model's class name changes, you will need to run a migration on this table to update the underlying `record_type` to your model's new class name.
 
-WARNING: If you are using UUIDs instead of integers as the primary key on your models you will need to change the column type of `record_id` for the `active_storage_attachments` table in the generated migration accordingly.
+WARNING: If you are using UUIDs instead of integers as the primary key on your models you will need to change the column type of `active_storage_attachments.record_id` and `active_storage_variant_records.id` in the generated migration accordingly.
 
 Declare Active Storage services in `config/storage.yml`. For each service your
 application uses, provide a name and the requisite configuration. The example


### PR DESCRIPTION
…UID if using UUID for active storage

### Summary

Documentation only update that adds further required instructions if using UUID for your models and active storage. This is only an issue if `Rails.application.config.active_storage.track_variants = true`, the new default for Rails 6.1.


### Other Information
Spent an hour chasing down this bug after setting up active storage to use UUIDs in Rails 6.1.

```
ActiveRecord::NotNullViolation (PG::NotNullViolation: ERROR:  null value in column "record_id" of relation "active_storage_attachments" violates not-null constraint
DETAIL:  Failing row contains (6, image, ActiveStorage::VariantRecord, null, 6, 2021-01-02 12:47:09.827378).
):
```

It was the generated active_storage_variant_records.id column still being an int. Changing to a UUID solved my problem.


```ruby
create_table :active_storage_variant_records, id: :uuid do |t|
  ...
end
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rails/rails/40998)
<!-- Reviewable:end -->
