### PR TITLE
Fix rake test:db loading in development

### DIFF
--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -24,7 +24,10 @@ namespace :test do
   task run: %w[test]
 
   desc "Run tests quickly, but also reset db"
-  task db: %w[db:test:prepare test]
+  task :db do
+    success = system({ "RAILS_ENV" => ENV.fetch("RAILS_ENV", "test") }, "rake", "db:test:prepare", "test")
+    success || exit(false)
+  end
 
   ["models", "helpers", "channels", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
     task name => "test:prepare" do


### PR DESCRIPTION
[Not setting the test environment for test tasks](41298) caused the `test:db` task to establish connection with the development environment.

This fixes it by running the prerequisite rake tasks in a process with RAILS_ENV set to test.

### Summary

In #41298 we forgot about `test:db`, which caused an issue if your development configuration is not able to establish connection. Previously it was only establishing a connection in the test environment. After that PR, it was briefly establishing the connection in the development environment, before doing the `db:test:prepare` with the test environment configuration.

### Other Information

It's really an weird edge case because you need a development environment that's badly configured (if it uses a valid host/username it will manage to establish the connection so that won't have any consequences):
* `db:test:prepare` connects to the test database
* `test` runs the tests in a process with the right RAILS_ENV.

For example, with something like this, where nope is a user that doesn't exist in the DB (using mysql here):

```yaml
# in config/database.yml
development:
  <<: *default
  database: my_app_development
  username: nope
```

```sh-session
$ RAILS_ENV=test rails db:create
$ rails test:db
```
Running this worked before #41298, and doesn't since, and after this PR it works again.

cc @rafaelfranca 