### PR TITLE
Resolve default annotation tags after config loads

### DIFF
--- a/railties/lib/rails/commands/notes/notes_command.rb
+++ b/railties/lib/rails/commands/notes/notes_command.rb
@@ -5,7 +5,7 @@ require "rails/source_annotation_extractor"
 module Rails
   module Command
     class NotesCommand < Base # :nodoc:
-      class_option :annotations, aliases: "-a", desc: "Filter by specific annotations, e.g. Foobar TODO", type: :array, default: Rails::SourceAnnotationExtractor::Annotation.tags
+      class_option :annotations, aliases: "-a", desc: "Filter by specific annotations, e.g. Foobar TODO", type: :array
 
       def perform(*)
         require_application_and_environment!
@@ -15,7 +15,7 @@ module Rails
 
       private
         def display_annotations
-          annotations = options[:annotations]
+          annotations = options[:annotations] || Rails::SourceAnnotationExtractor::Annotation.tags
           tag = (annotations.length > 1)
 
           Rails::SourceAnnotationExtractor.enumerate annotations.join("|"), tag: tag, dirs: directories


### PR DESCRIPTION
`Rails::SourceAnnotationExtractor::Annotation.tags` may be modified by app configuration.  Therefore, resolve default annotation tags after loading the app configuration.

This fixes errors like https://buildkite.com/rails/rails/builds/74268#240d60bc-baa7-4b6e-ad21-b3172095f939/1083-1092 resulting from erikhuda/thor@0222fe52ed3803fe3ee0033da5b6faac5ee6299c.
