### PR TITLE
Fix through association with through scope which has joins

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -131,13 +131,12 @@ module ActiveRecord
               if scope_chain_item == chain_head.scope
                 scope.merge! item.except(:where, :includes, :unscope, :order)
               elsif !item.references_values.empty?
-                scope.joins_values |= item.joins_values
-                scope.left_outer_joins_values |= item.left_outer_joins_values
+                scope.merge! item.only(:joins, :left_outer_joins)
 
                 associations = item.eager_load_values | item.includes_values
 
                 unless associations.empty?
-                  scope.joins_values << item.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+                  scope.joins! item.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
                 end
               end
 

--- a/activerecord/lib/active_record/associations/join_dependency/join_association.rb
+++ b/activerecord/lib/active_record/associations/join_dependency/join_association.rb
@@ -42,16 +42,17 @@ module ActiveRecord
           chain.reverse_each do |reflection, table|
             klass = reflection.klass
 
-            join_scope = reflection.join_scope(table, foreign_table, foreign_klass)
+            scope = reflection.join_scope(table, foreign_table, foreign_klass)
 
-            unless join_scope.references_values.empty?
-              join_dependency = join_scope.construct_join_dependency(
-                join_scope.eager_load_values | join_scope.includes_values, Arel::Nodes::OuterJoin
-              )
-              join_scope.joins!(join_dependency)
+            unless scope.references_values.empty?
+              associations = scope.eager_load_values | scope.includes_values
+
+              unless associations.empty?
+                scope.joins! scope.construct_join_dependency(associations, Arel::Nodes::OuterJoin)
+              end
             end
 
-            arel = join_scope.arel(alias_tracker.aliases)
+            arel = scope.arel(alias_tracker.aliases)
             nodes = arel.constraints.first
 
             if nodes.is_a?(Arel::Nodes::And)

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1070,14 +1070,21 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal expected, Author.eager_load(:lazy_readers_skimmers_or_not).first.lazy_readers_skimmers_or_not
   end
 
-  def test_has_many_through_with_join_scope
+  def test_has_many_through_with_through_scope_with_includes
     expected = [readers(:bob_welcome).becomes(LazyReader)]
     assert_equal expected, Author.last.lazy_readers_skimmers_or_not_2
     assert_equal expected, Author.preload(:lazy_readers_skimmers_or_not_2).last.lazy_readers_skimmers_or_not_2
     assert_equal expected, Author.eager_load(:lazy_readers_skimmers_or_not_2).last.lazy_readers_skimmers_or_not_2
   end
 
-  def test_duplicated_has_many_through_with_join_scope
+  def test_has_many_through_with_through_scope_with_joins
+    expected = [readers(:bob_welcome).becomes(LazyReader)]
+    assert_equal expected, Author.last.lazy_readers_skimmers_or_not_3
+    assert_equal expected, Author.preload(:lazy_readers_skimmers_or_not_3).last.lazy_readers_skimmers_or_not_3
+    assert_equal expected, Author.eager_load(:lazy_readers_skimmers_or_not_3).last.lazy_readers_skimmers_or_not_3
+  end
+
+  def test_duplicated_has_many_through_with_through_scope_with_joins
     Categorization.create!(author: authors(:david), post: posts(:thinking), category: categories(:technology))
 
     expected = [categorizations(:david_welcome_general)]

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -62,6 +62,7 @@ class Author < ActiveRecord::Base
   has_many :hello_posts, -> { where "posts.body = 'hello'" }, class_name: "Post"
   has_many :hello_post_comments, through: :hello_posts, source: :comments
   has_many :posts_with_no_comments, -> { where("comments.id" => nil).includes(:comments) }, class_name: "Post"
+  has_many :posts_with_no_comments_2, -> { left_joins(:comments).where("comments.id": nil) }, class_name: "Post"
 
   has_many :hello_posts_with_hash_conditions, -> { where(body: "hello") }, class_name: "Post"
   has_many :hello_post_comments_with_hash_conditions, through: :hello_posts_with_hash_conditions, source: :comments
@@ -183,6 +184,7 @@ class Author < ActiveRecord::Base
 
   has_many :lazy_readers_skimmers_or_not, through: :posts
   has_many :lazy_readers_skimmers_or_not_2, through: :posts_with_no_comments, source: :lazy_readers_skimmers_or_not
+  has_many :lazy_readers_skimmers_or_not_3, through: :posts_with_no_comments_2, source: :lazy_readers_skimmers_or_not
 
   attr_accessor :post_log
   after_initialize :set_post_log


### PR DESCRIPTION
Follow up to #39390.

#39390 works only for through scope with includes, joins are incorrectly
merged if source association and through association are based on
different klass.

Use `scope.merge` to avoid the merging scope issue.

Fixes #40220.
