### PR TITLE
Remove `Arel::Crud` from `Arel::Table`

### DIFF
--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -2,7 +2,6 @@
 
 module Arel # :nodoc: all
   class Table
-    include Arel::Crud
     include Arel::FactoryMethods
     include Arel::AliasPredication
 

--- a/activerecord/test/cases/arel/table_test.rb
+++ b/activerecord/test/cases/arel/table_test.rb
@@ -42,13 +42,6 @@ module Arel
       assert_equal "bar", join.right
     end
 
-    it "should return an insert manager" do
-      im = @relation.compile_insert "VALUES(NULL)"
-      assert_kind_of Arel::InsertManager, im
-      im.into Table.new(:users)
-      assert_equal "INSERT INTO \"users\" VALUES(NULL)", im.to_sql
-    end
-
     describe "skip" do
       it "should add an offset" do
         sm = @relation.skip 2


### PR DESCRIPTION
Originally `compile_update` and `compile_delete` doesn't work at all on
`Arel::Table` since `Arel::Table` doesn't have `@ast` and `@ctx`.

`compile_insert` and `create_insert` works but do not use the receiver's
information at all, so just use `Arel::InsertManager.new(arel_table)`
instead.
