### PR TITLE
Add attributes module to ActiveModel::Model

### DIFF
--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -65,6 +65,7 @@ module ActiveModel
     included do
       extend ActiveModel::Naming
       extend ActiveModel::Translation
+      include ActiveModel::Attributes
     end
 
     # Initializes a new model with the given +params+.

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -6,7 +6,6 @@ module ActiveModel
   class AttributesTest < ActiveModel::TestCase
     class ModelForAttributesTest
       include ActiveModel::Model
-      include ActiveModel::Attributes
 
       attribute :integer_field, :integer
       attribute :string_field, :string


### PR DESCRIPTION
### Summary

The attributes module isn't included when `ActiveModel::Model` module is.

### Other Information

You can read the full story [here](https://twitter.com/kaspth/status/1361330810004123653?s=20) 😅 