### PR TITLE
Avoid suggesting very unlikely changes in `rails app:update`

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -27,7 +27,7 @@ The process should go as follows:
 3. Fix tests and deprecated features.
 4. Move to the latest patch version of the next minor version.
 
-Repeat this process until you reach your target Rails version. Each time you move versions, you will need to change the Rails version number in the `Gemfile` (and possibly other gem versions) and run `bundle update`. Then run the Update task mentioned below to update configuration files, then run your tests.
+Repeat this process until you reach your target Rails version. Each time you move versions, you will need to change the Rails version number in the `Gemfile` (and possibly other gem versions) and run `bundle update`. Then run the [Update task](#the-update-task) and finally, your tests.
 
 You can find a list of all released Rails versions [here](https://rubygems.org/gems/rails/versions).
 
@@ -38,30 +38,21 @@ Rails generally stays close to the latest released Ruby version when it's releas
 * Rails 7 requires Ruby 2.7.0 or newer.
 * Rails 6 requires Ruby 2.5.0 or newer.
 * Rails 5 requires Ruby 2.2.2 or newer.
-* Rails 4 prefers Ruby 2.0 and requires 1.9.3 or newer.
-* Rails 3.2.x is the last branch to support Ruby 1.8.7.
-* Rails 3 and above require Ruby 1.8.7 or higher. Support for all of the previous Ruby versions has been dropped officially. You should upgrade as early as possible.
-
-TIP: Ruby 1.8.7 p248 and p249 have marshalling bugs that crash Rails. Ruby Enterprise Edition has these fixed since the release of 1.8.7-2010.02. On the 1.9 front, Ruby 1.9.1 is not usable because it outright segfaults, so if you want to use 1.9.x, jump straight to 1.9.3 for smooth sailing.
 
 ### The Update Task
 
-Rails provides the `app:update` command (`rake rails:update` on 4.2 and earlier). After updating the Rails version
+Rails provides the `rails app:update` command. After updating the Rails version
 in the `Gemfile`, run this command.
 This will help you with the creation of new files and changes of old files in an
 interactive session.
 
 ```bash
 $ bin/rails app:update
-   identical  config/boot.rb
        exist  config
-    conflict  config/routes.rb
-Overwrite /myapp/config/routes.rb? (enter "h" for help) [Ynaqdh]
-       force  config/routes.rb
     conflict  config/application.rb
 Overwrite /myapp/config/application.rb? (enter "h" for help) [Ynaqdh]
        force  config/application.rb
-    conflict  config/environment.rb
+      create  config/initializers/new_framework_defaults_7_0.rb
 ...
 ```
 
@@ -71,7 +62,7 @@ Don't forget to review the difference, to see if there were any unexpected chang
 
 The new Rails version might have different configuration defaults than the previous version. However, after following the steps described above, your application would still run with configuration defaults from the *previous* Rails version. That's because the value for `config.load_defaults` in `config/application.rb` has not been changed yet.
 
-To allow you to upgrade to new defaults one by one, the update task has created a file `config/initializers/new_framework_defaults.rb`. Once your application is ready to run with new defaults, you can remove this file and flip the `config.load_defaults` value.
+To allow you to upgrade to new defaults one by one, the update task has created a file `config/initializers/new_framework_defaults_X.Y.rb` (with the desired Rails version in the filename). You should enable the new configuration defaults by uncommenting them in the file; this can be done gradually over several deployments. Once your application is ready to run with new defaults, you can remove this file and flip the `config.load_defaults` value.
 
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `rails app:update` no longer prompts you to overwrite files that are generally modified in the
+    course of developing a Rails app. See [#41083](https://github.com/rails/rails/pull/41083) for
+    the full list of changes.
+
+    *Alex Ghiculescu*
+
 *   Change default branch for new Rails projects and plugins to `main`.
 
     *Prateek Choudhary*

--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -13,7 +13,7 @@ module Rails
       def app_generator
         @app_generator ||= begin
           gen = Rails::Generators::AppGenerator.new ["rails"], generator_options, destination_root: Rails.root
-          File.exist?(Rails.root.join("config", "application.rb")) ? gen.send(:app_const) : gen.send(:valid_const?)
+          gen.send(:valid_const?) unless File.exist?(Rails.root.join("config", "application.rb"))
           gen
         end
       end
@@ -30,6 +30,7 @@ module Rails
           options[:skip_puma]           = !defined?(Puma)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
           options[:skip_spring]         = !defined?(Spring)
+          options[:updating]            = true
           options
         end
     end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -120,17 +120,17 @@ module Rails
       empty_directory "config"
 
       inside "config" do
-        template "routes.rb"
+        template "routes.rb" unless options[:updating]
         template "application.rb"
         template "environment.rb"
-        template "cable.yml" unless options[:skip_action_cable]
-        template "puma.rb"   unless options[:skip_puma]
+        template "cable.yml" unless options[:updating] || options[:skip_action_cable]
+        template "puma.rb"   unless options[:updating] || options[:skip_puma]
         template "spring.rb" if spring_install?
-        template "storage.yml" unless skip_active_storage?
+        template "storage.yml" unless options[:updating] || skip_active_storage?
 
         directory "environments"
         directory "initializers"
-        directory "locales"
+        directory "locales" unless options[:updating]
       end
     end
 
@@ -148,7 +148,6 @@ module Rails
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
 
       config
-      configru
 
       unless cookie_serializer_config_exist
         gsub_file "config/initializers/cookies_serializer.rb", /json(?!,)/, "marshal"


### PR DESCRIPTION
While upgrading a Rails 6 app to Rails 6.1, I noticed that `rails app:update` asks you to review some file changes that you'd basically never want to accept. In this PR, I propose we make the update task do a bit less, by not offering to overwrite files where the developer has almost certainly changed them from the default.

Specific changes:

- Don't replace the following files, as they change very rarely at the framework level, so if the user has changes they almost certainly intend to keep them: [config/storage.yml](https://github.com/rails/rails/commits/main/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt) [config/cable.yml](https://github.com/rails/rails/commits/main/railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt) [config/puma.rb](https://github.com/rails/rails/commits/main/railties/lib/rails/generators/rails/app/templates/config/puma.rb.tt) [config.ru](https://github.com/rails/rails/commits/main/railties/lib/rails/generators/rails/app/templates/config.ru.tt).
- Don't overwrite the config/locales directory. There's basically no chance you'll want to replace your current `config/locales/en.yml` with a [hello world](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/locales/en.yml).
- Don't replace config/routes.rb. It's so unlikely that the user will want to replace their routes file with [an empty file](https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt).

With these changes, you will still be prompted to accept/decline changes to these files when doing an update:

- config/application.rb
- config/environments/{development|test|production}.rb
- All the default [initializers](https://github.com/rails/rails/tree/main/railties/lib/rails/generators/rails/app/templates/config/initializers) that you already have a copy of. I go back and forth on also opting some of these out, for example `assets.rb`, `filter_parameter_logging.rb`, `cors.rb`, `inflections.rb` pretty much have to be changed to be useful.
- All the default [binstubs](https://github.com/rails/rails/tree/main/railties/lib/rails/generators/rails/app/templates/bin) that you already have a copy of. I decided to still make the user review these, as bugs here are going to be annoying to debug, but it is good to use the latest versions if possible.

While here, I also made some touchups to the [upgrade guide](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html):

- Don't list unsupported (per [this](https://guides.rubyonrails.org/maintenance_policy.html)) Rails versions in the "Ruby versions" section.
- Explain new framework defaults a bit better.