### PR TITLE
Fix granular connection swapping when there are multiple abstract classes

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -91,6 +91,7 @@ module ActiveRecord
         db_config, owner_name = resolve_config_for_connection(database_key)
         handler = lookup_connection_handler(role.to_sym)
 
+        self.connection_class = true
         connections << handler.establish_connection(db_config, owner_name: owner_name, role: role)
       end
 
@@ -99,6 +100,7 @@ module ActiveRecord
           db_config, owner_name = resolve_config_for_connection(database_key)
           handler = lookup_connection_handler(role.to_sym)
 
+          self.connection_class = true
           connections << handler.establish_connection(db_config, owner_name: owner_name, role: role, shard: shard.to_sym)
         end
       end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -196,7 +196,7 @@ module ActiveRecord
         else
           connected_to_stack.reverse_each do |hash|
             return hash[:role] if hash[:role] && hash[:klasses].include?(Base)
-            return hash[:role] if hash[:role] && hash[:klasses].include?(abstract_base_class)
+            return hash[:role] if hash[:role] && hash[:klasses].include?(connection_classes)
           end
 
           default_role
@@ -215,7 +215,7 @@ module ActiveRecord
       def self.current_shard
         connected_to_stack.reverse_each do |hash|
           return hash[:shard] if hash[:shard] && hash[:klasses].include?(Base)
-          return hash[:shard] if hash[:shard] && hash[:klasses].include?(abstract_base_class)
+          return hash[:shard] if hash[:shard] && hash[:klasses].include?(connection_classes)
         end
 
         default_shard
@@ -237,7 +237,7 @@ module ActiveRecord
         else
           connected_to_stack.reverse_each do |hash|
             return hash[:prevent_writes] if !hash[:prevent_writes].nil? && hash[:klasses].include?(Base)
-            return hash[:prevent_writes] if !hash[:prevent_writes].nil? && hash[:klasses].include?(abstract_base_class)
+            return hash[:prevent_writes] if !hash[:prevent_writes].nil? && hash[:klasses].include?(connection_classes)
           end
 
           false
@@ -254,11 +254,19 @@ module ActiveRecord
         end
       end
 
-      def self.abstract_base_class # :nodoc:
+      def self.connection_class=(b) # :nodoc:
+        @connection_class = b
+      end
+
+      def self.connection_class? # :nodoc:
+        @connection_class
+      end
+
+      def self.connection_classes # :nodoc:
         klass = self
 
         until klass == Base
-          break if klass.abstract_class?
+          break if klass.connection_class?
           klass = klass.superclass
         end
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -31,10 +31,16 @@ require "active_support/core_ext/enumerable"
 
 class FirstAbstractClass < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to database: { writing: :arunit, reading: :arunit }
 end
+
 class SecondAbstractClass < FirstAbstractClass
   self.abstract_class = true
+
+  connects_to database: { writing: :arunit, reading: :arunit }
 end
+
 class Photo < SecondAbstractClass; end
 class Smarts < ActiveRecord::Base; end
 class CreditCard < ActiveRecord::Base
@@ -1647,33 +1653,33 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "can call connected_to with role and shard on abstract classes" do
-    AbstractCompany.connected_to(role: :reading, shard: :default) do
-      assert AbstractCompany.connected_to?(role: :reading, shard: :default)
+    SecondAbstractClass.connected_to(role: :reading, shard: :default) do
+      assert SecondAbstractClass.connected_to?(role: :reading, shard: :default)
     end
   end
 
   test "#connecting_to with role" do
-    AbstractCompany.connecting_to(role: :reading)
+    SecondAbstractClass.connecting_to(role: :reading)
 
-    assert AbstractCompany.connected_to?(role: :reading)
-    assert AbstractCompany.current_preventing_writes
+    assert SecondAbstractClass.connected_to?(role: :reading)
+    assert SecondAbstractClass.current_preventing_writes
   ensure
     ActiveRecord::Base.connected_to_stack.pop
   end
 
   test "#connecting_to with role and shard" do
-    AbstractCompany.connecting_to(role: :reading, shard: :default)
+    SecondAbstractClass.connecting_to(role: :reading, shard: :default)
 
-    assert AbstractCompany.connected_to?(role: :reading, shard: :default)
+    assert SecondAbstractClass.connected_to?(role: :reading, shard: :default)
   ensure
     ActiveRecord::Base.connected_to_stack.pop
   end
 
   test "#connecting_to with prevent_writes" do
-    AbstractCompany.connecting_to(role: :writing, prevent_writes: true)
+    SecondAbstractClass.connecting_to(role: :writing, prevent_writes: true)
 
