### PR TITLE
Optimize join table index

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/migration.rb.tt
@@ -18,11 +18,15 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
 <%- elsif migration_action == 'join' -%>
   def change
     create_join_table :<%= join_tables.first %>, :<%= join_tables.second %> do |t|
-    <%- attributes.each do |attribute| -%>
+    <%- attributes.each_with_index do |attribute, i| -%>
       <%- if attribute.reference? -%>
       t.references :<%= attribute.name %><%= attribute.inject_options %><%= foreign_key_type %>
       <%- elsif !attribute.virtual? -%>
-      <%= '# ' unless attribute.has_index? -%>t.index <%= attribute.index_name %><%= attribute.inject_index_options %>
+        <%- if i == 0 -%>
+          <%= '# ' unless attribute.has_index? -%>t.index <%= attribute.index_name %><%= attribute.inject_index_options %>, unique: true
+        <%- else %>
+          <%= '# ' unless attribute.has_index? -%>t.index :<%= attribute.name %>
+        <%- end -%>
       <%- end -%>
     <%- end -%>
     end


### PR DESCRIPTION

### Summary

Provide optimized join table index by default.
I think the `unique: true` is not needed possibly, but happy to iterate if possible (as well as update the guide to reflect the change)

### Other Information

I remember nerding out on this years ago, but whenever making performant join tables, the index matters!  Just had to re-look this up, but the TL;DR is:

```ruby
create_table(:event_item_member_fields) do |t|
  t.timestamps
  t.bigint "event_item_id", null: false
  t.bigint "member_field_id", null: false
  # building indexes below will cover BOTH directions of lookups
  # eg: member_field.event_items AND event_item.member_fields
  t.index ["event_item_id", "member_field_id"], unique: true
  t.index "member_field_id"
end
```

Source: https://pawelurbanek.com/rails-postgres-join-indexes

