### PR TITLE
Fix decorated type with `type_for_attribute` on the serialized attribute

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -128,11 +128,12 @@ module ActiveRecord
             Coders::YAMLColumn.new(attr_name, class_name_or_coder)
           end
 
-          decorate_attribute_type(attr_name.to_s, **options) do |cast_type|
+          attribute(attr_name, **options) do |cast_type|
             if type_incompatible_with_serialize?(cast_type, class_name_or_coder)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end
 
+            cast_type = cast_type.subtype if Type::Serialized === cast_type
             Type::Serialized.new(cast_type, coder)
           end
         end

--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -128,7 +128,7 @@ module ActiveRecord
             Coders::YAMLColumn.new(attr_name, class_name_or_coder)
           end
 
-          attribute(attr_name, **options) do |cast_type|
+          decorate_attribute_type(attr_name.to_s, **options) do |cast_type|
             if type_incompatible_with_serialize?(cast_type, class_name_or_coder)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -208,21 +208,14 @@ module ActiveRecord
       # tracking is performed. The methods +changed?+ and +changed_in_place?+
       # will be called from ActiveModel::Dirty. See the documentation for those
       # methods in ActiveModel::Type::Value for more details.
-      def attribute(name, cast_type = nil, **options, &decorator)
+      def attribute(name, cast_type = nil, **options, &block)
         name = name.to_s
         reload_schema_from_cache
 
-        prev_cast_type, prev_options, prev_decorator = attributes_to_define_after_schema_loads[name]
-
-        unless cast_type && prev_cast_type
-          cast_type ||= prev_cast_type
-          options = prev_options || options if options.empty?
-          decorator ||= prev_decorator
-        end
-
-        self.attributes_to_define_after_schema_loads = attributes_to_define_after_schema_loads.merge(
-          name => [cast_type, options, decorator]
-        )
+        self.attributes_to_define_after_schema_loads =
+          attributes_to_define_after_schema_loads.merge(
+            name => [cast_type || block, options]
+          )
       end
 
       # This is the low level API which sits beneath +attribute+. It only
@@ -255,16 +248,8 @@ module ActiveRecord
 
       def load_schema! # :nodoc:
         super
-        attributes_to_define_after_schema_loads.each do |name, (type, options, decorator)|
-          if type.is_a?(Symbol)
-            type = ActiveRecord::Type.lookup(type, **options.except(:default), adapter: ActiveRecord::Type.adapter_name_from(self))
-          elsif type.nil?
-            type = type_for_attribute(name)
-          end
-
-          type = decorator[type] if decorator
-
-          define_attribute(name, type, **options.slice(:default))
+        attributes_to_define_after_schema_loads.each do |name, (type, options)|
+          define_attribute(name, _lookup_cast_type(name, type, options), **options.slice(:default))
         end
       end
 
@@ -286,6 +271,32 @@ module ActiveRecord
             default_attribute = ActiveModel::Attribute.from_database(name, value, type)
           end
           _default_attributes[name] = default_attribute
+        end
+
+        def decorate_attribute_type(attr_name, **default)
+          type, options = attributes_to_define_after_schema_loads[attr_name]
+
+          default.with_defaults!(default: options[:default]) if options&.key?(:default)
+
+          attribute(attr_name, **default) do |cast_type|
+            if type && !type.is_a?(Proc)
+              cast_type = _lookup_cast_type(attr_name, type, options)
+            end
+
+            yield cast_type
+          end
+        end
+
+        def _lookup_cast_type(name, type, options)
+          case type
+          when Symbol
+            adapter_name = ActiveRecord::Type.adapter_name_from(self)
+            ActiveRecord::Type.lookup(type, **options.except(:default), adapter: adapter_name)
+          when Proc
+            type[type_for_attribute(name)]
+          else
+            type || type_for_attribute(name)
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -153,8 +153,10 @@ module ActiveRecord
         end
       end
 
+      attr_reader :subtype
+
       private
-        attr_reader :name, :mapping, :subtype
+        attr_reader :name, :mapping
     end
 
     def enum(definitions)
@@ -181,7 +183,8 @@ module ActiveRecord
 
         attr = attribute_alias?(name) ? attribute_alias(name) : name
 
-        decorate_attribute_type(attr, **default) do |subtype|
+        attribute(attr, **default) do |subtype|
+          subtype = subtype.subtype if EnumType === subtype
           EnumType.new(attr, enum_values, subtype)
         end
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -181,7 +181,7 @@ module ActiveRecord
 
         attr = attribute_alias?(name) ? attribute_alias(name) : name
 
