### PR TITLE
[ci skip] Not `masked_authenticity_token` but `form_authenticity_token` should be a public API

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -303,15 +303,15 @@ module ActionController #:nodoc:
         [form_authenticity_param, request.x_csrf_token]
       end
 
-      # Sets the token value for the current session.
-      def form_authenticity_token(form_options: {})
+      # Creates the authenticity token for the current request.
+      def form_authenticity_token(form_options: {}) # :doc:
         masked_authenticity_token(session, form_options: form_options)
       end
 
       # Creates a masked version of the authenticity token that varies
       # on each request. The masking is used to mitigate SSL attacks
       # like BREACH.
-      def masked_authenticity_token(session, form_options: {}) # :doc:
+      def masked_authenticity_token(session, form_options: {})
         action, method = form_options.values_at(:action, :method)
 
         raw_token = if per_form_csrf_tokens && action && method


### PR DESCRIPTION
`form_authenticity_token` would be a public API because:

1. The usage of this method [is described in the guide](https://github.com/rails/rails/blob/291a3d2ef29a3842d1156ada7526f4ee60dd2b59/guides/source/action_controller_overview.md#request-forgery-protection) and already [many Rails users depend on this method](https://stackoverflow.com/questions/941594/understanding-the-rails-authenticity-token).
2. This method [is set as helper_method](https://github.com/rails/rails/blob/291a3d2ef29a3842d1156ada7526f4ee60dd2b59/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L97) and called form ActionView. Inside the Rails components, it's already used as a public interface of ActionController.