### PR TITLE
Fix proxying keyword arguments for ActiveSupport::CurrentAttributes.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix proxying keyword arguments in `ActiveSupport::CurrentAttributes`.
+
+    *Marcin Kołodziej*
+
 *   Add `Enumerable#maximum` and `Enumerable#minimum` to easily calculate the maximum or minimum from extracted
     elements of an enumerable.
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -155,13 +155,17 @@ module ActiveSupport
           @current_instances_key ||= name.to_sym
         end
 
-        def method_missing(name, *args, &block)
+        def method_missing(name, *args, **kwargs, &block)
           # Caches the method definition as a singleton method of the receiver.
           #
           # By letting #delegate handle it, we avoid an enclosure that'll capture args.
           singleton_class.delegate name, to: :instance
 
-          send(name, *args, &block)
+          send(name, *args, **kwargs, &block)
+        end
+
+        def respond_to_missing?(name, _)
+          super || instance.respond_to?(name)
         end
     end
 

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -31,6 +31,13 @@ class CurrentAttributesTest < ActiveSupport::TestCase
       Session.current = person&.id
     end
 
+    def set_world_and_account(world:, account:)
+      self.world = world
+      self.account = account
+    end
+
+    def respond_to_test; end
+
     def request
       "#{super} something"
     end
@@ -126,6 +133,13 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     assert_equal "account/1", Current.account
   end
 
+  test "using keyword arguments" do
+    Current.set_world_and_account(world: "world/1", account: "account/1")
+
+    assert_equal "world/1", Current.world
+    assert_equal "account/1", Current.account
+  end
+
   setup { @testing_teardown = false }
   teardown { assert_equal 42, Session.current if @testing_teardown }
 
@@ -144,5 +158,9 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     Current.person = Person.new(42, "David", "Central Time (US & Canada)")
     assert_equal "David, in Central Time (US & Canada)", Current.intro
     assert_equal "David, in Central Time (US & Canada)", Current.instance.intro
+  end
+
+  test "respond_to? for methods that have not been called" do
+    assert_equal true, Current.respond_to?("respond_to_test")
   end
 end


### PR DESCRIPTION
Simple QoL improvement for people wishing to continue using keyword arguments after recent Ruby changes.

The `respond_to?` change aims to solve an issue of stubbing `CurrentAttributes` while verifying partial doubles in RSpec.

Not including documentation changes, as there should be no reason to assume keyword arguments do not work.