### PR TITLE
Prevent webpacker:install failures on missing Gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -405,11 +405,19 @@ module Rails
       end
 
       def run_webpack
-        if webpack_install?
-          rails_command "webpacker:install"
-          if options[:webpack] && options[:webpack] != "webpack"
-            rails_command "webpacker:install:#{options[:webpack]}"
-          end
+        return unless webpack_install?
+
+        unless bundle_install?
+          say <<~EXPLAIN
+            Skipping `rails webpacker:install` because `bundle install` was skipped.
+            To complete setup, you must run `bundle install` followed by `rails webpacker:install`.
+          EXPLAIN
+          return
+        end
+
+        rails_command "webpacker:install"
+        if options[:webpack] && options[:webpack] != "webpack"
+          rails_command "webpacker:install:#{options[:webpack]}"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/spring.tt
@@ -3,7 +3,7 @@ if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
   require "bundler"
 
   # Load Spring without loading other gems in the Gemfile, for speed.
-  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
     gem "spring", spring.version
     require "spring/binstub"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -107,12 +107,22 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_skip_bundle
-    generator([destination_root], skip_bundle: true, skip_webpack_install: true)
-    run_generator_instance
+    generator([destination_root], skip_bundle: true)
+    output = run_generator_instance
 
     assert_empty @bundle_commands
     # skip_bundle is only about running bundle install so ensure the Gemfile is still generated
     assert_file "Gemfile"
+    assert_webpack_installation_skipped(output)
+  end
+
+  def test_skip_gemfile
+    generator([destination_root], skip_gemfile: true)
+    output = run_generator_instance
+
+    assert_empty @bundle_commands
+    assert_no_file "Gemfile"
+    assert_webpack_installation_skipped(output)
   end
 
   def test_assets
@@ -1263,5 +1273,23 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_file "config/environments/development.rb" do |content|
         assert_match(/^\s*# config\.file_watcher = ActiveSupport::EventedFileUpdateChecker/, content)
       end
+    end
+
+    def assert_webpack_installation_skipped(output)
+      assert_match(/^Skipping `rails webpacker:install`/, output)
+
+      %w(
+        .browserslistrc
+        babel.config.js
+        bin/webpack
+        bin/webpack-dev-server
+        config/webpack
+        config/webpack/development.js
+        config/webpack/environment.js
+        config/webpack/production.js
+        config/webpack/test.js
+        config/webpacker.yml
+        postcss.config.js
+      ).each { |f| assert_no_file(f) }
     end
 end


### PR DESCRIPTION
fixes #41103 causing `rails webpacker:install` to fail when creating new app

