### PR TITLE
Support grouped collection for `collection_select`

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -170,6 +170,10 @@ module ActionView
       # as a +proc+, that will be called for each member of the +collection+ to
       # retrieve the value/text.
       #
+      # The members of +collection+ may also be grouped by a key (as by +Enumerable#group_by+), and an
+      # <tt><optgroup></tt> tag will be rendered for each group, using each group's key as the +label+
+      # attribute.
+      #
       # Example object structure for use with this method:
       #
       #   class Post < ActiveRecord::Base
@@ -179,21 +183,43 @@ module ActionView
       #   class Author < ActiveRecord::Base
       #     has_many :posts
       #
-      #     def name_with_initial
-      #       "#{first_name.first}. #{last_name}"
+      #     def full_name
+      #       "#{first_name} #{last_name}"
+      #     end
+      #
+      #     def first_initial
+      #       first_name.first
       #     end
       #   end
       #
       # Sample usage (selecting the associated Author for an instance of Post, <tt>@post</tt>):
       #
-      #   collection_select(:post, :author_id, Author.all, :id, :name_with_initial, prompt: true)
+      #   collection_select(:post, :author_id, Author.all, :id, :full_name, prompt: true)
       #
       # If <tt>@post.author_id</tt> is already <tt>1</tt>, this would return:
+      #
       #   <select name="post[author_id]" id="post_author_id">
       #     <option value="">Please select</option>
-      #     <option value="1" selected="selected">D. Heinemeier Hansson</option>
-      #     <option value="2">D. Thomas</option>
-      #     <option value="3">M. Clark</option>
+      #     <option value="1" selected="selected">David Heinemeier Hansson</option>
+      #     <option value="2">Dave Thomas</option>
+      #     <option value="3">Mike Clark</option>
+      #   </select>
+      #
+      # Choices may also be grouped by a key:
+      #
+      #   collection_select(:post, :author_id, Author.order(:first_name).group_by(&:first_initial), :id, :full_name, prompt: true)
+      #
+      # In the same context, this would return:
+      #
+      #   <select name="post[author_id]" id="post_author_id">
+      #     <option value="">Please select</option>
+      #     <optgroup label="D">
+      #       <option value="2">Dave Thomas</option>
+      #       <option value="1" selected="selected">David Heinemeier Hansson</option>
+      #     </optgroup>
+      #     <optgroup label="M">
+      #       <option value="3">Mike Clark</option>
+      #     </optgroup>
       #   </select>
       def collection_select(object, method, collection, value_method, text_method, options = {}, html_options = {})
         Tags::CollectionSelect.new(object, method, self, collection, value_method, text_method, options, html_options).render

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -14,16 +14,24 @@ module ActionView
         end
 
         def render
-          option_tags_options = {
-            selected: @options.fetch(:selected) { value },
-            disabled: @options[:disabled]
-          }
-
-          select_content_tag(
-            options_from_collection_for_select(@collection, @value_method, @text_method, option_tags_options),
-            @options, @html_options
-          )
+          select_content_tag(option_tags, @options, @html_options)
         end
+
+        private
+          def collection_grouped?
+            entry = @collection.first if @collection.is_a?(Hash) || @collection.is_a?(Array)
+            entry.respond_to?(:last) && entry.last.is_a?(Array)
+          end
+
+          def option_tags
+            html_options = { selected: @options.fetch(:selected) { value }, disabled: @options[:disabled] }
+
+            if collection_grouped?
+              option_groups_from_collection_for_select(@collection, :last, :first, @value_method, @text_method, html_options)
+            else
+              options_from_collection_for_select(@collection, @value_method, @text_method, html_options)
+            end
+          end
       end
     end
   end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1019,6 +1019,26 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_select_with_grouped_collection_as_nested_array
+    @post = Post.new
+    @post.origin = "dk"
+
+    assert_dom_equal(
+      %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
+      collection_select("post", "origin", dummy_continents.pluck(:continent_name, :countries), :country_id, :country_name)
+    )
+  end
+
+  def test_collection_select_with_grouped_collection_as_hash
+    @post = Post.new
+    @post.origin = "dk"
+
+    assert_dom_equal(
+      %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
+      collection_select("post", "origin", dummy_continents.pluck(:continent_name, :countries).to_h, :country_id, :country_name)
+    )
+  end
+
   def test_collection_select_under_fields_for
     @post = Post.new
     @post.author_name = "Babe"


### PR DESCRIPTION
This adds support for grouped collections to the `collection_select` helper, much like the `select` helper:

```ruby
collection_select :country_id, @countries.group_by(&:continent_name), :id, :name
```

This differs from `grouped_collection_select` in that it does not require a secondary model to group options:

```ruby
grouped_collection_select :country_id, @continents, :countries, :name, :id, :name
```

Of course, a secondary model can be used as well:

```ruby
collection_select :country_id, @countries.group_by { |country| country.continent.name }, :id, :name
```

---

This finishes #40338, which can't be reopened because `master` branch has been deleted.
