### PR TITLE
[ci skip]Inherit from correct base class in docs

### DIFF
--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -173,7 +173,7 @@ module ActiveRecord
       #   class Money < Struct.new(:amount, :currency)
       #   end
       #
-      #   class MoneyType < Type::Value
+      #   class MoneyType < ActiveRecord::Type::Value
       #     def initialize(currency_converter:)
       #       @currency_converter = currency_converter
       #     end


### PR DESCRIPTION
### Summary

As a developer when I was referring to the documentation and followed what was written, I could easily guess the right base class but there will be a lot of developers who might not even guess it. So, to make it more clear, use the correct and right base class in the documentation.