### PR TITLE
Fix merging select values from a different model's relation

### DIFF
--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -41,6 +41,20 @@ module ActiveRecord
     end
     private :assert_non_select_columns_wont_be_loaded
 
+    def test_merging_select_from_different_model
+      posts = Post.select(:id, :title).joins(:comments)
+      comments = Comment.where(body: "Thank you for the welcome")
+
+      [
+        posts.merge(comments.select(:body)).first,
+        posts.merge(comments.select("comments.body")).first,
+      ].each do |post|
+        assert_equal 1, post.id
+        assert_equal "Welcome to the weblog", post.title
+        assert_equal "Thank you for the welcome", post.body
+      end
+    end
+
     def test_type_casted_extra_select_with_eager_loading
       posts = Post.select("posts.id * 1.1 AS foo").eager_load(:comments)
       assert_equal 1.1, posts.first.foo


### PR DESCRIPTION
Unlike order values, where/having clause, etc, select values lazily
evaluates the attribute name resolution until building arel.

If select values are merged from a different model's relation, those may
be incorrectly resolved as a column in a wrong table.

In that case, the attribute name resolution should be done before
merging those.
