### PR TITLE
Update name of input in tip to match example [ci skip]

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -73,7 +73,7 @@ This will generate the following HTML:
 
 TIP: Passing `url: my_specified_path` to `form_with` tells the form where to make the request. However, as explained below, you can also pass ActiveRecord objects to the form.
 
-TIP: For every form input, an ID attribute is generated from its name (`"q"` in above example). These IDs can be very useful for CSS styling or manipulation of form controls with JavaScript.
+TIP: For every form input, an ID attribute is generated from its name (`"query"` in above example). These IDs can be very useful for CSS styling or manipulation of form controls with JavaScript.
 
 IMPORTANT: Use "GET" as the method for search forms. This allows users to bookmark a specific search and get back to it. More generally Rails encourages you to use the right HTTP verb for an action.
 


### PR DESCRIPTION
### Summary

PR https://github.com/rails/rails/commit/612eb35a5a98cb1424678304781ab1ae4ea7f7dc#diff-408c6c60781172cff60891421b3b2b162b3de4b0ce4ae591d0da242f39a93325L58 updated the example input from `q` to `query`, and a usage in a tip was missed. I didn't see further usages of the old `q` name.