### PR TITLE
Add Webpacker to Guides list

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -106,9 +106,6 @@
       name: Webpacker
       url: webpacker.html
       description: This guide introduces Webpacker, a Rails wrapper around the webpack build system.
-
-
-
 -
   name: Digging Deeper
   documents:

--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -102,6 +102,12 @@
       name: Action Cable Overview
       url: action_cable_overview.html
       description: This guide explains how Action Cable works, and how to use WebSockets to create real-time features.
+    -
+      name: Webpacker
+      url: webpacker.html
+      description: This guide introduces Webpacker, a Rails wrapper around the webpack build system.
+
+
 
 -
   name: Digging Deeper


### PR DESCRIPTION
Adds a link to the Webpacker guide (added in https://github.com/rails/rails/pull/40817) to the [guides list](https://guides.rubyonrails.org/) and "Guides Index" dropdown menu.

Before:
![image](https://user-images.githubusercontent.com/509837/104969016-0d29f580-59ad-11eb-85ce-757a1c11e4cd.png)

After (look in the bottom left):
![image](https://user-images.githubusercontent.com/509837/104969035-19ae4e00-59ad-11eb-845d-63355a89db48.png)
