### PR TITLE
Fix article_params method

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1885,7 +1885,7 @@ We also have to permit the `:status` key as part of the strong parameter, in `ap
 ```ruby
   private
     def article_params
-      params.require(:comment).permit(:commenter, :body, :status)
+      params.require(:article).permit(:title, :body, :status)
     end
 ```
 


### PR DESCRIPTION
### Summary

A small fix to the getting started guide.

In the [Using Concerns](https://edgeguides.rubyonrails.org/getting_started.html#using-concerns) section, the `article_params` method was the same as the `comment_params`.

