### PR TITLE
Add missing CHANGELOG entry for #40351

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Switch to database adapter return type for `ActiveRecord::Calculations.calculate`
+    when called with `:average` (aliased as `ActiveRecord::Calculations.average`)
+
+    Previously average aggregation returned `BigDecimal` for everything which
+    supported `to_d`. This was especially weird for floating point numbers.
+
+    Database adapters today map database column types to Ruby types more
+    accurately than 10 years ago. So now we simply pass them on
+    (except for special cases which are not `Numeric`).
+
+    ```ruby
+    # With the following schema:
+    create_table "measurements" do |t|
+      t.float "temperature"
+    end
+
+    # Before:
+    Measurement.average(:temperature).class
+    # => BigDecimal
+
+    # After:
+    Measurement.average(:temperature).class
+    # => Float
+    ```
+
+    *Josua Schmid*
+
 *   PostgreSQL: handle `timestamp with time zone` columns correctly in `schema.rb`.
 
     Previously they dumped as `t.datetime :column_name`, now they dump as `t.timestamptz :column_name`,

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -67,6 +67,14 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal 37.5, value
   end
 
+  def test_should_return_decimal_average_if_db_returns_such
+    NumericData.create!(decimal_number: 37.5)
+
+    value = NumericData.average(:decimal_number)
+    assert_instance_of BigDecimal, value
+    assert_equal 37.5, value
+  end
+
   def test_should_return_nil_as_average
     assert_nil NumericData.average(:bank_balance)
   end


### PR DESCRIPTION
This is the missing CHANGELOG entry for #40351.

While writing it, I noticed that there should be another test to show that we didn't break average aggregation for `decimal`.