### PR TITLE
Better: Use new DROP COLUMN feature from sqlite 3.35.00

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -257,7 +257,7 @@ module ActiveRecord
           end
         }
 
-        if ::SQLite3::SQLITE_VERSION_NUMBER >= 3035000
+        if ::SQLite3::SQLITE_VERSION_NUMBER >= 3035001
           begin
             super
           rescue ActiveRecord::StatementInvalid

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -260,7 +260,7 @@ module ActiveRecord
         if ::SQLite3::SQLITE_VERSION_NUMBER >= 3035000
           begin
             super
-          rescue ActiveRecord::StatementInvalid => e
+          rescue ActiveRecord::StatementInvalid
             old_way.call
           end
         else

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -128,9 +128,9 @@ module ActiveRecord
         add_column "test_models", :hat_name, :string
         add_index :test_models, :hat_name
 
-        assert_equal 1, connection.indexes("test_models").size
+        assert_equal 4, connection.columns("test_models").size
         remove_column("test_models", "hat_name")
-        assert_equal 0, connection.indexes("test_models").size
+        assert_equal 3, connection.columns("test_models").size
       end
 
       def test_remove_column_with_multi_column_index

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -128,8 +128,10 @@ module ActiveRecord
         add_column "test_models", :hat_name, :string
         add_index :test_models, :hat_name
 
+        assert_equal 1, connection.indexes("test_models").size
         assert_equal 4, connection.columns("test_models").size
         remove_column("test_models", "hat_name")
+        assert_equal 0, connection.indexes("test_models").size
         assert_equal 3, connection.columns("test_models").size
       end
 


### PR DESCRIPTION
### Summary

