### PR TITLE
Concise logging format for the binds of casted values

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -70,13 +70,12 @@ module ActiveRecord
           if attr.type.binary? && attr.value
             value = "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
           end
+          [attr.name, value]
         when Array
-          attr = attr.first
+          [attr.first&.name, value]
         else
-          attr = nil
+          value
         end
-
-        [attr&.name, value]
       end
 
       def colorize_payload_name(name, payload_name)


### PR DESCRIPTION
Related issue #41133.

In #39106, I've allowed binds of casted values as an alternative of the
legacy binds (an array of `[column || nil, value]`) to deprecate and
remove the legacy binds support in a future version of Rails.

At that time, I've respected the existing logging format for binds.

i.e.

```ruby
# legacy binds
conn.select_all("SELECT * FROM events WHERE id IN (?, ?)", nil, [[nil, 1], [nil, 2]])
# (0.1ms)  SELECT * FROM events WHERE id IN (?, ?)  [[nil, 1], [nil, 2]]

# casted binds
conn.select_all("SELECT * FROM events WHERE id IN (?, ?)", nil, [1, 2])
# (0.1ms)  SELECT * FROM events WHERE id IN (?, ?)  [[nil, 1], [nil, 2]]
```

To improve the performance of generating IN clause, 72fd0ba avoids
`build_bind_attribute` for each values, so now binds has become casted
values.

```ruby
conn.select_all(Event.where(id: [1, 2]))
# (0.1ms)  SELECT * FROM events WHERE id IN (?, ?)  [[nil, 1], [nil, 2]]
```

Regardless of whether 72fd0ba avoids `build_bind_attribute` or not, the
logging format for the binds of casted values is odd (at least not
pretty to me).

I'd like to concise the logging format to just use casted values.

```ruby
conn.select_all("SELECT * FROM events WHERE id IN (?, ?)", nil, [1, 2])
# (0.1ms)  SELECT * FROM events WHERE id IN (?, ?)  [1, 2]

conn.select_all(Event.where(id: [1, 2]))
# (0.1ms)  SELECT * FROM events WHERE id IN (?, ?)  [1, 2]
```
