### PR TITLE
Improve documentation of Rails::Command.find_by_namespace [skip ci]

### DIFF
--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -60,14 +60,12 @@ module Rails
       # Command names must end with "_command.rb". This is required because Rails
       # looks in load paths and loads the command just before it's going to be used.
       #
-      #   find_by_namespace :webrat, :rails, :integration
+      #   find_by_namespace :webrat, :integration
       #
       # Will search for the following commands:
       #
-      #   "rails:webrat", "webrat:integration", "webrat"
+      #   "webrat", "webrat:integration", "rails:webrat", "rails:webrat:integration"
       #
-      # Notice that "rails:commands:webrat" could be loaded as well, what
-      # Rails looks for is the first and last parts of the namespace.
       def find_by_namespace(namespace, command_name = nil) # :nodoc:
         lookups = [ namespace ]
         lookups << "#{namespace}:#{command_name}" if command_name


### PR DESCRIPTION
### Summary

* The documentation for `Rails::Command.find_by_namespace` shows an example
with 3 arguments but the method only accepts 2 arguments:
`namespace` and `command_name`.

* For both `namespace` and `namespace:command_name`, a namespace
with the `rails:` prepended is added.

* "rails:commands:webrat" isn't a namespace that can be returned as the
`Rails::Command::Base.namespace` removes the "commands:" part.
