### PR TITLE
Strict Loading - support `find_by`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Strict Loading violations now raise when you call `find_by` on a relation.
+
+    `find_by` always results in a new query, but this can be surprising. If you are using Strict Loading
+    you will now be alerted to these extra queries.
+
+    *Alex Ghiculescu*
+
 *   Skip optimised #exist? query when #include? is called on a relation
     with a having clause
 

--- a/activerecord/lib/active_record/association_relation.rb
+++ b/activerecord/lib/active_record/association_relation.rb
@@ -28,6 +28,16 @@ module ActiveRecord
     end
 
     private
+      def find_take_with_limit(limit)
+        @association.check_strict_loading_violation! if @association.find_from_target?
+        super
+      end
+
+      def find_take
+        @association.check_strict_loading_violation! if @association.find_from_target?
+        super
+      end
+
       def _new(attributes, &block)
         @association.build(attributes, &block)
       end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -211,11 +211,15 @@ module ActiveRecord
         _create_record(attributes, true, &block)
       end
 
+      def check_strict_loading_violation!
+        if (owner.strict_loading? || reflection.strict_loading?) && owner.validation_context.nil?
+          Base.strict_loading_violation!(owner: owner.class, reflection: reflection)
+        end
+      end
+
       private
         def find_target
-          if (owner.strict_loading? || reflection.strict_loading?) && owner.validation_context.nil?
-            Base.strict_loading_violation!(owner: owner.class, reflection: reflection)
-          end
+          check_strict_loading_violation!
 
           scope = self.scope
           return scope.to_a if skip_statement_cache?(scope)

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "ostruct"
+require "models/comment"
 
 class Developer < ActiveRecord::Base
   module TimestampAliases


### PR DESCRIPTION
In https://discuss.rubyonrails.org/t/how-to-enforce-strict-loading-of-records it was mentioned that strict loading violations aren't triggered when you call `find_by` on a relation. This is surprising if you don't that `find_by` always executes a query, even if you use `includes`/`preload`.

To make things less surprising, this PR expands strict loading to also work when calling `find_by`. This will happen even if you use `includes`, since a query would still execute. So, any of these will now raise:

```ruby
developer = Developer.first

Developer.strict_loading_by_default = true

Developer.first.audit_logs.find_by(criteria: "anything")
developer.audit_logs.find_by(criteria: "anything")

# bad despite `includes` because `find_by` always queries
Developer.includes(:audit_logs).first.audit_logs.find_by(criteria: "anything")

Developer.strict_loading_by_default = false

Developer.strict_loading.first.audit_logs.find_by(criteria: "anything")
```

To avoid the errors, either avoid using `find_by`, or don't enable strict loading on the relevant query. eg. these are fine:

```ruby
Developer.strict_loading_by_default = false

# fine because no strict loading enabled
Developer.first.audit_logs.find_by(criteria: "anything")
```

```ruby
Developer.strict_loading_by_default = true

# fine because no n+1
Developer.includes(:audit_logs).first.audit_logs.to_a.find {|a| a.criteria == "anything"}
```
