### PR TITLE
Search for yarn.cmd and yarn.ps1 in bin/yarn

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -2,7 +2,7 @@ APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
     select { |dir| File.expand_path(dir) != __dir__ }.
-    product(["yarn", "yarn.exe"]).
+    product(["yarn", "yarn.cmd", "yarn.ps1"]).
     map { |dir, file| File.expand_path(file, dir) }.
     find { |file| File.executable?(file) }
 


### PR DESCRIPTION
Follow-up to #40950.

On Windows, Yarn actually uses [`yarn.cmd`](https://github.com/yarnpkg/berry/blob/8376f9829cb7fee0a11d75b2829dbb8800d20938/scripts/dist-scripts/yarn.cmd) and [`yarn.ps1`](https://github.com/yarnpkg/berry/blob/8376f9829cb7fee0a11d75b2829dbb8800d20938/scripts/dist-scripts/yarn.ps1) for PowerShell.