### PR TITLE
Fix #41417 Handle Relations with having referencing aliased selects in #include?

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -352,7 +352,7 @@ module ActiveRecord
     # compared to the records in memory. If the relation is unloaded, an
     # efficient existence query is performed, as in #exists?.
     def include?(record)
-      if loaded? || offset_value || limit_value
+      if loaded? || offset_value || limit_value || having_clause.any?
         records.include?(record)
       else
         record.is_a?(klass) && exists?(record.id)

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -412,6 +412,15 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal true,  Customer.order(id: :desc).limit(2).include?(mary)
   end
 
+  def test_include_on_unloaded_relation_with_having_referencing_aliased_select
+    skip if current_adapter?(:PostgreSQLAdapter)
+    bob = authors(:bob)
+    mary = authors(:mary)
+
+    assert_equal false, Author.select("COUNT(*) as total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(bob)
+    assert_equal true, Author.select("COUNT(*) as total_posts", "authors.*").joins(:posts).group(:id).having("total_posts > 2").include?(mary)
+  end
+
   def test_include_on_loaded_relation_with_match
     customers = Customer.where(name: "David").load
     david     = customers(:david)


### PR DESCRIPTION
Skips optimised `#exists?` query in `#include?` for relations that have a having clause.

### Summary

Relations that have aliased select values AND a having clause that references an aliased select value would generate an error when `#include?` was called, due to an optimisation that would generate call `#exists?` on the relation instead, which effectively alters the select values of the query (and thus removes the aliased select values), but leaves the having clause intact. Because the having clause is then referencing an aliased column that is no longer present in the simplified query, an `ActiveRecord::InvalidStatement` error was raised.

An sample query affected by this problem:

```ruby
Author.select('COUNT(*) as total_posts', 'authors.*')
      .joins(:posts)
      .group(:id)
      .having('total_posts > 2')
      .include?(Author.first)
```

This change adds an additional condition that skips the simplified `#exists?` query, which simply checks for the presence of a having clause.

### Other Information

Not _all_ Relations that have a having clause actually trigger this problem. It's specifically the ones that have aliased select values AND where the having clause references an aliased select value.

The change does however skip the optimised `#exists?` query for _all_ relations that have a having clause. I attempted to find a decent way to detect when aliased select values where included in the relation, and when the having clause was referencing these aliases, and while I could actually do it for the specific example of query above, it involved effectively parsing SQL, and based on what I've read in other discussion in different issues, this is _strongly_ discouraged. So I figured in this case maybe the pragmatic path is just to skip the optimisation introduced in 166b63e for all relations that use a having condition. This way at least the problem for this very specific type of query is resolved, even if it means that a slightly broader group of queries are exempted from the optimisation as a result.

Fixes #41417