### PR TITLE
Add migrations_priority to database.yml

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -158,7 +158,7 @@ module ActiveRecord
           configurations.select { |db_config| db_config.env_name == env }
         else
           configurations
-        end
+        end.sort_by!(&:migrations_priority)
       end
 
       def build_configs(configs)

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -50,6 +50,11 @@ module ActiveRecord
         configuration_hash[:migrations_paths]
       end
 
+      # The priority of specific migrations paths.
+      def migrations_priority
+        configuration_hash[:migrations_priority]&.to_i || 0
+      end
+
       def host
         configuration_hash[:host]
       end

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -102,6 +102,16 @@ module ActiveRecord
         config = HashConfig.new("default_env", "primary", idle_timeout: "0")
         assert_nil config.idle_timeout
       end
+
+      def test_migrations_priority
+        config = HashConfig.new("default_env", "primary", migrations_priority: "1")
+        assert_equal 1, config.migrations_priority
+      end
+
+      def test_migrations_priority_default
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal 0, config.migrations_priority
+      end
     end
   end
 end

--- a/activerecord/test/cases/database_configurations_test.rb
+++ b/activerecord/test/cases/database_configurations_test.rb
@@ -97,6 +97,23 @@ class DatabaseConfigurationsTest < ActiveRecord::TestCase
     assert_equal ":memory:", config.database
   end
 
+  def test_migrations_priority_config
+    configs = ActiveRecord::DatabaseConfigurations.new({
+      ActiveRecord::ConnectionHandling::DEFAULT_ENV.call => {
+        "primary" => {
+          "adapter" => "randomadapter",
+          "migrations_priority" => 2
+        },
+        "secondary" => {
+          "adapter" => "randomadapter",
+          "migrations_priority" => 1
+        }
+      }
+    }).configs_for
+
+    assert_equal %w[secondary primary], configs.map(&:name)
+  end
+
   def test_to_h_turns_db_config_object_back_into_a_hash_and_is_deprecated
     configs = ActiveRecord::Base.configurations
     assert_equal "ActiveRecord::DatabaseConfigurations", configs.class.name


### PR DESCRIPTION
### Summary

Basically sometimes we need to specify the order for multiple database migrations, we can do that only with consecutive calls e.g. `rake db:migrate:secondary rake db:migrate:primary ... rake db:migrate:nth` (since positions in the `yml` file are ignored I believe)
But this is not always handy.

This requests brings new option for our `database.yml` called `migrations_priority` which will determine which db should migrate in which order.

By default all the priority set to 0, so it shouldn't affect previous behavior.