### PR TITLE
Delegated Type: support `find_or_create_by`

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -211,7 +211,7 @@ module ActiveRecord
           singular   = scope_name.singularize
           query      = "#{singular}?"
 
-          scope scope_name, -> { where(role_type => type) }
+          scope scope_name, -> { where(role_type => type).create_with(role => type.constantize.new) }
 
           define_method query do
             public_send(role_type) == type

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -406,6 +406,7 @@ ActiveRecord::Schema.define do
   end
 
   create_table :entries, force: true do |t|
+    t.text :label
     t.string  :entryable_type, null: false
     t.integer :entryable_id, null: false
   end


### PR DESCRIPTION
Currently `find_or_create_by` (or just `create`) doesn't work well with delegated types.

For example, if no entry is found, then `Entry.messages.find_or_create_by(label: "foo")` will raise when trying to create. Internally it will be calling `Entry.create(label: "foo", entryable_type: "Message")` which fails if the polymorphic columns (specifically `entryable_id`) can't be null. Instead, you have to do `Entry.messages.create_with(entryable: Message.new).find_or_create_by(label: "foo")` which feels yuck.

With this PR, the `create` call will now work. It is equivalent to `Entry.create(label: "foo", entryable: Message.new)`.

If there are additional fields required on the delegated type, you can either use `create_with` or pass a block to `create`.

cc @dhh