### PR TITLE
Fixes strict_loading! documentation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -9,7 +9,7 @@
     #or
     ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = '--no-defaults --skip-add-drop-table'
     ```
-     
+
     And also use it passing a hash, with one or more keys, where the key
     is the adapter
 
@@ -17,7 +17,7 @@
     ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = {
       mysql2: ['--no-defaults', '--skip-add-drop-table'],
       postgres: '--no-tablespaces'
-    }    
+    }
     ```
 
     *Gustavo Gonzalez*
@@ -38,17 +38,20 @@
 
     ```ruby
     class User < ApplicationRecord
+      has_many :bookmarks
       has_many :articles, strict_loading: true
     end
 
     user = User.first
-    user.articles
-    # => ActiveRecord::StrictLoadingViolationError
+    user.articles                        # => ActiveRecord::StrictLoadingViolationError
+    user.bookmarks                       # => #<ActiveRecord::Associations::CollectionProxy>
 
-    user = User.first
-    user.stict_loading!(false)
-    user.articles
-    # => #<ActiveRecord::Associations::CollectionProxy>
+    user.strict_loading!(true)           # => true
+    user.bookmarks                       # => ActiveRecord::StrictLoadingViolationError
+
+    user.strict_loading!(false)          # => false
+    user.bookmarks                       # => #<ActiveRecord::Associations::CollectionProxy>
+    user.articles.strict_loading!(false) # => #<ActiveRecord::Associations::CollectionProxy>
     ```
 
     *Ayrton De Craene*

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -663,9 +663,17 @@ module ActiveRecord
     # if the record tries to lazily load an association.
     #
     #   user = User.first
-    #   user.strict_loading!
-    #   user.comments.to_a
+    #   user.strict_loading! # => true
+    #   user.comments
     #   => ActiveRecord::StrictLoadingViolationError
+    #
+    # strict_loading! accepts a boolean argument to specify whether
+    # to enable or disable strict loading mode.
+    #
+    #   user = User.first
+    #   user.strict_loading!(false) # => false
+    #   user.comments
+    #   => #<ActiveRecord::Associations::CollectionProxy>
     def strict_loading!(value = true)
       @strict_loading = value
     end


### PR DESCRIPTION
Some documentation fixes for PR: #41181

- Fixes typo in the changelog for strict_loading.
- Fixes the example in the changelog for strict_loading. The `strict_loading!` on ActiveRecord object does not disable strict loading on the association if set to strict loading. The example spoke otherwise so updated in a manner to make it more clear.
- Add method level documentation as changelog was only way to communicate how strict_loading could be disabled on the record.
