### PR TITLE
Rescue Mime::Type::InvalidMimeType as HTTP 406 not acceptable

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -61,5 +61,9 @@
 
     *DHH*
 
+*   Return a 406 not acceptable HTTP error on invalid mime types
+
+    *Mathieu Gagné*
+
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -14,6 +14,7 @@ module ActionDispatch
       "ActionController::UnknownFormat"                    => :not_acceptable,
       "ActionDispatch::Http::MimeNegotiation::InvalidType" => :not_acceptable,
       "ActionController::MissingExactTemplate"             => :not_acceptable,
+      "Mime::Type::InvalidMimeType"                        => :not_acceptable,
       "ActionController::InvalidAuthenticityToken"         => :unprocessable_entity,
       "ActionController::InvalidCrossOriginRequest"        => :unprocessable_entity,
       "ActionDispatch::Http::Parameters::ParseError"       => :bad_request,


### PR DESCRIPTION
### Summary

Disclaimer: I don't understand the exploit nor the intent.

Our servers are getting a weird hacking attempt using the `Accept` header. Rails raises a `Mime::Type::InvalidMimeType` error when that occurs.

This pull request considers that if the mime type is invalid then Rails, by convention, returns a 406 not acceptable. Investigation has led us to believe this is not something `nginx` or other HTTP servers would usually handle.

### Other Information

Here's an example of that type of request.

```
curl \
 --compressed \
 -H "Accept: ../../../../../../../../../../etc/services{{" \
 -H "Accept-Encoding: gzip" \
 -H "Connection: upgrade" \
 -H "Host: 54.144.181.117" \
 -H "Referer: https://54.144.181.117/" \
 -H "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36" \
 -H "X-Forwarded-Port: 443" \
 -H "X-Forwarded-Proto: https" \
 -H "X-Request-Id: 4015ae81-44ab-4c46-8c9b-3ff5dfe05c1e" \
 "https://54.144.181.117/"
```

This is my first pull request to `rails`. Feel free to point out anything I could have done better :heart: 