### PR TITLE
Remove trailing commas in route constraints examples [ci skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -787,8 +787,8 @@ end
 
 Rails.application.routes.draw do
   constraints(RestrictedListConstraint.new) do
-    get '*path', to: 'restricted_list#index',
-    get '*other-path', to: 'other_restricted_list#index',
+    get '*path', to: 'restricted_list#index'
+    get '*other-path', to: 'other_restricted_list#index'
   end
 end
 ```
@@ -798,8 +798,8 @@ You can also use a `lambda`:
 ```ruby
 Rails.application.routes.draw do
   constraints(lambda { |request| RestrictedList.retrieve_ips.include?(request.remote_ip) }) do
-    get '*path', to: 'restricted_list#index',
-    get '*other-path', to: 'other_restricted_list#index',
+    get '*path', to: 'restricted_list#index'
+    get '*other-path', to: 'other_restricted_list#index'
   end
 end
 ```


### PR DESCRIPTION
### Summary

This is a typo fix for the 6.1.1 guides. Under [3.10.1 Constraints in a block form](https://guides.rubyonrails.org/routing.html#constraints-in-a-block-form), both examples have trailing commas after every route.
