### PR TITLE
Make .excluding work when a nil argument is passed

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1131,7 +1131,7 @@ module ActiveRecord
     def excluding(*records)
       records.flatten!(1)
 
-      if records.any? { |record| !record.is_a?(klass) }
+      if records.compact.any? { |record| !record.is_a?(klass) }
         raise ArgumentError, "You must only pass a single or collection of #{klass.name} objects to #excluding."
       end
 

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -46,13 +46,15 @@ class ExcludingTest < ActiveRecord::TestCase
   end
 
   def test_does_not_exclude_records_when_no_arguments
-    assert_includes Post.excluding(), posts(:welcome)
-    assert_equal Post.count, Post.excluding().count
+    assert_does_not_exclude_records { Post.excluding() }
   end
 
   def test_does_not_exclude_records_with_empty_collection_argument
-    assert_includes Post.excluding([]), posts(:welcome)
-    assert_equal Post.count, Post.excluding([]).count
+    assert_does_not_exclude_records { Post.excluding([]) }
+  end
+
+  def test_does_not_exclude_records_with_a_nil_argument
+    assert_does_not_exclude_records { Post.excluding(nil) }
   end
 
   def test_raises_on_record_from_different_class
@@ -70,4 +72,10 @@ class ExcludingTest < ActiveRecord::TestCase
 
     assert_not_includes Post.without(post).to_a, post
   end
+
+  private
+    def assert_does_not_exclude_records
+      assert_includes yield, posts(:welcome)
+      assert_equal Post.count, yield.count
+    end
 end


### PR DESCRIPTION
The changes from #41465 and #41439 broke existing code. Before, `.without` was delegated to `Array` and worked
with`nil` arguments. With the new implementation, passing a `nil` value makes it raise.

This is a plausible scenario if you use `&.`, example:

```ruby
entry.active_storage_blobs.without(entry.replied_entry&.active_storage_blobs)
```

This change removes `nil` values from the list of arguments. In this results in an empty list, it will generate a `1=1` (`true`) condition, as in https://github.com/rails/rails/pull/41601. 

CC @georgeclaghorn @GlenCrawford @ashiksp 
