### PR TITLE
Using pluck instead of map in activerecord tests

### DIFF
--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -867,7 +867,7 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_plucks_with_ids
-    assert_equal Company.all.map(&:id).sort, Company.ids.sort
+    assert_equal Company.pluck(:id).sort, Company.ids.sort
   end
 
   def test_pluck_with_includes_limit_and_empty_result

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -32,8 +32,8 @@ module ViewBehavior
 
   def test_reading
     books = Ebook.all
-    assert_equal [books(:rfr).id], books.map(&:id)
-    assert_equal ["Ruby for Rails"], books.map(&:name)
+    assert_equal [books(:rfr).id], books.pluck(:id)
+    assert_equal ["Ruby for Rails"], books.pluck(:name)
   end
 
   def test_views
@@ -118,7 +118,7 @@ if ActiveRecord::Base.connection.supports_views?
 
     def test_reading
       books = Paperback.all
-      assert_equal ["Agile Web Development with Rails"], books.map(&:name)
+      assert_equal ["Agile Web Development with Rails"], books.pluck(:name)
     end
 
     def test_views


### PR DESCRIPTION
Using pluck instead of map in active record test cases. 
This can save one query on these tests
.