### PR TITLE
Nudge engines to be compatible with include_all_helpers

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -141,6 +141,13 @@ module Rails
       if mountable?
         template "rails/routes.rb", "#{dummy_path}/config/routes.rb", force: true
       end
+      if engine? && !api?
+        insert_into_file "#{dummy_path}/config/application.rb", indent(<<~RUBY, 4), after: /^\s*config\.load_defaults.*\n/
+
+          # For compatibility with applications that use this config
+          config.action_controller.include_all_helpers = false
+        RUBY
+      end
     end
 
     def test_dummy_webpacker_assets

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -591,6 +591,34 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/dummy/config/application.rb", /^require "bukkits"/
   end
 
+  def test_dummy_application_sets_include_all_helpers_to_false_for_mountable
+    run_generator [destination_root, "--mountable"]
+
+    assert_file "test/dummy/config/application.rb", /^    config\.action_controller\.include_all_helpers = false$/
+  end
+
+  def test_dummy_application_sets_include_all_helpers_to_false_for_full
+    run_generator [destination_root, "--full"]
+
+    assert_file "test/dummy/config/application.rb", /include_all_helpers/
+  end
+
+  def test_dummy_application_does_not_set_include_all_helpers_for_regular
+    run_generator
+
+    assert_file "test/dummy/config/application.rb" do |content|
+      assert_no_match(/include_all_helpers/, content)
+    end
+  end
+
+  def test_dummy_application_does_not_set_include_all_helpers_for_api
+    run_generator [destination_root, "--mountable", "--api"]
+
+    assert_file "test/dummy/config/application.rb" do |content|
+      assert_no_match(/include_all_helpers/, content)
+    end
+  end
+
   def test_dummy_application_uses_dynamic_rails_version_number
     run_generator
 


### PR DESCRIPTION
When applications use this configuration setting, it may break an Engine relying implicitly on all helpers being included.

By setting the option in the dummy app, we help engine authors be compatible with this setting.

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>

### Summary

We had this issue in https://github.com/Shopify/maintenance_tasks/pull/337.

Application authors can set this configuration, and engines either need to only use helpers matching the controllers, or set `helper :all` in their `ApplicationController`. We decided not to put `helper :all` in the generated `ApplicationController` in a mountable plugin because it's not documented but that could have been another solution.


### Other Information

