### PR TITLE
Fix `build` multiple records on association relation not to raise deprecation warning

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -332,6 +332,13 @@ module ActiveRecord
           persisted + memory
         end
 
+        def build_record(attributes)
+          previous = klass.current_scope(true) if block_given?
+          super
+        ensure
+          klass.current_scope = previous if previous
+        end
+
         def _create_record(attributes, raise = false, &block)
           unless owner.persisted?
             raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -377,7 +377,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   test "building the association with an array" do
     speedometer = Speedometer.new(speedometer_id: "a")
     data = [{ name: "first" }, { name: "second" }]
-    speedometer.minivans.build(data)
+    speedometer.minivans.all.build(data)
 
     assert_equal 2, speedometer.minivans.size
     assert speedometer.save


### PR DESCRIPTION
It should restore the original `current_scope` if building multiple
records in a `scoping` since `_deprecated_scope_block` overrides
`current_scope` to raise the deprecation warning.

Fixes #41076.
