### PR TITLE
Handle error when file does not exist at filepath

### DIFF
--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -26,7 +26,11 @@ module ActionView
           if File.exist?(options[:file])
             Template::RawFile.new(options[:file])
           else
-            raise ArgumentError, "`render file:` should be given the absolute path to a file. '#{options[:file]}' was given instead"
+            if Pathname.new(options[:file]).absolute?
+              raise ArgumentError, "File #{options[:file]} does not exist"
+            else
+              raise ArgumentError, "`render file:` should be given the absolute path to a file. '#{options[:file]}' was given instead"
+            end
           end
         elsif options.key?(:inline)
           handler = Template.handler_for_extension(options[:type] || "erb")

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -79,7 +79,20 @@ module RenderTestCases
 
   def test_render_file_with_full_path_no_extension
     template_path = File.expand_path("../fixtures/test/hello_world", __dir__)
-    assert_raise(ArgumentError) { @view.render(file: template_path) }
+    e = assert_raise(ArgumentError) { @view.render(file: template_path) }
+    assert_match(/File (.+) does not exist/, e.message)
+  end
+
+  def test_render_file_with_invalid_full_path
+    template_path = File.expand_path("../fixtures/test/hello_world_invalid.erb", __dir__)
+    e = assert_raise(ArgumentError) { @view.render(file: template_path) }
+    assert_match(/File (.+) does not exist/, e.message)
+  end
+
+  def test_render_file_with_relative_path
+    template_path = "fixtures/test/hello_world.erb"
+    e = assert_raise(ArgumentError) { @view.render(file: template_path) }
+    assert_match(%r{`render file:` should be given the absolute path to a file. (.+) was given instead}, e.message)
   end
 
   # Test if :formats, :locale etc. options are passed correctly to the resolvers.


### PR DESCRIPTION
### Summary
Rails has enforced that all filepaths be absolute and returns an error message that a relative path has been given.

However if the path is actually an absolute path and the file doesn't exist, the error message still states that a relative path has been given.

This PR checks to see if the file is absolute and returns an error if it's actually missing.

Addresses:
https://github.com/rails/rails/issues/41265
