### PR TITLE
Add `uncountable?` method to ActiveModel::Name

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -171,6 +171,7 @@ module ActiveModel
       @klass        = klass
       @singular     = _singularize(@name)
       @plural       = ActiveSupport::Inflector.pluralize(@singular, locale)
+      @uncountable  = @plural == @singular
       @element      = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(@name))
       @human        = ActiveSupport::Inflector.humanize(@element)
       @collection   = ActiveSupport::Inflector.tableize(@name)
@@ -179,7 +180,7 @@ module ActiveModel
 
       @route_key          = (namespace ? ActiveSupport::Inflector.pluralize(@param_key, locale) : @plural.dup)
       @singular_route_key = ActiveSupport::Inflector.singularize(@route_key, locale)
-      @route_key << "_index" if @plural == @singular
+      @route_key << "_index" if @uncountable
     end
 
     # Transform the model name into a more human format, using I18n. By default,
@@ -205,6 +206,10 @@ module ActiveModel
 
       options = { scope: [@klass.i18n_scope, :models], count: 1, default: defaults }.merge!(options.except(:default))
       I18n.translate(defaults.shift, **options)
+    end
+
+    def uncountable?
+      @uncountable
     end
 
     private
@@ -280,7 +285,7 @@ module ActiveModel
     #   ActiveModel::Naming.uncountable?(Sheep) # => true
     #   ActiveModel::Naming.uncountable?(Post)  # => false
     def self.uncountable?(record_or_class)
-      plural(record_or_class) == singular(record_or_class)
+      model_name_from_record_or_class(record_or_class).uncountable?
     end
 
     # Returns string to use while generating route names. It differs for

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -42,6 +42,10 @@ class NamingTest < ActiveModel::TestCase
   def test_i18n_key
     assert_equal :"post/track_back", @model_name.i18n_key
   end
+
+  def test_uncountable
+    assert_equal false, @model_name.uncountable?
+  end
 end
 
 class NamingWithNamespacedModelInIsolatedNamespaceTest < ActiveModel::TestCase


### PR DESCRIPTION
Hello! 👋
I was confused, when got error:

```ruby
2.7.1 :001 > require 'active_model'
 => true 
2.7.1 :002 > ActiveModel.version
 => Gem::Version.new("6.1.1") 
2.7.1 :003 > class User
2.7.1 :004 >   extend ActiveModel::Naming
2.7.1 :005 > end
 => User 
2.7.1 :006 > User.model_name.plural
 => "users" 
2.7.1 :007 > User.model_name.singular
 => "user" 
2.7.1 :008 > User.model_name.uncountable?
Traceback (most recent call last):
  21: from /home/artem/.rvm/gems/ruby-2.7.1/bin/ruby_executable_hooks:24:in `<main>'
  20: from /home/artem/.rvm/gems/ruby-2.7.1/bin/ruby_executable_hooks:24:in `eval'
  19: from /home/artem/.rvm/gems/ruby-2.7.1/bin/irb:23:in `<main>'
  18: from /home/artem/.rvm/gems/ruby-2.7.1/bin/irb:23:in `load'
  17: from /home/artem/.rvm/gems/ruby-2.7.1/gems/irb-1.3.2/exe/irb:11:in `<top (required)>'
(irb):8:in `<main>': undefined method `uncountable?' for #<ActiveModel::Name:0x000056202b0bd3e8> (NoMethodError)

# But in this case it work
2.7.1 :009 > ActiveModel::Naming.uncountable?(User)
 => false
```

This PR fixed undefined method error.

Also, I think it's worth making a backport for Rails 5. What do you think?
Thanks.
