### PR TITLE
Fix #41413 by using a specific purpose for direct uploads

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   When attaching blobs by their signed ids, you can now configure to attach with `:private_id` or `:blob_id`.
+
+    This is important due to a security vulnerability described in [#41413](https://github.com/rails/rails/issues/41413) where
+    a malicious user could attach another user's blob to their own record. The recommended approach is to use `:private_id` which
+    won't be visible to any other user.
+
+    For a smooth migration there's an intermediate setting `:private_id_with_fallback` where both signature purposes will
+    be accepted for a short period of time.
+
+    *Santiago Bartesaghi*, *Juan E. Roig*, *brunvez*
+
 *   Allow to purge an attachment when record is not persisted for `has_one_attached`
 
     *Jacopo Beschi*

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -15,9 +15,20 @@ class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
     end
 
     def direct_upload_json(blob)
-      blob.as_json(root: false, methods: :signed_id).merge(direct_upload: {
-        url: blob.service_url_for_direct_upload,
-        headers: blob.service_headers_for_direct_upload
-      })
+      blob.as_json(root: false).merge(
+        signed_id: blob.signed_id(purpose: signature_purpose),
+        direct_upload: {
+          url: blob.service_url_for_direct_upload,
+          headers: blob.service_headers_for_direct_upload
+        }
+      )
+    end
+
+    def signature_purpose
+      if ActiveStorage.blob_attachment_mode == :blob_id
+        :blob_id
+      else
+        :private_id
+      end
     end
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -67,6 +67,7 @@ module ActiveStorage
 
   mattr_accessor :replace_on_assign_to_many, default: false
   mattr_accessor :track_variants, default: false
+  mattr_accessor :blob_attachment_mode, default: :blob_id
 
   module Transformers
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -95,6 +95,7 @@ module ActiveStorage
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
+        ActiveStorage.blob_attachment_mode = app.config.active_storage.blob_attachment_mode || :blob_id
       end
     end
 

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -175,6 +175,28 @@ class ActiveStorage::DiskDirectUploadsControllerTest < ActionDispatch::Integrati
     end
   end
 
+  test "using :private_id_with_fallback blob attachment mode signs the blob with :private_id" do
+    with_blob_attachment_mode :private_id_with_fallback do
+      post rails_direct_uploads_url, params: { blob: {
+        filename: "hello.txt", byte_size: 6, checksum: Digest::MD5.base64digest("Hello"), content_type: "text/plain", metadata: {} } }
+
+      @response.parsed_body.tap do |details|
+        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"], purpose: :private_id)
+      end
+    end
+  end
+
+  test "using :private_id blob attachment mode signs the blob with :private_id" do
+    with_blob_attachment_mode :private_id do
+      post rails_direct_uploads_url, params: { blob: {
+        filename: "hello.txt", byte_size: 6, checksum: Digest::MD5.base64digest("Hello"), content_type: "text/plain", metadata: {} } }
+
+      @response.parsed_body.tap do |details|
+        assert_equal ActiveStorage::Blob.find(details["id"]), ActiveStorage::Blob.find_signed!(details["signed_id"], purpose: :private_id)
+      end
+    end
+  end
+
   private
     def set_include_root_in_json(value)
       original = ActiveRecord::Base.include_root_in_json

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -108,6 +108,14 @@ class ActiveSupport::TestCase
     ensure
       ActiveStorage::Blob.service = previous_service
     end
+
+    def with_blob_attachment_mode(mode)
+      ActiveStorage.blob_attachment_mode, previous = mode, ActiveStorage.blob_attachment_mode
+
+      yield
+    ensure
+      ActiveStorage.blob_attachment_mode = previous
+    end
 end
 
 require "global_id"

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -220,6 +220,10 @@ module Rails
           if respond_to?(:action_mailer)
             action_mailer.smtp_timeout = 5
           end
+
+          if respond_to?(:active_storage)
+            active_storage.blob_attachment_mode = :private_id
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -37,3 +37,13 @@
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
 # Rails.application.config.action_mailer.smtp_timeout = 5
+
+# Only allow attaching blobs by their private signed ids.
+#
+# Direct uploaded blobs are now signed with a `:private_id` purpose. Previously, they were signed with `:blob_id`.
+# If you are using direct uploads or attaching blobs by their signed id,
+# your app will need to temporarily be able to find by both signature purposes.
+# To smoothly migrate you will need to first use the `:private_id_with_fallback` mode,
+# make sure your entire app is migrated and stable on 7.0 before setting the new `:private_id` mode.
+#
+# Rails.application.config.active_storage.blob_attachment_mode = :private_id

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3201,6 +3201,37 @@ module ApplicationTests
       assert_no_match(/You are running SQLite in production, this is generally not recommended/, Rails.logger.recording)
     end
 
+    test "ActiveStorage.blob_attachment_mode is :blob_id in the 6.1 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "6.1"'
+
+      app "production"
+
+      assert_equal :blob_id, ActiveStorage.blob_attachment_mode
+    end
+
+
+    test "ActiveStorage.blob_attachment_mode is :private_id in the 7.0 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "7.0"'
+
+      app "production"
+
+      assert_equal :private_id, ActiveStorage.blob_attachment_mode
+    end
+
+    test "ActiveStorage.blob_attachment_mode can be configured via config.active_storage.blob_attachment_mode" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_0.rb", <<-RUBY
+        Rails.application.config.active_storage.blob_attachment_mode = :private_id_with_fallback
+      RUBY
+
+      app "production"
+
+      assert_equal :private_id_with_fallback, ActiveStorage.blob_attachment_mode
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
### Summary

Fixes #41413 by using a specific `purpose` when generating the `signed_id` of `ActiveStorage::Blob`s for direct uploads. I think it would be important to fix it since a user should have the right to permanently delete blobs uploaded by them.

Before this change, the attack described in the issue was possible just by knowing the `signed_id` of a Blob. And the `signed_id` is present in shareable URLs, so it's expected that some people know some `signed_id`s.

After this change, the attack described would only be possible if intercepting the response of the direct uploads controller. Which wouldn't be possible just because of SSL.

This is a **breaking change** since it'd break any app that performs any `find_signed` call in the context of direct uploads because it's assuming the purpose would be `blob_id`.

cc @georgeclaghorn 