### PR TITLE
Allow preloader to batch at deeper levels

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Associations
+    class Preloader
+      class Batch #:nodoc:
+        def initialize(preloaders)
+          @preloaders = preloaders.reject(&:empty?)
+        end
+
+        def call
+          return if @preloaders.empty?
+
+          loaders = @preloaders.flat_map(&:loaders)
+          group_and_load_similar(loaders)
+          loaders.each(&:run)
+
+          child_preloaders = @preloaders.flat_map(&:child_preloaders)
+          Batch.new(child_preloaders).call
+        end
+
+        private
+          attr_reader :loaders
+
+          def group_and_load_similar(loaders)
+            loaders.grep_v(ThroughAssociation).group_by(&:grouping_key).each do |(_, _, association_key_name), similar_loaders|
+              next if similar_loaders.all? { |l| l.already_loaded? }
+
+              scope = similar_loaders.first.scope
+              Association.load_records_in_batch(scope, association_key_name, similar_loaders)
+            end
+          end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously in #41385 we taught the preloader to batch similar queries together when possible, however (to reduce scope) we only did this for preloads at the top level of the provided Hash.

This commit adds a new private `Associations::Preloader::Batch` class which now handles the batching operation and can do so for loaders from different preloaders. This also modifies child_preloaders to return an un-executed preloader instead of running immediately, so that we can perform batching as we recurse each level.

One intentional limitation of this is that we're only attempting to batch together associations which are at the same depth in the provided Hash. This greatly simplifies the implementation and ensures a consistent grouping happens.

Another limitation (which I hope to address later) is that this still does not attempt to perform any batching of :through associations (however children of through associations may still be batched).

cc @dinahshi @eileencodes @seejohnrun @HParker 

---

For example, from the added test:

``` ruby
Author
  .where(name: "David")
  .includes(:thinking_posts => :comments, :welcome_posts => :comments)
  .first
```

**Queries before:**

``` sql
SELECT "authors".* FROM "authors" WHERE "authors"."name" = ? ORDER BY "authors"."id" ASC LIMIT ?
SELECT "posts".* FROM "posts" WHERE "posts"."title" = ? AND "posts"."author_id" = ?
SELECT "posts".* FROM "posts" WHERE "posts"."title" = ? AND "posts"."author_id" = ?
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?
```

**Queries after:**

``` sql
SELECT "authors".* FROM "authors" WHERE "authors"."name" = ? ORDER BY "authors"."id" ASC LIMIT ?
SELECT "posts".* FROM "posts" WHERE "posts"."title" = ? AND "posts"."author_id" = ?
SELECT "posts".* FROM "posts" WHERE "posts"."title" = ? AND "posts"."author_id" = ?
SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = ?
```
