### PR TITLE
Fix CurrentAttributes.set when attribute readers are made private

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fixes `CurrentAttributes.set` when attribute readers are made private in
+    order to expose a limited interface.
+
+    *Cameron Bothner*
+
 *   Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
     invalid.
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -202,7 +202,7 @@ module ActiveSupport
       end
 
       def compute_attributes(keys)
-        keys.index_with { |key| public_send(key) }
+        keys.index_with { |key| send(key) }
       end
   end
 end

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -11,7 +11,9 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
   class Current < ActiveSupport::CurrentAttributes
     attribute :world, :account, :person, :request
-    delegate :time_zone, to: :person
+    private :person
+
+    delegate :name, :time_zone, to: :person
 
     before_reset { Session.previous = person&.id }
 
@@ -74,7 +76,7 @@ class CurrentAttributesTest < ActiveSupport::TestCase
   test "set attribute via overwritten method" do
     Current.account = "account/1"
     assert_equal "account/1", Current.account
-    assert_equal "account/1's person", Current.person.name
+    assert_equal "account/1's person", Current.name
   end
 
   test "set auxiliary class via overwritten method" do
@@ -124,6 +126,16 @@ class CurrentAttributesTest < ActiveSupport::TestCase
 
     assert_equal "world/1", Current.world
     assert_equal "account/1", Current.account
+  end
+
+  test "set attribute with private reader" do
+    Current.person = Person.new(42, "David", "Central Time (US & Canada)")
+
+    Current.set(person: Person.new(123, "Cameron", "Eastern Time (US & Canada)")) do
+      assert_equal "Cameron", Current.name
+    end
+
+    assert_equal "David", Current.name
   end
 
   setup { @testing_teardown = false }


### PR DESCRIPTION
As the documentation for CurrentAttributes notes, one must be careful to limit the interface of a global singleton to avoid tangling up your model. One strategy is to make a base attribute reader private and delegate only the methods that should be exposed. For example, CurrentRequest:

```ruby
class CurrentRequest < ActiveSupport::CurrentAttributes
  attribute :request
  private :request

  delegate :user_agent, :host, to: :request, allow_nil: true
end
```

Before this change, `CurrentRequest.set(request: request)` would fail with ``NoMethodError: private method `request' called
for #<CurrentRequest:0x00007f8c96d85e80 @attributes={}>``. This is because `compute_attributes` was using `public_send` to fetch the current value for the attribute.

This change swaps `public_send` for `send`. Since `compute_attributes` is a private method, it stands to reason that it should be able to call other private methods.