### PR TITLE
Changing 'rails new' --master to be --main

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -97,7 +97,7 @@ module Rails
         class_option :edge,                type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository"
 
-        class_option :master,              type: :boolean, default: false,
+        class_option :main,                type: :boolean, default: false, aliases: "--master",
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository main branch"
 
         class_option :rc,                  type: :string, default: nil,
@@ -279,7 +279,7 @@ module Rails
           [
             GemfileEntry.github("rails", "rails/rails", "main")
           ]
-        elsif options.master?
+        elsif options.main?
           [
             GemfileEntry.github("rails", "rails/rails", "main")
           ]

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -46,7 +46,7 @@ end
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  <%- if options.dev? || options.edge? || options.master? -%>
+  <%- if options.dev? || options.edge? || options.main? -%>
   gem 'web-console', github: 'rails/web-console'
   <%- else -%>
   gem 'web-console', '>= 4.1.0'

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  <%= '# ' if options.dev? || options.edge? || options.master? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
+  <%= '# ' if options.dev? || options.edge? || options.main? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
 end

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 <% if options[:skip_gemspec] -%>
-<%= '# ' if options.dev? || options.edge? || options.master? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
+<%= '# ' if options.dev? || options.edge? || options.main? -%>gem 'rails', '<%= Array(rails_version_specifier).join("', '") %>'
 <% else -%>
 # Specify your gem's dependencies in <%= name %>.gemspec.
 gemspec

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -809,8 +809,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_web_console_with_master_option
-    run_generator [destination_root, "--master"]
+  def test_web_console_with_main_option
+    run_generator [destination_root, "--main"]
 
     assert_file "Gemfile" do |content|
       assert_match(/gem 'web-console',\s+github: 'rails\/web-console'/, content)
@@ -862,6 +862,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_master_option
     generator([destination_root], master: true, skip_webpack_install: true)
+    run_generator_instance
+
+    assert_equal 1, @bundle_commands.count("install")
+    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
+  end
+
+  def test_main_option
+    generator([destination_root], main: true, skip_webpack_install: true)
     run_generator_instance
 
     assert_equal 1, @bundle_commands.count("install")

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -862,7 +862,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
   def test_master_option
     run_generator [destination_root, "--master"]
-    assert_equal 1, @bundle_commands.count("install")
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
   end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -861,9 +861,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_master_option
-    generator([destination_root], master: true, skip_webpack_install: true)
-    run_generator_instance
-
+    run_generator [destination_root, "--master"]
     assert_equal 1, @bundle_commands.count("install")
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
   end


### PR DESCRIPTION
### Summary

I thought a bit weird we have a `--master` flag when would track master when we now use `main`.

I updated the flag to be `--main`/`--no-main`, which will create a new project tracking the main branch explicitly in the Gemfile.

### Other Information

This is totally my first pull request to `rails/rails`, so bear with me if I've missed something really obvious.

The only thing I'm thinking we might want is a alias for `--master`/`--no-master` so that tracks the `main` branch also, what do you think?