### PR TITLE
`attribute` should not require a connection is established

### DIFF
--- a/activerecord/lib/active_record/type.rb
+++ b/activerecord/lib/active_record/type.rb
@@ -47,8 +47,7 @@ module ActiveRecord
       end
 
       def adapter_name_from(model) # :nodoc:
-        # TODO: this shouldn't depend on a connection to the database
-        model.connection.adapter_name.downcase.to_sym
+        model.connection_db_config.adapter.to_sym
       end
 
       private

--- a/activerecord/test/cases/attributes_test.rb
+++ b/activerecord/test/cases/attributes_test.rb
@@ -348,6 +348,14 @@ module ActiveRecord
       assert_equal "foo", klass.new(no_type: "foo").no_type
     end
 
+    test "attributes do not require a connection is established" do
+      assert_not_called(ActiveRecord::Base, :connection) do
+        Class.new(OverloadedType) do
+          attribute :foo, :string
+        end
+      end
+    end
+
     test "unknown type error is raised" do
       assert_raise(ArgumentError) do
         OverloadedType.attribute :foo, :unknown

--- a/activerecord/test/cases/type_test.rb
+++ b/activerecord/test/cases/type_test.rb
@@ -30,7 +30,7 @@ class TypeTest < ActiveRecord::TestCase
   end
 
   test "lookup defaults to the current adapter" do
-    current_adapter = ActiveRecord::Base.connection.adapter_name.downcase.to_sym
+    current_adapter = ActiveRecord::Type.adapter_name_from(ActiveRecord::Base)
     type = Struct.new(:args)
     adapter_type = Struct.new(:args)
     ActiveRecord::Type.register(:foo, type, override: false)


### PR DESCRIPTION
#41166 made `attribute` require a connection due to calling
`ActiveRecord::Type.adapter_name_from` immediately.

This fixes `adapter_name_from` to get the adapter name from the
connection db config to not retrieve a connection.
