### PR TITLE
Adjust response code for scaffolds in order to work with hotwire.

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -31,7 +31,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.save %>
       redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -40,7 +40,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
       redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
### Summary

New Magic aka Hotwire requires different header status codes in order to make form validation work.
@dhh made on twitter the comment that scaffolds need to be readjusted: https://twitter.com/dhh/status/1346448749170749449

This PR simply changes the status code for create and update controller methods to return `status: :unprocessable_entity` on the render calls.

WIP
