### PR TITLE
Stop generating a license for in-app plugins

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Stop generating a license for in-app plugins.
+
+    *Gannon McGibbon*
+
 *   `rails app:update` no longer prompts you to overwrite files that are generally modified in the
     course of developing a Rails app. See [#41083](https://github.com/rails/rails/pull/41083) for
     the full list of changes.

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -51,7 +51,7 @@ module Rails
     end
 
     def license
-      template "MIT-LICENSE"
+      template "MIT-LICENSE" unless inside_application?
     end
 
     def gemspec

--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -8,7 +8,9 @@ Gem::Specification.new do |spec|
   spec.homepage    = "TODO"
   spec.summary     = "TODO: Summary of <%= camelized_modules %>."
   spec.description = "TODO: Description of <%= camelized_modules %>."
+  <% unless inside_application? -%>
   spec.license     = "MIT"
+  <% end -%>
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -631,6 +631,18 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_creating_plugin_in_application_skips_license
+    with_simulated_app do |gemfile_path|
+      FileUtils.cd(destination_root)
+      run_generator ["bukkits"]
+
+      assert_file "bukkits/bukkits.gemspec" do |contents|
+        assert_no_match(/spec.license/, contents)
+      end
+      assert_no_file "bukkits/MIT-LICENSE"
+    end
+  end
+
   def test_generating_controller_inside_mountable_engine
     run_generator [destination_root, "--mountable"]
 


### PR DESCRIPTION
### Summary

I don't think in-app engines need licenses. Since we already support adding a gemfile entry, we can assume the engine will be embedded inside the app.