### PR TITLE
Add `config.action_dispatch.conceal_request_body_on_parse_error`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+*   Add `config.action_dispatch.conceal_request_body_on_parse_error` to toggle whether the raw post body is included in log messages
+    and exception messages on parse error. The default behavior of including the raw post body remains the same in test and development
+    environments. However, the default behavior of other environments (production) is to now omit the raw post body to avoid leaking
+    potentially sensitive information in logs.
+
+    *Aaron Lahey*
+
 *   Change the request method to a `GET` when passing failed requests down to `config.exceptions_app`.
 
     *Alex Robbin*

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -55,6 +55,11 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
+      if config.action_dispatch.conceal_request_body_on_parse_error.nil?
+        config.action_dispatch.conceal_request_body_on_parse_error = !Rails.env.test? && !Rails.env.development?
+      end
+      ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error = config.action_dispatch.conceal_request_body_on_parse_error
+
       ActionDispatch.test_app = app
     end
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -671,6 +671,11 @@ Defaults to `'signed cookie'`.
   in the `ActionDispatch::SSL` middleware. Defaults to `308` as defined in
   https://tools.ietf.org/html/rfc7538.
 
+* `config.action_dispatch.conceal_request_body_on_parse_error` configures whether the raw
+  request body will be included in log messages and exception messages on parse error.
+  Defaults to false in test and development. Defaults to true in other environments to avoid
+  leaking potentially sensitive information in logs.
+
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 
 * `ActionDispatch::Callbacks.after` takes a block of code to run after the request.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2967,6 +2967,60 @@ module ApplicationTests
       assert_nil Rails.application.config.active_record.legacy_connection_handling
     end
 
+    test "conceal_request_body_on_parse_error is false by default in test" do
+      app "test"
+
+      assert_equal false, Rails.application.config.action_dispatch.conceal_request_body_on_parse_error
+      assert_equal false, ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error
+    end
+
+    test "conceal_request_body_on_parse_error is configurable in test" do
+      add_to_config <<-RUBY
+        config.action_dispatch.conceal_request_body_on_parse_error = true
+      RUBY
+
+      app "test"
+
+      assert_equal true, Rails.application.config.action_dispatch.conceal_request_body_on_parse_error
+      assert_equal true, ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error
+    end
+
+    test "conceal_request_body_on_parse_error is false by default in development" do
+      app "development"
+
+      assert_equal false, Rails.application.config.action_dispatch.conceal_request_body_on_parse_error
+      assert_equal false, ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error
+    end
+
+    test "conceal_request_body_on_parse_error is configurable in development" do
+      add_to_config <<-RUBY
+        config.action_dispatch.conceal_request_body_on_parse_error = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, Rails.application.config.action_dispatch.conceal_request_body_on_parse_error
+      assert_equal true, ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error
+    end
+
+    test "conceal_request_body_on_parse_error is true by default in production" do
+      app "production"
+
+      assert_equal true, Rails.application.config.action_dispatch.conceal_request_body_on_parse_error
+      assert_equal true, ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error
+    end
+
+    test "conceal_request_body_on_parse_error is configurable in production" do
+      add_to_config <<-RUBY
+        config.action_dispatch.conceal_request_body_on_parse_error = false
+      RUBY
+
+      app "production"
+
+      assert_equal false, Rails.application.config.action_dispatch.conceal_request_body_on_parse_error
+      assert_equal false, ActionDispatch::Http::Parameters.conceal_request_body_on_parse_error
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
### Summary

Add `config.action_dispatch.conceal_request_body_on_parse_error` to toggle whether the raw post body is included in log messages and exception messages on parse error. The default behavior of including the raw post body remains the same in test and development environments. However, the default behavior of other environments (production) is to now omit the raw post body to avoid leaking potentially sensitive information in logs.

### Other Information

Related Issue: https://github.com/rails/rails/issues/41145