### PR TITLE
Add #download_with_index and #download_chunk methods to blob instances

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `download_with_index` method 
+
+    If you need to download files by chunks, you could send a block to the download method.
+    However, if for some reason the execution of this block failed, 
+    there was no way to resume the processing from the last successfully processed chunk.
+    
+    To take advantage of those previous chunks, it was necessary to re-implement
+    the reading of files by chunks, using the `download_chunk` method,
+    keeping a record of the execution point and updating offsets (something like a local pagination of chunks)
+    
+    With the `download_with_index` method we will receive the chunk and (optionally) the current index in each block.
+    In case of failures, you only need to restart the execution with the index
+
+    *Pablo Soldi*
+    
 *   Add ability to use pre-defined variants.
 
     ```ruby

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -259,6 +259,15 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.download key, &block
   end
 
+  # Return the partial content of the file at the +key+ with an index, which starts from offset.
+  def download_with_index(index = 0, &block)
+    service.download_with_index(key, index, &block)
+  end
+
+  # Return the partial content in the byte +range+ of the file at the +key+.
+  def download_chunk(range)
+    service.download_chunk(key, range)
+  end
   # Downloads the blob to a tempfile on disk. Yields the tempfile.
   #
   # The tempfile's name is prefixed with +ActiveStorage-+ and the blob's ID. Its extension matches that of the blob.

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -81,6 +81,11 @@ module ActiveStorage
       raise NotImplementedError
     end
 
+    # Return the partial content of the file at the +key+ with an index, which starts from offset.
+    def download_with_index(key, index = 0)
+      raise NotImplementedError
+    end
+
     # Return the partial content in the byte +range+ of the file at the +key+.
     def download_chunk(key, range)
       raise NotImplementedError

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -13,7 +13,7 @@ module ActiveStorage
   class Service::MirrorService < Service
     attr_reader :primary, :mirrors
 
-    delegate :download, :download_chunk, :exist?, :url,
+    delegate :download, :download_with_index, :download_chunk, :exist?, :url,
       :url_for_direct_upload, :headers_for_direct_upload, :path_for, to: :primary
 
     # Stitch together from named services.

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -134,6 +134,28 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal "a" * 64.kilobytes, chunks.second
   end
 
+  test "download with index skip first chunk" do
+    blob   = create_blob data: "a" * 5.0625.megabytes
+    chunks = []
+    index = 1
+    indexes = []
+
+    blob.download_with_index(index) do |chunk, i|
+      chunks << chunk
+      indexes << i
+    end
+
+    assert_equal 1, chunks.size
+    assert_equal "a" * 64.kilobytes, chunks.first
+    assert_equal [1], indexes
+  end
+
+  test "download a chunk" do
+    blob = create_blob data: "a" * 3.megabytes + "b" * 4.megabytes
+    chunk = blob.download_chunk(2.megabytes..5.megabytes - 1)
+    assert_equal "a" * 1.megabyte + "b" * 2.megabytes, chunk
+  end
+
   test "open with integrity" do
     create_file_blob(filename: "racecar.jpg").tap do |blob|
       blob.open do |file|

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -68,6 +68,51 @@ module ActiveStorage::Service::SharedServiceTests
       end
     end
 
+    test "downloading with index default" do
+      key = SecureRandom.base58(24)
+      expected_chunks = [ "a" * 5.megabytes, "b" ]
+      actual_chunks = []
+      expected_indexes = [0, 1]
+      actual_indexes = []
+
+      begin
+        @service.upload key, StringIO.new(expected_chunks.join)
+
+        @service.download_with_index key do |chunk, index|
+          actual_chunks << chunk
+          actual_indexes << index
+        end
+
+        assert_equal expected_chunks, actual_chunks, "Downloaded chunks did not match uploaded data"
+        assert_equal expected_indexes, actual_indexes, "Downloaded indexes did not match uploaded data"
+      ensure
+        @service.delete key
+      end
+    end
+
+    test "downloading with index value" do
+      key = SecureRandom.base58(24)
+      all_the_chunks = [ "a" * 5.megabytes, "b" ]
+      expected_chunks = ["b"]
+      actual_chunks = []
+      expected_indexes = [1]
+      actual_indexes = []
+      index = 1
+
+      begin
+        @service.upload key, StringIO.new(all_the_chunks.join)
+
+        @service.download_with_index(key, index) do |chunk, i|
+          actual_chunks << chunk
+          actual_indexes << i
+        end
+
+        assert_equal expected_chunks, actual_chunks, "Downloaded chunks did not match uploaded data"
+        assert_equal expected_indexes, actual_indexes, "Downloaded indexes did not match uploaded data"
+      ensure
+        @service.delete key
+      end
+    end
 
     test "downloading in chunks" do
       key = SecureRandom.base58(24)


### PR DESCRIPTION
Add #download_with_index and #download_chunk methods to blob instances
If you need to download files by chunks, you could send a block to the download method.
However, if for some reason the execution of this block failed, there was no way to resume the processing from the last successfully processed chunk.

To take advantage of those previous chunks, it was necessary to re-implement the reading of files by chunks, using the `download_chunk` method, keeping a record of the execution point and updating offsets (something like a local pagination of chunks)

With the `download_with_index` method we will receive the chunk and (optionally) the current index in each block.
In case of failures, you only need to restart the execution with the index

```ruby
a_tb_file.download_with_index(last_successfully_processed_chunk_index) do |chunk, index|
  # ...
  last_successfully_processed_chunk_index = index
end
```
