### PR TITLE
Handle throwing in controller action in log subscriber

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+*   Fix error in `ActionController::LogSubscriber` that would happen when throwing inside a controller action.
+
+    *Janko Marohnić*
+
 *   Change the request method to a `GET` when passing failed requests down to `config.exceptions_app`.
 
     *Alex Robbin*

--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -23,7 +23,7 @@ module ActionController
         additions = ActionController::Base.log_process_action(payload)
         status = payload[:status]
 
-        if status.nil? && (exception_class_name = payload[:exception].first)
+        if status.nil? && (exception_class_name = payload[:exception]&.first)
           status = ActionDispatch::ExceptionWrapper.status_code_for_exception(exception_class_name)
         end
 

--- a/actionpack/test/controller/log_subscriber_test.rb
+++ b/actionpack/test/controller/log_subscriber_test.rb
@@ -64,6 +64,10 @@ module Another
       render inline: "<%= cache_unless(true, 'foo') { 'bar' } %>"
     end
 
+    def with_throw
+      throw :halt
+    end
+
     def with_exception
       raise Exception
     end
@@ -188,6 +192,14 @@ class ACLogSubscriberTest < ActionController::TestCase
     get :show
     wait
     assert_match(/Completed 200 OK in \d+ms/, logs[1])
+  end
+
+  def test_process_action_with_throw
+    catch(:halt) do
+      get :with_throw
+      wait
+    end
+    assert_match(/Completed   in \d+ms/, logs[1])
   end
 
   def test_append_info_to_payload_is_called_even_with_exception


### PR DESCRIPTION
### Summary

When throw was used in a controller action, and there is matching catch around the request in a Rack middleware, then `:exception` won't be present in the event payload.

This is because `ActiveSupport::Notifications::Instrumenter.instrument` sets `:exception` in a rescue handler, but rescue is never called in a throw/catch scenario:

```rb
catch(:halt) do
  begin
    throw :halt
  rescue Exception => e
    puts "rescue" # never reached
  ensure
    puts "ensure"
  end
end
```

Missing `:exception` was actually handled prior to Rails 6.1.0, but an [optimization](https://github.com/rails/rails/commit/f0fdeaa175ccb1230b9027d25d7d4cfe62d04e46) updated the code to assume `:exception` was present. I found it easiest to just revert the commit. This PR can therefore be considered a regression fix.

### Other Information

I've experienced this issue when using Rodauth with Rails, which throws `:halt` when redirecting (with Rodauth middleware catching `:halt`), and there are use cases in which Rodauth's redirect method is called inside a controller action.
