### PR TITLE
Make ActiveStorage update migration compatible with install migration

### DIFF
--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,7 +1,7 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
     # Use Active Record's configured type for primary key
-    create_table :active_storage_variant_records, id: primary_key_type do |t|
+    create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
       t.string :variation_digest, null: false
 


### PR DESCRIPTION
If you install ActiveStorage in rails 6.1, then use `rails app:update`, the service name migration handles that case but not the variant records one, which fails trying to re-create the table.

### Summary

I updated an app to Rails 6.1, but forgot to run `rails app:update` immediately. Then later I installed ActiveStorage, and finally came back to run the update task.
When I saw the update migrations being created in the app, I assumed they would fail but was pleasantly surprised that the service name passed by checking for the presence of the column. So I felt maybe we'd want to do the same to the other migration. We can also assume users will understand and just remove the migrations.

Repro steps:

```sh-session
$ rails _6.1.1_ new my_app && cd my_app
$ rails active_storage:install && rails db:migrate
$ rails app:update && rails db:migrate
# fails on CreateActiveStorageVariantRecords
```

### Other Information

It works perfectly in the regular case:

```sh-session
$ rails _6.0.3.4_ new my_app && cd my_app
$ rails active_storage:install && rails db:migrate
$ $EDITOR Gemfile && bundle update # update to 6.1
$ yes | rails app:update && rails db:migrate
```