### PR TITLE
Improve ActiveStorage security documentation [ci skip]

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 # Proxy files through application. This avoids having a redirect and makes files easier to cache.
+#
+# WARNING: All Active Storage controllers are publicly accessible by default. The
+# generated URLs are hard to guess, but permanent by design. If your files
+# require a higher level of protection consider implementing
+# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 

--- a/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 # Take a signed permanent reference for a blob and turn it into an expiring service URL for download.
-# Note: These URLs are publicly accessible. If you need to enforce access protection beyond the
-# security-through-obscurity factor of the signed blob references, you'll need to implement your own
-# authenticated redirection controller.
+#
+# WARNING: All Active Storage controllers are publicly accessible by default. The
+# generated URLs are hard to guess, but permanent by design. If your files
+# require a higher level of protection consider implementing
+# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 # Proxy files through application. This avoids having a redirect and makes files easier to cache.
+#
+# WARNING: All Active Storage controllers are publicly accessible by default. The
+# generated URLs are hard to guess, but permanent by design. If your files
+# require a higher level of protection consider implementing
+# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::ProxyController < ActiveStorage::Representations::BaseController
   def show
     http_cache_forever public: true do

--- a/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 # Take a signed permanent reference for a blob representation and turn it into an expiring service URL for download.
-# Note: These URLs are publicly accessible. If you need to enforce access protection beyond the
-# security-through-obscurity factor of the signed blob and variation reference, you'll need to implement your own
-# authenticated redirection controller.
+#
+# WARNING: All Active Storage controllers are publicly accessible by default. The
+# generated URLs are hard to guess, but permanent by design. If your files
+# require a higher level of protection consider implementing
+# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::RedirectController < ActiveStorage::Representations::BaseController
   def show
     expires_in ActiveStorage.service_urls_expire_in

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -646,8 +646,10 @@ guess but permanent. Anyone that knows the blob URL will be able to access it,
 even if a `before_action` in your `ApplicationController` would otherwise
 require a login. If your files require a higher level of protection, you can
 implement your own authenticated controllers, based on the
-[`ActiveStorage::Blobs::RedirectController`](ActiveStorage::Blobs::RedirectController) and
-[`ActiveStorage::Representations::RedirectController`](ActiveStorage::Representations::RedirectController)
+[`ActiveStorage::Blobs::RedirectController`](ActiveStorage::Blobs::RedirectController),
+[`ActiveStorage::Blobs::ProxyController`](ActiveStorage::Blobs::ProxyController),
+[`ActiveStorage::Representations::RedirectController`](ActiveStorage::Representations::RedirectController) and
+[`ActiveStorage::Representations::ProxyController`](ActiveStorage::Representations::ProxyController)
 
 To only allow an account to access their own logo you could do the following:
 
@@ -675,7 +677,9 @@ end
 ```
 
 [ActiveStorage::Blobs::RedirectController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb)
+[ActiveStorage::Blobs::ProxyController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb)
 [ActiveStorage::Representations::RedirectController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/redirect_controller.rb)
+[ActiveStorage::Representations::ProxyController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/proxy_controller.rb)
 
 Downloading Files
 -----------------


### PR DESCRIPTION
### Summary

Improve documentation on ActiveStorage security. Before the changes, it could not be clear that `security-through-obscurity` is not a good enough security mechanism for sensitive files.

https://discuss.rubyonrails.org/t/activestorage-direct-uploads-safe-by-default-how-to-make-it-safe/74863/2

Should we also add a section here https://guides.rubyonrails.org/security.html ?