### PR TITLE
Clear ActiveStorage::Blob column information in migration file

### DIFF
--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -7,6 +7,8 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
         ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
       end
 
+      ActiveStorage::Blob.reset_column_information
+
       change_column :active_storage_blobs, :service_name, :string, null: false
     end
   end


### PR DESCRIPTION
This is just a proposal for an improvement. If you feel it's meaningless, I'm okay to withdraw. 

### Summary

This pull request attempts to eliminate a possible problem that could happen when calling `ActiveStorage::Blobs` in future migrations.

As documented in https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-reset_column_information, we can avoid the problem by calling `reset_column_information` before calling the model in the next migration script. 

However, I think it's a better practice to call `reset_column_information` after touching a model in advance in order to eliminate a future problem rather than postponing the problem in the future.

### Other Information

Nothing.
