### PR TITLE
Remove confusing part of JavaScript guide regarding confirmations [ci skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -331,10 +331,6 @@ The attribute is also allowed on form submit buttons. This allows you to customi
 the warning message depending on the button which was activated. In this case,
 you should **not** have `data-confirm` on the form itself.
 
-The default confirmation uses a JavaScript confirm dialog, but you can customize
-this by listening to the `confirm` event, which is fired just before the confirmation
-window appears to the user. To cancel this default confirmation, have the confirm
-handler return `false`.
 
 ### Automatic disabling
 


### PR DESCRIPTION
### Summary

Working on a Rails application I came in touch with the confirmation functionality of `jquery-ujs`. In the corresponding rails guide is said:

> The default confirmation uses a JavaScript confirm dialog, but you can customize this by listening to the `confirm` event, which is fired just before the confirmation window appears to the user. To cancel this default confirmation, have the confirm handler return `false`.

Looking at the [source code of `jquery-ujs`](https://github.com/rails/jquery-ujs/blob/master/src/rails.js#L297)  I got totally confused: Setting up a listener on the `confirm` event and returning `false` is semantically equivalent to having an element whose default action (e. g. submit of a form) is not allowed. As a developer I have no chance to get this action allowed in this case by using `jquery-ujs` API / functions. I suggest to remove this confusing part of the guide, thus. Solving the issue requires custom javascript - independent from `jquery-ujs` default functionality.