### PR TITLE
Overwrite bin/yarn when running app:binstub:yarn

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -107,9 +107,7 @@ module Rails
     end
 
     def yarn_when_updating
-      return if File.exist?("bin/yarn")
-
-      template "bin/yarn" do |content|
+      template "bin/yarn", force: true do |content|
         "#{shebang}\n" + content
       end
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -301,6 +301,22 @@ module ApplicationTests
       end
     end
 
+    test "app:binstub:yarn generates bin/yarn" do
+      yarn_binstub = File.join(app_path, "bin/yarn")
+      rails "app:binstub:yarn"
+
+      assert_path_exists yarn_binstub
+      assert_match %r/\A#!/, File.read(yarn_binstub)
+    end
+
+    test "app:binstub:yarn overwrites existing bin/yarn" do
+      yarn_binstub = File.join(app_path, "bin/yarn")
+      File.write(yarn_binstub, "existing")
+      rails "app:binstub:yarn"
+
+      assert_match %r/\A#!/, File.read(yarn_binstub)
+    end
+
     def test_template_load_initializers
       app_file "config/initializers/dummy.rb", "puts 'Hello, World!'"
       app_file "template.rb", ""


### PR DESCRIPTION
This ensures that commands which delegate to `app:binstub:yarn`, such as `action_text:install`, will update `bin/yarn`.