### PR TITLE
upsert_all fails cleanly for MySQL

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -77,7 +77,11 @@ module ActiveRecord
       attr_reader :scope_attributes
 
       def find_unique_index_for(unique_by)
-        return unique_by if !connection.supports_insert_conflict_target?
+        if !connection.supports_insert_conflict_target?
+          return if unique_by.nil?
+
+          raise ArgumentError, "#{connection.class} does not support :unique_by"
+        end
 
         name_or_columns = unique_by || model.primary_key
         match = Array(name_or_columns).map(&:to_s)

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -486,6 +486,15 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "written", Book.find(2).status
   end
 
+  def test_upsert_all_with_unique_by_fails_cleanly_for_adapters_not_supporting_insert_conflict_target
+    skip if supports_insert_conflict_target?
+
+    error = assert_raises ArgumentError do
+      Book.upsert_all [{ name: "Rework", author_id: 1 }], unique_by: :isbn
+    end
+    assert_match "#{ActiveRecord::Base.connection.class} does not support :unique_by", error.message
+  end
+
   private
     def capture_log_output
       output = StringIO.new


### PR DESCRIPTION
### Summary

This makes sure `upsert_all` with `unique_by` is failing cleanly when being used with MySQL.

It's currently failing with a not very helpful error:

```
NoMethodError: undefined method `columns' for :isbn:Symbol
    /Users/codechimp/projects/rails/activerecord/lib/active_record/insert_all.rb:120:in `unique_by_columns'
    /Users/codechimp/projects/rails/activerecord/lib/active_record/insert_all.rb:39:in `updatable_columns'
    /Users/codechimp/projects/rails/activerecord/lib/active_record/insert_all.rb:26:in `initialize'
    /Users/codechimp/projects/rails/activerecord/lib/active_record/persistence.rb:243:in `new'
    /Users/codechimp/projects/rails/activerecord/lib/active_record/persistence.rb:243:in `upsert_all'
    test/cases/insert_all_test.rb:473:in `test_upsert_all_with_unique_by_fails_cleanly_for_adapters_not_supporting_insert_conflict_target'
```

When using `insert_all` the `ensure_valid_options_for_connection!` method would throw a proper exception but for `upset_all` this method is never reached.