### PR TITLE
TokenList and Attributes Objects

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Change `token_lists` and `class_names` to return instances of `TokenList`,
+    and `tag.attributes` helpers to return instances of `Attributes`. These
+    objects know how to serialize themselves into HTML views through their `#to_s`
+    methods. `TokenList` instances how to merge themselves with other `TokenList`
+    and `Enumerable` instances, and `Attributes` know how to merge themselves
+    with other `Hash` and `Attributes` instances, and know how to splat themselves
+    out like a `Hash`.
+
+    ```ruby
+    def button
+      class_names "py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2"
+    end
+
+    def primary_button
+      button | "bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75"
+    end
+
+    button_tag "Save", class: primary_button | "uppercase"
+    #=> "<button class="py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2 bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75 uppercase">Save</button>
+    ```
+
+    *Sean Doyle*
+
 *   Deprecate `render` locals to be assigned to instance variables.
 
     *Petrik de Heus*

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -349,18 +349,18 @@ class TagHelperTest < ActionView::TestCase
     [:token_list, :class_names].each do |helper_method|
       helper = ->(*arguments) { public_send(helper_method, *arguments) }
 
-      assert_equal "song play", helper.(["song", { "play": true }])
-      assert_equal "song", helper.({ "song": true, "play": false })
-      assert_equal "song", helper.([{ "song": true }, { "play": false }])
-      assert_equal "song", helper.({ song: true, play: false })
-      assert_equal "song", helper.([{ song: true }, nil, false])
-      assert_equal "song", helper.(["song", { foo: false }])
-      assert_equal "song play", helper.({ "song": true, "play": true })
-      assert_equal "", helper.({ "song": false, "play": false })
-      assert_equal "123", helper.(nil, "", false, 123, { "song": false, "play": false })
-      assert_equal "song", helper.("song", "song")
-      assert_equal "song", helper.("song song")
-      assert_equal "song", helper.("song\nsong")
+      assert_equal "song play", helper.(["song", { "play": true }]).to_s
+      assert_equal "song", helper.({ "song": true, "play": false }).to_s
+      assert_equal "song", helper.([{ "song": true }, { "play": false }]).to_s
+      assert_equal "song", helper.({ song: true, play: false }).to_s
+      assert_equal "song", helper.([{ song: true }, nil, false]).to_s
+      assert_equal "song", helper.(["song", { foo: false }]).to_s
+      assert_equal "song play", helper.({ "song": true, "play": true }).to_s
+      assert_equal "", helper.({ "song": false, "play": false }).to_s
+      assert_equal "123", helper.(nil, "", false, 123, { "song": false, "play": false }).to_s
+      assert_equal "song", helper.("song", "song").to_s
+      assert_equal "song", helper.("song song").to_s
+      assert_equal "song", helper.("song\nsong").to_s
     end
   end
 
@@ -503,5 +503,158 @@ class TagHelperTest < ActionView::TestCase
 
   def test_respond_to
     assert_respond_to tag, :any_tag
