### PR TITLE
Reduce memory allocations

### DIFF
--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -35,7 +35,7 @@ module ActionDispatch
           US_ASCII = Encoding::US_ASCII
           UTF_8    = Encoding::UTF_8
           EMPTY    = (+"").force_encoding(US_ASCII).freeze
-          DEC2HEX  = (0..255).map { |i| (ENCODE % i).force_encoding(US_ASCII) }.freeze
+          DEC2HEX  = (0..255).map { |i| (ENCODE % i).force_encoding(US_ASCII) }
 
           ALPHA = "a-zA-Z"
           DIGIT = "0-9"

--- a/actionpack/lib/action_dispatch/journey/router/utils.rb
+++ b/actionpack/lib/action_dispatch/journey/router/utils.rb
@@ -35,7 +35,7 @@ module ActionDispatch
           US_ASCII = Encoding::US_ASCII
           UTF_8    = Encoding::UTF_8
           EMPTY    = (+"").force_encoding(US_ASCII).freeze
-          DEC2HEX  = (0..255).to_a.map { |i| ENCODE % i }.map { |s| s.force_encoding(US_ASCII) }
+          DEC2HEX  = (0..255).map { |i| (ENCODE % i).force_encoding(US_ASCII) }.freeze
 
           ALPHA = "a-zA-Z"
           DIGIT = "0-9"


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Group sequential maps and remove unnecessary `to_a` in range to reduce memory allocations. I know this is pretty basic but I think anything helps!

### Other Information

A basic benchmark using [Benchmark.memory](https://github.com/michaelherold/benchmark-memory) (via [benchable](https://github.com/MatheusRich/benchable)):

```ruby
Benchable.bench(:memory) do
  bench 'to_a + map + map' do
    (0..255).to_a.map { |i| i.to_s }.map { |i| i.upcase }
  end

  bench 'only map' do
    (0..255).map { |i| i.to_s.upcase }
  end
end

# Calculating -------------------------------------
#     to_a + map + map    27.168k memsize (     0.000  retained)
#                        518.000  objects (     0.000  retained)
#                         50.000  strings (     0.000  retained)
#             only map    22.992k memsize (     0.000  retained)
#                        516.000  objects (     0.000  retained)
#                         50.000  strings (     0.000  retained)
# 
# Comparison:
#             only map:      22992 allocated
#     to_a + map + map:      27168 allocated - 1.18x more
```