### PR TITLE
Adding `local: true` to the `form_with` example - Issue #41159

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -837,7 +837,7 @@ Let's create `app/views/articles/new.html.erb` with the following contents:
 ```html+erb
 <h1>New Article</h1>
 
-<%= form_with model: @article do |form| %>
+<%= form_with model: @article, local: true do |form| %>
   <div>
     <%= form.label :title %><br>
     <%= form.text_field :title %>


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

The default behavior of form_with is to submit data using an XHR (Ajax) request. When attempting to work with validation errors in the view as documented, the validation errors won't exist without setting `local: true`.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
