### PR TITLE
Added an optional foreign_keys parameter to add_index helper function 

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+* Added an optional `foreign_keys` parameter to `add_index` that when provided, will 
+attach a `_id` postfix to all of the given columns, provided that there exists a column defined in the table. This would help keeping the migration files more Railsy. So a code that might look like this 
+    ```ruby
+        def change
+            create_table :people_projects do |t|
+              t.belongs_to :person, null: false, foreign_key: true
+              t.belongs_to :project, null: true, foreign_key: true
+            end
+  
+            # Before
+            add_index :people_projects, %i[person_id project_id], unique: true
+            
+            # After
+            add_index :people_projects, %i[person project], foreign_keys: true, unique: true
+        end
+    ```
+    this is optional and can backward compatible with the older ways of defining indexes.
+    *Ahmed Khattab*
+
 *   Skip optimised #exist? query when #include? is called on a relation
     with a having clause
 

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -17,8 +17,8 @@ module ActiveRecord
           t.column :bar, :string, limit: 100
 
           # mimic a foreign key
-          t.column :key_1
-          t.column :key_2
+          t.column :key_1, :string, limit: 100
+          t.column :key_2, :string, limit: 100
 
           t.string :first_name
           t.string :last_name, limit: 100
@@ -204,7 +204,7 @@ module ActiveRecord
       end
 
       def test_add_index_foreign_keys_appends_id_to_foreign_keys
-        connection.add_index :testings, [:key_1, :key_2], foreign_keys: true
+        connection.add_index :testings, [:key_1, :key_2], foreign_keys: true, length: 10
 
         assert connection.index_exists?(:testings, [:key_1, :key_2])
       end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -16,6 +16,10 @@ module ActiveRecord
           t.column :foo, :string, limit: 100
           t.column :bar, :string, limit: 100
 
+          # mimic a foreign key
+          t.column :key_1
+          t.column :key_2
+
           t.string :first_name
           t.string :last_name, limit: 100
           t.string :key,       limit: 100
@@ -197,6 +201,18 @@ module ActiveRecord
         connection.add_index :testings, [:foo, :bar], length: { foo: 10, bar: nil }
 
         assert connection.index_exists?(:testings, [:foo, :bar])
+      end
+
+      def test_add_index_foreign_keys_appends_id_to_foreign_keys
+        connection.add_index :testings, [:key_1, :key_2], foreign_keys: true
+
+        assert connection.index_exists?(:testings, [:key_1, :key_2])
+      end
+
+      def test_add_index_foreign_keys_appends_id_to_foreign_keys_will_fail_if_no_related_belongs_to_column_exists
+        assert_raise(ArgumentError) do
+          connection.add_index :testings, [:foo, :bar], foreign_keys: true
+        end
       end
 
       def test_add_index


### PR DESCRIPTION
### Summary

Added an optional `foreign_keys` parameter to `add_index` that when provided, will 
attach a `_id` postfix to all of the given columns, provided that there exists a column defined in the table. This would help keeping the migration files more Railsy. So a code that might look like this 

```ruby
        def change
            create_table :people_projects do |t|
              t.belongs_to :person, null: false, foreign_key: true
              t.belongs_to :project, null: true, foreign_key: true
            end
  
            # Before
            add_index :people_projects, %i[person_id project_id], unique: true
            
            # After
            add_index :people_projects, %i[person project], foreign_keys: true, unique: true
        end
 ```
