### PR TITLE
activerecord: Extract primary key constraints hash to a method

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -687,14 +687,14 @@ module ActiveRecord
         verify_readonly_attribute(name) || name
       end
 
-      id_in_database = self.id_in_database
+      update_constraints = _primary_key_constraints_hash
       attributes.each do |k, v|
         write_attribute_without_type_cast(k, v)
       end
 
       affected_rows = self.class._update_record(
         attributes,
-        @primary_key => id_in_database
+        update_constraints
       )
 
       affected_rows == 1
@@ -893,6 +893,10 @@ module ActiveRecord
         (self.class.default_scopes?(all_queries: true) || self.class.global_current_scope)
     end
 
+    def _primary_key_constraints_hash
+      { @primary_key => id_in_database }
+    end
+
     # A hook to be overridden by association modules.
     def destroy_associations
     end
@@ -902,7 +906,7 @@ module ActiveRecord
     end
 
     def _delete_row
-      self.class._delete_record(@primary_key => id_in_database)
+      self.class._delete_record(_primary_key_constraints_hash)
     end
 
     def _touch_row(attribute_names, time)
@@ -918,7 +922,7 @@ module ActiveRecord
     def _update_row(attribute_names, attempted_action = "update")
       self.class._update_record(
         attributes_with_values(attribute_names),
-        @primary_key => id_in_database
+        _primary_key_constraints_hash
       )
     end
 


### PR DESCRIPTION
cc @rafaelfranca 

Extract the primary key constraints hash, used for the WHERE scope to update or delete a record, into a method.  This is just a small step towards supporting a composite primary key, where we would want constraints on all primary key columns.

### Context

We have a use case for using a composite primary key for performance reasons, which isn't actually supported in rails at the moment.  Specifically, we use a parent record id along with the actual id to keep the associated records together for efficient querying (e.g. `(parent_id, id)`).

We can use `self.primary_key = :id` in the model to make most things work, along with a secondary `(id)` index.  However, that will end up taking gap locks in the innodb mysql engine when there is only an equality constraint on `id`, causing unnecessary lock contention.