### PR TITLE
Use postgres specific safer string quoting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -8,7 +8,7 @@ module ActiveRecord
     module Quoting
       # Quotes the column value to help prevent
       # {SQL injection attacks}[https://en.wikipedia.org/wiki/SQL_injection].
-      def quote(value)
+      def quote(value, quoted_string_delimiter: nil)
         if value.is_a?(Base)
           ActiveSupport::Deprecation.warn(<<~MSG)
             Passing an Active Record object to `quote` directly is deprecated
@@ -17,7 +17,7 @@ module ActiveRecord
           value = value.id_for_database
         end
 
-        _quote(value)
+        _quote(value, quoted_string_delimiter: quoted_string_delimiter)
       end
 
       # Cast a +value+ to a type that the database understands. For example,
@@ -214,7 +214,7 @@ module ActiveRecord
           type_map.lookup(sql_type)
         end
 
-        def _quote(value)
+        def _quote(value, quoted_string_delimiter: nil)
           case value
           when String, Symbol, ActiveSupport::Multibyte::Chars
             "'#{quote_string(value.to_s)}'"


### PR DESCRIPTION
### Summary

tl;dr Using the default single quote for quoting strings doesn't always work,
and the simplest thing in postgres is to use a dollar-sign quoted identifier like `$quote$I'm quoted$quote$`

e.g.

```ruby
job_number = "HP123 Howard's Paving".downcase
ApplicationRecord.connection.execute(%(SELECT regexp_split_to_array($quote$#{job_number}$quote$, '\s*?,\s*?'))).to_a
  # works, whereas
ApplicationRecord.connection.execute(%(SELECT regexp_split_to_array('#{job_number}', '\s*?,\s*?')).to_a
  #  raises
  #   PG::SyntaxError: ERROR:  syntax error at or near "s"
  #     SELECT regexp_split_to_array('hp123 howard's paving',
```

I didn't find any issues around this.  I made this PR as a proposal with intent to get
feedback on the API at which time I'll write tests.

 ### Other Information

 see https://stackoverflow.com/a/12320729/879854

 #### What does Rails usually do?

- For conditions:
  - connection.quote_string is called by sanitize_sql_array
  - sanitize_sql_array is called by sanitize_sql_for_conditions
  - active_record/connection_adapters/postgresql/quoting.rb

    ```ruby
    # connection.quote_string is +@connection.escape(s)+
    # in https://github.com/ged/ruby-pg/blob/fb465855ce1dd12cf7eb69c92af222052aa956ce/ext/pg_connection.c
    #  SINGLETON_ALIAS(rb_cPGconn, "escape", "escape_string");
    #    where the +escape_string+ singleton calls PQescapeString which is defined as https://www.postgresql.org/docs/10/libpq-exec.html
    #     > PQescapeStringConn does not generate the single quotes that must surround PostgreSQL string literals; they should be provided in the SQL command that the result is inserted into
    #     where we see pg function hard codes the escape character `char        quote_char = as_ident ? '"' : '\'';`

    connection.quote_string("hi")
    => "hi"
    connection.quote_string("h'i")
    => "h''i"
    ```

- For bind variables:
  -  connection.quote is called by quote_bound_value
  -  quote_bound_value is called by replace_bind_variable
  -  replace_bind_variable is called by replace_bind_variables
  -  replace_bind_variables is called by sanitize_sql_array
  -  active_record/sanitization.rb
  -  active_record/connection_adapters/abstract/quoting.rb
  -  active_record/connection_adapters/postgresql/quoting.rb

  -  connection.quote calls connection._quote which probably hits the abstract _quote code
  -  which is hard coded to return e.g. `"'#{quote_string(value.to_s)}'"`

    ```ruby
    connection.quote("h'i")
    => "'h''i'"
    connection.quote("hi")
    => "'hi'"
    ```