### PR TITLE
Fix the underscore inflector optimization

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -97,13 +97,7 @@ module ActiveSupport
       return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
       word = camel_cased_word.to_s.gsub("::", "/")
       word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
-      word.gsub!(/([A-Z\d]+)([A-Z][a-z])|([a-z\d])([A-Z])/) do
-        if first_match = $1
-          first_match << "_" << $2
-        else
-          $3 << "_" << $4
-        end
-      end
+      word.gsub!(/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }
       word.tr!("-", "_")
       word.downcase!
       word

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -119,7 +119,8 @@ module InflectorTestCases
     "Product"               => "product",
     "SpecialGuest"          => "special_guest",
     "ApplicationController" => "application_controller",
-    "Area51Controller"      => "area51_controller"
+    "Area51Controller"      => "area51_controller",
+    "AppCDir"               => "app_c_dir"
   }
 
   UnderscoreToLowerCamel = {


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/41382

It introduced a regression for strings with a group of exactly two capital letters.

~~I'm afraid there's now way to handle this case with a single pass `gsub`, as in such case the two sides of the regexp need to match the same character.~~

Thanks to @matthewd's suggestion, we can actually use lookahead to fix the problem while also gaining a tiny bit more performance.

~~This reverts commit 58147cd2b494beec92f810a40dc9a736ff688a01.~~

cc @eileencodes @kaspth @leequarella 