### PR TITLE
Fix inline code markup [ci-skip]

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -15,9 +15,9 @@ module ActionCable
       end
     end
 
-    # Stub `stream_from` to track streams for the channel.
-    # Add public aliases for `subscription_confirmation_sent?` and
-    # `subscription_rejected?`.
+    # Stub +stream_from+ to track streams for the channel.
+    # Add public aliases for +subscription_confirmation_sent?+ and
+    # +subscription_rejected?+.
     module ChannelStub
       def confirmed?
         subscription_confirmation_sent?
@@ -123,7 +123,7 @@ module ActionCable
     # <b>connection</b>::
     #      An ActionCable::Channel::ConnectionStub, representing the current HTTP connection.
     # <b>subscription</b>::
-    #      An instance of the current channel, created when you call `subscribe`.
+    #      An instance of the current channel, created when you call +subscribe+.
     # <b>transmissions</b>::
     #      A list of all messages that have been transmitted into the channel.
     #

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -84,7 +84,7 @@ module ActionController
     #
     # If no <tt>options</tt> hash is passed or if <tt>:update</tt> is specified, then:
     #
-    # If an object responding to `render_in` is passed, `render_in` is called on the object,
+    # If an object responding to +render_in+ is passed, +render_in+ is called on the object,
     # passing in the current view context.
     #
     # Otherwise, a partial is rendered using the second parameter as the locals hash.

--- a/actionpack/lib/action_dispatch/http/mime_type.rb
+++ b/actionpack/lib/action_dispatch/http/mime_type.rb
@@ -329,7 +329,7 @@ module Mime
   end
 
   # ALL isn't a real MIME type, so we don't register it for lookup with the
-  # other concrete types. It's a wildcard match that we use for `respond_to`
+  # other concrete types. It's a wildcard match that we use for +respond_to+
   # negotiation internals.
   ALL = AllType.instance
 

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -13,7 +13,7 @@ module ActionDispatch
   #
   # When a request comes to an unauthorized host, the +response_app+
   # application will be executed and rendered. If no +response_app+ is given, a
-  # default one will run, which responds with +403 Forbidden+.
+  # default one will run, which responds with <tt>403 Forbidden</tt>.
   class HostAuthorization
     class Permissions # :nodoc:
       def initialize(hosts)

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -43,7 +43,7 @@ module ActionDispatch
     end
 
     # This class is used to instrument the execution of a single middleware.
-    # It proxies the `call` method transparently and instruments the method
+    # It proxies the +call+ method transparently and instruments the method
     # call.
     class InstrumentationProxy
       EVENT_NAME = "process_middleware.action_dispatch"

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -32,12 +32,12 @@ module ActionDispatch
   #
   # Precompressed versions of these files are checked first. Brotli (.br)
   # and gzip (.gz) files are supported. If +path+.br exists, this
-  # endpoint returns that file with a +Content-Encoding: br+ header.
+  # endpoint returns that file with a <tt>Content-Encoding: br</tt> header.
   #
   # If no matching file is found, this endpoint responds 404 Not Found.
   #
   # Pass the +root+ directory to search for matching files, an optional
-  # +index: "index"+ to change the default +path+/index.html, and optional
+  # <tt>index: "index"</tt> to change the default +path+/index.html, and optional
   # additional response headers.
   class FileHandler
     # Accept-Encoding value -> file extension

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -163,7 +163,7 @@ module ActionDispatch
       #     "http://#{request.host_with_port}/#{path}"
       #   }
       #
-      # Note that the +do end+ syntax for the redirect block wouldn't work, as Ruby would pass
+      # Note that the <tt>do end</tt> syntax for the redirect block wouldn't work, as Ruby would pass
       # the block to +get+ instead of +redirect+. Use <tt>{ ... }</tt> instead.
       #
       # The options version of redirect allows you to supply only the parts of the URL which need

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -199,11 +199,11 @@ module ActionDispatch
       #   merged into the Rack env hash.
       # - +env+: Additional env to pass, as a Hash. The headers will be
       #   merged into the Rack env hash.
-      # - +xhr+: Set to `true` if you want to make and Ajax request.
+      # - +xhr+: Set to +true+ if you want to make and Ajax request.
       #   Adds request headers characteristic of XMLHttpRequest e.g. HTTP_X_REQUESTED_WITH.
       #   The headers will be merged into the Rack env hash.
       # - +as+: Used for encoding the request with different content type.
