### PR TITLE
Address `Rails 7.0 will return Content-Type header without modification`

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/relay/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/relay/inbound_emails_controller.rb
@@ -57,7 +57,7 @@ module ActionMailbox
 
     private
       def require_valid_rfc822_message
-        unless request.content_type == "message/rfc822"
+        unless request.media_type == "message/rfc822"
           head :unsupported_media_type
         end
       end


### PR DESCRIPTION
### Summary

This pull request addresses these warnings.

```ruby
$ cd actionmailbox
$ bin/test test/controllers/ingresses/relay/inbound_emails_controller_test.rb
Run options: --seed 32561

DEPRECATION WARNING: Rails 7.0 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from call at /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15)
...DEPRECATION WARNING: Rails 7.0 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from call at /home/yahonda/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/tempfile_reaper.rb:15)
..

Finished in 0.114883s, 43.5224 runs/s, 87.0447 assertions/s.
5 runs, 10 assertions, 0 failures, 0 errors, 0 skips
$
```

Follow-up https://github.com/rails/rails/commit/84055130713
related to https://github.com/rails/rails/pull/41251
