### PR TITLE
Remove unused requires on lib/active_record/associations.rb

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/enumerable"
-require "active_support/core_ext/string/conversions"
-
 module ActiveRecord
   class AssociationNotFoundError < ConfigurationError #:nodoc:
     attr_reader :record, :association_name

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/enumerable"
+
 module ActiveRecord
   module Associations
     # = Active Record Association Collection


### PR DESCRIPTION
### Summary

"active_support/core_ext/string/conversions" was added on https://github.com/rails/rails/commit/3f1cdb85b80b935791018e59161e527617af6f1f for `constantize`.

Also, "active_support/core_ext/string/conversions" does not define `constantize` anymore.

"active_support/core_ext/enumerable" was added on https://github.com/rails/rails/commit/ea290e77e6c50b13a0c9000eceaa5412de6918bc for `index_by`.

Both usages of `index_by` and `constantize` were removed at https://github.com/rails/rails/commit/52f8e4b9dae6137fcd95793dffc26ddff80b623e#diff-7c2226b7a4aa7f86f7d9e5e16b10686056c02efc725a60e378b5f9d7e52e8403

So looks like they are no longer used. 

