### PR TITLE
Fix dirty check for Float::NAN

### DIFF
--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -26,7 +26,7 @@ module ActiveModel
 
         def changed?(old_value, _new_value, new_value_before_type_cast) # :nodoc:
           return false if old_value.try(:nan?) && new_value_before_type_cast.try(:nan?)
-          
+
           super || number_to_non_number?(old_value, new_value_before_type_cast)
         end
 

--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -25,6 +25,8 @@ module ActiveModel
         end
 
         def changed?(old_value, _new_value, new_value_before_type_cast) # :nodoc:
+          return false if old_value.try(:nan?) && new_value_before_type_cast.try(:nan?)
+          
           super || number_to_non_number?(old_value, new_value_before_type_cast)
         end
 


### PR DESCRIPTION
### Summary

The problem: Float::NAN is [special value](https://bugs.ruby-lang.org/issues/1720) in ruby. It can't be compared with `==`. Because of this dirty check failed

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", "~> 6.1"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :warehouse_receipts, force: true do |t|
    t.decimal :vat_coef
  end
end

class WarehouseReceipt < ActiveRecord::Base
end

class Test < Minitest::Test
  def test_nan_dirty
    wr = WarehouseReceipt.create!(vat_coef: Float::NAN)
    wr.vat_coef = Float::NAN
    assert !wr.changed? # Expected false to be truthy.
  end
end
```

