### PR TITLE
Run bin/yarn via Ruby

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -68,7 +68,7 @@ module ActionText
         end
 
         def yarn_command(command, config = {})
-          in_root { run "bin/yarn #{command}", abort_on_failure: true, **config }
+          in_root { run "#{Thor::Util.ruby_command} bin/yarn #{command}", abort_on_failure: true, **config }
         end
     end
   end

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -73,6 +73,17 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_action_text_tables.action_text.rb"
   end
 
+  test "#yarn_command runs bin/yarn via Ruby" do
+    ran = nil
+    run_stub = -> (command, *) { ran = command }
+
+    generator.stub(:run, run_stub) do
+      generator.send(:yarn_command, "foo")
+    end
+
+    assert_match %r"\S bin/yarn foo$", ran
+  end
+
   private
     def run_generator_instance
       @yarn_commands = []


### PR DESCRIPTION
Windows cannot directly run shebang scripts, such as `bin/yarn`.  Therefore, run `bin/yarn` via Ruby.

Actually fixes #40942.
Fixes #41123.
