### PR TITLE
Enumerable#in_order_of

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -520,10 +520,7 @@ module ActiveRecord
         result = except(:limit, :offset).where(primary_key => ids).records
 
         if result.size == ids.size
-          pk_type = @klass.type_for_attribute(primary_key)
-
-          records_by_id = result.index_by(&:id)
-          ids.map { |id| records_by_id.fetch(pk_type.cast(id)) }
+          result.in_order_of(:id, ids.map { |id| @klass.type_for_attribute(primary_key).cast(id) })
         else
           raise_record_not_found_exception!(ids, result.size, ids.size)
         end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `Enumerable#in_order_of` to put an Enumerable in a certain order by a key.
+
+    *DHH*
+
 *   `ActiveSupport::Inflector.camelize` behaves expected when provided a symbol `:upper` or `:lower` argument. Matches
     `String#camelize` behavior.
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -202,7 +202,7 @@ module Enumerable
   # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
   def in_order_of(key, series)
     indexed_by_key = index_by(&key)
-    series.filter_map { |s| indexed_by_key[s] }
+    indexed_by_key.values_at(*series).compact
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -197,6 +197,9 @@ module Enumerable
   #
   #   [ Person.find(5), Person.find(3), Person.find(1) ].in_order_of(:id, [ 1, 5, 3 ])
   #   => [ Person.find(1), Person.find(5), Person.find(3) ]
+  #
+  # If the +series+ include keys that have no corresponding element in the Enumerable, these are ignored.
+  # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
   def in_order_of(key, series)
     indexed_by_key = index_by(&key)
     series.map { |s| indexed_by_key[s] }.compact

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -202,7 +202,7 @@ module Enumerable
   # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
   def in_order_of(key, series)
     indexed_by_key = index_by(&key)
-    series.map { |s| indexed_by_key[s] }.compact
+    series.filter_map { |s| indexed_by_key[s] }
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -191,6 +191,16 @@ module Enumerable
   def compact_blank
     reject(&:blank?)
   end
+
+  # Returns a new +Array+ where the order has been set to that provided in the +series+, based on the +key+ of the
+  # objects in the original enumerable.
+  #
+  #   [ Person.find(5), Person.find(3), Person.find(1) ].in_order_of(:id, [ 1, 5, 3 ])
+  #   => [ Person.find(1), Person.find(5), Person.find(3) ]
+  def in_order_of(key, series)
+    indexed_by_key = index_by(&key)
+    series.map { |s| indexed_by_key[s] }.compact
+  end
 end
 
 class Hash

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -201,8 +201,7 @@ module Enumerable
   # If the +series+ include keys that have no corresponding element in the Enumerable, these are ignored.
   # If the Enumerable has additional elements that aren't named in the +series+, these are not included in the result.
   def in_order_of(key, series)
-    indexed_by_key = index_by(&key)
-    indexed_by_key.values_at(*series).compact
+    index_by(&key).values_at(*series).compact
   end
 end
 

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -289,4 +289,14 @@ class EnumerableTests < ActiveSupport::TestCase
     values = [ Payment.new(5), Payment.new(1), Payment.new(3) ]
     assert_equal [ Payment.new(1), Payment.new(5), Payment.new(3) ], values.in_order_of(:price, [ 1, 5, 3 ])
   end
+
+  def test_in_order_of_ignores_missing_series
+    values = [ Payment.new(5), Payment.new(1), Payment.new(3) ]
+    assert_equal [ Payment.new(1), Payment.new(5), Payment.new(3) ], values.in_order_of(:price, [ 1, 2, 4, 5, 3 ])
+  end
+
+  def test_in_order_of_drops_elements_not_named_in_series
+    values = [ Payment.new(5), Payment.new(1), Payment.new(3) ]
+    assert_equal [ Payment.new(1), Payment.new(5) ], values.in_order_of(:price, [ 1, 5 ])
+  end
 end

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -284,4 +284,9 @@ class EnumerableTests < ActiveSupport::TestCase
     values.compact_blank!
     assert_equal({ b: 1, f: true }, values)
   end
+
+  def test_in_order_of
+    values = [ Payment.new(5), Payment.new(1), Payment.new(3) ]
+    assert_equal [ Payment.new(1), Payment.new(5), Payment.new(3) ], values.in_order_of(:price, [ 1, 5, 3 ])
+  end
 end


### PR DESCRIPTION
ActiveRecord::Base#find will return records in the order of the primary keys used as arguments. This relies on an index_by/map combo, which is useful outside of just #find. This extracts that pattern as Enumerable#in_order_of.