### PR TITLE
Allow users to customize ActiveStorage controllers without having to override them

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Proxy files through application. This avoids having a redirect and makes files easier to cache.
-class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
+class ActiveStorage::Blobs::ProxyController < ActiveStorage.parent_controller.constantize
   include ActiveStorage::SetBlob
 
   def show

--- a/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -4,7 +4,7 @@
 # Note: These URLs are publicly accessible. If you need to enforce access protection beyond the
 # security-through-obscurity factor of the signed blob references, you'll need to implement your own
 # authenticated redirection controller.
-class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
+class ActiveStorage::Blobs::RedirectController < ActiveStorage.parent_controller.constantize
   include ActiveStorage::SetBlob
 
   def show

--- a/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
+++ b/activestorage/app/controllers/active_storage/direct_uploads_controller.rb
@@ -3,7 +3,7 @@
 # Creates a new blob on the server side in anticipation of a direct-to-service upload from the client side.
 # When the client-side upload is completed, the signed_blob_id can be submitted as part of the form to reference
 # the blob that was created up front.
-class ActiveStorage::DirectUploadsController < ActiveStorage::BaseController
+class ActiveStorage::DirectUploadsController < ActiveStorage.parent_controller.constantize
   def create
     blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_args)
     render json: direct_upload_json(blob)

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Proxy files through application. This avoids having a redirect and makes files easier to cache.
-class ActiveStorage::Representations::ProxyController < ActiveStorage::BaseController
+class ActiveStorage::Representations::ProxyController < ActiveStorage.parent_controller.constantize
   include ActiveStorage::SetBlob
 
   def show

--- a/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
@@ -4,7 +4,7 @@
 # Note: These URLs are publicly accessible. If you need to enforce access protection beyond the
 # security-through-obscurity factor of the signed blob and variation reference, you'll need to implement your own
 # authenticated redirection controller.
-class ActiveStorage::Representations::RedirectController < ActiveStorage::BaseController
+class ActiveStorage::Representations::RedirectController < ActiveStorage.parent_controller.constantize
   include ActiveStorage::SetBlob
 
   def show

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -63,6 +63,7 @@ module ActiveStorage
 
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
   mattr_accessor :draw_routes, default: true
+  mattr_accessor :parent_controller, default: "ActiveStorage::BaseController"
   mattr_accessor :resolve_model_to_route, default: :rails_storage_redirect
 
   mattr_accessor :replace_on_assign_to_many, default: false

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -84,6 +84,7 @@ module ActiveStorage
         ActiveStorage.paths             = app.config.active_storage.paths || {}
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
+        ActiveStorage.parent_controller = app.config.active_storage.parent_controller || "ActiveStorage::BaseController"
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []


### PR DESCRIPTION
### Summary

Related to https://github.com/rails/rails/pull/41503 , it should be normal for production apps to add authentication and authorization to their ActiveStorage controllers. Unfortunately, there are 2 possible ways to achieve it currently:
- Not drawing ActiveStorage routes and do everything by yourself
- Override/monkey patch ActiveStorage controllers

None of them is ideal because in the end you can't benefit from Rails upgrades (bug fixes, etc) so the intention of this PR is to let people define a parent controller (inspired by Devise, maybe @carlosantoniodasilva can tell us his experience on this feature) so that people can add authentication and authorization in a single place and still benefit from the default controllers.

Usage example:
```ruby
# app/controllers/active_storage/application_controller.rb
class ActiveStorage::ApplicationController < ActiveStorage::BaseController
  before_action :authenticate_user!, if: :needs_authentication?
  before_action :authorize_access, if: :needs_authorization?

  # ...
end
```

```ruby
# config/application.rb
  # ...
  config.active_storage.parent_controller = "ActiveStorage::ApplicationController"
  # ...
```

If there is interest in a feature like this I can add tests, add it to the guides and CHANGELOG. Please let me know