### PR TITLE
Serialized value on the enum attribute should be type casted by the subtype

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -144,7 +144,7 @@ module ActiveRecord
       end
 
       def serialize(value)
-        mapping.fetch(value, value)
+        subtype.serialize(mapping.fetch(value, value))
       end
 
       def assert_valid_value(value)

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -81,6 +81,14 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal books(:ddd), Book.where(last_read: "forgotten").first
   end
 
+  test "find via where should be type casted" do
+    book = Book.enabled.create!
+    assert_predicate book, :enabled?
+
+    enabled = Book.boolean_statuses[:enabled].to_s
+    assert_equal book, Book.where(boolean_status: enabled).last
+  end
+
   test "build from scope" do
     assert_predicate Book.written.build, :written?
     assert_not_predicate Book.written.build, :proposed?


### PR DESCRIPTION
`EnumType#serialize` just does `mapping.fetch(value, value)`, so it is
not always an appropriate value for the subtype. `subtype.serialize`
should also be done on the enum attribute as a decorator type.

https://github.com/rails/rails/blob/effed76ec6d7863ff59fb2df02508ce6202498a9/activerecord/lib/active_record/enum.rb#L146-L148
