### PR TITLE
Fix deprecation message s/Rails 6.1 will return/Rails 7.0 will return/

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -36,11 +36,11 @@ module ActionDispatch
       def content_type
         if self.class.return_only_media_type_on_content_type
           ActiveSupport::Deprecation.warn(
-            "Rails 6.1 will return Content-Type header without modification." \
+            "Rails 7.0 will return Content-Type header without modification." \
             " If you want just the MIME type, please use `#media_type` instead."
           )
 
-          content_mime_type && content_mime_type.to_s
+          content_mime_type&.to_s
         else
           super
         end


### PR DESCRIPTION
`return_only_media_type_on_content_type` will be introduced in Rails 6.2
so the changing of returning Content-Type will happen in a future
version of Rails (probably 7.0).

cc @rafaelfranca 