### PR TITLE
Handle Symbol arguments in `ActiveSupport::Inflector.camelize`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Inflector.camelize` behaves expected when provided a symbol `:upper` or `:lower` argument. Matches
+    `String#camelize` behavior.
+
+    *Alex Ghiculescu*
+
 *   Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
     invalid.
 

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -68,7 +68,9 @@ module ActiveSupport
     #   camelize(underscore('SSLError'))        # => "SslError"
     def camelize(term, uppercase_first_letter = true)
       string = term.to_s
-      if uppercase_first_letter
+      # String#camelize takes a symbol (:upper or :lower), so we match that to avoid surprises:
+      upcase = true == uppercase_first_letter || :upper == uppercase_first_letter
+      if upcase
         string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize! || match }
       else
         string = string.sub(inflections.acronyms_camelize_regex) { |match| match.downcase! || match }

--- a/activesupport/test/core_ext/string_ext_test.rb
+++ b/activesupport/test/core_ext/string_ext_test.rb
@@ -112,6 +112,10 @@ class StringInflectionsTest < ActiveSupport::TestCase
     assert_equal("capital", "Capital".camelize(:lower))
   end
 
+  def test_camelize_upper
+    assert_equal("Capital", "Capital".camelize(:upper))
+  end
+
   def test_camelize_invalid_option
     e = assert_raise ArgumentError do
       "Capital".camelize(nil)

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -140,8 +140,24 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
-  def test_camelize_with_lower_downcases_the_first_letter
+  def test_camelize_with_true_upcases_the_first_letter
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", true))
+  end
+
+  def test_camelize_with_upper_upcases_the_first_letter
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", :upper))
+  end
+
+  def test_camelize_with_false_downcases_the_first_letter
     assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", false))
+  end
+
+  def test_camelize_with_lower_downcases_the_first_letter
+    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", :lower))
+  end
+
+  def test_camelize_with_any_other_arg_downcases_the_first_letter
+    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", 222))
   end
 
   def test_camelize_with_underscores


### PR DESCRIPTION
This was raised on the discussion forum: https://discuss.rubyonrails.org/t/inconsistency-between-string-camelize-and-activesupportinflector-camelize

`String#camelize` takes a symbol (`:upper` or `:lower`) as an argument. But `ActiveSupport::Inflector.camelize` takes a bool. This can result in surprising behavior if you assume the methods are interchangeable, and call `ActiveSupport::Inflector.camelize('active_support', :lower)` (the `:lower` argument is truthy so the return value is upcased).

This PR changes `ActiveSupport::Inflector.camelize` to match `String#camelize` behavior. It will now return an upcased string if you provide `true` or `:upper` as an argument, otherwise it will be downcased.