-      #   Supports `:json` by default and will set the appropriate request headers.
+      #   Supports +:json+ by default and will set the appropriate request headers.
       #   The headers will be merged into the Rack env hash.
       #
       # This method is rarely used directly. Use +#get+, +#post+, or other standard

--- a/actionview/lib/action_view/helpers/asset_url_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_url_helper.rb
@@ -98,7 +98,7 @@ module ActionView
     # have SSL certificates for each of the asset hosts this technique allows you
     # to avoid warnings in the client about mixed media.
     # Note that the +request+ parameter might not be supplied, e.g. when the assets
-    # are precompiled with the command `bin/rails assets:precompile`. Make sure to use a
+    # are precompiled with the command <tt>bin/rails assets:precompile</tt>. Make sure to use a
     # +Proc+ instead of a lambda, since a +Proc+ allows missing parameters and sets them
     # to +nil+.
     #

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -24,7 +24,7 @@ module ActionView
       #
       # If no <tt>options</tt> hash is passed or if <tt>:update</tt> is specified, then:
       #
-      # If an object responding to `render_in` is passed, `render_in` is called on the object,
+      # If an object responding to +render_in+ is passed, +render_in+ is called on the object,
       # passing in the current view context.
       #
       # Otherwise, a partial is rendered using the second parameter as the locals hash.

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -29,7 +29,7 @@ module ActiveJob
 
     # Performs the job immediately. The job is not sent to the queuing adapter
     # but directly executed by blocking the execution of others until it's finished.
-    # `perform_now` returns the value of your job's `perform` method.
+    # +perform_now+ returns the value of your job's +perform+ method.
     #
     #   class MyJob < ActiveJob::Base
     #     def perform

--- a/activejob/lib/active_job/queue_adapter.rb
+++ b/activejob/lib/active_job/queue_adapter.rb
@@ -26,7 +26,7 @@ module ActiveJob
       end
 
       # Returns string denoting the name of the configured queue adapter.
-      # By default returns +"async"+.
+      # By default returns <tt>"async"</tt>.
       def queue_adapter_name
         _queue_adapter_name
       end

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -119,11 +119,11 @@ module ActiveModel
     attr_reader :base
     # The attribute of +base+ which the error belongs to
     attr_reader :attribute
-    # The type of error, defaults to `:invalid` unless specified
+    # The type of error, defaults to +:invalid+ unless specified
     attr_reader :type
-    # The raw value provided as the second parameter when calling `errors#add`
+    # The raw value provided as the second parameter when calling +errors#add+
     attr_reader :raw_type
-    # The options provided when calling `errors#add`
+    # The options provided when calling +errors#add+
     attr_reader :options
 
     # Returns the error message.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -110,7 +110,7 @@ module ActiveModel
     # Imports one error
     # Imported errors are wrapped as a NestedError,
     # providing access to original error object.
-    # If attribute or type needs to be overridden, use `override_options`.
+    # If attribute or type needs to be overridden, use +override_options+.
     #
     # override_options - Hash
     # @option override_options [Symbol] :attribute Override the attribute the error belongs to

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -75,13 +75,13 @@ module ActiveRecord
       # Prevent writing to the database regardless of role.
       #
       # In some cases you may want to prevent writes to the database
-      # even if you are on a database that can write. `while_preventing_writes`
+      # even if you are on a database that can write. +while_preventing_writes+
       # will prevent writes to the database for the duration of the block.
       #
       # This method does not provide the same protection as a readonly
       # user and is meant to be a safeguard against accidental writes.
       #
-      # See `READ_QUERY` for the queries that are blocked by this
+      # See +READ_QUERY+ for the queries that are blocked by this
       # method.
       def while_preventing_writes(enabled = true)
         unless ActiveRecord::Base.legacy_connection_handling

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -391,7 +391,7 @@ module ActiveRecord
 
       # Inserts the given fixture into the table. Overridden in adapters that require
       # something beyond a simple insert (e.g. Oracle).
