### PR TITLE
[ci skip] Clarify 5.2.4.1 Changelog entry

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -26,6 +26,11 @@
 
     The `ActionDispatch::Session::MemcacheStore` is still vulnerable given it requires the
     gem dalli to be updated as well.
+    
+    _Breaking changes:_
+    *   `session.id` now returns an instance of `Rack::Session::SessionId` and not a String (use `session.id.public_id` to restore the old behaviour, see #38063)
+    *   Accessing the session id using `session[:session_id]`/`session['session_id']` no longer works with
+        ruby 2.2 (see https://github.com/rails/rails/commit/2a52a38cb51b65d71cf91fc960777213cf96f962#commitcomment-37929811)
 
     CVE-2019-16782.
 


### PR DESCRIPTION
### Summary

Adds a note to the Changelog entry for the 5.2.4.1 release, warning of a couple of breaking changes that occurred around session ids as a result of the security patch.

### Other Information

While I think the origins of the change lie in `rack` and I am very grateful for the security patch having been released, having just deployed a buggy release after updating a rails 5.2 app (in part due to that app not testing the return type of `session.id`) I hope this can help others avoid the same fate.

Note that I have not been directly affected by the breaking change for ruby 2.2 users, but I've attempted to pinpoint the exact use case that will run into the problem.