### PR TITLE
Use Enumerator#all? and Enumerator#any? with classes instead of iterations

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_negotiation.rb
+++ b/actionpack/lib/action_dispatch/http/mime_negotiation.rb
@@ -102,7 +102,7 @@ module ActionDispatch
       def variant=(variant)
         variant = Array(variant)
 
-        if variant.all? { |v| v.is_a?(Symbol) }
+        if variant.all?(Symbol)
           @variant = ActiveSupport::ArrayInquirer.new(variant)
         else
           raise ArgumentError, "request.variant must be set to a Symbol or an Array of Symbols."

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -392,9 +392,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   test "#dig converts hashes to parameters" do
     assert_kind_of ActionController::Parameters, @params.dig(:person)
     assert_kind_of ActionController::Parameters, @params.dig(:person, :addresses, 0)
-    assert @params.dig(:person, :addresses).all? do |value|
-      value.is_a?(ActionController::Parameters)
-    end
+    assert @params.dig(:person, :addresses).all?(ActionController::Parameters)
   end
 
   test "mutating #dig return value mutates underlying parameters" do

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -152,7 +152,7 @@ module ActiveModel
       def validate(*args, &block)
         options = args.extract_options!
 
-        if args.all? { |arg| arg.is_a?(Symbol) }
+        if args.all?(Symbol)
           options.each_key do |k|
             unless VALID_OPTIONS_FOR_VALIDATE.include?(k)
               raise ArgumentError.new("Unknown key: #{k.inspect}. Valid keys are: #{VALID_OPTIONS_FOR_VALIDATE.map(&:inspect).join(', ')}. Perhaps you meant to call `validates` instead of `validate`?")

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -75,8 +75,7 @@ class ValidatesWithTest < ActiveModel::TestCase
     validator = Minitest::Mock.new
     validator.expect(:new, validator, [{ foo: :bar, if: :condition_is_true, class: Topic }])
     validator.expect(:validate, nil, [topic])
-    validator.expect(:is_a?, false, [Symbol])
-    validator.expect(:is_a?, false, [String])
+    validator.expect(:is_a?, false, [String]) # Call run by ActiveSupport::Callbacks::Callback.build
 
     Topic.validates_with(validator, if: :condition_is_true, foo: :bar)
     assert_predicate topic, :valid?

--- a/activerecord/lib/active_record/aggregations.rb
+++ b/activerecord/lib/active_record/aggregations.rb
@@ -264,7 +264,7 @@ module ActiveRecord
               end
 
               hash_from_multiparameter_assignment = part.is_a?(Hash) &&
-                part.each_key.all? { |k| k.is_a?(Integer) }
+                part.keys.all?(Integer)
               if hash_from_multiparameter_assignment
                 raise ArgumentError unless part.size == part.each_key.max
                 part = klass.new(*part.sort.map(&:last))

--- a/activerecord/lib/active_record/attribute_assignment.rb
+++ b/activerecord/lib/active_record/attribute_assignment.rb
@@ -46,7 +46,7 @@ module ActiveRecord
       def execute_callstack_for_multiparameter_attributes(callstack)
         errors = []
         callstack.each do |name, values_with_empty_parameters|
-          if values_with_empty_parameters.each_value.all?(&:nil?)
+          if values_with_empty_parameters.each_value.all?(NilClass)
             values = nil
           else
             values = values_with_empty_parameters

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -166,7 +166,7 @@ module ActiveRecord
         return configs if configs.is_a?(Array)
 
         db_configs = configs.flat_map do |env_name, config|
-          if config.is_a?(Hash) && config.all? { |_, v| v.is_a?(Hash) }
+          if config.is_a?(Hash) && config.values.all?(Hash)
             walk_configs(env_name.to_s, config)
           else
             build_db_config_from_raw_config(env_name.to_s, "primary", config)

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -264,7 +264,7 @@ module ActiveRecord
       end
 
       def assert_valid_enum_definition_values(values)
-        unless values.is_a?(Hash) || values.all? { |v| v.is_a?(Symbol) } || values.all? { |v| v.is_a?(String) }
+        unless values.is_a?(Hash) || values.all?(Symbol) || values.all?(String)
           error_message = <<~MSG
             Enum values #{values} must be either a hash, an array of symbols, or an array of strings.
           MSG

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -260,7 +260,7 @@ class ReflectionTest < ActiveRecord::TestCase
   end
 
   def test_reflections_should_return_keys_as_strings
-    assert Category.reflections.keys.all? { |key| key.is_a? String }, "Model.reflections is expected to return string for keys"
+    assert Category.reflections.keys.all?(String), "Model.reflections is expected to return string for keys"
   end
 
   def test_has_and_belongs_to_many_reflection

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -356,7 +356,7 @@ module ActiveSupport
             return EMPTY_ARRAY if conditionals.blank?
 
             conditionals = Array(conditionals)
-            if conditionals.any? { |c| c.is_a?(String) }
+            if conditionals.any?(String)
               raise ArgumentError, <<-MSG.squish
                 Passing string to be evaluated in :if and :unless conditional
                 options is not supported. Pass a symbol for an instance method,

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -187,7 +187,7 @@ class Array
     options[:indent]  ||= 2
     options[:builder] ||= Builder::XmlMarkup.new(indent: options[:indent])
     options[:root]    ||= \
-      if first.class != Hash && all? { |e| e.is_a?(first.class) }
+      if first.class != Hash && all?(first.class)
         underscored = ActiveSupport::Inflector.underscore(first.class.name)
         ActiveSupport::Inflector.pluralize(underscored).tr("/", "_")
       else

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -20,7 +20,7 @@ module ActiveSupport
         def assert_called_with(object, method_name, args, returns: nil)
           mock = Minitest::Mock.new
 
-          if args.all? { |arg| arg.is_a?(Array) }
+          if args.all?(Array)
             args.each { |arg| mock.expect(:call, returns, arg) }
           else
             mock.expect(:call, returns, args)


### PR DESCRIPTION
### Summary

These methods have changed in Ruby 2.5 to be more akin to grep:

https://bugs.ruby-lang.org/issues/11286

Using classes seems to be faster (and a bit more expressive) than iterating over
the collection items:

```
Warming up --------------------------------------
    #all? with class   504.000  i/100ms
     #all? with proc   189.000  i/100ms
Calculating -------------------------------------
    #all? with class      4.960k (± 1.6%) i/s -     25.200k in   5.082049s
     #all? with proc      1.874k (± 2.8%) i/s -      9.450k in   5.047866s

Comparison:
    #all? with class:     4959.9 i/s
     #all? with proc:     1873.8 i/s - 2.65x  (± 0.00) slower
```

Benchmark script:

```ruby
require "minitest/autorun"
require "benchmark/ips"

class BugTest < Minitest::Test
  def test_enumerators_with_classes
    arr = (1..10000).to_a << nil

    assert_equal arr.all?(Integer), arr.all? { |v| v.is_a?(Integer) }

    Benchmark.ips do |x|
      x.report("#all? with class") do
        arr.all?(Integer)
      end

      x.report("#all? with proc") do
        arr.all? { |v| v.is_a?(Integer) }
      end

      x.compare!
    end
  end
end
```

### Other Information

There are other cases where this can apply i.e. `array.none?(/regexp/)`, but it seems to be slower than iterations.

cc @kaspth 