### PR TITLE
Populate ARGV with Rails::Command.invoke args

### DIFF
--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -40,10 +40,8 @@ module Rails
         command_name, namespace = "help", "help" if command_name.blank? || HELP_MAPPINGS.include?(command_name)
         command_name, namespace = "version", "version" if %w( -v --version ).include?(command_name)
 
-        # isolate ARGV to ensure that commands depend only on the args they are given
-        args = args.dup # args might *be* ARGV so dup before clearing
-        old_argv = ARGV.dup
-        ARGV.clear
+        original_argv = ARGV.dup
+        ARGV.replace(args)
 
         command = find_by_namespace(namespace, command_name)
         if command && command.all_commands[command_name]
@@ -52,7 +50,7 @@ module Rails
           find_by_namespace("rake").perform(full_namespace, args, config)
         end
       ensure
-        ARGV.replace(old_argv)
+        ARGV.replace(original_argv)
       end
 
       # Rails finds namespaces similar to Thor, it only adds one rule:

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -110,8 +110,7 @@ module Rails
                                            desc: "Show this help message and quit"
       end
 
-      def initialize(positional_argv, option_argv, *)
-        @argv = [*positional_argv, *option_argv]
+      def initialize(*)
         @gem_filter = lambda { |gem| true }
         super
       end
@@ -149,14 +148,9 @@ module Rails
       end
 
       def apply_rails_template # :doc:
-        original_argv = ARGV.dup
-        ARGV.replace(@argv)
-
         apply rails_template if rails_template
       rescue Thor::Error, LoadError, Errno::ENOENT => e
         raise Error, "The template [#{rails_template}] could not be loaded. Error: #{e}"
-      ensure
-        ARGV.replace(original_argv)
       end
 
       def set_default_accessors! # :doc:

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -13,21 +13,29 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
     assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands
   end
 
+  test "ARGV is populated" do
+    class Rails::Command::ArgvCommand < Rails::Command::Base
+      def check_populated(*args)
+        raise "not populated" if ARGV.empty? || ARGV != args
+      end
+    end
+
+    assert_nothing_raised { Rails::Command.invoke("argv:check_populated", %w[foo bar]) }
+  end
+
   test "ARGV is isolated" do
     class Rails::Command::ArgvCommand < Rails::Command::Base
-      def check_isolation
-        raise "not isolated" unless ARGV.empty?
+      def check_isolated
         ARGV << "isolate this"
       end
     end
 
-    old_argv = ARGV.dup
-    new_argv = ["foo", "bar"]
-    ARGV.replace(new_argv)
+    original_argv = ARGV.dup
+    ARGV.clear
 
-    Rails::Command.invoke("argv:check_isolation") # should not raise
-    assert_equal new_argv, ARGV
+    Rails::Command.invoke("argv:check_isolated")
+    assert_empty ARGV
   ensure
-    ARGV.replace(old_argv)
+    ARGV.replace(original_argv)
   end
 end

--- a/railties/test/fixtures/lib/template.rb
+++ b/railties/test/fixtures/lib/template.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
 say "It works from file!"
-say "With ARGV! #{ARGV.join(" ")}"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -741,13 +741,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
-  def test_argv_is_populated_for_template
-    FileUtils.cd(Rails.root)
-    argv = [destination_root, "-m", "lib/template.rb"]
-
-    assert_match %r/With ARGV! #{Regexp.escape argv.join(" ")}/, run_generator(argv)
-  end
-
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc


### PR DESCRIPTION
Follow-up to #38495.

Similar to #40994, but for all Rails commands.  Programmatic and CLI invocations of Rails commands will still behave identically, and `ARGV` will still be isolated between invocations.

---

Relying on the contents of `ARGV` can be problematic, but there is code in the wild that does so (e.g. https://github.com/rails/rails/issues/40945#issuecomment-789020443), and we should avoid breaking it if possible.
