### PR TITLE
Fix typo in deprecation warning

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -88,13 +88,13 @@ module ActionDispatch # :nodoc:
 
     def self.return_only_media_type_on_content_type=(*)
       ActiveSupport::Deprecation.warn(
-        ".return_only_media_type_on_content_type= is dreprecated with no replacement and will be removed in 7.0."
+        ".return_only_media_type_on_content_type= is deprecated with no replacement and will be removed in 7.0."
       )
     end
 
     def self.return_only_media_type_on_content_type
       ActiveSupport::Deprecation.warn(
-        ".return_only_media_type_on_content_type is dreprecated with no replacement and will be removed in 7.0."
+        ".return_only_media_type_on_content_type is deprecated with no replacement and will be removed in 7.0."
       )
     end
 


### PR DESCRIPTION
### Summary

👋 

`dreprecated` should've been `deprecated`.

✌️ 