### PR TITLE
Prevent app crash when postgres prepared query keys become out of sync with Rails

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Increment postgres prepared statement counter before making a prepared statement, so if the statement is aborted 
+    without Rails knowledge (e.g., if app gets kill -9d during long-running query or due to Rack::Timeout), app won't end 
+    up in perpetual crash state for being inconsistent with Postgres.
+
+    *wbharding*, *Martin Tepper*
+
 *   Switch to database adapter return type for `ActiveRecord::Calculations.calculate`
     when called with `:average` (aliased as `ActiveRecord::Calculations.average`)
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -228,11 +228,7 @@ module ActiveRecord
         end
 
         def next_key
-          "a#{@counter + 1}"
-        end
-
-        def []=(sql, key)
-          super.tap { @counter += 1 }
+          "a#{@counter += 1}"
         end
 
         private


### PR DESCRIPTION
### Summary

Increment @counter of prepared postgres statements prior to running the query, so if the query gets interrupted without Rails' knowledge we don't end up with a crashed app in a state of perpetual failure to prepare the next query.

### Other information

Based on this PR https://github.com/rails/rails/pull/41034 , thanks wbharding, I only streamlined the change and added a test.
Relates to #25827 . At my current project, we got hit pretty hard by the "prepared statement "ax" already exists" error and while I understand the reluctance to "fix" this in Rails, and we've already taken measures to stop the error at the root, I feel like not allowing connections to get completely stuck in a perpetual error is a good move in any case.

Any suggestions on improving the test welcome! My first time digging into the Rails (test-)code base.
