### PR TITLE
Address `ActionDispatch::ExceptionWrapperTest#test_#framework_trace_returns_traces_outside_the_application` failure

### DIFF
--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -75,10 +75,10 @@ module ActionDispatch
     end
 
     test "#framework_trace returns traces outside the application" do
-      exception = TestError.new(caller.prepend("lib/file.rb:42:in `index'"))
+      exception = TestError.new(caller.prepend("lib/file.rb:42:in `index'")) ; original_caller = caller
       wrapper = ExceptionWrapper.new(@cleaner, exception)
 
-      assert_equal caller, wrapper.framework_trace
+      assert_equal original_caller, wrapper.framework_trace
     end
 
     test "#framework_trace cannot be nil" do


### PR DESCRIPTION
### Summary

This pull request address `ActionDispatch::ExceptionWrapperTest#test_#framework_trace_returns_traces_outside_the_application` failure reported at https://buildkite.com/rails/rails/builds/75249#adbf6c5b-a1f2-4060-8f3c-1a74f4139831/978-986

Ruby 3.0.0 this backtrace does not show the test file itself.
Since https://github.com/ruby/ruby/commit/87437326214e4587a41946c8937e11418d983acd, it shows "rails/actionpack/test/dispatch/exception_wrapper_test.rb:<line nuber>:in `block in <class:ExceptionWrapperTest>'"

These ExceptionWrapperTest failures are due to the line number difference, which is an expected result of this Ruby change.

- expected
"exception_wrapper_test.rb:81:in `block in <class:ExceptionWrapperTest>'"
- actual
"exception_wrapper_test.rb:78:in `block in <class:ExceptionWrapperTest>'"

This commit addresses this failure by executing two callers at the same line.

```ruby
$ ruby -v
ruby 3.1.0dev (2021-02-20T02:17:47Z master cfd162d535) [x86_64-linux]
$ cd actionpack/
$ bin/test test/dispatch/exception_wrapper_test.rb:78
Run options: --seed 57371

F

Failure:
ActionDispatch::ExceptionWrapperTest#test_#framework_trace_returns_traces_outside_the_application [/home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/exception_wrapper_test.rb:81]:
--- expected
+++ actual
@@ -1 +1 @@
-["/home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/exception_wrapper_test.rb:81:in `block in <class:ExceptionWrapperTest>'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:98:in `block (3 levels) in run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:195:in `capture_exceptions'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:95:in `block (2 levels) in run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:272:in `time_it'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:94:in `block in run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:367:in `on_signal'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:211:in `with_info_handler'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:93:in `run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:1029:in `run_one_method'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:50:in `block in perform_job'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:367:in `on_signal'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:354:in `with_info_handler'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:49:in `perform_job'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:38:in `work_from_queue'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:27:in `block in start'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:15:in `fork'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:15:in `start'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:37:in `block in start'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `times'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `each'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `map'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `start'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:138:in `run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:68:in `block in autorun'"]
+["/home/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/exception_wrapper_test.rb:78:in `block in <class:ExceptionWrapperTest>'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:98:in `block (3 levels) in run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:195:in `capture_exceptions'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:95:in `block (2 levels) in run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:272:in `time_it'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:94:in `block in run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:367:in `on_signal'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:211:in `with_info_handler'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest/test.rb:93:in `run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:1029:in `run_one_method'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:50:in `block in perform_job'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:367:in `on_signal'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:354:in `with_info_handler'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:49:in `perform_job'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:38:in `work_from_queue'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:27:in `block in start'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:15:in `fork'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization/worker.rb:15:in `start'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:37:in `block in start'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `times'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `each'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `map'", "/home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/parallelization.rb:36:in `start'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:138:in `run'", "/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/minitest-5.14.3/lib/minitest.rb:68:in `block in autorun'"]

bin/test test/dispatch/exception_wrapper_test.rb:77

Finished in 0.205553s, 4.8649 runs/s, 4.8649 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips

$
```

Refer
https://github.com/ruby/ruby/pull/4120
https://bugs.ruby-lang.org/issues/17581


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
