### PR TITLE
[ci skip] Clarify maintenance policy for bug fixes to security patches

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -59,6 +59,11 @@ be built from 1.2.2, and then added to the end of 1-2-stable. This means that
 security releases are easy to upgrade to if you're running the latest version
 of Rails.
 
+Only direct security patches will be included in security releases. Fixes for
+non-security related bugs resulting from a security patch may be published on a
+release's x-y-stable branch, and will only be released as a new gem in
+accordance with the Bug Fixes policy.
+
 **Currently included series:** `7.0.Z`, `6.1.Z`, `5.2.Z`.
 
 Severe Security Issues


### PR DESCRIPTION
### Summary

The policy for security patches is very strict, and some people may find it surprising that even breaking changes as a result of an oversight or bug in a security fix will neither receive a release of their own nor be included in any subsequent security patches to address other security issues. Hopefully this additional text will help clarify this and avoid confusion.

### Other Information

After seeing (and contributing to) the numerous comments on commits, PRs and even new issues raised due to confusion as to why bug fixes for the rails 5.2.4.1 security release are present on the `5-2-stable` branch but have not been released with any of the four subsequent security releases (5.2.4.2 to 5.2.4.5), I am trying to address things constructively :)

I've gone with wrapping at 80 characters although it doesn't seem like the file is 100% consistent.