### PR TITLE
Fix rollback of parent destruction with nested dependent:destroy

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -9,8 +9,7 @@ module ActiveRecord
 
         case options[:dependent]
         when :destroy
-          target.destroy
-          raise ActiveRecord::Rollback unless target.destroyed?
+          raise ActiveRecord::Rollback unless target.destroy
         when :destroy_async
           id = owner.public_send(reflection.foreign_key.to_sym)
           primary_key_column = reflection.active_record_primary_key.to_sym


### PR DESCRIPTION
### Summary

When a class has a `:belongs_to` relation with `dependent :destroy` enabled nested multiple levels doesn't delete the object if one of his children wasn't deleted.

Example:

    class User < ActiveRecord::Base
      belongs_to :user_account, dependent: :destroy
    end

    class UserAccount < ActiveRecord::Base
      belongs_to :profile, dependent: :destroy
    end

    class Profile < ActiveRecord::Base
      before_destroy prepend: true do
        throw :abort
      end
    end

    user = User.create!(user_account: UserAccount.new(profile: Profile.new))
    user.destroy

    user.destroyed? # expected: false; actual: true;

Fixes #40550



<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->



<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
