### PR TITLE
Remove update_table_definition from add_reference[6.0] migration log

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -59,7 +59,8 @@ module ActiveRecord
         end
 
         def add_reference(table_name, ref_name, **options)
-          ReferenceDefinition.new(ref_name, **options).add_to(update_table_definition(table_name, self))
+          ReferenceDefinition.new(ref_name, **options)
+            .add_to(connection.update_table_definition(table_name, self))
         end
         alias :add_belongs_to :add_reference
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

6.0 `add_reference` compatibility migration method triggered not wanted long message printed to stdout for `update_table_definition` invocation. The reason for this was that `method_missing` method was invoked which is responsible, among others, for printing migration logs and delegating the invocation into `connector`. To remove unwanted log entry `update_table_definition` is invoked directly on the `connector` instance.

References #40999