### PR TITLE
ActionMailer default values should not be evaluated when overridden

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -901,7 +901,7 @@ module ActionMailer
       end
 
       def apply_defaults(headers)
-        default_values = self.class.default.transform_values do |value|
+        default_values = self.class.default.except(*headers.keys).transform_values do |value|
           compute_default(value)
         end
 

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -833,6 +833,14 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("Thanks for signing up this afternoon", mail.subject)
   end
 
+  test "proc default values are not evaluated when overridden" do
+    with_default BaseMailer, from: -> { flunk }, to: -> { flunk } do
+      email = BaseMailer.welcome(from: "overridden-from@example.com", to: "overridden-to@example.com")
+      assert_equal ["overridden-from@example.com"], email.from
+      assert_equal ["overridden-to@example.com"], email.to
+    end
+  end
+
   test "modifying the mail message with a before_action" do
     class BeforeActionMailer < ActionMailer::Base
       before_action :add_special_header!


### PR DESCRIPTION
Hello !

### Summary

I ran into an issue with ActionMailer today where, when I override the default `from` or `to` headers that are defined with procs, those procs are still evaluated even if they are overridden at the action level (in the mail method). This is a problem because even if I know that the content of the proc will raise an exception and I try to override those procs at the action level, I will still get an error.

I added a test with the `LazyProcMailer`. I would like the welcome action not to raise an error.

```rb
class LazyProcMailer < ActionMailer::Base
  default from: -> { flunk }, to: -> { flunk }

  def welcome
    # This should not raise an error because the from and to options are overridden
    # in the #mail method
    mail from: "overridden-from@example.com", to: "overridden-to@example.com"
  end
end
```

### Other Information

I didn't open an issue because I could submit a pull request directly but please tell me if I need to open one. This is my first contribution to Rails so I hope I made things right. Please tell me if I need to change anything!
Thanks for Rails, it's awesome!

Closes #42415 