### PR TITLE
Proposal / Discussion: Encode optional parameters metadata with signed_id

### DIFF
--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -65,6 +65,12 @@ module ActiveRecord
         end
       end
 
+      def signed_params(signed_id, purpose: nil)
+        if message = signed_id_verifier.verified(signed_id, purpose: combine_signed_id_purposes(purpose))
+          message.respond_to?(:fetch) ? message.fetch(:params) : nil
+        end
+      end
+
       # The verifier instance that all signed ids are generated and verified from. By default, it'll be initialized
       # with the class-level +signed_id_verifier_secret+, which within Rails comes from the
       # Rails.application.key_generator. By default, it's SHA256 for the digest and JSON for the serialization.


### PR DESCRIPTION
I'm not quite sure if this is a good idea or not, but I do know that the problem is real and it would be nice to have a convent way to include metadata in the same way that `signed_id` works.

Wondering if there's any interest in something like this. I'm happy to change the implementation if there are suggestions for better ways to solve the problem.

### Summary

__Motivation:__

I'm building a feature to allow a user to change their email address in our app. We require the user to confirm the email before completing the change, which is a perfect use case for `signed_id`, however to ensure that we update the email address to the correct value after confirmation we must: 1. Store the email on the server side before it is verified, 2. Request the email address from the user again, or 3. Include the email as a parameter in the confirmation link.

I'd prefer not to store non-confirmed email addresses in the db and only store the address after it is confirmed at the time the change takes effect. I don't want to make the user type the email twice (not to mention that we'd have no way to ensure that the email they type the second time is the one they confirmed).

The final option is to include the email address in the confirmation url. This seems the most obvious, however, if the email is included in the url, it's subject to tampering.

I could use an `ActiveSupport::MessageVerifier` directly, but then I need to figure out what secret I should use and I also lose the convenience that `signed_id` gives me by being built right in to the model that I want to modify.

I could also use `record.class.signed_id_verifier` to generate a second parameter and put that in my URL separately. This is just ok because I have two different ways of signing messages as a developer implementing the feature and it makes things more complex.

It would be ideal if `ActiveRecord::SignedId#signed_id` would allow me to include some metadata with the signed id.

This PR proposes adding an optional parameter `params` to `ActiveRecord::SignedId#signed_id`. In this proposal, `params` is `nil` by default. When it's `nil`, the behavior of `signed_id`, `find_signed` and `find_signed!` are unchanged. When `params` is passed to `ActiveRecord::SignedId#signed_id` the resulting message is a hash with two keys: `id` and `params`. `id` contains the resource id and params contains the value of the `params` parameter.

Now it is possible to include additional metadata with the generated `signed_id`. For the example above of requiring an email confirmation to change an email address, the usage would look something like this:

Optionally include metadata with the `signed_id`:
```ruby
message = current_user.signed_id(expires_in: 1.day, purpose: :change_email, params: { email: 'new-address@exmample.com' })
```

Nothing changes about how records are looked up with a `signed_id`:
```ruby
u = User.find_signed!(message)
```

Read the metadata and update the user:
```ruby
u.update(User.signed_params(message))
```