### PR TITLE
Retain interval when serializing Duration to iso8601

### DIFF
--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -36,11 +36,10 @@ module ActiveSupport
       private
         # Return pair of duration's parts and whole duration sign.
         # Parts are summarized (as they can become repetitive due to addition, etc).
-        # Zero parts are removed as not significant.
         # If all parts are negative it will negate all of them and return minus as a sign.
         def normalize
           parts = @duration.parts.each_with_object(Hash.new(0)) do |(k, v), p|
-            p[k] += v  unless v.zero?
+            p[k] += v
           end
 
           # Convert weeks to days and remove weeks if mixed with date parts

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -623,7 +623,9 @@ class DurationTest < ActiveSupport::TestCase
       ["PT1S",          1.second                         ],
       ["PT1.4S",        (1.4).seconds                    ],
       ["P1Y1M1DT1H",    1.year + 1.month + 1.day + 1.hour],
-      ["PT0S",          0.minutes                        ],
+      ["PT0S",          0.seconds                        ],
+      ["P0D",           0.days                           ], # 0-length duration retains its interval
+      ["P1Y",           1.year + 0.weeks + 0.days        ], # Adding 0-length parts doesn't change duration
       ["PT-0.2S",       (-0.2).seconds                   ],
     ]
     expectations.each do |expected_output, duration|


### PR DESCRIPTION
### Summary

Currently a 0 length duration (`0.days`, `0.years`, ...) will always be serialized to ISO8601 as `PT0S` (0 seconds). This leads to data loss when serializing and re-parsing the iso8601 value:

```rb
0.days
=> 0 days 

0.days.iso8601
=> "PT0S"

0.years.iso8601
=> "PT0S"

ActiveSupport::Duration.parse(0.years.iso8601)
=> 0 seconds
```

While the numeric representation is the same for 0 days, 0 months or 0 millenia (it's just `0`), I don't think it's correct to try and flatten the specific makeup of the `Duration` itself when serializing it to `iso8601`. 

The intervals can be significant depending on the use case, and I would expect a serialization method to serialize the object as accurately as possible (within the constraints of the serialization format). 

Flattening a duration to its most concise form (eg turning `1.week + 6.days + 24.hours` into `2.weeks`) is a useful action, but I think it should be an explicit action rather than implicit since it does lose precision.

## Changes

This PR changes the `normalize` method to _not_ strip 0 length parts before serializing.

Result: iso8601 output accurately represents the Duration object

```rb
# When only 0-length part, it keeps the interval
0.days.iso8601
=> "P0D"

# Adding only 0-length parts results in a multi-part Duration. Serializing retains all parts
duration = (0.years + 0.minutes)
=> "0 years and 0 minutes"
duration.iso8601
=> "P0YT0M"

# Adding 0-length parts to a duration doesn't change the duration itself, so it also isn't included when serialized.
duration = (1.year + 0.minutes)
=> "1 year" 
duration.iso8601
=> "P1Y"
```