### PR TITLE
Remove checks for Module#method_defined? arity

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -155,20 +155,6 @@ module ActiveRecord
 
     module ClassMethods # :nodoc:
       private
-        if Module.method(:method_defined?).arity == 1 # MRI 2.5 and older
-          using Module.new {
-            refine Module do
-              def method_defined?(method, inherit = true)
-                if inherit
-                  super(method)
-                else
-                  instance_methods(false).include?(method.to_sym)
-                end
-              end
-            end
-          }
-        end
-
         def define_non_cyclic_method(name, &block)
           return if method_defined?(name, false)
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -844,18 +844,12 @@ module ActiveSupport
             __callbacks[name.to_sym]
           end
 
-          if Module.instance_method(:method_defined?).arity == 1 # Ruby 2.5 and older
-            def set_callbacks(name, callbacks) # :nodoc:
-              self.__callbacks = __callbacks.merge(name.to_sym => callbacks)
+          def set_callbacks(name, callbacks) # :nodoc:
+            unless singleton_class.method_defined?(:__callbacks, false)
+              self.__callbacks = __callbacks.dup
             end
-          else # Ruby 2.6 and newer
-            def set_callbacks(name, callbacks) # :nodoc:
-              unless singleton_class.method_defined?(:__callbacks, false)
-                self.__callbacks = __callbacks.dup
-              end
-              self.__callbacks[name.to_sym] = callbacks
-              self.__callbacks
-            end
+            self.__callbacks[name.to_sym] = callbacks
+            self.__callbacks
           end
       end
   end


### PR DESCRIPTION
### Summary

The method signature has changed in Ruby 2.6:

https://bugs.ruby-lang.org/issues/14944

Rails 7.0 requires Ruby 2.7+ now and these checks/monkey patches
shouldn't be needed anymore.