### PR TITLE
Do not capture output when running bin/yarn

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -12,7 +12,7 @@ module ActionText
         rails_command "app:binstub:yarn", inline: true
 
         say "Installing JavaScript dependencies", :green
-        yarn_command "add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}", capture: true
+        yarn_command "add #{js_dependencies.map { |name, version| "#{name}@#{version}" }.join(" ")}"
       end
 
       def append_dependencies_to_package_file


### PR DESCRIPTION
The purpose of `bin/yarn` is to display a friendly error message when Yarn is not installed.  Capturing its output prevents that error message from being shown.

---

Marking this as draft because there are some UX concerns which were previously discussed in #37824.  One option would be to also drop `abort_on_failure: true`, manually capture `stderr`, and then manually print and abort when `bin/yarn` fails.
