### PR TITLE
"empty?" docs: Suggest "load.empty?" over "length.zero?"

### DIFF
--- a/activerecord/lib/active_record/associations/collection_proxy.rb
+++ b/activerecord/lib/active_record/associations/collection_proxy.rb
@@ -813,7 +813,7 @@ module ActiveRecord
       # to <tt>collection.size.zero?</tt>. If the collection has not been loaded,
       # it is equivalent to <tt>!collection.exists?</tt>. If the collection has
       # not already been loaded and you are going to fetch the records anyway it
-      # is better to check <tt>collection.length.zero?</tt>.
+      # is better to check <tt>collection.load.empty?</tt>.
       #
       #   class Person < ActiveRecord::Base
       #     has_many :pets


### PR DESCRIPTION
If "collection.empty?" is what you wanted to do, but you need to work around a collection-loading gotcha, "collection.load.empty?" is much closer to the intended code than changing the method entirely to do "collection.length.zero?" instead.

Read more: https://thepugautomatic.com/2021/02/using-load-with-any-to-avoid-double-queries-from-activerecord/

Would be nice to add similar docs to `any?` but I'll make a separate PR for that if this one is merged.