### PR TITLE
Action Text rich text area tag should use to_trix_html value

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -29,7 +29,7 @@ module ActionText
       options[:data][:blob_url_template] = main_app.rails_service_blob_url(":signed_id", ":filename")
 
       editor_tag = content_tag("trix-editor", "", options)
-      input_tag = hidden_field_tag(name, value, id: options[:input])
+      input_tag = hidden_field_tag(name, value.try(:to_trix_html) || value, id: options[:input])
 
       input_tag + editor_tag
     end
@@ -46,11 +46,7 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
-      @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { editable_value }, options.except("value"))
-    end
-
-    def editable_value
-      value&.body.try(:to_trix_html)
+      @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
     end
   end
 

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -22,6 +22,10 @@ module ActionText
       body&.to_plain_text.to_s
     end
 
+    def to_trix_html
+      body&.to_trix_html
+    end
+
     delegate :blank?, :empty?, :present?, to: :to_plain_text
   end
 end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -25,6 +25,22 @@ class ActionText::FormHelperTest < ActionView::TestCase
     )
   end
 
+  test "rich text area tag" do
+    message = Message.new
+
+    form_with model: message, scope: :message do |form|
+      rich_text_area_tag :content, message.content, { input: "trix_input_1" }
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="content" id="trix_input_1" />' \
+        '<trix-editor input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
+
   test "form with rich text area" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_text_area :content
@@ -69,13 +85,13 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
   test "modelless form with rich text area" do
     form_with url: "/messages", scope: :message do |form|
-      form.rich_text_area :content
+      form.rich_text_area :content, { input: "trix_input_2" }
     end
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
-        '<input type="hidden" name="message[content]" id="trix_input_1" />' \
-        '<trix-editor id="message_content" input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+        '<input type="hidden" name="message[content]" id="trix_input_2" />' \
+        '<trix-editor id="message_content" input="trix_input_2" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
       output_buffer


### PR DESCRIPTION
Related to: https://github.com/rails/rails/issues/38027#issuecomment-783082920

This PR aims to suggest to use `to_trix_html` instead of action text `to_s` when using `rich_text_area_tag`. Added a delegate in the model to make `to_trix_html` method available easier similar to `to_s` or `to_plain_text`. Not sure if this would require changelog entry. Please do let me know and I'll add the changelog if needed 😊 