### PR TITLE
Write RichText#body column as plain-text

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Write a RichText's content as plain-text to the database to support
+    full-text search without HTML debris.
+
+    *Sean Doyle*
+
 *   Add `config.action_text.attachment_tag_name`, to specify the HTML tag that contains attachments.
 
     *Mark VanLandingham*

--- a/actiontext/app/models/action_text/rich_text.rb
+++ b/actiontext/app/models/action_text/rich_text.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module ActionText
-  # The RichText record holds the content produced by the Trix editor in a serialized +body+ attribute.
+  # The RichText record holds the content produced by the Trix editor in a serialized +body+ attribute,
+  # along with a sanitized, plain-text variant as its +plain_text_body+ attribute.
   # It also holds all the references to the embedded files, which are stored using Active Storage.
   # This record is then associated with the Active Record model the application desires to have
   # rich text content using the +has_rich_text+ class method.
@@ -16,6 +17,7 @@ module ActionText
 
     before_save do
       self.embeds = body.attachables.grep(ActiveStorage::Blob).uniq if body.present?
+      self.plain_text_body = to_plain_text
     end
 
     def to_plain_text

--- a/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
@@ -3,6 +3,7 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
     create_table :action_text_rich_texts do |t|
       t.string     :name, null: false
       t.text       :body, size: :long
+      t.text       :plain_text_body, size: :long
       t.references :record, null: false, polymorphic: true, index: false
 
       t.timestamps

--- a/actiontext/test/dummy/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/test/dummy/db/migrate/20180528164100_create_action_text_tables.rb
@@ -3,6 +3,7 @@ class CreateActionTextTables < ActiveRecord::Migration[6.0]
     create_table :action_text_rich_texts do |t|
       t.string     :name, null: false
       t.text       :body, size: :long
+      t.text       :plain_text_body, size: :long
       t.references :record, null: false, polymorphic: true, index: false
 
       t.timestamps

--- a/actiontext/test/dummy/db/schema.rb
+++ b/actiontext/test/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -15,8 +15,9 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
+    t.text "plain_text_body"
     t.string "record_type", null: false
-    t.integer "record_id", null: false
+    t.bigint "record_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
@@ -47,7 +48,7 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
   create_table "active_storage_variant_records", force: :cascade do |t|
     t.integer "blob_id", null: false
     t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_on_blob_id"
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "messages", force: :cascade do |t|
@@ -69,7 +70,7 @@ ActiveRecord::Schema.define(version: 2019_03_17_200724) do
   end
 
   create_table "reviews", force: :cascade do |t|
-    t.integer "message_id", null: false
+    t.bigint "message_id", null: false
     t.string "author_name", null: false
     t.index ["message_id"], name: "index_reviews_on_message_id"
   end

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -60,6 +60,11 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_equal "Hello world", message.content.to_plain_text
   end
 
+  test "saving content writes to plain_text_body" do
+    message = Message.create(subject: "Greetings", content: "<h1>Hello world</h1>")
+    assert_equal "Hello world", message.content.plain_text_body
+  end
+
   test "saving body" do
     message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.body.to_plain_text


### PR DESCRIPTION

### Summary

Write a `RichText`'s content as plain-text to the database to support
full-text search without HTML debris.

Once the column is available, it can be full-text searched. For example,
to add support in Postgres, we can index that column as a [tsvector][]:

```ruby
class AddPlainTextBodyIndexToActionTextRichTexts < ActiveRecord::Migration[7.0]
  def change
    change_table :action_text_rich_texts do |t|
      t.index "to_tsvector('english', plain_text_body)", using: :gin, name: "tsvector_plain_text_body_idx"
    end
  end
end
```

Once the column exists, it can be queried through Active Record:

```ruby
ActiveSupport.on_load :action_text_rich_text do
  include(Module.new do
    scope :with_body_containing, ->(query) { where <<~SQL, query: query }
      to_tsvector('english', plain_text_body) @@ websearch_to_tsquery(:query)
    SQL
  end)
end

class Message < ApplicationRecord
  has_rich_text :content

  scope :containing, ->(query) { joins(:rich_text_content).merge(ActionText::RichText.with_body_containing(query)) }
end
```

What I'm not sure about:
---

* Should this be behind a generator flag?
* Can we Do The Right Thing :tm: at the generator level when detecting
  the Active Record adapter? For example, generate the code above for
  PG, something similar for MySQL (if possible), something for SQLite?
* Does if we proceed, should this be a change to the existing migration,
  or does backward support dictate that we add a new migration for
  upgrading?
* If this is too invasive of a change, would it be better as a PR to the
  Action Text or Active Record guides? Clients would need to add the
  column and a variation of the callback themselves. Is re-opening the
  classes the best way to do that?

[tsvector]: https://www.postgresql.org/docs/13/textsearch-controls.html
