### PR TITLE
Avoid stack level too deep in predicate builder

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -85,7 +85,9 @@ module ActiveRecord
 
             klass ||= AssociationQueryValue
             queries = klass.new(associated_table, value).queries.map do |query|
-              expand_from_hash(query).reduce(&:and)
+              # If the query produced is identical to attributes don't go any deeper.
+              # Prevents stack level too deep errors when association and foreign_key are identical.
+              query == attributes ? build(table.arel_attribute(key), value) : expand_from_hash(query).reduce(&:and)
             end
             queries.reduce(&:or)
           elsif table.aggregated_with?(key)

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2991,6 +2991,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal [1, 2], posts.first.comments.map(&:id)
   end
 
+  def test_has_many_association_with_same_foreign_key_name
+    assert_nothing_raised do
+      firm = Firm.find(15)
+      assert_not_nil(firm.comments.first)
+    end
+  end
+
   private
     def force_signal37_to_load_all_clients_of_firm
       companies(:first_firm).clients_of_firm.load_target

--- a/activerecord/test/fixtures/comments.yml
+++ b/activerecord/test/fixtures/comments.yml
@@ -63,3 +63,10 @@ sub_special_comment:
   post_id: 4
   body: Sub special comment
   type: SubSpecialComment
+
+recursive_association_comment:
+  id: 13
+  post_id: 5
+  body: afrase
+  type: Comment
+  company: 15

--- a/activerecord/test/fixtures/companies.yml
+++ b/activerecord/test/fixtures/companies.yml
@@ -65,3 +65,8 @@ another_first_firm_client:
   client_of: 1
   name: Apex
   firm_name: 37signals
+
+recursive_association_fk:
+  id: 15
+  type: Firm
+  name: RVshare

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -14,6 +14,7 @@ class Comment < ActiveRecord::Base
   belongs_to :post, counter_cache: true
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
+  belongs_to :company, foreign_key: 'company'
 
   has_many :ratings
 

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -12,6 +12,7 @@ class Company < AbstractCompany
   has_one :dummy_account, foreign_key: "firm_id", class_name: "Account"
   has_many :contracts
   has_many :developers, through: :contracts
+  has_many :comments, foreign_key: 'company'
 
   attribute :metadata, :json
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -213,6 +213,7 @@ ActiveRecord::Schema.define do
     t.datetime :updated_at
     t.datetime :deleted_at
     t.integer :comments
+    t.integer :company
   end
 
   create_table :companies, force: true do |t|


### PR DESCRIPTION

### Summary

If you have an association with the same name as the foreign key then a `SystemStackError: stack level too deep` error is raised.

This PR addresses the issue by checking if the `query` variable is different from `attributes` argument before recursively calling `expand_from_hash`. We have been running this fix in production for a number of years without issue at the company I work for.

This issue has been mentioned in a number of issues https://github.com/rails/rails/issues/26778, https://github.com/rails/rails/issues/34869, https://github.com/rails/rails/issues/31110.

### Other Information

Something to note is the setter for the association can raise errors. I have another [branch](https://github.com/afrase/rails/tree/recursive-association-writer-fix) that fixes that but I'm not sure if using an association extension is the best way to handle it.

Thanks