### PR TITLE
Update 6.1 release notes about size method rename in ActiveSupport::Cache::Entry [ci-skip]

### DIFF
--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -394,6 +394,8 @@ Please refer to the [Changelog][active-support] for detailed changes.
 
 ### Notable changes
 
+*  `ActiveSupport::Cache::Entry.size` has been renamed to `ActiveSupport::Cache::Entry.bytesize`.
+
 Active Job
 ----------
 


### PR DESCRIPTION
### Summary

Hello! We recently went through a Rails 6.x to 6.1.x upgrade at Netlify and, thanks to our test suite, it caught that the method `ActiveSupport::Cache::Entry.size` got renamed to `ActiveSupport::Cache::Entry.bytesize` in https://github.com/rails/rails/pull/39770.  This change wasn't in list of notable changes for `ActiveSupport`, so I wanted to get that added in case anyone else is running in to this issue.

This is also my first PR to rails, so if this needs to be added somewhere else, that is fine with me!
