### PR TITLE
Add missing require to ActiveJob::TestHelper

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/class/subclasses"
+require "active_support/testing/assertions"
 
 module ActiveJob
   # Provides helper methods for testing Active Job


### PR DESCRIPTION
Following PR #40780, it now fails after requiring active_job:

    irb(main):001:0> require 'active_job'
    => true
    irb(main):002:0> ActiveJob::VERSION::STRING
    => "6.1.1"
    irb(main):003:0> ActiveJob::TestHelper
    [redacted]
    NameError (uninitialized constant ActiveSupport::Testing)