### PR TITLE
Fix `where` on polymorphic association with empty array

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/association_query_value.rb
@@ -9,7 +9,7 @@ module ActiveRecord
       end
 
       def queries
-        [associated_table.join_foreign_key => ids]
+        [ associated_table.join_foreign_key => ids ]
       end
 
       private

--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -9,6 +9,8 @@ module ActiveRecord
       end
 
       def queries
+        return [ associated_table.join_foreign_key => values ] if values.empty?
+
         type_to_ids_mapping.map do |type, ids|
           query = {}
           query[associated_table.join_foreign_type] = type if type

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -51,6 +51,10 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_equal comments(:greetings), Comment.where(author: [nil]).first
   end
 
+  def test_where_on_polymorphic_association_with_empty_array
+    assert_empty Comment.where(author: [])
+  end
+
   def test_assigning_belongs_to_on_destroyed_object
     client = Client.create!(name: "Client")
     client.destroy!


### PR DESCRIPTION
Fix for https://github.com/rails/rails/pull/40951#issuecomment-757078536.
