### PR TITLE
Strip whitespace in disallow_raw_sql!

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Removing trailing whitespace when matching columns in
+    `ActiveRecord::Sanitization.disallow_raw_sql!`.
+
+    *Gannon McGibbon*, *Adrian Hirt*
+
 *   Expose a way for applications to set a `primary_abstract_class`
 
     Multiple database applications that use a primary abstract class that is not

--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -137,7 +137,7 @@ module ActiveRecord
       def disallow_raw_sql!(args, permit: connection.column_name_matcher) # :nodoc:
         unexpected = nil
         args.each do |arg|
-          next if arg.is_a?(Symbol) || Arel.arel_node?(arg) || permit.match?(arg.to_s)
+          next if arg.is_a?(Symbol) || Arel.arel_node?(arg) || permit.match?(arg.to_s.strip)
           (unexpected ||= []) << arg
         end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -914,6 +914,11 @@ class CalculationsTest < ActiveRecord::TestCase
       Account.order(:id).pluck("id, credit_limit")
   end
 
+  def test_pluck_with_line_endings
+    assert_equal [[1, 50], [2, 50], [3, 50], [4, 60], [5, 55], [6, 53]],
+      Account.order(:id).pluck("id, credit_limit\n")
+  end
+
   def test_pluck_with_multiple_columns_and_includes
     Company.create!(name: "test", contracts: [Contract.new(developer_id: 7)])
     companies_and_developers = Company.order("companies.id").includes(:contracts).pluck(:name, :developer_id)


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/41307

Support proper SQL parsing for multiple column strings in pluck.

Before:
```
User.pluck("first_name, last_name") #=> SELECT first_name, last_name FROM "users"
User.pluck("first_name, last_name\n") #=> ActiveRecord::UnknownAttributeReference
```

After:
```
User.pluck("first_name, last_name") #=> SELECT first_name, last_name FROM "users"
User.pluck("first_name, last_name\n") #=> SELECT first_name, last_name\n FROM "users"
```

Simply strips whitespace from the SQL sanitization checks of `pluck`.
