### PR TITLE
Respect ActiveStorage default serving strategy

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,5 +1,5 @@
 *   After setting `config.active_storage.resolve_model_to_route = :rails_storage_proxy`
-    `rails_blob_path` will generate proxy URLs by default.
+    `rails_blob_path` and `rails_representation_path` will generate proxy URLs by default.
 
     *Ali Ismayilov*
 

--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   After setting `config.active_storage.resolve_model_to_route = :rails_storage_proxy`
+    `rails_blob_path` will generate proxy URLs by default.
+
+    *Ali Ismayilov*
+
 *   Declare `ActiveStorage::FixtureSet` and `ActiveStorage::FixtureSet.blob` to
     improve fixture integration
 

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   resolve("ActiveStorage::Preview") { |preview, options| route_for(ActiveStorage.resolve_model_to_route, preview, options) }
 
   direct :rails_blob do |blob, options|
-    route_for(:rails_service_blob, blob.signed_id, blob.filename, options)
+    route_for(ActiveStorage.resolve_model_to_route, blob, options)
   end
 
   resolve("ActiveStorage::Blob")       { |blob, options| route_for(ActiveStorage.resolve_model_to_route, blob, options) }

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -16,11 +16,7 @@ Rails.application.routes.draw do
   end
 
   direct :rails_representation do |representation, options|
-    signed_blob_id = representation.blob.signed_id
-    variation_key  = representation.variation.key
-    filename       = representation.blob.filename
-
-    route_for(:rails_blob_representation, signed_blob_id, variation_key, filename, options)
+    route_for(ActiveStorage.resolve_model_to_route, representation, options)
   end
 
   resolve("ActiveStorage::Variant") { |variant, options| route_for(ActiveStorage.resolve_model_to_route, variant, options) }

--- a/activestorage/test/urls/rails_storage_proxy_url_test.rb
+++ b/activestorage/test/urls/rails_storage_proxy_url_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class RailsStorageProxyUrlTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+
+  setup do
+    @blob = create_file_blob filename: "racecar.jpg"
+    @was_resolve_model_to_route, ActiveStorage.resolve_model_to_route = ActiveStorage.resolve_model_to_route, :rails_storage_proxy
+  end
+
+  teardown do
+    ActiveStorage.resolve_model_to_route = @was_resolve_model_to_route
+  end
+
+  test "rails_storage_proxy_path generates proxy path" do
+    assert_includes rails_storage_proxy_path(@blob, only_path: true), "/rails/active_storage/blobs/proxy/"
+  end
+
+  test "rails_storage_redirect_path generates redirect path" do
+    assert_includes rails_storage_redirect_path(@blob, only_path: true), "/rails/active_storage/blobs/redirect/"
+  end
+
+  test "rails_blob_path generates proxy path" do
+    assert_includes rails_blob_path(@blob, only_path: true), "/rails/active_storage/blobs/proxy/"
+  end
+
+  test "rails_blob_path with variant generates proxy path" do
+    variant = @blob.variant(resize: "100x100")
+    assert_includes rails_blob_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
+  end
+end

--- a/activestorage/test/urls/rails_storage_proxy_url_test.rb
+++ b/activestorage/test/urls/rails_storage_proxy_url_test.rb
@@ -31,4 +31,9 @@ class RailsStorageProxyUrlTest < ActiveSupport::TestCase
     variant = @blob.variant(resize: "100x100")
     assert_includes rails_blob_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
   end
+
+  test "rails_representation_path generates proxy path" do
+    variant = @blob.variant(resize: "100x100")
+    assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
+  end
 end

--- a/activestorage/test/urls/rails_storage_redirect_url_test.rb
+++ b/activestorage/test/urls/rails_storage_redirect_url_test.rb
@@ -31,4 +31,9 @@ class RailsStorageRedirectUrlTest < ActiveSupport::TestCase
     variant = @blob.variant(resize: "100x100")
     assert_includes rails_blob_path(variant, only_path: true), "/rails/active_storage/representations/redirect/"
   end
+
+  test "rails_representation_path generates proxy path" do
+    variant = @blob.variant(resize: "100x100")
+    assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/redirect/"
+  end
 end

--- a/activestorage/test/urls/rails_storage_redirect_url_test.rb
+++ b/activestorage/test/urls/rails_storage_redirect_url_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class RailsStorageRedirectUrlTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+
+  setup do
+    @blob = create_file_blob filename: "racecar.jpg"
+    @was_resolve_model_to_route, ActiveStorage.resolve_model_to_route = ActiveStorage.resolve_model_to_route, :rails_storage_redirect
+  end
+
+  teardown do
+    ActiveStorage.resolve_model_to_route = @was_resolve_model_to_route
+  end
+
+  test "rails_storage_proxy_path generates proxy path" do
+    assert_includes rails_storage_proxy_path(@blob, only_path: true), "/rails/active_storage/blobs/proxy/"
+  end
+
+  test "rails_storage_redirect_path generates redirect path" do
+    assert_includes rails_storage_redirect_path(@blob, only_path: true), "/rails/active_storage/blobs/redirect/"
+  end
+
+  test "rails_blob_path generates redirect path" do
+    assert_includes rails_blob_path(@blob, only_path: true), "/rails/active_storage/blobs/redirect/"
+  end
+
+  test "rails_blob_path with variant generates redirect path" do
+    variant = @blob.variant(resize: "100x100")
+    assert_includes rails_blob_path(variant, only_path: true), "/rails/active_storage/representations/redirect/"
+  end
+end


### PR DESCRIPTION
fixes https://github.com/rails/rails/issues/41172

### Summary

`rails_blob_path` and `rails_blob_url` should be generating urls based on the ActiveStorage default serving strategy.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

I wasn't sure where/if to add the changelog. Please let me know how to proceed.
