### PR TITLE
Fix ActiveRecord::ConnectionAdapters::QueryCache#dirties_query_cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -7,7 +7,7 @@ module ActiveRecord
     module QueryCache
       class << self
         def included(base) #:nodoc:
-          dirties_query_cache base, :insert, :update, :delete, :truncate, :truncate_tables,
+          dirties_query_cache base, :create, :insert, :update, :delete, :truncate, :truncate_tables,
             :rollback_to_savepoint, :rollback_db_transaction, :exec_insert_all
 
           base.set_callback :checkout, :after, :configure_query_cache!

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -442,6 +442,19 @@ module ActiveRecord
       end
     end
 
+    def test_create_with_query_cache
+      @connection.enable_query_cache!
+
+      count = Post.count
+
+      @connection.create("INSERT INTO posts(title, body) VALUES ('', '')")
+
+      assert_equal count + 1, Post.count
+    ensure
+      reset_fixtures("posts")
+      @connection.disable_query_cache!
+    end
+
     def test_truncate
       assert_operator Post.count, :>, 0
 


### PR DESCRIPTION
### Summary

In the [active_record/connection_adapters/abstract/database_statements.rb](https://github.com/rails/rails/blob/5cfaefbd11b336fcdf1e2bebc73bec8e863784e5/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L174) file, `#create` method is alias of `#insert` method.  
In the [active_record/connection_adapters/abstract/query_cache.rb](https://github.com/rails/rails/blob/5cfaefbd11b336fcdf1e2bebc73bec8e863784e5/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L10-#L11) file, `#create` method is not cleanup query cache.  
We should override `#create` method cleanup query cache too.