-      # Most of adapters should implement `insert_fixtures_set` that leverages bulk SQL insert.
+      # Most of adapters should implement +insert_fixtures_set+ that leverages bulk SQL insert.
       # We keep this method to provide fallback
       # for databases like sqlite that do not support bulk inserts.
       def insert_fixture(fixture, table_name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -122,10 +122,10 @@ module ActiveRecord
       # Returns true if the connection is a replica.
       #
       # If the application is using legacy handling, returns
-      # true if `connection_handler.prevent_writes` is set.
+      # true if +connection_handler.prevent_writes+ is set.
       #
       # If the application is using the new connection handling
-      # will return true based on `current_preventing_writes`.
+      # will return true based on +current_preventing_writes+.
       def preventing_writes?
         return true if replica?
         return ActiveRecord::Base.connection_handler.prevent_writes if ActiveRecord::Base.legacy_connection_handling

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -114,7 +114,7 @@ module ActiveRecord
     #
     # If only a role is passed, Active Record will look up the connection
     # based on the requested role. If a non-established role is requested
-    # an `ActiveRecord::ConnectionNotEstablished` error will be raised:
+    # an +ActiveRecord::ConnectionNotEstablished+ error will be raised:
     #
     #   ActiveRecord::Base.connected_to(role: :writing) do
     #     Dog.create! # creates dog using dog writing connection
@@ -125,7 +125,7 @@ module ActiveRecord
     #   end
     #
     # When swapping to a shard, the role must be passed as well. If a non-existent
-    # shard is passed, an `ActiveRecord::ConnectionNotEstablished` error will be
+    # shard is passed, an +ActiveRecord::ConnectionNotEstablished+ error will be
     # raised.
     #
     # When a shard and role is passed, Active Record will first lookup the role,
@@ -160,11 +160,11 @@ module ActiveRecord
       with_role_and_shard(role, shard, prevent_writes, &blk)
     end
 
-    # Connects a role and/or shard to the provided connection names. Optionally `prevent_writes`
-    # can be passed to block writes on a connection. `reading` will automatically set
-    # `prevent_writes` to true.
+    # Connects a role and/or shard to the provided connection names. Optionally +prevent_writes+
+    # can be passed to block writes on a connection. +reading+ will automatically set
+    # +prevent_writes+ to true.
     #
-    # `connected_to_many` is an alternative to deeply nested `connected_to` blocks.
+    # +connected_to_many+ is an alternative to deeply nested +connected_to+ blocks.
     #
     # Usage:
     #
@@ -198,7 +198,7 @@ module ActiveRecord
     # being used. For example, when booting a console in readonly mode.
     #
     # It is not recommended to use this method in a request since it
-    # does not yield to a block like `connected_to`.
+    # does not yield to a block like +connected_to+.
     def connecting_to(role: default_role, shard: default_shard, prevent_writes: false)
       if legacy_connection_handling
         raise NotImplementedError, "`connecting_to` is not available with `legacy_connection_handling`."
@@ -212,13 +212,13 @@ module ActiveRecord
     # Prevent writing to the database regardless of role.
     #
     # In some cases you may want to prevent writes to the database
-    # even if you are on a database that can write. `while_preventing_writes`
+    # even if you are on a database that can write. +while_preventing_writes+
     # will prevent writes to the database for the duration of the block.
     #
     # This method does not provide the same protection as a readonly
     # user and is meant to be a safeguard against accidental writes.
     #
-    # See `READ_QUERY` for the queries that are blocked by this
+    # See +READ_QUERY+ for the queries that are blocked by this
     # method.
     def while_preventing_writes(enabled = true, &block)
       if legacy_connection_handling

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -181,7 +181,7 @@ module ActiveRecord
   #     end
   #   end
   #
-  # If you preload your test database with all fixture data (probably by running `bin/rails db:fixtures:load`)
+  # If you preload your test database with all fixture data (probably by running <tt>bin/rails db:fixtures:load</tt>)
   # and use transactional tests, then you may omit all fixtures declarations in your test cases since
   # all the data's already there and every case rolls back its changes.
   #

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -319,7 +319,7 @@ module ActiveRecord
   #   +table_name+. Passing a hash containing <tt>:from</tt> and <tt>:to</tt>
   #   as +default_or_changes+ will make this change reversible in the migration.
   # * <tt>change_column_null(table_name, column_name, null, default = nil)</tt>:
-  #   Sets or removes a +NOT NULL+ constraint on +column_name+. The +null+ flag
+  #   Sets or removes a <tt>NOT NULL</tt> constraint on +column_name+. The +null+ flag
   #   indicates whether the value can be +NULL+. See
   #   ActiveRecord::ConnectionAdapters::SchemaStatements#change_column_null for
   #   details.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -122,9 +122,9 @@ module ActiveRecord
     # :singleton-method: immutable_strings_by_default=
     # :call-seq: immutable_strings_by_default=(bool)
     #
-    # Determines whether columns should infer their type as `:string` or
-    # `:immutable_string`. This setting does not affect the behavior of
-    # `attribute :foo, :string`. Defaults to false.
+    # Determines whether columns should infer their type as +:string+ or
+    # +:immutable_string+. This setting does not affect the behavior of
+    # <tt>attribute :foo, :string</tt>. Defaults to false.
 
     included do
       mattr_accessor :primary_key_prefix_type, instance_writer: false
@@ -316,7 +316,7 @@ module ActiveRecord
       #     self.ignored_columns = [:category]
       #   end
       #
-      # The schema still contains `category`, but now the model omits it, so any meta-driven code or
+      # The schema still contains "category", but now the model omits it, so any meta-driven code or
       # schema caching will not attempt to use the column:
       #
       #   Project.columns_hash["category"] => nil

--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -54,7 +54,7 @@ module ActiveRecord
 
         # Checks if the model has any default scopes. If all_queries
         # is set to true, the method will check if there are any
-        # default_scopes for the model  where `all_queries` is true.
+        # default_scopes for the model  where +all_queries+ is true.
         def default_scopes?(all_queries: false)
           if all_queries
             self.default_scopes.map(&:all_queries).include?(true)
@@ -80,7 +80,7 @@ module ActiveRecord
           #   Article.create.published # => true
           #
           # To apply a #default_scope when updating or deleting a record, add
-          # `all_queries: true`:
+          # <tt>all_queries: true</tt>:
           #
           #   class Article < ActiveRecord::Base
           #     default_scope { where(blog_id: 1) }, all_queries: true

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -115,7 +115,7 @@ module ActiveSupport
     # <tt>ActiveSupport::HashWithIndifferentAccess</tt> or a regular +Hash+.
     # In either case the merge respects the semantics of indifferent access.
     #
-    # If the argument is a regular hash with keys +:key+ and +"key"+ only one
+    # If the argument is a regular hash with keys +:key+ and <tt>"key"</tt> only one
     # of the values end up in the receiver, but which one is unspecified.
     #
     # When given a block, the value for duplicated keys will be determined

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -178,7 +178,7 @@ module ActiveSupport
   #
   # Subscribers using a regexp or other pattern-matching object will remain subscribed
   # to all events that match their original pattern, unless those events match a string
-  # passed to `unsubscribe`:
+  # passed to +unsubscribe+:
   #
   #   subscriber = ActiveSupport::Notifications.subscribe(/render/) { }
   #   ActiveSupport::Notifications.unsubscribe('render_template.action_view')

--- a/activesupport/lib/active_support/parameter_filter.rb
+++ b/activesupport/lib/active_support/parameter_filter.rb
@@ -38,7 +38,7 @@ module ActiveSupport
     #
     # ==== Options
     #
-    # * <tt>:mask</tt> - A replaced object when filtered. Defaults to +"[FILTERED]"+
+    # * <tt>:mask</tt> - A replaced object when filtered. Defaults to <tt>"[FILTERED]"</tt>.
     def initialize(filters = [], mask: FILTERED)
       @filters = filters
       @mask = mask

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -301,7 +301,7 @@ module ActiveSupport
     alias_method :in, :+
 
     # Subtracts an interval of time and returns a new TimeWithZone object unless
-    # the other value `acts_like?` time. Then it will return a Float of the difference
+    # the other value +acts_like?+ time. Then it will return a Float of the difference
     # between the two times that represents the difference between the current
     # object's time and the +other+ time.
     #

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -508,7 +508,7 @@ module ActiveSupport
     # Time#in_time_zone() instead.
     #
     # As of tzinfo 2, utc_to_local returns a Time with a non-zero utc_offset.
-    # See the `utc_to_local_returns_utc_offset_times` config for more info.
+    # See the +utc_to_local_returns_utc_offset_times+ config for more info.
     def utc_to_local(time)
       tzinfo.utc_to_local(time).yield_self do |t|
         ActiveSupport.utc_to_local_returns_utc_offset_times ?

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -72,7 +72,7 @@ module Rails
     #
     # See <tt>#find_in</tt> for a list of file extensions that will be taken into account.
     #
-    # This class method is the single entry point for the `rails notes` command.
+    # This class method is the single entry point for the <tt>rails notes</tt> command.
     def self.enumerate(tag = nil, options = {})
       tag ||= Annotation.tags.join("|")
       extractor = new(tag)


### PR DESCRIPTION
RDoc Markup does not support backticks the way Markdown does to mark up inline code.  Additionally, `<tt>` must be used to mark up inline code that includes spaces or certain punctuation characters (e.g. quotes).
