### PR TITLE
Allow passing anything with `#to_str` into `redirect_to`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -48,6 +48,10 @@
 
     *Janko Marohnić*
 
+*   Allow anything with `#to_str` (like `Addressable::URI`) as a `redirect_to` location
+
+    *ojab*
+
 *   Change the request method to a `GET` when passing failed requests down to `config.exceptions_app`.
 
     *Alex Robbin*

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -106,7 +106,7 @@ module ActionController
       # See https://tools.ietf.org/html/rfc3986#section-3.1
       # The protocol relative scheme starts with a double slash "//".
       when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
-        options
+        options.to_str
       when String
         request.protocol + request.host_with_port + options
       when Proc

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -96,6 +96,16 @@ class RedirectController < ActionController::Base
     redirect_to "http://www.rubyonrails.org/"
   end
 
+  def redirect_to_url_with_stringlike
+    stringlike = Object.new
+
+    def stringlike.to_str
+      "http://www.rubyonrails.org/"
+    end
+
+    redirect_to stringlike
+  end
+
   def redirect_to_url_with_unescaped_query_string
     redirect_to "http://example.com/query?status=new"
   end
@@ -253,6 +263,12 @@ class RedirectTest < ActionController::TestCase
 
   def test_redirect_to_url
     get :redirect_to_url
+    assert_response :redirect
+    assert_redirected_to "http://www.rubyonrails.org/"
+  end
+
+  def test_redirect_to_url_with_stringlike
+    get :redirect_to_url_with_stringlike
     assert_response :redirect
     assert_redirected_to "http://www.rubyonrails.org/"
   end


### PR DESCRIPTION
### Summary

`Addressable::URI` has `#to_str` and as a result we have
```
[1] pry(main)> /\A([a-z][a-z\d\-+.]*:|\/\/).*/i === Addressable::URI.parse("https://example.ca/")
=> true
```
on `redirect_to Addressable::URI`, which becomes `Addressable::URI#delete("\0\r\n")` and `NoMethodError`. Fix it.

https://github.com/rails/rails/pull/41373 had a bogus testcase, fixed here.

CC @gmcgibbon 