### PR TITLE
Remove redundant check for frozen keys on deep dup

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+++ b/activesupport/lib/active_support/core_ext/object/deep_dup.rb
@@ -43,7 +43,7 @@ class Hash
   def deep_dup
     hash = dup
     each_pair do |key, value|
-      if (::String === key && key.frozen?) || ::Symbol === key
+      if ::String === key || ::Symbol === key
         hash[key] = value.deep_dup
       else
         hash.delete(key)


### PR DESCRIPTION
As Hash keys are deduped and frozen when [stored](https://ruby-doc.org/core-2.7.0/Hash.html#method-i-5B-5D-3D).
It should be ok to skip the frozen check right now. It's also a follow up to https://github.com/rails/rails/pull/40033#discussion_r469942633 

I think it should be ok to remove the extra frozen check? If not, feel free to close this if it's not worth it. It does seem slightly faster without the extra check when applying the same benchmarks from #40033 

```ruby

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "activesupport", github: "rails/rails", branch: "main"
  gem "benchmark-ips"
  gem "benchmark-memory", require: "benchmark/memory"
end

require 'active_support/core_ext/object/deep_dup'

class Hash
  def deep_dup_skip_frozen_check
    hash = dup
    each_pair do |key, value|
      if ::String === key || ::Symbol === key
        hash[key] = value.deep_dup
      else
        hash.delete(key)
        hash[key.deep_dup] = value.deep_dup
      end
    end
    hash
  end
end

data_symbols = Hash[('aaa'..'zzz').map {|k| [k.to_sym, k]}]
data_strings = Hash[('aaa'..'zzz').map {|k| [k, k]}]

Benchmark.ips do |x|
  x.report("data_symbols.deep_dup")                  { data_symbols.deep_dup  }
  x.report("data_symbols.deep_dup_skip_frozen_check") { data_symbols.deep_dup_skip_frozen_check }
  x.compare!
end

Benchmark.ips do |x|
  x.report("data_strings.deep_dup")                  { data_strings.deep_dup  }
  x.report("data_strings.deep_dup_skip_frozen_check") { data_strings.deep_dup_skip_frozen_check }
  x.compare!
end

```

Result:

```
Warming up --------------------------------------
data_symbols.deep_dup
                        17.000  i/100ms
data_symbols.deep_dup_skip_frozen_check
                        18.000  i/100ms
Calculating -------------------------------------
data_symbols.deep_dup
                        177.807  (±12.4%) i/s -    884.000  in   5.067841s
data_symbols.deep_dup_skip_frozen_check
                        192.254  (± 3.1%) i/s -    972.000  in   5.060775s

Comparison:
data_symbols.deep_dup_skip_frozen_check:      192.3 i/s
data_symbols.deep_dup:      177.8 i/s - same-ish: difference falls within error

Warming up --------------------------------------
data_strings.deep_dup
                        18.000  i/100ms
data_strings.deep_dup_skip_frozen_check
                        19.000  i/100ms
Calculating -------------------------------------
data_strings.deep_dup
                        184.347  (± 2.7%) i/s -    936.000  in   5.081570s
data_strings.deep_dup_skip_frozen_check
                        197.728  (± 2.0%) i/s -      1.007k in   5.095122s

Comparison:
data_strings.deep_dup_skip_frozen_check:      197.7 i/s
data_strings.deep_dup:      184.3 i/s - 1.07x  (± 0.00) slower
```

Co-authored-by: Daniel Pepper <pepper.daniel@gmail.com>