### PR TITLE
Show a warning when running no migration using SCOPE

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -276,6 +276,8 @@ module ActiveRecord
 
         Base.connection.migration_context.migrate(target_version) do |migration|
           scope.blank? || scope == migration.scope
+        end.tap do |migrations_ran|
+          Migration.write("No migrations ran. (using #{scope} scope)") if scope.present? && migrations_ran.empty?
         end
 
         ActiveRecord::Base.clear_cache!

--- a/activerecord/test/migrations/scope/1_unscoped.rb
+++ b/activerecord/test/migrations/scope/1_unscoped.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Unscoped < ActiveRecord::Migration::Current
+  def self.change
+    create_table "unscoped"
+  end
+end

--- a/activerecord/test/migrations/scope/2_mysql_only.mysql.rb
+++ b/activerecord/test/migrations/scope/2_mysql_only.mysql.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MysqlOnly < ActiveRecord::Migration::Current
+  def self.change
+    create_table "mysql_only"
+  end
+end


### PR DESCRIPTION
### Summary

When running a migration with `ENV["SCOPE"]` set returns a warning if no migrations ran.
The message serves as a hint for the end-user to make sure he knows that the migration have been filtered by `SCOPE`.

Closes #41100

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
