### PR TITLE
Add config.enable_response_compression

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -22,7 +22,7 @@ module Rails
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
-                    :rake_eager_load
+                    :rake_eager_load, :enable_response_compression
 
       attr_reader :encoding, :api_only, :loaded_config_version, :autoloader
 

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -79,6 +79,10 @@ module Rails
           middleware.use ::Rack::ConditionalGet
           middleware.use ::Rack::ETag, "no-cache"
 
+          if config.enable_response_compression
+            middleware.use ::Rack::Deflater
+          end
+
           middleware.use ::Rack::TempfileReaper unless config.api_only
         end
       end

--- a/railties/test/application/middleware_test.rb
+++ b/railties/test/application/middleware_test.rb
@@ -344,6 +344,12 @@ module ApplicationTests
       assert_equal "/foo/?something", env["ORIGINAL_FULLPATH"]
     end
 
+    test "includes deflater if enable_response_compression is enabled" do
+      add_to_config "config.enable_response_compression = true"
+      boot!
+      assert_includes middleware, "Rack::Deflater"
+    end
+
     private
       def boot!
         require "#{app_path}/config/environment"


### PR DESCRIPTION
### Summary

`config.enable_response_compression` enables HTTP compression by adding [`Rack::Deflater` middleware](https://github.com/rack/rack/blob/master/lib/rack/deflater.rb). The compression is  when the flag is enabled and by adding the following header to the request `Accept-Encoding: gzip, deflate`, that presence means that clients know how to handle the response encoding.

**HTTP compression** is a capability that can be built into web servers and web clients to improve transfer speed and bandwidth utilization [[1](https://en.wikipedia.org/wiki/HTTP_compression)], compression can be done at web server level, e.g [NGINX reverse proxy](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/). However, some Platform as a service for Rails might not provide the options of changing/adding this "low level" settings(https://devcenter.heroku.com/articles/compressing-http-messages-with-gzip), one possible way to add HTTP compression for dynamic content is to use a `Rack::Deflater`