### PR TITLE
Show default help when calling help outside a Rails application

### DIFF
--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -11,7 +11,11 @@ Signal.trap("INT") { puts; exit(1) }
 
 require "rails/command"
 
-if ARGV.first == "plugin"
+case ARGV.first
+when Rails::Command::HELP_MAPPINGS, "help", nil
+  ARGV.shift
+  Rails::Command.invoke :help, ARGV
+when "plugin"
   ARGV.shift
   Rails::Command.invoke :plugin, ARGV
 else

--- a/railties/lib/rails/commands/help/USAGE
+++ b/railties/lib/rails/commands/help/USAGE
@@ -13,5 +13,3 @@ The most common rails commands are:
 <% end -%>
 
 All commands can be run with -h (or --help) for more information.
-In addition to those commands, there are:
-

--- a/railties/lib/rails/commands/help/help_command.rb
+++ b/railties/lib/rails/commands/help/help_command.rb
@@ -7,8 +7,13 @@ module Rails
 
       def help(*)
         say self.class.desc
+      end
 
-        Rails::Command.print_commands
+      def help_extended(*)
+        say self.class.desc
+
+        say "In addition to those commands, there are:"
+        Rails::Command.print_extended_commands
       end
     end
   end

--- a/railties/test/application/help_test.rb
+++ b/railties/test/application/help_test.rb
@@ -21,5 +21,31 @@ class HelpTest < ActiveSupport::TestCase
   test "short-cut alias works" do
     output = rails("-h")
     assert_match "The most common rails commands are", output
+    assert_match "In addition to those commands", output
+  end
+
+  test "help is the default command when no arguments are passed" do
+    output = rails("")
+    assert_match "The most common rails commands are", output
+    assert_no_match "In addition to those commands", output
+  end
+
+  test "outside application root it lists common commands only" do
+    output = gem_rails("")
+    assert_match "The most common rails commands are", output
+    assert_no_match "In addition to those commands", output
+  end
+
+  test "outside application root it lists common commands only with help option" do
+    output = gem_rails("-h")
+    assert_match "The most common rails commands are", output
+    assert_no_match "In addition to those commands", output
+  end
+
+  def gem_rails(cmd)
+    cmd = "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd}"
+    output = `#{cmd}`
+    raise "Command #{cmd.inspect} failed. Output:\n#{output}" unless $?.success?
+    output
   end
 end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1062,7 +1062,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "config/webpacker.yml"
 
     output = Dir.chdir(destination_root) do
-      `bin/rails help`
+      `bin/rails -h`
     end
 
     assert_match(/The most common rails commands are:/, output)


### PR DESCRIPTION
### Summary

When running `rails -h` or just `rails` outside a Rails application,
Rails outputs all options for running the `rails new` command. This can be
confusing to users when they probably want to see the common Rails commands.

Instead, we should always show the common commands when running `rails -h`
inside or outside a Rails application.

With this change help works as follows...

Outside a Rails application we always show the default help when calling `rails`
without a command like `new`. 
We never show the extended commands: db:migrate, etc...
The extended commands require a Rails application.
They also take up a lot screen space.

- `rails`        outputs the help for the common commands
- `rails -h`     outputs the help for the common commands.
- `rails new -h` outputs the help for the new command.

Inside a Rails application it works mostly as before. The only change is
that calling plain `bin/rails` now only outputs the common commands and
not the extended commands.

- `bin/rails`    outputs the help for the common commands
- `bin/rails -h` outputs the help for the common commands and the
  extended commands

This is a work in progress for #40823 
cc @olivierlacan 
