### PR TITLE
Fix timestamp type for sqlite3

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -71,6 +71,10 @@ module ActiveRecord
           end
         CODE
       end
+
+      def aliased_types(name, fallback)
+        "timestamp" == name ? :datetime : fallback
+      end
     end
 
     AddColumnDefinition = Struct.new(:column) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -271,7 +271,7 @@ module ActiveRecord
       def change_column(table_name, column_name, type, **options) #:nodoc:
         alter_table(table_name) do |definition|
           definition[column_name].instance_eval do
-            self.type = type
+            self.type = aliased_types(type.to_s, type)
             self.options.merge!(options)
           end
         end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -290,6 +290,28 @@ module ActiveRecord
         end
       end
 
+      def test_change_column_with_timestamp_type
+        connection.create_table :testings do |t|
+          t.column :foo, :datetime, null: false
+        end
+
+        connection.change_column :testings, :foo, :timestamp
+
+        column = connection.columns(:testings).find { |c| c.name == "foo" }
+
+        assert_equal :datetime, column.type
+
+        if current_adapter?(:PostgreSQLAdapter)
+          assert_equal "timestamp without time zone", column.sql_type
+        elsif current_adapter?(:Mysql2Adapter)
+          assert_equal "timestamp", column.sql_type
+        elsif current_adapter?(:OracleAdapter)
+          assert_equal "TIMESTAMP(6)", column.sql_type
+        else
+          assert_equal connection.type_to_sql("datetime"), column.sql_type
+        end
+      end
+
       def test_change_column_quotes_column_names
         connection.create_table :testings do |t|
           t.column :select, :string


### PR DESCRIPTION
According to the tests and code, sqlite3 converts the `timestamp` type
from `timestamp` to `datetime.` This can be seen in the change schema
tests.

This caused behavior to differ from `add_column` and `change_column`
because `change_column` wasn't calling `aliased_types`. The change here
fixes `change_column` so that it calls `aliased_types` the same way
`add_column` does.

Fixes #41310