### PR TITLE
Missing require for `delegate` in `ActiveSupport::CurrentAttributes`

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -2,6 +2,7 @@
 
 require "active_support/callbacks"
 require "active_support/core_ext/enumerable"
+require "active_support/core_ext/module/delegation"
 
 module ActiveSupport
   # Abstract super class that provides a thread-isolated attributes singleton, which resets automatically


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

There is a missing require for `delegate` that `ActiveSupport::CurrentAttributes` depends on. This can be seen by running the following script:
```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "activesupport"
end

require "active_support"

p ActiveSupport::CurrentAttributes
```
which outputs something like the following before this PR:
```
Traceback (most recent call last):
	5: from foo.rb:10:in `<main>'
	4: from foo.rb:10:in `require'
	3: from /Users/ufuk/.gem/ruby/2.7.2/gems/activesupport-6.1.3/lib/active_support/current_attributes.rb:6:in `<top (required)>'
	2: from /Users/ufuk/.gem/ruby/2.7.2/gems/activesupport-6.1.3/lib/active_support/current_attributes.rb:88:in `<module:ActiveSupport>'
	1: from /Users/ufuk/.gem/ruby/2.7.2/gems/activesupport-6.1.3/lib/active_support/current_attributes.rb:92:in `<class:CurrentAttributes>'
/Users/ufuk/.gem/ruby/2.7.2/gems/activesupport-6.1.3/lib/active_support/current_attributes.rb:134:in `singleton class': undefined method `delegate' for #<Class:ActiveSupport::CurrentAttributes> (NoMethodError)
Did you mean?  DelegateClass
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

I am not sure how to test for this, since, obviously, the test framework has already loaded `delegate` by the time the unit test is running. I'd be happy to add a test if there is a way around that.