### PR TITLE
Only override Github git_source for legacy Bundler

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Only override `git_source(:github)` in Gemfile when running Bundler 1.x
+
+    *Christian Sutter*
+
 *   Add benchmark method that can be called from anywhere.
 
     This method is used as a quick way to measure & log the speed of some code.

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
+<% unless Bundler.respond_to?(:bundler_major_version) && Bundler.bundler_major_version >= 2 -%>
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+<% end -%>
 
 ruby <%= "'#{RUBY_VERSION}'" -%>
 


### PR DESCRIPTION
### Summary

Bundler 1.x used an insecure `git://` URL as the default for gems
specified with the `:github` source in Gemfiles, and this common
workaround was added to the Gemfile template for newly generated apps to
override the then Bundler default.

As of Bundler 2.0.0, the `:github` source in Gemfiles defaults to HTTPS
(c.f. https://github.com/rubygems/bundler/releases/tag/v2.0.0) – so we
no longer need to include this if we generate a Gemfile in an
environment running a recent version of Bundler.

When Rails moves to require Bundler >= 2.0, this can be removed
entirely.