### PR TITLE
Allow addresses to support `nil` values

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   `ActiveSupport::Cache::MemCacheStore` now accepts an explicit `nil` for its `addresses` argument.
+
+    ```ruby
+    config.cache_store = :mem_cache_store, nil
+
+    # is now equivalent to
+
+    config.cache_store = :mem_cache_store
+
+    # and is also equivalent to
+
+    config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"] || "localhost:11211"
+
+    # which is the fallback behavior of Dalli
+    ```
+
+    This helps those migrating from `:dalli_store`, where an explicit `nil` was permitted.
+
+    *Michael Overmeyer*
+
 *   Add `Enumerable#in_order_of` to put an Enumerable in a certain order by a key.
 
     *DHH*

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -64,7 +64,7 @@ module ActiveSupport
       def self.build_mem_cache(*addresses) # :nodoc:
         addresses = addresses.flatten
         options = addresses.extract_options!
-        addresses = nil if addresses.empty?
+        addresses = nil if addresses.compact.empty?
         pool_options = retrieve_pool_options(options)
 
         if pool_options.empty?

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -197,6 +197,14 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_falls_back_to_localhost_if_address_provided_as_nil
+    with_memcache_servers_environment_variable(nil) do
+      cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, nil)
+
+      assert_equal ["127.0.0.1:11211"], servers(cache)
+    end
+  end
+
   def test_falls_back_to_localhost_if_no_address_provided_and_memcache_servers_defined
     with_memcache_servers_environment_variable("custom_host") do
       cache = ActiveSupport::Cache.lookup_store(:mem_cache_store)


### PR DESCRIPTION
### Summary

Users of `:dalli_store` may have been passing an explicit `nil` parameter for the servers:

```ruby
config.cache_store = :dalli_cache, nil, { expires_in: 2.hour, compress: true }
```

If they simply changed `:dalli_cache` and `:mem_cache_store`, the existing code passes `addresses = [nil]` to Dalli (instead of `nil`), which cause exceptions when people try to access the cache:

```
> Rails.cache.fetch('foo')
NoMethodError: undefined method `match' for nil:NilClass
```

This change allows users to continue passing the explicit `nil`, making migrations from `:dalli_store` to `:mem_cache_store` simpler.