### PR TITLE
Unite Active Storage configs in `load_defaults '6.1'` into one if-section

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -163,10 +163,6 @@ module Rails
             active_record.legacy_connection_handling = false
           end
 
-          if respond_to?(:active_storage)
-            active_storage.track_variants = true
-          end
-
           if respond_to?(:active_job)
             active_job.retry_jitter = 0.15
             active_job.skip_after_callbacks_if_terminated = true
@@ -187,6 +183,8 @@ module Rails
           end
 
           if respond_to?(:active_storage)
+            active_storage.track_variants = true
+
             active_storage.queues.analysis = nil
             active_storage.queues.purge = nil
           end


### PR DESCRIPTION

When I was comparing 'defaults' for 6.1 in this method and our configuring
guide, I was confused that some active_storage options are missing.

This change doesn't bring any implementation changes and feels like
a cosmetic change. Please feel free to close this if you think so and don't
see that we could benefit this change.
