### PR TITLE
Use String#grapheme_clusters instead of String#scan

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/filters.rb
+++ b/activesupport/lib/active_support/core_ext/string/filters.rb
@@ -106,7 +106,7 @@ class String
       self.class.new.tap do |cut|
         cut_at = truncate_at - omission.bytesize
 
-        scan(/\X/) do |grapheme|
+        each_grapheme_cluster do |grapheme|
           if cut.bytesize + grapheme.bytesize <= cut_at
             cut << grapheme
           else

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -126,16 +126,16 @@ module ActiveSupport #:nodoc:
 
       # Performs canonical decomposition on all the characters.
       #
-      #   'é'.length                         # => 2
-      #   'é'.mb_chars.decompose.to_s.length # => 3
+      #   'é'.length                         # => 1
+      #   'é'.mb_chars.decompose.to_s.length # => 2
       def decompose
         chars(Unicode.decompose(:canonical, @wrapped_string.codepoints.to_a).pack("U*"))
       end
 
       # Performs composition on all the characters.
       #
-      #   'é'.length                       # => 3
-      #   'é'.mb_chars.compose.to_s.length # => 2
+      #   'é'.length                       # => 1
+      #   'é'.mb_chars.compose.to_s.length # => 1
       def compose
         chars(Unicode.compose(@wrapped_string.codepoints.to_a).pack("U*"))
       end
@@ -143,7 +143,7 @@ module ActiveSupport #:nodoc:
       # Returns the number of grapheme clusters in the string.
       #
       #   'क्षि'.mb_chars.length   # => 4
-      #   'क्षि'.mb_chars.grapheme_length # => 3
+      #   'क्षि'.mb_chars.grapheme_length # => 2
       def grapheme_length
         @wrapped_string.grapheme_clusters.length
       end

--- a/activesupport/lib/active_support/multibyte/chars.rb
+++ b/activesupport/lib/active_support/multibyte/chars.rb
@@ -103,7 +103,7 @@ module ActiveSupport #:nodoc:
       #
       #   'Café'.mb_chars.reverse.to_s # => 'éfaC'
       def reverse
-        chars(@wrapped_string.scan(/\X/).reverse.join)
+        chars(@wrapped_string.grapheme_clusters.reverse.join)
       end
 
       # Limits the byte size of the string to a number of bytes without breaking
@@ -145,7 +145,7 @@ module ActiveSupport #:nodoc:
       #   'क्षि'.mb_chars.length   # => 4
       #   'क्षि'.mb_chars.grapheme_length # => 3
       def grapheme_length
-        @wrapped_string.scan(/\X/).length
+        @wrapped_string.grapheme_clusters.length
       end
 
       # Replaces all ISO-8859-1 or CP1252 characters by their UTF-8 equivalent


### PR DESCRIPTION
### Summary

Both methods were introduced in Ruby 2.5 and are faster than scanning
unicode graphemes with `String#scan`

```
Warming up --------------------------------------
           scan(/X/)    43.127k i/100ms
   grapheme_clusters   103.348k i/100ms
Calculating -------------------------------------
           scan(/X/)    427.853k (± 2.4%) i/s -      2.156M in   5.042967s
   grapheme_clusters      1.045M (± 0.8%) i/s -      5.271M in   5.042360s

Comparison:
   grapheme_clusters:  1045353.5 i/s
           scan(/X/):   427852.8 i/s - 2.44x  (± 0.00) slower
```

Benchmark script:

```ruby
require "minitest/autorun"
require "benchmark/ips"

class BugTest < Minitest::Test
  def test_grapheme_clusters
    string = [0x0924, 0x094D, 0x0930].pack("U*") # "त्र"
    # string = [0x000D, 0x000A].pack("U*") # CRLF
    # string = "こにちわ"

    assert string.scan(/\X/) == string.grapheme_clusters

    Benchmark.ips do |x|
      x.report("scan(/\X/)") do
        string.scan(/\X/)
      end

      x.report("grapheme_clusters") do
        string.grapheme_clusters
      end

      x.compare!
    end
  end
end
```

### Other Information

`String#grapheme_clusters` had a bug with CRLF, which was fixed in Ruby
2.6: https://bugs.ruby-lang.org/issues/15337

Now that Rails requires Ruby 2.7+, it shouldn't be an issue.

I also noticed some of the documentation examples for `ActiveSupport::Multibyte::Chars#compose` and `ActiveSupport::Multibyte::Chars#grapheme_length` are wrong. I'm not sure if I should fix them too.

```Ruby
# It says
'क्षि'.mb_chars.grapheme_length # => 3

# It returns
'क्षि'.mb_chars.grapheme_length # => 2
```