### PR TITLE
Always render attachment partials as HTML with :html format inside trix editor

### DIFF
--- a/actiontext/lib/action_text/attachments/trix_conversion.rb
+++ b/actiontext/lib/action_text/attachments/trix_conversion.rb
@@ -28,7 +28,7 @@ module ActionText
       private
         def trix_attachment_content
           if partial_path = attachable.try(:to_trix_content_attachment_partial_path)
-            ActionText::Content.render(partial: partial_path, object: self, as: model_name.element)
+            ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element)
           end
         end
     end

--- a/actiontext/test/dummy/app/views/messages/edit.json.erb
+++ b/actiontext/test/dummy/app/views/messages/edit.json.erb
@@ -1,0 +1,4 @@
+{
+  "id": <%= @message.id %>,
+  "form": "<%= j render partial: "form", formats: :html, locals: { message: @message } %>"
+}

--- a/actiontext/test/integration/controller_render_test.rb
+++ b/actiontext/test/integration/controller_render_test.rb
@@ -24,6 +24,15 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
     assert_select content, "img:match('src', ?)", %r"//loocalhoost/.+/racecar"
   end
 
+  test "renders Trix with content attachment as HTML when the request format is not HTML" do
+    message_with_person_attachment = messages(:hello_alice)
+
+    get edit_message_path(message_with_person_attachment, format: :json)
+
+    form_html = response.parsed_body["form"]
+    assert_match %r" class=\S+mentionable-person\b", form_html
+  end
+
   test "resolves partials when controller is namespaced" do
     blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
     message = Message.create!(content: ActionText::Content.new.append_attachables(blob))


### PR DESCRIPTION
### Summary

Attachable partials within the trix editor are rendered using the request format rather than HTML. This PR overrides the rendering of the template format to always be `:html`.

This fix is related to the fix provided at #40702 which resolves this issue for cases that do not involve rendering the attachable inside the editor and the fix was inspired by referencing that PR.

### Other Information

Firing a request with `format: :json` and then having the responding controller action `render formats: :html` would not result in the attachable partial rendering as html, but rather attempting to locate a json partial:

```ruby
ActionView::Template::Error: Missing partial people/_trix_content_attachment with {:locale=>[:en], :formats=>[:json], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}
```