### PR TITLE
Fix preventing writes for ApplicationRecord

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -24,7 +24,7 @@ module ActiveRecord
 
       attr_accessor :schema_cache
 
-      def owner_name
+      def connection_klass
         nil
       end
     end
@@ -360,7 +360,7 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config, :owner_name
+      attr_reader :db_config, :size, :reaper, :pool_config, :connection_klass
 
       delegate :schema_cache, :schema_cache=, to: :pool_config
 
@@ -375,7 +375,7 @@ module ActiveRecord
 
         @pool_config = pool_config
         @db_config = pool_config.db_config
-        @owner_name = pool_config.connection_specification_name
+        @connection_klass = pool_config.connection_klass
 
         @checkout_timeout = db_config.checkout_timeout
         @idle_timeout = db_config.idle_timeout
@@ -1040,7 +1040,7 @@ module ActiveRecord
       end
       alias :connection_pools :connection_pool_list
 
-      def establish_connection(config, owner_name: Base.name, role: ActiveRecord::Base.current_role, shard: Base.current_shard)
+      def establish_connection(config, owner_name: Base, role: ActiveRecord::Base.current_role, shard: Base.current_shard)
         owner_name = config.to_s if config.is_a?(Symbol)
 
         pool_config = resolve_pool_config(config, owner_name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -111,7 +111,7 @@ module ActiveRecord
         @config.fetch(:use_metadata_table, true)
       end
 
-      # Determines whether writes are currently being prevents.
+      # Determines whether writes are currently being prevented.
       #
       # Returns true if the connection is a replica.
       #
@@ -123,10 +123,9 @@ module ActiveRecord
       def preventing_writes?
         return true if replica?
         return ActiveRecord::Base.connection_handler.prevent_writes if ActiveRecord::Base.legacy_connection_handling
-        return false if owner_name.nil?
+        return false if connection_klass.nil?
 
-        klass = self.owner_name.safe_constantize
-        klass&.current_preventing_writes
+        connection_klass.current_preventing_writes
       end
 
       def migrations_paths # :nodoc:
@@ -202,8 +201,8 @@ module ActiveRecord
         @owner = Thread.current
       end
 
-      def owner_name # :nodoc:
-        @pool.owner_name
+      def connection_klass # :nodoc:
+        @pool.connection_klass
       end
 
       def schema_cache

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -341,7 +341,7 @@ module ActiveRecord
         self.connection_specification_name = owner_name
 
         db_config = Base.configurations.resolve(config_or_env)
-        [db_config, owner_name]
+        [db_config, self]
       end
 
       def with_handler(handler_key, &blk)

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -40,7 +40,7 @@ module ActiveRecord
 
       def test_close
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("test", "primary", {})
-        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", db_config)
+        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config)
         pool = Pool.new(pool_config)
         pool.insert_connection_for_test! @adapter
         @adapter.pool = pool

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
         # Keep a duplicate pool so we do not bother others
         @db_config = ActiveRecord::Base.connection_pool.db_config
-        @pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", @db_config)
+        @pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, @db_config)
         @pool = ConnectionPool.new(@pool_config)
 
         if in_memory_db?
@@ -204,7 +204,7 @@ module ActiveRecord
         config = @db_config.configuration_hash.merge(idle_timeout: "0.02")
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
 
-        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", db_config)
+        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config)
         @pool = ConnectionPool.new(pool_config)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
@@ -231,7 +231,7 @@ module ActiveRecord
 
         config = @db_config.configuration_hash.merge(idle_timeout: -5)
         db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
-        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", db_config)
+        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config)
         @pool = ConnectionPool.new(pool_config)
         idle_conn = @pool.checkout
         @pool.checkin(idle_conn)
@@ -743,7 +743,7 @@ module ActiveRecord
         def with_single_connection_pool
           config = @db_config.configuration_hash.merge(pool: 1)
           db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", config)
-          pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new("primary", db_config)
+          pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config)
 
           yield(pool = ConnectionPool.new(pool_config))
         ensure

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -59,7 +59,7 @@ module ActiveRecord
 
       def test_pool_has_reaper
         config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
-        pool_config = PoolConfig.new("primary", config)
+        pool_config = PoolConfig.new(ActiveRecord::Base, config)
         pool = ConnectionPool.new(pool_config)
 
         assert pool.reaper
@@ -171,7 +171,7 @@ module ActiveRecord
         def duplicated_pool_config(merge_config_options = {})
           old_config = ActiveRecord::Base.connection_pool.db_config.configuration_hash.merge(merge_config_options)
           db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", old_config.dup)
-          PoolConfig.new("primary", db_config)
+          PoolConfig.new(ActiveRecord::Base, db_config)
         end
 
         def new_conn_in_thread(pool)


### PR DESCRIPTION
Alt to https://github.com/rails/rails/pull/40966, fixes https://github.com/rails/rails/issues/40559

ApplicationRecord is special. If you have a multiple database
application we need to treat `ApplicationRecord` and
`ActiveRecord::Base` as the same connection, otherwise applications
will end up with duplicate connections to the same database. This is
problematic because there are a limited number of open connections an
application could have to a single database. By not treating
`ActiveRecord::Base` and `ApplicationRecord` the same we could
effectively double connections to a database (then multiplied by the
number of processes).

In the case of granular connection swapping we need to be able to read
`ApplicationRecord` off the stack while storing the
`connection_specification_name` as `ActiveRecord::Base`. In order to do
this we read the `current_preventing_writes` off the pool's
"owner_name" which was `connection_specification_name`.

To fix the issue here need to pass the original class to
`establish_connection` on the handler and then down to the `PoolConfig`.
We can then determine the `connection_specification_name` from the
`connection_klass` the same way we did in `resolve_config_for_connection`.
This isn't ideal, and I'd like to move away from the string class but
this has been part of the known API for awhile so I don't feel
comfortable changing that without investigation.

We can then read the `connection_klass` in `preventing_writes?` instead
of the connection specification name. If you're using a nil or string
value for your class, then multiple databases really won't work so
there's no point in supporting prevent writes for that.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>
Co-authored-by: alpaca-tc <alpaca-tc@alpaca.tc>

cc/ @alpaca-tc