### PR TITLE
Improve `strict_loading` violation error message

### DIFF
--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -211,12 +211,8 @@ module ActiveRecord
 
       private
         def find_target
-          if owner.strict_loading? && owner.validation_context.nil?
-            Base.strict_loading_violation!(owner: owner.class, association: klass)
-          end
-
-          if reflection.strict_loading? && owner.validation_context.nil?
-            Base.strict_loading_violation!(owner: owner.class, association: reflection.name)
+          if (owner.strict_loading? || reflection.strict_loading?) && owner.validation_context.nil?
+            Base.strict_loading_violation!(owner: owner.class, reflection: reflection)
           end
 
           scope = self.scope

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -277,14 +277,14 @@ module ActiveRecord
       self.default_role = writing_role
       self.default_shard = :default
 
-      def self.strict_loading_violation!(owner:, association:) # :nodoc:
+      def self.strict_loading_violation!(owner:, reflection:) # :nodoc:
         case action_on_strict_loading_violation
         when :raise
-          message = "`#{association}` called on `#{owner}` is marked for strict_loading and cannot be lazily loaded."
+          message = "`#{owner}` is marked for strict_loading. The `#{reflection.klass}` association named `:#{reflection.name}` cannot be lazily loaded."
           raise ActiveRecord::StrictLoadingViolationError.new(message)
         when :log
           name = "strict_loading_violation.active_record"
-          ActiveSupport::Notifications.instrument(name, owner: owner, association: association)
+          ActiveSupport::Notifications.instrument(name, owner: owner, reflection: reflection)
         end
       end
     end

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -22,9 +22,10 @@ module ActiveRecord
     def strict_loading_violation(event)
       debug do
         owner = event.payload[:owner]
-        association = event.payload[:association]
+        association = event.payload[:reflection].klass
+        name = event.payload[:reflection].name
 
-        color("Strict loading violation: #{association} lazily loaded on #{owner}.", RED)
+        color("Strict loading violation: #{owner} is marked for strict loading. The #{association} association named :#{name} cannot be lazily loaded.", RED)
       end
     end
 

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -407,7 +407,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
     developer.strict_loading!
     assert_predicate developer, :strict_loading?
 
-    assert_logged("Strict loading violation: AuditLog lazily loaded on Developer.") do
+    assert_logged("Strict loading violation: Developer is marked for strict loading. The AuditLog association named :audit_logs cannot be lazily loaded.") do
       developer.audit_logs.to_a
     end
   ensure


### PR DESCRIPTION
If you're using `strict_loading` in an application the previous message
only told you what class was lazily loaded. This change updates the
error message to include both the class and the association name. This
is useful because now you won't need to lookup the association name in
the application, the error message will tell you exactly which symbol
preload is missing.