### PR TITLE
Opting out of strict loading on a per-record base

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Allow to opt-out of `strict_loading` mode on a per-record base.
+
+    This is useful when strict loading is enabled application wide or on a
+    model level.
+
+    ```ruby
+    class User < ApplicationRecord
+      has_many :articles, strict_loading: true
+    end
+
+    user = User.first
+    user.articles
+    # => ActiveRecord::StrictLoadingViolationError
+
+    user = User.first
+    user.stict_loading!(false)
+    user.articles
+    # => #<ActiveRecord::Associations::CollectionProxy>
+    ```
+
+    *Ayrton De Craene*
+
 *   Add `FinderMethods#sole` and `#find_sole_by` to find and assert the
     presence of exactly one record.
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -654,8 +654,8 @@ module ActiveRecord
     #   user.strict_loading!
     #   user.comments.to_a
     #   => ActiveRecord::StrictLoadingViolationError
-    def strict_loading!
-      @strict_loading = true
+    def strict_loading!(value = true)
+      @strict_loading = value
     end
 
     # Marks this record as read only.

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -24,6 +24,13 @@ class StrictLoadingTest < ActiveRecord::TestCase
     assert_raises ActiveRecord::StrictLoadingViolationError do
       developer.audit_logs.to_a
     end
+
+    developer.strict_loading!(false)
+    assert_not_predicate developer, :strict_loading?
+
+    assert_nothing_raised do
+      developer.audit_logs.to_a
+    end
   end
 
   def test_strict_loading
@@ -147,6 +154,10 @@ class StrictLoadingTest < ActiveRecord::TestCase
     dev = Developer.eager_load(:strict_loading_audit_logs).first
 
     assert dev.strict_loading_audit_logs.all?(&:strict_loading?), "Expected all audit logs to be strict_loading"
+
+    dev = Developer.eager_load(:strict_loading_audit_logs).strict_loading(false).first
+
+    assert dev.audit_logs.none?(&:strict_loading?), "Expected no audit logs to be strict_loading"
   end
 
   def test_eager_load_audit_logs_are_strict_loading_because_parent_is_strict_loading
@@ -160,6 +171,11 @@ class StrictLoadingTest < ActiveRecord::TestCase
 
     assert_predicate dev, :strict_loading?
     assert dev.audit_logs.all?(&:strict_loading?), "Expected all audit logs to be strict_loading"
+
+    dev = Developer.eager_load(:audit_logs).strict_loading(false).first
+
+    assert_not_predicate dev, :strict_loading?
+    assert dev.audit_logs.none?(&:strict_loading?), "Expected no audit logs to be strict_loading"
   end
 
   def test_eager_load_audit_logs_are_strict_loading_because_it_is_strict_loading_by_default


### PR DESCRIPTION
### Summary

Provide a way to opt out of strict loader on a per-record base. This is useful when strict loading is enabled application wide or on model level.

__How__:

Similar to defining the value of `strict_loading` on [relations](https://github.com/rails/rails/pull/37400/files#diff-79b53b2602bf702bdd8ce677e096be6a6923a54236e17237c16068a510078683) we accept an optional value on a [record](https://github.com/rails/rails/pull/37400/files#diff-4411c7993e3f8ccfd8e09f44a81f10dfac3ea7dbd44cabd60b369040a00be324).

This was initially reported in #41171.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
