### PR TITLE
ActionView: Implement Tag Helpers with Nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PATH
       activesupport (= 7.0.0.alpha)
       builder (~> 3.1)
       erubi (~> 1.4)
+      nokogiri (>= 1.8.5)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
     activejob (7.0.0.alpha)
@@ -381,6 +382,7 @@ GEM
       thor
     raabro (1.4.0)
     racc (1.5.2)
+    racc (1.5.2-java)
     rack (2.2.3)
     rack-cache (1.12.1)
       rack (>= 0.4)

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Implement `tag` and `content_tag` helpers as wrappers around
+    `Nokogiri::XML::Node#to_html`.
+
+    *Sean Doyle*
+
 *   Deprecate `render` locals to be assigned to instance variables.
 
     *Petrik de Heus*

--- a/actionview/actionview.gemspec
+++ b/actionview/actionview.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "erubi",         "~> 1.4"
   s.add_dependency "rails-html-sanitizer", "~> 1.1", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"
+  s.add_dependency "nokogiri", ">= 1.8.5"
 
   s.add_development_dependency "actionpack",  version
   s.add_development_dependency "activemodel", version

--- a/actionview/lib/action_view/helpers/javascript_helper.rb
+++ b/actionview/lib/action_view/helpers/javascript_helper.rb
@@ -88,7 +88,7 @@ module ActionView
       end
 
       def javascript_cdata_section(content) #:nodoc:
