### PR TITLE
Guides: fix the wrong example of default render [ci-skip]

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -243,14 +243,14 @@ You can also do:
 By default `ActionView::Partials::PartialRenderer` has its object in a local variable with the same name as the template. So, given:
 
 ```erb
-<%= render partial: "product" %>
+<%= render @product %>
 ```
 
 within `_product` partial we'll get `@product` in the local variable `product`,
 as if we had written:
 
 ```erb
-<%= render partial: "product", locals: { product: @product } %>
+<%= render partial: "prodcuts/product", locals: { product: @product } %>
 ```
 
 The `object` option can be used to directly specify which object is rendered into the partial; useful when the template's object is elsewhere (e.g. in a different instance variable or in a local variable).

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -250,7 +250,7 @@ within `_product` partial we'll get `@product` in the local variable `product`,
 as if we had written:
 
 ```erb
-<%= render partial: "prodcuts/product", locals: { product: @product } %>
+<%= render partial: "products/product", locals: { product: @product } %>
 ```
 
 The `object` option can be used to directly specify which object is rendered into the partial; useful when the template's object is elsewhere (e.g. in a different instance variable or in a local variable).

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -943,7 +943,7 @@ You can supply a hash of additional HTML options:
 <%= image_tag "icons/delete.gif", {height: 45} %>
 ```
 
-You can supply alternate text for the image which will be used if the user has images turned off in their browser or if an image file cannot be loaded.
+You can supply alternate text for the image which will be used if the user has images turned off in their browser or if the image cannot be loaded.
 
 ```erb
 <%= image_tag "home.gif", alt: "Home" %>

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -943,10 +943,9 @@ You can supply a hash of additional HTML options:
 <%= image_tag "icons/delete.gif", {height: 45} %>
 ```
 
-You can supply alternate text for the image which will be used if the user has images turned off in their browser. If you do not specify an alt text explicitly, it defaults to the file name of the file, capitalized and with no extension. For example, these two image tags would return the same code:
+You can supply alternate text for the image which will be used if the user has images turned off in their browser or if an image file cannot be loaded.
 
 ```erb
-<%= image_tag "home.gif" %>
 <%= image_tag "home.gif", alt: "Home" %>
 ```
 


### PR DESCRIPTION
Hello :)
I noticed that the example short-hand default render is wrong. The guide says:
`<%= render partial: "product" %>`
is equal to
`<%= render partial: "product", locals: { product: @Product } %>`

I believe it's not true. I guess that the author meant to show that:
`<%= render @product %>`
results in
`<%= render partial: "products/product", locals: { product: @Product } %>`
(src: https://api.rubyonrails.org/classes/ActionView/PartialRenderer.html - Rendering the default case).

Notice that the partial is loaded from "products/product", not just from "product" (as if the partial were in the same directory).

If anyone wants to tinker, I've created a demo app to prove my points: https://github.com/jakubzelazny/partial_renderer_demo

Please tell me if I'm wrong or if I misunderstood the guide :)