### PR TITLE
Add guard for calling `finalize` when NullSession is present

### DIFF
--- a/activerecord/lib/active_record/asynchronous_queries_tracker.rb
+++ b/activerecord/lib/active_record/asynchronous_queries_tracker.rb
@@ -50,7 +50,7 @@ module ActiveRecord
     end
 
     def finalize_session
-      @current_session&.finalize
+      @current_session.finalize if @current_session.respond_to?(:finalize)
       @current_session = NullSession
     end
   end

--- a/activerecord/lib/active_record/asynchronous_queries_tracker.rb
+++ b/activerecord/lib/active_record/asynchronous_queries_tracker.rb
@@ -7,6 +7,9 @@ module ActiveRecord
         def active?
           true
         end
+
+        def finalize
+        end
       end
     end
 
@@ -50,7 +53,7 @@ module ActiveRecord
     end
 
     def finalize_session
-      @current_session.finalize if @current_session.respond_to?(:finalize)
+      @current_session.finalize
       @current_session = NullSession
     end
   end

--- a/activerecord/lib/active_record/asynchronous_queries_tracker.rb
+++ b/activerecord/lib/active_record/asynchronous_queries_tracker.rb
@@ -7,9 +7,6 @@ module ActiveRecord
         def active?
           true
         end
-
-        def finalize
-        end
       end
     end
 

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -408,20 +408,6 @@ module ActiveRecord
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
-
-    def test_async_query_finalize_with_null_session
-      assert_nothing_raised do
-        @connection.select_all "SELECT * FROM posts", async: true
-      end
-
-      @connection.transaction do
-        assert_raises AsynchronousQueryInsideTransactionError do
-          @connection.select_all "SELECT * FROM posts", async: true
-        end
-      end
-    ensure
-      ActiveRecord::Base.asynchronous_queries_tracker.finalize_session
-    end
   end
 
   class AsynchronousQueriesTest < ActiveRecord::TestCase


### PR DESCRIPTION
https://github.com/rails/rails/pull/41372 Added `ActiveRecord::AsynchronousQueriesTracker::NullSession` which replaced a
use of `nil` in `AsynchronousQueriesTracker`.

This commit changes the `finalize_session` method to match that change from `nil` and properly handle cases where it is called with a `NullSession` present.