### PR TITLE
Alias scopes for delegated types with `for_`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Provide prepended scope name for `delegated_type
+
+    Scopes for entries by type can now be accessed through `Entry.for_type` in addition 
+    to `Entry.type`, which makes clearer that the method returns scoped entries and not
+    the associated type.
+
+    *Roland Studer*
+
 *   Allow applications to configure the thread pool for async queries
 
     Some applications may want one thread pool per database whereas others want to use

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -148,10 +148,12 @@ module ActiveRecord
     #   Entry#entryable_class # => +Message+ or +Comment+
     #   Entry#entryable_name  # => "message" or "comment"
     #   Entry.messages        # => Entry.where(entryable_type: "Message")
+    #   Entry.for_messages    # => alias for Entry.messages
     #   Entry#message?        # => true when entryable_type == "Message"
     #   Entry#message         # => returns the message record, when entryable_type == "Message", otherwise nil
     #   Entry#message_id      # => returns entryable_id, when entryable_type == "Message", otherwise nil
     #   Entry.comments        # => Entry.where(entryable_type: "Comment")
+    #   Entry.for_comments    # => alias for Entry.comments
     #   Entry#comment?        # => true when entryable_type == "Comment"
     #   Entry#comment         # => returns the comment record, when entryable_type == "Comment", otherwise nil
     #   Entry#comment_id      # => returns entryable_id, when entryable_type == "Comment", otherwise nil
@@ -207,11 +209,14 @@ module ActiveRecord
         end
 
         types.each do |type|
-          scope_name = type.tableize.gsub("/", "_")
-          singular   = scope_name.singularize
-          query      = "#{singular}?"
+          scope_name         = type.tableize.gsub("/", "_")
+          aliased_scope_name = "for_#{scope_name}"
+          singular           = scope_name.singularize
+          query              = "#{singular}?"
 
           scope scope_name, -> { where(role_type => type) }
+
+          define_singleton_method(aliased_scope_name, singleton_method(scope_name))
 
           define_method query do
             public_send(role_type) == type

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -47,6 +47,11 @@ class DelegatedTypeTest < ActiveRecord::TestCase
     assert Entry.comments.first.comment?
   end
 
+  test "aliased scope" do
+    assert Entry.for_messages.first.message?
+    assert Entry.for_comments.first.comment?
+  end
+
   test "accessor" do
     assert @entry_with_message.message.is_a?(Message)
     assert_nil @entry_with_message.comment


### PR DESCRIPTION
### Summary

This adds an alias method for scopes by type for `delegated_type` like so
```ruby
`Entry.for_comments` # instead of Entry.comments
```

### Why?

This feels more semantically correct, as `Entry.comments`
implies the method to return `comments`, when in fact it
returns `entries`. An example

```ruby
# model
class Recommendation
  delegated_type :recommendable, types: %w[Wine Shop]
end

# controller action

@entries = current_user.recommendations.wines
# in isolation the methods implies I get wines, it does not look like a scope
# but rather like an association.

@entries = current_user.recommendations.for_wines
# makes immediately clear that no wines are returned
```

