### PR TITLE
Fix `Time.at` to not lose `in` option

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -42,14 +42,8 @@ class Time
 
     # Layers additional behavior on Time.at so that ActiveSupport::TimeWithZone and DateTime
     # instances can be used when called with a single argument
-    def at_with_coercion(*args, **kwargs)
-      if args.size != 1
-        if kwargs.empty?
-          return at_without_coercion(*args)
-        else
-          return at_without_coercion(*args, **kwargs)
-        end
-      end
+    def at_with_coercion(*args)
+      return at_without_coercion(*args) if args.size != 1
 
       # Time.at can be called with a time or numerical value
       time_or_number = args.first
@@ -62,6 +56,7 @@ class Time
         at_without_coercion(time_or_number)
       end
     end
+    ruby2_keywords(:at_with_coercion) if respond_to?(:ruby2_keywords, true)
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -921,7 +921,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   if RUBY_VERSION >= "2.6.0"
     def test_at_with_in_option
-      assert_equal Time.new(1970, 1, 1, 0, 42, 17, "-08:00"), Time.at(31337, in: -28800)
+      assert_equal Time.new(1970, 1, 1, 0, 42, 17, "-08:00").to_s, Time.at(31337, in: -28800).to_s
     end
   end
 


### PR DESCRIPTION
Looks like `Time#==` returns true if both Time objects has the same
seconds from Epoch like `Time#eql?`.

We should test the result of `Time#to_s` or `Time#inspect` to compare
UTC offset.
