### PR TITLE
Use round(scale) in  ActiveModel NumericalityValidator

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -71,6 +71,8 @@ module ActiveModel
           raw_value if raw_value.is_a?(Range)
         elsif raw_value.is_a?(Float)
           parse_float(raw_value, precision, scale)
+        elsif raw_value.is_a?(BigDecimal)
+          round(raw_value, scale)
         elsif raw_value.is_a?(Numeric)
           raw_value
         elsif is_integer?(raw_value)
@@ -81,7 +83,11 @@ module ActiveModel
       end
 
       def parse_float(raw_value, precision, scale)
-        (scale ? raw_value.truncate(scale) : raw_value).to_d(precision)
+        round(raw_value, scale).to_d(precision)
+      end
+
+      def round(raw_value, scale)
+        scale ? raw_value.round(scale) : raw_value
       end
 
       def is_number?(raw_value, precision, scale)

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -103,6 +103,21 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     assert_not_predicate subject, :valid?
   end
 
+  def test_virtual_attribute_with_precision_and_scale
+    model_class.attribute(:virtual_decimal_number, :decimal, precision: 4, scale: 2)
+    model_class.validates_numericality_of(
+      :virtual_decimal_number, less_than_or_equal_to: 99.99
+    )
+
+    subject = model_class.new(virtual_decimal_number: 99.994)
+    assert_equal 99.99.to_d(4), subject.virtual_decimal_number
+    assert_predicate subject, :valid?
+
+    subject = model_class.new(virtual_decimal_number: 99.999)
+    assert_equal 100.00.to_d(4), subject.virtual_decimal_number
+    assert_not_predicate subject, :valid?
+  end
+
   def test_aliased_attribute
     model_class.validates_numericality_of(:new_bank_balance, greater_or_equal_than: 0)
 

--- a/activerecord/test/cases/validations_test.rb
+++ b/activerecord/test/cases/validations_test.rb
@@ -187,9 +187,17 @@ class ValidationsTest < ActiveRecord::TestCase
       validates_numericality_of :wibble, greater_than_or_equal_to: BigDecimal("97.18")
     end
 
-    assert_not_predicate klass.new(wibble: "97.179"), :valid?
-    assert_not_predicate klass.new(wibble: 97.179), :valid?
-    assert_not_predicate klass.new(wibble: BigDecimal("97.179")), :valid?
+    ["97.179", 97.179, BigDecimal("97.179")].each do |raw_value|
+      subject = klass.new(wibble: raw_value)
+      assert_equal 97.18.to_d(4), subject.wibble
+      assert_predicate subject, :valid?
+    end
+
+    ["97.174", 97.174, BigDecimal("97.174")].each do |raw_value|
+      subject = klass.new(wibble: raw_value)
+      assert_equal 97.17.to_d(4), subject.wibble
+      assert_not_predicate subject, :valid?
+    end
   end
 
   def test_numericality_validator_wont_be_affected_by_custom_getter


### PR DESCRIPTION
### Summary

f72f743 introduces `truncate(scale)` in the `Numericality` validator.
This behaviour conflicts with ActiveRecord decimal type conversion, which uses [round(scale)](https://github.com/rails/rails/blob/v6.1.1/activemodel/lib/active_model/type/decimal.rb#L62) instead.

Changes `Numericality` validator in order to use `round(scale)` for consistency.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Fixes #40902

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
