### PR TITLE
Remove redundant requires from some AR files

### DIFF
--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-require "erb"
-require "yaml"
 require "zlib"
-require "set"
-require "active_support/dependencies"
 require "active_support/core_ext/digest/uuid"
 require "active_record/fixture_set/file"
 require "active_record/fixture_set/render_context"

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -33,7 +33,6 @@ require "models/vertex"
 require "models/publisher"
 require "models/publisher/article"
 require "models/publisher/magazine"
-require "active_support/core_ext/string/conversions"
 
 class ProjectWithAfterCreateHook < ActiveRecord::Base
   self.table_name = "projects"

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -6,8 +6,6 @@ require "stringio"
 
 require "active_record"
 require "cases/test_case"
-require "active_support/dependencies"
-require "active_support/logger"
 require "active_support/core_ext/kernel/singleton_class"
 
 require "support/config"


### PR DESCRIPTION
### Summary

In this Pull Request some redundant `require`s in `activerecord` have been removed.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
