### PR TITLE
Fix code block in Webpacker Guide [ci skip]

### DIFF
--- a/guides/source/webpacker.md
+++ b/guides/source/webpacker.md
@@ -105,6 +105,7 @@ require("channels")
 You'll need to include a pack that requires these packages to use them in your Rails application.
 
 It is important to note that only webpack entry files should be placed in the `app/javascript/packs` directory; webpack will create a separate dependency graph for each entry point so a large number of packs will increase compilation overhead. The rest of your asset source code should live outside this directory though Webpacker does not place any restrictions or make any suggestions on how to structure your source code. Here is an example:
+
 ```sh
 app/javascript:
   ├── packs:


### PR DESCRIPTION
Formatting fix: the example directory tree listing was bleeding into the
previous paragraph and had extraneous characters due to a missing
newline.

### Summary

Fix formatting problem in https://edgeguides.rubyonrails.org/webpacker.html#using-webpacker-for-javascript. The preformatted block immediately after _"...or make any suggestions on how to structure your source code. Here is an example:"_ is not displaying as a preformatted block.

### Other Information

This fix is separate from the fixes in #41165.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
