### PR TITLE
Async queries: use a single executor and default to an ImmediateExecutor

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -144,13 +144,6 @@ module ActiveRecord
 
         @lock_thread = false
 
-        @async_executor = Concurrent::ThreadPoolExecutor.new(
-          min_threads: 0,
-          max_threads: @size,
-          max_queue: @size * 4,
-          fallback_policy: :caller_runs
-        )
-
         @reaper = Reaper.new(self, db_config.reaping_frequency)
         @reaper.run
       end
@@ -455,10 +448,6 @@ module ActiveRecord
             checkout_timeout: checkout_timeout
           }
         end
-      end
-
-      def schedule_query(future_result) # :nodoc:
-        @async_executor.post { future_result.execute_or_skip }
       end
 
       private

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -194,6 +194,8 @@ module ActiveRecord
         @@connection_handlers = handlers
       end
 
+      mattr_accessor :asynchronous_queries_executor, instance_accessor: false, default: Concurrent::ImmediateExecutor.new
+
       def self.asynchronous_queries_session # :nodoc:
         asynchronous_queries_tracker.current_session
       end

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -21,7 +21,7 @@ module ActiveRecord
 
     def schedule!(session)
       @session = session
-      @pool.schedule_query(self)
+      ActiveRecord::Base.asynchronous_queries_executor.post { execute_or_skip }
     end
 
     def execute!(connection)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -414,7 +414,19 @@ module ActiveRecord
     include AsynchronousQueriesSharedTests
 
     def setup
+      @previous_executor = ActiveRecord::Base.asynchronous_queries_executor
+      ActiveRecord::Base.asynchronous_queries_executor = Concurrent::ThreadPoolExecutor.new(
+        min_threads: 0,
+        max_threads: 2,
+        max_queue: 4,
+        fallback_policy: :caller_runs
+       )
+
       @connection = ActiveRecord::Base.connection
+    end
+
+    def teardown
+      ActiveRecord::Base.asynchronous_queries_executor = @previous_executor
     end
 
     def test_async_select_all
@@ -452,8 +464,19 @@ module ActiveRecord
     include AsynchronousQueriesSharedTests
 
     def setup
+      @previous_executor = ActiveRecord::Base.asynchronous_queries_executor
+      ActiveRecord::Base.asynchronous_queries_executor = Concurrent::ThreadPoolExecutor.new(
+        min_threads: 0,
+        max_threads: 2,
+        max_queue: 4,
+        fallback_policy: :caller_runs
+       )
       @connection = ActiveRecord::Base.connection
       @connection.materialize_transactions
+    end
+
+    def teardown
+      ActiveRecord::Base.asynchronous_queries_executor = @previous_executor
     end
   end
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/40037
Ref: https://github.com/rails/rails/pull/41372

As mentioned in https://github.com/rails/rails/pull/41372#issuecomment-777281980, I think having one executor per pool was a mistake. The idea was to isolate each connection pool so that they would never wait on each others, but it means that multi-database setups could easily end up with ridiculous amounts of idle threads. 

So instead it's probably better to have a single executor for the whole process, that makes it much easier for app developers to configure.

While I was at it, I changed the default executor to `Concurrent::ImmediateExecutor`, which is basically a noop (it immediately execute jobs in the calling threads). It is probably a better default to make sure upgraded apps don't sudently have concurrency enabled. For newly generated apps, we can try to set a good default for `load_defaults '7.0'`, but at this stage I don't think we can make such decision yet.

I also allow to set an arbitrary concurrent-ruby executor, as I'd like to experiment with a few different configurations.

cc @eileencodes @jhawthorn @rafaelfranca @tenderlove 