### PR TITLE
Deprecate render locals to be assigned to instance variables

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `render` locals to be assigned to instance variables.
+
+    *Petrik de Heus*
+
 *   Remove legacy default `media=screen` from `stylesheet_link_tag`.
 
     *André Luis Leal Cardoso Junior*

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -319,6 +319,13 @@ module ActionView
         # Only locals with valid variable names get set directly. Others will
         # still be available in local_assigns.
         locals = @locals - Module::RUBY_RESERVED_KEYWORDS
+        deprecated_locals = locals.grep(/\A@+/)
+        if deprecated_locals.any?
+          ActiveSupport::Deprecation.warn(<<~MSG)
+            Passing instance variables to `render` is deprecated.
+            In Rails 7.0, #{deprecated_locals.to_sentence} will be ignored.
+          MSG
+        end
         locals = locals.grep(/\A@?(?![A-Z0-9])(?:[[:alnum:]_]|[^\0-\177])+\z/)
 
         # Assign for the same variable is to suppress unused variable warning

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -52,7 +52,10 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
   end
 
   def test_template_with_instance_variable_identifier
-    assert_equal "bar", render(template: "test/render_file_instance_variable", locals: { "@foo": "bar" })
+    expected_deprecation = "In Rails 7.0, @foo will be ignored."
+    assert_deprecated(expected_deprecation) do
+      assert_equal "bar", render(template: "test/render_file_instance_variable", locals: { "@foo": "bar" })
+    end
   end
 
   def test_template_gets_recompiled_when_using_different_keys_in_local_assigns


### PR DESCRIPTION
Rails partial rendering allows assigning instance variables.
For example:

    render 'partial', :@name => "Maceo"

This sets `@name` to `"Maceo"` on the `ActionView::Base` object.

The allowed instance variables aren't restricted to the user's defined
instance variables but can also override private Rails variables like
`@_assigns`, `@output_buffer` and `@_config`, `@_default_form_builder`.

This was submitted to Hackerone at first. @tenderlove decided to
deprecate this behaviour in public.
