### PR TITLE
Add ActiveStorage::Blob.compose

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `Add ActiveStorage::Blob.compose` to concatenate multiple blobs.
+
+    *Gannon McGibbon*
+
 *   Setting custom metadata on blobs are now persisted to remote storage.
 
     *joshuamsager*

--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -10,7 +10,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.text     :metadata
       t.string   :service_name, null: false
       t.bigint   :byte_size,    null: false
-      t.string   :checksum,     null: false
+      t.string   :checksum
 
       if connection.supports_datetime_with_precision?
         t.datetime :created_at, precision: 6, null: false

--- a/activestorage/db/update_migrate/20211119233751_remove_not_null_on_active_storage_blobs_checksum.rb
+++ b/activestorage/db/update_migrate/20211119233751_remove_not_null_on_active_storage_blobs_checksum.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:active_storage_blobs, :checksum, true)
+  end
+end

--- a/activestorage/lib/active_storage/downloader.rb
+++ b/activestorage/lib/active_storage/downloader.rb
@@ -8,10 +8,10 @@ module ActiveStorage
       @service = service
     end
 
-    def open(key, checksum:, name: "ActiveStorage-", tmpdir: nil)
+    def open(key, checksum: nil, verify: true, name: "ActiveStorage-", tmpdir: nil)
       open_tempfile(name, tmpdir) do |file|
         download key, file
-        verify_integrity_of file, checksum: checksum
+        verify_integrity_of(file, checksum: checksum) if verify
         yield file
       end
     end

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -90,6 +90,11 @@ module ActiveStorage
       ActiveStorage::Downloader.new(self).open(*args, **options, &block)
     end
 
+    # Concatenate multiple files into a single "composed" file. Returns the checksum of the composed file.
+    def compose(*source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
+      raise NotImplementedError
+    end
+
     # Delete the file at the +key+.
     def delete(key)
       raise NotImplementedError

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -107,6 +107,24 @@ module ActiveStorage
       { "Content-Type" => content_type, "Content-MD5" => checksum, "x-ms-blob-content-disposition" => content_disposition, "x-ms-blob-type" => "BlockBlob", **custom_metadata_headers(custom_metadata) }
     end
 
+    def compose(*source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
+      content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
+
+      client.create_append_blob(
+        container,
+        destination_key,
+        content_type: content_type,
+        content_disposition: content_disposition,
+        metadata: custom_metadata,
+      ).tap do |blob|
+        source_keys.each do |source_key|
+          stream(source_key) do |chunk|
+            client.append_blob_block(container, blob.name, chunk)
+          end
+        end
+      end
+    end
+
     private
       def private_url(key, expires_in:, filename:, disposition:, content_type:, **)
         signer.signed_uri(

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -100,6 +100,16 @@ module ActiveStorage
       File.join root, folder_for(key), key
     end
 
+    def compose(*source_keys, destination_key, **)
+      File.open(make_path_for(destination_key), "w") do |destination_file|
+        source_keys.each do |source_key|
+          File.open(path_for(source_key), "rb") do |source_file|
+            IO.copy_stream(source_file, destination_file)
+          end
+        end
+      end
+    end
+
     private
       def private_url(key, expires_in:, filename:, content_type:, disposition:, **)
         generate_url(key, expires_in: expires_in, filename: filename, content_type: content_type, disposition: disposition)

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -134,6 +134,14 @@ module ActiveStorage
       headers
     end
 
+    def compose(*source_keys, destination_key, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
+      bucket.compose(source_keys, destination_key).update do |file|
+        file.content_type = content_type
+        file.content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
+        file.metadata = custom_metadata
+      end
+    end
+
     private
       def private_url(key, expires_in:, filename:, content_type:, disposition:, **)
         args = {

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -14,7 +14,7 @@ module ActiveStorage
     attr_reader :primary, :mirrors
 
     delegate :download, :download_chunk, :exist?, :url,
-      :url_for_direct_upload, :headers_for_direct_upload, :path_for, to: :primary
+      :url_for_direct_upload, :headers_for_direct_upload, :path_for, :compose, to: :primary
 
     # Stitch together from named services.
     def self.build(primary:, mirrors:, name:, configurator:, **options) # :nodoc:

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -84,6 +84,26 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_match(/^[a-z0-9]{28}$/, build_blob_after_unfurling.key)
   end
 
+  test "compose" do
+    blobs = 3.times.map { create_blob(data: "123", filename: "numbers.txt", content_type: "text/plain", identify: false) }
+    blob = ActiveStorage::Blob.compose(filename: "all_numbers.txt", blobs: blobs)
+
+    assert_equal "123123123", blob.download
+    assert_equal "text/plain", blob.content_type
+    assert_equal blobs.first.byte_size * blobs.count, blob.byte_size
+    assert_predicate(blob, :composed)
+    assert_nil blob.checksum
+  end
+
+  test "compose with unpersisted blobs" do
+    blobs = 3.times.map { create_blob(data: "123", filename: "numbers.txt", content_type: "text/plain", identify: false).dup }
+
+    error = assert_raises(ActiveRecord::RecordNotSaved) do
+      ActiveStorage::Blob.compose(filename: "all_numbers.txt", blobs: blobs)
+    end
+    assert_equal "All blobs must be persisted.", error.message
+  end
+
   test "image?" do
     blob = create_file_blob filename: "racecar.jpg"
     assert_predicate blob, :image?

--- a/activestorage/test/service/shared_service_tests.rb
+++ b/activestorage/test/service/shared_service_tests.rb
@@ -138,5 +138,24 @@ module ActiveStorage::Service::SharedServiceTests
       @service.delete("#{key}/a/a/b")
       @service.delete("#{key}/a/b/a")
     end
+
+    test "compose" do
+      keys = 3.times.map { SecureRandom.base58(24) }
+      data = %w(To get her)
+      keys.zip(data).each do |key, data|
+        @service.upload(
+          key,
+          StringIO.new(data),
+          checksum: Digest::MD5.base64digest(data),
+          disposition: :attachment,
+          filename: ActiveStorage::Filename.new("test.html"),
+          content_type: "text/html",
+        )
+      end
+      destination_key = SecureRandom.base58(24)
+      @service.compose(*keys, destination_key)
+
+      assert_equal "Together", @service.download(destination_key)
+    end
   end
 end


### PR DESCRIPTION
### Summary

Retry of https://github.com/rails/rails/pull/37314

I'd like to be able to use GCS' compose feature within Active Storage. Essentially, it allows you to combine multiple files together. This is particularly useful when handling multiple large files.

One issue I can see is that it is impossible to compute the checksum for a file that's assembled on the storage provider's end. In this implementation, composed blobs cannot be opened as they would fail integrity checks. We could make a special blob type ( eg. `conposed: true`) that skips checksum verification, but I'm not sure if that's a preferred approach for this use-case. What do you think?
