### PR TITLE
Add `nonce: true` option to stylesheet_link_tag helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a `nonce: true` option to the `stylesheet_link_tag` helper to support automatic nonce generation for Content Security Policies.
+
+    *AJ Esler*
+
 *   Remove legacy default `media=screen` from `stylesheet_link_tag`.
 
     *André Luis Leal Cardoso Junior*

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -128,6 +128,22 @@ module ActionView
       # If the server supports Early Hints header links for these assets will be
       # automatically pushed.
       #
+      # ==== Options
+      #
+      # When the last parameter is a hash you can add HTML attributes using that
+      # parameter. The following options are supported:
+      #
+      # * <tt>:protocol</tt>  - Sets the protocol of the generated URL. This option only
+      #   applies when a relative URL and +host+ options are provided.
+      # * <tt>:host</tt>  - When a relative URL is provided the host is added to the
+      #   that path.
+      # * <tt>:skip_pipeline</tt>  - This option is used to bypass the asset pipeline
+      #   when it is set to true.
+      # * <tt>:nonce</tt>  - When set to true, adds an automatic nonce value if
+      #   you have Content Security Policy enabled.
+      #
+      # ==== Examples
+      #
       #   stylesheet_link_tag "style"
       #   # => <link href="/assets/style.css" rel="stylesheet" />
       #
@@ -146,6 +162,9 @@ module ActionView
       #   stylesheet_link_tag "random.styles", "/css/stylish"
       #   # => <link href="/assets/random.styles" rel="stylesheet" />
       #   #    <link href="/css/stylish.css" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "style", nonce: true
+      #   # => <link href="/assets/style.css" rel="stylesheet" nonce="..." />
       def stylesheet_link_tag(*sources)
         options = sources.extract_options!.stringify_keys
         path_options = options.extract!("protocol", "host", "skip_pipeline").symbolize_keys
@@ -174,6 +193,9 @@ module ActionView
             tag_options[:media] = "screen"
           end
 
+          if tag_options["nonce"] == true
+            tag_options["nonce"] = content_security_policy_nonce
+          end
           tag(:link, tag_options)
         }.join("\n").html_safe
 

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -515,6 +515,10 @@ class AssetTagHelperTest < ActionView::TestCase
     ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default = original_default_media
   end
 
+  def test_stylesheet_link_tag_with_nonce
+    assert_dom_equal %(<link href="http://www.example.com/styles/style.css" rel="stylesheet" nonce="iyhD0Yc0W+c=" />), stylesheet_link_tag("http://www.example.com/styles/style.css", nonce: true)
+  end
+
   def test_javascript_include_tag_without_request
     @request = nil
     assert_dom_equal %(<script src="/javascripts/foo.js"></script>), javascript_include_tag("foo.js")

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1145,10 +1145,11 @@ as part of `html_options`. Example:
 <% end -%>
 ```
 
-The same works with `javascript_include_tag`:
+The same works with `javascript_include_tag` and the `stylesheet_link_tag`:
 
 ```html+erb
 <%= javascript_include_tag "script", nonce: true %>
+<%= stylesheet_link_tag "style.css", nonce: true %>
 ```
 
 Use [`csp_meta_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/CspHelper.html#method-i-csp_meta_tag)


### PR DESCRIPTION
This provides a shortcut for setting a Content Security Policy nonce on
a stylesheet_link_tag.

### Summary

This makes `stylesheet_link_tag` consistent with `javascript_include_tag` in that you can provide a nonce option to both. 