### PR TITLE
Add Hash#delete_at

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `Hash#delete_at` to delete values from a list keyed by its arguments.
+Mirrors the `Hash#values_at` interface, and pairs nicely with multiple
+    assignment.
+
+    ```ruby
+    hash = { a: true, b: false, c: nil }
+    a, c = hash.delete_at(:a, :c) # => [ true, nil ]
+    hash # => { b: false }
+    ```
+
+    *Sean Doyle*
+
 *   Allow nested access to keys on `Rails.application.credentials`
 
     Previously only top level keys in `credentials.yml.enc` could be accessed with method calls. Now any key can.

--- a/activesupport/lib/active_support/core_ext/hash.rb
+++ b/activesupport/lib/active_support/core_ext/hash.rb
@@ -3,6 +3,7 @@
 require "active_support/core_ext/hash/conversions"
 require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/hash/deep_transform_values"
+require "active_support/core_ext/hash/delete_at"
 require "active_support/core_ext/hash/except"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/hash/keys"

--- a/activesupport/lib/active_support/core_ext/hash/delete_at.rb
+++ b/activesupport/lib/active_support/core_ext/hash/delete_at.rb
@@ -10,6 +10,6 @@ class Hash
   #   hash # => { b: false }
   #
   def delete_at(*keys)
-    keys.map { |key| delete(key) }
+    keys.map! { |key| delete(key) }
   end unless method_defined?(:delete_at)
 end

--- a/activesupport/lib/active_support/core_ext/hash/delete_at.rb
+++ b/activesupport/lib/active_support/core_ext/hash/delete_at.rb
@@ -9,9 +9,7 @@ class Hash
   #   a, c = hash.delete_at(:a, :c) # => [ true, nil ]
   #   hash # => { b: false }
   #
-  def delete_at(*keys, &block)
-    block ||= default_proc
-
-    keys.map { |key| delete(key, &block) || default }
+  def delete_at(*keys)
+    keys.map { |key| delete(key) }
   end unless method_defined?(:delete_at)
 end

--- a/activesupport/lib/active_support/core_ext/hash/delete_at.rb
+++ b/activesupport/lib/active_support/core_ext/hash/delete_at.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Hash
+  # From a list of keys, delete and return their corresponding values as an
+  # Array. Mirros the `Hash#values_at` interfaces, and pairs nicely with
+  # multiple assignment.
+  #
+  #   hash = { a: true, b: false, c: nil }
+  #   a, c = hash.delete_at(:a, :c) # => [ true, nil ]
+  #   hash # => { b: false }
+  #
+  def delete_at(*keys, &block)
+    block ||= default_proc
+
+    keys.map { |key| delete(key, &block) || default }
+  end unless method_defined?(:delete_at)
+end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -434,6 +434,34 @@ class HashExtTest < ActiveSupport::TestCase
       original.except(:a)
     end
   end
+
+  def test_delete_at
+    original = { a: "a", b: "b", c: "c" }
+
+    assert_equal ["a", "c", nil], original.delete_at(:a, :c, :c)
+    assert_equal({ b: "b" }, original)
+  end
+
+  def test_delete_at_with_block
+    original = {}
+
+    assert_equal [0], original.delete_at(:a) { 0 }
+    assert_empty original
+  end
+
+  def test_delete_at_missing_key_with_default_value
+    original = Hash.new(0)
+
+    assert_equal [0], original.delete_at(:a)
+    assert_empty original
+  end
+
+  def test_delete_at_missing_key_with_default_block
+    original = Hash.new { 0 }
+
+    assert_equal [0], original.delete_at(:a)
+    assert_empty original
+  end
 end
 
 class IWriteMyOwnXML

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -442,24 +442,17 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal({ b: "b" }, original)
   end
 
-  def test_delete_at_with_block
-    original = {}
-
-    assert_equal [0], original.delete_at(:a) { 0 }
-    assert_empty original
-  end
-
   def test_delete_at_missing_key_with_default_value
     original = Hash.new(0)
 
-    assert_equal [0], original.delete_at(:a)
+    assert_equal [nil], original.delete_at(:a)
     assert_empty original
   end
 
   def test_delete_at_missing_key_with_default_block
     original = Hash.new { 0 }
 
-    assert_equal [0], original.delete_at(:a)
+    assert_equal [nil], original.delete_at(:a)
     assert_empty original
   end
 end


### PR DESCRIPTION
Add `Hash#delete_at` to delete values from a list keyed by its
arguments. Mirrors the [Hash#values_at][] and [Array#delete_at][]
interfaces, and pairs nicely with multiple assignment.

```ruby
hash = { a: true, b: false, c: nil }
a, c = hash.delete_at(:a, :c) # => [ true, nil ]
hash # => { b: false }
```

[Array#delete_at]: https://ruby-doc.org/core-3.0.0/Array.html#method-i-delete_at
[Hash#values_at]: https://ruby-doc.org/core-3.0.0/Hash.html#method-i-values_at