### PR TITLE
Fixed multiple enums declaration with _prefix/_suffix

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -187,11 +187,17 @@ module ActiveRecord
 
         value_method_names = []
         _enum_methods_module.module_eval do
-          enum_prefix = name if enum_prefix == true
-          prefix = "#{enum_prefix}_" if enum_prefix
+          prefix = if enum_prefix == true
+            "#{name}_"
+          elsif enum_prefix
+            "#{enum_prefix}_"
+          end
 
-          enum_suffix = name if enum_suffix == true
-          suffix = "_#{enum_suffix}" if enum_suffix
+          suffix = if enum_suffix == true
+            "_#{name}"
+          elsif enum_suffix
+            "_#{enum_suffix}"
+          end
 
           pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
           pairs.each do |label, value|

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -511,6 +511,38 @@ class EnumTest < ActiveRecord::TestCase
     assert_predicate book2, :single?
   end
 
+  test "declare multiple enums with { _prefix: true }" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+
+      enum(
+        status: [:value_1],
+        last_read: [:value_1],
+        _prefix: true
+      )
+    end
+
+    instance = klass.new
+    assert_respond_to instance, :status_value_1?
+    assert_respond_to instance, :last_read_value_1?
+  end
+
+  test "declare multiple enums with { _suffix: true }" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+
+      enum(
+        status: [:value_1],
+        last_read: [:value_1],
+        _suffix: true
+      )
+    end
+
+    instance = klass.new
+    assert_respond_to instance, :value_1_status?
+    assert_respond_to instance, :value_1_last_read?
+  end
+
   test "enum with alias_attribute" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"


### PR DESCRIPTION
### Summary

enum is broken when multiple values and `_prefix/_suffix: true` options
are passed.
Because the `enum_prefix/enum_suffix` variables are overwritten from `true` to
`name` during the first loop, and one should return `true` at the second loop, got already overwritten.

This behavior is introduced by https://github.com/rails/rails/pull/40992

### Other Information

A simple example of this bug.

```ruby
Post.enum(
  enum_a: %i[
    value_1
  ],
  enum_b: %i[
    value_1
  ],
  _prefix: true
)
#=> ArgumentError: You tried to define an enum named "enum_b" on the model "Post", but this will generate a instance method "enum_a_value_1?", which is already defined by another enum.
```