+  end
+
+  test "token_list de-duplicates tokens" do
+    tokens = token_list("one two", [ "three" ], "three", { four: true })
+
+    assert_equal "one two three four", tokens.to_s
+  end
+
+  test "token_list accepts TokenList instances" do
+    tokens = token_list("one two", token_list("three"))
+
+    assert_equal "one two three", tokens.to_s
+  end
+
+  test "token_list merges TokenList instances" do
+    tokens = token_list("one two").merge(token_list("three"))
+
+    assert_equal "one two three", tokens.to_s
+  end
+
+  test "token_list without arguments returns a blank list" do
+    tokens = token_list
+
+    assert_empty tokens.to_a
+  end
+
+  test "tag.attributes without arguments returns blank Attributes" do
+    attributes = tag.attributes
+
+    assert_empty attributes.to_h
+  end
+
+  test "tag.attributes merges into TokenList attributes" do
+    attributes = tag.attributes(class: class_names("one")).merge(class: "one two")
+
+    assert_equal %(class="one two"), attributes.to_s
+  end
+
+  test "tag.attributes can be splatted" do
+    attributes = { id: 1, **tag.attributes(class: class_names("one")) }
+
+    assert_equal({ id: 1, class: class_names("one") }, attributes)
+  end
+
+  test "tag.attributes merges like a Hash of attributes" do
+    attributes = tag.attributes(id: 1, class: "one").merge(hidden: true)
+
+    assert_equal %(id="1" class="one" hidden="hidden"), attributes.to_s
+  end
+
+  test "tag.attributes combines TokenList attributes" do
+    attributes = tag.attributes(class: class_names("one")).merge(class: class_names("one two"))
+
+    assert_equal %(class="one two"), attributes.to_s
+  end
+
+  test "tag.attributes deeply merges Hash attributes" do
+    assert_equal %(data-controller="one two"), tag.attributes(data: { controller: token_list("one") }).merge(data: { controller: "two" }).to_s
+    assert_equal %(data-controller="one two"), tag.attributes(data: { controller: "one" }).merge(data: { controller: token_list("two") }).to_s
+  end
+
+  test "tag.attributes reverse merges Attributes" do
+    one = tag.attributes(class: "one")
+    two = tag.attributes(class: class_names("two"))
+
+    assert_equal %(class="one two"), (one + two).to_s
+  end
+
+  test "tag.attributes deeply merges TokenList attributes" do
+    attributes = tag.attributes(data: { controller: token_list("one") }).merge(data: { controller: token_list("two") })
+
+    assert_equal %(data-controller="one two"), attributes.to_s
+  end
+
+  test "tag.attributes automatically wraps class values as TokenList instances" do
+    attributes = tag.attributes class: ["one two", { three: false }, { four: true }]
+
+    tokens = attributes[:class]
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two four ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps aria: { labelledby: ... } values as TokenList instances" do
+    attributes = tag.attributes aria: { labelledby: "one two" }
+
+    tokens = attributes.dig(:aria, :labelledby)
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps aria-labelledby  values as TokenList instances" do
+    attributes = tag.attributes "aria-labelledby": "one two"
+
+    tokens = attributes["aria-labelledby".to_sym]
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps aria: { describedby: ... } values as TokenList instances" do
+    attributes = tag.attributes aria: { describedby: "one two" }
+
+    tokens = attributes.dig(:aria, :describedby)
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps aria-describedby values as TokenList instances" do
+    attributes = tag.attributes "aria-describedby": "one two"
+
+    tokens = attributes["aria-describedby".to_sym]
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps data: { action: ... } values as TokenList instances" do
+    attributes = tag.attributes data: { action: "one two" }
+
+    tokens = attributes.dig(:data, :action)
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps data-action values as TokenList instances" do
+    attributes = tag.attributes "data-action": "one two"
+
+    tokens = attributes["data-action".to_sym]
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps data: { controller: ... } values as TokenList instances" do
+    attributes = tag.attributes data: { controller: "one two" }
+
+    tokens = attributes.dig(:data, :controller)
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
+  end
+
+  test "tag.attributes automatically wraps data-controller values as TokenList instances" do
+    attributes = tag.attributes "data-controller": "one two"
+
+    tokens = attributes["data-controller".to_sym]
+
+    assert_kind_of TokenList, tokens
+    assert_equal %w[ one two ], tokens.to_a
   end
 end


### PR DESCRIPTION
### Summary

Expend `token_list` and `tag.attributes` helpers to construct
`Attributes` and `TokenList` instances that are smart about merging with
other values turning themselves into HTML.

For example, consider the following helpers:

```ruby
module ApplicationHelper
  def feed_section
    class_names "max-w-prose max-w-sm w-full lg:w-1/3"
  end

  def button
    class_names "py-2 px-4 font-semibold shadow-md focus:outline-none focus:ring-2"
  end

  def primary_button
    button | "bg-black rounded-lg text-white hover:bg-yellow-300 focus:ring-yellow-300 focus:ring-opacity-75"
  end

  def pagination_controller
    tag.attributes data: { controller: "pagination", action: "turbo:before-cache@document->pagination#preserveScroll turbo:before-render@document->pagination#injectIntoVisit" }
  end

  def sorted_controller
    tag.attributes data: { controller: "sorted", sorted_attribute_name_value: "data-code" }
  end
end
```

