### PR TITLE
Allow jobs to rescue all exceptions

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,4 +1,6 @@
+*   Allow `rescue_from` to rescue all exceptions.
 
+    *Adrianna Chang*, *Étienne Barrié*
 
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -47,7 +47,7 @@ module ActiveJob
       run_callbacks :perform do
         perform(*arguments)
       end
-    rescue => exception
+    rescue Exception => exception
       rescue_with_handler(exception) || raise
     end
 

--- a/activejob/test/cases/rescue_test.rb
+++ b/activejob/test/cases/rescue_test.rb
@@ -33,4 +33,9 @@ class RescueTest < ActiveSupport::TestCase
     RescueJob.perform_later [Person.new(404)]
     assert_includes JobBuffer.values, "DeserializationError original exception was Person::RecordNotFound"
   end
+
+  test "rescue from exceptions that don't inherit from StandardError" do
+    RescueJob.perform_later("rafael")
+    assert_equal ["rescued from NotImplementedError"], JobBuffer.values
+  end
 end

--- a/activejob/test/jobs/rescue_job.rb
+++ b/activejob/test/jobs/rescue_job.rb
@@ -18,12 +18,18 @@ class RescueJob < ActiveJob::Base
     JobBuffer.add("DeserializationError original exception was #{e.cause.class.name}")
   end
 
+  rescue_from(NotImplementedError) do
+    JobBuffer.add("rescued from NotImplementedError")
+  end
+
   def perform(person = "david")
     case person
     when "david"
       raise ArgumentError, "Hair too good"
     when "other"
       raise OtherError, "Bad hair"
+    when "rafael"
+      raise NotImplementedError, "Hair is just perfect"
     else
       JobBuffer.add("performed beautifully")
     end


### PR DESCRIPTION
Before this commit, only `StandardError` exceptions can be handled by `rescue_from` handlers.

This changes the rescue clause to catch all `Exception` objects, allowing rescue handlers to be defined for `Exception` classes not inheriting from `StandardError`.

This means that rescue handlers that are rescuing `Exception`s outside of `StandardError` exceptions may rescue exceptions that were not being rescued before this change.

### Other Information

When this was introduced in ef4aff07a41f1249baade695e68c75a8db3ded58, ActionController was already rescuing all Exception objects, so maybe this was intentional, but there's no specific test about it.

There is some incompatibility in the sense that if an app is using `rescue_from(Exception)`, previously it would not have caught some exceptions, and now it will. But it was probably the expected behavior they wanted. We're not sure how we would go about making it fully backwards compatible anyway.

cc @rafaelfranca @byroot 