### PR TITLE
Added ActiveRecord::Relation#without as alias for #excluding.

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
-      :pluck, :pick, :ids, :strict_loading, :excluding
+      :pluck, :pick, :ids, :strict_loading, :excluding, :without
     ].freeze # :nodoc:
     delegate(*QUERYING_METHODS, to: :all)
 

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1140,6 +1140,11 @@ module ActiveRecord
       spawn.excluding!(records)
     end
 
+    # Alias for #excluding.
+    def without(*records)
+      excluding(*records)
+    end
+
     def excluding!(records) # :nodoc:
       # Treat single and multiple records differently in order to keep query
       # clean in case of single record, ie, use != operator instead of NOT IN ().

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -68,4 +68,10 @@ class ExcludingTest < ActiveRecord::TestCase
     end
     assert_equal "You must only pass a single or collection of Post objects to #excluding.", exception.message
   end
+
+  def test_result_set_does_not_include_without_record
+    post = posts(:welcome)
+
+    assert_not_includes Post.without(post).to_a, post
+  end
 end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This is a followup PR for https://github.com/rails/rails/pull/41439

This PR adds an alias `#without` for ActiveRecord::Relation#excluding, a short-hand method to exclude the specified record (or collection of records) from the resulting relation. We have the same method available for Enumerable as well (https://api.rubyonrails.org/v6.1.2.1/classes/Enumerable.html#method-i-without).

```
Post.without(post)
# SELECT "posts".* FROM "posts" WHERE "posts"."id" != 1

Post.without(post_one, post_two)
# SELECT "posts".* FROM "posts" WHERE "posts"."id" NOT IN (1, 2)

# And on associations (also supports collections as above).
post.comments.without(comment)
# SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 1 AND "comments"."id" != 2
```



