### PR TITLE
Fixes typo in the async query executor documentation added in #41495 [ci skip]

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -158,7 +158,7 @@ module ActiveRecord
       mattr_accessor :application_record_class, instance_accessor: false, default: nil
 
       # Sets the async_query_executor for an application. By default the thread pool executor
-      # set to `:immediate. Options are:
+      # set to +:immediate+. Options are:
       #
       #   * :immediate - Initializes a single +Concurrent::ImmediateExecutor+
       #   * :global_thread_pool - Initializes a single +Concurrent::ThreadPoolExecutor+


### PR DESCRIPTION
Documentation had incomplete quotes. This PR fixes quote and updates it to `+` as per Rails guide. 