### PR TITLE
Avoid nokogiri v1.11.0 to make our CI green

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ group :test do
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
-  gem "nokogiri", ">= 1.8.1"
+  gem "nokogiri", ">= 1.8.1", "!= 1.11.0"
 
   # Needed for compiling the ActionDispatch::Journey parser.
   gem "racc", ">=1.4.6", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,11 +348,6 @@ GEM
     nio4r (2.5.4-java)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.10-java)
-    nokogiri (1.10.10-x64-mingw32)
-      mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.10-x86-mingw32)
-      mini_portile2 (~> 2.4.0)
     os (1.1.1)
     parallel (1.19.2)
     parser (2.7.2.0)
@@ -582,7 +577,7 @@ DEPENDENCIES
   minitest-reporters
   minitest-retry
   mysql2 (~> 0.5)!
-  nokogiri (>= 1.8.1)
+  nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.1)
   psych (~> 3.0)
   puma


### PR DESCRIPTION
https://buildkite.com/rails/rails/builds/73847#8a8b56c0-ebdf-4a34-8072-62b688412970/986-995

I think it is definitely an issue for nokogiri, so I'll avoid the
version to make our CI green.
