### PR TITLE
Update Rails version in deprecation and add non-deprecated code

### DIFF
--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -323,10 +323,12 @@ module ActionView
         if deprecated_locals.any?
           ActiveSupport::Deprecation.warn(<<~MSG)
             Passing instance variables to `render` is deprecated.
-            In Rails 7.0, #{deprecated_locals.to_sentence} will be ignored.
+            In Rails 7.1, #{deprecated_locals.to_sentence} will be ignored.
           MSG
+          locals = locals.grep(/\A@?(?![A-Z0-9])(?:[[:alnum:]_]|[^\0-\177])+\z/)
+        else
+          locals = locals.grep(/\A(?![A-Z0-9])(?:[[:alnum:]_]|[^\0-\177])+\z/)
         end
-        locals = locals.grep(/\A@?(?![A-Z0-9])(?:[[:alnum:]_]|[^\0-\177])+\z/)
 
         # Assign for the same variable is to suppress unused variable warning
         locals.each_with_object(+"") { |key, code| code << "#{key} = local_assigns[:#{key}]; #{key} = #{key};" }

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -52,7 +52,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
   end
 
   def test_template_with_instance_variable_identifier
-    expected_deprecation = "In Rails 7.0, @foo will be ignored."
+    expected_deprecation = "In Rails 7.1, @foo will be ignored."
     assert_deprecated(expected_deprecation) do
       assert_equal "bar", render(template: "test/render_file_instance_variable", locals: { "@foo": "bar" })
     end


### PR DESCRIPTION
Passing instance variables to `render` will be deprecated in the next
version, which is Rails 7.1.
Also add the non-deprecated implementation, which removes `@?` from the
Regexp, to make removal of the deprecation easier.

As noticed by @jhawthorn in #41464