### PR TITLE
Batch Preloader::Association queries having similar queries

### DIFF
--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -40,6 +40,7 @@ class Post < ActiveRecord::Base
   belongs_to :author_with_posts, -> { includes(:posts) }, class_name: "Author", foreign_key: :author_id
   belongs_to :author_with_address, -> { includes(:author_address) }, class_name: "Author", foreign_key: :author_id
   belongs_to :author_with_select, -> { select(:id) }, class_name: "Author", foreign_key: :author_id
+  belongs_to :author_with_the_letter_a, -> { where("name LIKE '%a%'") }, class_name: "Author", foreign_key: :author_id
 
   def first_comment
     super.body
@@ -367,4 +368,10 @@ class FakeKlass
   end
 
   inherited self
+end
+
+class Postesque < ActiveRecord::Base
+  belongs_to :author, class_name: "Author", foreign_key: :author_name, primary_key: :name
+  belongs_to :author_with_address, class_name: "Author", foreign_key: :author_id
+  belongs_to :author_with_the_letter_a, class_name: "Author", foreign_key: :author_id
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -805,6 +805,11 @@ ActiveRecord::Schema.define do
     t.integer :tags_with_nullify_count, default: 0
   end
 
+  create_table :postesques, force: true do |t|
+    t.string :author_name
+    t.string :author_id
+  end
+
   create_table :serialized_posts, force: true do |t|
     t.integer :author_id
     t.string :title, null: false


### PR DESCRIPTION
### Summary

This pull request optimizes the Preloader to execute fewer queries when loading associations. It addresses two cases: 1) loading associations of a single model on differing parent models, and 2) loading one or more associations that are backed by the same table. We can batch these queries.

As a concrete example,

```ruby
# Case 1: different parent models, same association
ActiveRecord::Associations::Preloader.new(records: [book, post], associations: :author).call

# Case 2: same parent models, > 1 association backed by same table
ActiveRecord::Associations::Preloader.new(records: favorites, associations: [:author, :favorite_author]).call
```

Currently, two identical queries are run in both cases:

```SQL
SELECT "authors".* FROM "authors" WHERE "authors"."id" = ?
SELECT "authors".* FROM "authors" WHERE "authors"."id" = ?
```

This change groups queries that would have executed the same SQL, leading to the above query being executed only once. It does this by building all the loaders, grouping them by scope, then feeding the batch-loaded records into the `Preloader::Association` to override the prior loading logic.

This PR currently only batches similar parent level queries and does not address through associations. I.e. `Preloader.new(records: favorites, associations: [{ author: :comments }, { favorite_author: :comments }]).call` still executes two queries against the comments table. Child queries need to be handled slightly differently due to the recursive nature of nested associations. To be addressed in a follow up.

Co-authored-by @jhawthorn @eileencodes

### Other Information

Benchmark script and report below. Significant improvement when queries are grouped (12.642k in 5.044390s to 16.200k in 5.049223s or ~20% reduction). Slightly slower on the control query but this expected due to the added call to `to_sql` which is needed to determine which loaders to group.

```ruby
require "active_record"
require "benchmark/ips"

ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
{
  'authors' => 'name VARCHAR, created_at DATETIME, updated_at DATETIME',
  'articles' => 'author_id INTEGER, body VARCHAR, created_at DATETIME, updated_at DATETIME',
  'books' => 'author_id INTEGER, title VARCHAR, created_at DATETIME, updated_at DATETIME'
}.each do |table, columns|
  ActiveRecord::Base.connection.execute "CREATE TABLE #{table} (id INTEGER NOT NULL PRIMARY KEY, #{columns})"
end

class Author < ActiveRecord::Base
  has_many :articles
  has_many :books
end

class Article < ActiveRecord::Base
  belongs_to :author
end

class Book < ActiveRecord::Base
  belongs_to :author
end

author = Author.create!(name: "jhawthorn")
5.times { |i| Article.create!(author: author, body: "Hello, world.") }
5.times { |i| Book.create!(author: author, title: "Book #{i}") }

article = Article.first
book = Book.first
two_articles = Article.first(2)

Benchmark.ips do |x|
  x.report "Different sources" do
    article.association(:author).reset
    book.association(:author).reset
    
    ActiveRecord::Associations::Preloader.new(records: [article, book], associations: :author).call
  end
  x.report "Same source" do
    two_articles.each { |a| a.association(:author).reset }
    
    ActiveRecord::Associations::Preloader.new(records: two_articles, associations: :author).call
  end
end

```

Before:

```
$ bundle exec ruby benchmark.rb
Warming up --------------------------------------
   Different sources   258.000  i/100ms
         Same source   500.000  i/100ms
Calculating -------------------------------------
   Different sources      2.510k (± 3.5%) i/s -     12.642k in   5.044390s
         Same source      4.904k (± 4.0%) i/s -     24.500k in   5.004911s
```

After

```
$ bundle exec ruby benchmark.rb
Warming up --------------------------------------
   Different sources   324.000  i/100ms
         Same source   406.000  i/100ms
Calculating -------------------------------------
   Different sources      3.211k (± 2.5%) i/s -     16.200k in   5.049223s
         Same source      4.032k (± 2.7%) i/s -     20.300k in   5.038256s
```