### PR TITLE
Clarify when `enctype="multipart/form-data"` gets added to forms [docs]

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2426,7 +2426,7 @@ module ActionView
       # hash with +options+. These options will be tagged onto the HTML as an HTML element attribute as in the example
       # shown.
       #
-      # Using this method inside a +form_for+ block will set the enclosing form's encoding to <tt>multipart/form-data</tt>.
+      # Using this method inside a +form_with+ block will set the enclosing form's encoding to <tt>multipart/form-data</tt>.
       #
       # ==== Options
       # * Creates standard HTML attributes for the tag.

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -644,7 +644,7 @@ Output:
 Uploading Files
 ---------------
 
-A common task is uploading some sort of file, whether it's a picture of a person or a CSV file containing data to process. File upload fields can be rendered with the [`file_field`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-file_field) helper. The most important thing to remember with file uploads is that the rendered form's `enctype` attribute **must** be set to "multipart/form-data". If you use `form_with` with `:model`, this is done automatically:
+A common task is uploading some sort of file, whether it's a picture of a person or a CSV file containing data to process. File upload fields can be rendered with the [`file_field`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-file_field) helper.
 
 ```erb
 <%= form_with model: @person do |form| %>
@@ -652,11 +652,11 @@ A common task is uploading some sort of file, whether it's a picture of a person
 <% end %>
 ```
 
-If you use `form_with` without `:model`, you must set it yourself:
+The most important thing to remember with file uploads is that the rendered form's `enctype` attribute **must** be set to "multipart/form-data". This is done automatically if you use a `file_field` inside a `form_with`. You can also set the attribute manually:
 
 ```erb
 <%= form_with url: "/uploads", multipart: true do |form| %>
-  <%= form.file_field :picture %>
+  <%= file_field_tag :picture %>
 <% end %>
 ```
 


### PR DESCRIPTION
As noted in https://github.com/rails/rails/issues/41632 the docs for this are incorrect. The `enctype` attribute is automatically added anytime you make a form with a `file_field`.

Resolves https://github.com/rails/rails/issues/41632
