### PR TITLE
Allow all tree managers' initializer takes a table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -477,8 +477,7 @@ module ActiveRecord
           end
 
           table = Arel::Table.new(table_name)
-          manager = Arel::InsertManager.new
-          manager.into(table)
+          manager = Arel::InsertManager.new(table)
 
           if values_list.size == 1
             values = values_list.shift

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -363,8 +363,7 @@ module ActiveRecord
           end
         end
 
-        im = Arel::InsertManager.new
-        im.into(arel_table)
+        im = Arel::InsertManager.new(arel_table)
 
         if values.empty?
           im.insert(connection.empty_insert_statement_value(primary_key))
@@ -386,8 +385,7 @@ module ActiveRecord
           constraints << current_scope.where_clause.ast
         end
 
-        um = Arel::UpdateManager.new
-        um.table(arel_table)
+        um = Arel::UpdateManager.new(arel_table)
         um.set(_substitute_values(values))
         um.wheres = constraints
 
@@ -405,8 +403,7 @@ module ActiveRecord
           constraints << current_scope.where_clause.ast
         end
 
-        dm = Arel::DeleteManager.new
-        dm.from(arel_table)
+        dm = Arel::DeleteManager.new(arel_table)
         dm.wheres = constraints
 
         connection.delete(dm, "#{self} Destroy")

--- a/activerecord/lib/arel/delete_manager.rb
+++ b/activerecord/lib/arel/delete_manager.rb
@@ -4,10 +4,11 @@ module Arel # :nodoc: all
   class DeleteManager < Arel::TreeManager
     include TreeManager::StatementMethods
 
-    def initialize
-      super
+    def initialize(table = nil)
+      super()
       @ast = Nodes::DeleteStatement.new
       @ctx = @ast
+      @ast.relation = table
     end
 
     def from(relation)

--- a/activerecord/lib/arel/insert_manager.rb
+++ b/activerecord/lib/arel/insert_manager.rb
@@ -2,9 +2,10 @@
 
 module Arel # :nodoc: all
   class InsertManager < Arel::TreeManager
-    def initialize
-      super
+    def initialize(table = nil)
+      super()
       @ast = Nodes::InsertStatement.new
+      @ast.relation = table
     end
 
     def into(table)

--- a/activerecord/lib/arel/update_manager.rb
+++ b/activerecord/lib/arel/update_manager.rb
@@ -4,10 +4,11 @@ module Arel # :nodoc: all
   class UpdateManager < Arel::TreeManager
     include TreeManager::StatementMethods
 
-    def initialize
-      super
+    def initialize(table = nil)
+      super()
       @ast = Nodes::UpdateStatement.new
       @ctx = @ast
+      @ast.relation = table
     end
 
     ###


### PR DESCRIPTION
Currently `SelectManager` takes a table (it was happened at 80ad95b),
but other managers does not, even though it is required to generate a
query.

I think that all tree managers' initializer could take a table, like
`SelectManager` already does.
