### PR TITLE
Don't check if QC is enabled

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -30,10 +30,10 @@ module ActiveRecord
 
       if ActiveRecord::Base.legacy_connection_handling
         ActiveRecord::Base.connection_handlers.each do |key, handler|
-          pools.concat(handler.connection_pool_list.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
+          pools.concat(handler.connection_pool_list.each { |p| p.enable_query_cache! })
         end
       else
-        pools.concat(ActiveRecord::Base.connection_handler.all_connection_pools.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
+        pools.concat(ActiveRecord::Base.connection_handler.all_connection_pools.each { |p| p.enable_query_cache! })
       end
 
       pools


### PR DESCRIPTION
There's no harm in enabling the query cache if it's already enabled and
it's less expensive to just turn it on than to check if it's on.

John Hawthorn <john@hawthorn.email>
