### PR TITLE
Add pointer cursor to Exception layout

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -153,6 +153,7 @@
       font-weight: bold;
       margin: 0;
       padding: 10px 18px;
+      cursor: pointer;
       -webkit-appearance: none;
     }
     input[type="submit"]:focus,


### PR DESCRIPTION
This is a very minor CSS fix to show a "pointer" (or "hand") cursor when hovering submit inputs such as the "Run pending migrations" button. This is the current behavior:

![image](https://media.giphy.com/media/sxpFiTaSw44WGUJdyC/giphy.gif)

I am not sure if this PR is considered “cosmetic in nature” as I feel that it’s an (albeit minor) usability enhancement. Feel free to close it if not.