### PR TITLE
Bump minimum MySQL version to 5.7.9

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Bump minimum MySQL version to 5.7.9.
+
+    *Yasuo Honda*
+
 *   Allow applications to configure the thread pool for async queries
 
     Some applications may want one thread pool per database whereas others want to use

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -105,16 +105,16 @@ module ActiveRecord
       end
 
       def supports_datetime_with_precision?
-        mariadb? || database_version >= "5.6.4"
+        true
       end
 
       def supports_virtual_columns?
-        mariadb? || database_version >= "5.7.5"
+        true
       end
 
       # See https://dev.mysql.com/doc/refman/en/optimizer-hints.html for more details.
       def supports_optimizer_hints?
-        !mariadb? && database_version >= "5.7.7"
+        !mariadb?
       end
 
       def supports_common_table_expressions?
@@ -556,8 +556,8 @@ module ActiveRecord
       end
 
       def check_version # :nodoc:
-        if database_version < "5.5.8"
-          raise "Your version of MySQL (#{database_version}) is too old. Active Record supports MySQL >= 5.5.8."
+        if database_version < "5.7.9"
+          raise "Your version of MySQL (#{database_version}) is too old. Active Record supports MySQL >= 5.7.9."
         end
       end
 
@@ -728,7 +728,7 @@ module ActiveRecord
           if mariadb?
             database_version >= "10.5.2"
           else
-            database_version >= "5.7.6"
+            true
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -132,7 +132,7 @@ module ActiveRecord
             if mariadb?
               database_version >= "10.2.2"
             else
-              database_version >= "5.7.9"
+              true
             end
           end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -60,7 +60,7 @@ module ActiveRecord
       end
 
       def supports_json?
-        !mariadb? && database_version >= "5.7.8"
+        !mariadb?
       end
 
       def supports_comments?

--- a/activerecord/test/cases/adapters/mysql2/datetime_precision_quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/datetime_precision_quoting_test.rb
@@ -7,16 +7,8 @@ class Mysql2DatetimePrecisionQuotingTest < ActiveRecord::Mysql2TestCase
     @connection = ActiveRecord::Base.connection
   end
 
-  test "microsecond precision for MySQL gte 5.6.4" do
-    stub_version "5.6.4" do
-      assert_microsecond_precision
-    end
-  end
-
-  test "no microsecond precision for MySQL lt 5.6.4" do
-    stub_version "5.6.3" do
-      assert_no_microsecond_precision
-    end
+  test "microsecond precision for MySQL" do
+    assert_microsecond_precision
   end
 
   test "microsecond precision for MariaDB gte 5.3.0" do
@@ -28,10 +20,6 @@ class Mysql2DatetimePrecisionQuotingTest < ActiveRecord::Mysql2TestCase
   private
     def assert_microsecond_precision
       assert_match_quoted_microsecond_datetime(/\.123456\z/)
-    end
-
-    def assert_no_microsecond_precision
-      assert_match_quoted_microsecond_datetime(/:55\z/)
     end
 
     def assert_match_quoted_microsecond_datetime(match)

--- a/activerecord/test/cases/adapters/mysql2/sp_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sp_test.rb
@@ -9,9 +9,6 @@ class Mysql2StoredProcedureTest < ActiveRecord::Mysql2TestCase
 
   def setup
     @connection = ActiveRecord::Base.connection
-    unless ActiveRecord::Base.connection.database_version >= "5.6.0"
-      skip("no stored procedure support")
-    end
   end
 
   # Test that MySQL allows multiple results for stored procedures

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1313,8 +1313,6 @@ development:
 
 If your development database has a root user with an empty password, this configuration should work for you. Otherwise, change the username and password in the `development` section as appropriate.
 
-NOTE: If your MySQL version is 5.5 or 5.6 and want to use the `utf8mb4` character set by default, please configure your MySQL server to support the longer key prefix by enabling `innodb_large_prefix` system variable.
-
 Advisory Locks are enabled by default on MySQL and are used to make database migrations concurrent safe. You can disable advisory locks by setting `advisory_locks` to `false`:
 
 ```yaml

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/jdbcmysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# MySQL. Versions 5.7.9 and up are supported.
 #
 # Install the MySQL driver:
 #   gem install activerecord-jdbcmysql-adapter

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -1,4 +1,4 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# MySQL. Versions 5.7.9 and up are supported.
 #
 # Install the MySQL driver
 #   gem install mysql2


### PR DESCRIPTION
### Summary

This pull request bumps the minimum MySQL version to 5.7.9.

- Better support for utf8mb4 character set

Starting from Rails 6.0, the default character set of MySQL is utf8mb4.
Users who want to use this character set with MySQL 5.5 or 5.6 need to enable the innodb_large_prefix system variable at the MySQL server.

Without enabling this system variable enabled, MySQL 5.5 or 5.6 users will get `Specified key was too long; max key length is 767 bytes error`.
MySQL 5.7.9 supports a longer index key prefix by default there is no need to configure the MySQL server to use the utf8mb4 character set.

- MySQL 5.5 and 5.6 are “EOL”
https://www.mysql.com/support/eol-notice.html

> MySQL 5.6 is covered under Oracle Lifetime Sustaining Support Per Oracle’s Lifetime Support policy,
> as of February 1, 2021, MySQL 5.6 is covered under Oracle Sustaining Support.

> MySQL 5.5 covered under Oracle Lifetime Sustaining Support
> Per Oracle's Lifetime Support policy, as of December 31, 2018,
> MySQL 5.5 is covered under Oracle Sustaining Support.

Here Oracle Lifetime Sustaining Support will not provide new releases,
not provide new fixes then I think we can call MySQL 5.5 and 5.6 are “EOL”.

Refer "MySQL Technical Support" page for detail.
https://www.mysql.com/support/

- `supports_datetime_with_precision?` is always returns true with MySQL 5.7.9 or higher

Update Mysql2DatetimePrecisionQuotingTest and remove tests which stubs connection as if MySQL 5.6.3.

### Other Information

Proposed at https://discuss.rubyonrails.org/t/proposal-to-bump-the-minimum-version-of-postgresql-to-9-6-and-mysql-to-5-7-for-rails-7/77234