### PR TITLE
Stop setting RAILS_ENV when test_unit railtie is loaded

### DIFF
--- a/railties/lib/rails/test_unit/railtie.rb
+++ b/railties/lib/rails/test_unit/railtie.rb
@@ -2,10 +2,6 @@
 
 require "rails/test_unit/line_filtering"
 
-if defined?(Rake.application) && Rake.application.top_level_tasks.grep(/^(default$|test(:|$))/).any?
-  ENV["RAILS_ENV"] ||= Rake.application.options.show_tasks ? "development" : "test"
-end
-
 module Rails
   class TestUnitRailtie < Rails::Railtie
     config.app_generators do |c|


### PR DESCRIPTION
Because the [TestUnit::Runner is used to run the tests from Rake test tasks](https://github.com/rails/rails/pull/41132), we don't need to set the Rails environment based on the name of the task anymore.

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>

### Summary

This shows why it was brittle in 6.1 and before:

```sh-session
$ rails _6.1.1_ new my_app && cd my_app
$ cat <<EOF > test/environment_test.rb                                                                        
require 'test_helper'

class EnvironmenTest < ActiveSupport::TestCase
  test "environment is test" do
    assert_predicate Rails.env, :test?
  end
end
EOF
$ echo 'task my_test: :test' >> Rakefile
$ bundle exec rake my_test
Run options: --seed 11291

# Running:

F

Failure:
EnvironmenTest#test_environment_is_test [/Users/etienne/2021-02-01/my_app/test/environment_test.rb:5]:
Expected "development" to be test?.


rails test test/environment_test.rb:4



Finished in 0.005128s, 195.0078 runs/s, 195.0078 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
```

But this worked:

```
$ echo 'task "test:task" => :test' >> Rakefile 
$ bundle exec rake test:task
```

And it's fixed on main because we also use the test runner since #41132, and [it sets the environment to test](https://github.com/etiennebarrie/rails/blob/da740d63b2b9cb22998d10bc79d798050eec22ed/railties/lib/rails/test_unit/runner.rb#L26):

```sh-session
BUNDLE_GEMFILE=$PWD/rails/Gemfile bundle exec rails new my_app_dev && cd my_app_dev && bundle
$ cat <<EOF > test/environment_test.rb                                                                        
require 'test_helper'

class EnvironmenTest < ActiveSupport::TestCase
  test "environment is test" do
    assert_predicate Rails.env, :test?
  end
end
EOF
$ echo 'task my_test: :test' >> Rakefile
$ bundle exec rake my_test
```

This has a consequence on compatibility because rake tasks may have expected to be running in the test environment based on their task name. I'm not sure if we need to handle that and how.

### Other Information

We found this while developing an engine, running the `rails test:system` would not set the environment to test, and we found out that the environment was set while requiring `railties/lib/rails/test_unit/railtie.rb`, too early because of all the frameworks are loaded from `bin/rails`, only in an engine: `railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt`.

We think we may want to also remove the loading of frameworks from `bin/rails` in engines, but it only fixes the `rails test:system` case and not `rake my_test`.