### PR TITLE
Raise `ActiveStorage::PreviewCaptureError` when a `Previewer` is unable to capture a preview

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Raise `ActiveStorage::PreviewCaptureError` when a `Previewer` is unable to capture a preview.
+
+    *Alex Robbin*
+
 *   Add ability to use pre-defined variants.
 
     ```ruby

--- a/activestorage/lib/active_storage/errors.rb
+++ b/activestorage/lib/active_storage/errors.rb
@@ -23,4 +23,11 @@ module ActiveStorage
   # Raised when ActiveStorage::Blob#download is called on a blob where the
   # backing file is no longer present in its service.
   class FileNotFoundError < Error; end
+
+  # Raised when ActiveStorage::Previewer#capture is unable to generate a preview image.
+  class PreviewCaptureError < Error
+    def initialize(args, exit_code)
+      super "Failed to generate preview with args: #{args.inspect}. Exited with code: #{exit_code}"
+    end
+  end
 end

--- a/activestorage/lib/active_storage/previewer.rb
+++ b/activestorage/lib/active_storage/previewer.rb
@@ -71,6 +71,9 @@ module ActiveStorage
       def capture(*argv, to:)
         to.binmode
         IO.popen(argv, err: File::NULL) { |out| IO.copy_stream(out, to) }
+
+        raise ActiveStorage::PreviewCaptureError.new(argv, $?.exitstatus) unless $?.success?
+
         to.rewind
       end
 

--- a/activestorage/test/previewer/mupdf_previewer_test.rb
+++ b/activestorage/test/previewer/mupdf_previewer_test.rb
@@ -31,4 +31,12 @@ class ActiveStorage::Previewer::MuPDFPreviewerTest < ActiveSupport::TestCase
       assert_equal 145, image.height
     end
   end
+
+  test "previewing a PDF that can't be previewed" do
+    blob = create_file_blob(filename: "video.mp4", content_type: "application/pdf")
+
+    assert_raises ActiveStorage::PreviewCaptureError do
+      ActiveStorage::Previewer::MuPDFPreviewer.new(blob).preview
+    end
+  end
 end

--- a/activestorage/test/previewer/poppler_pdf_previewer_test.rb
+++ b/activestorage/test/previewer/poppler_pdf_previewer_test.rb
@@ -31,4 +31,12 @@ class ActiveStorage::Previewer::PopplerPDFPreviewerTest < ActiveSupport::TestCas
       assert_equal 145, image.height
     end
   end
+
+  test "previewing a PDF that can't be previewed" do
+    blob = create_file_blob(filename: "video.mp4", content_type: "application/pdf")
+
+    assert_raises ActiveStorage::PreviewCaptureError do
+      ActiveStorage::Previewer::PopplerPDFPreviewer.new(blob).preview
+    end
+  end
 end

--- a/activestorage/test/previewer/video_previewer_test.rb
+++ b/activestorage/test/previewer/video_previewer_test.rb
@@ -6,12 +6,10 @@ require "database/setup"
 require "active_storage/previewer/video_previewer"
 
 class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
-  setup do
-    @blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
-  end
-
   test "previewing an MP4 video" do
-    ActiveStorage::Previewer::VideoPreviewer.new(@blob).preview do |attachable|
+    blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
+
+    ActiveStorage::Previewer::VideoPreviewer.new(blob).preview do |attachable|
       assert_equal "image/jpeg", attachable[:content_type]
       assert_equal "video.jpg", attachable[:filename]
 
@@ -19,6 +17,14 @@ class ActiveStorage::Previewer::VideoPreviewerTest < ActiveSupport::TestCase
       assert_equal 640, image.width
       assert_equal 480, image.height
       assert_equal "image/jpeg", image.mime_type
+    end
+  end
+
+  test "previewing a video that can't be previewed" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "video/mp4")
+
+    assert_raises ActiveStorage::PreviewCaptureError do
+      ActiveStorage::Previewer::VideoPreviewer.new(blob).preview
     end
   end
 end


### PR DESCRIPTION
If a preview cannot be generated, the IO stream that is captured is empty, resulting in a 0-byte preview file being generated and stored in the Active Storage service.

We came across this because Poppler was failing to generate previews of some PDFs, resulting in 0-byte files. Resizing those "previews" then resulted in a MiniMagick error. The MiniMagick error feels like the right end result if it's attempted on a 0-byte file, what doesn't feel right is `Previewer` proceeding normally if the child process that attempted to capture a preview exited unsuccessfully.

Now, if the previewer child process exits with a non-0 status code, we raise an exception.