### PR TITLE
Allow `build` multiple records even on non association relation

### DIFF
--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -27,16 +27,6 @@ module ActiveRecord
       RUBY
     end
 
-    def build(attributes = nil, &block)
-      if attributes.is_a?(Array)
-        attributes.collect { |attr| build(attr, &block) }
-      else
-        block = current_scope_restoring_block(&block)
-        scoping { _new(attributes, &block) }
-      end
-    end
-    alias new build
-
     private
       def _new(attributes, &block)
         @association.build(attributes, &block)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -67,8 +67,12 @@ module ActiveRecord
     #   user = users.new { |user| user.name = 'Oscar' }
     #   user.name # => Oscar
     def new(attributes = nil, &block)
-      block = current_scope_restoring_block(&block)
-      scoping { _new(attributes, &block) }
+      if attributes.is_a?(Array)
+        attributes.collect { |attr| new(attr, &block) }
+      else
+        block = current_scope_restoring_block(&block)
+        scoping { _new(attributes, &block) }
+      end
     end
     alias build new
 

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1278,6 +1278,34 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal post, comment.post
   end
 
+  def test_new_with_array
+    green_birds = Bird.where(color: "green").new([{ name: "parrot" }, { name: "canary" }])
+    assert_equal ["parrot", "canary"], green_birds.map(&:name)
+    assert_equal ["green", "green"], green_birds.map(&:color)
+    green_birds.each { |bird| assert_not_predicate bird, :persisted? }
+  end
+
+  def test_build_with_array
+    green_birds = Bird.where(color: "green").build([{ name: "parrot" }, { name: "canary" }])
+    assert_equal ["parrot", "canary"], green_birds.map(&:name)
+    assert_equal ["green", "green"], green_birds.map(&:color)
+    green_birds.each { |bird| assert_not_predicate bird, :persisted? }
+  end
+
+  def test_create_with_array
+    green_birds = Bird.where(color: "green").create([{ name: "parrot" }, { name: "canary" }])
+    assert_equal ["parrot", "canary"], green_birds.map(&:name)
+    assert_equal ["green", "green"], green_birds.map(&:color)
+    green_birds.each { |bird| assert_predicate bird, :persisted? }
+  end
+
+  def test_create_bang_with_array
+    green_birds = Bird.where(color: "green").create!([{ name: "parrot" }, { name: "canary" }])
+    assert_equal ["parrot", "canary"], green_birds.map(&:name)
+    assert_equal ["green", "green"], green_birds.map(&:color)
+    green_birds.each { |bird| assert_predicate bird, :persisted? }
+  end
+
   def test_first_or_create
     parrot = Bird.where(color: "green").first_or_create(name: "parrot")
     assert_kind_of Bird, parrot


### PR DESCRIPTION
Follow up to #41342.

The reason why the problem of #41342 occurred is that unlike `create`,
`build` did not support the creation of multiple records, so it did not
address the problem.

It is weird that `post.commnets.where(foo: "bar").build([obj1, obj2])`
is allowed but `Comment.where(foo: "bar").build([obj1, obj2])` is not
allowed.

To avoid the confusion, it allows `build` multiple records even on non
association relation.
