### PR TITLE
Use length == 0 instead of empty? in Preloader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -98,7 +98,7 @@ module ActiveRecord
       end
 
       def call
-        return [] if records.empty? || associations.nil?
+        return [] if associations.nil? || records.length == 0
 
         build_preloaders
       end

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -379,6 +379,25 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_predicate post.comments, :loaded?
     assert_equal [comments(:greetings)], post.comments
   end
+
+  def test_preload_makes_correct_number_of_queries_on_array
+    post = posts(:welcome)
+
+    assert_queries(1) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: [post], associations: :comments)
+      preloader.call
+    end
+  end
+
+  def test_preload_makes_correct_number_of_queries_on_relation
+    post = posts(:welcome)
+    relation = Post.where(id: post.id)
+
+    assert_queries(2) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: relation, associations: :comments)
+      preloader.call
+    end
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase


### PR DESCRIPTION
Previously we were checking `empty?` on the association which would make a query. Instead we can check `length == 0` to ensure we are using the length of the loaded records and not issuing extra queries. This was only an issue when passing in unloaded relations.

```
require "active_record"
require "logger"
require "benchmark/ips"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
  create_table :comments, force: true do |t|
    t.belongs_to :post
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

Post.create!
Post.last.comments.create!
Post.last.comments.create!
Post.create!
Post.last.comments.create!


result = Benchmark.ips do |x|
  x.report "prefill associations" do
    ActiveRecord::Associations::Preloader.new(records: Post.all, associations: [:comments]).call
  end
end
```

**Before**

```
Warming up --------------------------------------
prefill associations   252.000  i/100ms
Calculating -------------------------------------
prefill associations      2.549k (± 1.4%) i/s -     12.852k in   5.043288s
```

**After**

```
Warming up --------------------------------------
prefill associations   335.000  i/100ms
Calculating -------------------------------------
prefill associations      3.361k (± 0.5%) i/s -     17.085k in   5.082847s
```


Co-authored-by: Dinah Shi <dinahshi@github.com>

cc @eileencodes 
