### PR TITLE
Fix autoload for NullPool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -30,10 +30,14 @@ module ActiveRecord
       autoload :DatabaseStatements
       autoload :DatabaseLimits
       autoload :Quoting
-      autoload :ConnectionPool
       autoload :ConnectionHandler
       autoload :QueryCache
       autoload :Savepoints
+    end
+
+    autoload_at "active_record/connection_adapters/abstract/connection_pool" do
+      autoload :ConnectionPool
+      autoload :NullPool
     end
 
     autoload_at "active_record/connection_adapters/abstract/transaction" do


### PR DESCRIPTION
In external adapters that super to `initialize` in `ConnectionHandler`
may not have loaded `ConnectionPool` and therefore don't have
`NullPool`. In this case running tests for our internal mysql adapter at
GitHub we saw the following:

```
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::NullPool
```

In order to fix this I moved the autoload for `ConnectionPool` to inclue
`NullPool`. This doesn't fail on AR tests because we always have a
connection established which means that the `ConnectionPool` was loaded
before we do the adapter tests. In the gem we have, we don't have a
connection separate from the adpater so the connection pool is never
loaded.

The behavior change was introduced by #41339