### PR TITLE
Update test names to match their behaviour

### DIFF
--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -488,7 +488,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal new_account.firm_name, "Account"
   end
 
-  def test_creation_failure_without_dependent_option
+  def test_create_association_replaces_existing_without_dependent_option
     pirate = pirates(:blackbeard)
     orig_ship = pirate.ship
 
@@ -501,7 +501,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_not orig_ship.changed? # check it was saved
   end
 
-  def test_creation_failure_with_dependent_option
+  def test_create_association_replaces_existing_with_dependent_option
     pirate = pirates(:blackbeard).becomes(DestructivePirate)
     orig_ship = pirate.dependent_ship
 


### PR DESCRIPTION
These tests were named `…creation_failure…` but there's no creation
failing in the tests themselves. Instead creation is succeeding, via
the `create_association` method which is added by the `has_one` relation.

I found these test names very confusing when reading this issue:
https://github.com/rails/rails/issues/13197
And the commit it links to: c6e10b0

The least we can do to make that issue less confusing is to start by
fixing these test names.
[ci skip]

