### PR TITLE
Correct logic warning about initializers

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1553,7 +1553,7 @@ The `initializer` method takes three arguments with the first being the name for
 
 Initializers defined using the `initializer` method will be run in the order they are defined in, with the exception of ones that use the `:before` or `:after` methods.
 
-WARNING: You may put your initializer before or after any other initializer in the chain, as long as it is logical. Say you have 4 initializers called "one" through "four" (defined in that order) and you define "four" to go _before_ "four" but _after_ "three", that just isn't logical and Rails will not be able to determine your initializer order.
+WARNING: You may put your initializer before or after any other initializer in the chain, as long as it is logical. Say you have 4 initializers called "one" through "four" (defined in that order) and you define "four" to go _before_ "two" but _after_ "three", that just isn't logical and Rails will not be able to determine your initializer order.
 
 The block argument of the `initializer` method is the instance of the application itself, and so we can access the configuration on it by using the `config` method as done in the example.
 


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/41116

Defining initializer 4 to run before itself and after 3 is possible (sortable), but not when the before constraint contradicts the after constraint via 2.