### PR TITLE
Improve AJAX example [ci skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -44,7 +44,7 @@ fetch("/test")
   .then((data) => data.text())
   .then((html) => {
     const results = document.querySelector("#results");
-    results.insertAdjacentHTML("beforeend", data);
+    results.insertAdjacentHTML("beforeend", html);
   });
 ```
 


### PR DESCRIPTION
The example uses `fetch` to retrieve HTML from the server and append it to an element on the page. This commit updates the example to append the response HTML rather than the full response object. I think this is what the original author intended to do but please correct me if I'm wrong!