### PR TITLE
Update SDOC to 2.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.0.3"
+  gem "sdoc", ">= 2.0.4"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,7 +468,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (2.0.3)
+    sdoc (2.0.4)
       rdoc (>= 5.0)
     selenium-webdriver (4.0.0.alpha7)
       childprocess (>= 0.5, < 5.0)
@@ -619,7 +619,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails
-  sdoc (>= 2.0.3)
+  sdoc (>= 2.0.4)
   selenium-webdriver (>= 4.0.0.alpha7)
   sequel
   sidekiq


### PR DESCRIPTION
This version has two layout fixes:
* Using HTML5 doctype accross all HTML files.
* Fix overflow CSS property of panel elements.

https://my.diffend.io/gems/sdoc/2.0.3/2.0.4