### PR TITLE
Remove reference to globalize gem from I18n guide

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1189,7 +1189,6 @@ The I18n API described in this guide is primarily intended for translating inter
 
 Several gems can help with this:
 
-* [Globalize](https://github.com/globalize/globalize): Store translations on separate translation tables, one for each translated model
 * [Mobility](https://github.com/shioyama/mobility): Provides support for storing translations in many formats, including translation tables, json columns (PostgreSQL), etc.
 * [Traco](https://github.com/barsoom/traco): Translatable columns stored in the model table itself
 


### PR DESCRIPTION
The globalize I18n gem is not actively maintained anymore and
their official documentation now points new users to
[use the mobility gem](https://github.com/globalize/globalize#current-state-of-the-gem) instead.

This PR removes the reference to the gem from the I18n guide.