### PR TITLE
Only compare media type of content types in ActiveStorage::DiskController#update

### DIFF
--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -49,6 +49,6 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     end
 
     def acceptable_content?(token)
-      token[:content_type] == request.content_mime_type && token[:content_length] == request.content_length
+      token[:content_type] == request.content_type && token[:content_length] == request.content_length
     end
 end

--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -49,6 +49,7 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     end
 
     def acceptable_content?(token)
-      token[:content_type] == request.content_type && token[:content_length] == request.content_length
+      media_type = token[:content_type][/^([^,;]*)/]
+      media_type == request.content_mime_type && token[:content_length] == request.content_length
     end
 end

--- a/activestorage/test/controllers/disk_controller_test.rb
+++ b/activestorage/test/controllers/disk_controller_test.rb
@@ -102,6 +102,16 @@ class ActiveStorage::DiskControllerTest < ActionDispatch::IntegrationTest
     assert_equal data, blob.download
   end
 
+  test "directly uploading blob with provided content type including encoding" do
+    data = "Something else entirely!"
+    blob = create_blob_before_direct_upload(
+      byte_size: data.size, checksum: Digest::MD5.base64digest(data), content_type: "text/plain; charset=UTF-8")
+
+    put blob.service_url_for_direct_upload, params: data, headers: { "Content-Type" => "text/plain; charset=UTF-8" }
+    assert_response :no_content
+    assert_equal data, blob.download
+  end
+
   test "directly uploading blob with mismatched content length" do
     data = "Something else entirely!"
     blob = create_blob_before_direct_upload byte_size: data.size - 1, checksum: Digest::MD5.base64digest(data)


### PR DESCRIPTION
### Summary

Fixes a bug where you are trying to upload a file which has a Content Type that includes a charset (eg. `text/html; charset=UTF-8`).
Previously that would trigger a `422 Unprocessable Entity` error in `ActiveStorage::DiskController#update`.

### Other Information

`content_mime_type` currently strips all parameters from the Content Type which caused the comparison to fail.

https://github.com/rails/rails/blob/840551307139324300b943901d84cbacba11862d/actionpack/lib/action_dispatch/http/mime_negotiation.rb#L23-L34
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
