### PR TITLE
Fix preloading through_relation multiple times with different scopes

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -105,7 +105,8 @@ module ActiveRecord
           association: nil,
           children: @associations,
           associate_by_default: @associate_by_default,
-          scope: @scope
+          scope: @scope,
+          through_reflection_names: kwargs.fetch(:through_reflection_names, Set.new)
         )
         @tree.preloaded_records = @records
       end

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -70,7 +70,7 @@ module ActiveRecord
           end
 
           def source_preloaders
-            @source_preloaders ||= ActiveRecord::Associations::Preloader.new(records: middle_records, associations: source_reflection.name, scope: scope, associate_by_default: false).loaders
+            @source_preloaders ||= ActiveRecord::Associations::Preloader.new(records: middle_records, associations: source_reflection.name, scope: scope, associate_by_default: false, through_reflection_names: through_reflection_names).loaders
           end
 
           def middle_records
@@ -78,7 +78,7 @@ module ActiveRecord
           end
 
           def through_preloaders
-            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false).loaders
+            @through_preloaders ||= ActiveRecord::Associations::Preloader.new(records: owners, associations: through_reflection.name, scope: through_scope, associate_by_default: false, through_reflection_names: through_reflection_names).loaders
           end
 
           def through_reflection

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -4,6 +4,7 @@ class Club < ActiveRecord::Base
   has_one :membership, touch: true
   has_many :memberships, inverse_of: false
   has_many :members, through: :memberships
+  has_many :members_alias, through: :memberships, source: :member
   has_one :sponsor
   has_one :sponsored_member, through: :sponsor, source: :sponsorable, source_type: :Member
   belongs_to :category


### PR DESCRIPTION
### Summary

Previously when the same `through_relation` was preloaded multiple times but using a different scope the relation was incorrectly cached; this led into returning the wrong results.

The issue is fixed by checking if the relation to preload has a `preload_scope` and is preloaded from a `through_relation`.

Fixes #41378
Fixes #41868

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
