### PR TITLE
ActiveSupport deprecated method cleanup for rails 7.0

### DIFF
--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -8,18 +8,6 @@ module ActiveSupport
       # The Unicode version that is supported by the implementation
       UNICODE_VERSION = RbConfig::CONFIG["UNICODE_VERSION"]
 
-      def default_normalization_form
-        ActiveSupport::Deprecation.warn(
-          "ActiveSupport::Multibyte::Unicode.default_normalization_form is deprecated and will be removed in Rails 7.0."
-        )
-      end
-
-      def default_normalization_form=(_)
-        ActiveSupport::Deprecation.warn(
-          "ActiveSupport::Multibyte::Unicode.default_normalization_form= is deprecated and will be removed in Rails 7.0."
-        )
-      end
-
       # Decompose composed characters to the decomposed form.
       def decompose(type, codepoints)
         if type == :compatibility

--- a/guides/source/7_0_release_notes.md
+++ b/guides/source/7_0_release_notes.md
@@ -119,6 +119,7 @@ Active Support
 Please refer to the [Changelog][active-support] for detailed changes.
 
 ### Removals
+*   Remove deprecated `ActiveSupport::Multibyte::Unicode.default_normalization_form`.
 
 ### Deprecations
 


### PR DESCRIPTION
Removed Deprecated method from active support that are removed in rails 7.0 
referencing https://guides.rubyonrails.org/6_1_release_notes.html#active-support-deprecations