### PR TITLE
Enumerable#maximum

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted
+    elements of an enumerable.
+
+    ```ruby
+    payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
+
+    payments.minimum(:price) # => 5
+    payments.maximum(:price) # => 20
+    ```
+
+    This also allows passing enumerables to `fresh_when` and `stale?` in Action Controller.
+    See PR [#41404](https://github.com/rails/rails/pull/41404) for an example.
+
+    *Ayrton De Craene*
+
 *   `ActiveSupport::Cache::MemCacheStore` now accepts an explicit `nil` for its `addresses` argument.
 
     ```ruby

--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -16,6 +16,22 @@ module Enumerable
 
   # :startdoc:
 
+  # Calculates the minimum from the extracted elements.
+  #
+  # payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
+  # payments.minimum(:price) # => 5
+  def minimum(key)
+    map(&key).min
+  end
+
+  # Calculates the maximum from the extracted elements.
+  #
+  # payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
+  # payments.maximum(:price) # => 15
+  def maximum(key)
+    map(&key).max
+  end
+
   # Calculates a sum from the elements.
   #
   #  payments.sum { |p| p.price * p.tax_rate }

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -29,6 +29,16 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal(e, v, msg)
   end
 
+  def test_minimum
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
+    assert_equal 5, payments.minimum(:price)
+  end
+
+  def test_maximum
+    payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
+    assert_equal 15, payments.maximum(:price)
+  end
+
   def test_sums
     enum = GenericEnumerable.new([5, 15, 10])
     assert_equal 30, enum.sum


### PR DESCRIPTION
### Summary

Adds some parity between `Enumerable` and [`ActiveRecord::Calculations`](https://api.rubyonrails.org/v6.1.1/classes/ActiveRecord/Calculations.html) by adding `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted elements.

```rb
payments = [Payment.new(5), Payment.new(15), Payment.new(10)]
payments.minimum(:price) # => 5
payments.maximum(:price) # => 20
```

This also allows passing enumerables to [`fresh_when`](https://github.com/rails/rails/blob/914caca2d31bd753f47f9168f2a375921d9e91cc/actionpack/lib/action_controller/metal/conditional_get.rb#L108) and `stale?` in Action Controller.

```ruby
def index
  @payments = current_user.payments.limit(20).to_a
                                                                                                                                                                                                                                                                                                             
  fresh_when @payments
end
```

The above is the shortened equivalent of:

```ruby
def index
  @payments = current_user.payments.limit(20).to_a
                                                                                                                                                                                                                                                                                                             
  fresh_when @payments, last_modified: @payments.maximum(:updated_at)
end
```

Prior to this PR you could mimic this behavior with:
                                                                                                                                                                                                                                                                                                             
```ruby
def index
  @payments = current_user.payments.limit(20).to_a
                                                                                                                                                                                                                                                                                                             
  fresh_when @payments, last_modified: @payments.pluck(:updated_at).max
end
```

### Extra information

The advantage of passing an array as object to `fresh_when` or `stale?`, as opposed to an AR scope, is that
it will save you from making two unnecessary DB calls.
                                                                                                                                                                                                                                                                                                             
```
(1.0ms)  SELECT COUNT(*) AS "size", MAX(subquery_for_cache_key.collection_cache_key_timestamp) AS timestamp FROM (SELECT "payments"."updated_at" AS collection_cache_key_timestamp FROM "payments" WHERE "payments"."user_id" = $1 LIMIT $2) subquery_for_cache_key  [["user_id", 135138680], ["LIMIT", 20]]
(0.3ms)  SELECT MAX("payments"."updated_at") FROM "payments" WHERE "payments"."user_id" = $1 LIMIT $2  [["user_id", 135138680], ["LIMIT", 20]]
```
                                                                                                                                                                                                                                                                                                             
These queries are executed, to calculate the `Last-Modified` cache header and the generated etag value.

__For completeness:__
                                                                                                                                                                                                                                                                                                             
The generated (unhashed) etag of the array object looks like:
                                                                                                                                                                                                                                                                                                             
```
"payments/595373086-20210210164232722074/payments/595373085-20210210082856288172"
```
                                                                                                                                                                                                                                                                                                             
The generated (unhashed) etag of the scope object looks like:
                                                                                                                                                                                                                                                                                                             
```
"payments/query-57b31c5e46bb42c8f986c2d77194a31b-2-20210210164232722074"
```                                                                                                                                                                                                                                                                                                  