### PR TITLE
Improve ActiveRecord strict_loading documentation

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1439,7 +1439,8 @@ module ActiveRecord
         #   Useful for defining methods on associations, especially when they should be shared between multiple
         #   association objects.
         # [:strict_loading]
-        #   Enforces strict loading every time the associated record is loaded through this association.
+        #   When set to +true+, enforces strict loading every time the associated record is loaded through this
+        #   association.
         # [:ensuring_owner_was]
         #   Specifies an instance method to be called on the owner. The method must return true in order for the
         #   associated records to be deleted in a background job.


### PR DESCRIPTION
### Summary

Apply the same structure as the documentation of `validate` option by starting the description of the option `strict_loading` with "When set to `true`". 

This implies, that the value passed to the option should be a boolean. Otherwise, it's not that clear which value we could pass.