### PR TITLE
correcting article_params for adding status key

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1885,7 +1885,7 @@ We also have to permit the `:status` key as part of the strong parameter, in `ap
 ```ruby
   private
     def article_params
-      params.require(:comment).permit(:commenter, :body, :status)
+      params.require(:article).permit(:title, :body, :status)
     end
 ```
 


### PR DESCRIPTION
Adding the status concerns to the articles controller was a slapdash copy paste of the concerns of the comments controller.

corrected the require comment and permit commenter to require article and permit title.

