### PR TITLE
Load timesetamps on join tables for `has_many :through` fixtures

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Fixtures for `has_many :through` associations now load timestamps on join tables
+
+    Given this fixture:
+
+    ```yml
+    ### monkeys.yml
+    george:
+      name: George the Monkey
+      fruits: apple
+
+    ### fruits.yml
+    apple:
+      name: apple
+    ```
+
+    If the join table (`fruit_monkeys`) contains `created_at` or `updated_at` columns,
+    these will now be populated when loading the fixture. Previously, fixture loading
+    would crash if these columns were required, and leave them as null otherwise.
+
+    *Alex Ghiculescu*
+
 *   Allow applications to configure the thread pool for async queries
 
     Some applications may want one thread pool per database whereas others want to use

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -33,6 +33,10 @@ module ActiveRecord
         def join_table
           @association.through_reflection.table_name
         end
+
+        def timestamp_column_names
+          ModelMetadata.new(@association.through_reflection.klass).timestamp_column_names
+        end
       end
 
       def initialize(fixture, table_rows:, label:, now:)
@@ -141,8 +145,12 @@ module ActiveRecord
 
             targets = targets.is_a?(Array) ? targets : targets.split(/\s*,\s*/)
             joins   = targets.map do |target|
-              { lhs_key => @row[model_metadata.primary_key_name],
-                rhs_key => ActiveRecord::FixtureSet.identify(target, column_type) }
+              join = { lhs_key => @row[model_metadata.primary_key_name],
+                       rhs_key => ActiveRecord::FixtureSet.identify(target, column_type) }
+              association.timestamp_column_names.each do |col|
+                join[col] = @now
+              end
+              join
             end
             @table_rows.tables[table_name].concat(joins)
           end

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -311,7 +311,7 @@ module ActiveRecord
   #
   # Just provide the polymorphic target type and Active Record will take care of the rest.
   #
-  # === has_and_belongs_to_many
+  # === has_and_belongs_to_many or has_many :through
   #
   # Time to give our monkey some fruit.
   #

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -19,6 +19,8 @@ require "models/developer"
 require "models/dog"
 require "models/doubloon"
 require "models/joke"
+require "models/loot"
+require "models/loot_parrot"
 require "models/matey"
 require "models/other_dog"
 require "models/parrot"
@@ -566,7 +568,7 @@ class HasManyThroughFixture < ActiveRecord::TestCase
     Class.new(ActiveRecord::Base) { define_singleton_method(:name) { name } }
   end
 
-  def test_has_many_through_with_default_table_name
+  def test_has_many_through_with_join_table_name_changed_to_match_habtm_table_name
     pt = make_model "ParrotTreasure"
     parrot = make_model "Parrot"
     treasure = make_model "Treasure"
@@ -585,7 +587,7 @@ class HasManyThroughFixture < ActiveRecord::TestCase
     assert_equal load_has_and_belongs_to_many["parrots_treasures"], rows["parrots_treasures"]
   end
 
-  def test_has_many_through_with_renamed_table
+  def test_has_many_through_with_default_table_name_on_join_table
     pt = make_model "ParrotTreasure"
     parrot = make_model "Parrot"
     treasure = make_model "Treasure"
@@ -1101,7 +1103,8 @@ class FoxyFixturesTest < ActiveRecord::TestCase
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   self.use_transactional_tests = false
   fixtures :parrots, :parrots_pirates, :pirates, :treasures, :mateys, :ships, :computers,
-           :developers, :"admin/accounts", :"admin/users", :live_parrots, :dead_parrots, :books
+           :developers, :"admin/accounts", :"admin/users", :live_parrots, :dead_parrots, :books,
+           :loots
 
   if ActiveRecord::Base.connection.adapter_name == "PostgreSQL"
     require "models/uuid_parent"
@@ -1187,6 +1190,14 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert(pirates(:blackbeard).parrots.include?(parrots(:george)))
     assert(pirates(:blackbeard).parrots.include?(parrots(:louis)))
     assert(parrots(:george).pirates.include?(pirates(:blackbeard)))
+  end
+
+  def test_supports_timestamps_in_join_tables
+    assert_not_nil parrots(:looter).created_at
+    assert_not_nil loots(:bounty).created_at
+    assert_equal loots(:bounty), parrots(:looter).loots.first
+    assert_equal loots(:bounty), parrots(:looter).loot_parrots.first.loot
+    assert_not_nil parrots(:looter).loot_parrots.first.created_at
   end
 
   def test_supports_inline_habtm

--- a/activerecord/test/fixtures/loots.yml
+++ b/activerecord/test/fixtures/loots.yml
@@ -1,0 +1,2 @@
+bounty:
+  value: 123.45

--- a/activerecord/test/fixtures/parrots.yml
+++ b/activerecord/test/fixtures/parrots.yml
@@ -25,6 +25,9 @@ polly:
   treasures: sapphire, ruby
   <<: *DEAD_PARROT
 
+looter:
+  loots: bounty
+
 DEFAULTS: &DEFAULTS
   treasures: sapphire, ruby
   parrot_sti_class: LiveParrot

--- a/activerecord/test/models/loot.rb
+++ b/activerecord/test/models/loot.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Loot < ActiveRecord::Base
+  has_many :loot_parrots, class_name: "LootParrot"
+  has_many :parrots, through: :loot_parrots
+end

--- a/activerecord/test/models/loot_parrot.rb
+++ b/activerecord/test/models/loot_parrot.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class LootParrot < ActiveRecord::Base
+  belongs_to :parrot
+  belongs_to :loot
+end

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -5,7 +5,8 @@ class Parrot < ActiveRecord::Base
 
   has_and_belongs_to_many :pirates
   has_and_belongs_to_many :treasures
-  has_many :loots, as: :looter
+  has_many :loot_parrots, class_name: "LootParrot"
+  has_many :loots, through: :loot_parrots
   alias_attribute :title, :name
 
   validates_presence_of :name

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -562,6 +562,17 @@ ActiveRecord::Schema.define do
     t.timestamps null: true
   end
 
+  create_table :loots, force: true do |t|
+    t.float :value
+    t.timestamps
+  end
+
+  create_table :loot_parrots, force: true do |t|
+    t.references :loot, null: false
+    t.references :parrot, null: false
+    t.timestamps
+  end
+
   create_table :magazines, force: true do |t|
   end
 
@@ -741,7 +752,14 @@ ActiveRecord::Schema.define do
       t.references :pirate, foreign_key: true
     end
 
+    # used by tests that do `Parrot.has_and_belongs_to_many :treasures` (the default)
     create_table :parrots_treasures, id: false, force: true do |t|
+      t.references :parrot, foreign_key: true
+      t.references :treasure, foreign_key: true
+    end
+
+    # used by tests that do `Parrot.has_many :treasures, through: :parrot_treasures`, and don't want to override the through relation's `table_name`
+    create_table :parrot_treasures, id: false, force: true do |t|
       t.references :parrot, foreign_key: true
       t.references :treasure, foreign_key: true
     end


### PR DESCRIPTION
Given this fixture (from the examples [here](https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html)):

```yml
george:
  name: George the Monkey
  fruits: apple

apple:
  name: apple
```

If the join table (`fruit_monkeys`) contains `created_at` or `updated_at` columns, these will now be populated when loading the fixture. Previously, fixture loading would crash if these columns were required, and leave them as null otherwise.

This means the examples at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html will now work even if you create your tables with `t.timestamps` (the default, which is `null: false`)
