### PR TITLE
Fix ActionMailer's deliver later default queue

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -433,7 +433,7 @@ module ActionMailer
   # * <tt>deliveries</tt> - Keeps an array of all the emails sent out through the Action Mailer with
   #   <tt>delivery_method :test</tt>. Most useful for unit and functional testing.
   #
-  # * <tt>deliver_later_queue_name</tt> - The name of the queue used with <tt>deliver_later</tt>. Defaults to +mailers+.
+  # * <tt>deliver_later_queue_name</tt> - The name of the queue used with <tt>deliver_later</tt>.
   class Base < AbstractController::Base
     include DeliveryMethods
     include Rescuable


### PR DESCRIPTION
Hi, 👋🏼

this is my first attempt to contribute to Rails

### Summary

The default queue name used by `deliver_later` is no longer `mailers`.

This commit removes the misleading information from the class
documentation

Ref: #40848
