### PR TITLE
Update add_column with if_not_exists? to properly handle int column type

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -135,6 +135,7 @@ module ActiveRecord
       def column_exists?(table_name, column_name, type = nil, **options)
         column_name = column_name.to_s
         checks = []
+        type = :integer if type == :int
         checks << lambda { |c| c.name == column_name }
         checks << lambda { |c| c.type == type.to_sym rescue nil } if type
         column_options_keys.each do |attr|
@@ -604,7 +605,7 @@ module ActiveRecord
       #  # Ignores the method call if the column exists
       #  add_column(:shapes, :triangle, 'polygon', if_not_exists: true)
       def add_column(table_name, column_name, type, **options)
-        return if options[:if_not_exists] == true && column_exists?(table_name, column_name, type, options.slice(:unsigned))
+        return if options[:if_not_exists] == true && column_exists?(table_name, column_name, type)
 
         at = create_alter_table table_name
         at.add_column(column_name, type, **options)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -604,7 +604,7 @@ module ActiveRecord
       #  # Ignores the method call if the column exists
       #  add_column(:shapes, :triangle, 'polygon', if_not_exists: true)
       def add_column(table_name, column_name, type, **options)
-        return if options[:if_not_exists] == true && column_exists?(table_name, column_name, type)
+        return if options[:if_not_exists] == true && column_exists?(table_name, column_name, type, options.slice(:unsigned))
 
         at = create_alter_table table_name
         at.add_column(column_name, type, **options)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -325,7 +325,7 @@ class MigrationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_add_int_column_with_if_not_exists_set_to_true_does_note_raise
+  def test_add_int_column_with_if_not_exists_set_to_true_does_not_raise
     migration_a = Class.new(ActiveRecord::Migration::Current) {
       def version; 100 end
       def migrate(x)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -325,18 +325,18 @@ class MigrationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_add_column_with_if_not_exists_set_to_true_does_not_raise_if_types_with_an_option_match
+  def test_add_int_column_with_if_not_exists_set_to_true_does_note_raise
     migration_a = Class.new(ActiveRecord::Migration::Current) {
       def version; 100 end
       def migrate(x)
-        add_column "people", "last_name", :int, unsigned: true
+        add_column "people", "last_name", :int
       end
     }.new
 
     migration_b = Class.new(ActiveRecord::Migration::Current) {
       def version; 101 end
       def migrate(x)
-        add_column "people", "last_name", :int, unsigned: true, if_not_exists: true
+        add_column "people", "last_name", :int, if_not_exists: true
       end
     }.new
 


### PR DESCRIPTION
Support for `if_exists?` and `if_not_exists?` was added in https://github.com/rails/rails/pull/38352. It's possible to add `integer` columns using `:int` or `:integer`. The internal AR `column` defines `#type` for integers as `:integer`. When a developer adds a column using `:int`, `if_not_exists?` did not work properly because `c.type != type.to_sym` in this example and could lead to duplicate column errors even if the integer column did already exist.

This change updates the `column_exists?` logic to handle `int` and `integer` types being passed in.

I'm sure there are better ways to solve this problem and I'm very open to feedback. Thank you!