### PR TITLE
Move ActiveStorage fixture hooks to on_load

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -782,3 +782,5 @@ module ActiveRecord
     end
   end
 end
+
+ActiveSupport.run_load_hooks :active_record_fixture_set, ActiveRecord::FixtureSet

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -388,10 +388,6 @@ db_namespace = namespace :db do
         Dir["#{fixtures_dir}/**/*.yml"].map { |f| f[(fixtures_dir.size + 1)..-5] }
       end
 
-      if defined? ActiveStorage::FixtureSet
-        ActiveStorage::FixtureSet.file_fixture_path = File.join fixtures_dir, "files"
-      end
-
       ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
     end
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -143,5 +143,19 @@ module ActiveStorage
         ActiveRecord::Reflection.singleton_class.prepend(Reflection::ReflectionExtension)
       end
     end
+
+    initializer "active_storage.fixture_set" do
+      ActiveSupport.on_load(:active_record_fixture_set) do
+        ActiveStorage::FixtureSet.file_fixture_path ||= Rails.root.join(*[
+          ENV.fetch("FIXTURES_PATH") { File.join("test", "fixtures") },
+          ENV["FIXTURES_DIR"],
+          "files"
+        ].compact_blank)
+      end
+
+      ActiveSupport.on_load(:active_support_test_case) do
+        ActiveStorage::FixtureSet.file_fixture_path = ActiveSupport::TestCase.file_fixture_path
+      end
+    end
   end
 end

--- a/railties/lib/rails/test_help.rb
+++ b/railties/lib/rails/test_help.rb
@@ -31,10 +31,6 @@ if defined?(ActiveRecord::Base)
   ActiveSupport.on_load(:action_dispatch_integration_test) do
     self.fixture_path = ActiveSupport::TestCase.fixture_path
   end
-
-  ActiveSupport.on_load(:active_storage_record) do
-    ActiveStorage::FixtureSet.file_fixture_path = ActiveSupport::TestCase.file_fixture_path
-  end
 end
 
 # :enddoc:


### PR DESCRIPTION
In a test environment, rely on the loading of
`:active_support_test_case`.

Introduce the `:active_record_fixture_set` hook for the Active Storage
engine to listen for during the load process in a development
environment (like when running `db:fixtures:load`).

Since this commit moves the task-aware path resolution out of the block
that provided local variables, it recreates part of the fixture
directory path resolution logic.