### PR TITLE
Fixed start_with? crash in schema_statements

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -165,7 +165,7 @@ module ActiveRecord
             if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(default)
               default, default_function = nil, default
             elsif type_metadata.extra == "DEFAULT_GENERATED"
-              default = +"(#{default})" unless default.start_with?("(")
+              default = +"(#{default})" unless default&.start_with?("(")
               default, default_function = nil, default
             end
 


### PR DESCRIPTION
### Summary

When using UUID with MySQL as varchar with default to UUID(), I am getting "undefined method `start_with?' for nil:NilClass" on this line:
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb#L168

The issue only happened on Heroku and not locally.

This fixes that issue.