### PR TITLE
Revert #22610 by default and make it opt-in

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `:all` option to `inclusion` validator.
+
+    *Jacopo Beschi*
+
 *   `has_secure_password` now supports password challenges via a
     `password_challenge` accessor and validation.
 

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -11,6 +11,8 @@ module ActiveModel
       ERROR_MESSAGE = "An object with the method #include? or a proc, lambda or symbol is required, " \
                       "and must be supplied as the :in (or :within) option of the configuration hash"
 
+      RESERVED_OPTIONS = [:in, :within, :all].freeze
+
       def check_validity!
         unless delimiter.respond_to?(:include?) || delimiter.respond_to?(:call) || delimiter.respond_to?(:to_sym)
           raise ArgumentError, ERROR_MESSAGE
@@ -21,7 +23,7 @@ module ActiveModel
       def include?(record, value)
         members = resolve_value(record, delimiter)
 
-        if value.is_a?(Array)
+        if value.is_a?(Array) && options[:all] == true
           value.all? { |v| members.public_send(inclusion_method(members), v) }
         else
           members.public_send(inclusion_method(members), value)

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -9,7 +9,7 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         if include?(record, value)
-          record.errors.add(attribute, :exclusion, **options.except(:in, :within).merge!(value: value))
+          record.errors.add(attribute, :exclusion, **options.except(*RESERVED_OPTIONS).merge!(value: value))
         end
       end
     end

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -9,7 +9,7 @@ module ActiveModel
 
       def validate_each(record, attribute, value)
         unless include?(record, value)
-          record.errors.add(attribute, :inclusion, **options.except(:in, :within).merge!(value: value))
+          record.errors.add(attribute, :inclusion, **options.except(*RESERVED_OPTIONS).merge!(value: value))
         end
       end
     end
@@ -24,6 +24,7 @@ module ActiveModel
       #     validates_inclusion_of :format, in: %w( jpg gif png ), message: "extension %{value} is not included in the list"
       #     validates_inclusion_of :states, in: ->(person) { STATES[person.country] }
       #     validates_inclusion_of :karma, in: :available_karmas
+      #     validates_inclusion_of :karmas, in: %w( abe monkey ), all: true
       #   end
       #
       # Configuration options:
@@ -33,6 +34,8 @@ module ActiveModel
       #   with <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>. When using
       #   a proc or lambda the instance under validation is passed as an argument.
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
+      # * <tt>:all</tt> - If attribute is an <tt>Array</tt> validates the inclusion of
+      #   all the attribute items within the set of values provided with <tt>:in</tt>
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   not included in the list").
       #

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -189,8 +189,8 @@ class InclusionValidationTest < ActiveModel::TestCase
     Person.clear_validators!
   end
 
-  def test_validates_inclusion_of_with_array_value
-    Person.validates_inclusion_of :karma, in: %w( abe monkey )
+  def test_validates_inclusion_of_with_array_value_and_all_option_is_true
+    Person.validates_inclusion_of :karma, in: %w( abe monkey ), all: true
 
     p = Person.new
     p.karma = %w(Lifo monkey)
@@ -202,6 +202,17 @@ class InclusionValidationTest < ActiveModel::TestCase
     p.karma = %w(abe monkey)
 
     assert p.valid?
+  ensure
+    Person.clear_validators!
+  end
+
+  def test_validates_inclusion_of_with_array_value_and_all_option_is_falsey
+    Person.validates_inclusion_of :karma, in: %w( abe monkey ), all: false
+
+    p = Person.new
+    p.karma = %w(abe monkey)
+
+    assert p.invalid?
   ensure
     Person.clear_validators!
   end


### PR DESCRIPTION
### Summary

Change #22610 in order to revert the behaviour by default.
If the option `all: true` is given applies the new behaviour.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Fixes #41051

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
