### PR TITLE
Fix docs formatting [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -364,7 +364,7 @@ end
 
 Call `avatar.variant(:thumb)` to get a thumb variant of an avatar:
 
-```ruby
+```erb
 <%= image_tag user.avatar.variant(:thumb) %>
 ```
 


### PR DESCRIPTION
Format should be `erb` not `ruby`

![image](https://user-images.githubusercontent.com/6373536/107960353-4a20e200-6f83-11eb-8be5-9a7ec868b446.png)
