### PR TITLE
Fix Flaky ActiveStorage test

### DIFF
--- a/activestorage/lib/active_storage/fixture_set.rb
+++ b/activestorage/lib/active_storage/fixture_set.rb
@@ -52,7 +52,12 @@ module ActiveStorage
     #   # tests/fixtures/action_text/blobs.yml
     #   second_thumbnail_blob: <%= ActiveStorage::FixtureSet.blob(
     #     filename: "second.svg",
+    #   ) %>
+    #
+    #   third_thumbnail_blob: <%= ActiveStorage::FixtureSet.blob(
+    #     filename: "third.svg",
     #     content_type: "image/svg+xml",
+    #     service_name: "public"
     #   ) %>
     #
     def self.blob(filename:, **attributes)

--- a/activestorage/test/fixture_set_test.rb
+++ b/activestorage/test/fixture_set_test.rb
@@ -4,9 +4,6 @@ require "test_helper"
 require "database/setup"
 
 class ActiveStorage::FixtureSetTest < ActiveSupport::TestCase
-  self.fixture_path = File.expand_path("fixtures", __dir__)
-  self.use_transactional_tests = true
-
   fixtures :all
 
   def test_active_storage_blob

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -104,7 +104,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     blob = create_blob
     @user.avatar.attach(blob)
 
-    signed_id_generated_old_way = ActiveStorage.verifier.generate(@user.avatar.id, purpose: :blob_id)
+    signed_id_generated_old_way = ActiveStorage.verifier.generate(@user.avatar.blob.id, purpose: :blob_id)
     assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id_generated_old_way)
   end
 

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -50,6 +50,8 @@ class ActiveSupport::TestCase
 
   include ActiveRecord::TestFixtures
 
+  self.fixture_path = File.expand_path("fixtures", __dir__)
+
   setup do
     ActiveStorage::Current.host = "https://example.com"
   end


### PR DESCRIPTION
Fixes a flaky Active Storage test introduced by [rails/rails#41065][],
and improves the documentation.

It seems that the test is covering the backwards compatibility of an
older interface for retrieving records through
`ActiveStorage::Record#find_signed!`. The test itself would pass
unpredictably. To isolate the failure and reproduce it consistently, a
see value was found after some trial and error:

```
SEED=59729 bin/test test/fixture_set_test.rb test/models/attachment_test.rb
```

This _used_ to pass consistently because [rails/rails#41065][]
introduced a call to `fixtures :all`, which introduces more variation in
the database's ID generation sequence. Without that line, `id` values
start at `1`, so the fact that calls to
`ActiveStorage::Attached::One#id` and `ActiveStorage::Blob#id` **both
return `1`** is purely coincidence.

The proposed resolution changes the test slightly. Prior to this change,
the identifier used during retrieval and verification fetched from
`@user.avatar.id`, where `@user.avatar` is an instance of
`ActiveStorage::Attached::One`. The verifier/retriever combination in
that test expected a signed identifier for an `ActiveStorage::Blob`
instance. The change involved retrieving an instance through
`@user.avatar.blob`.

To better emphasize how global the `fixtures :all` declaration is, move
it from the `test/fixture_set_test.rb` file to the `test/test_helper.rb`
file.

[rails/rails#41065]: https://github.com/rails/rails/pull/41065