### PR TITLE
RemoteConnection#disconnect: fix ArgumentError on ruby 3.0

### DIFF
--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -45,7 +45,7 @@ module ActionCable
 
         # Uses the internal channel to disconnect the connection.
         def disconnect
-          server.broadcast internal_channel, type: "disconnect"
+          server.broadcast internal_channel, { type: "disconnect" }
         end
 
         # Returns all the identifiers that were applied to this connection.

--- a/actioncable/lib/action_cable/test_helper.rb
+++ b/actioncable/lib/action_cable/test_helper.rb
@@ -82,7 +82,7 @@ module ActionCable
     # Asserts that the specified message has been sent to the stream.
     #
     #   def test_assert_transmitted_message
-    #     ActionCable.server.broadcast 'messages', text: 'hello'
+    #     ActionCable.server.broadcast 'messages', { text: 'hello' }
     #     assert_broadcast_on('messages', text: 'hello')
     #   end
     #
@@ -90,7 +90,7 @@ module ActionCable
     #
     #   def test_assert_broadcast_on_again
     #     assert_broadcast_on('messages', text: 'hello') do
-    #       ActionCable.server.broadcast 'messages', text: 'hello'
+    #       ActionCable.server.broadcast 'messages', { text: 'hello' }
     #     end
     #   end
     #

--- a/actioncable/test/server/base_test.rb
+++ b/actioncable/test/server/base_test.rb
@@ -35,4 +35,21 @@ class BaseTest < ActionCable::TestCase
       @server.restart
     end
   end
+
+  test "#disconnect disconnects remote connection" do
+    @server = TestServer.new
+    identifiers = { id: 1 }
+    remote_connections = Minitest::Mock.new @server.remote_connections
+    remote_conn = TestRemoteConnections::TestRemoteConnection.new(@server, identifiers)
+
+    remote_connections.expect(:where, remote_conn, [identifiers])
+
+    @server.stub(:remote_connections, remote_connections) do
+      assert_called(remote_conn, :disconnect) do
+        @server.disconnect(identifiers)
+      end
+    end
+
+    assert remote_connections.verify
+  end
 end

--- a/actioncable/test/stubs/test_remote_connections.rb
+++ b/actioncable/test/stubs/test_remote_connections.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class TestRemoteConnections
+  attr_reader :server
+
+  def initialize(server)
+    @server = server
+  end
+
+  def where(identifier)
+    TestRemoteConnection.new(server, identifier)
+  end
+
+  private
+    class TestRemoteConnection
+      def initialize(server, ids)
+        @server = server
+        @ids = ids
+      end
+
+      def disconnect
+        @server.broadcast "action_cable/#{@ids}", { type: "disconnect" }
+      end
+    end
+end

--- a/actioncable/test/stubs/test_server.rb
+++ b/actioncable/test/stubs/test_server.rb
@@ -16,6 +16,10 @@ class TestServer
     @mutex = Monitor.new
   end
 
+  def disconnect(identifiers)
+    remote_connections.where(identifiers).disconnect
+  end
+
   def pubsub
     @pubsub ||= @config.subscription_adapter.new(self)
   end
@@ -28,5 +32,9 @@ class TestServer
 
   def worker_pool
     @worker_pool ||= ActionCable::Server::Worker.new(max_size: 5)
+  end
+
+  def remote_connections
+    @remote_connections ||= TestRemoteConnections.new(self)
   end
 end


### PR DESCRIPTION
### Summary
ActionCable.server.broadcast raises ArgumentError in Ruby 3.0.0 when the message parameter is passed traditionally without using hashes.

Docs were fixed in https://github.com/rails/rails/pull/41050, but there is no fix for `RemoteConnection#disconnect`, which still uses an old syntax.

My env: 
```
$ rails -v
Rails 6.1.3
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
```

Actual behavior:
```ruby
ActionCable.server.broadcast("sample_channel", type: "ping")
>> ArgumentError: wrong number of arguments (given 1, expected 2)

ActionCable.server.broadcast("sample_channel", { type: "ping" })
>> [ActionCable] Broadcasting to sample_channel: {:type=>"ping"}
```
 

Also check this related link: https://github.com/rails/rails/issues/40993