### PR TITLE
Improve documentation of FormHelper#form_with `local` option [ci skip]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -604,10 +604,15 @@ module ActionView
       #   This is helpful when fragment-caching the form. Remote forms
       #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
       #   unnecessary unless you support browsers without JavaScript.
-      # * <tt>:local</tt> - By default form submits via typical HTTP requests.
-      #   Enable remote and unobtrusive XHRs submits with <tt>local: false</tt>.
-      #   Remote forms may be enabled by default by setting
-      #   <tt>config.action_view.form_with_generates_remote_forms = true</tt>.
+      # * <tt>:local</tt> - Whether to use standard HTTP form submission.
+      #   When <tt>false</tt>, the form will be a "remote form" which means
+      #   form submission will be handled by rails UJS as an XHR.
+      #   If this option is not specified, the behavior is the inverse of the value of
+      #   <tt>config.action_view.form_with_generates_remote_forms</tt>.
+      #   As of Rails 6.1, that configuration option defaults to <tt>false</tt>
+      #   (which has the equivalent effect of passing <tt>local: true</tt>).
+      #   In previous versions of Rails, that configuration option defaults to
+      #   <tt>true</tt> (the equivalent of passing <tt>local: false</tt>).
       # * <tt>:skip_enforcing_utf8</tt> - If set to true, a hidden input with name
       #   utf8 is not output.
       # * <tt>:builder</tt> - Override the object used to build the form.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -605,10 +605,11 @@ module ActionView
       #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
       #   unnecessary unless you support browsers without JavaScript.
       # * <tt>:local</tt> - Whether to use standard HTTP form submission.
-      #   When <tt>false</tt>, the form will be a "remote form" which means
-      #   form submission will be handled by rails UJS as an XHR.
-      #   If this option is not specified, the behavior is the inverse of the value of
-      #   <tt>config.action_view.form_with_generates_remote_forms</tt>.
+      #   When set to <tt>true</tt>, the form is submitted via standard HTTP.
+      #   When set to <tt>false</tt>, the form is submitted as a "remote form", which 
+      #   is handled by Rails UJS as an XHR. When unspecified, the behavior is derived 
+      #   from <tt>config.action_view.form_with_generates_remote_forms</tt> where the 
+      #   config's value is actually the inverse of what <tt>local</tt>'s value would be.
       #   As of Rails 6.1, that configuration option defaults to <tt>false</tt>
       #   (which has the equivalent effect of passing <tt>local: true</tt>).
       #   In previous versions of Rails, that configuration option defaults to

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -606,9 +606,9 @@ module ActionView
       #   unnecessary unless you support browsers without JavaScript.
       # * <tt>:local</tt> - Whether to use standard HTTP form submission.
       #   When set to <tt>true</tt>, the form is submitted via standard HTTP.
-      #   When set to <tt>false</tt>, the form is submitted as a "remote form", which 
-      #   is handled by Rails UJS as an XHR. When unspecified, the behavior is derived 
-      #   from <tt>config.action_view.form_with_generates_remote_forms</tt> where the 
+      #   When set to <tt>false</tt>, the form is submitted as a "remote form", which
+      #   is handled by Rails UJS as an XHR. When unspecified, the behavior is derived
+      #   from <tt>config.action_view.form_with_generates_remote_forms</tt> where the
       #   config's value is actually the inverse of what <tt>local</tt>'s value would be.
       #   As of Rails 6.1, that configuration option defaults to <tt>false</tt>
       #   (which has the equivalent effect of passing <tt>local: true</tt>).


### PR DESCRIPTION
### Summary

Improve clarity of the `local` option to `FormHelper#form_with` and the configuration option that controls its implicit default.

### Other Information

I brought this up in #41245. To summarize:

The existing documentation is confusing because:
- The first line states the default behavior but that's misleading. The default behavior actually depends on a configuration option which might be different from the default in the project one is working in, and depends on the version of Rails the project was generated by, and whether the default config has been changed during a subsequent upgrade, and whether the default config is overridden in the application config.
-  the configuration option is named "form_with_generates_remote_forms"
  - "generates" seems to indicate that it has something to do with the rails generator
  - `#form_with` doesn't take a "remote" argument (like `#form_for` does) but the word "remote" is in the configuration option name
  - It's inconsistent with its use of the terms "remote" and "local" and understanding it requires processing at least one double-negative

My goal is to:
- Document the option itself as a boolean, defining the behavior when two possible values are specified.
- Reference the Rails configuration option as a way to control behavior of this method when the `local` option is not provided to the method.
- Document the default value of the configuration option to make it clear that the default value dependent on the version of Rails. (This is most important because developers working in older applications may end up reading this documentation without realizing that the documentation is incorrect for their version of Rails. Also keep in mind that since the "6.0 defaults" are actually still part of the Rails codebase, this documentation is referring to code/default values that are in the codebase, not code/default values that have been removed or changed completely.)

Closes #41245 