### PR TITLE
Reorder column definition constraints to match MySQL documentation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -135,11 +135,11 @@ module ActiveRecord
         end
 
         def add_column_options!(sql, options)
-          sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
           # must explicitly check for :null to allow change_column to work on migrations
           if options[:null] == false
             sql << " NOT NULL"
           end
+          sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)
           if options[:auto_increment] == true
             sql << " AUTO_INCREMENT"
           end

--- a/activerecord/test/cases/column_definition_test.rb
+++ b/activerecord/test/cases/column_definition_test.rb
@@ -27,7 +27,7 @@ module ActiveRecord
 
       def test_should_specify_not_null_if_null_option_is_false
         column_def = ColumnDefinition.new("title", "string", limit: 20, default: "Hello", null: false)
-        assert_equal "title varchar(20) DEFAULT 'Hello' NOT NULL", @viz.accept(column_def)
+        assert_equal "title varchar(20) NOT NULL DEFAULT 'Hello'", @viz.accept(column_def)
       end
     end
   end


### PR DESCRIPTION
### Summary
The MySQL documentation at https://dev.mysql.com/doc/refman/5.7/en/create-table.html specifies that `NOT NULL` constraint should come before the `DEFAULT` constraint, even though both orderings work.

This PR reorders the column definition constraints to match the MySQL documentation