### PR TITLE
Multiple DB migrations priority

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1140,7 +1140,11 @@ module ActiveRecord
     end
 
     def needs_migration? # :nodoc:
-      (migrations.collect(&:version) - get_all_versions).size > 0
+      pending_migration_versions.size > 0
+    end
+
+    def pending_migration_versions # :nodoc:
+      migrations.collect(&:version) - get_all_versions
     end
 
     def migrations # :nodoc:

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1140,11 +1140,15 @@ module ActiveRecord
     end
 
     def needs_migration? # :nodoc:
-      pending_migration_versions.size > 0
+      !pending_migration_versions.empty?
     end
 
     def pending_migration_versions # :nodoc:
-      migrations.collect(&:version) - get_all_versions
+      migrations.map(&:version) - get_all_versions
+    end
+
+    def pending_migrations # :nodoc:
+      migrations.select { |migration| pending_migration_versions.include?(migration.version) }
     end
 
     def migrations # :nodoc:

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -268,13 +268,13 @@ module ActiveRecord
         end
       end
 
-      def migrate
+      def migrate(version = nil)
         check_target_version
 
         scope = ENV["SCOPE"]
         verbose_was, Migration.verbose = Migration.verbose, verbose?
 
-        Base.connection.migration_context.migrate(target_version) do |migration|
+        Base.connection.migration_context.migrate(target_version || version) do |migration|
           scope.blank? || scope == migration.scope
         end.tap do |migrations_ran|
           Migration.write("No migrations ran. (using #{scope} scope)") if scope.present? && migrations_ran.empty?


### PR DESCRIPTION
Summary

Basically sometimes we need to specify the order for multiple database migrations, we can do that only with consecutive calls e.g. `rake db:migrate:secondary rake db:migrate:primary ... rake db:migrate:nth `(or by position in YAML file)
But this is not always handy.

This request is going from discussion https://github.com/rails/rails/pull/41538
and tries to change migrations behavior like they are all in one folder (`flat_map`) (execution by timestamp aka version)