### PR TITLE
WIP: `belongs_to` w/ `counter_cache, touch: true` doesn't execute `after_commit` callback on parent model

### DIFF
--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -263,7 +263,7 @@ class CounterCacheTest < ActiveRecord::TestCase
     topic = ::TopicWithAfterCommitCallback.create!(title: "Topic with after commit callback")
     assert_equal ::Task.count, 1
 
-    reply = ::ReplyWithTouch.create!(topic: topic)
+    ::ReplyWithTouch.create!(topic: topic)
     assert_equal ::Task.count, 2
   end
 


### PR DESCRIPTION
NOTE: This is not ready to be merged! :)

### Summary

As per API documentation:
https://api.rubyonrails.org/v6.0.3.5/classes/ActiveRecord/Persistence.html#method-i-touch
> Please note that no validation is performed and only the `after_touch`, `after_commit` and `after_rollback` callbacks are executed.

I expected that `counter_cache, touch: true` would execute `after_commit` callback on parent model.

However, that doesn't seem to be the case. The `counter_cache` column is properly updated in the database table (of a parent model) and, since `touch: true` is specified it also updates the `updated_at` column, as expected. However, it doesn't execute `after_commit` callback on parent model.

I've created a repro test case (I'm not very familiar with MiniTest, pardon the ugliness of the test code).
If you uncommend the `after_commit` in the child model (`ReplyWithTouch`), it will correctly "touch" the `TopicWithAfterCommitCallback` and execute `after_commit` callback on parent model (`TopicWithAfterCommitCallback`).