### PR TITLE
Add Preloader::Association::LoaderQuery

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -29,9 +29,8 @@ module ActiveRecord
           attr_reader :loaders
 
           def group_and_load_similar(loaders)
-            loaders.grep_v(ThroughAssociation).group_by(&:grouping_key).each do |(_, _, association_key_name), similar_loaders|
-              scope = similar_loaders.first.scope
-              Association.load_records_in_batch(scope, association_key_name, similar_loaders)
+            loaders.grep_v(ThroughAssociation).group_by(&:loader_query).each_pair do |query, similar_loaders|
+              query.load_records_in_batch(similar_loaders)
             end
           end
       end

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -76,6 +76,11 @@ module ActiveRecord
         other.is_a?(WhereClause) &&
           predicates == other.predicates
       end
+      alias :eql? :==
+
+      def hash
+        [self.class, predicates].hash
+      end
 
       def invert
         if predicates.size == 1

--- a/activerecord/test/cases/relation/where_clause_test.rb
+++ b/activerecord/test/cases/relation/where_clause_test.rb
@@ -245,6 +245,19 @@ class ActiveRecord::Relation
       assert_equal only_common, common_with_extra.or(only_common)
     end
 
+    test "supports hash equality" do
+      h = Hash.new(0)
+      h[WhereClause.new(["a"])] += 1
+      h[WhereClause.new(["a"])] += 1
+      h[WhereClause.new(["b"])] += 1
+
+      expected = {
+        WhereClause.new(["a"]) => 2,
+        WhereClause.new(["b"]) => 1
+      }
+      assert_equal expected, h
+    end
+
     private
       def table
         Arel::Table.new("table")


### PR DESCRIPTION
Follow up to #41385 

This class represents the query a `Preloader::Association` uses to load its records. This replaces the previous concept of a grouping_key and serves both to group `Preloader::Associations` by their query and to run the query to load the records (which nicely avoids using `.first`).

This should not change any functionality but should be slightly faster due to being able to avoid calling `scope.to_sql` unless necessary.

cc @dinahshi @eileencodes @HParker 
