### PR TITLE
Preserve index sort order when altering sqlite3 table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -451,6 +451,7 @@ module ActiveRecord
               options = { name: name.gsub(/(^|_)(#{from})_/, "\\1#{to}_"), internal: true }
               options[:unique] = true if index.unique
               options[:where] = index.where if index.where
+              options[:order] = index.orders if index.orders
               add_index(to, columns, **options)
             end
           end


### PR DESCRIPTION
### Summary

Any method in the `SQLite3Adapter` that calls `#alter_table` (ie. `remove_column`, `change_column`) results in the table losing sort order on its indexes. This is because the `index.orders` option is not included in the options kwargs when the index(es) are added to the copied table. We need to preserve the order option in `#copy_table_indexes`.
