### PR TITLE
Add ActiveRecord::Result.empty

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -65,7 +65,7 @@ module ActiveRecord
 
         select(sql, name, binds, prepare: prepared_statements && preparable, async: async && FutureResult::SelectAll)
       rescue ::RangeError
-        ActiveRecord::Result.new([], [])
+        ActiveRecord::Result.empty
       end
 
       # Returns a record hash with the column names as keys and column values

--- a/activerecord/lib/active_record/future_result.rb
+++ b/activerecord/lib/active_record/future_result.rb
@@ -90,7 +90,7 @@ module ActiveRecord
           def exec_query(*, **)
             super
           rescue ::RangeError
-            ActiveRecord::Result.new([], [])
+            ActiveRecord::Result.empty
           end
       end
   end

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -195,7 +195,7 @@ module ActiveRecord
         relation.select_values = columns
         result = skip_query_cache_if_necessary do
           if where_clause.contradiction?
-            ActiveRecord::Result.new([], [])
+            ActiveRecord::Result.empty
           else
             klass.connection.select_all(relation.arel, "#{klass.name} Pluck")
           end

--- a/activerecord/lib/active_record/result.rb
+++ b/activerecord/lib/active_record/result.rb
@@ -36,12 +36,19 @@ module ActiveRecord
 
     attr_reader :columns, :rows, :column_types
 
+    def self.empty # :nodoc:
+      EMPTY
+    end
+
     def initialize(columns, rows, column_types = {})
       @columns      = columns
       @rows         = rows
       @hash_rows    = nil
       @column_types = column_types
     end
+
+    EMPTY = new([].freeze, [].freeze, {}.freeze)
+    private_constant :EMPTY
 
     # Returns true if this result set includes the column named +name+
     def includes_column?(name)


### PR DESCRIPTION
This change is extracted from #39547 which we never finished. This minor
refactoring makes a new `empty` method to clean up places where we want
to specifically return an empty result.

Co-authored-by: Aaron Patterson tenderlove@ruby-lang.org

cc/ @tenderlove 