### PR TITLE
Require a path for `config.cache_store = :file_store`

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -63,7 +63,13 @@ module ActiveSupport
         case store
         when Symbol
           options = parameters.extract_options!
-          retrieve_store_class(store).new(*parameters, **options)
+          # clean this up once Ruby 2.7 support is dropped
+          # see https://github.com/rails/rails/pull/41522#discussion_r581186602
+          if options.empty?
+            retrieve_store_class(store).new(*parameters)
+          else
+            retrieve_store_class(store).new(*parameters, **options)
+          end
         when Array
           lookup_store(*store)
         when nil

--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -20,7 +20,7 @@ module ActiveSupport
       FILEPATH_MAX_SIZE = 900 # max is 1024, plus some room
       GITKEEP_FILES = [".gitkeep", ".keep"].freeze
 
-      def initialize(cache_path, options = nil)
+      def initialize(cache_path, **options)
         super(options)
         @cache_path = cache_path.to_s
       end

--- a/activesupport/test/cache/cache_store_setting_test.rb
+++ b/activesupport/test/cache/cache_store_setting_test.rb
@@ -21,6 +21,12 @@ class CacheStoreSettingTest < ActiveSupport::TestCase
     assert_equal "/path/to/cache/directory", store.cache_path
   end
 
+  def test_file_store_requires_a_path
+    assert_raises(ArgumentError) do
+      ActiveSupport::Cache.lookup_store :file_store
+    end
+  end
+
   def test_mem_cache_fragment_cache_store
     assert_called_with(Dalli::Client, :new, [%w[localhost], {}]) do
       store = ActiveSupport::Cache.lookup_store :mem_cache_store, "localhost"


### PR DESCRIPTION
Currently if you do `config.cache_store = :file_store` in an initializer, your app will boot and the cache contents will be stored in a directory called `{}` in your project root. This is unlikely to be the intended outcome.

This PR raises an error if you call `config.cache_store = :file_store` without a path. The correct way to use the default cache path is:

```ruby
config.cache_store = :file_store, "#{config.root}/tmp/cache/"
```