### PR TITLE
Include record in ActiveRecord::RecordNotSaved

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -338,7 +338,7 @@ module ActiveRecord
 
         def _create_record(attributes, raise = false, &block)
           unless owner.persisted?
-            raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"
+            raise ActiveRecord::RecordNotSaved.new("You cannot call create unless the parent is saved", owner)
           end
 
           if attributes.is_a?(Array)

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -70,7 +70,7 @@ module ActiveRecord
                 if save && !record.save
                   nullify_owner_attributes(record)
                   set_owner_attributes(target) if target
-                  raise RecordNotSaved, "Failed to save the new associated #{reflection.name}."
+                  raise RecordNotSaved.new("Failed to save the new associated #{reflection.name}.", record)
                 end
               end
             end
@@ -102,8 +102,11 @@ module ActiveRecord
 
             if target.persisted? && owner.persisted? && !target.save
               set_owner_attributes(target)
-              raise RecordNotSaved, "Failed to remove the existing associated #{reflection.name}. " \
-                                    "The record failed to save after its foreign key was set to nil."
+              raise RecordNotSaved.new(
+                "Failed to remove the existing associated #{reflection.name}. " \
+                "The record failed to save after its foreign key was set to nil.",
+                target
+              )
             end
           end
         end
@@ -122,7 +125,7 @@ module ActiveRecord
 
         def _create_record(attributes, raise_error = false, &block)
           unless owner.persisted?
-            raise ActiveRecord::RecordNotSaved, "You cannot call create unless the parent is saved"
+            raise ActiveRecord::RecordNotSaved.new("You cannot call create unless the parent is saved", owner)
           end
 
           super

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1034,21 +1034,23 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_create_with_bang_on_has_many_when_parent_is_new_raises
+    firm = Firm.new
     error = assert_raise(ActiveRecord::RecordNotSaved) do
-      firm = Firm.new
       firm.plain_clients.create! name: "Whoever"
     end
 
     assert_equal "You cannot call create unless the parent is saved", error.message
+    assert_equal firm, error.record
   end
 
   def test_regular_create_on_has_many_when_parent_is_new_raises
+    firm = Firm.new
     error = assert_raise(ActiveRecord::RecordNotSaved) do
-      firm = Firm.new
       firm.plain_clients.create name: "Whoever"
     end
 
     assert_equal "You cannot call create unless the parent is saved", error.message
+    assert_equal firm, error.record
   end
 
   def test_create_with_bang_on_has_many_raises_when_record_not_saved
@@ -1059,11 +1061,13 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_create_with_bang_on_habtm_when_parent_is_new_raises
+    developer = Developer.new("name" => "Aredridel")
     error = assert_raise(ActiveRecord::RecordNotSaved) do
-      Developer.new("name" => "Aredridel").projects.create!
+      developer.projects.create!
     end
 
     assert_equal "You cannot call create unless the parent is saved", error.message
+    assert_equal developer, error.record
   end
 
   def test_adding_a_mismatch_class

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -340,6 +340,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal "You cannot call create unless the parent is saved", error.message
+    assert_equal firm, error.record
   end
 
   def test_reload_association
@@ -519,6 +520,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal "Failed to save the new associated ship.", error.message
+    assert_equal new_ship, error.record
     assert_nil pirate.ship
     assert_nil new_ship.pirate_id
   end
@@ -536,6 +538,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_equal pirate.id, pirate.ship.pirate_id
     assert_equal "Failed to remove the existing associated ship. " \
                  "The record failed to save after its foreign key was set to nil.", error.message
+    assert_equal pirate.ship, error.record
   end
 
   def test_replacement_failure_due_to_new_record_should_raise_error
@@ -547,6 +550,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     end
 
     assert_equal "Failed to save the new associated ship.", error.message
+    assert_equal new_ship, error.record
     assert_equal ships(:black_pearl), pirate.ship
     assert_equal pirate.id, pirate.ship.pirate_id
     assert_equal pirate.id, ships(:black_pearl).reload.pirate_id


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Include the relation required to be saved in the
`ActiveRecord::RecordNotSaved` exception raised when saving an association
that requires the record to be saved.

Example:

```ruby
class Post < ApplicationRecord
  has_many :comments

  validates :title, presence: true
end

class Comment < ApplicationRecord
  belongs_to :post
end
```

* Before the fix

``` ruby
>> post = Post.new(title: :foo)
=> #<Post id: nil, title: "foo", body: nil, created_at: nil, updated_at: nil>
>> post.comments.create!
Traceback (most recent call last):
        1: from (irb):2
ActiveRecord::RecordNotSaved (You cannot call create unless the parent is saved)
>> e = _
=> #<ActiveRecord::RecordNotSaved: You cannot call create unless the parent is saved>
>> e.record
=> nil
```

* After the fix

```ruby
>> post = Post.new(title: :foo)
=> #<Post id: nil, title: "foo", body: nil, created_at: nil, updated_at: nil>
>> post.comments.create!
Traceback (most recent call last):
        1: from (irb):2
ActiveRecord::RecordNotSaved (You cannot call create unless the parent is saved)
>> e = _
=> #<ActiveRecord::RecordNotSaved: You cannot call create unless the parent is saved>
>> e.record
=> #<Post id: nil, title: "foo", body: nil, created_at: nil, updated_at: nil>
```


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