This is an attempt to use the native DROP COLUMN sql statement introduced in sqlite 3.35.00 (see https://sqlite.org/changes.html)

### Other Information

Now:

```
ylecuyer@inwin:~/Projects/test-sqlite-drop$ bundle exec rake db:migrate_with_sql

D, [2021-03-13T21:37:56.154357 #27940] DEBUG -- :    (0.2ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:37:56.154623 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:37:56.162980 #27940] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:37:56.163202 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
I, [2021-03-13T21:37:56.163280 #27940]  INFO -- : Migrating to AddPasswordToUsers (20210313094039)
== 20210313094039 AddPasswordToUsers: migrating ===============================
-- add_column(:users, :password, :string)
D, [2021-03-13T21:37:56.163946 #27940] DEBUG -- :   TRANSACTION (0.0ms)  begin transaction
D, [2021-03-13T21:37:56.164202 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:37:56.164502 #27940] DEBUG -- :    (0.3ms)  ALTER TABLE "users" ADD "password" varchar
D, [2021-03-13T21:37:56.164786 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
   -> 0.0010s
== 20210313094039 AddPasswordToUsers: migrated (0.0010s) ======================

D, [2021-03-13T21:37:56.166383 #27940] DEBUG -- :   ActiveRecord::SchemaMigration Create (0.1ms)  INSERT INTO "schema_migrations" ("version") VALUES (?)  [["version", "20210313094039"]]
D, [2021-03-13T21:37:56.166695 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:37:56.171430 #27940] DEBUG -- :   TRANSACTION (4.6ms)  commit transaction
D, [2021-03-13T21:37:56.171772 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:37:56.174350 #27940] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.2ms)  SELECT "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = ? LIMIT ?  [["key", "environment"], ["LIMIT", 1]]
D, [2021-03-13T21:37:56.174750 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:37:56.182212 #27940] DEBUG -- :    (0.0ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:37:56.182539 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:37:56.183211 #27940] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:37:56.183438 #27940] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'

ylecuyer@inwin:~/Projects/test-sqlite-drop$ bundle exec rake db:rollback_with_sql

D, [2021-03-13T21:38:05.101279 #28016] DEBUG -- :    (0.2ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:38:05.101548 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.110908 #28016] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:38:05.111143 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.111398 #28016] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:38:05.111615 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.111841 #28016] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:38:05.112054 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.112554 #28016] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:38:05.112824 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
I, [2021-03-13T21:38:05.112913 #28016]  INFO -- : Migrating to AddPasswordToUsers (20210313094039)
== 20210313094039 AddPasswordToUsers: reverting ===============================
-- remove_column(:users, :password, :string)
D, [2021-03-13T21:38:05.116090 #28016] DEBUG -- :   TRANSACTION (0.0ms)  begin transaction
D, [2021-03-13T21:38:05.116995 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.117969 #28016] DEBUG -- :    (0.9ms)  ALTER TABLE "users" DROP COLUMN "password"
D, [2021-03-13T21:38:05.118812 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
   -> 0.0029s
== 20210313094039 AddPasswordToUsers: reverted (0.0054s) ======================

D, [2021-03-13T21:38:05.120909 #28016] DEBUG -- :   ActiveRecord::SchemaMigration Destroy (0.1ms)  DELETE FROM "schema_migrations" WHERE "schema_migrations"."version" = ?  [["version", "20210313094039"]]
D, [2021-03-13T21:38:05.121177 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.129684 #28016] DEBUG -- :   TRANSACTION (8.4ms)  commit transaction
D, [2021-03-13T21:38:05.130685 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.131589 #28016] DEBUG -- :    (0.0ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:38:05.132561 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:38:05.134156 #28016] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:38:05.135319 #28016] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
```

Before:

```
ylecuyer@inwin:~/Projects/test-sqlite-drop$ bundle exec rake db:migrate_with_sql

D, [2021-03-13T21:39:55.026843 #28742] DEBUG -- :    (0.9ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:39:55.027708 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:55.049505 #28742] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:55.050173 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
I, [2021-03-13T21:39:55.050297 #28742]  INFO -- : Migrating to AddPasswordToUsers (20210313094039)
== 20210313094039 AddPasswordToUsers: migrating ===============================
-- add_column(:users, :password, :string)
D, [2021-03-13T21:39:55.051432 #28742] DEBUG -- :   TRANSACTION (0.0ms)  begin transaction
D, [2021-03-13T21:39:55.051833 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:55.052160 #28742] DEBUG -- :    (0.3ms)  ALTER TABLE "users" ADD "password" varchar
D, [2021-03-13T21:39:55.052546 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
   -> 0.0013s
== 20210313094039 AddPasswordToUsers: migrated (0.0015s) ======================

D, [2021-03-13T21:39:55.055267 #28742] DEBUG -- :   ActiveRecord::SchemaMigration Create (0.1ms)  INSERT INTO "schema_migrations" ("version") VALUES (?)  [["version", "20210313094039"]]
D, [2021-03-13T21:39:55.055589 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:55.060246 #28742] DEBUG -- :   TRANSACTION (4.5ms)  commit transaction
D, [2021-03-13T21:39:55.061253 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:55.068753 #28742] DEBUG -- :   ActiveRecord::InternalMetadata Load (0.1ms)  SELECT "ar_internal_metadata".* FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = ? LIMIT ?  [["key", "environment"], ["LIMIT", 1]]
D, [2021-03-13T21:39:55.069002 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:55.071619 #28742] DEBUG -- :    (0.0ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:39:55.075784 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:55.076699 #28742] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:55.076918 #28742] DEBUG -- :   ↳ lib/tasks/custom.rake:5:in `block (2 levels) in <main>'

ylecuyer@inwin:~/Projects/test-sqlite-drop$ bundle exec rake db:rollback_with_sql

D, [2021-03-13T21:39:59.662739 #28818] DEBUG -- :    (0.2ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:39:59.662968 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.671013 #28818] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:59.671263 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.671508 #28818] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:59.671761 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.671965 #28818] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:59.672118 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.672534 #28818] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:59.672748 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
I, [2021-03-13T21:39:59.672814 #28818]  INFO -- : Migrating to AddPasswordToUsers (20210313094039)
== 20210313094039 AddPasswordToUsers: reverting ===============================
-- remove_column(:users, :password, :string)
D, [2021-03-13T21:39:59.674246 #28818] DEBUG -- :   TRANSACTION (0.0ms)  begin transaction
D, [2021-03-13T21:39:59.674473 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.674767 #28818] DEBUG -- :    (0.0ms)  PRAGMA foreign_keys
D, [2021-03-13T21:39:59.675093 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.675241 #28818] DEBUG -- :    (0.1ms)  PRAGMA defer_foreign_keys
D, [2021-03-13T21:39:59.675498 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.675623 #28818] DEBUG -- :    (0.1ms)  PRAGMA defer_foreign_keys = ON
D, [2021-03-13T21:39:59.675871 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.675955 #28818] DEBUG -- :    (0.0ms)  PRAGMA foreign_keys = OFF
D, [2021-03-13T21:39:59.676180 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.676823 #28818] DEBUG -- :    (0.1ms)  CREATE TEMPORARY TABLE "ausers" ("id" integer NOT NULL PRIMARY KEY, "name" varchar DEFAULT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL, "password" varchar DEFAULT NULL)
D, [2021-03-13T21:39:59.677050 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.677390 #28818] DEBUG -- :    (0.0ms)  INSERT INTO "ausers" ("id","name","created_at","updated_at","password")
                     SELECT "id","name","created_at","updated_at","password" FROM "users"
D, [2021-03-13T21:39:59.677604 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.677807 #28818] DEBUG -- :    (0.1ms)  DROP TABLE "users"
D, [2021-03-13T21:39:59.678018 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.678631 #28818] DEBUG -- :    (0.1ms)  CREATE TABLE "users" ("id" integer NOT NULL PRIMARY KEY, "name" varchar DEFAULT NULL, "created_at" datetime(6) NOT NULL, "updated_at" datetime(6) NOT NULL)
D, [2021-03-13T21:39:59.678838 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.679149 #28818] DEBUG -- :    (0.0ms)  INSERT INTO "users" ("id","name","created_at","updated_at")
                     SELECT "id","name","created_at","updated_at" FROM "ausers"
D, [2021-03-13T21:39:59.679429 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.679600 #28818] DEBUG -- :    (0.1ms)  DROP TABLE "ausers"
D, [2021-03-13T21:39:59.679847 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.679968 #28818] DEBUG -- :    (0.1ms)  PRAGMA defer_foreign_keys = 0
D, [2021-03-13T21:39:59.680189 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.680259 #28818] DEBUG -- :    (0.0ms)  PRAGMA foreign_keys = 1
D, [2021-03-13T21:39:59.680439 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
   -> 0.0064s
== 20210313094039 AddPasswordToUsers: reverted (0.0072s) ======================

D, [2021-03-13T21:39:59.681162 #28818] DEBUG -- :   ActiveRecord::SchemaMigration Destroy (0.1ms)  DELETE FROM "schema_migrations" WHERE "schema_migrations"."version" = ?  [["version", "20210313094039"]]
D, [2021-03-13T21:39:59.681364 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.698098 #28818] DEBUG -- :   TRANSACTION (16.6ms)  commit transaction
D, [2021-03-13T21:39:59.698397 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.699209 #28818] DEBUG -- :    (0.0ms)  SELECT sqlite_version(*)
D, [2021-03-13T21:39:59.699423 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
D, [2021-03-13T21:39:59.700053 #28818] DEBUG -- :   ActiveRecord::SchemaMigration Pluck (0.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
D, [2021-03-13T21:39:59.700283 #28818] DEBUG -- :   ↳ lib/tasks/custom.rake:11:in `block (2 levels) in <main>'
```

The native DROP COLUMN from sqlite has some limitations (see https://sqlite.org/lang_altertable.html#altertabdropcol) for those cases the code falls back to the legacy way (creating a temp table)

Also, I'm pretty sure the CI is running with an older version of sqlite but I couldn't find how to create a matrix build with the latest sqlite version. Where can I find the config file for the CI?