### PR TITLE
Add app concern and test keepfiles to generated engine plugins

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add app concern and test keepfiles to generated engine plugins.
+
+    *Gannon McGibbon*
+
 *   Stop generating a license for in-app plugins.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -26,11 +26,15 @@ module Rails
           empty_directory_with_keep_file "app/assets/images/#{namespaced_name}"
         end
 
+        empty_directory_with_keep_file "app/models/concerns"
+        empty_directory_with_keep_file "app/controllers/concerns"
         remove_dir "app/mailers" if options[:skip_action_mailer]
         remove_dir "app/jobs" if options[:skip_active_job]
       elsif full?
         empty_directory_with_keep_file "app/models"
         empty_directory_with_keep_file "app/controllers"
+        empty_directory_with_keep_file "app/models/concerns"
+        empty_directory_with_keep_file "app/controllers/concerns"
         empty_directory_with_keep_file "app/mailers" unless options[:skip_action_mailer]
         empty_directory_with_keep_file "app/jobs" unless options[:skip_active_job]
 
@@ -90,12 +94,22 @@ module Rails
     def test
       template "test/test_helper.rb"
       template "test/%namespaced_name%_test.rb"
-      append_file "Rakefile", <<-EOF
-
-#{rakefile_test_tasks}
-task default: :test
+      append_file "Rakefile", <<~EOF
+        #{rakefile_test_tasks}
+        task default: :test
       EOF
+
       if engine?
+        empty_directory_with_keep_file "test/fixtures/files"
+        empty_directory_with_keep_file "test/controllers"
+        empty_directory_with_keep_file "test/mailers"
+        empty_directory_with_keep_file "test/models"
+        empty_directory_with_keep_file "test/integration"
+
+        unless api?
+          empty_directory_with_keep_file "test/helpers"
+        end
+
         template "test/integration/navigation_test.rb"
       end
     end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -481,6 +481,57 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_creating_full_engine_mode_adds_keeps
+    run_generator [destination_root, "--full"]
+    folders_with_keep = %w(
+      app/models/concerns
+      app/controllers/concerns
+      test/fixtures/files
+      test/controllers
+      test/mailers
+      test/models
+      test/helpers
+      test/integration
+    )
+    folders_with_keep.each do |folder|
+      assert_file("#{folder}/.keep")
+    end
+  end
+
+  def test_creating_full_api_engine_adds_keeps
+    run_generator [destination_root, "--full", "--api"]
+    folders_with_keep = %w(
+      app/models/concerns
+      app/controllers/concerns
+      test/fixtures/files
+      test/controllers
+      test/mailers
+      test/models
+      test/integration
+    )
+    folders_with_keep.each do |folder|
+      assert_file("#{folder}/.keep")
+    end
+    assert_no_file("test/helpers/.keep")
+  end
+
+  def test_creating_mountable_engine_mode_adds_keeps
+    run_generator [destination_root, "--mountable"]
+    folders_with_keep = %w(
+      app/models/concerns
+      app/controllers/concerns
+      test/fixtures/files
+      test/controllers
+      test/mailers
+      test/models
+      test/helpers
+      test/integration
+    )
+    folders_with_keep.each do |folder|
+      assert_file("#{folder}/.keep")
+    end
+  end
+
   def test_creating_gemspec
     run_generator
     assert_file "bukkits.gemspec", /spec\.name\s+= "bukkits"/


### PR DESCRIPTION
### Summary

Generated engines don't have all the keep files a normal application has. This adds keeps for generated engines similar to what you would expect for an application.
