### PR TITLE
Handle postgresql database not found error more gracefully

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -77,7 +77,7 @@ module ActiveRecord
         def new_client(conn_params)
           PG.connect(conn_params)
         rescue ::PG::Error => error
-          if conn_params && conn_params[:dbname] && error.message.include?(conn_params[:dbname])
+          if conn_params && conn_params[:dbname] && error.message.include?("database \"#{conn_params[:dbname]}\" does not exist")
             raise ActiveRecord::NoDatabaseError
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -78,7 +78,7 @@ module ActiveRecord
           PG.connect(conn_params)
         rescue ::PG::Error => error
           if conn_params && conn_params[:dbname] && error.message.include?("database \"#{conn_params[:dbname]}\" does not exist")
-            raise ActiveRecord::NoDatabaseError
+            raise ActiveRecord::NoDatabaseError, error.message
           else
             raise ActiveRecord::ConnectionNotEstablished, error.message
           end

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -67,6 +67,12 @@ module ActiveRecord
         end
       end
 
+      def test_bad_connection_error_when_hostname_and_dbname_same_but_invalid
+        assert_raises ActiveRecord::ConnectionNotEstablished do
+          ActiveRecord::Base.postgresql_connection(host: "localhost1", dbname: "localhost1")
+        end
+      end
+
       def test_database_exists_returns_false_when_the_database_does_not_exist
         config = { database: "non_extant_database", adapter: "postgresql" }
         assert_not ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.database_exists?(config),


### PR DESCRIPTION
### Summary

Fixes #41606 

```ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client``` method had this logic to handle errors such way that if error message had ```dbName``` then raise exception  ```ActiveRecord::NoDatabaseError```

But there can be scenarios when ```dbName``` and ```host``` values  are same and ```host``` value is invalid.

So in that scenario actual error from ```PG.connect``` method is related to unable to establish connection.

But error returned was  ```ActiveRecord::NoDatabaseError```


I have made changes to return ```ActiveRecord::NoDatabaseError``` in more explicit scenario.

