### PR TITLE
at least one Connection identifier required

### DIFF
--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -64,7 +64,7 @@ module ActionCable
 
           def valid_identifiers?(ids)
             keys = ids.keys
-            identifiers.all? { |id| keys.include?(id) }
+            identifiers.any? { |id| keys.include?(id) }
           end
       end
   end


### PR DESCRIPTION
### Summary

Some scenarios require me to use `ActionCable.server.remote_connections.where(session_id: request.session.id).disconnect` to disconnect an active connection from the server.

Today, if you have an ActionCable Connection that contains more than one `identified_by` declaration, all accessors must point to valid objects in order to disconnect a client.

I use two identifiers - `current_user` and `session_id` to facilitate a hybrid approach. This allows me to support anonymous visitors and authenticated users:

```rb
module ApplicationCable
  class Connection < ActionCable::Connection::Base
    identified_by :session_id
    identified_by :current_user

    def connect
      self.current_user = env["warden"].user
      self.session_id = request.session.id
      reject_unauthorized_connection unless self.current_user || self.session_id
    end

  end
end
```

The issue is that when the user authenticates, I want to disconnect their ActionCable Connection. This allows the ActionCable client to establish a new connection with an authenticated user context and elevated access permissions.

Unfortunately, `valid_identifiers?` - as it is currently implemented - returns false when attempting to find a Connection by `session_id`. This is because `current_user` won't be set until after the authentication.

By changing `all?` to `any?` we can satisify the apparent spiritual intent of the method, which is to make sure that there's a reference to a valid identifier that points to the Connection. **One is enough!**

### Other Information

I don't know the original intention behind choosing `all?`, but given the provenance it seems like it's just sort of always been this way. There could be a historical reason for it that I don't see, but I suspect most people just use one identifier and it never came up.