### PR TITLE
Fix aggregate attribute on Enum types

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -310,6 +310,7 @@ module ActiveRecord
         if operation != "count"
           type = column.try(:type_caster) ||
             lookup_cast_type_from_join_dependencies(column_name.to_s) || Type.default_value
+          type = type.subtype if Enum::EnumType === type
         end
 
         type_cast_calculated_value(result.cast_values.first, operation, type)
@@ -384,6 +385,7 @@ module ActiveRecord
         if operation != "count"
           type = column.try(:type_caster) ||
             lookup_cast_type_from_join_dependencies(column_name.to_s) || Type.default_value
+          type = type.subtype if Enum::EnumType === type
         end
 
         hash_rows.each_with_object({}) do |row, result|

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -1162,15 +1162,15 @@ class CalculationsTest < ActiveRecord::TestCase
     assert_equal({ "proposed" => 2, "published" => 2 }, Book.group(:status).count)
   end
 
-  def test_aggregate_attribute_on_custom_type
-    assert_nil Book.sum(:status)
-    assert_equal "medium", Book.sum(:difficulty)
-    assert_equal "easy", Book.minimum(:difficulty)
-    assert_equal "medium", Book.maximum(:difficulty)
-    assert_equal({ "proposed" => "proposed", "published" => nil }, Book.group(:status).sum(:status))
-    assert_equal({ "proposed" => "easy", "published" => "medium" }, Book.group(:status).sum(:difficulty))
-    assert_equal({ "proposed" => "easy", "published" => "easy" }, Book.group(:status).minimum(:difficulty))
-    assert_equal({ "proposed" => "easy", "published" => "medium" }, Book.group(:status).maximum(:difficulty))
+  def test_aggregate_attribute_on_enum_type
+    assert_equal 4, Book.sum(:status)
+    assert_equal 1, Book.sum(:difficulty)
+    assert_equal 0, Book.minimum(:difficulty)
+    assert_equal 1, Book.maximum(:difficulty)
+    assert_equal({ "proposed" => 0, "published" => 4 }, Book.group(:status).sum(:status))
+    assert_equal({ "proposed" => 0, "published" => 1 }, Book.group(:status).sum(:difficulty))
+    assert_equal({ "proposed" => 0, "published" => 0 }, Book.group(:status).minimum(:difficulty))
+    assert_equal({ "proposed" => 0, "published" => 1 }, Book.group(:status).maximum(:difficulty))
   end
 
   def test_minimum_and_maximum_on_non_numeric_type


### PR DESCRIPTION
To address the issues #39248 and #39271, #39255 and #39274 made
aggregated results type casted by the attribute types.

But I've realised that we could avoid enum mapping when implemented
#41431.

This change restores the expectation of #39039 especially in the Enum
case.

Fixes #41600.
