### PR TITLE
remove misleading comment about `spawn` being overridden in other class

### DIFF
--- a/activerecord/lib/active_record/relation/spawn_methods.rb
+++ b/activerecord/lib/active_record/relation/spawn_methods.rb
@@ -6,7 +6,6 @@ require "active_record/relation/merger"
 
 module ActiveRecord
   module SpawnMethods
-    # This is overridden by Associations::CollectionProxy
     def spawn #:nodoc:
       already_in_scope? ? klass.all : clone
     end


### PR DESCRIPTION
Hello 👋 

I believe this is an old comment, thus it's no longer true. That's why I suggest to remove it. Apologies if I'm wrong.
