### PR TITLE
Bump the minimum version of PostgreSQL to 9.5

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bump minimum PostgreSQL version to 9.5.
+
+    *Yasuo Honda*
+
 *   Fix compatibility with `psych >= 4`.
 
     Starting in Psych 4.0.0 `YAML.load` behaves like `YAML.safe_load`. To preserve compatibility

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -229,7 +229,7 @@ module ActiveRecord
       end
 
       def supports_insert_on_conflict?
-        database_version >= 90500
+        true
       end
       alias supports_insert_on_duplicate_skip? supports_insert_on_conflict?
       alias supports_insert_on_duplicate_update? supports_insert_on_conflict?
@@ -378,8 +378,9 @@ module ActiveRecord
       end
 
       def supports_pgcrypto_uuid?
-        database_version >= 90400
+        true
       end
+      deprecate :supports_pgcrypto_uuid?
 
       def supports_optimizer_hints?
         unless defined?(@has_pg_hint_plan)
@@ -479,8 +480,8 @@ module ActiveRecord
       end
 
       def check_version # :nodoc:
-        if database_version < 90300
-          raise "Your version of PostgreSQL (#{database_version}) is too old. Active Record supports PostgreSQL >= 9.3."
+        if database_version < 90500
+          raise "Your version of PostgreSQL (#{database_version}) is too old. Active Record supports PostgreSQL >= 9.5."
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -234,6 +234,10 @@ module ActiveRecord
       end
     end
 
+    def test_supports_supports_pgcrypto_uuid_is_deprecated
+      assert_deprecated { @connection.supports_pgcrypto_uuid? }
+    end
+
     private
       def with_warning_suppression
         log_level = @connection.client_min_messages

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -247,9 +247,6 @@ class PostgreSQLGeometricLineTest < ActiveRecord::PostgreSQLTestCase
   class PostgresqlLine < ActiveRecord::Base; end
 
   setup do
-    unless ActiveRecord::Base.connection.database_version >= 90400
-      skip("line type is not fully implemented")
-    end
     @connection = ActiveRecord::Base.connection
     @connection.create_table("postgresql_lines") do |t|
       t.line :a_line

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -2,15 +2,13 @@
 
 ActiveRecord::Schema.define do
   enable_extension!("uuid-ossp", ActiveRecord::Base.connection)
-  enable_extension!("pgcrypto",  ActiveRecord::Base.connection) if ActiveRecord::Base.connection.supports_pgcrypto_uuid?
+  enable_extension!("pgcrypto",  ActiveRecord::Base.connection)
 
-  uuid_default = connection.supports_pgcrypto_uuid? ? {} : { default: "uuid_generate_v4()" }
-
-  create_table :uuid_parents, id: :uuid, force: true, **uuid_default do |t|
+  create_table :uuid_parents, id: :uuid, force: true do |t|
     t.string :name
   end
 
-  create_table :uuid_children, id: :uuid, force: true, **uuid_default do |t|
+  create_table :uuid_children, id: :uuid, force: true do |t|
     t.string :name
     t.uuid :uuid_parent_id
   end
@@ -106,23 +104,23 @@ _SQL
   end
 
   create_table :uuid_comments, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :content
   end
 
   create_table :uuid_entries, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :entryable_type, null: false
     t.uuid :entryable_uuid, null: false
   end
 
   create_table :uuid_items, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :title
   end
 
   create_table :uuid_messages, force: true, id: false do |t|
-    t.uuid :uuid, primary_key: true, **uuid_default
+    t.uuid :uuid, primary_key: true
     t.string :subject
   end
 

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -14,7 +14,7 @@ After reading this guide, you will know:
 
 --------------------------------------------------------------------------------
 
-In order to use the PostgreSQL adapter you need to have at least version 9.3
+In order to use the PostgreSQL adapter you need to have at least version 9.5
 installed. Older versions are not supported.
 
 To get started with PostgreSQL have a look at the

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -695,7 +695,7 @@ We had to create the **gitapp** directory and initialize an empty git repository
 
 ```bash
 $ cat config/database.yml
-# PostgreSQL. Versions 9.3 and up are supported.
+# PostgreSQL. Versions 9.5 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcpostgresql.yml.tt
@@ -1,4 +1,4 @@
-# PostgreSQL. Versions 9.3 and up are supported.
+# PostgreSQL. Versions 9.5 and up are supported.
 #
 # Configure Using Gemfile
 # gem "activerecord-jdbcpostgresql-adapter"

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -1,4 +1,4 @@
-# PostgreSQL. Versions 9.3 and up are supported.
+# PostgreSQL. Versions 9.5 and up are supported.
 #
 # Install the pg driver:
 #   gem install pg


### PR DESCRIPTION
This pull request bumps the minimum version of PostgreSQL to 9.6.

### Summary

#### PostgreSQL 9.3 to 9.5 are EOL
https://www.postgresql.org/support/versioning/

- PostgreSQL 9.3 is EOL since November 2018
- PostgreSQL 9.4 is EOL since February 2020
- PostgreSQL 9.5 is EOL since Feb 11, 2021

#### Deprecated `supports_pgcrypto_uuid?` since no other database adapters have this method.

#### PostgreSQL 9.4 or higher supports line geometric type

- 8.8. Geometric Types

https://www.postgresql.org/docs/9.4/datatype-geometric.html
`line` geometric type says `Infinite line`, removed `(not fully implemented)`

https://www.postgresql.org/docs/9.3/datatype-geometric.html
`line` geometric type says `Infinite line (not fully implemented)`


### Other Information

Proposed at https://discuss.rubyonrails.org/t/proposal-to-bump-the-minimum-version-of-postgresql-to-9-6-and-mysql-to-5-7-for-rails-7/77234
