### PR TITLE
Unset script name if it's empty

### DIFF
--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -44,7 +44,7 @@ module ActionController
           options[:original_script_name] = original_script_name
         else
           if same_origin
-            options[:script_name] = request.script_name.empty? ? "" : request.script_name.dup
+            options[:script_name] = request.script_name.empty? ? nil : request.script_name.dup
           else
             options[:script_name] = script_name
           end


### PR DESCRIPTION
### Summary

We're tying to move rails service to `/gateway/service` under API gateway, so there is a need to prefix routes with `/gateway/service` if they're accessed from the API gateway while preserving original path if not.
Right now `script_name` is always set even if it's empty, so dynamic override of `:relative_url_root` from `Controller#url_options` doesn't work (well, `super.except(:script_name)` does the trick, but looks  hacky) . Fix it.