### PR TITLE
Fix test failing on ruby master

### DIFF
--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -81,7 +81,18 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     assert_predicate(subject, :valid?)
   end
 
-  def test_virtual_attribute_with_precision
+  def test_virtual_attribute_with_precision_round_down
+    model_class.attribute(:virtual_decimal_number, :decimal, precision: 5)
+    model_class.validates_numericality_of(
+      :virtual_decimal_number, equal_to: 123.45
+    )
+
+    subject = model_class.new(virtual_decimal_number: 123.454)
+
+    assert_predicate subject, :valid?
+  end
+
+  def test_virtual_attribute_with_precision_round_half_even
     model_class.attribute(:virtual_decimal_number, :decimal, precision: 5)
     model_class.validates_numericality_of(
       :virtual_decimal_number, equal_to: 123.45
@@ -89,7 +100,24 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
     subject = model_class.new(virtual_decimal_number: 123.455)
 
-    assert_predicate subject, :valid?
+    if RUBY_VERSION > "3.0.0"
+      # BigDecimal's to_d behavior changed in BigDecimal 3.0.1, see https://github.com/ruby/bigdecimal/issues/70
+      # TOOD: replace this with a check against BigDecimal::VERSION
+      assert_not_predicate subject, :valid?
+    else
+      assert_predicate subject, :valid?
+    end
+  end
+
+  def test_virtual_attribute_with_precision_round_up
+    model_class.attribute(:virtual_decimal_number, :decimal, precision: 5)
+    model_class.validates_numericality_of(
+      :virtual_decimal_number, equal_to: 123.45
+    )
+
+    subject = model_class.new(virtual_decimal_number: 123.456)
+
+    assert_not_predicate subject, :valid?
   end
 
   def test_virtual_attribute_with_scale


### PR DESCRIPTION
https://github.com/ruby/bigdecimal/pull/180 is causing a test to fail when running activerecord against ruby master (eg. [here](https://buildkite.com/rails/rails/builds/74067#24ffeea4-7f61-4804-990f-84f00f26d545)). I've reported that to the author here: https://github.com/ruby/bigdecimal/issues/70#issuecomment-759832301 - but I'm not sure if it's considered correct behavior or not.

In the meantime, I replaced it with tests where there should be no doubt about which direction to round in.

cc @gmcgibbon since you added the test originally.