Using those helpers (or some other means of declaring re-usable
`class_names`, `token_list`, or `tag.attributes` calls), consider the
following diffs:

```diff
 <% if page.before_last? %>
   <div class="hidden last-of-type:flex justify-center my-6">
-    <%= link_to url_for(page: page.next_param, q: params[:q]), rel: "next", class: "py-2 px-4 bg-black text-white font-semibold rounded-lg shadow-md hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-300 focus:ring-opacity-75" do %>
+    <%= link_to url_for(page: page.next_param, q: params[:q]), rel: "next", class: primary_button do %>
       Load more
     <% end %>
   </div>

-  <%= form.button class: "colspan-2 py-2 px-4 bg-black text-white font-semibold rounded-lg shadow-md hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-300 focus:ring-opacity-75" do %>
+  <%= form.button class: primary_button | "colspan-2" do %>
     Sign in
   <% end %>
 <% end %>

-<section id="entries" class="max-w-prose max-w-sm w-full lg:w-1/3" data-controller="pagination sorted" data-sorted-attribute-name-value="data-code" data-action="turbo:before-cache@document->pagination#preserveScroll turbo:before-render@document->pagination#injectNextPageIntoBody">
+<section id="entries" class="<%= feed_section %>" <%= pagination_controller | sorted_controller %>>
   <%= render partial: "entries/page", object: @page %>
 </section>
```

### Other Information

If we're interested in supporting this, there is some other related work:

* If there are scenarios where a view wants to opt-out of the values that have been iteratively built up to that point, it might be useful to declare `class_names!`, `token_list!`, and `tag.attributes!` variants to construct instances that don't merge and instead reset the values passed: 
```ruby
class_names("font-semibold") | class_names!("font-bold") #=> "font-bold"
```
* If an application's shared `class_names` and `tag.attributes` calls are declared in a Helper module (like `ApplicationHelper`), changes to them wouldn't be visible to Action View's fragment caching calculations. This is a problem if their call sites don't include a fragment cache busting comment. **Is there currently other work in-flight to incorporate Helper module source code into cache key generation the way that view partial source code is incorporated?**
* We could potentially push this even further and implement [`TagHelper.build_tag_values`](https://github.com/rails/rails/blob/90d0b42bd8206e942597b64163837287caf7119d/actionview/lib/action_view/helpers/tag_helper.rb#L377-L395) and [`TagBuilder#tag_options`](https://github.com/rails/rails/blob/90d0b42bd8206e942597b64163837287caf7119d/actionview/lib/action_view/helpers/tag_helper.rb#L82-L122), [`TagBuilder#boolean_tag_option`](https://github.com/rails/rails/blob/90d0b42bd8206e942597b64163837287caf7119d/actionview/lib/action_view/helpers/tag_helper.rb#L124-L126), [`TagBuilder#tag_option`](https://github.com/rails/rails/blob/90d0b42bd8206e942597b64163837287caf7119d/actionview/lib/action_view/helpers/tag_helper.rb#L128-L140), [`TagBuilder#prefix_tag_option`](https://github.com/rails/rails/blob/90d0b42bd8206e942597b64163837287caf7119d/actionview/lib/action_view/helpers/tag_helper.rb#L143-L149), and the supporting [constant declarations](https://github.com/rails/rails/blob/90d0b42bd8206e942597b64163837287caf7119d/actionview/lib/action_view/helpers/tag_helper.rb#L18-L42) in terms of the new `Attributes` class, (perhaps in a file or namespace of its own).

**Tangent:** Even bigger picture
---

I'm curious if transitioning Action View's `tag` and `content_tag` helpers from String concatenation into an architecture that outsourced element and attribute construction to something like Nokogiri or Nokogumbo would reduce Action View's footprint. For example, if calls to helpers like `button_tag` or `form_with` returned Nokogiri `Node` instances that knew how to turn themselves into HTML, dealing with merging attribute and DOMTokenList values ([denoted as `kwattr_*` for "keyword attributes" in Nokogiri](https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#kwattr_add-instance_method)) might be more straightforward to implement.