### PR TITLE
Fix the duplicated media attribute in stylesheet_link_tag

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -170,8 +170,8 @@ module ActionView
             "href" => href
           }.merge!(options)
 
-          if apply_stylesheet_media_default && tag_options[:media].blank?
-            tag_options[:media] = "screen"
+          if apply_stylesheet_media_default && tag_options["media"].blank?
+            tag_options["media"] = "screen"
           end
 
           tag(:link, tag_options)


### PR DESCRIPTION
https://github.com/rails/rails/pull/41215 introduced a bug that cause the stylesheet links to have two `media=` attributes.

Because `tag_options` has string keys, `tag_options[:media].blank?` always evaluate to `true` and `tag_options` end up with both `:media` and `"media"` keys, and both end up as attributes.

This wasn't caught by the test because `assert_dom_equal %(<link href="/file.css" media="all" rel="stylesheet" />), stylesheet_link_tag("/file", media: "all")` ignore extra attributes.

I'm not sure how this is best tested. I could do a regular `assert_equal` but I suspect it would break a lot.

cc @rafaelfranca @etiennebarrie @andrehjr