### PR TITLE
Match the show action case in the new(updated) scaffold generator

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -15,6 +15,6 @@
 
 <% end -%>
   <p>
-    <%%= link_to "Show this <%= human_name %>", <%= singular_table_name %> %>
+    <%%= link_to "Show this <%= human_name.downcase %>", <%= singular_table_name %> %>
   </p>
 </div>


### PR DESCRIPTION
The updated scaffold generator adds a partial with show action. This PR just fixes and makes the button(link) text consistent with other actions added in the view by the generator.

Before:
![image](https://user-images.githubusercontent.com/7736232/106896052-0e7e5080-6717-11eb-99c5-f3761501ccae.png)


After:
![image](https://user-images.githubusercontent.com/7736232/106895929-dd9e1b80-6716-11eb-8285-af5d7c98701d.png)


cc/ @dhh 