### PR TITLE
Improve rack_test integration for system tests

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -24,7 +24,7 @@ module ActionDispatch
 
       private
         def registerable?
-          [:selenium, :poltergeist, :webkit].include?(@name)
+          [:selenium, :poltergeist, :webkit, :rack_test].include?(@name)
         end
 
         def register
@@ -35,6 +35,7 @@ module ActionDispatch
             when :selenium then register_selenium(app)
             when :poltergeist then register_poltergeist(app)
             when :webkit then register_webkit(app)
+            when :rack_test then register_rack_test(app)
             end
           end
         end
@@ -57,6 +58,10 @@ module ActionDispatch
           Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
             driver.resize_window_to(driver.current_window_handle, *@screen_size)
           end
+        end
+
+        def register_rack_test(app)
+          Capybara::RackTest::Driver.new(app, { respect_data_method: true }.merge(@options))
         end
 
         def setup

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -51,10 +51,6 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ skip_image_loading: true }), driver.instance_variable_get(:@options)
   end
 
-  test "registerable? returns false if driver is rack_test" do
-    assert_not ActionDispatch::SystemTesting::Driver.new(:rack_test).send(:registerable?)
-  end
-
   test "define extra capabilities using chrome" do
     driver = ActionDispatch::SystemTesting::Driver.new(:selenium, screen_size: [1400, 1400], using: :chrome) do |option|
       option.add_argument("start-maximized")


### PR DESCRIPTION
### Summary

As it is, Rails does not provide the better out of the box experience regarding the capybara rack_test integration.

Capybara and rack_test supports a specific option that respects the `data-method` attribute for links. That way, you can use a very fast driver when you don't need to support any javascript in the test, while still benefiting from the `data-method` to properly follow links.

I was surprised at first when writing system tests using rack_test because I assumed Rails already took care of correctly initializing the driver and had to dig up the capybara source to figure out how the driver was configured. I'm pretty sure I'm not the only one bitten by this

I didn't added any tests as I'm not sure how to test this.

Fixes https://github.com/rails/rails/issues/41466
