### PR TITLE
Add `fetch_with_deferred_update` method to `ActiveSupport::Cache` for out-of-band cache updates

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,66 +1,73 @@
-- Add `:defer_update` option to `ActiveSupport::Cache.fetch`.
+*   Add `Cache#fetch_with_deferred_update` to allow out-of-band updates of cache values.
 
-  _Erik Brännström_
+    ```ruby
+    Rails.cache.fetch_with_deferred_update(cache_key, 5.minutes) do
+      HeavyComputationJob.perform_later cache_key
+    end
+    ```
 
-- Add `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted
-  elements of an enumerable.
+    *Erik Brännström*
 
-  ```ruby
-  payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
+*   Add `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted
+    elements of an enumerable.
 
-  payments.minimum(:price) # => 5
-  payments.maximum(:price) # => 20
-  ```
+    ```ruby
+    payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
 
-  This also allows passing enumerables to `fresh_when` and `stale?` in Action Controller.
-  See PR [#41404](https://github.com/rails/rails/pull/41404) for an example.
+    payments.minimum(:price) # => 5
+    payments.maximum(:price) # => 20
+    ```
 
-  _Ayrton De Craene_
+    This also allows passing enumerables to `fresh_when` and `stale?` in Action Controller.
+    See PR [#41404](https://github.com/rails/rails/pull/41404) for an example.
 
-- `ActiveSupport::Cache::MemCacheStore` now accepts an explicit `nil` for its `addresses` argument.
+    *Ayrton De Craene*
 
-  ```ruby
-  config.cache_store = :mem_cache_store, nil
+*   `ActiveSupport::Cache::MemCacheStore` now accepts an explicit `nil` for its `addresses` argument.
 
-  # is now equivalent to
+    ```ruby
+    config.cache_store = :mem_cache_store, nil
 
-  config.cache_store = :mem_cache_store
+    # is now equivalent to
 
-  # and is also equivalent to
+    config.cache_store = :mem_cache_store
 
-  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+    # and is also equivalent to
 
-  # which is the fallback behavior of Dalli
-  ```
+    config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"
 
-  This helps those migrating from `:dalli_store`, where an explicit `nil` was permitted.
+    # which is the fallback behavior of Dalli
+    ```
 
-  _Michael Overmeyer_
+    This helps those migrating from `:dalli_store`, where an explicit `nil` was permitted.
 
-- Add `Enumerable#in_order_of` to put an Enumerable in a certain order by a key.
+    *Michael Overmeyer*
 
-  _DHH_
+*   Add `Enumerable#in_order_of` to put an Enumerable in a certain order by a key.
 
-- `ActiveSupport::Inflector.camelize` behaves expected when provided a symbol `:upper` or `:lower` argument. Matches
-  `String#camelize` behavior.
+    *DHH*
 
-  _Alex Ghiculescu_
+*   `ActiveSupport::Inflector.camelize` behaves expected when provided a symbol `:upper` or `:lower` argument. Matches
+    `String#camelize` behavior.
 
-- Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
-  invalid.
+    *Alex Ghiculescu*
 
-  _Vipul A M_
+*   Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
+    invalid.
 
-- `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
+    *Vipul A M*
 
-  _Nathaniel Woodthorpe_
+*   `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
 
-- consume dalli’s `cache_nils` configuration as `ActiveSupport::Cache`'s `skip_nil` when using `MemCacheStore`.
+    *Nathaniel Woodthorpe*
 
-  _Ritikesh G_
+*   consume dalli’s `cache_nils` configuration as `ActiveSupport::Cache`'s `skip_nil` when using `MemCacheStore`.
 
-- add `RedisCacheStore#stats` method similar to `MemCacheStore#stats`. Calls `redis#info` internally.
+    *Ritikesh G*
 
-  _Ritikesh G_
+*   add `RedisCacheStore#stats` method similar to `MemCacheStore#stats`. Calls `redis#info` internally.
+
+    *Ritikesh G*
+
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,63 +1,66 @@
-*   Add `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted
-    elements of an enumerable.
+- Add `:defer_update` option to `ActiveSupport::Cache.fetch`.
 
-    ```ruby
-    payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
+  _Erik Brännström_
 
-    payments.minimum(:price) # => 5
-    payments.maximum(:price) # => 20
-    ```
+- Add `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted
+  elements of an enumerable.
 
-    This also allows passing enumerables to `fresh_when` and `stale?` in Action Controller.
-    See PR [#41404](https://github.com/rails/rails/pull/41404) for an example.
+  ```ruby
+  payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
 
-    *Ayrton De Craene*
+  payments.minimum(:price) # => 5
+  payments.maximum(:price) # => 20
+  ```
 
-*   `ActiveSupport::Cache::MemCacheStore` now accepts an explicit `nil` for its `addresses` argument.
+  This also allows passing enumerables to `fresh_when` and `stale?` in Action Controller.
+  See PR [#41404](https://github.com/rails/rails/pull/41404) for an example.
 
-    ```ruby
-    config.cache_store = :mem_cache_store, nil
+  _Ayrton De Craene_
 
-    # is now equivalent to
+- `ActiveSupport::Cache::MemCacheStore` now accepts an explicit `nil` for its `addresses` argument.
 
-    config.cache_store = :mem_cache_store
+  ```ruby
+  config.cache_store = :mem_cache_store, nil
 
-    # and is also equivalent to
+  # is now equivalent to
 
-    config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+  config.cache_store = :mem_cache_store
 
-    # which is the fallback behavior of Dalli
-    ```
+  # and is also equivalent to
 
-    This helps those migrating from `:dalli_store`, where an explicit `nil` was permitted.
+  config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"
 
-    *Michael Overmeyer*
+  # which is the fallback behavior of Dalli
+  ```
 
-*   Add `Enumerable#in_order_of` to put an Enumerable in a certain order by a key.
+  This helps those migrating from `:dalli_store`, where an explicit `nil` was permitted.
 
-    *DHH*
+  _Michael Overmeyer_
 
-*   `ActiveSupport::Inflector.camelize` behaves expected when provided a symbol `:upper` or `:lower` argument. Matches
-    `String#camelize` behavior.
+- Add `Enumerable#in_order_of` to put an Enumerable in a certain order by a key.
 
-    *Alex Ghiculescu*
+  _DHH_
 
-*   Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
-    invalid.
+- `ActiveSupport::Inflector.camelize` behaves expected when provided a symbol `:upper` or `:lower` argument. Matches
+  `String#camelize` behavior.
 
-    *Vipul A M*
+  _Alex Ghiculescu_
 
-*   `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
+- Raises an `ArgumentError` when the first argument of `ActiveSupport::Notification.subscribe` is
+  invalid.
 
-    *Nathaniel Woodthorpe*
+  _Vipul A M_
 
-*   consume dalli’s `cache_nils` configuration as `ActiveSupport::Cache`'s `skip_nil` when using `MemCacheStore`.
+- `HashWithIndifferentAccess#deep_transform_keys` now returns a `HashWithIndifferentAccess` instead of a `Hash`.
 
-    *Ritikesh G*
+  _Nathaniel Woodthorpe_
 
-*   add `RedisCacheStore#stats` method similar to `MemCacheStore#stats`. Calls `redis#info` internally.
+- consume dalli’s `cache_nils` configuration as `ActiveSupport::Cache`'s `skip_nil` when using `MemCacheStore`.
 
-    *Ritikesh G*
+  _Ritikesh G_
 
+- add `RedisCacheStore#stats` method similar to `MemCacheStore#stats`. Calls `redis#info` internally.
+
+  _Ritikesh G_
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,7 +1,7 @@
 *   Add `Cache#fetch_with_deferred_update` to allow out-of-band updates of cache values.
 
     ```ruby
-    Rails.cache.fetch_with_deferred_update(cache_key, 5.minutes) do
+    Rails.cache.fetch_with_deferred_update(cache_key, race_condition_ttl: 5.minutes) do
       HeavyComputationJob.perform_later cache_key
     end
     ```

--- a/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
@@ -15,13 +15,13 @@ module CacheStoreVersionBehavior
 
   def test_fetch_with_deferred_update_with_right_version_should_hit
     @cache.write("foo", "bar", version: 1)
-    @cache.fetch_with_deferred_update("foo", 5.minutes, version: 1) { }
+    @cache.fetch_with_deferred_update("foo", race_condition_ttl: 5.minutes, version: 1) { }
     assert_equal "bar", @cache.read("foo", version: 1)
   end
 
   def test_fetch_with_deferred_update_with_wrong_version_should_miss
     @cache.write("foo", "bar", version: 1)
-    @cache.fetch_with_deferred_update("foo", 5.minutes, version: 1) { }
+    @cache.fetch_with_deferred_update("foo", race_condition_ttl: 5.minutes, version: 1) { }
     assert_nil @cache.read("foo", version: 2)
   end
 

--- a/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
@@ -13,6 +13,18 @@ module CacheStoreVersionBehavior
     assert_nil @cache.read("foo", version: 2)
   end
 
+  def test_fetch_with_deferred_update_with_right_version_should_hit
+    @cache.write("foo", "bar", version: 1)
+    @cache.fetch_with_deferred_update("foo", 5.minutes, version: 1) { }
+    assert_equal "bar", @cache.read("foo", version: 1)
+  end
+
+  def test_fetch_with_deferred_update_with_wrong_version_should_miss
+    @cache.write("foo", "bar", version: 1)
+    @cache.fetch_with_deferred_update("foo", 5.minutes, version: 1) { }
+    assert_nil @cache.read("foo", version: 2)
+  end
+
   def test_read_with_right_version_should_hit
     @cache.write("foo", "bar", version: 1)
     assert_equal "bar", @cache.read("foo", version: 1)

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -13,7 +13,7 @@ module FailureSafetyBehavior
     @cache.write("foo", "bar")
 
     emulating_unavailability do |cache|
-      assert_nil cache.fetch_with_deferred_update("foo", 5.minutes) { }
+      assert_nil cache.fetch_with_deferred_update("foo", race_condition_ttl: 5.minutes) { }
     end
   end
 

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -9,6 +9,14 @@ module FailureSafetyBehavior
     end
   end
 
+  def test_fetch_with_deferred_update_read_failure_returns_nil
+    @cache.write("foo", "bar")
+
+    emulating_unavailability do |cache|
+      assert_nil cache.fetch_with_deferred_update("foo", 5.minutes) { }
+    end
+  end
+
   def test_fetch_read_failure_does_not_attempt_to_write
   end
 


### PR DESCRIPTION
### Summary

The new option specifies that `Cache.fetch` will call the given block and then return the expired value from the cache. This allows cache updates to be performed out-of-band, which can be useful for computation heavy operations.

An alternative would be to continuously update the cached value using a scheduled task, but that decouples the logic and will make it hard to know where the update takes place.

The following code would for example update the cache every 6 hours. Once the cache value expires, the block will be called which starts a job that will eventually update the cache with a new value. During the grace period specified by `race_condition_ttl` the expired value will be returned for all calls to `fetch`.
```ruby
Rails.cache.fetch(cache_key, expires_in: 6.hours, defer_update: true, race_condition_ttl: 300) do
  HeavyComputationJob.perform_later cache_key
end
```

I believe this could be useful for more people than just me, and I'm looking forward to get the input of the community! Also, this is my first PR to Rails! I've followed along the contribution guide, but if I missed something I will try to fix it ASAP!

### Discussion / Questions
**Option naming**
I have struggled somewhat with the naming of the option. I think `defer_update` is fairly good, but it could potentially imply that the block itself will be magically called asynchronously. I'm open for suggestions on this one!

**`fetch_multi`**
I have not implemented this behavior for `fetch_multi` because I didn't feel it made as much sense, but one could argue it makes the methods somewhat asymmetric. Not sure if that is a problem though.