### PR TITLE
Add local error page custom env key support

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
@@ -12,7 +12,12 @@
 
 <div class="details">
   <div class="summary"><a href="#" onclick="return toggleSessionDump()">Toggle session dump</a></div>
-  <div id="session_dump" style="display:none"><pre><%= debug_hash @request.session %></pre></div>
+  <div id="session_dump" style="display:none">
+    <pre><%= debug_hash @request.session %></pre>
+    <% Rails.configuration.x.additional_error_request_env_keys.to_a.each do |key| %>
+      <pre><%= debug_hash {k => @request.env[key]} %></pre>
+    <% end %>
+  </div>
 </div>
 
 <div class="details">


### PR DESCRIPTION
### Summary

This would make it simple to add any rack env keys to the error page to aid in debugging.

### Other Information

This is clearly not the correct solution, but the code I hope illustrates the idea.  Happy to iterate/refactor if this seems like a useful feature.

Example usage:

```ruby
config.x.additional_error_request_env_keys = %w[.sampleapp.identity sampleapp.roles sampleapp.debug  ]
# ...
request.env["sampleapp.identity"] = session[:identity_id] && Identity.find(session[:identity_id])
request.env["sampleapp.roles"] = request.env["sampleapp.identity"].try(:roles)
request.env["sampleapp.debug"] = nil # replace to help debug code
```
