### PR TITLE
Harmonize average aggregation with minimum and maximum

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -49,15 +49,13 @@
 
     *Eileen M. Uchitelle*
 
-*   Switch to database adapter return type for `ActiveRecord::Calculations.calculate`
-    when called with `:average` (aliased as `ActiveRecord::Calculations.average`)
+*   `ActiveRecord::Calculations.calculate` called with `:average`
+    (aliased as `ActiveRecord::Calculations.average`) will now use column based
+    type casting. This means that floating point number columns will now be
+    aggregated as `Float` and decimal columns will be aggregated as `BigDecimal`.
 
-    Previously average aggregation returned `BigDecimal` for everything which
-    supported `to_d`. This was especially weird for floating point numbers.
-
-    Database adapters today map database column types to Ruby types more
-    accurately than 10 years ago. So now we simply pass them on
-    (except for special cases which are not `Numeric`).
+    Integers are handled as a special case returning `BigDecimal` always
+    (this was the case before already).
 
     ```ruby
     # With the following schema:
@@ -73,6 +71,11 @@
     Measurement.average(:temperature).class
     # => Float
     ```
+
+    Before this change, Rails just called `to_d` on average aggregates from the
+    database adapter. This is not the case anymore. If you relied on that kind
+    of magic, you now need to register your own `ActiveRecord::Type`
+    (see `ActiveRecord::Attributes::ClassMethods` for documentation).
 
     *Josua Schmid*
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -49,7 +49,9 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_should_return_decimal_average_of_integer_field
     value = Account.average(:id)
+
     assert_equal 3.5, value
+    assert_instance_of BigDecimal, value
   end
 
   def test_should_return_integer_average_if_db_returns_such
@@ -61,10 +63,18 @@ class CalculationsTest < ActiveRecord::TestCase
 
   def test_should_return_float_average_if_db_returns_such
     NumericData.create!(temperature: 37.5)
-
     value = NumericData.average(:temperature)
-    assert_instance_of Float, value
+
     assert_equal 37.5, value
+    assert_instance_of Float, value
+  end
+
+  def test_should_return_decimal_average_if_db_returns_such
+    NumericData.create!(bank_balance: 37.50)
+    value = NumericData.average(:bank_balance)
+
+    assert_equal 37.50, value
+    assert_instance_of BigDecimal, value
   end
 
   def test_should_return_nil_as_average


### PR DESCRIPTION
The real problem behind the previous implementation of average
aggregation was not that float columns returned `BigDecimal` but that
average skipped `ActiveModel` type casting.

This change introduces handling for the only needed special case
of average: integers. Any integer based fields will be casted to
`BigDecimal` when aggregated with average now.