### PR TITLE
Fix doc: stylesheet_include_tag -> stylesheet_link_tag

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -362,13 +362,13 @@ For example, the following escaped ERB tag would be needed in the template
 (note the extra `%`)...
 
 ```erb
-<%%= stylesheet_include_tag :application %>
+<%%= stylesheet_link_tag :application %>
 ```
 
 ...to generate the following output:
 
 ```erb
-<%= stylesheet_include_tag :application %>
+<%= stylesheet_link_tag :application %>
 ```
 
 Adding Generators Fallbacks


### PR DESCRIPTION
### Summary 

There's a reference to a non-existent method called 'stylesheet_include_tag' on the guide. This PR fixes it :)

Following the generators guide step-by-step would return the following error:

```
undefined method `stylesheet_include_tag' for #<ActionView::Base:0x007fd5bc9c52e0>
Did you mean?  stylesheet_link_tag
               stylesheet_pack_tag
```