### PR TITLE
Fixes #41521, ActiveModel::Dirty fails on to_json

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `to_json` for `ActiveModel::Dirty` object.
+    
+    Exclude +mutations_from_database+ attribute from json as it lead to recursion.
+
+    *Anil Maurya*
+
 *   Add `ActiveModel::AttributeSet#values_for_database`
 
     Returns attributes with values for assignment to the database.

--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -140,6 +140,11 @@ module ActiveModel
       @mutations_from_database = nil
     end
 
+    def as_json(options = {}) # :nodoc:
+      options[:except] = [options[:except], "mutations_from_database"].flatten
+      super(options)
+    end
+
     # Clears dirty data and moves +changes+ to +previous_changes+ and
     # +mutations_from_database+ to +mutations_before_last_save+ respectively.
     def changes_applied

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "active_support/json"
 
 class DirtyTest < ActiveModel::TestCase
   class DirtyModel
@@ -236,5 +237,20 @@ class DirtyTest < ActiveModel::TestCase
 
   test "model can be dup-ed without Attributes" do
     assert @model.dup
+  end
+
+  test "to_json should work on model" do
+    @model.name = "Dmitry"
+    assert_equal "{\"name\":\"Dmitry\",\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json
+  end
+
+  test "to_json should work on model with :except string option " do
+    @model.name = "Dmitry"
+    assert_equal "{\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json(except: "name")
+  end
+
+  test "to_json should work on model with :except array option " do
+    @model.name = "Dmitry"
+    assert_equal "{\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json(except: ["name"])
   end
 end


### PR DESCRIPTION
### Summary

This PR fixes #41521

ActiveModel::Dirty adds `mutation_from_database` attribute which contains `ActiveModel::ForcedMutationTracker` object.
`ActiveModel::ForcedMutationTracker` has attributes pointing to ActiveModel::Dirty class which again has `ActiveModel::ForcedMutationTracker`. This causes to_json to  stuck in forever loop.

Example:
```
class Person
  include ActiveModel::Dirty

  define_attribute_methods :name

  def initialize
    @name = nil
    @profile = Profile.new(20, "21/21/21")
  end

  def name
    @name
  end

  def name=(val)
    name_will_change! unless val == @name
    @name = val
  end

  def save
    # do persistence work

    changes_applied
  end

  def reload!
    # get the values from the persistence layer

    clear_changes_information
  end

  def rollback!
    restore_attributes
  end
end

class Profile
  attr_accessor :age, :dob
  
  def initialize(age, dob)
    @age = age
    @dob = dob
  end
end

person = Person.new()
person.name = 'test'

p person
{"name"=>"test",
 "profile"=>#<Profile:0x00007fc9ef5d4bf0 @age=20, @dob="21/21/21">,
 "mutations_from_database"=>
  #<ActiveModel::ForcedMutationTracker:0x00007fc9ef5d4ad8
   @attributes=
    #<Person:0x00007fc9ef5d4c40
     @mutations_from_database=#<ActiveModel::ForcedMutationTracker:0x00007fc9ef5d4ad8 ...>,
     @name="test",
     @profile=#<Profile:0x00007fc9ef5d4bf0 @age=20, @dob="21/21/21">>,
   @finalized_changes=nil,
   @forced_changes={"name"=>nil}>}


```
This PR excludes "mutations_from_database" when invoking to_json on ActiveModel::Dirty

