### PR TITLE
Address `warning: Passing only keyword arguments to Struct#initialize`

### DIFF
--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -68,7 +68,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_url_for_with_back
     referer = "http://www.example.com/referer"
-    @controller = Struct.new(:request).new(Struct.new(:env).new("HTTP_REFERER" => referer))
+    @controller = Struct.new(:request).new(Struct.new(:env).new({ "HTTP_REFERER" => referer }))
 
     assert_equal "http://www.example.com/referer", url_for(:back)
   end
@@ -85,13 +85,13 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_url_for_with_back_and_javascript_referer
     referer = "javascript:alert(document.cookie)"
-    @controller = Struct.new(:request).new(Struct.new(:env).new("HTTP_REFERER" => referer))
+    @controller = Struct.new(:request).new(Struct.new(:env).new({ "HTTP_REFERER" => referer }))
     assert_equal "javascript:history.back()", url_for(:back)
   end
 
   def test_url_for_with_invalid_referer
     referer = "THIS IS NOT A URL"
-    @controller = Struct.new(:request).new(Struct.new(:env).new("HTTP_REFERER" => referer))
+    @controller = Struct.new(:request).new(Struct.new(:env).new({ "HTTP_REFERER" => referer }))
     assert_equal "javascript:history.back()", url_for(:back)
   end
 

--- a/activerecord/test/cases/arel/support/fake_record.rb
+++ b/activerecord/test/cases/arel/support/fake_record.rb
@@ -89,7 +89,7 @@ module FakeRecord
   end
 
   class ConnectionPool
-    class Spec < Struct.new(:config)
+    class Spec < Struct.new(:adapter, keyword_init: true)
     end
 
     attr_reader :spec, :connection

--- a/activerecord/test/cases/type/adapter_specific_registry_test.rb
+++ b/activerecord/test/cases/type/adapter_specific_registry_test.rb
@@ -76,7 +76,6 @@ module ActiveRecord
     end
 
     test "construct args are passed to the type" do
-      type = Struct.new(:args)
       registry = Type::AdapterSpecificRegistry.new
       registry.register(:foo, type)
 
@@ -117,7 +116,6 @@ module ActiveRecord
 
     test "registering adapter specific modifiers" do
       decoration = Struct.new(:value)
-      type = Struct.new(:args)
       registry = Type::AdapterSpecificRegistry.new
       registry.register(:foo, type)
       registry.add_modifier({ array: true }, decoration, adapter: :postgresql)
@@ -131,5 +129,17 @@ module ActiveRecord
         registry.lookup(:foo, array: true, adapter: :sqlite3)
       )
     end
+
+    TYPE = Class.new do
+      attr_reader :args
+
+      def initialize(args = nil)
+        @args = args
+      end
+
+      def ==(other) self.args == other.args end
+    end
+
+    private def type; TYPE end
   end
 end


### PR DESCRIPTION
### Summary

This pull request addresses the following warnings enabled since https://github.com/ruby/ruby/pull/4070

* Warnings without this fix 1

```ruby
% ruby -v
ruby 3.1.0dev (2021-02-01T10:54:21Z master 1cdae49d39) [x86_64-darwin20]
% bin/test test/cases/arel/visitors/sqlite_test.rb:36
... snip ...
/Users/yahonda/src/github.com/rails/rails/activerecord/test/cases/arel/support/fake_record.rb:98: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
.

Finished in 0.003538s, 2261.1645 runs/s, 2543.8101 assertions/s.
8 runs, 9 assertions, 0 failures, 0 errors, 0 skips
%
```

* Warnings without this fix 2

```ruby
% ruby -v
ruby 3.1.0dev (2021-02-01T10:54:21Z master 1cdae49d39) [x86_64-darwin20]
% bin/test test/cases/type/adapter_specific_registry_test.rb
Using sqlite3
Run options: --seed 53175

......./Users/yahonda/src/github.com/rails/rails/activerecord/test/cases/type/adapter_specific_registry_test.rb:126: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/type/registry.rb:18: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/yahonda/src/github.com/rails/rails/activerecord/test/cases/type/adapter_specific_registry_test.rb:130: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/type/registry.rb:18: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
.../Users/yahonda/src/github.com/rails/rails/activerecord/test/cases/type/adapter_specific_registry_test.rb:85: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/type/registry.rb:18: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/yahonda/src/github.com/rails/rails/activerecord/test/cases/type/adapter_specific_registry_test.rb:86: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
/Users/yahonda/src/github.com/rails/rails/activemodel/lib/active_model/type/registry.rb:18: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
.

Finished in 0.011424s, 962.8852 runs/s, 2450.9804 assertions/s.
11 runs, 28 assertions, 0 failures, 0 errors, 0 skips
%
```

Refer:
https://github.com/ruby/ruby/pull/4070
https://bugs.ruby-lang.org/issues/16806


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
