### PR TITLE
Handle STI models for has_many dependent: :destroy_async

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -42,7 +42,7 @@ module ActiveRecord
             enqueue_destroy_association(
               owner_model_name: owner.class.to_s,
               owner_id: owner.id,
-              association_class: association_class.to_s,
+              association_class: reflection.klass.to_s,
               association_ids: ids,
               association_primary_key_column: primary_key_column,
               ensuring_owner_was_method: options.fetch(:ensuring_owner_was, nil)

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -134,6 +134,16 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     end
   end
 
+  test "has_many with sti parent class destroys all children class records" do
+    book = BookDestroyAsync.create!
+    LongEssayDestroyAsync.create!(book: book)
+    ShortEssayDestroyAsync.create!(book: book)
+    book.destroy
+
+    assert_difference -> { EssayDestroyAsync.count }, -2 do
+      perform_enqueued_jobs only: ActiveRecord::DestroyAssociationAsyncJob
+    end
+  end
 
   test "enqueues the has_many to be deleted with custom primary key" do
     dl_keyed_has_many = DlKeyedHasMany.new

--- a/activerecord/test/models/essay_destroy_async.rb
+++ b/activerecord/test/models/essay_destroy_async.rb
@@ -4,3 +4,9 @@ class EssayDestroyAsync < ActiveRecord::Base
   self.table_name = "essays"
   belongs_to :book, dependent: :destroy_async, class_name: "BookDestroyAsync"
 end
+
+class LongEssayDestroyAsync < EssayDestroyAsync
+end
+
+class ShortEssayDestroyAsync < EssayDestroyAsync
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -408,6 +408,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :essays, force: true do |t|
+    t.string :type
     t.string :name
     t.string :writer_id
     t.string :writer_type


### PR DESCRIPTION
### Summary

has_many dependent: :destroy_async currently doesn't work with STI models and only deletes the records related to the first child in the associated records.

Related to #41008

