### PR TITLE
Fix controller name in Getting Started [ci skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1430,7 +1430,7 @@ Associations](association_basics.html) guide.
 
 ### Adding a Route for Comments
 
-As with the `welcome` controller, we will need to add a route so that Rails
+As with the `articles` controller, we will need to add a route so that Rails
 knows where we would like to navigate to see `comments`. Open up the
 `config/routes.rb` file again, and edit it as follows:
 


### PR DESCRIPTION
### Summary

Fix controller name from `welcome` to `articles` in "Adding a Route for Comments" section.

### Other Information

Changed in https://github.com/rails/rails/pull/40481