### PR TITLE
Added Active Storage support for byte ranges

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for byte range requests
+
+    *Tom Prats*
+
 *   Attachments can be deleted after their association is no longer defined.
 
     Fixes #42514

--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -10,8 +10,15 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 
   def show
-    http_cache_forever public: true do
-      send_blob_stream @blob
+    if request.headers["Range"].present?
+      send_blob_byte_range_data @blob, request.headers["Range"]
+    else
+      http_cache_forever public: true do
+        response.headers["Accept-Ranges"] = "bytes"
+        response.headers["Content-Length"] = @blob.byte_size.to_s
+
+        send_blob_stream @blob
+      end
     end
   end
 end

--- a/activestorage/app/controllers/concerns/active_storage/streaming.rb
+++ b/activestorage/app/controllers/concerns/active_storage/streaming.rb
@@ -1,11 +1,55 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module ActiveStorage::Streaming
   DEFAULT_BLOB_STREAMING_DISPOSITION = "inline"
 
+  include ActionController::DataStreaming
   include ActionController::Live
 
   private
+    # Stream the blob in byte ranges specified through the header
+    def send_blob_byte_range_data(blob, range_header, disposition: nil) #:doc:
+      ranges = Rack::Utils.get_byte_ranges(range_header, blob.byte_size)
+
+      return head(:range_not_satisfiable) if ranges.blank? || ranges.all?(&:blank?)
+
+      if ranges.length == 1
+        range = ranges.first
+        content_type = blob.content_type_for_serving
+        data = blob.download_chunk(range)
+
+        response.headers["Content-Range"] = "bytes #{range.begin}-#{range.end}/#{blob.byte_size}"
+      else
+        boundary = SecureRandom.hex
+        content_type = "multipart/byteranges; boundary=#{boundary}"
+        data = +""
+
+        ranges.compact.each do |range|
+          chunk = blob.download_chunk(range)
+
+          data << "\r\n--#{boundary}\r\n"
+          data << "Content-Type: #{blob.content_type_for_serving}\r\n"
+          data << "Content-Range: bytes #{range.begin}-#{range.end}/#{blob.byte_size}\r\n\r\n"
+          data << chunk
+        end
+
+        data << "\r\n--#{boundary}--\r\n"
+      end
+
+      response.headers["Accept-Ranges"] = "bytes"
+      response.headers["Content-Length"] = data.length.to_s
+
+      send_data(
+        data,
+        disposition: blob.forced_disposition_for_serving || disposition || DEFAULT_BLOB_STREAMING_DISPOSITION,
+        filename: blob.filename.sanitized,
+        status: :partial_content,
+        type: content_type
+      )
+    end
+
     # Stream the blob from storage directly to the response. The disposition can be controlled by setting +disposition+.
     # The content type and filename is set directly from the +blob+.
     def send_blob_stream(blob, disposition: nil) #:doc:

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -253,6 +253,11 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.download key, &block
   end
 
+  # Downloads a part of the file associated with this blob.
+  def download_chunk(range)
+    service.download_chunk key, range
+  end
+
   # Downloads the blob to a tempfile on disk. Yields the tempfile.
   #
   # The tempfile's name is prefixed with +ActiveStorage-+ and the blob's ID. Its extension matches that of the blob.


### PR DESCRIPTION
### Summary

This PR allows Active Storage to have byte-range support.

I’m serving audio for a podcast using Active Storage’s proxy feature with AWS’s S3. But the audio on iOS devices weren't playing because Apple appears to (sometimes?) require byte range support. I ended up forking Rails and have been using this branch in production for a month and all seems well.

### Other Information

I opened a discussion on the forum/email list and didn't receive a lot of feedback.

https://discuss.rubyonrails.org/t/byte-range-support/76791

Let me know if there's anything else I can do to help get this moving!