### PR TITLE
Use string in the example[ci skip]

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -68,8 +68,8 @@ module ActiveSupport
   # return the original value. But messages can be set to expire at a given
   # time with +:expires_in+ or +:expires_at+.
   #
-  #   @verifier.generate(parcel, expires_in: 1.month)
-  #   @verifier.generate(doowad, expires_at: Time.now.end_of_year)
+  #   @verifier.generate("parcel", expires_in: 1.month)
+  #   @verifier.generate("doowad", expires_at: Time.now.end_of_year)
   #
   # Then the messages can be verified and returned up to the expire time.
   # Thereafter, the +verified+ method returns +nil+ while +verify+ raises


### PR DESCRIPTION
In the docs [here](https://apidock.com/rails/v6.0.0/ActiveSupport/MessageVerifier) under the `Making messages expire` section, it was a little unclear what is `doowad` & `parcel` which ideally be a +string+ or a variable but in the complete documentation, we haven't used the reference of any variables except +token+, so these 2 should be a string.
