### PR TITLE
Handle Symbol arguments in `ActiveSupport::Inflector.camelize` (v2)

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -68,12 +68,11 @@ module ActiveSupport
     #   camelize(underscore('SSLError'))        # => "SslError"
     def camelize(term, uppercase_first_letter = true)
       string = term.to_s
-      # String#camelize takes a symbol (:upper or :lower), so we match that to avoid surprises:
-      upcase = true == uppercase_first_letter || :upper == uppercase_first_letter
-      if upcase
-        string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize! || match }
-      else
+      # String#camelize takes a symbol (:upper or :lower), so here we also support :lower to keep the methods consistent.
+      if !uppercase_first_letter || uppercase_first_letter == :lower
         string = string.sub(inflections.acronyms_camelize_regex) { |match| match.downcase! || match }
+      else
+        string = string.sub(/^[a-z\d]*/) { |match| inflections.acronyms[match] || match.capitalize! || match }
       end
       string.gsub!(/(?:_|(\/))([a-z\d]*)/i) do
         word = $2

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -142,22 +142,37 @@ class InflectorTest < ActiveSupport::TestCase
 
   def test_camelize_with_true_upcases_the_first_letter
     assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", true))
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", true))
   end
 
   def test_camelize_with_upper_upcases_the_first_letter
     assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", :upper))
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", :upper))
   end
 
   def test_camelize_with_false_downcases_the_first_letter
     assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", false))
+    assert_equal("capital", ActiveSupport::Inflector.camelize("capital", false))
+  end
+
+  def test_camelize_with_nil_downcases_the_first_letter
+    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", nil))
+    assert_equal("capital", ActiveSupport::Inflector.camelize("capital", nil))
   end
 
   def test_camelize_with_lower_downcases_the_first_letter
     assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", :lower))
+    assert_equal("capital", ActiveSupport::Inflector.camelize("capital", :lower))
   end
 
-  def test_camelize_with_any_other_arg_downcases_the_first_letter
-    assert_equal("capital", ActiveSupport::Inflector.camelize("Capital", 222))
+  def test_camelize_with_any_other_arg_upcases_the_first_letter
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", :true))
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("Capital", :true))
+
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", :false))
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", :foo))
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital", 42))
+    assert_equal("Capital", ActiveSupport::Inflector.camelize("capital"))
   end
 
   def test_camelize_with_underscores


### PR DESCRIPTION
Better implementation of https://github.com/rails/rails/pull/41313

Now, `nil`, `false` and `:lower` as args will return a downcased first character (before https://github.com/rails/rails/pull/41313 only  `nil` and  `false` did). Everything else returns an upcased first character, which is the default.

cc @kamipo - thanks for the feedback!

Co-authored-by: Ryuta Kamizono <kamipo@gmail.com>
