### PR TITLE
Fix joins that reserved word association is referenced in `where`

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -195,7 +195,7 @@ module ActiveRecord
               next table, true
             end
 
-            table_name = @references[reflection.name.to_sym]
+            table_name = @references[reflection.name.to_sym]&.to_s
 
             table = alias_tracker.aliased_table_for(reflection.klass.arel_table, table_name) do
               name = reflection.alias_candidate(parent.table_name)

--- a/activerecord/test/cases/associations/inner_join_association_test.rb
+++ b/activerecord/test/cases/associations/inner_join_association_test.rb
@@ -122,6 +122,11 @@ class InnerJoinAssociationTest < ActiveRecord::TestCase
     assert_equal 1, authors.count
   end
 
+  def test_join_with_reserved_word
+    assert_equal [categories_posts(:technology_welcome)],
+      Post::CategoryPost.joins(:group).where("group.id": categories(:technology))
+  end
+
   def test_find_with_implicit_inner_joins_without_select_does_not_imply_readonly
     authors = Author.joins(:posts)
     assert_not authors.empty?, "expected authors to be non-empty"

--- a/activerecord/test/fixtures/categories_posts.yml
+++ b/activerecord/test/fixtures/categories_posts.yml
@@ -1,3 +1,6 @@
+_fixture:
+  model_class: Post::CategoryPost
+
 general_welcome:
   category_id: 1
   post_id: 1

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -3,6 +3,7 @@
 class Post < ActiveRecord::Base
   class CategoryPost < ActiveRecord::Base
     self.table_name = "categories_posts"
+    belongs_to :group, foreign_key: :category_id, class_name: "Category"
     belongs_to :category
     belongs_to :post
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -169,7 +169,7 @@ ActiveRecord::Schema.define do
     t.integer :categorizations_count
   end
 
-  create_table :categories_posts, force: true, id: false do |t|
+  create_table :categories_posts, force: true do |t|
     t.integer :category_id, null: false
     t.integer :post_id, null: false
   end


### PR DESCRIPTION
It is caused by #40749.

`Arel.sql`ed string will be avoided from quoting, it should be raw
string before using it for table alias.

Fixes https://github.com/rails/rails/issues/41010#issuecomment-761994291.
