### PR TITLE
Forward sql.active_record notifications back into the calling thread

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -103,6 +103,19 @@ module ActiveRecord
         )
       end
 
+      EXCEPTION_NEVER = { Exception => :never }.freeze # :nodoc:
+      EXCEPTION_IMMEDIATE = { Exception => :immediate }.freeze # :nodoc:
+      private_constant :EXCEPTION_NEVER, :EXCEPTION_IMMEDIATE
+      def with_instrumenter(instrumenter, &block) # :nodoc:
+        Thread.handle_interrupt(EXCEPTION_NEVER) do
+          previous_instrumenter = @instrumenter
+          @instrumenter = instrumenter
+          Thread.handle_interrupt(EXCEPTION_IMMEDIATE, &block)
+        ensure
+          @instrumenter = previous_instrumenter
+        end
+      end
+
       def check_if_write_query(sql) # :nodoc:
         if preventing_writes? && write_query?(sql)
           raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -32,6 +32,7 @@ module ActiveRecord
       @predicate_builder = predicate_builder
       @delegate_to_klass = false
       @future_result = nil
+      @records = nil
     end
 
     def initialize_copy(other)
@@ -703,7 +704,7 @@ module ActiveRecord
       @delegate_to_klass = false
       @to_sql = @arel = @loaded = @should_eager_load = nil
       @offsets = @take = nil
-      @records = [].freeze
+      @records = nil
       self
     end
 

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -198,6 +198,10 @@ module ActiveSupport
         notifier.publish(name, *args)
       end
 
+      def publish_event(event) # :nodoc;
+        notifier.publish_event(event)
+      end
+
       def instrument(name, payload = {})
         if notifier.listening?(name)
           instrumenter.instrument(name, payload) { yield payload if block_given? }

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -150,6 +150,11 @@ module ActiveSupport
       send(method, event)
     end
 
+    def publish_event(event) # :nodoc:
+      method = event.name.split(".").first
+      send(method, event)
+    end
+
     private
       def event_stack
         SubscriberQueueRegistry.instance.get_queue(@queue_key)

--- a/activesupport/test/notifications/instrumenter_test.rb
+++ b/activesupport/test/notifications/instrumenter_test.rb
@@ -61,6 +61,47 @@ module ActiveSupport
         assert_equal [["foo", instrumenter.id, payload]], notifier.finishes
         assert_empty notifier.starts
       end
+
+      def test_record
+        called = false
+        event = instrumenter.new_event("foo", payload)
+        event.record {
+          called = true
+        }
+
+        assert called
+      end
+
+      def test_record_yields_the_payload_for_further_modification
+        event = instrumenter.new_event("awesome")
+        event.record { |p| p[:result] = 1 + 1 }
+        assert_equal 2, event.payload[:result]
+
+        assert_equal "awesome", event.name
+        assert_equal Hash[result: 2], event.payload
+        assert_equal instrumenter.id, event.transaction_id
+        assert_not_nil event.time
+        assert_not_nil event.end
+      end
+
+      def test_record_works_without_a_block
+        event = instrumenter.new_event("no.block", payload)
+        event.record
+
+        assert_equal "no.block", event.name
+        assert_equal payload, event.payload
+        assert_equal instrumenter.id, event.transaction_id
+        assert_not_nil event.time
+        assert_not_nil event.end
+      end
+
+      def test_record_with_exception
+        event = instrumenter.new_event("crash", payload)
+        assert_raises RuntimeError do
+          event.record { raise "Oopsies" }
+        end
+        assert_equal "Oopsies", event.payload[:exception_object].message
+      end
     end
   end
 end

--- a/activesupport/test/subscriber_test.rb
+++ b/activesupport/test/subscriber_test.rb
@@ -115,4 +115,16 @@ class SubscriberTest < ActiveSupport::TestCase
 
     assert_equal [], TestSubscriber.events
   end
+
+  def test_supports_publish_event
+    TestSubscriber.attach_to :doodle
+
+    original_event = ActiveSupport::Notifications::Event.new("open_party.doodle", Time.at(0), Time.at(10), "id", { foo: "bar" })
+
+    ActiveSupport::Notifications.publish_event(original_event)
+
+    assert_equal original_event, TestSubscriber.events.first
+  ensure
+    TestSubscriber.detach_from :doodle
+  end
 end


### PR DESCRIPTION
It is not uncommon for `sql.active_record` subscribers to rely on
thread local or fiber local state. For instance the `buffered-logger`
gem buffer the logs in a thread variable.

With the introduction of async queries, the `sql.active_record`
events can now be produced from a background thread and that break
some expectations.

This makes it hard for subscriber to map the event to the request
or job that scheduled it.

That is why I believe we should instead store the event and
publish it back on the calling thread when the results are
accessed.

cc @rafaelfranca @etiennebarrie @eileencodes @jhawthorn @tenderlove 

NB: this will conflict a bit with https://github.com/rails/rails/pull/41586, once one is merged the other will have to rebase.