### PR TITLE
Enable scoping to apply to all queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add ability to apply `scoping` to `all_queries`.
+
+    Some applications may want to use the `scoping` method but previously it only
+    worked on certain types of queries. This change allows the `scoping` method to apply
+    to all queries for a model in a block.
+
+    ```ruby
+    Post.where(blog_id: post.blog_id).scoping(all_queries: true) do
+      post.update(title: "a post title") # adds `posts.blog_id = 1` to the query
+    end
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Switch to database adapter return type for `ActiveRecord::Calculations.calculate`
     when called with `:average` (aliased as `ActiveRecord::Calculations.average`)
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -99,6 +99,8 @@ module ActiveRecord
       def scope
         if (scope = klass.current_scope) && scope.try(:proxy_association) == self
           scope.spawn
+        elsif scope = klass.global_current_scope
+          target_scope.merge!(association_scope).merge!(scope)
         else
           target_scope.merge!(association_scope)
         end

--- a/activerecord/lib/active_record/scoping.rb
+++ b/activerecord/lib/active_record/scoping.rb
@@ -30,6 +30,14 @@ module ActiveRecord
       def current_scope=(scope)
         ScopeRegistry.set_value_for(:current_scope, self, scope)
       end
+
+      def global_current_scope(skip_inherited_scope = false)
+        ScopeRegistry.value_for(:global_current_scope, self, skip_inherited_scope)
+      end
+
+      def global_current_scope=(scope)
+        ScopeRegistry.set_value_for(:global_current_scope, self, scope)
+      end
     end
 
     def populate_with_current_scope_attributes # :nodoc:
@@ -69,7 +77,7 @@ module ActiveRecord
     class ScopeRegistry # :nodoc:
       extend ActiveSupport::PerThreadRegistry
 
-      VALID_SCOPE_TYPES = [:current_scope, :ignore_default_scope]
+      VALID_SCOPE_TYPES = [:current_scope, :ignore_default_scope, :global_current_scope]
 
       def initialize
         @registry = Hash.new { |hash, key| hash[key] = {} }

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -349,6 +349,87 @@ class RelationScopingTest < ActiveRecord::TestCase
     end
     assert_equal posts, Post.left_joins(comments: :post).first(10)
   end
+
+  def test_scoping_applies_to_update_with_all_queries
+    Author.all.limit(5).update_all(organization_id: 1)
+
+    dev = Author.where(organization_id: 1).first
+
+    Author.where(organization_id: 1).scoping do
+      update_sql = capture_sql { dev.update(name: "Eileen") }.first
+      assert_no_match(/organization_id/, update_sql)
+    end
+
+    Author.where(organization_id: 1).scoping(all_queries: true) do
+      update_scoped_sql = capture_sql { dev.update(name: "Not Eileen") }.first
+      assert_match(/organization_id/, update_scoped_sql)
+    end
+  end
+
+  def test_scoping_applies_to_delete_with_all_queries
+    Author.all.limit(5).update_all(organization_id: 1)
+
+    dev1 = Author.where(organization_id: 1).first
+    dev2 = Author.where(organization_id: 1).last
+
+    Author.where(organization_id: 1).scoping do
+      delete_sql = capture_sql { dev1.delete }.first
+      assert_no_match(/organization_id/, delete_sql)
+    end
+
+    Author.where(organization_id: 1).scoping(all_queries: true) do
+      delete_scoped_sql = capture_sql { dev2.delete }.first
+      assert_match(/organization_id/, delete_scoped_sql)
+    end
+  end
+
+  def test_scoping_applies_to_reload_with_all_queries
+    Author.all.limit(5).update_all(organization_id: 1)
+
+    dev1 = Author.where(organization_id: 1).first
+
+    Author.where(organization_id: 1).scoping do
+      reload_sql = capture_sql { dev1.reload }.first
+      assert_no_match(/organization_id/, reload_sql)
+    end
+
+    Author.where(organization_id: 1).scoping(all_queries: true) do
+      scoped_reload_sql = capture_sql { dev1.reload }.first
+      assert_match(/organization_id/, scoped_reload_sql)
+    end
+  end
+
+  def test_nested_scoping_applies_with_all_queries_set
+    Author.all.limit(5).update_all(organization_id: 1)
+
+    Author.where(organization_id: 1).scoping(all_queries: true) do
+      select_sql = capture_sql { Author.first }.first
+      assert_match(/organization_id/, select_sql)
+
+      Author.where(owned_essay_id: nil).scoping do
+        second_select_sql = capture_sql { Author.first }.first
+        assert_match(/organization_id/, second_select_sql)
+        assert_match(/owned_essay_id/, second_select_sql)
+      end
+
+      third_select_sql = capture_sql { Author.first }.first
+      assert_match(/organization_id/, third_select_sql)
+      assert_no_match(/owned_essay_id/, third_select_sql)
+    end
+  end
+
+  def test_raises_error_if_all_queries_is_set_to_false_while_nested
+    Author.all.limit(5).update_all(organization_id: 1)
+
+    Author.where(organization_id: 1).scoping(all_queries: true) do
+      select_sql = capture_sql { Author.first }.first
+      assert_match(/organization_id/, select_sql)
+
+      assert_raises ArgumentError do
+        Author.where(organization_id: 1).scoping(all_queries: false) { }
+      end
+    end
+  end
 end
 
 class NestedRelationScopingTest < ActiveRecord::TestCase
@@ -481,6 +562,21 @@ class HasManyScopingTest < ActiveRecord::TestCase
     michael = Person.where(id: people(:michael).id).includes(:bad_references).first
     magician = BadReference.find(1)
     assert_equal [magician], michael.bad_references
+  end
+
+  def test_scoping_applies_to_all_queries_on_has_many_when_set
+    @welcome.comments.update_all(author_id: 1)
+
+    comments_sql = capture_sql { @welcome.comments.to_a }.last
+    assert_no_match(/author_id/, comments_sql)
+
+    Comment.where(author_id: 1).scoping(all_queries: true) do
+      scoped_comments_sql = capture_sql { @welcome.comments.reload.to_a }.last
+      assert_match(/author_id/, scoped_comments_sql)
+    end
+
+    unscoped_comments_sql = capture_sql { @welcome.comments.reload.to_a }.last
+    assert_no_match(/author_id/, unscoped_comments_sql)
   end
 end
 


### PR DESCRIPTION
Similar to https://github.com/rails/rails/pull/40720
and https://github.com/rails/rails/pull/40805 this change allows for the
`scoping` method to apply to all queries in the block. Previously this
would only apply to queries on the class and not the instance. Ie
`Post.create`, `Post.all`, but not `post.update`, or `post.delete`.

The change here will create a global scope that is applied to all
queries for a relation for the duration of the block.

Benefits:

This change allows applications to add a scope to any query for the
duration of a block. This is useful for applications using sharding to
be able to control the query without requiring a `default_scope`. This
is useful if you want to have more control over when a `scoping` is used
on a relation. This also brings `scoping` in parity with the behavior of
`default_scope` so there are less surprises between the behavior of
these two methods.

There are a caveats to this behavior:

1) The `scoping` only applies to objects of the same type. IE you cannot
scope `Post.where(blog_id: 1).scoping` and then expect `post.comments`
will apply `blog_id = 1` to the `Comment` query. This is not possible
because the scope is `posts.blog_id = 1` and we can't apply the `posts`
scope to a `comments` query. To solve this, scopes must be nested.
2) If a block is scoped to `all_queries` it cannot be unscoped without
exiting the block. I couldn't find a way around this but ActiveRecord
scoping is a bit complex and turning off `all_queries` when it's already
on in nested scoping blocks had interesting behavior that I decided was
best left out.