### PR TITLE
Removes Symbol#start_with? and Symbol#end_with? since they are defined in Ruby 2.7

### DIFF
--- a/activesupport/lib/active_support/core_ext/symbol/starts_ends_with.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/starts_ends_with.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 class Symbol
-  def start_with?(*prefixes)
-    to_s.start_with?(*prefixes)
-  end unless method_defined?(:start_with?)
-
-  def end_with?(*suffixes)
-    to_s.end_with?(*suffixes)
-  end unless method_defined?(:end_with?)
-
   alias :starts_with? :start_with?
   alias :ends_with? :end_with?
 end

--- a/activesupport/test/core_ext/symbol_ext_test.rb
+++ b/activesupport/test/core_ext/symbol_ext_test.rb
@@ -4,21 +4,6 @@ require_relative "../abstract_unit"
 require "active_support/core_ext/symbol"
 
 class SymbolStartsEndsWithTest < ActiveSupport::TestCase
-  def test_start_end_with
-    s = :hello
-    assert s.start_with?("h")
-    assert s.start_with?("hel")
-    assert_not s.start_with?("el")
-    assert s.start_with?("he", "lo")
-    assert_not s.start_with?("el", "lo")
-
-    assert s.end_with?("o")
-    assert s.end_with?("lo")
-    assert_not s.end_with?("el")
-    assert s.end_with?("he", "lo")
-    assert_not s.end_with?("he", "ll")
-  end
-
   def test_starts_ends_with_alias
     s = :hello
     assert s.starts_with?("h")


### PR DESCRIPTION
### Summary

This commit just removes the implementation of those methods since Ruby 2.7 is required now.
