### PR TITLE
Call `run` after preloading records

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -103,7 +103,7 @@ module ActiveRecord
 
         loaders = build_preloaders
         group_and_load_similar(loaders)
-        loaders.map(&:run)
+        loaders.each(&:run)
 
         child_preloaders.each { |reflection, child, parents| build_child_preloader(reflection, child, parents) }
 

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -30,7 +30,8 @@ require "models/price_estimate"
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
-           :computers, :people, :readers, :authors, :author_addresses, :author_favorites
+           :computers, :people, :readers, :authors, :author_addresses, :author_favorites,
+           :comments, :posts
 
   def test_eager_loading_should_not_change_count_of_children
     liquid = Liquid.create(name: "salty")
@@ -407,9 +408,27 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_queries(1) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [book, post], associations: :author)
       preloader.call
+    end
 
+    assert_no_queries do
       book.author
       post.author
+    end
+  end
+
+  def test_preload_through
+    comments = [
+      comments(:eager_sti_on_associations_s_comment1),
+      comments(:eager_sti_on_associations_s_comment2),
+    ]
+
+    assert_queries(2) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: comments, associations: [:author, :post])
+      preloader.call
+    end
+
+    assert_no_queries do
+      comments.each(&:author)
     end
   end
 
@@ -423,7 +442,9 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_queries(1) do
       preloader = ActiveRecord::Associations::Preloader.new(records: favorites, associations: [:author, :favorite_author])
       preloader.call
+    end
 
+    assert_no_queries do
       favorites.first.author
       favorites.first.favorite_author
     end
@@ -440,7 +461,9 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_queries(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post, postesque], associations: :author_with_the_letter_a)
       preloader.call
+    end
 
+    assert_no_queries do
       post.author_with_the_letter_a
       postesque.author_with_the_letter_a
     end
@@ -452,7 +475,9 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_queries(3) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post, postesque], associations: :author_with_address)
       preloader.call
+    end
 
+    assert_no_queries do
       post.author_with_address
       postesque.author_with_address
     end
@@ -466,7 +491,9 @@ class PreloaderTest < ActiveRecord::TestCase
     assert_queries(2) do
       preloader = ActiveRecord::Associations::Preloader.new(records: [post, postesque], associations: :author)
       preloader.call
+    end
 
+    assert_no_queries do
       post.author
       postesque.author
     end


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/41385

This addresses a regression introduced in https://github.com/rails/rails/pull/41385

There was two issues addressed here:

### `already_loaded?` memoization

Previously preloaders would be instantiated and ran sequentially, e.g.:

```ruby
Preloader::Association.new(...).run
Preloader::Association.new(...).run
Preloader::Association.new(...).run
```

After https://github.com/rails/rails/pull/41385, they're all instantiated at the same time and then later ran, e.g.:

```ruby
preloaders << Preloader::Association.new(...)
preloaders << Preloader::Association.new(...)
preloaders << Preloader::Association.new(...)

preloaders.each(&:run)
```

Since `@already_loaded` was computed in the `initialize`, if a previous preloader would load the relevant association, the `run` method wouldn't know about it.

To fix that I delay the `already_loaded` check, and only memoize it if it returns `true`

### `load_records_in_batch` would only preload records

`load_records_in_batch` would preload the records, but the association wouldn't be actually `already_loaded` until `run` is called.

And since the `load_records_in_batch` and `run` order was totally uncorrelated, a `ThroughAssociation` might be ran before a preloaded `Association`, causing the query to be ran again.

To fix that I call `run` on all `Association` before all `ThroughAssociation`

### Notes

This patch is quite ad hoc, and makes the code quite more cryptic. But since it's being actively refactored I'd rather keep the change short for now.

@eileencodes @jhawthorn @dinahshi @rafaelfranca 