### PR TITLE
Fix raw params method to not raise an exception

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -484,7 +484,7 @@ module ActionController
       def raw_params(auth)
         _raw_params = auth.sub(TOKEN_REGEX, "").split(/\s*#{AUTHN_PAIR_DELIMITERS}\s*/)
 
-        if !_raw_params.first.start_with?(TOKEN_KEY)
+        if !_raw_params.first&.start_with?(TOKEN_KEY)
           _raw_params[0] = "#{TOKEN_KEY}#{_raw_params.first}"
         end
 

--- a/actionpack/test/controller/http_token_authentication_test.rb
+++ b/actionpack/test/controller/http_token_authentication_test.rb
@@ -155,7 +155,7 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     assert_equal(expected, actual)
   end
 
-  test "token_and_options returns correct token with nounce option" do
+  test "token_and_options returns correct token with nonce option" do
     token = "rcHu+HzSFw89Ypyhn/896A="
     nonce_hash = { nonce: "123abc" }
     actual = ActionController::HttpAuthentication::Token.token_and_options(sample_request(token, nonce_hash))
@@ -174,6 +174,20 @@ class HttpTokenAuthenticationTest < ActionController::TestCase
     auth = sample_request("rcHu+HzSFw89Ypyhn/896A=").authorization.to_s
     actual = ActionController::HttpAuthentication::Token.raw_params(auth)
     expected = ["token=\"rcHu+HzSFw89Ypyhn/896A=\"", "nonce=\"def\""]
+    assert_equal(expected, actual)
+  end
+
+  test "raw_params returns a tuple of key value pair strings when auth does not contain a token key" do
+    auth = sample_request_without_token_key("rcHu+HzSFw89Ypyhn/896A=").authorization.to_s
+    actual = ActionController::HttpAuthentication::Token.raw_params(auth)
+    expected = ["token=rcHu+HzSFw89Ypyhn/896A="]
+    assert_equal(expected, actual)
+  end
+
+  test "raw_params returns a tuple of key strings when auth does not contain a token key and value" do
+    auth = sample_request_without_token_key(nil).authorization.to_s
+    actual = ActionController::HttpAuthentication::Token.raw_params(auth)
+    expected = ["token="]
     assert_equal(expected, actual)
   end
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

https://github.com/rails/rails/issues/41279

Starting from 6.1.1, ActionController::HttpAuthentication::Token::ControllerMethods#authenticate_with_http_token can raise an exception.
It happens when the http authorization request header has only a type and no credential.
```ruby
token = nil # or token = ''
request.headers['Authorization'] = "Bearer #{token}"
request.get
```
```ruby
authenticate_with_http_token do |token, _options|
  # 
end
```
```
NoMethodError:
       undefined method `start_with?' for nil:NilClass
```

Under 6.1.1, nil is returned in such a case.
As a specification, I think it is correct to return nil instead of an exception when the token is invalid.
Therefore, I fixed ActionController::HttpAuthentication::Token#raw_params which raises an exception.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
In addition, I fixed the typo.
https://github.com/rails/rails/commit/61a9c13a65776afc2c2e7c00f774d85ca4d0e87c