### PR TITLE
Fix fixture_file_upload deprecation with relative file_fixture_path

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -29,7 +29,7 @@ module ActionDispatch
               haven't set yet. Set `file_fixture_path` to discard this warning.
             EOM
           elsif path.exist?
-            non_deprecated_path = path.relative_path_from(Pathname(self.class.file_fixture_path))
+            non_deprecated_path = Pathname(File.absolute_path(path)).relative_path_from(Pathname(File.absolute_path(self.class.file_fixture_path)))
             ActiveSupport::Deprecation.warn(<<~EOM)
               Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
               In Rails 6.2, the path needs to be relative to `file_fixture_path`.

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -960,6 +960,19 @@ XML
     end
   end
 
+  def test_fixture_file_upload_relative_to_fixture_path_with_relative_file_fixture_path
+    TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
+      TestCaseTest.stub :file_fixture_path, "test/fixtures/multipart" do
+        expected = "`fixture_file_upload(\"multipart/ruby_on_rails.jpg\")` to `fixture_file_upload(\"ruby_on_rails.jpg\")`"
+
+        assert_deprecated(expected) do
+          uploaded_file = fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpg")
+          assert_equal File.open("#{FILES_DIR}/ruby_on_rails.jpg", READ_PLAIN).read, uploaded_file.read
+        end
+      end
+    end
+  end
+
   def test_fixture_file_upload_ignores_fixture_path_given_full_path
     TestCaseTest.stub :fixture_path, __dir__ do
       uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpg")


### PR DESCRIPTION
Followup to https://github.com/rails/rails/pull/39086.

When using `Pathname#relative_path_from`, the receiver and the argument must either both be absolute or both be relative:

https://ruby-doc.org/stdlib-2.7.2/libdoc/pathname/rdoc/Pathname.html#method-i-relative_path_from

> If self is absolute, then base_directory must be absolute too.
>
> If self is relative, then base_directory must be relative too.

If `file_fixture_path` is a relative path and `fixture_path` is an absolute path (which [is true](https://github.com/rspec/rspec-rails/blob/v4.0.2/lib/rspec/rails/configuration.rb#L84) [by default](https://github.com/rspec/rspec-rails/blob/v4.0.2/lib/generators/rspec/install/templates/spec/rails_helper.rb#L38) when using RSpec), this line would previously raise an ArgumentError.