### PR TITLE
Fix Hash#except unsetting default value for hash 

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/except.rb
+++ b/activesupport/lib/active_support/core_ext/hash/except.rb
@@ -10,7 +10,7 @@ class Hash
   # This is useful for limiting a set of parameters to everything but a few known toggles:
   #   @person.update(params[:person].except(:admin))
   def except(*keys)
-    slice(*self.keys - keys)
+    dup.except!(*keys)
   end unless method_defined?(:except)
 
   # Removes the given keys from hash and returns it.

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -295,9 +295,6 @@ module ActiveSupport
       super(convert_key(key))
     end
 
-    def except(*keys)
-      slice(*self.keys - keys.map { |key| convert_key(key) })
-    end
     alias_method :without, :except
 
     def stringify_keys!; self end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -434,6 +434,15 @@ class HashExtTest < ActiveSupport::TestCase
       original.except(:a)
     end
   end
+
+  def test_except_does_not_alter_default_value
+    default = 5
+    original = Hash.new(default)
+    original[:a] = "x"
+    original[:b] = "y"
+
+    assert_equal default, original.except(:a)[:c]
+  end
 end
 
 class IWriteMyOwnXML

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -742,6 +742,15 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     end
   end
 
+  def test_indifferent_without_does_not_alter_default_value
+    default = 5
+    original = Hash.new(default)
+    original[:a] = "x"
+    original[:b] = "y"
+
+    assert_equal original.with_indifferent_access.without(:a)[:c], default
+  end
+
   def test_indifferent_extract
     original = { :a => 1, "b" => 2, :c => 3, "d" => 4 }.with_indifferent_access
     expected = { a: 1, b: 2 }.with_indifferent_access


### PR DESCRIPTION
### Summary

Although 32db884967a8af0409bfcb2158ee948cd7ef619c sped up these methods, it had the unintended side effect of unsetting the default value/proc for the Hash.

This reverts that change and includes a test to ensure the regression is not reintroduced.

Fixes #41330.
