### PR TITLE
Allow passing `URI` (or whatever responds to `#to_s`) into `redirect_to`

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -106,7 +106,7 @@ module ActionController
       # See https://tools.ietf.org/html/rfc3986#section-3.1
       # The protocol relative scheme starts with a double slash "//".
       when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
-        options
+        options.to_s
       when String
         request.protocol + request.host_with_port + options
       when Proc

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -96,6 +96,10 @@ class RedirectController < ActionController::Base
     redirect_to "http://www.rubyonrails.org/"
   end
 
+  def redirect_to_uri_url
+    redirect_to URI.parse("http://www.rubyonrails.org/")
+  end
+
   def redirect_to_url_with_unescaped_query_string
     redirect_to "http://example.com/query?status=new"
   end
@@ -253,6 +257,12 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_url
     get :redirect_to_url
+    assert_response :redirect
+    assert_redirected_to "http://www.rubyonrails.org/"
+  end
+
+  def test_redirect_to_uri_url
+    get :redirect_to_uri_url
     assert_response :redirect
     assert_redirected_to "http://www.rubyonrails.org/"
   end


### PR DESCRIPTION
### Summary

Right now if URI is passed to `redirect_to` it can match `when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i` (due to implicit typecast), we're doing `URI#delete("\0\r\n")` and getting `NoMethodError`. Fix it.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
