### PR TITLE
Cast precision to int while rounding numbers in number helper

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -12,7 +12,9 @@ module ActiveSupport
         helper = RoundingHelper.new(options)
         rounded_number = helper.round(number)
 
-        if precision = options[:precision]
+        if options[:precision]
+          precision = options[:precision].to_i
+
           if options[:significant] && precision > 0
             digits = helper.digit_count(rounded_number)
             precision -= digits

--- a/activesupport/lib/active_support/number_helper/rounding_helper.rb
+++ b/activesupport/lib/active_support/number_helper/rounding_helper.rb
@@ -28,22 +28,22 @@ module ActiveSupport
           when Float, String
             BigDecimal(number.to_s)
           when Rational
-            BigDecimal(number, digit_count(number.to_i) + options[:precision])
+            BigDecimal(number, digit_count(number.to_i) + precision)
           else
             number.to_d
           end
         end
 
         def absolute_precision(number)
-          if significant && options[:precision] > 0
-            options[:precision] - digit_count(convert_to_decimal(number))
+          if options[:significant] && precision > 0
+            precision - digit_count(convert_to_decimal(number))
           else
-            options[:precision]
+            precision
           end
         end
 
-        def significant
-          options[:significant]
+        def precision
+          options[:precision] && options[:precision].to_i
         end
     end
   end

--- a/activesupport/test/number_helper_i18n_test.rb
+++ b/activesupport/test/number_helper_i18n_test.rb
@@ -11,11 +11,11 @@ module ActiveSupport
     def setup
       I18n.backend.store_translations "ts",
         number: {
-        format: { precision: 3, round_mode: :half_even, delimiter: ",", separator: ".", significant: false, strip_insignificant_zeros: false },
-        currency: { format: { unit: "&$", format: "%u - %n", negative_format: "(%u - %n)", precision: 2 } },
+        format: { precision: "3", round_mode: :half_even, delimiter: ",", separator: ".", significant: false, strip_insignificant_zeros: false },
+        currency: { format: { unit: "&$", format: "%u - %n", negative_format: "(%u - %n)", precision: "2" } },
         human: {
           format: {
-            precision: 2,
+            precision: "2",
             significant: true,
             strip_insignificant_zeros: true
           },
@@ -40,7 +40,7 @@ module ActiveSupport
             }
           }
         },
-        percentage: { format: { delimiter: "", precision: 2, strip_insignificant_zeros: true } },
+        percentage: { format: { delimiter: "", precision: "2", strip_insignificant_zeros: true } },
         precision: { format: { delimiter: "", significant: true } }
       },
       custom_units_for_number_to_human: { mili: "mm", centi: "cm", deci: "dm", unit: "m", ten: "dam", hundred: "hm", thousand: "km" }


### PR DESCRIPTION
Greetings,

when I open console and call `helper.number_to_human_size 13.megabytes` the result is:

```
ArgumentError: comparison of String with 0 failed
from /usr/share/gems/gems/activesupport-6.1.1/lib/active_support/number_helper/rounding_helper.rb:38:in `>'
```

I think it would be way more beautiful if it could just return `13 MB`.

Apparently all it comes down to is a fact that `NumberHelper` rounding code loads locale specific format options. So numbers (like precision) declared in locale file are stored as strings in options hash and in consequence comparisons of strings and integers happens.

I made PR that ensures number helper rounding uses precision cast to integer value.

Happens on activesupport 6.1.1 and 5.4.2.

Cheers
🍷 