### PR TITLE
Provide a working example for a filter_parameters lambda

### DIFF
--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -468,7 +468,7 @@ module ApplicationTests
     test "filter_parameters should be able to set via config.filter_parameters" do
       add_to_config <<-RUBY
         config.filter_parameters += [ :foo, 'bar', lambda { |key, value|
-          value = value.reverse if /baz/.match?(key)
+          value.reverse! if /baz/.match?(key)
         }]
       RUBY
 


### PR DESCRIPTION
The one provided wouldn't actually change the value in the logs.
Based on https://github.com/rails/rails/blob/48ca9e2557d18a01fb3f6002645363f8dea28019/actionpack/lib/action_dispatch/http/filter_parameters.rb#L26
