### PR TITLE
normalize virtual attributes on ActiveRecord::Persistence#becomes

### DIFF
--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -95,6 +95,11 @@ module ActiveModel
       attributes == other.attributes
     end
 
+    def slice!(*keep)
+      attributes.slice!(*keep)
+      self
+    end
+
     protected
       attr_reader :attributes
 

--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -57,6 +57,11 @@ module ActiveModel
       end
     end
 
+    def slice!(*keep)
+      [ values, types, @attributes ].each { |v| v.slice!(*keep) }
+      self
+    end
+
     protected
       def attributes
         unless @materialized
@@ -154,6 +159,11 @@ module ActiveModel
       else
         initialize(*values)
       end
+    end
+
+    def slice!(*keep)
+      [ delegate_hash, values, types ].each { |v| v.slice!(*keep) }
+      self
     end
 
     protected

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -272,6 +272,17 @@ module ActiveModel
       assert_not_equal attributes2, attributes3
     end
 
+    test "slice! removes any non-matching attributes" do
+      builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new, removed: Type::Integer.new, removed_2: Type::Float.new)
+      attributes = builder.build_from_database(foo: "1.1", bar: "2.2", removed: "3.3", removed_2: "4.4")
+
+      assert_equal [ :foo, :bar, :removed, :removed_2 ], attributes.keys
+
+      attributes.slice!(:foo, :bar)
+
+      assert_equal [ :foo, :bar ], attributes.keys
+    end
+
     private
       def attributes_with_uninitialized_key
         builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Float.new)

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Synchronize virtual attributes between classes on `ActiveRecord::Persistence#becomes`
+
+    Before, if any attributes existed only in one class it would cause an
+    `ActiveRecord::UnknownAttributeError` in both directions
+
+    ```ruby
+    class Person < ApplicationRecord
+    end
+
+    class WebUser < Person
+      attribute :is_admin, :boolean
+      after_initialize :set_admin
+
+      def set_admin
+        @attributes.write_cast_value("is_admin", email =~ /@ourcompany\.com$/)
+      end
+    end
+
+    person = Person.find_by(email: "email@ourcompany.com")
+    person.respond_to? :is_admin
+    # => false
+    person.becomes(User).is_admin?
+    # => true
+    ```
+
+    *Sampson Crowley*
+
 *   Add `FinderMethods#sole` and `#find_sole_by` to find and assert the
     presence of exactly one record.
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -578,6 +578,14 @@ module ActiveRecord
     def becomes(klass)
       became = klass.allocate
 
+      @attributes.slice!(*klass.attribute_names)
+
+      klass.attribute_types.each do |k, type|
+        unless @attributes.key?(k)
+          @attributes[k] = ActiveModel::Attribute.with_cast_value(k, nil, type)
+        end
+      end
+
       became.send(:initialize) do |becoming|
         becoming.instance_variable_set(:@attributes, @attributes)
         becoming.instance_variable_set(:@mutations_from_database, @mutations_from_database ||= nil)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -239,6 +239,18 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal %w{name}, client.changed
   end
 
+  def test_becomes_initializes_missing_attributes
+    company = Company.new(name: "GrowingCompany")
+    client = company.becomes(LargeClient)
+    assert_equal 50, client.extra_size
+  end
+
+  def test_becomes_drops_extra_attributes
+    client = LargeClient.new(name: "ShrinkingCompany")
+    company = client.becomes(Company)
+    assert_equal false, company.respond_to?(:extra_size)
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -208,6 +208,16 @@ class ExclusivelyDependentFirm < Company
   has_many :dependent_conditional_clients_of_firm, -> { order("id").where("name = ?", "BigShot Inc.") }, foreign_key: "client_of", class_name: "Client", dependent: :delete_all
 end
 
+class LargeClient < Client
+  attribute :extra_size, :integer
+
+  after_initialize :set_extra_size
+
+  def set_extra_size
+    self[:extra_size] = 50
+  end
+end
+
 class SpecialClient < Client
 end
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
#### ActiveRecord::Persistence#becomes

Currently if any virtual attributes are set on a child model that don't exist on the parent (to cache calculated values, for instance),
an `UnknownAttribute` error will be raised, because the additional attributes aren't added and removed on `#becomes`

This slices out any non-existent attributes and initializes any only-existent ones