### PR TITLE
Fix counter_cache create/concat with overlapping counter_cache_column

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -249,7 +249,9 @@ module ActiveRecord
       # Hence this method.
       def inverse_which_updates_counter_cache
         return @inverse_which_updates_counter_cache if defined?(@inverse_which_updates_counter_cache)
-        @inverse_which_updates_counter_cache = klass.reflect_on_all_associations(:belongs_to).find do |inverse|
+        inverse_candidates = inverse_of ? [inverse_of] : klass.reflect_on_all_associations(:belongs_to)
+        @inverse_which_updates_counter_cache = inverse_candidates.find do |inverse|
+          next false if inverse.klass_suppress_errors && inverse.klass_suppress_errors != active_record
           inverse.counter_cache_column == counter_cache_column
         end
       end
@@ -296,6 +298,11 @@ module ActiveRecord
       protected
         def actual_source_reflection # FIXME: this is a horrible name
           self
+        end
+
+        def klass_suppress_errors
+          klass
+        rescue NameError, ArgumentError
         end
 
       private

--- a/activerecord/test/models/comment_overlapping_counter_cache.rb
+++ b/activerecord/test/models/comment_overlapping_counter_cache.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CommentOverlappingCounterCache < ActiveRecord::Base
+  belongs_to :user_comments_count, counter_cache: :comments_count
+  belongs_to :post_comments_count, class_name: "PostCommentsCount"
+  belongs_to :commentable, polymorphic: true, counter_cache: :comments_count
+end
+
+class UserCommentsCount < ActiveRecord::Base
+  has_many :comments, as: :commentable, class_name: "CommentOverlappingCounterCache"
+end
+
+class PostCommentsCount < ActiveRecord::Base
+  has_many :comments, class_name: "CommentOverlappingCounterCache"
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -244,8 +244,14 @@ ActiveRecord::Schema.define do
     t.integer :company
   end
 
+  create_table :comment_overlapping_counter_caches, force: true do |t|
+    t.integer :user_comments_count_id
+    t.integer :post_comments_count_id
+    t.references :commentable, polymorphic: true, index: false
+  end
+
   create_table :companies, force: true do |t|
-    t.string  :type
+    t.string :type
     t.references :firm, index: false
     t.string  :firm_name
     t.string  :name
@@ -843,6 +849,10 @@ ActiveRecord::Schema.define do
     t.string :author_id
   end
 
+  create_table :post_comments_counts, force: true do |t|
+    t.integer :comments_count, default: 0
+  end
+
   create_table :serialized_posts, force: true do |t|
     t.integer :author_id
     t.string :title, null: false
@@ -1263,6 +1273,10 @@ ActiveRecord::Schema.define do
   create_table :users, force: true do |t|
     t.string :token
     t.string :auth_token
+  end
+
+  create_table :user_comments_counts, force: true do |t|
+    t.integer :comments_count, default: 0
   end
 
   create_table :test_with_keyword_column_name, force: true do |t|


### PR DESCRIPTION
### Summary

Fix when multiple `belongs_to` maps to the same counter_cache column. 
In such situation `inverse_which_updates_counter_cache` may find the wrong relation which leads into an invalid increment of the counter_cache.

This is done by improving the inverse relation detection in 2 ways:
- by comparing `inverse.klass` with the current `active_record` (doesn't work for polymorphic)
- by relying on `inverse_of`

The above adjustments allows to correctly map the `inverse_which_updates_counter_cache` for both non-polymorphic/polymorphic relations.

Fixes #41250
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
