### PR TITLE
Use Range#cover? for Object#in?`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Use `Range.cover?` when calling `Object.in?` with range argument.
+
+    *Ali Ismayilov*
+
 *   Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
     invalid.
 

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -18,7 +18,7 @@ class Object
       another_object.include?(self)
     end
   rescue NoMethodError
-    raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
+    raise ArgumentError.new("The parameter passed to #in? must respond to #include? or be a Range")
   end
 
   # Returns the receiver if it's included in the argument otherwise returns +nil+.

--- a/activesupport/lib/active_support/core_ext/object/inclusion.rb
+++ b/activesupport/lib/active_support/core_ext/object/inclusion.rb
@@ -2,15 +2,21 @@
 
 class Object
   # Returns true if this object is included in the argument. Argument must be
-  # any object which responds to +#include?+. Usage:
+  # any object which responds to +#include?+ or is a +Range+. Usage:
   #
   #   characters = ["Konata", "Kagami", "Tsukasa"]
   #   "Konata".in?(characters) # => true
   #
+  # In case the object is an instance of a +Range+, it will use +#cover?+.
+  #
   # This will throw an +ArgumentError+ if the argument doesn't respond
-  # to +#include?+.
+  # to +#include?+ or is not a +Range+.
   def in?(another_object)
-    another_object.include?(self)
+    if another_object.is_a?(Range)
+      another_object.cover?(self)
+    else
+      another_object.include?(self)
+    end
   rescue NoMethodError
     raise ArgumentError.new("The parameter passed to #in? must respond to #include?")
   end

--- a/activesupport/test/core_ext/object/inclusion_test.rb
+++ b/activesupport/test/core_ext/object/inclusion_test.rb
@@ -26,6 +26,16 @@ class InTest < ActiveSupport::TestCase
     assert_not 75.in?(1..50)
   end
 
+  def test_in_range_cover
+    mocked_range = Minitest::Mock.new
+    mocked_range.expect :is_a?, true, [Range]
+    mocked_range.expect :cover?, true, [Integer]
+
+    25.in?(mocked_range)
+
+    mocked_range.verify
+  end
+
   def test_in_set
     s = Set.new([1, 2])
     assert 1.in?(s)


### PR DESCRIPTION
### Summary

since https://github.com/rails/rails/pull/38186 all calls with `time_instance.in?(Range)` are printing deprecation message.

It should be safe to use `Range.cover?` instead.