-        attribute(attr, **default) do |subtype|
+        decorate_attribute_type(attr, **default) do |subtype|
           EnumType.new(attr, enum_values, subtype)
         end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -68,15 +68,6 @@ module ActiveRecord
       assert_equal "the overloaded default", klass.new.overloaded_string_with_limit
     end
 
-    test "attributes with overridden types keep their type when a default value is configured separately" do
-      child = Class.new(OverloadedType) do
-        attribute :overloaded_float, default: "123"
-      end
-
-      assert_equal OverloadedType.type_for_attribute("overloaded_float"), child.type_for_attribute("overloaded_float")
-      assert_equal 123, child.new.overloaded_float
-    end
-
     test "extra options are forwarded to the type caster constructor" do
       klass = Class.new(OverloadedType) do
         attribute :starts_at, :datetime, precision: 3, limit: 2, scale: 1, default: -> { Time.now.utc }
@@ -302,15 +293,6 @@ module ActiveRecord
       model = child.last
 
       assert_equal 123, model.non_existent_decimal
-    end
-
-    test "attributes not backed by database columns keep their type when a default value is configured separately" do
-      child = Class.new(OverloadedType) do
-        attribute :non_existent_decimal, default: "123"
-      end
-
-      assert_equal OverloadedType.type_for_attribute("non_existent_decimal"), child.type_for_attribute("non_existent_decimal")
-      assert_equal 123, child.new.non_existent_decimal
     end
 
     test "attributes not backed by database columns properly interact with mutation and dirty" do

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -68,6 +68,15 @@ module ActiveRecord
       assert_equal "the overloaded default", klass.new.overloaded_string_with_limit
     end
 
+    test "attributes with overridden types keep their type when a default value is configured separately" do
+      child = Class.new(OverloadedType) do
+        attribute :overloaded_float, default: "123"
+      end
+
+      assert_equal OverloadedType.type_for_attribute("overloaded_float"), child.type_for_attribute("overloaded_float")
+      assert_equal 123, child.new.overloaded_float
+    end
+
     test "extra options are forwarded to the type caster constructor" do
       klass = Class.new(OverloadedType) do
         attribute :starts_at, :datetime, precision: 3, limit: 2, scale: 1, default: -> { Time.now.utc }
@@ -293,6 +302,15 @@ module ActiveRecord
       model = child.last
 
       assert_equal 123, model.non_existent_decimal
+    end
+
+    test "attributes not backed by database columns keep their type when a default value is configured separately" do
+      child = Class.new(OverloadedType) do
+        attribute :non_existent_decimal, default: "123"
+      end
+
+      assert_equal OverloadedType.type_for_attribute("non_existent_decimal"), child.type_for_attribute("non_existent_decimal")
+      assert_equal 123, child.new.non_existent_decimal
     end
 
     test "attributes not backed by database columns properly interact with mutation and dirty" do

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -442,6 +442,18 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     ActiveRecord::Type.registry = old_registry
   end
 
+  def test_decorated_type_with_decorator_block
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = Topic.table_name
+      store :content
+      attribute(:content) { |subtype| EncryptedType.new(subtype: subtype) }
+    end
+
+    topic = klass.create!(content: { trial: true })
+
+    assert_equal({ "trial" => true }, topic.content)
+  end
+
   def test_mutation_detection_does_not_double_serialize
     coder = Object.new
     def coder.dump(value)


### PR DESCRIPTION
The regression #41138 which is caused by #39929 is happened due to using `cast_type` (`:encrypted`) with `prev_decorator` (`serialize` in `store`).

Since multiple decorations (`:encrypted` on `store` on the original attribute) were never officially supported, it was just a coincidence that it worked, but I don't want to break that in exchange of allowing to ommit a type on subclasses.

IMO, even if a type on subclasses can be ommited, I'd not recommend to ommit the type on subclasses for devs.

```ruby
# app/models/post.rb
class Post < ActiveRecord::Base
  attribute :x, :integer
end

# app/models/special_post.rb
class SpecialPost < Post
  # :integer can be ommited, but it is less obvious.
  attribute :x, default: 42

  # I'd recommend to not ommit the :integer for devs.
  attribute :x, :integer, default: 42
end
```

It is a similar point of view with https://github.com/rails/rails/commit/94ba417ecec8272700805268b76be7de9a470a59#r41923157.

Fixes #41138.

cc @georgeclaghorn @kaspth @jonathanhefner 