### PR TITLE
Add name to ActionCable threads

### DIFF
--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -19,6 +19,7 @@ module ActionCable
 
       def initialize(max_size: 5)
         @executor = Concurrent::ThreadPoolExecutor.new(
+          name: "ActionCable",
           min_threads: 1,
           max_threads: max_size,
           max_queue: 0,


### PR DESCRIPTION
To assist in various debugging scenarios, such as [tracking which types of threads are using db connections](https://github.com/puma/puma/issues/1512#issuecomment-756760388)

Thread names will now be "ActionCable-worker-N" instead of "worker-N".

This is safe for all ruby versions. In versions which do not have thread names, [concurrent-ruby does not attempt to add the name](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb#L312)

In the environment I happened to be testing in:

```ruby
e = Concurrent::ThreadPoolExecutor.new(name: 'ActionCable', min_threads: 2, max_threads: 2)
e.post{sleep 100}
e.post{sleep 100}
Thread.list.map(&:name)
# => [nil, nil, nil, nil, "listen-wait_thread", "listen-worker_thread", "listen-wait_thread", "listen-worker_thread", "listen-wait_thread", "listen-worker_thread", "ActionCable-worker-1", "ActionCable-worker-2"]
```
