### PR TITLE
Add validate numericality in range

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `in: range`  parameter to `numericality` validator.
+
+   *Michal Papis*
+
 *   Add `locale` argument to `ActiveModel::Name#initialize` to be used to generate the `singular`,
    `plural`, `route_key` and `singular_route_key` values.
 

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -32,5 +32,6 @@ en:
       less_than: "must be less than %{count}"
       less_than_or_equal_to: "must be less than or equal to %{count}"
       other_than: "must be other than %{count}"
+      in: "must be in %{count}"
       odd: "must be odd"
       even: "must be even"

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -7,7 +7,7 @@ module ActiveModel
     class NumericalityValidator < EachValidator # :nodoc:
       CHECKS = { greater_than: :>, greater_than_or_equal_to: :>=,
                  equal_to: :==, less_than: :<, less_than_or_equal_to: :<=,
-                 odd: :odd?, even: :even?, other_than: :!= }.freeze
+                 odd: :odd?, even: :even?, other_than: :!=, in: :in? }.freeze
 
       RESERVED_OPTIONS = CHECKS.keys + [:only_integer]
 
@@ -16,10 +16,15 @@ module ActiveModel
       HEXADECIMAL_REGEX = /\A[+-]?0[xX]/
 
       def check_validity!
-        keys = CHECKS.keys - [:odd, :even]
+        keys = CHECKS.keys - [:odd, :even, :in]
         options.slice(*keys).each do |option, value|
           unless value.is_a?(Numeric) || value.is_a?(Proc) || value.is_a?(Symbol)
             raise ArgumentError, ":#{option} must be a number, a symbol or a proc"
+          end
+        end
+        options.slice(:in).each do |option, value|
+          unless value.is_a?(Range)
+            raise ArgumentError, ":#{option} must be a range"
           end
         end
       end
@@ -51,7 +56,7 @@ module ActiveModel
               option_value = record.send(option_value)
             end
 
-            option_value = parse_as_number(option_value, precision, scale)
+            option_value = parse_as_number(option_value, precision, scale, option)
 
             unless value.public_send(CHECKS[option], option_value)
               record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
@@ -61,8 +66,10 @@ module ActiveModel
       end
 
     private
-      def parse_as_number(raw_value, precision, scale)
-        if raw_value.is_a?(Float)
+      def parse_as_number(raw_value, precision, scale, option = nil)
+        if option == :in
+          raw_value if raw_value.is_a?(Range)
+        elsif raw_value.is_a?(Float)
           parse_float(raw_value, precision, scale)
         elsif raw_value.is_a?(Numeric)
           raw_value

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -7,6 +7,7 @@ require "models/person"
 
 require "bigdecimal"
 require "active_support/core_ext/big_decimal"
+require "active_support/core_ext/object/inclusion"
 
 class NumericalityValidationTest < ActiveModel::TestCase
   def teardown
@@ -204,6 +205,13 @@ class NumericalityValidationTest < ActiveModel::TestCase
 
     invalid!([0, 0.0])
     valid!([-1, 42])
+  end
+
+  def test_validates_numericality_with_in
+    Topic.validates_numericality_of :approved, in: 1..3
+
+    invalid!([0, 4])
+    valid!([1, 2, 3])
   end
 
   def test_validates_numericality_with_other_than_using_string_value

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -528,6 +528,8 @@ constraints to acceptable values:
   less than or equal to %{count}"_.
 * `:other_than` - Specifies the value must be other than the supplied value.
   The default error message for this option is _"must be other than %{count}"_.
+* `:in` - Specifies the value must be in the supplied range.
+  The default error message for this option is _"must be in %{count}"_.
 * `:odd` - Specifies the value must be an odd number if set to true. The
   default error message for this option is _"must be odd"_.
 * `:even` - Specifies the value must be an even number if set to true. The

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -993,6 +993,7 @@ So, for example, instead of the default error message `"cannot be blank"` you co
 | numericality | :less_than_or_equal_to    | :less_than_or_equal_to    | count         |
 | numericality | :other_than               | :other_than               | count         |
 | numericality | :only_integer             | :not_an_integer           | -             |
+| numericality | :in                       | :in                       | count         |
 | numericality | :odd                      | :odd                      | -             |
 | numericality | :even                     | :even                     | -             |
 


### PR DESCRIPTION
### Summary

Simplifies numeric value validation for a range, like a percent:
```ruby
validates :percentage, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
```
to:
```ruby
validates :percentage, numericality: { in: 0..100 }
```

this is in line with `length: { in: x..y }` validation.
