### PR TITLE
Fix execution timing of `active_record.set_filter_attributes`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Run `initializer "active_record.set_filter_attributes"` after running the initialization process.
+
+    Fixed an issue where the `Rails.application.config.filter_parameters` set in `config/initializers/filter_parameter_logging.rb` was not inherited by the `filter_attributes` in `ActiveRecord`. This happens when `ActiveRecord` is loaded before `config/initializers/filter_parameters_logging.rb`.
+
+    *Shodai Suzuki*
+
 *   Removing trailing whitespace when matching columns in
     `ActiveRecord::Sanitization.disallow_raw_sql!`.
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -265,8 +265,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
     end
 
     initializer "active_record.set_filter_attributes" do
-      ActiveSupport.on_load(:active_record) do
-        self.filter_attributes += Rails.application.config.filter_parameters
+      config.after_initialize do
+        ActiveSupport.on_load(:active_record) do
+          self.filter_attributes += Rails.application.config.filter_parameters
+        end
       end
     end
 


### PR DESCRIPTION
### Summary
#### Issue
The `Rails.application.config.filter_parameters` set in `config/initializers/filter_parameter_logging.rb` is not carried over to the `filter_attributes` in`ActiveRecord`.

The current implementation uses `Rails.application.config.filter_parameters` to initialize`self.filter_attributes`.
The user sets `Rails.application.config.filter_parameters` in `config/initializers/filter_parameter_logging.rb`, but this is executed in the initialize process.

Therefore, when `initializer "active_record.set_filter_attributes"` is executed, the initialization process has not yet been executed, so `Rails.application.config.filter_parameters` result of is always `[]`.

#### Solution
I solved this problem by letting `initializer "active_record.set_filter_attributes"` run the initialization process.
