### PR TITLE
Fix Mysql schema for virtual column expressions with quotes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -79,7 +79,10 @@ module ActiveRecord
                     " WHERE table_schema = #{scope[:schema]}" \
                     "   AND table_name = #{scope[:name]}" \
                     "   AND column_name = #{column_name}"
-              @connection.query_value(sql, "SCHEMA").inspect
+              # Calling .inspect leads into issues with the query result
+              # which already returns escaped quotes.
+              # We remove the escape sequence from the result in order to deal with double escaping issues.
+              @connection.query_value(sql, "SCHEMA").gsub("\\'", "'").inspect
             end
           end
       end

--- a/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/virtual_column_test.rb
@@ -19,6 +19,8 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
         t.virtual :upper_name,  type: :string,  as: "UPPER(`name`)"
         t.virtual :name_length, type: :integer, as: "LENGTH(`name`)", stored: true
         t.virtual :name_octet_length, type: :integer, as: "OCTET_LENGTH(`name`)", stored: true
+        t.json    :profile
+        t.virtual :profile_email, type: :string, as: "json_extract(`profile`,_utf8mb4'$.email')", stored: true
       end
       VirtualColumn.create(name: "Rails")
     end
@@ -58,6 +60,7 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "(?:UPPER|UCASE)\(`name`\)"$/i, output)
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "(?:octet_length|length)\(`name`\)",\s+stored: true$/i, output)
+      assert_match(/t\.virtual\s+"profile_email",\s+type: :string,\s+as: "json_extract\(`profile`,\w*?'\$\.email'\)", stored: true$/i, output)
     end
   end
 end


### PR DESCRIPTION
### Summary

Mysql automatically escapes quotes in generated columns expressions.
This leads into the generation of a double escape sequence when using .inspect on the SQL result.
In order to fix this we remove the escape sequence from the SQL result.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Fixes #41156


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
