### PR TITLE
Use ruby2_keywords for delegation with Ruby 2.7+

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -42,8 +42,8 @@ class Time
 
     # Layers additional behavior on Time.at so that ActiveSupport::TimeWithZone and DateTime
     # instances can be used when called with a single argument
-    def at_with_coercion(*args, **kwargs)
-      return at_without_coercion(*args, **kwargs) if args.size != 1 || !kwargs.empty?
+    def at_with_coercion(*args)
+      return at_without_coercion(*args) if args.size != 1
 
       # Time.at can be called with a time or numerical value
       time_or_number = args.first
@@ -56,6 +56,7 @@ class Time
         at_without_coercion(time_or_number)
       end
     end
+    ruby2_keywords(:at_with_coercion) if respond_to?(:ruby2_keywords, true)
     alias_method :at_without_coercion, :at
     alias_method :at, :at_with_coercion
 

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -921,6 +921,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
 
   def test_at_with_in_option
     assert_equal Time.new(1970, 1, 1, 0, 42, 17, "-08:00"), Time.at(31337, in: -28800)
+    assert_equal Time.new(1970, 1, 1, 0, 42, 17, "-08:00").to_s, Time.at(31337, in: -28800).to_s
   end
 
   def test_at_with_time_with_zone_returns_local_time


### PR DESCRIPTION
* `(*args, **kwargs)`-delegation doesn't work correctly in all cases on Ruby 2.7.
* Fixes https://github.com/rails/rails/issues/41583
* Same approach as https://github.com/rails/rails/pull/41592

### Summary

`(*args, **kwargs)`-delegation doesn't work correctly in all cases on Ruby 2.7, so use `ruby2_keywords`.
See https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html

The current delegation might work on 2.7+ in this specific case but delegation with `**kwargs` seems brittle and could be incorrect in some corner cases for Ruby 2.7, so I think we should use `ruby2_keywords` on `main` too.
It also has the advantage to make `6-1-stable` consistent with `main` (this PR is basically a reverse-backport of https://github.com/rails/rails/pull/41592 by @kamipo).