### PR TITLE
Add docs on how to write tests when using Active Storage

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -8,14 +8,14 @@ module ActionDispatch
     module FixtureFile
       # Shortcut for <tt>Rack::Test::UploadedFile.new(File.join(ActionDispatch::IntegrationTest.file_fixture_path, path), type)</tt>:
       #
-      #   post :change_avatar, params: { avatar: fixture_file_upload('spongebob.png', 'image/png') }
+      #   post :change_avatar, params: { avatar: fixture_file_upload('david.png', 'image/png') }
       #
       # Default fixture files location is <tt>test/fixtures/files</tt>.
       #
       # To upload binary files on Windows, pass <tt>:binary</tt> as the last parameter.
       # This will not affect other platforms:
       #
-      #   post :change_avatar, params: { avatar: fixture_file_upload('spongebob.png', 'image/png', :binary) }
+      #   post :change_avatar, params: { avatar: fixture_file_upload('david.png', 'image/png', :binary) }
       def fixture_file_upload(path, mime_type = nil, binary = false)
         if self.class.respond_to?(:fixture_path) && self.class.fixture_path &&
             !File.exist?(path)

--- a/activestorage/lib/active_storage/fixture_set.rb
+++ b/activestorage/lib/active_storage/fixture_set.rb
@@ -37,7 +37,7 @@ module ActiveStorage
   #     blob: first_thumbnail_blob
   #
   # When processed, Active Record will insert database records for each fixture
-  # entry and will ensure the Action Text relationship is intact.
+  # entry and will ensure the Active Storage relationship is intact.
   class FixtureSet
     include ActiveSupport::Testing::FileFixtures
     include ActiveRecord::SecureToken


### PR DESCRIPTION
Adds some missing examples that I found handy:

- Introduces `fixture_file_upload`, and adds an example.
- Adds example of how to make fixtures for Active Storage attachments (inspired by [this answer](https://stackoverflow.com/a/55835955/641293), edited with thanks to @gmcgibbon suggestions).
- Adds example of how to safely clean up files when running tests in parallel (which is the default in a new Rails app)

Tidies up a few things:

- Makes the sections on cleaning up files lower level headers (no need for them to be primary sections).
- Updates the suggested service name for testing to match the one used in a new Rails app.
- Updates the path to delete files from. Rather than hard coding it, just get it from Active Storage.
