### PR TITLE
Refine asset_host to action_mailer only in Action Mailer rails guide

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -621,7 +621,7 @@ As the `:asset_host` usually is consistent across the application you can
 configure it globally in `config/application.rb`:
 
 ```ruby
-config.asset_host = 'http://example.com'
+config.action_mailer.asset_host = 'http://example.com'
 ```
 
 Now you can display an image inside your email.


### PR DESCRIPTION
### Summary

This refinement limits the application config `asset_host` to affect the Action Mailer only, so that it only affects images in emails, and not images elsewhere throughout the application as well.