### PR TITLE
Fix CREATE INDEX statement generation for PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -94,8 +94,8 @@ module ActiveRecord
           sql = ["CREATE"]
           sql << "UNIQUE" if index.unique
           sql << "INDEX"
-          sql << "IF NOT EXISTS" if o.if_not_exists
           sql << o.algorithm if o.algorithm
+          sql << "IF NOT EXISTS" if o.if_not_exists
           sql << index.type if index.type
           sql << "#{quote_column_name(index.name)} ON #{quote_table_name(index.table)}"
           sql << "USING #{index.using}" if supports_index_using? && index.using

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -40,6 +40,9 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
     expected = %(CREATE INDEX CONCURRENTLY "index_people_on_last_name" ON "people" ("last_name"))
     assert_equal expected, add_index(:people, :last_name, algorithm: :concurrently)
 
+    expected = %(CREATE INDEX CONCURRENTLY IF NOT EXISTS "index_people_on_last_name" ON "people" ("last_name"))
+    assert_equal expected, add_index(:people, :last_name, if_not_exists: true, algorithm: :concurrently)
+
     expected = %(CREATE INDEX "index_people_on_last_name_and_first_name" ON "people" ("last_name" DESC, "first_name" ASC))
     assert_equal expected, add_index(:people, [:last_name, :first_name], order: { last_name: :desc, first_name: :asc })
     assert_equal expected, add_index(:people, ["last_name", :first_name], order: { last_name: :desc, "first_name" => :asc })


### PR DESCRIPTION
### Summary

This PR fixes the `CREATE INDEX` statement generation for PostgreSQL when both `algorithm` and `if_not_exists` are specified, as reported in #41480.

Consider the following code (taken from the issue I linked to above):

```ruby
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.integer :owner_id
  end

  add_index(:posts, :owner_id, algorithm: :concurrently, if_not_exists: true)
end
```

As it currently stands, the above `add_index()` call would generate a statement like below:

`CREATE INDEX IF NOT EXISTS CONCURRENTLY ...`

which is a syntax error. With the fix, the generated SQL statement becomes:

`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`

I've also added a test for this bug which should fail when ran against the main branch:

```bash
# you can run tests as follows
cd activerecord
bundle exec rake test:postgresql
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

