### PR TITLE
Add error message value formatter to the numericality validator

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -7,5 +7,9 @@
 
     *Lukas Pokorny*
 
+*   Add `value_format` parametor to `numericality` validator,
+    this will allow to format the value being shown in an error message.
+
+    *João Mangilli*
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -59,7 +59,13 @@ module ActiveModel
             option_value = parse_as_number(option_value, precision, scale, option)
 
             unless value.public_send(CHECKS[option], option_value)
-              record.errors.add(attr_name, option, **filtered_options(value).merge!(count: option_value))
+              record.errors.add(
+                attr_name,
+                option,
+                **filtered_options(value).merge!(
+                  count: formatted_value(record, option_value)
+                )
+              )
             end
           end
         end
@@ -118,6 +124,19 @@ module ActiveModel
           options[:only_integer].call(record)
         else
           options[:only_integer]
+        end
+      end
+
+      def formatted_value(record, value)
+        value_format = options[:value_format]
+
+        case value_format
+        when Proc
+          value_format.call(value)
+        when Symbol
+          record.send(value_format, value)
+        else
+          value
         end
       end
 

--- a/activemodel/test/cases/validations/numericality_validation_test.rb
+++ b/activemodel/test/cases/validations/numericality_validation_test.rb
@@ -317,6 +317,21 @@ class NumericalityValidationTest < ActiveModel::TestCase
     valid!([Float("65.6"), BigDecimal("65.6")])
   end
 
+  def test_validates_numericality_with_value_format_as_proc
+    Topic.validates_numericality_of :approved, greater_than: 50000, value_format: proc { |value| "50,000.00" }
+
+    invalid!([10], "must be greater than 50,000.00")
+  end
+
+  def test_validates_numericality_with_value_format_as_symbol
+    Topic.define_method(:value_format) { |value| "50,000.00" }
+    Topic.validates_numericality_of :approved, greater_than: 50000, value_format: :value_format
+
+    invalid!([10], "must be greater than 50,000.00")
+  ensure
+    Topic.remove_method :value_format
+  end
+
   private
     def invalid!(values, error = nil)
       with_each_topic_approved_value(values) do |topic, value|

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -534,6 +534,8 @@ constraints to acceptable values:
   default error message for this option is _"must be odd"_.
 * `:even` - Specifies the value must be an even number if set to true. The
   default error message for this option is _"must be even"_.
+* `:value_format` - Allow to format the value being shown in an error message.
+  Should be a proc or a function passing the name as a symbol, that receive the value as a parameter.
 
 NOTE: By default, `numericality` doesn't allow `nil` values. You can use `allow_nil: true` option to permit it.
 


### PR DESCRIPTION
### Summary

Sometimes, we need to format the value being shown in an error message in the numericality validator (like `greater_than_or_equal_to: 25`, we want to format the number 25 to something like 25.00) to match a monetary value or something like that. 

This PR opens an option to format that value the way you need it.