### PR TITLE
Update ActionCable docs to be compatible with Ruby 3 [ci skip]

### DIFF
--- a/actioncable/lib/action_cable/channel/streams.rb
+++ b/actioncable/lib/action_cable/channel/streams.rb
@@ -25,7 +25,7 @@ module ActionCable
     #
     # An example broadcasting for this channel looks like so:
     #
-    #   ActionCable.server.broadcast "comments_for_45", author: 'DHH', content: 'Rails is just swell'
+    #   ActionCable.server.broadcast "comments_for_45", { author: 'DHH', content: 'Rails is just swell' }
     #
     # If you have a stream that is related to a model, then the broadcasting used can be generated from the model and channel.
     # The following example would subscribe to a broadcasting like <tt>comments:Z2lkOi8vVGVzdEFwcC9Qb3N0LzE</tt>.

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -326,7 +326,7 @@ Then, elsewhere in your Rails application, you can broadcast to such a room by
 calling [`broadcast`][]:
 
 ```ruby
-ActionCable.server.broadcast("chat_Best Room", body: "This Room is Best Room.")
+ActionCable.server.broadcast("chat_Best Room", { body: "This Room is Best Room." })
 ```
 
 If you have a stream that is related to a model, then the broadcasting name
@@ -446,8 +446,10 @@ consumer.subscriptions.create({ channel: "ChatChannel", room: "Best Room" }, {
 # from a NewCommentJob.
 ActionCable.server.broadcast(
   "chat_#{room}",
-  sent_by: 'Paul',
-  body: 'This is a cool chat app.'
+  {
+    sent_by: 'Paul',
+    body: 'This is a cool chat app.'
+  }
 )
 ```
 


### PR DESCRIPTION
### Summary

Sample code in [Action Cable Overview — Ruby on Rails Guides](https://guides.rubyonrails.org/action_cable_overview.html#client-server-interactions) doesn’t work with Ruby 3, as described in #40993.
This PR refines the sample code.
