### PR TITLE
Bump Action Text trix version in the installer

### DIFF
--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rails/activestorage": "^6.0.0-alpha"
+    "@rails/activestorage": "^6.0.0"
   },
   "peerDependencies": {
     "trix": "^1.3.1"

--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -24,6 +24,6 @@
     "@rails/activestorage": "^6.0.0-alpha"
   },
   "peerDependencies": {
-    "trix": "^1.2.0"
+    "trix": "^1.3.1"
   }
 }


### PR DESCRIPTION
Running Action Text install always installs the older version of Trix as peer dependency. Trix package recently received some security updates and some addition. Check the release log: https://github.com/basecamp/trix/releases

Thought upgrading the version would be better for Rails 7.0 development or Rails 6.1.x. 

While I was at it, saw active storage dependency always points to the alpha version. I think it should be atleast `6.0.0` shoud made another commit for it. Maybe Rails team can take better call over it and if not needed we can remove the commit from this PR.