### PR TITLE
Define Singleton#duplicable? and return false

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -47,3 +47,14 @@ class UnboundMethod
     false
   end
 end
+
+require "singleton"
+
+module Singleton
+  # Singleton instances are not duplicable:
+  #
+  # Class.new.include(Singleton).instance.dup # TypeError (can't dup instance of singleton
+  def duplicable?
+    false
+  end
+end

--- a/activesupport/test/core_ext/object/duplicable_test.rb
+++ b/activesupport/test/core_ext/object/duplicable_test.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/object/duplicable"
 require "active_support/core_ext/numeric/time"
 
 class DuplicableTest < ActiveSupport::TestCase
-  RAISE_DUP = [method(:puts), method(:puts).unbind]
+  RAISE_DUP = [method(:puts), method(:puts).unbind, Class.new.include(Singleton).instance]
   ALLOW_DUP = ["1", "symbol_from_string".to_sym, Object.new, /foo/, [], {}, Time.now, Class.new, Module.new, BigDecimal("4.56"), nil, false, true, 1, 2.3, Complex(1), Rational(1)]
 
   def test_duplicable


### PR DESCRIPTION
### Context

In our app we ended up with:

```
/usr/local/lib/ruby/2.7.0/singleton.rb:102:in `dup': can't dup instance of singleton Mime::NullType (TypeError)
    from bundler/gems/rails-8a91423b92e6/activesupport/lib/active_support/core_ext/object/deep_dup.rb:16:in `deep_dup'
```

e.g. `Mime::NullType.instance` ends up in a datastructure that is then `deep_dup`, and that fails because `Singleton` prevent `dup`.

### Solution

I think Active Support could mark `Singleton` as `duplicable? => false`. Active Support already require `"singleton"` anyway. 

@rafaelfranca thoughts?