### PR TITLE
Adding robots.txt to guide as Lighthouse is warning about it

### DIFF
--- a/guides/assets/robots.txt
+++ b/guides/assets/robots.txt
@@ -1,1 +1,3 @@
-Sitemap: sitemap.txt
+# Allow crawling of all content
+User-agent: *
+Disallow:

--- a/guides/assets/robots.txt
+++ b/guides/assets/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: sitemap.txt


### PR DESCRIPTION
### Summary

I ran the current the current [Rails Guides](https://guides.rubyonrails.org/index.html) site against [lighthouse](https://web.dev/measure/) & one of the things it suggested was to add a valid robots.txt file.

![image](https://user-images.githubusercontent.com/325384/108888286-299bfc00-7603-11eb-98ad-ece7130674a2.png)

When I inspected the current [robots.txt](https://edgeguides.rubyonrails.org/robots.txt), it's 404'ing.

So I added one copying the [HTML5 Boilerplate](https://github.com/h5bp/html5-boilerplate/blob/master/src/robots.txt) example.

### Other Information

To test this locally I ran `rake guides:generate` & inspected the `output` folder. 

I did look into adding a sitemap also, but I think I'll save that for another PR :) 