### PR TITLE
Truthy argument upcases the first letter for `ActiveSupport::Inflector.camelize`

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -69,11 +69,10 @@ module ActiveSupport
     def camelize(term, uppercase_first_letter = true)
       string = term.to_s
       # String#camelize takes a symbol (:upper or :lower), so we match that to avoid surprises:
-      upcase = true == uppercase_first_letter || :upper == uppercase_first_letter
-      if upcase
-        string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize! || match }
-      else
+      if !uppercase_first_letter || :lower == uppercase_first_letter
         string = string.sub(inflections.acronyms_camelize_regex) { |match| match.downcase! || match }
+      else
+        string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize! || match }
       end
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) do
         word = $2

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -156,8 +156,8 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", :lower))
   end
 
-  def test_camelize_with_any_other_arg_downcases_the_first_letter
-    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", 222))
+  def test_camelize_with_truthy_arg_upcases_the_first_letter
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", 222))
   end
 
   def test_camelize_with_underscores


### PR DESCRIPTION
Context: https://github.com/rails/rails/pull/41313#discussion_r568977313

Preserving the original behavior is more safer.
