### PR TITLE
Configuration variable to disable caching in routes.url_helper

### DIFF
--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -23,6 +23,7 @@ module ActionDispatch
     config.action_dispatch.use_authenticated_cookie_encryption = false
     config.action_dispatch.use_cookies_with_metadata = false
     config.action_dispatch.perform_deep_munge = true
+    config.action_dispatch.cache_url_helpers_built_modules = true
     config.action_dispatch.request_id_header = "X-Request-Id"
 
     config.action_dispatch.default_headers = {

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -477,10 +477,14 @@ module ActionDispatch
       end
 
       def url_helpers(supports_path = true)
-        if supports_path
-          @url_helpers_with_paths ||= generate_url_helpers(true)
+        if Railtie.config.action_dispatch.cache_url_helpers_built_modules
+          if supports_path
+            @url_helpers_with_paths ||= generate_url_helpers(true)
+          else
+            @url_helpers_without_paths ||= generate_url_helpers(false)
+          end
         else
-          @url_helpers_without_paths ||= generate_url_helpers(false)
+          generate_url_helpers(supports_path)
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_6_1.rb.tt
@@ -65,3 +65,9 @@
 # Generate a `Link` header that gives a hint to modern browsers about
 # preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
 # Rails.application.config.action_view.preload_links_header = true
+
+# Caching modules built with routes.url_helpers
+# Creating new controllers should be faster with this.  However there are
+# cases with isolated engines and inheritance that could conflict
+# (see https://github.com/rails/rails/issues/41038).
+# Rails.application.config.action_dispatch.cache_url_helpers_built_modules = true


### PR DESCRIPTION
Configuration variable `config.action_dispatch.cache_url_helpers_built_modules` to disable caching of new modules created with `routes.url_helpers` introduced for rails 6.1 with <https://github.com/rails/rails/commit/37e778b6b44ae087ce052ff380b1e3aaee31473d>

### Summary

Do the caching only if the configuration variable is true, otherwise 
behave like in in rails 6.0

This is required because in some cases the caching produce the error `ActionController::UrlGenerationError`  see #41038

### Other Information

I wonder if @jhawthorn has a better idea, since he introduced the caching.