### PR TITLE
Fix custom url helpers with query strings

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -629,7 +629,15 @@ module ActionDispatch
         end
 
         def call(t, args, only_path = false)
-          options = args.extract_options!
+          last = args.last
+          options = \
+            case last
+            when Hash
+              args.pop
+            when ActionController::Parameters
+              args.pop
+            end.to_h
+
           url = t.full_url_for(eval_block(t, args, options))
 
           if only_path

--- a/actionpack/test/dispatch/routing/custom_url_helpers_test.rb
+++ b/actionpack/test/dispatch/routing/custom_url_helpers_test.rb
@@ -85,6 +85,7 @@ class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
     get "/profile", to: "users#profile", as: :profile
     get "/media/:id", to: "media#show", as: :media
     get "/pages/:id", to: "pages#show", as: :page
+    get "/posts/:post_id/comments/:id", to: "comments#show", as: :post_comments
 
     resources :categories, :collections, :products, :manufacturers
 
@@ -103,6 +104,7 @@ class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
     direct(:array)    { [:admin, :dashboard] }
     direct(:options)  { |options| [:products, options] }
     direct(:defaults, size: 10) { |options| [:products, options] }
+    direct(:comments) { |comment_id, *args| post_comments_url(1, comment_id, *args) }
 
     direct(:browse, page: 1, size: 10) do |options|
       [:products, options.merge(params.permit(:page, :size).to_h.symbolize_keys)]
@@ -176,6 +178,10 @@ class TestCustomUrlHelpers < ActionDispatch::IntegrationTest
     assert_equal "/basket", Routes.url_helpers.hash_path
     assert_equal "/admin/dashboard", array_path
     assert_equal "/admin/dashboard", Routes.url_helpers.array_path
+
+    assert_equal "/posts/1/comments/1", comments_path(1)
+    assert_equal "/posts/1/comments/1?foo=bar", comments_path(1, { foo: :bar })
+    assert_equal post_comments_path(1, 1, params.permit!), comments_path(1, params.permit!)
 
     assert_equal "/products?page=2", options_path(page: 2)
     assert_equal "/products?page=2", Routes.url_helpers.options_path(page: 2)


### PR DESCRIPTION
### Summary

This change fixes the behaviour of custom url helpers and matches it with the other url helpers when the options are provided as an `ActionController::Parameter` object.