### PR TITLE
Raise error on invalid fixture primary key

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -6,6 +6,7 @@ require "models/admin"
 require "models/admin/account"
 require "models/admin/randomly_named_c1"
 require "models/admin/user"
+require "models/author"
 require "models/binary"
 require "models/book"
 require "models/bulb"
@@ -18,6 +19,7 @@ require "models/course"
 require "models/developer"
 require "models/dog"
 require "models/doubloon"
+require "models/essay"
 require "models/joke"
 require "models/matey"
 require "models/other_dog"
@@ -1489,6 +1491,16 @@ class FileFixtureConflictTest < ActiveRecord::TestCase
     self.class.fixtures :all
 
     assert_equal %w(developers namespaced/accounts people tasks), fixture_table_names.sort
+  end
+end
+
+class PrimaryKeyErrorTest < ActiveRecord::TestCase
+  test "generates the correct value" do
+    e = assert_raise(ActiveRecord::FixtureSet::TableRow::PrimaryKeyError) do
+      ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT + "/primary_key_error", "primary_key_error")
+    end
+
+    assert_includes e.message, "Unable to set"
   end
 end
 

--- a/activerecord/test/fixtures/primary_key_error/primary_key_error.yml
+++ b/activerecord/test/fixtures/primary_key_error/primary_key_error.yml
@@ -1,0 +1,6 @@
+_fixture:
+  model_class: Author
+
+david:
+  name: David
+  owned_essay: a_modest_proposal


### PR DESCRIPTION
### Summary

When you're using a custom primary key on a belongs_to and you're trying to load that value through the association shorthand in a fixture, you end up getting the primary key of the table and not the primary key specified in the join. This makes sense to keep as the behavior because it's super fast (just hashing the name of the fixture), but it's still surprising so we should warn the developer that it's not possible to do what they want.