### PR TITLE
Re-add the strict loading example removed in the PR: #41210 [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -38,6 +38,7 @@
 
     ```ruby
     class User < ApplicationRecord
+      has_many :bookmarks
       has_many :articles, strict_loading: true
     end
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/41210/files#r570183256