### PR TITLE
Introduces Action Text for API only application

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Introduces Action Text for API only application.
+
+    You can install Action Text for API only application using:
+
+    ```ruby
+      ./bin/rails action_text:install:api
+    ```
+
+    *Abhay Nikam*
+
 *   Add support for passing `form:` option to `rich_text_area_tag` and
     `rich_text_area` helpers to specify the `<input type="hidden" form="...">`
     value.

--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -8,7 +8,11 @@ module ActionText
     class InstallGenerator < ::Rails::Generators::Base
       source_root File.expand_path("templates", __dir__)
 
+      class_option :api, type: :boolean, aliases: "-a",
+                                         desc: "Configures Action Text for API application"
+
       def install_javascript_dependencies
+        return if options[:api]
         rails_command "app:binstub:yarn", inline: true
 
         say "Installing JavaScript dependencies", :green
@@ -16,6 +20,7 @@ module ActionText
       end
 
       def append_dependencies_to_package_file
+        return if options[:api]
         in_root do
           if (app_javascript_pack_path = Pathname.new("app/javascript/packs/application.js")).exist?
             js_dependencies.each_key do |dependency|
@@ -43,6 +48,7 @@ module ActionText
       end
 
       def create_actiontext_files
+        return if options[:api]
         template "actiontext.scss", "app/assets/stylesheets/actiontext.scss"
 
         copy_file "#{GEM_ROOT}/app/views/active_storage/blobs/_blob.html.erb",

--- a/actiontext/lib/tasks/actiontext.rake
+++ b/actiontext/lib/tasks/actiontext.rake
@@ -4,3 +4,7 @@ desc "Copy over the migration, stylesheet, and JavaScript files"
 task "action_text:install" do
   Rails::Command.invoke :generate, ["action_text:install"]
 end
+
+task "action_text:install:api" do
+  Rails::Command.invoke :generate, ["action_text:install", "--api"]
+end

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -228,6 +228,28 @@ By default, all `ActiveRecord::Base` descendants mix-in
 
 [global-id]: https://github.com/rails/globalid#usage
 
+### API Applications
+
+Action Text in API only application helps in managing the
+rich text content with embedded attachments.
+
+You can install Action Text for API only application using:
+
+```bash
+$ ./bin/rails action_text:install:api
+```
+
+Action Text in API only application can only serve the raw HTML
+and processed Trix HTML. The [Trix editor](https://trix-editor.org)
+will handle formatting of Trix HTML in the editor.
+
+Your API response would look something like:
+
+```ruby
+json.title post.title
+json.content post.content.to_trix_html
+```
+
 ## Avoid N+1 queries
 
 If you wish to preload the dependent `ActionText::RichText` model, assuming your rich text field is named `content`, you can use the named scope:

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -84,6 +84,21 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     assert_match %r"\S bin/yarn foo$", ran
   end
 
+  test "installs Action Text for API only application" do
+    generator([destination_root], api: true)
+    run_generator_instance
+    yarn_commands = @yarn_commands.join("\n")
+
+    assert_migration "db/migrate/create_active_storage_tables.active_storage.rb"
+    assert_migration "db/migrate/create_action_text_tables.action_text.rb"
+
+    assert_no_match %r"^add .*@rails/actiontext@", yarn_commands
+    assert_no_match %r"^add .*trix@", yarn_commands
+    assert_no_file "app/assets/stylesheets/actiontext.scss"
+    assert_no_file "app/views/active_storage/blobs/_blob.html.erb"
+    assert_no_file "app/views/layouts/action_text/contents/_content.html.erb"
+  end
+
   private
     def run_generator_instance
       @yarn_commands = []


### PR DESCRIPTION
Problem statement: Action Text cannot be used with the API-only
application as the action installer warns the missing webpacker
configurations and tries to install Action Text packages which
are not required in API-only app. Secondly, Action Text is best
solution for rich text content editing with support of embeds
and works well with Trix editor but has some missing documentation
which can be confusing at times.

This PR attempts to fix the Action Text installer and document
the usage. Action Text would still fail `post.content.body.to_html`
as it would return an empty ActionText::Content.
This is because `to_html` depends on `ApplicationController.renderer`
which is absent in API only application.

Related to #39266

Please feel free to close the PR if this change is not required. :)