### PR TITLE
fix ActionView::Base.raise_on_missing_translations

### DIFF
--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -156,9 +156,6 @@ module ActionView #:nodoc:
     # Specify default_formats that can be rendered.
     cattr_accessor :default_formats
 
-    # Specify whether an error should be raised for missing translations
-    cattr_accessor :raise_on_missing_translations, default: false
-
     # Specify whether submit_tag should automatically disable on click
     cattr_accessor :automatically_disable_submit_tag, default: true
 
@@ -170,6 +167,8 @@ module ActionView #:nodoc:
 
     class << self
       delegate :erb_trim_mode=, to: "ActionView::Template::Handlers::ERB"
+      delegate :raise_on_missing_translations, to: "AbstractController::Translation"
+      delegate :raise_on_missing_translations=, to: "AbstractController::Translation"
 
       def cache_template_loading
         ActionView::Resolver.caching?


### PR DESCRIPTION
### Summary

On Ruby 3.0.0, this method is causing the following error:

    ActionView::Template::Error: class variable @@raise_on_missing_translations of ActionView::Base is overtaken by AbstractController::Translation

Since both of them are defining the class variable and Ruby 3.0.0 now makes this into an error. The one in `ActionView::Base` seems to be deprecated now, so I figured it would be safe enough for the `cattr_accessor` to be replaced with a simple delegation to `AbstractController::Translation`.

I have monkey-patched this into my current project and it seems to be working fine.
