### PR TITLE
Add send_stream to do for dynamic streams what send_data does for static files

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add `ActionController::Live#send_stream` that makes it more convenient to send generated streams:
+
+    ```ruby
+    send_stream(filename: "subscribers.csv") do |stream|
+      stream.write "email_address,updated_at\n"
+    
+      @subscribers.find_each do |subscriber|
+        stream.write "#{subscriber.email_address},#{subscriber.updated_at}\n"
+      end
+    end
+    ```
+    
+    *DHH*
+
 *   `ActionDispatch::Request#content_type` now returned Content-Type header as it is.
 
     Previously, `ActionDispatch::Request#content_type` returned value does NOT contain charset part.


### PR DESCRIPTION
Add `ActionController::Live#send_stream` that makes it more convenient to send generated streams:

 ```ruby
    send_stream(filename: "subscribers.csv") do |stream|
      stream.write "email_address,updated_at\n"
    
      @subscribers.find_each do |subscriber|
        stream.write "#{subscriber.email_address},#{subscriber.updated_at}\n"
      end
    end
```