### PR TITLE
Add ActiveRecord::Base.connection.with_advisory_lock

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `ActiveRecord::Base.connection.with_advisory_lock`.
+
+    This method allow applications to obtain an exclusive session level advisory lock,
+    if available, for the duration of the block.
+
+    If another session already have the lock, the method will return `false` and the block will
+    not be executed.
+
+    *Rafael Mendonça França*
+
 *   Removing trailing whitespace when matching columns in
     `ActiveRecord::Sanitization.disallow_raw_sql!`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -436,11 +436,28 @@ module ActiveRecord
         supports_advisory_locks? && @advisory_locks_enabled
       end
 
+      # Obtains an exclusive session level advisory lock, if available, for the duration of the block.
+      #
+      # Returns +false+ without executing the block if the lock could not be obtained.
+      def with_advisory_lock(lock_id, timeout = 0)
+        lock_acquired = get_advisory_lock(lock_id, timeout)
+
+        if lock_acquired
+          yield
+        end
+
+        lock_acquired
+      ensure
+        if lock_acquired && !release_advisory_lock(lock_id)
+          raise ReleaseAdvisoryLockError
+        end
+      end
+
       # This is meant to be implemented by the adapters that support advisory
       # locks
       #
       # Return true if we got the lock, otherwise false
-      def get_advisory_lock(lock_id) # :nodoc:
+      def get_advisory_lock(lock_id, timeout = 0) # :nodoc:
       end
 
       # This is meant to be implemented by the adapters that support advisory

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -372,7 +372,7 @@ module ActiveRecord
         true
       end
 
-      def get_advisory_lock(lock_id) # :nodoc:
+      def get_advisory_lock(lock_id, timeout = 0) # :nodoc:
         unless lock_id.is_a?(Integer) && lock_id.bit_length <= 63
           raise(ArgumentError, "PostgreSQL requires advisory lock ids to be a signed 64 bit integer")
         end

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -396,6 +396,13 @@ module ActiveRecord
   class LockWaitTimeout < StatementInvalid
   end
 
+  # ReleaseAdvisoryLockError will be raised when a advisory lock fail to be released.
+  class ReleaseAdvisoryLockError < StatementInvalid
+    def initialize(message = "Failed to release advisory lock")
+      super
+    end
+  end
+
   # StatementTimeout will be raised when statement timeout exceeded.
   class StatementTimeout < QueryAborted
   end

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -201,8 +201,59 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
       "expected release_advisory_lock to return false when there was no lock to release"
   end
 
+  def test_with_advisory_lock
+    lock_name = "test lock'n'name"
+
+    got_lock = @connection.with_advisory_lock(lock_name) do
+      assert_equal test_lock_free(lock_name), false,
+      "expected the test advisory lock to be held but it wasn't"
+    end
+
+    assert got_lock, "get_advisory_lock should have returned true but it didn't"
+
+    assert test_lock_free(lock_name), "expected the test lock to be available after releasing"
+  end
+
+  def test_with_advisory_lock_with_an_already_existing_lock
+    lock_name = "test lock'n'name"
+
+    with_another_process_holding_lock(lock_name) do
+      assert_equal test_lock_free(lock_name), false, "expected the test advisory lock to be held but it wasn't"
+
+      got_lock = @connection.with_advisory_lock(lock_name) do
+        flunk "lock should not be acquired"
+      end
+
+      assert_equal test_lock_free(lock_name), false, "expected the test advisory lock to be held but it wasn't"
+
+      assert_not got_lock, "get_advisory_lock should have returned false but it didn't"
+    end
+  end
+
   private
     def test_lock_free(lock_name)
       @connection.select_value("SELECT IS_FREE_LOCK(#{@connection.quote(lock_name)})") == 1
+    end
+
+    def with_another_process_holding_lock(lock_id)
+      thread_lock = Concurrent::CountDownLatch.new
+      test_terminated = Concurrent::CountDownLatch.new
+
+      other_process = Thread.new do
+        conn = ActiveRecord::Base.connection_pool.checkout
+        conn.get_advisory_lock(lock_id)
+        thread_lock.count_down
+        test_terminated.wait # hold the lock open until we tested everything
+      ensure
+        conn.release_advisory_lock(lock_id)
+        ActiveRecord::Base.connection_pool.checkin(conn)
+      end
+
+      thread_lock.wait # wait until the 'other process' has the lock
+
+      yield
+
+      test_terminated.count_down
+      other_process.join
     end
 end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1016,10 +1016,7 @@ class MigrationTest < ActiveRecord::TestCase
         end
       end
 
-      assert_match(
-        /#{ActiveRecord::ConcurrentMigrationError::RELEASE_LOCK_FAILED_MESSAGE}/,
-        e.message
-      )
+      assert_match(/Failed to release advisory lock/, e.message)
     end
   end
 


### PR DESCRIPTION
This method allow applications to obtain an exclusive session level advisory lock, if available, for the duration of the block.

If another session already have the lock, the method will return `false` and the block will not be executed.