-    assert AbstractCompany.connected_to?(role: :writing)
-    assert AbstractCompany.current_preventing_writes
+    assert SecondAbstractClass.connected_to?(role: :writing)
+    assert SecondAbstractClass.current_preventing_writes
   ensure
     ActiveRecord::Base.connected_to_stack.pop
   end
@@ -1683,7 +1689,7 @@ class BasicsTest < ActiveRecord::TestCase
     ActiveRecord::Base.legacy_connection_handling = true
 
     assert_raises NotImplementedError do
-      AbstractCompany.connecting_to(role: :writing, prevent_writes: true)
+      SecondAbstractClass.connecting_to(role: :writing, prevent_writes: true)
     end
   ensure
     ActiveRecord::Base.legacy_connection_handling = old_value
@@ -1694,7 +1700,7 @@ class BasicsTest < ActiveRecord::TestCase
     ActiveRecord::Base.legacy_connection_handling = true
 
     assert_raises NotImplementedError do
-      ActiveRecord::Base.connected_to_many([AbstractCompany], role: :writing)
+      ActiveRecord::Base.connected_to_many([SecondAbstractClass], role: :writing)
     end
   ensure
     ActiveRecord::Base.legacy_connection_handling = old_value
@@ -1702,7 +1708,7 @@ class BasicsTest < ActiveRecord::TestCase
 
   test "#connected_to_many cannot be called on anything but ActiveRecord::Base" do
     assert_raises NotImplementedError do
-      AbstractCompany.connected_to_many([AbstractCompany], role: :writing)
+      SecondAbstractClass.connected_to_many([SecondAbstractClass], role: :writing)
     end
   end
 
@@ -1713,23 +1719,23 @@ class BasicsTest < ActiveRecord::TestCase
   end
 
   test "#connected_to_many sets prevent_writes if role is reading" do
-    ActiveRecord::Base.connected_to_many([AbstractCompany], role: :reading) do
-      assert AbstractCompany.current_preventing_writes
+    ActiveRecord::Base.connected_to_many([SecondAbstractClass], role: :reading) do
+      assert SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
 
   test "#connected_to_many with a single argument for classes" do
-    ActiveRecord::Base.connected_to_many(AbstractCompany, role: :reading) do
-      assert AbstractCompany.current_preventing_writes
+    ActiveRecord::Base.connected_to_many(SecondAbstractClass, role: :reading) do
+      assert SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
 
   test "#connected_to_many with a multiple classes without brackets works" do
-    ActiveRecord::Base.connected_to_many(AbstractCompany, FirstAbstractClass, role: :reading) do
-      assert AbstractCompany.current_preventing_writes
+    ActiveRecord::Base.connected_to_many(FirstAbstractClass, SecondAbstractClass, role: :reading) do
       assert FirstAbstractClass.current_preventing_writes
+      assert SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -35,6 +35,13 @@ module ActiveRecord
       class TertiaryModel < TertiaryBase
       end
 
+      class NonConnectionAbstractClass < SecondaryBase
+        self.abstract_class = true
+      end
+
+      class ModelInheritingFromNonConnectionAbstractClass < NonConnectionAbstractClass
+      end
+
       unless in_memory_db?
         def test_roles_can_be_swapped_granularly
           previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
@@ -70,8 +77,16 @@ module ActiveRecord
 
                 # Switch only secondary to writing
                 SecondaryBase.connected_to(role: :writing) do
+                  assert_equal :writing, ModelInheritingFromNonConnectionAbstractClass.current_role
                   assert_equal "primary_replica", PrimaryBase.connection_pool.db_config.name
                   assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
+                end
+
+                # Switch only secondary to reading
+                SecondaryBase.connected_to(role: :reading) do
+                  assert_equal :reading, ModelInheritingFromNonConnectionAbstractClass.current_role
+                  assert_equal "primary_replica", PrimaryBase.connection_pool.db_config.name
+                  assert_equal "secondary_replica", SecondaryBase.connection_pool.db_config.name
                 end
 
                 # Ensure restored to global reading


### PR DESCRIPTION
Some applications maybe have multiple abstract classes in the
inheritance chain but only one of those abstract classes is the one we
want to switch connections on. Previously, multiple abstract class
inhertance would break `connected_to` and not switch models to the
correct connection context.

To fix this we added a boolean that is set on the class when a
connection is established so we can check for whether it's identified as
a `connection_class?`. This allows us to delete the `abstract_class?`
check, since you cannot establish a connection on a non-abstract class.

The existing tests were changed because they were not calling
`connects_to` and granular swapping won't work on classes that didn't
establish the connection. The issue in these tests will be prevented
when #40965 is merged.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>