### PR TITLE
Uniqueness validation can give details on conflicts

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -65,8 +65,8 @@ module ActiveModel
     extend Forwardable
     def_delegators :@errors, :size, :clear, :blank?, :empty?, :uniq!, :any?
     # TODO: forward all enumerable methods after `each` deprecation is removed.
-    def_delegators :@errors, :count
-
+    def_delegators :@errors, :count, :relation
+    
     LEGACY_ATTRIBUTES = [:messages, :details].freeze
     private_constant :LEGACY_ATTRIBUTES
 

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -66,7 +66,7 @@ module ActiveModel
     def_delegators :@errors, :size, :clear, :blank?, :empty?, :uniq!, :any?
     # TODO: forward all enumerable methods after `each` deprecation is removed.
     def_delegators :@errors, :count, :relation
-    
+
     LEGACY_ATTRIBUTES = [:messages, :details].freeze
     private_constant :LEGACY_ATTRIBUTES
 

--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -43,6 +43,7 @@ module ActiveRecord
         if relation.exists?
           error_options = options.except(:case_sensitive, :scope, :conditions)
           error_options[:value] = value
+          error_options[:relation] = relation
 
           record.errors.add(attribute, :taken, **error_options)
         end
@@ -150,6 +151,15 @@ module ActiveRecord
       # record exists in the database with the given value for the specified
       # attribute (that maps to a column). When the record is updated,
       # the same check is made but disregarding the record itself.
+      #
+      # The results of this check are available via a custom error message
+      #
+      #   class Article < ActiveRecord::Base
+      #     validates_uniqueness_of :title, message: ->(object, data) {
+      #       "has already been taken by %s" % [ data[:relation].pluck(:id).to_sentence ]
+      #     }
+      #   end
+      #
       #
       # Configuration options:
       #

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -50,7 +50,7 @@ class I18nValidationTest < ActiveRecord::TestCase
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_uniqueness_of on generated message #{name}" do
       Topic.validates_uniqueness_of :title, validation_options
-      @topic.title = unique_topic.titlerelation
+      @topic.title = unique_topic.title
       assert_called_with(ActiveModel::Error, :generate_message, [:title, :taken, @topic, generate_message_options.merge(value: "unique!", relation: Topic.where(title: "unique!"))]) do
         @topic.valid?
         @topic.errors.messages

--- a/activerecord/test/cases/validations/i18n_validation_test.rb
+++ b/activerecord/test/cases/validations/i18n_validation_test.rb
@@ -50,8 +50,8 @@ class I18nValidationTest < ActiveRecord::TestCase
   COMMON_CASES.each do |name, validation_options, generate_message_options|
     test "validates_uniqueness_of on generated message #{name}" do
       Topic.validates_uniqueness_of :title, validation_options
-      @topic.title = unique_topic.title
-      assert_called_with(ActiveModel::Error, :generate_message, [:title, :taken, @topic, generate_message_options.merge(value: "unique!")]) do
+      @topic.title = unique_topic.titlerelation
+      assert_called_with(ActiveModel::Error, :generate_message, [:title, :taken, @topic, generate_message_options.merge(value: "unique!", relation: Topic.where(title: "unique!"))]) do
         @topic.valid?
         @topic.errors.messages
       end


### PR DESCRIPTION
### Summary

Adds an option to existing ActiveRecord Uniqueness validator to allow custom messages to include what records caused the validation error

### Why?

Adding one line replaces the need for custom validators - now it's just a dynamic custom message.

Asked about in #41494, here is the PR