### PR TITLE
[ci-skip] Adding options example in ActiveModel::Errors doc

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -378,6 +378,14 @@ module ActiveModel
     # If +type+ is a symbol, it will be translated using the appropriate
     # scope (see +generate_message+).
     #
+    #   person.errors.add(:name, :blank)
+    #   person.errors.messages
+    #   # => {:name=>["can't be blank"]}
+    #
+    #   person.errors.add(:name, :too_long, { count: 25 })
+    #   person.errors.messages
+    #   # => ["is too long (maximum is 25 characters)"]
+    #
     # If +type+ is a proc, it will be called, allowing for things like
     # <tt>Time.now</tt> to be used within an error.
     #


### PR DESCRIPTION
👋 

This diff closes #41124

As stated in the issue, a quick example of how options can be used to be part of the generated message was missing, but appearing in another method doc (`added?`)

I didn't move the piece in `added?` because it seems to be well-belonging there, but copied the example in `add`

