### PR TITLE
actionpack: Use an infinite sized queue in testing ActionController::Live

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix ActionController::Live controller test deadlocks by removing the body buffer size limit for tests.
+
+    *Dylan Thacker-Smith*
+
 *   Drop support for the `SERVER_ADDR` header
 
     Following up https://github.com/rack/rack/pull/1573 and https://github.com/rails/rails/pull/42349

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -127,6 +127,11 @@ module ActionController
     class Buffer < ActionDispatch::Response::Buffer #:nodoc:
       include MonitorMixin
 
+      class << self
+        attr_accessor :queue_size
+      end
+      @queue_size = 10
+
       # Ignore that the client has disconnected.
       #
       # If this value is `true`, calling `write` after the client
@@ -136,7 +141,7 @@ module ActionController
       attr_accessor :ignore_disconnect
 
       def initialize(response)
-        super(response, SizedQueue.new(10))
+        super(response, build_queue(self.class.queue_size))
         @error_callback = lambda { true }
         @cv = new_cond
         @aborted = false
@@ -218,6 +223,10 @@ module ActionController
             break unless str
             yield str
           end
+        end
+
+        def build_queue(queue_size)
+          queue_size ? SizedQueue.new(queue_size) : Queue.new
         end
     end
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -24,6 +24,9 @@ module ActionController
     def new_controller_thread # :nodoc:
       yield
     end
+
+    # Avoid a deadlock from the queue filling up
+    Buffer.queue_size = nil
   end
 
   # ActionController::TestCase will be deprecated and moved to a gem in the future.


### PR DESCRIPTION
Fixes #31813

## Problem Summary

ActionController::Live normally processes the request in another thread, however, a monkey patch in [ActionController::Live monkey patch in action_controller/test_case.rb] forces it to instead get processed in the same thread.  Since the writes go to a `SizedQueue.new(10)` in ActionController::Live::Buffer, a test will deadlock if the controller makes more than 10 writes.

## Solution

The fix is similar to #31938, we use an infinitely sized `Queue.new` for testing.  This PR just does this more cleanly by using an attribute on the class to configure the queue size, which allows both the test and normal behaviour to be tested cleanly.