### PR TITLE
Tweak dark mode CSS

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -51,22 +51,13 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    body {
-      background-color: #222;
-      color: #ECECEC;
-    }
-
     #route_table tbody tr:nth-child(odd) {
-      background: #333;
+      background: #282828;
     }
 
-    #route_table tbody tr:nth-child(even) {
-      background: #444;
-    }
-
-    #route_table tbody.exact_matches,
-    #route_table tbody.fuzzy_matches {
-      color: #333;
+    #route_table tbody.exact_matches tr,
+    #route_table tbody.fuzzy_matches tr {
+      background: DarkSlateGrey;
     }
   }
 <% end %>

--- a/railties/lib/rails/templates/layouts/application.html.erb
+++ b/railties/lib/rails/templates/layouts/application.html.erb
@@ -25,6 +25,21 @@
 
     h2 { padding-left: 10px; }
 
+    @media (prefers-color-scheme: dark) {
+      body {
+        background-color: #222;
+        color: #ececec;
+      }
+
+      pre {
+        background-color: #333;
+      }
+
+      a { color: #fff; }
+      a:visited { color: #999; }
+      a:hover { color: #000; background-color: #fff; }
+    }
+
     <%= yield :style %>
   </style>
 </head>


### PR DESCRIPTION
Follow-up to #40960.

This fixes a few different visual issues with links and table rows when using dark mode.

**Before**

![dark-mode-before](https://user-images.githubusercontent.com/771968/103465103-59630d80-4cfe-11eb-9368-3638887ce329.png)

**After**

![dark-mode-after](https://user-images.githubusercontent.com/771968/103465104-5bc56780-4cfe-11eb-88dc-7e4739a951ec.png)

---

/cc @cseelus I've added you as a co-author since you were working on this in #40896.
