### PR TITLE
Make sure that `ActionView::Helpers::AssetTagHelper.preload_links_header` is `nil` without Rails 6.1 defaults

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -732,7 +732,7 @@ Defaults to `'signed cookie'`.
 
 * `config.action_view.annotate_rendered_view_with_filenames` determines whether to annotate rendered view with template file names. This defaults to `false`.
 
-* `config.action_view.preload_links_header` determines whether `javascript_include_tag` and `stylesheet_link_tag` will generate a `Link` header that preload assets. This defaults to `true`.
+* `config.action_view.preload_links_header` determines whether `javascript_include_tag` and `stylesheet_link_tag` will generate a `Link` header that preload assets.
 
 ### Configuring Action Mailbox
 
@@ -1059,6 +1059,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `ActiveSupport.utc_to_local_returns_utc_offset_times`: `true`
 - `config.action_controller.urlsafe_csrf_tokens`: `true`
 - `config.action_view.form_with_generates_remote_forms`: `false`
+- `config.action_view.preload_links_header`: `true`
 
 #### For '6.0', defaults from previous versions below and:
 
@@ -1100,6 +1101,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.action_dispatch.cookies_same_site_protection`: `nil`
 - `config.action_mailer.delivery_job`: `ActionMailer::DeliveryJob`
 - `config.action_view.form_with_generates_ids`: `false`
+- `config.action_view.preload_links_header`: `nil`
 - `config.active_job.retry_jitter`: `0.0`
 - `config.active_job.skip_after_callbacks_if_terminated`: `false`
 - `config.action_mailbox.queues.incineration`: `:action_mailbox_incineration`

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2410,6 +2410,14 @@ module ApplicationTests
       assert_equal true, ActionView::Helpers::AssetTagHelper.preload_links_header
     end
 
+    test "ActionView::Helpers::AssetTagHelper.preload_links_header is nil by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "6.0"'
+      app "development"
+
+      assert_nil ActionView::Helpers::AssetTagHelper.preload_links_header
+    end
+
     test "ActionView::Helpers::AssetTagHelper.preload_links_header can be configured via config.action_view.preload_links_header" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do


### PR DESCRIPTION
In https://github.com/rails/rails/pull/39939 we automatically set `Link` header for each stylesheet and script.
In https://github.com/rails/rails/pull/40882 we  added `config.action_view.preload_links_header` option
to configure whether `stylesheet_link_tag` and `javascript_include_tag`
should set automatically `Link` header.

This commit adds test to make sure that it is disabled by default
for updated apps that haven't adopted new '6.1' defaults.
Also, added changes to Configuring guide
 - Mentioned this option in "Results of `config.load_defaults`" section
 - Mentioned this option in "Baseline defaults:" section (see ff881137a8ceab951211a66afa2389ae599b2ce7)

/cc @pixeltrix