### PR TITLE
Support phone_to options when name not specified

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -644,8 +644,8 @@ module ActionView
       #   phone_to "1234567890", "Phone me"
       #   # => <a href="tel:134567890">Phone me</a>
       #
-      #   phone_to "1234567890", "Phone me", country_code: "01"
-      #   # => <a href="tel:+015155555785">Phone me</a>
+      #   phone_to "1234567890", country_code: "01"
+      #   # => <a href="tel:+015155555785">1234567890</a>
       #
       # You can use a block as well if your link target is hard to fit into the name parameter. \ERB example:
       #
@@ -656,7 +656,7 @@ module ActionView
       #          <strong>Phone me:</strong>
       #        </a>
       def phone_to(phone_number, name = nil, html_options = {}, &block)
-        html_options, name = name, nil if block_given?
+        html_options, name = name, nil if name.is_a?(Hash)
         html_options = (html_options || {}).stringify_keys
 
         country_code = html_options.delete("country_code").presence

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -832,6 +832,11 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
 
     assert_dom_equal(
+      %{<a class="example-class" href="tel:+011234567890">1234567890</a>},
+      phone_to("1234567890", class: "example-class", country_code: "01")
+    )
+
+    assert_dom_equal(
       %{<a href="tel:+011234567890">Phone</a>},
       phone_to("1234567890", "Phone", country_code: "01")
     )


### PR DESCRIPTION
When `name` is not specified, `phone_to` uses `phone_number` as the link text.  This commit allows options to be specified in such a case.  This enables using the `country_code` option to include the country code in the link `href`, while a country-code-less `phone_number` is used as the link text.