### PR TITLE
Apply patch for reaper to use one thread and fix thread leak

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -3,6 +3,7 @@
 require "thread"
 require "concurrent/map"
 require "monitor"
+require "weakref"
 
 module ActiveRecord
   # Raised when a connection could not be obtained within the connection
@@ -294,15 +295,49 @@ module ActiveRecord
           @frequency = frequency
         end
 
+        @mutex = Mutex.new
+        @pools = {}
+        @threads = {}
+
+        class << self
+          def register_pool(pool, frequency) # :nodoc:
+            @mutex.synchronize do
+              unless @threads[frequency]&.alive?
+                @threads[frequency] = spawn_thread(frequency)
+              end
+              @pools[frequency] ||= []
+              @pools[frequency] << WeakRef.new(pool)
+            end
+          end
+
+          private
+            def spawn_thread(frequency)
+              Thread.new(frequency) do |t|
+                running = true
+                while running
+                  sleep t
+                  @mutex.synchronize do
+                    @pools[frequency].select!(&:weakref_alive?)
+                    @pools[frequency].each do |p|
+                      p.reap
+                      p.flush
+                    rescue WeakRef::RefError
+                    end
+
+                    if @pools[frequency].empty?
+                      @pools.delete(frequency)
+                      @threads.delete(frequency)
+                      running = false
+                    end
+                  end
+                end
+              end
+            end
+        end
+
         def run
           return unless frequency && frequency > 0
-          Thread.new(frequency, pool) { |t, p|
-            loop do
-              sleep t
-              p.reap
-              p.flush
-            end
-          }
+          self.class.register_pool(pool, frequency)
         end
       end
 


### PR DESCRIPTION
Bring patches to rails 5.2 from rails 6+ to:
 · Make reaper use a single thread for all ConnectionPool Reapers (#36296)
 · Use WeakRef in Reaper to avoid leaking connection pools (#36345)

### Summary

Backport of one bug and one feature solved in Rails 6+, non existent in Rails 5.1.7. After suffering the connection pool leakage issue in a real production environment that killed the servers in a few hours periodically, I forked Rails 5.2 to fix the issue using Reaper code from the corresponding fix in Rails 6+. While I was fixing the bug, I also brought the enhancement to use a single thread for connection pool reapers, which is really useful since we had a lot (nearly 100 per server) reaper threads running. Now down to one per application. I have tested the code in our production environment and it is working as expected. The code changes really belong to #36296 and #36345, there was no reason to add or remove code.

### Other Information

Rails 5.2 is unable to close open threads generated by stablish_connection. I have suffered this issue in a production environment with thousands of users after upgrading 9 applications, having servers fail every few hours continuously. I have tested the same applications on Rails 5.1.7 and it worked as expected, however I didn't feel like downgrading was the answer. After researching I found #36345 had been fixed in Rails 6.1 and backported to Rails 6.0, but not to Rails 5.2. While I understand that Rails 5.2 is not under development, this bug can break a production environment, and I would really like for it to be fixed in Rails 5.2 so other users don't have to deal with it. I also found stackoverflow unresolved posts related to this issue, before answering them I'd love to point them to the official repo and not to my forked repo. Thanks for your time.

