### PR TITLE
Consider onion services secure for cookies

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Consider onion services secure for cookies.
+
+    *Justin Tracey*
+
 *   Remove deprecated `Rails.config.action_view.raise_on_missing_translations`.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -439,7 +439,7 @@ module ActionDispatch
         end
 
         def write_cookie?(cookie)
-          request.ssl? || !cookie[:secure] || always_write_cookie
+          request.ssl? || request.host.end_with?(".onion") || !cookie[:secure] || always_write_cookie
         end
 
         def handle_options(options)

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -457,6 +457,13 @@ class CookiesTest < ActionController::TestCase
     assert_equal({ "user_name" => "david" }, @response.cookies)
   end
 
+  def test_setting_cookie_with_secure_on_onion_address
+    @request.host = "fake.onion"
+    get :authenticate_with_secure
+    assert_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
+    assert_equal({ "user_name" => "david" }, @response.cookies)
+  end
+
   def test_setting_cookie_with_secure_when_always_write_cookie_is_true
     old_cookie, @request.cookie_jar.always_write_cookie = @request.cookie_jar.always_write_cookie, true
     get :authenticate_with_secure


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
Adds a new `trustworthy?` method to the `Request` class, and uses it to consider HTTPS as well as onion services to be secure for the purposes of the `secure` flag in cookies. Fixes #41426.

### Other Information

I added the `trustworthy?` method instead of directly checking in `write_cookie?` for onion services, since this allows any other spots in the code that should be conditional on secure connections rather than HTTPS specifically to use it instead (anything we're missing now, plus any future code), and it gives a single place to add any future fancy secure standards that browsers implement.

The name "trustworthy?" comes from the [W3C secure contexts draft](https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy), which is roughly [what Firefox uses to decide whether secure cookies should be sent](https://bugzilla.mozilla.org/show_bug.cgi?id=1633015). It's a bit of a misnomer though, since one of the main things the draft lists as "potentially trustworthy origins" is localhost, which Rails does not. I would be willing to change the name to something less misleading (e.g., "secure?"), or to add localhost connections to the list of connections considered trustworthy, but the latter would be a pretty major change in how Rails works IIUC, so I thought I'd leave it for others to decide.

Of course, let me know anything that should be different (names, structure, tests, etc.).