-        "\n//#{cdata_section("\n#{content}\n//")}\n".html_safe
+        CGI.unescapeHTML("\n//#{cdata_section("\n#{content}\n//")}\n")
       end
     end
   end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -695,11 +695,11 @@ class AssetTagHelperTest < ActionView::TestCase
 
   def test_image_tag_interpreting_email_cid_correctly
     # An inline image has no need for an alt tag to be automatically generated from the cid:
-    assert_equal '<img src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid")
+    assert_dom_equal '<img src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid")
   end
 
   def test_image_tag_interpreting_email_adding_optional_alt_tag
-    assert_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
+    assert_dom_equal '<img alt="Image" src="cid:thi%25%25sis@acontentid" />', image_tag("cid:thi%25%25sis@acontentid", alt: "Image")
   end
 
   def test_should_not_modify_source_string

--- a/actionview/test/template/csp_helper_test.rb
+++ b/actionview/test/template/csp_helper_test.rb
@@ -14,11 +14,11 @@ class CspHelperWithCspEnabledTest < ActionView::TestCase
   end
 
   def test_csp_meta_tag
-    assert_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
+    assert_dom_equal "<meta name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag
   end
 
   def test_csp_meta_tag_with_options
-    assert_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
+    assert_dom_equal "<meta property=\"csp-nonce\" name=\"csp-nonce\" content=\"iyhD0Yc0W+c=\" />", csp_meta_tag(property: "csp-nonce")
   end
 end
 

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -608,14 +608,14 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice
-    assert_equal(
+    assert_dom_equal(
       %(<input type="submit" name="commit" value="Save" data-confirm="Are you sure?" data-disable-with="Processing..." />),
       submit_tag("Save", "data-disable-with" => "Processing...", "data-confirm" => "Are you sure?")
     )
   end
 
   def test_submit_tag_doesnt_have_data_disable_with_twice_with_hash
-    assert_equal(
+    assert_dom_equal(
       %(<input type="submit" name="commit" value="Save" data-disable-with="Processing..." />),
       submit_tag("Save", data: { disable_with: "Processing..." })
     )

--- a/actionview/test/template/output_safety_helper_test.rb
+++ b/actionview/test/template/output_safety_helper_test.rb
@@ -83,7 +83,7 @@ class OutputSafetyHelperTest < ActionView::TestCase
     expected = %(<a href="#{url}">#{url}</a> and <p>&lt;marquee&gt;shady stuff&lt;/marquee&gt;<br /></p>)
     actual = to_sentence([link_to(url, url), ptag])
     assert_predicate actual, :html_safe?
-    assert_equal(expected, actual)
+    assert_dom_equal(expected, actual)
   end
 
   test "to_sentence handles blank strings" do

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -418,8 +418,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_honors_html_safe_for_param_values
     ["1&amp;2", "1 &lt; 2", "&#8220;test&#8220;"].each do |escaped|
-      assert_equal %(<a href="#{escaped}" />), tag("a", href: escaped.html_safe)
-      assert_equal %(<a href="#{escaped}"></a>), tag.a(href: escaped.html_safe)
+      assert_dom_equal %(<a title="#{escaped}" />), tag("a", title: escaped.html_safe)
+      assert_dom_equal %(<a title="#{escaped}"></a>), tag.a(title: escaped.html_safe)
     end
   end
 
@@ -445,8 +445,8 @@ class TagHelperTest < ActionView::TestCase
 
   def test_skip_invalid_escaped_attributes
     ["&1;", "&#1dfa3;", "& #123;"].each do |escaped|
-      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", href: escaped)
-      assert_equal %(<a href="#{escaped.gsub(/&/, '&amp;')}"></a>), tag.a(href: escaped)
+      assert_dom_equal %(<a title="#{escaped.gsub(/&/, '&amp;')}" />), tag("a", title: escaped)
+      assert_dom_equal %(<a title="#{escaped.gsub(/&/, '&amp;')}"></a>), tag.a(title: escaped)
     end
   end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -8,8 +8,8 @@ class TagHelperTest < ActionView::TestCase
   tests ActionView::Helpers::TagHelper
 
   def test_tag
-    assert_equal "<br />", tag("br")
-    assert_equal "<br clear=\"left\" />", tag(:br, clear: "left")
+    assert_dom_equal "<br />", tag("br")
+    assert_dom_equal "<br clear=\"left\" />", tag(:br, clear: "left")
     assert_equal "<br>", tag("br", nil, true)
   end
 
@@ -24,7 +24,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_builder_void_tag_with_forced_content
-    assert_equal "<br>some content</br>", tag.br("some content")
+    assert_equal "<br>", tag.br("some content")
   end
 
   def test_tag_builder_is_singleton
@@ -33,14 +33,14 @@ class TagHelperTest < ActionView::TestCase
 
   def test_tag_options
     str = tag("p", "class" => "show", :class => "elsewhere")
-    assert_match(/class="show"/, str)
+    assert_no_match(/class="show"/, str)
     assert_match(/class="elsewhere"/, str)
   end
 
   def test_tag_options_with_array_of_numeric
     str = tag(:input, value: [123, 456])
 
-    assert_equal("<input value=\"123 456\" />", str)
+    assert_dom_equal("<input value=\"123 456\" />", str)
   end
 
   def test_tag_options_with_array_of_random_objects
@@ -52,11 +52,11 @@ class TagHelperTest < ActionView::TestCase
 
     str = tag(:input, value: [klass.new])
 
-    assert_equal("<input value=\"hello\" />", str)
+    assert_dom_equal("<input value=\"hello\" />", str)
   end
 
   def test_tag_options_rejects_nil_option
-    assert_equal "<p />", tag("p", ignored: nil)
+    assert_dom_equal "<p />", tag("p", ignored: nil)
   end
 
   def test_tag_builder_options_rejects_nil_option
@@ -64,7 +64,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_false_option
-    assert_equal "<p value=\"false\" />", tag("p", value: false)
+    assert_dom_equal "<p value=\"false\" />", tag("p", value: false)
   end
 
   def test_tag_builder_options_accepts_false_option
@@ -72,7 +72,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_blank_option
-    assert_equal "<p included=\"\" />", tag("p", included: "")
+    assert_dom_equal "<p included=\"\" />", tag("p", included: "")
   end
 
   def test_tag_builder_options_accepts_blank_option
@@ -80,11 +80,11 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_options_accepts_symbol_option_when_not_escaping
-    assert_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
+    assert_dom_equal "<p value=\"symbol\" />", tag("p", { value: :symbol }, false, false)
   end
 
   def test_tag_options_accepts_integer_option_when_not_escaping
-    assert_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
+    assert_dom_equal "<p value=\"42\" />", tag("p", { value: 42 }, false, false)
   end
 
   def test_tag_options_converts_boolean_option
@@ -451,7 +451,7 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_disable_escaping
-    assert_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
+    assert_dom_equal '<a href="&amp;" />', tag("a", { href: "&amp;" }, false, false)
   end
 
   def test_tag_builder_disable_escaping

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -30,15 +30,15 @@ class TextHelperTest < ActionView::TestCase
   def test_simple_format
     assert_equal "<p></p>", simple_format(nil)
 
-    assert_equal "<p>crazy\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("crazy\r\n cross\r platform linebreaks")
+    assert_dom_equal "<p>crazy\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("crazy\r\n cross\r platform linebreaks")
     assert_equal "<p>A paragraph</p>\n\n<p>and another one!</p>", simple_format("A paragraph\n\nand another one!")
-    assert_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
+    assert_dom_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
 
     text = "A\nB\nC\nD"
-    assert_equal "<p>A\n<br />B\n<br />C\n<br />D</p>", simple_format(text)
+    assert_dom_equal "<p>A\n<br />B\n<br />C\n<br />D</p>", simple_format(text)
 
     text = "A\r\n  \nB\n\n\r\n\t\nC\nD"
-    assert_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
+    assert_dom_equal "<p>A\n<br />  \n<br />B</p>\n\n<p>\t\n<br />C\n<br />D</p>", simple_format(text)
 
     assert_equal '<p class="test">This is a classy test</p>', simple_format("This is a classy test", class: "test")
     assert_equal %Q(<p class="test">para 1</p>\n\n<p class="test">para 2</p>), simple_format("para 1\n\npara 2", class: "test")


### PR DESCRIPTION
# Experiment: Add Nokogiri dependency to Action View

There is already an ActionText implementation-side dependency on Nokogiri. ActionText is an optional dependency of Rails, but since 7.0 is a major version bump from 6.1, it feels like an appropriate time to experiment with something like this.

This work is in parallel and support of https://github.com/rails/rails/pull/41638. If this proves to be viable, we could consider returning `Nokogiri::XML::Node` extensions from these helpers instead of Strings so that ERB templates or View Helpers can have instance-level access prior to encoding them to response HTML content.

# Summary

ActionView: Implement Tag Helpers with Nokogiri
---
    
Implement `tag` and `content_tag` helpers as wrappers around
[Nokogiri::XML::Node#to_html][].

[Nokogiri::XML::Node#to_html]: https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#to_html-instance_method

s/href/title/ to avoid URL _and_ HTML escaping
---
    
Since Nokogiri is responsible for transforming nodes into HTML, it's
strict handling of the `[href]` attribute is _URL_ escaping values,
which was not occurring in the prior tests.

In an effort to exercise the code in the same spirit as the original
coverage, replace the `href:` assignments with `title:` assignments,
since they're both attributes but a `title` has no restrictions on
format or validity.

### Other Information

In its current form, there are still two classes of test failure: escaping and encoding.

```
Failure:
TagHelperTest#test_content_tag_with_unescaped_conditional_hash_classes [/Users/seanpdoyle/Work/rails/rails/actionview/test/template/tag_helper_test.rb:334]:
--- expected
+++ actual
@@ -1 +1 @@
-"<p class=\"song play>\">limelight</p>"
+"<p class=\"song play&gt;\">limelight</p>"
```

There are tests that assert that attributes marked as `#html_safe` won't be escaped, even if they would result in invalid HTML. For example, the failure above is expecting that the `>` character exist in the attribute instead of the `&gt;`.

```
Failure:                                                                       
FormCollectionsHelperTest#test_collection_radio_generates_labels_for_non-English_values_correctly [/Users/seanpdoyle/Work/rails/rails/actionview/test/template
/form_collections_helper_test.rb:46]:                                          
<Господин> expected but was   <ÐÐ¾ÑÐ¿Ð¾Ð´Ð¸Ð½>..                                                                                                                                          Expected 0 to be >= 1.

Failure:                                                                                                                                                      
UrlHelperTest#test_link_tag_with_html_safe_string [/Users/seanpdoyle/Work/rails/rails/actionview/test/template/url_helper_test.rb:498]:                       
Expected: <a href="/article/Gerd_M%C3%BCller">Gerd Müller</a>                                                                                                 
Actual: <a href="/article/Gerd_M%C3%BCller">Gerd M&Atilde;&frac14;ller</a>  
```

I'm unsure whether or not Nokogiri's formatting can be configured to account for these situations.

## Benchmarks

I've run preliminary benchmarks on [eileencodes:master...seanpdoyle:rails/action-view-nokogiri](https://github.com/seanpdoyle/integration_performance_test/compare/master...seanpdoyle:rails/action-view-nokogiri) (forked from [eileencodes/integration_performance_test](https://github.com/eileencodes/integration_performance_test)).

**Before**

```
❯ ruby -Ilib:test test/integration/documents_benchmark_test.rb
Calculating -------------------------------------
INDEX: Integration Test
                        37.000  i/100ms
-------------------------------------------------
INDEX: Integration Test
                        473.783  (± 4.6%) i/s -      2.368k
Calculating -------------------------------------
CREATE: Integration Test
                        13.000  i/100ms
-------------------------------------------------
CREATE: Integration Test
                        133.276  (± 6.0%) i/s -    676.000
```

**After**

```
❯ ruby -Ilib:test test/integration/documents_benchmark_test.rb
Calculating -------------------------------------
INDEX: Integration Test
                        37.000  i/100ms
-------------------------------------------------
INDEX: Integration Test
                        439.594  (± 6.8%) i/s -      2.220k
Calculating -------------------------------------
CREATE: Integration Test
                        11.000  i/100ms
-------------------------------------------------
CREATE: Integration Test
                        111.989  (± 8.0%) i/s -    561.000 
```

### Open Questions

I'm a little unsure about the performance characteristics of instantiating Nokogiri instances instead of allocating and concatenating Strings. My gut tells me that it might be possible for the replacement to be a net-zero change, but I'm curious how the two will compare to one another.

Having said that, are there any red flags that I'm missing that are worth considering ahead of time? Any showstoppers you all might have more context and history on?

Currently, Action Text has a hard dependency on Nokogiri, but Action View does not. What is the history behind that decision? Does the release of nokogiri@1.11.0 and its bundled pre-compiled libraries make an Action View dependency on Nokogiri more palatable?

If this proves to be viable, what other logic and HTML validation code would we be able to drop from the suite of ActionView::Helpers?