### PR TITLE
Pass binds on PostgreSQL exec_query even when prepared statements off globally

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -653,9 +653,7 @@ module ActiveRecord
             raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"
           end
 
-          if without_prepared_statement?(binds)
-            result = exec_no_cache(sql, name, [])
-          elsif !prepare
+          if !prepare || without_prepared_statement?(binds)
             result = exec_no_cache(sql, name, binds)
           else
             result = exec_cache(sql, name, binds)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -254,35 +254,33 @@ module ActiveRecord
         end
       end
 
-      if ActiveRecord::Base.connection.prepared_statements
-        def test_exec_with_binds
-          with_example_table do
-            string = @connection.quote("foo")
-            @connection.exec_query("INSERT INTO ex (id, data) VALUES (1, #{string})")
+      def test_exec_with_binds
+        with_example_table do
+          string = @connection.quote("foo")
+          @connection.exec_query("INSERT INTO ex (id, data) VALUES (1, #{string})")
 
-            bind = Relation::QueryAttribute.new("id", 1, Type::Value.new)
-            result = @connection.exec_query("SELECT id, data FROM ex WHERE id = $1", nil, [bind])
+          bind = Relation::QueryAttribute.new("id", 1, Type::Value.new)
+          result = @connection.exec_query("SELECT id, data FROM ex WHERE id = $1", nil, [bind])
 
-            assert_equal 1, result.rows.length
-            assert_equal 2, result.columns.length
+          assert_equal 1, result.rows.length
+          assert_equal 2, result.columns.length
 
-            assert_equal [[1, "foo"]], result.rows
-          end
+          assert_equal [[1, "foo"]], result.rows
         end
+      end
 
-        def test_exec_typecasts_bind_vals
-          with_example_table do
-            string = @connection.quote("foo")
-            @connection.exec_query("INSERT INTO ex (id, data) VALUES (1, #{string})")
+      def test_exec_typecasts_bind_vals
+        with_example_table do
+          string = @connection.quote("foo")
+          @connection.exec_query("INSERT INTO ex (id, data) VALUES (1, #{string})")
 
-            bind = Relation::QueryAttribute.new("id", "1-fuu", Type::Integer.new)
-            result = @connection.exec_query("SELECT id, data FROM ex WHERE id = $1", nil, [bind])
+          bind = Relation::QueryAttribute.new("id", "1-fuu", Type::Integer.new)
+          result = @connection.exec_query("SELECT id, data FROM ex WHERE id = $1", nil, [bind])
 
-            assert_equal 1, result.rows.length
-            assert_equal 2, result.columns.length
+          assert_equal 1, result.rows.length
+          assert_equal 2, result.columns.length
 
-            assert_equal [[1, "foo"]], result.rows
-          end
+          assert_equal [[1, "foo"]], result.rows
         end
       end
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

When prepared statements are off globally on PostgreSQL connection adapters, bind variables are dropped in `exec_query` resulting in errors. These bind variables can be passed into the query instead, which will execute as expected. See #41299, which was closed prematurely.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
