### PR TITLE
Warn when `:lower` is passed as a second arg of `ActiveSupport::Inflector.camelize`

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -67,6 +67,10 @@ module ActiveSupport
     #
     #   camelize(underscore('SSLError'))        # => "SslError"
     def camelize(term, uppercase_first_letter = true)
+      if uppercase_first_letter == :lower
+        warn ":lower is passed but returning upper camel case. To get lower camel case, pass false to the second argument."
+      end
+
       string = term.to_s
       if uppercase_first_letter
         string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize }

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -144,6 +144,13 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", false))
   end
 
+  def test_camelize_with_lower_downcases_the_first_letter_with_lower_argument
+    assert_output(nil, ":lower is passed but returning upper camel case. To get lower camel case, pass false to the second argument.\n") do
+      ActiveSupport::Inflector.camelize("Capital", :lower)
+    end
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", :lower))
+  end
+
   def test_camelize_with_underscores
     assert_equal("CamelCase", ActiveSupport::Inflector.camelize("Camel_Case"))
   end


### PR DESCRIPTION
### Summary

`ActiveSupport::Inflector.camelize` takes its second argument differently than `String#camelize` does.
Some might pass `:lower` as a second argument to AS::Inflector.camelize with the expectation to get lowerCamelCase.
However, it returns UpperCamelCase, which might be surprising.
This behaviour cannot be changed without breaking backward compatibility, but should be warn.

### Other Information

I'm not a native speaker of English and the warning message can be improved.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
