### PR TITLE
Ensure test rake commands run immediately

### DIFF
--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -30,9 +30,9 @@ module Rails
         end
 
         def rake_run(argv = [])
-          ARGV.replace Shellwords.split(ENV["TESTOPTS"] || "")
-
-          run(argv)
+          # Ensure the tests run during the Rake Task action, not when the process exits
+          success = system("rails", "test", *argv, *Shellwords.split(ENV["TESTOPTS"] || ""))
+          success || exit(false)
         end
 
         def run(argv = [])

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -8,8 +8,6 @@ task default: :test
 
 desc "Runs all tests in test folder except system ones"
 task :test do
-  $: << "test"
-
   if ENV.key?("TEST")
     Rails::TestUnit::Runner.rake_run([ENV["TEST"]])
   else
@@ -30,35 +28,29 @@ namespace :test do
 
   ["models", "helpers", "channels", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
     task name => "test:prepare" do
-      $: << "test"
       Rails::TestUnit::Runner.rake_run(["test/#{name}"])
     end
   end
 
   desc "Runs all tests, including system tests"
   task all: "test:prepare" do
-    $: << "test"
     Rails::TestUnit::Runner.rake_run(["test/**/*_test.rb"])
   end
 
   task generators: "test:prepare" do
-    $: << "test"
     Rails::TestUnit::Runner.rake_run(["test/lib/generators"])
   end
 
   task units: "test:prepare" do
-    $: << "test"
     Rails::TestUnit::Runner.rake_run(["test/models", "test/helpers", "test/unit"])
   end
 
   task functionals: "test:prepare" do
-    $: << "test"
     Rails::TestUnit::Runner.rake_run(["test/controllers", "test/mailers", "test/functional"])
   end
 
   desc "Run system tests only"
   task system: "test:prepare" do
-    $: << "test"
     Rails::TestUnit::Runner.rake_run(["test/system"])
   end
 end


### PR DESCRIPTION
Before this commit, Rails test Rake tasks only load the test files, and the tests only run in an `at_exit` hook via minitest/autorun.

This prevents conditionally running tasks only when tests pass, or even more simply in the right order. As a simple example, if you have:

```ruby
task default: [:test, :rubocop]
```

The `rubocop` task will run after the `test` task loads the test files but before the tests actually run.

This commit changes the test Rake tasks to shell out to the test runner as a new process.

This diverges from previous behavior because now, any changes made in the Rakefile or other code loaded by Rake won't be available to the child process. However this brings the behavior of `rake test` closer to the behavior of `rails test`.

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>

### Other Information

We decided to keep the shellwords splitting in `Rails::TestUnit::Runner`, that way we didn't duplicate that across all the tasks or define a new method at the top-level.

We thought about calling `sh` from `Rails::TestUnit::Runner` but that involved either including `FileUtils` and adding a lot of methods to it, or creating an Object on which we extended that module. Calling `sh` from that file felt a bit out of place as opposed to calling it in a Rakefile, but let us know if you'd prefer that.

Something else to confirm is whether we can rely on the `rails` command being on the PATH. From our test it was ok, even with a vendored bundle.

cc @rafaelfranca