### PR TITLE
Resets the destroyed flag when reloading an object

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -817,6 +817,7 @@ module ActiveRecord
       @attributes = fresh_object.instance_variable_get(:@attributes)
       @new_record = false
       @previously_new_record = false
+      @destroyed = false
       self
     end
 

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1058,6 +1058,25 @@ class PersistenceTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.disable_query_cache!
   end
 
+  def test_reload_resets_destroyed_flag
+    topic = Topic.find(1)
+
+    topic.destroy
+
+    assert_equal true, topic.destroyed?
+
+    Topic.insert(topic.attributes)
+
+    # hard reload
+    hard_reloaded_topic = Topic.find(topic.id)
+    assert_equal false, hard_reloaded_topic.destroyed?
+
+    # soft reload
+    topic.reload
+
+    assert_equal false, topic.destroyed?
+  end
+
   def test_save_touch_false
     parrot = Parrot.create!(
       name: "Bob",


### PR DESCRIPTION
### Summary

There are cases where we have to rollback a deletion of a record
without being able to rely on a classic transaction block.

Calling reload on the destroyed (and then inserted) instance would
still mark the instance as being destroyed. 

You can follow the steps to reproduce here: https://gist.github.com/schnika/30be816fd77675269a80f330763df7c0 or have a look at the test provided in this pr.

### Other Information

closes #40820

CHANGELOG

* `object#reload` resets the `@destroyed` flag now.
