### PR TITLE
Add back ActiveStorage::Blob#find_signed

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -74,6 +74,14 @@ class ActiveStorage::Blob < ActiveStorage::Record
     # that was created ahead of the upload itself on form submission.
     #
     # The signed ID is also used to create stable URLs for the blob through the BlobsController.
+    def find_signed(id, record: nil, purpose: :blob_id)
+      super(id, purpose: purpose)
+    end
+
+    # Works like +find_signed+, but will raise an +ActiveSupport::MessageVerifier::InvalidSignature+
+    # exception if the +signed_id+ has either expired, has a purpose mismatch, is for another record,
+    # or has been tampered with. It will also raise an +ActiveRecord::RecordNotFound+ exception if
+    # the valid signed id can't find a record.
     def find_signed!(id, record: nil, purpose: :blob_id)
       super(id, purpose: purpose)
     end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -89,6 +89,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
 
     signed_id = @user.avatar.signed_id
     assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id)
+    assert_equal blob, ActiveStorage::Blob.find_signed(signed_id)
   end
 
   test "getting a signed blob ID from an attachment with a custom purpose" do


### PR DESCRIPTION
Closes https://github.com/rails/rails/issues/41204

Rails 6.0 had a [public `find_signed` method][docs], but we changed it
to `find_signed!` in https://github.com/rails/rails/commit/31148cd6bef4f3a3059c51c587a8bff78a2e73e3.

This commit adds back `find_signed` alongside `find_signed!` so that both pass along the default purpose to the corresponding [Active Record methods][].

[docs]: https://api.rubyonrails.org/v6.0.0/classes/ActiveStorage/Blob.html#method-c-find_signed
[Active Record methods]: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/signed_id.rb#L42-L66