### PR TITLE
Avoid testing Thor internals

### DIFF
--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -82,18 +82,17 @@ module SharedGeneratorTests
   end
 
   def test_template_is_executed_when_supplied_an_https_path
-    path = "https://gist.github.com/josevalim/103208/raw/"
-    template = +%{ say "It works!" }
-    template.instance_eval "def read; self; end" # Make the string respond to read
+    url = "https://gist.github.com/josevalim/103208/raw/"
+    generator([destination_root], template: url, skip_webpack_install: true)
 
-    check_open = -> *args do
-      assert_equal [ path, "Accept" => "application/x-thor-template" ], args
-      template
+    applied = nil
+    apply_stub = -> (path, *) { applied = path }
+
+    generator.stub(:apply, apply_stub) do
+      run_generator_instance
     end
 
-    generator([destination_root], template: path, skip_webpack_install: true).stub(:open, check_open, template) do
-      assert_match(/It works!/, run_generator_instance)
-    end
+    assert_equal url, applied
   end
 
   def test_skip_gemfile


### PR DESCRIPTION
Thor's `apply` method is responsible for fetching a template when given a URL.  Therefore, assume that `apply` behaves correctly, and simply test that `apply` is called correctly.

This avoids errors like https://buildkite.com/rails/rails/builds/74245#540ecdf1-58ea-470a-a397-09f675520eb9/1100-1109 resulting from erikhuda/thor@4ce38c5478a5a13f2214ca833eafc167615b4e6a.
