### PR TITLE
Disable strict loading on ActiveStorage::Attached::Changes

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one.rb
@@ -30,6 +30,7 @@ module ActiveStorage
     end
 
     def save
+      record.strict_loading!(false)
       record.public_send("#{name}_attachment=", attachment)
       record.public_send("#{name}_blob=", blob)
     end

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -108,7 +108,7 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id_generated_old_way)
   end
 
-  test "attaching with strict_loading abd getting a signed blob ID from an attachment" do
+  test "attaching with strict_loading and getting a signed blob ID from an attachment" do
     blob = create_blob
     @user.strict_loading!(true)
     @user.avatar.attach(blob)

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -108,6 +108,15 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id_generated_old_way)
   end
 
+  test "attaching with strict_loading abd getting a signed blob ID from an attachment" do
+    blob = create_blob
+    @user.strict_loading!(true)
+    @user.avatar.attach(blob)
+
+    signed_id = @user.avatar.signed_id
+    assert_equal blob, ActiveStorage::Blob.find_signed(signed_id)
+  end
+
   private
     def assert_blob_identified_before_owner_validated(owner, blob, content_type)
       validated_content_type = nil


### PR DESCRIPTION
### Summary

When we try to attach a new file with `strict_loading_by_default = true` on the model, will always raise an ActiveRecord::StrictLoadingViolationError because of validation of active storage (https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/attached/changes/create_one.rb#L43).
This validation is trigger always without loading any association (https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/attached/model.rb#L65)

In past, we already disable strict_loading on validations(https://github.com/rails/rails/pull/40775), but active_storage still keeps this validation. This PR disable strict_loading on save of `Attached::Changes::CreateOne`


This PR solves the issue: https://github.com/rails/rails/issues/41453

### Setup
```shell
rails new sl-with-as --database=postgresql --no-skip-active-storage
cd sl-with-as/
rails active_storage:install
rails generate model Example name:string
rails db:create && rails db:migrate
echo 'class Example < ActiveRecord::Base; self.strict_loading_by_default = true; has_one_attached :file; end' > app/models/example.rb
rails console
example = Example.create(name: 'Lorem')
example.file.attach({ io: File.new("tmp/temp1.txt"), filename: 'tempfile1' }) # ActiveRecord::StrictLoadingViolationError
```