### PR TITLE
Move away from using the Digest::SHA2 class

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -152,7 +152,7 @@ module ActiveRecord
   # - define a helper method in <tt>test_helper.rb</tt>
   #     module FixtureFileHelpers
   #       def file_sha(path)
-  #         Digest::SHA2.hexdigest(File.read(Rails.root.join('test/fixtures', path)))
+  #         OpenSSL::Digest::SHA256.hexdigest(File.read(Rails.root.join('test/fixtures', path)))
   #       end
   #     end
   #     ActiveRecord::FixtureSet.context_class.include FixtureFileHelpers

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -191,7 +191,7 @@ module ActiveSupport
           key = super.dup
           key = key.force_encoding(Encoding::ASCII_8BIT)
           key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-          key = "#{key[0, 213]}:md5:#{ActiveSupport::Digest.hexdigest(key)}" if key.size > 250
+          key = "#{key[0, 212]}:hash:#{ActiveSupport::Digest.hexdigest(key)}" if key.size > 250
           key
         end
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -15,7 +15,7 @@ begin
 rescue LoadError
 end
 
-require "digest/sha2"
+require "active_support/digest"
 require "active_support/core_ext/marshal"
 
 module ActiveSupport
@@ -46,7 +46,7 @@ module ActiveSupport
     #   4.0.1+ for distributed mget support.
     # * +delete_matched+ support for Redis KEYS globs.
     class RedisCacheStore < Store
-      # Keys are truncated with their own SHA2 digest if they exceed 1kB
+      # Keys are truncated with the ActiveSupport digest if they exceed 1kB
       MAX_KEY_BYTESIZE = 1024
 
       DEFAULT_REDIS_OPTIONS = {
@@ -449,7 +449,7 @@ module ActiveSupport
 
         def truncate_key(key)
           if key && key.bytesize > max_key_bytesize
-            suffix = ":sha2:#{::Digest::SHA2.hexdigest(key)}"
+            suffix = ":hash:#{ActiveSupport::Digest.hexdigest(key)}"
             truncate_at = max_key_bytesize - suffix.bytesize
             "#{key.byteslice(0, truncate_at)}#{suffix}"
           else

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -1496,7 +1496,7 @@ included in the newly introduced `ActiveRecord::FixtureSet.context_class`, in
 ```ruby
 module FixtureFileHelpers
   def file_sha(path)
-    Digest::SHA2.hexdigest(File.read(Rails.root.join('test/fixtures', path)))
+    OpenSSL::Digest::SHA256.hexdigest(File.read(Rails.root.join('test/fixtures', path)))
   end
 end
 


### PR DESCRIPTION
### Summary

The Digest::SHA2 class implicitly ends up using SHA256 by default, but there's no OpenSSL version of the same class (OpenSSL::Digest::SHA2 does not exist).

To make it easier to force OpenSSL for hash usage and not use deprecated OpenSSL APIs from Digest on older Ruby versions before 3.0, an approach like https://github.com/ruby/openssl/pull/377 might be used.

That approach won't work with this SHA2 class though, so it shouldn't be used. The discussion in https://github.com/rails/rails/pull/40770 also indicates that in general the intent is to move to OpenSSL constants anyway, so this makes that move a lot easier as well.

Lastly, this updates the cache key usage in the Redis cache store. This store seems to be the only one not using the configured ActiveSupport::Digest class like all other cache usage. Switching it from the not recommended SHA2 class to the ActiveSupport one makes it more consistent with the rest. This also updates the cache key name to not call out the implementation of the hash, and updates memcache in a similar way (where it was still referring to MD5 which is not guaranteed to be used for ActiveSupport::Digest).

### Other Information

This is part of the more general effort identified in https://github.com/rails/rails/pull/40770 to move things to the OpenSSL constants in Rails by default, and this is a case of not a simple find replace so I extracted this into a separate change first. 