### PR TITLE
Auto-generation of timestamps for HMT fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Allow auto-generation of timestamps for join tables in has_many :through
+    associations.
+
+    Previously, if you defined an association in a fixture that used a has_many
+    :through association, and the join table used timestamps, the timestamps
+    would not be automatically populated as they are for other fixtures. This
+    problem is exacerbated when (as it is by default) timestamp columns have a
+    not null constraint. The only way around it was to tediously define your
+    join records in a fixture file, and losing a degree of maintainability to
+    your fixtures.
+
+    *Mike Campbell*
+
 *   OpenSSL constants are now used for Digest computations.
 
     *Dirkjan Bussink*

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -37,12 +37,16 @@ module ActiveRecord
         def timestamp_column_names
           @association.through_reflection.klass.all_timestamp_attributes_in_model
         end
+
+        def join_model
+          @association.through_reflection.klass
+        end
       end
 
-      def initialize(fixture, table_rows:, label:, now:)
+      def initialize(fixture, table_rows:, label:)
         @table_rows = table_rows
         @label = label
-        @now = now
+        @now = ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
         @row = fixture.to_hash
         fill_row_model_attributes
       end
@@ -138,21 +142,29 @@ module ActiveRecord
         def add_join_records(association)
           # This is the case when the join table has no fixtures file
           if (targets = @row.delete(association.name.to_s))
-            table_name  = association.join_table
             column_type = association.primary_key_type
-            lhs_key     = association.lhs_key
-            rhs_key     = association.rhs_key
+            lhs_key = association.lhs_key
+            rhs_key = association.rhs_key
+            join_table_name = association.join_table
+            join_model = association.join_model
 
             targets = targets.is_a?(Array) ? targets : targets.split(/\s*,\s*/)
-            joins   = targets.map do |target|
-              join = { lhs_key => @row[model_metadata.primary_key_name],
-                       rhs_key => ActiveRecord::FixtureSet.identify(target, column_type) }
-              association.timestamp_column_names.each do |col|
-                join[col] = @now
-              end
-              join
+            join_fixtures = targets.map do |target|
+              row = {
+                lhs_key => @row[model_metadata.primary_key_name],
+                rhs_key => ActiveRecord::FixtureSet.identify(target, column_type),
+              }
+
+              [row.values.join("_"), ActiveRecord::Fixture.new(row, join_model)]
             end
-            @table_rows.tables[table_name].concat(joins)
+
+            join_table_rows = TableRows.new(
+              join_table_name,
+              model_class: join_model,
+              fixtures: join_fixtures,
+            )
+
+            @table_rows.merge!(join_table_rows)
           end
         end
     end

--- a/activerecord/lib/active_record/fixture_set/table_rows.rb
+++ b/activerecord/lib/active_record/fixture_set/table_rows.rb
@@ -28,16 +28,17 @@ module ActiveRecord
         @model_metadata ||= ModelMetadata.new(model_class)
       end
 
+      def merge!(table_rows)
+        tables.merge!(table_rows.tables) { |_k, o, n| o + n }
+      end
+
       private
         def build_table_rows_from(table_name, fixtures)
-          now = ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
-
           @tables[table_name] = fixtures.map do |label, fixture|
             TableRow.new(
               fixture,
               table_rows: self,
               label: label,
-              now: now,
             )
           end
         end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -18,6 +18,9 @@ require "models/course"
 require "models/developer"
 require "models/dog"
 require "models/doubloon"
+require "models/hmt_course"
+require "models/hmt_enrolment"
+require "models/hmt_student"
 require "models/joke"
 require "models/matey"
 require "models/other_dog"
@@ -1655,5 +1658,13 @@ if current_adapter?(:SQLite3Adapter) && !in_memory_db?
       def readonly_config
         default_config.merge("replica" => true)
       end
+  end
+
+  class HmtAutoTimestampTest < ActiveRecord::TestCase
+    fixtures :hmt_students, :hmt_courses
+
+    def test_has_many_though_table_with_timestamps
+      assert_not_nil hmt_students(:alice).hmt_enrolments.first.created_at
+    end
   end
 end

--- a/activerecord/test/fixtures/hmt_courses.yml
+++ b/activerecord/test/fixtures/hmt_courses.yml
@@ -1,0 +1,2 @@
+math: {}
+english: {}

--- a/activerecord/test/fixtures/hmt_students.yml
+++ b/activerecord/test/fixtures/hmt_students.yml
@@ -1,0 +1,2 @@
+alice:
+  hmt_courses: math, english

--- a/activerecord/test/models/hmt_course.rb
+++ b/activerecord/test/models/hmt_course.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class HmtCourse < ActiveRecord::Base
+  has_many :hmt_enrolments
+  has_many :hmt_students, through: :hmt_enrolments
+end

--- a/activerecord/test/models/hmt_enrolment.rb
+++ b/activerecord/test/models/hmt_enrolment.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class HmtEnrolment < ActiveRecord::Base
+  belongs_to :hmt_course
+  belongs_to :hmt_student
+end

--- a/activerecord/test/models/hmt_student.rb
+++ b/activerecord/test/models/hmt_student.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class HmtStudent < ActiveRecord::Base
+  has_many :hmt_enrolments
+  has_many :hmt_courses, through: :hmt_enrolments
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -480,6 +480,21 @@ ActiveRecord::Schema.define do
     t.string :where
   end
 
+  create_table :hmt_courses, force: true do |t|
+    t.timestamps null: false
+  end
+
+  create_table :hmt_enrolments, force: true do |t|
+    t.references :hmt_course
+    t.references :hmt_student
+
+    t.timestamps null: false
+  end
+
+  create_table :hmt_students, force: true do |t|
+    t.timestamps null: false
+  end
+
   create_table :guids, force: true do |t|
     t.column :key, :string
   end


### PR DESCRIPTION
This change is a revival of @hayesr's work in https://github.com/rails/rails/pull/21337 .

> Currently if a hm:t join model was created using the rails generator, the migration will have timestamps with null: false by default. Loading fixtures will fail because of the database constraint.
> 
> Gist with failing example: https://gist.github.com/hayesr/3756183d34a6305d5143

### Summary

The code change itself is to use the TableRows/TableRow classes to generate the join record fixtures also, rather than a plain hash. This naturally incorporates the existing logic to add timestamps and applies it to the join records also.

The following test is failing with `ActiveRecord::StatementInvalid: Could not find table 'parrot_treasures'` because the join table in the test doesn't actually exist. That was fine before, it didn't need to, but it does now because `timestamp_column_names` causes a `load_schema`. Not sure what the best approach is; should I just add the table to the schema?

```
ARCONN=sqlite3 bundle exec ruby -w -Itest test/cases/fixtures_test.rb -n test_has_many_through_with_renamed_table
```
