### PR TITLE
Should not change serializable value for the enum attribute

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -138,16 +138,12 @@ module ActiveRecord
         mapping.key(subtype.deserialize(value))
       end
 
-      def serializable?(value)
-        (value.blank? || mapping.has_key?(value) || mapping.has_value?(value)) && super
-      end
-
       def serialize(value)
         mapping.fetch(value, value)
       end
 
       def assert_valid_value(value)
-        unless serializable?(value)
+        unless value.blank? || mapping.has_key?(value) || mapping.has_value?(value)
           raise ArgumentError, "'#{value}' is not a valid #{name}"
         end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -55,17 +55,28 @@ class EnumTest < ActiveRecord::TestCase
 
     assert_equal @book, Book.where(status: published).first
     assert_not_equal @book, Book.where(status: written).first
-    assert_equal @book, Book.where(status: [published]).first
-    assert_not_equal @book, Book.where(status: [written]).first
-    assert_not_equal @book, Book.where("status <> ?", published).first
-    assert_equal @book, Book.where("status <> ?", written).first
+    assert_equal @book, Book.where(status: [published, published]).first
+    assert_not_equal @book, Book.where(status: [written, written]).first
+    assert_not_equal @book, Book.where.not(status: published).first
+    assert_equal @book, Book.where.not(status: written).first
+  end
+
+  test "find via where with values.to_s" do
+    published, written = Book.statuses[:published].to_s, Book.statuses[:written].to_s
+
+    assert_equal @book, Book.where(status: published).first
+    assert_not_equal @book, Book.where(status: written).first
+    assert_equal @book, Book.where(status: [published, published]).first
+    assert_not_equal @book, Book.where(status: [written, written]).first
+    assert_not_equal @book, Book.where.not(status: published).first
+    assert_equal @book, Book.where.not(status: written).first
   end
 
   test "find via where with symbols" do
     assert_equal @book, Book.where(status: :published).first
     assert_not_equal @book, Book.where(status: :written).first
-    assert_equal @book, Book.where(status: [:published]).first
-    assert_not_equal @book, Book.where(status: [:written]).first
+    assert_equal @book, Book.where(status: [:published, :published]).first
+    assert_not_equal @book, Book.where(status: [:written, :written]).first
     assert_not_equal @book, Book.where.not(status: :published).first
     assert_equal @book, Book.where.not(status: :written).first
     assert_equal books(:ddd), Book.where(last_read: :forgotten).first
@@ -74,8 +85,8 @@ class EnumTest < ActiveRecord::TestCase
   test "find via where with strings" do
     assert_equal @book, Book.where(status: "published").first
     assert_not_equal @book, Book.where(status: "written").first
-    assert_equal @book, Book.where(status: ["published"]).first
-    assert_not_equal @book, Book.where(status: ["written"]).first
+    assert_equal @book, Book.where(status: ["published", "published"]).first
+    assert_not_equal @book, Book.where(status: ["written", "written"]).first
     assert_not_equal @book, Book.where.not(status: "published").first
     assert_equal @book, Book.where.not(status: "written").first
     assert_equal books(:ddd), Book.where(last_read: "forgotten").first


### PR DESCRIPTION
`EnumType#serializable?` which allows values only in the enum mapping
was added in 72fd0ba, and it is called only in `HomogeneousIn`, it
caused the serialization inconsistency whether the values are in `IN`
clause or not.

```ruby
# SELECT "users".* FROM "users" WHERE "users"."role" = '0'
User.where(role: "0")

# SELECT "users".* FROM "users" WHERE "users"."role" = '1'
User.where(role: "1")

# SELECT "users".* FROM "users" WHERE "users"."role" IN (NULL)
User.where(role: ["0", "1"])
```

Even if we introduce validation for the enum serialization in the future,
we should at least not cause the inconsistency for now.

Fixes #41474.

cc @eileencodes 