### PR TITLE
Fix schema dumper for infinite dates in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/date.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/date.rb
@@ -16,6 +16,14 @@ module ActiveRecord
               super
             end
           end
+
+          def type_cast_for_schema(value)
+            case value
+            when ::Float::INFINITY then "::Float::INFINITY"
+            when -::Float::INFINITY then "-::Float::INFINITY"
+            else super
+            end
+          end
         end
       end
     end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -598,6 +598,8 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
         t.float    :float_with_nan_default,    default: Float::NAN
         t.datetime :beginning_of_time,         default: "-infinity"
         t.datetime :end_of_time,               default: "infinity"
+        t.date :date_with_neg_inf_default,     default: -::Float::INFINITY
+        t.date :date_with_pos_inf_default,     default: ::Float::INFINITY
       end
     end
   end
@@ -623,5 +625,7 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     assert_match %r{t\.float\s+"float_with_nan_default",\s+default: ::Float::NAN}, output
     assert_match %r{t\.datetime\s+"beginning_of_time",\s+default: -::Float::INFINITY}, output
     assert_match %r{t\.datetime\s+"end_of_time",\s+default: ::Float::INFINITY}, output
+    assert_match %r{t\.date\s+"date_with_neg_inf_default",\s+default: -::Float::INFINITY}, output
+    assert_match %r{t\.date\s+"date_with_pos_inf_default",\s+default: ::Float::INFINITY}, output
   end
 end


### PR DESCRIPTION
### Summary

A default value of Float::INFINITY for a date does not round-trip
correctly. It will be correctly loaded as 'infinity'::date, but
when the schema is dumped, it will appear in the schema file as
"Infinity," which then will not load correctly.

This change is based on the fixes for #22396 and #40751, which
address the exact same issue for floats and date-times, respectively.