### PR TITLE
[ci skip] Fix database.yml example in multiple databases Rails Guide

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -49,7 +49,8 @@ The `database.yml` looks like this:
 ```yaml
 production:
   database: my_primary_database
-  user: root
+  username: root
+  password: <%= ENV['ROOT_PASSWORD'] %>
   adapter: mysql
 ```
 
@@ -67,21 +68,25 @@ will use `[CONFIGURATION_NAMESPACE]_schema.rb` for the filename.
 production:
   primary:
     database: my_primary_database
-    user: root
+    username: root
+    password: <%= ENV['ROOT_PASSWORD'] %>
     adapter: mysql
   primary_replica:
     database: my_primary_database
-    user: root_readonly
+    username: root_readonly
+    password: <%= ENV['ROOT_READONLY_PASSWORD'] %>
     adapter: mysql
     replica: true
   animals:
     database: my_animals_database
-    user: animals_root
+    username: animals_root
+    password: <%= ENV['ANIMALS_ROOT_PASSWORD'] %>
     adapter: mysql
     migrations_paths: db/animals_migrate
   animals_replica:
     database: my_animals_database
-    user: animals_readonly
+    username: animals_readonly
+    password: <%= ENV['ANIMALS_READONLY_PASSWORD'] %>
     adapter: mysql
     replica: true
 ```


### PR DESCRIPTION
### Summary

I studied Rails multiple databases feature by following [Multiple Databases with Active Record Rails Guide](https://guides.rubyonrails.org/active_record_multiple_databases.html).
For working multiple databases in my local environment, some fixes are required in `database.yml`.
So I created this PR.

Here is the changes.

* Fix the key name `:user` to `:username`. This is a required fix.
* Add `*default` reference and `:password`.
  * These configuration are copied from default `database.yml` generated by `rails new` command.
  * `:password` is almost required.
  * `*default` reference is also better to be added because it has `:pool` and `:encoding` configurations.
* Add `:host`.
  * This is not required, but in most cases, `:host` are different from each databases. So I added.

If unnecessary changes are included in this PR, I'll fix or remove it.

#### Before

![image](https://user-images.githubusercontent.com/3458295/109405791-7e4ec680-79b7-11eb-9add-624a6ec294b1.png)

![image](https://user-images.githubusercontent.com/3458295/109405794-87d82e80-79b7-11eb-8903-a599c79aaae7.png)

#### After

![image](https://user-images.githubusercontent.com/3458295/109406014-097c8c00-79b9-11eb-9fd6-06d93e6ece54.png)

![image](https://user-images.githubusercontent.com/3458295/109406024-1c8f5c00-79b9-11eb-8e13-c93c0fe7cb06.png)

