### PR TITLE
Fix binds logging for "WHERE ... IN ..." statements

### DIFF
--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -80,8 +80,8 @@ module ActiveRecord
         self
       end
 
-      def add_binds(binds)
-        @binds.concat binds
+      def add_binds(binds, proc_for_binds = nil)
+        @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         binds.size.times do |i|
           @parts << ", " unless i == 0
           @parts << Substitute.new

--- a/activerecord/lib/arel/collectors/bind.rb
+++ b/activerecord/lib/arel/collectors/bind.rb
@@ -16,8 +16,8 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_binds(binds)
-        @binds.concat binds
+      def add_binds(binds, proc_for_binds = nil)
+        @binds.concat proc_for_binds ? binds.map(&proc_for_binds) : binds
         self
       end
 

--- a/activerecord/lib/arel/collectors/composite.rb
+++ b/activerecord/lib/arel/collectors/composite.rb
@@ -22,9 +22,9 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_binds(binds, &block)
-        left.add_binds(binds, &block)
-        right.add_binds(binds, &block)
+      def add_binds(binds, proc_for_binds = nil, &block)
+        left.add_binds(binds, proc_for_binds, &block)
+        right.add_binds(binds, proc_for_binds, &block)
         self
       end
 

--- a/activerecord/lib/arel/collectors/sql_string.rb
+++ b/activerecord/lib/arel/collectors/sql_string.rb
@@ -18,7 +18,7 @@ module Arel # :nodoc: all
         self
       end
 
-      def add_binds(binds, &block)
+      def add_binds(binds, proc_for_binds = nil, &block)
         self << (@bind_index...@bind_index += binds.size).map(&block).join(", ")
         self
       end

--- a/activerecord/lib/arel/collectors/substitute_binds.rb
+++ b/activerecord/lib/arel/collectors/substitute_binds.rb
@@ -20,7 +20,7 @@ module Arel # :nodoc: all
         self << quoter.quote(bind)
       end
 
-      def add_binds(binds)
+      def add_binds(binds, proc_for_binds = nil)
         self << binds.map { |bind| quoter.quote(bind) }.join(", ")
       end
 

--- a/activerecord/lib/arel/nodes/homogeneous_in.rb
+++ b/activerecord/lib/arel/nodes/homogeneous_in.rb
@@ -55,6 +55,10 @@ module Arel # :nodoc: all
         casted_values
       end
 
+      def proc_for_binds
+        -> value { ActiveModel::Attribute.with_cast_value(attribute.name, value, attribute.type_caster) }
+      end
+
       def fetch_attribute(&block)
         if attribute
           yield attribute

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -337,7 +337,7 @@ module Arel # :nodoc: all
           if values.empty?
             collector << @connection.quote(nil)
           else
-            collector.add_binds(values, &bind_block)
+            collector.add_binds(values, o.proc_for_binds, &bind_block)
           end
 
           collector << ")"

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -246,6 +246,12 @@ class LogSubscriberTest < ActiveRecord::TestCase
   end
 
   if ActiveRecord::Base.connection.prepared_statements
+    def test_where_in_binds_logging_include_attribute_names
+      Developer.where(id: [1, 2, 3, 4, 5]).load
+      wait
+      assert_match(%{["id", 1], ["id", 2], ["id", 3], ["id", 4], ["id", 5]}, @logger.logged(:debug).last)
+    end
+
     def test_binary_data_is_not_logged
       Binary.create(data: "some binary data")
       wait


### PR DESCRIPTION
After the new node `Arel::Nodes::HomogeneousIn` was introduced in
72fd0ba, the way bindings are printed by the log subscriber was left
in a kind of broken state:

Rails 6.0.3 example output

```
User Load (0.7ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9)  [["id", 1], ["id", 2], ["id", 3], ["id", 4], ["id", 5], ["id", 6], ["id", 7], ["id", 8], ["id", 9]]
```

Rails 6.1.0 example output

```
User Load (0.5ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9)  [[nil, 1], [nil, 2], [nil, 3], [nil, 4], [nil, 5], [nil, 6], [nil, 7], [nil, 8], [nil, 9]]
```

The original implementation relied on the predicate builder to create
a list of `BindParam` nodes, each with a `QueryAttribute` used to wrap
the attribute name and value, whereas the new implementation just
passes an array of casted values as the binds.

This patch does a lighter version of that process by applying a proc
to the binds right before adding them to the collectors. Credits to @kamipo.

```ruby
ids = (1..10000).each.map do |n|
  Post.create!.id
end

Benchmark.ips do |x|
  x.report("where with ids") do
    Post.where(id: ids).to_a
  end

  x.report("where with sanitize") do
    Post.where(ActiveRecord::Base.sanitize_sql(["id IN (?)", ids])).to_a
  end

  x.compare!
end
```

Before patch (main)
```
Warming up --------------------------------------
      where with ids     1.000  i/100ms
 where with sanitize     1.000  i/100ms
Calculating -------------------------------------
      where with ids     12.097  (± 0.0%) i/s -     61.000  in   5.047874s
 where with sanitize     13.657  (± 0.0%) i/s -     69.000  in   5.057082s

Comparison:
 where with sanitize:       13.7 i/s
      where with ids:       12.1 i/s - 1.13x  (± 0.00) slower
```

After patch
```
Warming up --------------------------------------
      where with ids     1.000  i/100ms
 where with sanitize     1.000  i/100ms
Calculating -------------------------------------
      where with ids     12.346  (± 8.1%) i/s -     62.000  in   5.030338s
 where with sanitize     13.885  (± 7.2%) i/s -     70.000  in   5.051146s

Comparison:
 where with sanitize:       13.9 i/s
      where with ids:       12.3 i/s - same-ish: difference falls within error
```

<details>
  <summary>Reproduction script</summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "pg"
end

require "active_record"
require "active_support/log_subscriber/test_helper"

require "minitest/autorun"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "postgresql", database: "rails_bug04")
ActiveRecord::Base.logger = nil

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :email
  end

  create_table :messages, force: true do |t|
    t.bigint :user_id
    t.string :content
  end
end

class User < ActiveRecord::Base
  has_many :messages
end

class Message < ActiveRecord::Base
  belongs_to :user
end

class BugTest < Minitest::Test
  def setup
    10.times do |n|
      user = User.create(email: "user#{n + 1}@example.com")
      Message.create(user: user, content: "Message #{n + 1}")
    end

    ActiveSupport::LogSubscriber.colorize_logging = false
  end

  def test_where_in_logging_bug
    old_logger = ActiveRecord::Base.logger
    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
    ActiveRecord::Base.logger = logger

    Message.includes(:user).load

    assert_match(%{["id", 1], ["id", 2], ["id", 3], ["id", 4], ["id", 5], ["id", 6], ["id", 7], ["id", 8], ["id", 9], ["id", 10]}, logger.logged(:debug).last)
  ensure
    ActiveRecord::Base.logger = old_logger
  end
end
```
</details>
