### PR TITLE
Remove redundant regexp escape

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -105,7 +105,7 @@ module ActionDispatch
       def authorized?(request)
         valid_host = /
           \A
-          (?<host>[a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])
+          (?<host>[a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\])
           (:\d+)?
           \z
         /x


### PR DESCRIPTION
Follow-up to 83a6ac3fee8fd538ce7e0088913ff54f0f9bcb6f.

Fixes https://github.com/rails/rails/runs/1874631263#step:6:9.
