### PR TITLE
Use major + minor AR versions in 'Directly inheriting' error message

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -556,10 +556,12 @@ module ActiveRecord
     def self.inherited(subclass) #:nodoc:
       super
       if subclass.superclass == Migration
+        major = ActiveRecord::VERSION::MAJOR
+        minor = ActiveRecord::VERSION::MINOR
         raise StandardError, "Directly inheriting from ActiveRecord::Migration is not supported. " \
-          "Please specify the Rails release the migration was written for:\n" \
+          "Please specify the Active Record release the migration was written for:\n" \
           "\n" \
-          "  class #{subclass} < ActiveRecord::Migration[4.2]"
+          "  class #{subclass} < ActiveRecord::Migration[#{major}.#{minor}]"
       end
     end
 


### PR DESCRIPTION
The error message when inheriting directly from `ActiveRecord::Migration` had two things wrong with it:

1. It mentioned the _Rails_ release, instead of the _Active Record_ release.
2. The version number was hard-coded to 4.2.

Let's use the current version of active record for this error.
