### PR TITLE
Use RouteWithParams to generate path instead path_for

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -766,8 +766,7 @@ module ActionDispatch
 
         route_name = options.delete :use_route
         generator = generate(route_name, options, recall)
-        path_info = path_for(options, route_name, [])
-        [URI(path_info).path, generator.params.except(:_recall).keys]
+        [generator.path(nil), generator.params.except(:_recall).keys]
       end
 
       def generate(route_name, options, recall = {}, method_name = nil)


### PR DESCRIPTION
### Summary

I have recently upgraded an application from `6.0.3.3` to `6.1.3` (Ruby 2.7.1p83). When running a controller integration test I faced the following error: 

```
     TypeError:
       no implicit conversion of Array into Hash
```

After some research, I found this [PR](https://github.com/rails/rails/pull/39705/files) that recently changed the behaviour behind this method. So I'm basically changing it to use the `Generator` instead of the path for. 

I have tried to create some tests but I was not able to find the right place but I ran the specs and seems to be ok.

### Other Information

These are the params being used in my application:

```ruby
{"issue_type"=>"dispatch_no_courier_interaction", "params"=>[{"name"=>"courier_notified_before_seconds", "value"=>2}]}
``` 

In RSpec I have the following call

```ruby
put :update, params: issue_creation_param_fixture
```

backtrace: 

```ruby
["/Users/g.malaquias/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/actionpack-6.1.3/lib/action_dispatch/routing/route_set.rb:827:in `merge!'", "/Users/g.malaquias/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/ge
ms/actionpack-6.1.3/lib/action_dispatch/routing/route_set.rb:827:in `url_for'", "/Users/g.malaquias/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/actionpack-6.1.3/lib/action_dispatch/routing/route_set.rb:796
:in `path_for'", "/Users/g.malaquias/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/actionpack-6.1.3/lib/action_dispatch/routing/route_set.rb:770:in `generate_extras'", "/Users/g.malaquias/.rbenv/versions/2.7
.1/lib/ruby/gems/2.7.0/gems/actionpack-6.1.3/lib/action_controller/test_case.rb:554:in `setup_request'", "/Users/g.malaquias/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/actionpack-6.1.3/lib/action_controll
er/test_case.rb:496:in `process'", "/Users/g.malaquias/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/actionpack-6.1.3/lib/action_controller/test_case.rb:416:in `put'",
```
