### PR TITLE
Trim new lines in USAGE ERB tags

### DIFF
--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -32,7 +32,7 @@ module Rails
           if usage
             super
           else
-            @desc ||= ERB.new(File.read(usage_path)).result(binding) if usage_path
+            @desc ||= ERB.new(File.read(usage_path), trim_mode: "-").result(binding) if usage_path
           end
         end
 

--- a/railties/lib/rails/commands/help/USAGE
+++ b/railties/lib/rails/commands/help/USAGE
@@ -6,10 +6,10 @@ The most common rails commands are:
  test:system  Run system tests
  dbconsole    Start a console for the database specified in config/database.yml
               (short-cut alias: "db")
-<% unless engine? %>
+<% unless engine? -%>
  new          Create a new Rails application. "rails new my_app" creates a
               new application called MyApp in "./my_app"
-<% end %>
+<% end -%>
 
 All commands can be run with -h (or --help) for more information.
 In addition to those commands, there are:


### PR DESCRIPTION
The USAGE file uses ERB tags for conditionals.
The ERB tags should not output new lines.
Adding the trim_mode option removes the new lines.

## Before
```
...
 dbconsole    Start a console for the database specified in config/database.yml
              (short-cut alias: "db")

 new          Create a new Rails application. "rails new my_app" creates a
              new application called MyApp in "./my_app"


All commands can be run with -h (or --help) for more information.
...
```

## After
```
...
 dbconsole    Start a console for the database specified in config/database.yml
              (short-cut alias: "db")
 new          Create a new Rails application. "rails new my_app" creates a
              new application called MyApp in "./my_app"

All commands can be run with -h (or --help) for more information.
...
```