### PR TITLE
Fix log with async queries

### DIFF
--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -25,7 +25,7 @@ module ActiveRecord
     end
 
     def execute!(connection)
-      execute_query(connection)
+      execute_query(connection, async: true)
     end
 
     def execute_or_skip


### PR DESCRIPTION
While testing out #41372 in a demo application I noticed that the
`ASYNC` portion wasn't getting added to the log. I tracked it down to
this method not passing `async: true` to `execute_query` so the `sql`
subscriber was always getting `async: false` for the payload.

Before:

```
(0.3ms)  SELECT * FROM dogs where name = 'fido 1'
(0.1ms)  SELECT * FROM dogs where name = 'fido 2'
(0.1ms)  SELECT * FROM dogs where name = 'fido 3'
```

After:

```
ASYNC  (0.3ms)  SELECT * FROM dogs where name = 'fido 1'
ASYNC  (0.2ms)  SELECT * FROM dogs where name = 'fido 2'
ASYNC  (0.2ms)  SELECT * FROM dogs where name = 'fido 3'
```

I also verified that this fixes `Dog Load` to `ASYNC Dog Load` in the
new PR. It will be easier to add a test for this functionality when
we merge #41372.


cc/ @byroot 