### PR TITLE
use proper style name snake_form for table naming convention [ci-skip]

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -79,8 +79,7 @@ a class `Book`, you should have a database table called **books**. The Rails
 pluralization mechanisms are very powerful, being capable of pluralizing (and
 singularizing) both regular and irregular words. When using class names composed
 of two or more words, the model class name should follow the Ruby conventions,
-using the CamelCase form, while the table name must contain the words separated
-by underscores. Examples:
+using the CamelCase form, while the table name must use the snake_case form. Examples:
 
 * Model Class - Singular with the first letter of each word capitalized (e.g.,
 `BookClub`).


### PR DESCRIPTION
get rid of `contain the words separated
by underscores` and instead use `use the snake_case form.` for the sake of clarity, coherence and accuracy for anyone unfamiliar with naming convention term.