### PR TITLE
Make .excluding work when no arguments are passed

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1131,8 +1131,6 @@ module ActiveRecord
     def excluding(*records)
       records.flatten!(1)
 
-      raise ArgumentError, "You must pass at least one #{klass.name} object to #excluding." if records.empty?
-
       if records.any? { |record| !record.is_a?(klass) }
         raise ArgumentError, "You must only pass a single or collection of #{klass.name} objects to #excluding."
       end

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -45,18 +45,14 @@ class ExcludingTest < ActiveRecord::TestCase
     assert_not_includes relation.to_a, comment_more_greetings
   end
 
-  def test_raises_on_no_arguments
-    exception = assert_raises ArgumentError do
-      Post.excluding()
-    end
-    assert_equal "You must pass at least one Post object to #excluding.", exception.message
+  def test_does_not_exclude_records_when_no_arguments
+    assert_includes Post.excluding(), posts(:welcome)
+    assert_equal Post.count, Post.excluding().count
   end
 
-  def test_raises_on_empty_collection_argument
-    exception = assert_raises ArgumentError do
-      Post.excluding([])
-    end
-    assert_equal "You must pass at least one Post object to #excluding.", exception.message
+  def test_does_not_exclude_records_with_empty_collection_argument
+    assert_includes Post.excluding([]), posts(:welcome)
+    assert_equal Post.count, Post.excluding([]).count
   end
 
   def test_raises_on_record_from_different_class


### PR DESCRIPTION
The changes from #41465 and #41439 broke existing code. Before, `.without` was delegated to `Array` and worked
with empty arguments. With the new implementation, code passing an empty array started to fail.

This change removes the check for empty arguments. In that case ActiveRecord will generate a `1=1` (`true`) condition. 

Even if it wasn't breaking the previous behavior, I think this is a better default. This way the caller doesn't have to care about whether it's passing an empty array or not.

CC @georgeclaghorn @GlenCrawford @ashiksp 

