### PR TITLE
Don't execute queries in background when max_threads is 0

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -429,8 +429,9 @@ module ActiveRecord
         true
       end
 
-      def async_enabled?
-        supports_concurrent_connections? && !Base.async_query_executor.nil?
+      def async_enabled? # :nodoc:
+        supports_concurrent_connections? &&
+          !Base.async_query_executor.nil? && !pool.async_executor.nil?
       end
 
       # This is meant to be implemented by the adapters that support extensions

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -3,6 +3,7 @@
 require "cases/helper"
 require "models/post"
 require "models/comment"
+require "models/other_dog"
 
 module ActiveRecord
   class LoadAsyncTest < ActiveRecord::TestCase
@@ -278,6 +279,235 @@ module ActiveRecord
 
         assert_equal false, defered_posts.empty?
         assert_predicate defered_posts, :loaded?
+      end
+    end
+
+    class LoadAsyncMultiThreadPoolExecutorTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
+
+      fixtures :posts, :comments
+
+      def setup
+        @old_config = ActiveRecord::Base.async_query_executor
+        ActiveRecord::Base.async_query_executor = :multi_thread_pool
+
+        handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+        config_hash1 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash
+        new_config1 = config_hash1.merge(min_threads: 0, max_threads: 10)
+        db_config1 = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit", "primary", new_config1)
+
+
+        config_hash2 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit2", name: "primary").configuration_hash
+        new_config2 = config_hash2.merge(min_threads: 0, max_threads: 10)
+        db_config2 = ActiveRecord::DatabaseConfigurations::HashConfig.new("arunit2", "primary", new_config2)
+
+        handler.establish_connection(db_config1)
+        handler.establish_connection(db_config2, owner_name: ARUnit2Model)
+      end
+
+      def teardown
+        ActiveRecord::Base.async_query_executor = @old_config
+        clean_up_connection_handler
+      end
+
+      def test_scheduled?
+        defered_posts = Post.where(author_id: 1).load_async
+        assert_predicate defered_posts, :scheduled?
+        assert_predicate defered_posts, :loaded?
+        defered_posts.to_a
+        assert_not_predicate defered_posts, :scheduled?
+      end
+
+      def test_reset
+        defered_posts = Post.where(author_id: 1).load_async
+        assert_predicate defered_posts, :scheduled?
+        defered_posts.reset
+        assert_not_predicate defered_posts, :scheduled?
+      end
+
+      def test_simple_query
+        expected_records = Post.where(author_id: 1).to_a
+
+        status = {}
+        monitor = Monitor.new
+        condition = monitor.new_cond
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "Post Load"
+            status[:executed] = true
+            status[:async] = event.payload[:async]
+            monitor.synchronize { condition.signal }
+          end
+        end
+
+        defered_posts = Post.where(author_id: 1).load_async
+
+        monitor.synchronize do
+          condition.wait_until { status[:executed] }
+        end
+
+        assert_equal expected_records, defered_posts.to_a
+        assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+      def test_load_async_from_transaction
+        posts = nil
+        Post.transaction do
+          Post.where(author_id: 1).update_all(title: "In Transaction")
+          posts = Post.where(author_id: 1).load_async
+          assert_predicate posts, :scheduled?
+          assert_predicate posts, :loaded?
+          raise ActiveRecord::Rollback
+        end
+
+        assert_not_nil posts
+        assert_equal ["In Transaction"], posts.map(&:title).uniq
+      end
+
+      def test_eager_loading_query
+        expected_records = Post.where(author_id: 1).eager_load(:comments).to_a
+
+        status = {}
+        monitor = Monitor.new
+        condition = monitor.new_cond
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "SQL"
+            status[:executed] = true
+            status[:async] = event.payload[:async]
+            monitor.synchronize { condition.signal }
+          end
+        end
+
+        defered_posts = Post.where(author_id: 1).eager_load(:comments).load_async
+
+        assert_predicate defered_posts, :scheduled?
+
+        monitor.synchronize do
+          condition.wait_until { status[:executed] }
+        end
+
+        assert_equal expected_records, defered_posts.to_a
+        assert_queries(0) do
+          defered_posts.each(&:comments)
+        end
+        assert_equal Post.connection.supports_concurrent_connections?, status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+      end
+
+      def test_contradiction
+        assert_queries(0) do
+          assert_equal [], Post.where(id: []).load_async.to_a
+        end
+
+        Post.where(id: []).load_async.reset
+      end
+
+      def test_pluck
+        titles = Post.where(author_id: 1).pluck(:title)
+        assert_equal titles, Post.where(author_id: 1).load_async.pluck(:title)
+      end
+
+      def test_size
+        expected_size = Post.where(author_id: 1).size
+
+        defered_posts = Post.where(author_id: 1).load_async
+
+        assert_equal expected_size, defered_posts.size
+        assert_predicate defered_posts, :loaded?
+      end
+
+      def test_empty?
+        defered_posts = Post.where(author_id: 1).load_async
+
+        assert_equal false, defered_posts.empty?
+        assert_predicate defered_posts, :loaded?
+      end
+    end
+
+    class LoadAsyncMixedThreadPoolExecutorTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
+
+      fixtures :posts, :comments, :other_dogs
+
+      def setup
+        @previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
+        @old_config = ActiveRecord::Base.async_query_executor
+        ActiveRecord::Base.async_query_executor = :multi_thread_pool
+        config_hash1 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash
+        config_hash2 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit2", name: "primary").configuration_hash
+        config = {
+          "default_env" => {
+            "animals" => config_hash2.merge({ min_threads: 0, max_threads: 0 }),
+            "primary" => config_hash1.merge({ min_threads: 0, max_threads: 10 })
+          }
+        }
+        @prev_configs, ActiveRecord::Base.configurations = ActiveRecord::Base.configurations, config
+
+        ActiveRecord::Base.establish_connection(:primary)
+        ARUnit2Model.establish_connection(:animals)
+      end
+
+      def teardown
+        ENV["RAILS_ENV"] = @previous_env
+        ActiveRecord::Base.configurations = @prev_configs
+        ActiveRecord::Base.async_query_executor = @old_config
+        clean_up_connection_handler
+      end
+
+      def test_scheduled?
+        defered_posts = Post.where(author_id: 1).load_async
+        assert_predicate defered_posts, :scheduled?
+        assert_predicate defered_posts, :loaded?
+        defered_posts.to_a
+        assert_not_predicate defered_posts, :scheduled?
+
+        defered_dogs = OtherDog.where(id: 1).load_async
+        assert_not_predicate defered_dogs, :scheduled?
+        assert_predicate defered_dogs, :loaded?
+      end
+
+      def test_simple_query
+        expected_records = Post.where(author_id: 1).to_a
+        expected_dogs = OtherDog.where(id: 1).to_a
+
+        status = {}
+        dog_status = {}
+        monitor = Monitor.new
+        condition = monitor.new_cond
+
+        subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
+          if event.payload[:name] == "Post Load"
+            status[:executed] = true
+            status[:async] = event.payload[:async]
+            monitor.synchronize { condition.signal }
+          end
+
+          if event.payload[:name] == "OtherDog Load"
+            dog_status[:executed] = true
+            dog_status[:async] = event.payload[:async]
+            monitor.synchronize { condition.signal }
+          end
+        end
+
+        defered_posts = Post.where(author_id: 1).load_async
+        defered_dogs = OtherDog.where(id: 1).load_async
+
+        monitor.synchronize do
+          condition.wait_until { status[:executed] }
+          condition.wait_until { dog_status[:executed] }
+        end
+
+        assert_equal expected_records, defered_posts.to_a
+        assert_equal expected_dogs, defered_dogs.to_a
+
+        assert_equal Post.connection.async_enabled?, status[:async]
+        assert_equal OtherDog.connection.async_enabled?, dog_status[:async]
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
       end
     end
   end


### PR DESCRIPTION
In the multi_thread_pool executor it's possible to have a database
configuration that wouldn't work well with a thread exectutor. This
change checks the `@db_config.max_threads` and if it is not greater than
0 we won't create a thread pool for that configuration. Database
configurations without a proper value set for `max_threads` will return
a `nil` async executor and will run queries for those connection pools
in the foreground. This allows applications to more easily control which
database configurations in their app support async queries. In this
setup one database coule be configured to run parallel queries while all
other databases run queries in the foreground.

cc/ @jhawthorn @rafaelfranca @byroot 