### PR TITLE
Revert qc changes

### DIFF
--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -26,26 +26,30 @@ module ActiveRecord
     end
 
     def self.run
+      pools = []
+
       if ActiveRecord::Base.legacy_connection_handling
-        ActiveRecord::Base.connection_handlers.each_value do |handler|
-          handler.connection_pool_list.each(&:enable_query_cache!)
+        ActiveRecord::Base.connection_handlers.each do |key, handler|
+          pools.concat(handler.connection_pool_list.each { |p| p.enable_query_cache! })
         end
       else
-        ActiveRecord::Base.connection_handler.all_connection_pools.each(&:enable_query_cache!)
+        pools.concat(ActiveRecord::Base.connection_handler.all_connection_pools.each { |p| p.enable_query_cache! })
       end
+
+      pools
     end
 
-    def self.complete(_)
+    def self.complete(pools)
+      pools.each { |pool| pool.disable_query_cache! }
+
       if ActiveRecord::Base.legacy_connection_handling
-        ActiveRecord::Base.connection_handlers.each_value do |handler|
+        ActiveRecord::Base.connection_handlers.each do |_, handler|
           handler.connection_pool_list.each do |pool|
-            pool.disable_query_cache!
             pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
           end
         end
       else
         ActiveRecord::Base.connection_handler.all_connection_pools.each do |pool|
-          pool.disable_query_cache!
           pool.release_connection if pool.active_connection? && !pool.connection.transaction_open?
         end
       end

--- a/activerecord/lib/active_record/query_cache.rb
+++ b/activerecord/lib/active_record/query_cache.rb
@@ -30,10 +30,10 @@ module ActiveRecord
 
       if ActiveRecord::Base.legacy_connection_handling
         ActiveRecord::Base.connection_handlers.each do |key, handler|
-          pools.concat(handler.connection_pool_list.each { |p| p.enable_query_cache! })
+          pools.concat(handler.connection_pool_list.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
         end
       else
-        pools.concat(ActiveRecord::Base.connection_handler.all_connection_pools.each { |p| p.enable_query_cache! })
+        pools.concat(ActiveRecord::Base.connection_handler.all_connection_pools.reject { |p| p.query_cache_enabled }.each { |p| p.enable_query_cache! })
       end
 
       pools


### PR DESCRIPTION
Reverts #41046 and #41192.

The change @jhawthorn and I made in #41046 caused the query cache to stop working on (some? most?) requests in our API. We haven't quite figured out why this affect just our API, we saw no regression in the frontend requests. One important note is our API is Sinatra inside Rails. However we do install the Executor in the API and previously it was working fine. The performance hit in some endpoints was really obvious (ones that queried more data or had a high number of the same records to load ie Author), but in others not clear at all.

@jhawthorn noticed that the reject is important because it will return a different set of pools and then those pools get disabled when complete is called. But we still don't know why this wouldn't have been an issue everywhere.

cc/ @rafaelfranca and @tenderlove for Shopify
cc/ @kamipo for revert of #41192