### PR TITLE
Fix issue routing with optional parts of a segment

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -45,13 +45,13 @@ module ActionDispatch
 
           terminals.each_with_index { |s, index|
             next if index < 1
-            next unless s.symbol?
+            next if s.type == :DOT || s.type == :SLASH
 
             back = terminals[index - 1]
             fwd = terminals[index + 1]
 
             # we also don't support this yet, constraints must be regexps
-            return false if s.regexp.is_a?(Array)
+            return false if s.symbol? && s.regexp.is_a?(Array)
 
             return false if back.literal?
             return false if !fwd.nil? && fwd.literal?

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -1459,6 +1459,18 @@ class TestRoutingMapper < ActionDispatch::IntegrationTest
     assert_equal "projects#index", @response.body
   end
 
+  def test_optional_part_of_segment
+    draw do
+      get "/star-trek(-tng)/:episode", to: "star_trek#show"
+    end
+
+    get "/star-trek/02-15-the-trouble-with-tribbles"
+    assert_equal "star_trek#show", @response.body
+
+    get "/star-trek-tng/05-02-darmok"
+    assert_equal "star_trek#show", @response.body
+  end
+
   def test_scope_with_format_option
     draw do
       get "direct/index", as: :no_format_direct, format: false


### PR DESCRIPTION
In our recent optimizations to route matching performance we introduced an issue with routes that had an optional segment which wasn't separated by a "." or "/".

This includes a previously failing test.

cc @theojulienne 