### PR TITLE
Handle nil key for MemCacheStore#normalize_key

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -188,10 +188,12 @@ module ActiveSupport
         # before applying the regular expression to ensure we are escaping all
         # characters properly.
         def normalize_key(key, options)
-          key = super.dup
-          key = key.force_encoding(Encoding::ASCII_8BIT)
-          key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
-          key = "#{key[0, 212]}:hash:#{ActiveSupport::Digest.hexdigest(key)}" if key.size > 250
+          key = super
+          if key
+            key = key.dup.force_encoding(Encoding::ASCII_8BIT)
+            key = key.gsub(ESCAPE_KEY_CHARS) { |match| "%#{match.getbyte(0).to_s(16).upcase}" }
+            key = "#{key[0, 213]}:md5:#{ActiveSupport::Digest.hexdigest(key)}" if key.size > 250
+          end
           key
         end
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -45,7 +45,6 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     @namespace = "test-#{SecureRandom.hex}"
     @cache = lookup_store(expires_in: 60)
     @peek = lookup_store
-    @cache.silence!
     @cache.logger = ActiveSupport::Logger.new(File::NULL)
   end
 


### PR DESCRIPTION
Closes #41352  

There is already an existing test case for this 
https://github.com/rails/rails/blob/8db3fefac00eb642357656d792516ffba1d25751/activesupport/test/cache/behaviors/cache_store_behavior.rb#L113-L117

But it passed for memcached because of `@store.silence!` and the relevant branch with a bug was skipped.