### PR TITLE
Fix create migration generator with `--pretend` option

### DIFF
--- a/railties/lib/rails/generators/actions/create_migration.rb
+++ b/railties/lib/rails/generators/actions/create_migration.rb
@@ -20,6 +20,8 @@ module Rails
         end
 
         def invoke!
+          return super if pretend?
+
           invoked_file = super
           File.exist?(@destination) ? invoked_file : relative_existing_migration
         end

--- a/railties/test/generators/create_migration_test.rb
+++ b/railties/test/generators/create_migration_test.rb
@@ -55,6 +55,8 @@ class CreateMigrationTest < Rails::Generators::TestCase
   def test_invoke_pretended
     create_migration(default_destination_path, {}, { pretend: true })
 
+    stdout = invoke!
+    assert_match(/create  db\/migrate\/1_create_articles\.rb\n/, stdout)
     assert_no_file @migration.destination
   end
 


### PR DESCRIPTION
### Summary

There will be errors when generate new migrations with `--pretend` option, for example:
```sh
$ bin/rails generate migration a_new_migration --pretend
```
will cause:

> /thor-1.0.1/lib/thor/actions.rb:116:in `relative_to_original_destination_root': undefined method `start_with?' for false:FalseClass (NoMethodError)
from /railties-6.1.1/lib/rails/generators/actions/create_migration.rb:37:in `relative_existing_migration'
from /railties-6.1.1/lib/rails/generators/actions/create_migration.rb:25:in `invoke!'

That's becasue `relative_existing_migration` return `false` when generate new migrations,  which been introduced by [#38870](https://github.com/rails/rails/pull/38870/files#diff-c17a56e2f43ac50506d0f200a27a228fca4f62f015a42315d79239cdd038bd25)

This PR fixed that, and add additional test to prevent future regret.

@y-yagi @kaspth