### PR TITLE
Be sure to return a copy when String#underscore makes no changes

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -90,7 +90,7 @@ module ActiveSupport
     #
     #   camelize(underscore('SSLError'))  # => "SslError"
     def underscore(camel_cased_word)
-      return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+      return camel_cased_word.dup unless /[A-Z-]|::/.match?(camel_cased_word)
       word = camel_cased_word.to_s.gsub("::", "/")
       word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -130,6 +130,14 @@ class StringInflectionsTest < ActiveSupport::TestCase
       assert_equal(underscore, camel.underscore)
     end
 
+    # Ensure a copy of an alread-underscored string is returned,
+    # not the original string itself.
+    CamelToUnderscore.each_value do |already_underscore|
+      underscored = already_underscore.underscore
+      assert_equal already_underscore, underscored
+      assert_not_same already_underscore, underscored
+    end
+
     assert_equal "html_tidy", "HTMLTidy".underscore
     assert_equal "html_tidy_generator", "HTMLTidyGenerator".underscore
   end


### PR DESCRIPTION
Previous behavior was inconsistent in terms of returning the original string or a new string when calling String#underscore. This inconsistency can result in unexpected behaviors. With the previous implementation, the method below may or may not modify the `my_string` argument, depending on the string's content:

```ruby
def my_method(my_string)
  my_new_string = my_string.underscore
  my_new_string.tr!("/", "_")
  my_new_string
end
```