### PR TITLE
Fix numericality validator without precision in Active Record

### DIFF
--- a/activerecord/lib/active_record/validations/numericality.rb
+++ b/activerecord/lib/active_record/validations/numericality.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Validations
     class NumericalityValidator < ActiveModel::Validations::NumericalityValidator # :nodoc:
       def validate_each(record, attribute, value, precision: nil, scale: nil)
-        precision = [column_precision_for(record, attribute) || BigDecimal.double_fig, BigDecimal.double_fig].min
+        precision = [column_precision_for(record, attribute) || Float::DIG, Float::DIG].min
         scale     = column_scale_for(record, attribute)
         super(record, attribute, value, precision: precision, scale: scale)
       end

--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -81,6 +81,17 @@ class NumericalityValidationTest < ActiveRecord::TestCase
     assert_predicate(subject, :valid?)
   end
 
+  def test_virtual_attribute_without_precision
+    model_class.attribute(:virtual_decimal_number, :decimal)
+    model_class.validates_numericality_of(
+      :virtual_decimal_number, equal_to: BigDecimal("65.6")
+    )
+
+    subject = model_class.new(virtual_decimal_number: 65.6)
+
+    assert_predicate subject, :valid?
+  end
+
   def test_virtual_attribute_with_precision_round_down
     model_class.attribute(:virtual_decimal_number, :decimal, precision: 5)
     model_class.validates_numericality_of(


### PR DESCRIPTION
Test case which was added at #32852 passes in Active Model but doesn't
pass in Active Record since #38210 due to `Float::DIG` has changed to
`BigDecimal.double_fig`.

```ruby
irb(main):001:0> require 'bigdecimal/util'
=> true
irb(main):002:0> 65.6.to_d
=> 0.656e2
irb(main):003:0> 65.6.to_d(Float::DIG)
=> 0.656e2
irb(main):004:0> 65.6.to_d(BigDecimal.double_fig)
=> 0.6559999999999999e2
```
