### PR TITLE
Raise unknown type error on the definition time

### DIFF
--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -142,5 +142,11 @@ module ActiveModel
       data.freeze
       assert_nothing_raised { data.freeze }
     end
+
+    test "unknown type error is raised" do
+      assert_raise(ArgumentError) do
+        ModelForAttributesTest.attribute :foo, :unknown
+      end
+    end
   end
 end

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -214,8 +214,7 @@ module ActiveRecord
 
         case cast_type
         when Symbol
-          type = cast_type
-          cast_type = -> _ { Type.lookup(type, **options, adapter: Type.adapter_name_from(self)) }
+          cast_type = Type.lookup(cast_type, **options, adapter: Type.adapter_name_from(self))
         when nil
           if (prev_cast_type, prev_default = attributes_to_define_after_schema_loads[name])
             default = prev_default if default == NO_DEFAULT_PROVIDED

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -7,7 +7,7 @@ class PostgresqlTime < ActiveRecord::Base
   # Declare attributes to get rid from deprecation warnings on ActiveRecord 6.1
   attribute :time_interval,        :string
   attribute :scaled_time_interval, :interval
-end
+end if current_adapter?(:PostgreSQLAdapter)
 
 class PostgresqlOid < ActiveRecord::Base
 end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -16,7 +16,7 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
     attribute :legacy_x, :legacy_point
     attribute :legacy_y, :legacy_point
     attribute :legacy_z, :legacy_point
-  end
+  end if current_adapter?(:PostgreSQLAdapter)
 
   def setup
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/interval_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/interval_test.rb
@@ -12,7 +12,7 @@ class PostgresqlIntervalTest < ActiveRecord::PostgreSQLTestCase
     attribute :default_term, :interval
     attribute :all_terms,    :interval, array: true
     attribute :legacy_term,  :string
-  end
+  end if current_adapter?(:PostgreSQLAdapter)
 
   class DeprecatedIntervalDataType < ActiveRecord::Base; end
 

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -348,6 +348,12 @@ module ActiveRecord
       assert_equal "foo", klass.new(no_type: "foo").no_type
     end
 
+    test "unknown type error is raised" do
+      assert_raise(ArgumentError) do
+        OverloadedType.attribute :foo, :unknown
+      end
+    end
+
     test "immutable_strings_by_default changes schema inference for string columns" do
       with_immutable_strings do
         OverloadedType.reset_column_information

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -597,15 +597,8 @@ end
 
 class InheritanceAttributeMappingTest < ActiveRecord::TestCase
   setup do
-    @old_registry = ActiveRecord::Type.registry
-    ActiveRecord::Type.registry = ActiveRecord::Type.registry.dup
-    ActiveRecord::Type.register :omg_sti, InheritanceAttributeMappingTest::OmgStiType
     Company.delete_all
     Sponsor.delete_all
-  end
-
-  teardown do
-    ActiveRecord::Type.registry = @old_registry
   end
 
   class OmgStiType < ActiveRecord::Type::String
@@ -623,6 +616,8 @@ class InheritanceAttributeMappingTest < ActiveRecord::TestCase
       end
     end
   end
+
+  ActiveRecord::Type.register :omg_sti, OmgStiType
 
   class Company < ActiveRecord::Base
     self.table_name = "companies"


### PR DESCRIPTION
If unknow type is given for attribute (`attribute :foo, :unknown`),
unknown type error isn't raised on the definition time but runtime.

It should be raised on the definition time.
