### PR TITLE
Fixing delegated types example.

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -66,7 +66,7 @@ module ActiveRecord
   # resides in the +Entry+ "superclass". But the +Entry+ absolutely can stand alone in terms of querying capacity
   # in particular. You can now easily do things like:
   #
-  #   Account.entries.order(created_at: :desc).limit(50)
+  #   Account.find(1).entries.order(created_at: :desc).limit(50)
   #
   # Which is exactly what you want when displaying both comments and messages together. The entry itself can
   # be rendered as its delegated type easily, like so:


### PR DESCRIPTION
### Summary

I was reading [the documentation for Delegated Types](https://edgeapi.rubyonrails.org/classes/ActiveRecord/DelegatedType.html) and stumbled on an example I couldn't make sense of:

```
Account.entries.order(created_at: :desc).limit(50)
```

I _think_ the intention was to provide an example like this (which I've included in this PR):

```
Account.find(1).entries.order(created_at: :desc).limit(50)
```

Alternatively the example could be:

```
account.entries.order(created_at: :desc).limit(50)
```

But I think it would be less clear to readers what `account` is.

Sorry in advance if I misunderstood the original example!
