### PR TITLE
Allows passing sub protocols with ActionCable

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -151,11 +151,12 @@
         logger.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`);
         return false;
       } else {
-        logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`);
+        const socketProtocols = [ ...protocols, ...this.consumer.subprotocols || [] ];
+        logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${socketProtocols}`);
         if (this.webSocket) {
           this.uninstallEventHandlers();
         }
-        this.webSocket = new adapters.WebSocket(this.consumer.url, protocols);
+        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
         this.installEventHandlers();
         this.monitor.start();
         return true;
@@ -443,6 +444,7 @@
       this._url = url;
       this.subscriptions = new Subscriptions(this);
       this.connection = new Connection(this);
+      this.subprotocols = [];
     }
     get url() {
       return createWebSocketURL(this._url);
@@ -462,6 +464,9 @@
       if (!this.connection.isActive()) {
         return this.connection.open();
       }
+    }
+    addSubProtocol(subprotocol) {
+      this.subprotocols = [ ...this.subprotocols, subprotocol ];
     }
   }
   function createWebSocketURL(url) {

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -157,11 +157,12 @@ class Connection {
       logger.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`);
       return false;
     } else {
-      logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`);
+      const socketProtocols = [ ...protocols, ...this.consumer.subprotocols || [] ];
+      logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${socketProtocols}`);
       if (this.webSocket) {
         this.uninstallEventHandlers();
       }
-      this.webSocket = new adapters.WebSocket(this.consumer.url, protocols);
+      this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
       this.installEventHandlers();
       this.monitor.start();
       return true;
@@ -456,6 +457,7 @@ class Consumer {
     this._url = url;
     this.subscriptions = new Subscriptions(this);
     this.connection = new Connection(this);
+    this.subprotocols = [];
   }
   get url() {
     return createWebSocketURL(this._url);
@@ -475,6 +477,9 @@ class Consumer {
     if (!this.connection.isActive()) {
       return this.connection.open();
     }
+  }
+  addSubProtocol(subprotocol) {
+    this.subprotocols = [ ...this.subprotocols, subprotocol ];
   }
 }
 

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -151,11 +151,12 @@
         logger.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`);
         return false;
       } else {
-        logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`);
+        const socketProtocols = [ ...protocols, ...this.consumer.subprotocols || [] ];
+        logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${socketProtocols}`);
         if (this.webSocket) {
           this.uninstallEventHandlers();
         }
-        this.webSocket = new adapters.WebSocket(this.consumer.url, protocols);
+        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
         this.installEventHandlers();
         this.monitor.start();
         return true;
@@ -443,6 +444,7 @@
       this._url = url;
       this.subscriptions = new Subscriptions(this);
       this.connection = new Connection(this);
+      this.subprotocols = [];
     }
     get url() {
       return createWebSocketURL(this._url);
@@ -462,6 +464,9 @@
       if (!this.connection.isActive()) {
         return this.connection.open();
       }
+    }
+    addSubProtocol(subprotocol) {
+      this.subprotocols = [ ...this.subprotocols, subprotocol ];
     }
   }
   function createWebSocketURL(url) {

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -33,9 +33,10 @@ class Connection {
       logger.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`)
       return false
     } else {
-      logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`)
+      const socketProtocols = [...protocols, ...this.consumer.subprotocols || []]
+      logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${socketProtocols}`)
       if (this.webSocket) { this.uninstallEventHandlers() }
-      this.webSocket = new adapters.WebSocket(this.consumer.url, protocols)
+      this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols)
       this.installEventHandlers()
       this.monitor.start()
       return true

--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -32,6 +32,7 @@ export default class Consumer {
     this._url = url
     this.subscriptions = new Subscriptions(this)
     this.connection = new Connection(this)
+    this.subprotocols = []
   }
 
   get url() {
@@ -54,6 +55,10 @@ export default class Consumer {
     if (!this.connection.isActive()) {
       return this.connection.open()
     }
+  }
+
+  addSubProtocol(subprotocol) {
+    this.subprotocols = [...this.subprotocols, subprotocol]
   }
 }
 

--- a/actioncable/test/javascript/src/test_helpers/consumer_test_helper.js
+++ b/actioncable/test/javascript/src/test_helpers/consumer_test_helper.js
@@ -20,6 +20,8 @@ export default function(name, options, callback) {
     const connection = consumer.connection
     const monitor = connection.monitor
 
+    if ("subprotocols" in options) consumer.addSubProtocol(options.subprotocols)
+
     server.on("connection", function() {
       const clients = server.clients()
       assert.equal(clients.length, 1)

--- a/actioncable/test/javascript/src/unit/consumer_test.js
+++ b/actioncable/test/javascript/src/unit/consumer_test.js
@@ -16,4 +16,12 @@ module("ActionCable.Consumer", () => {
     client.addEventListener("close", done)
     consumer.disconnect()
   })
+
+  consumerTest("#addSubProtocol", {subprotocols: "some subprotocol"}, ({consumer, server, assert, done}) => {
+    server.on("connection", () => {
+      assert.equal(consumer.subprotocols.length, 1)
+      assert.equal(consumer.subprotocols[0], "some subprotocol")
+      done()
+    })
+  })
 })


### PR DESCRIPTION
### Summary

The goal of this PR is to allow passing sub protocols to the backend via ActionCable.

### Usage

```javascript
const consumer = ActionCable.createConsumer()

consumer.addSubProtocol('custom-protocol')

consumer.connect()
```

which will sends the following protocol list : `[ "actioncable-v1-json", "actioncable-unsupported", "custom-protocol" ]`
