### PR TITLE
Reiterate the SQL injection warning in find_by_sql API doc

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -43,6 +43,9 @@ module ActiveRecord
     #
     #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
     #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]
+    #
+    # Note that building your own SQL query string from user input may expose your application to
+    # injection attacks (https://guides.rubyonrails.org/security.html#sql-injection).
     def find_by_sql(sql, binds = [], preparable: nil, &block)
       _load_from_sql(_query_by_sql(sql, binds, preparable: preparable), &block)
     end


### PR DESCRIPTION
### Summary

ActiveRecord::Querying.find_by_sql is the method that people new to Rails (who can't be counted on to have read the Rails security guide) are the most likely to reach for when composing or optimizing complex database queries. Having a warning about SQL injection in this method's API doc might discourage unsafe use of this method and remind people that this is a use case where Rails is not going to hold their hand.

### Other Information

ActiveRecord::QueryMethods.where already includes a similar warning. I am not sure if there's other methods that similarly leave room for SQL injection and should also warn against unsafe string interpolation from user input.