### PR TITLE
ActionCable guides suggest test adapter for test env [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -702,7 +702,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: redis


### PR DESCRIPTION
### Summary

It serves two purposes:
- Suggest the proper setup for test env in the guides
- Be consistent with the default value in `railties/lib/rails/generators/rails/app/templates/config/cable.yml.tt`