### PR TITLE
yarn:install on windows would crash

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -10,13 +10,13 @@ namespace :yarn do
     end
 
     yarn_flags =
-      if `"#{Rails.root}/bin/yarn" --version`.start_with?("1")
+      if `#{RbConfig.ruby} "#{Rails.root}/bin/yarn" --version`.start_with?("1")
         "--no-progress --frozen-lockfile"
       else
         "--immutable"
       end
 
-    system({ "NODE_ENV" => node_env }, "\"#{Rails.root}/bin/yarn\" install #{yarn_flags}")
+    system({ "NODE_ENV" => node_env }, "#{RbConfig.ruby} \"#{Rails.root}/bin/yarn\" install #{yarn_flags}")
   rescue Errno::ENOENT
     $stderr.puts "bin/yarn was not found."
     $stderr.puts "Please run `bundle exec rails app:update:bin` to create it."


### PR DESCRIPTION
### Summary

Windows can't implicitly run the `bin/yarn` using backticks, as it throws an `Errno::EINVAL` if you try. This change adds the ruby interpreter path to the call to let the OS know what to run the file with.