### PR TITLE
Fix Active Storage update task when running in an engine

### DIFF
--- a/activestorage/lib/tasks/activestorage.rake
+++ b/activestorage/lib/tasks/activestorage.rake
@@ -17,6 +17,10 @@ namespace :active_storage do
   task update: :environment do
     ENV["MIGRATIONS_PATH"] = "db/update_migrate"
 
-    Rake::Task["active_storage:install"].invoke
+    if Rake::Task.task_defined?("active_storage:install")
+      Rake::Task["active_storage:install"].invoke
+    else
+      Rake::Task["app:active_storage:install"].invoke
+    end
   end
 end

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1613,6 +1613,21 @@ en:
       end
     end
 
+    test "active_storage:update task works within engine" do
+      @plugin.write "Rakefile", <<-RUBY
+        APP_RAKEFILE = '#{app_path}/Rakefile'
+        load "rails/tasks/engine.rake"
+      RUBY
+
+      Dir.chdir(@plugin.path) do
+        output = `bundle exec rake app:active_storage:update`
+        assert $?.success?, output
+
+        assert migrations.detect { |migration| migration.name == "AddServiceNameToActiveStorageBlobs" }
+        assert migrations.detect { |migration| migration.name == "CreateActiveStorageVariantRecords" }
+      end
+    end
+
   private
     def app
       Rails.application


### PR DESCRIPTION
Currently, running the update Rake task for Active Storage fails in Engines. This is because the task that needs to be called, `app:active_storage:install`, is namespaced. This is essentially like #31391 but for the update task.