### PR TITLE
Address CI failure due to non-determined sort order

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -2244,7 +2244,7 @@ class RelationTest < ActiveRecord::TestCase
     mary = authors(:mary)
 
     authors = Author.where(name: ["David", "Mary"].to_set)
-    assert_equal [david, mary], authors
+    assert_equal [david, mary], authors.order(:id)
   end
 
   test "#where with empty set" do


### PR DESCRIPTION
### Summary

This pull request addresses CI failure due to non-determined sort order
https://buildkite.com/rails/rails/builds/75313#7ce8978a-4795-4bae-af61-c56eb21608e8/1061-1072

```
Failure:
RelationTest#test_#where_with_set [/rails/activerecord/test/cases/relations_test.rb:2247]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Author id: 1, name: "David", author_address_id: 1, author_address_extra_id: 2, organization_id: "No Such Agency", owned_essay_id: "A Modest Proposal">, #<Author id: 2, name: "Mary", author_address_id: 3, author_address_extra_id: nil, organization_id: nil, owned_essay_id: nil>]
+#<ActiveRecord::Relation [#<Author id: 2, name: "Mary", author_address_id: 3, author_address_extra_id: nil, organization_id: nil, owned_essay_id: nil>, #<Author id: 1, name: "David", author_address_id: 1, author_address_extra_id: 2, organization_id: "No Such Agency", owned_essay_id: "A Modest Proposal">]>
```

* Without this commit
```
Author Load (0.6ms)  SELECT "authors".* FROM "authors" WHERE "authors"."name" IN ($1, $2)  [[nil, "David"], [nil, "Mary"]]
```

* With this commit
```
Author Load (0.8ms)  SELECT "authors".* FROM "authors" WHERE "authors"."name" IN ($1, $2) ORDER BY "authors"."id" ASC  [[nil, "David"], [nil, "Mary"]]
````

This pull request is related to #41526