### PR TITLE
Improve help for Rake tasks

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Show Rake task description if command is run with -h.
+
+    Adding `-h` (or `--help`) to a Rails command that's a Rake task, now returns
+    the task description instead of the general Rake help.
+
+    *Petrik de Heus*
+
 *   Fix `config_for` error when there's only a shared root array.
 
     *Loïc Delmaire*

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -47,6 +47,7 @@ module Rails
         if command && command.all_commands[command_name]
           command.perform(command_name, args, config)
         else
+          args = ["--describe", full_namespace] if HELP_MAPPINGS.include?(args[0])
           find_by_namespace("rake").perform(full_namespace, args, config)
         end
       ensure

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -41,6 +41,15 @@ module ApplicationTests
       assert_match(/^Rails version/, rails("invoke_about"))
     end
 
+    test "help arguments describe rake tasks" do
+      task_description = <<~DESC
+          rails db:migrate
+              Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog).
+      DESC
+
+      assert_match task_description, rails("db:migrate", "-h")
+    end
+
     test "task backtrace is silenced" do
       add_to_config <<-RUBY
         rake_tasks do


### PR DESCRIPTION
When running `bin/rails -h` the following messages is shown:

> All commands can be run with -h (or --help) for more information.

This doesn't apply to the commands that are Rake tasks like db:migrate.
If you run `bin/rails db:migrate -h` you'll get the Rake help, which
can be confusing...

Instead, if we replace the `-h` argument with `--describe db:migrate`
Rails outputs the Rake task descriptions, which are a lot more helpful:

    rails db:migrate
        Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog).
