### PR TITLE
Make sure to check against a truthy value

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       LOCAL_HOSTS = ["127.0.0.1", "localhost"]
 
       def check_protected_environments!
-        unless ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"]
+        unless ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"] == '1'
           current = ActiveRecord::Base.connection.migration_context.current_environment
           stored  = ActiveRecord::Base.connection.migration_context.last_stored_environment
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       LOCAL_HOSTS = ["127.0.0.1", "localhost"]
 
       def check_protected_environments!
-        unless ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"] == '1'
+        unless ENV["DISABLE_DATABASE_ENVIRONMENT_CHECK"] == "1"
           current = ActiveRecord::Base.connection.migration_context.current_environment
           stored  = ActiveRecord::Base.connection.migration_context.last_stored_environment
 


### PR DESCRIPTION
### Summary

If you e.g. try running `rails db:setup` in `production` you will get the exception:

```
ActiveRecord::ProtectedEnvironmentError: You are attempting to run a destructive action against your 'production' database.
If you are sure you want to continue, run the same command with the environment variable:
DISABLE_DATABASE_ENVIRONMENT_CHECK=1
```

This is a great feature, but if you then set it to e.g. `DISABLE_DATABASE_ENVIRONMENT_CHECK=0` it will actually take that for a `1` as it just checks for the var being set 😱. That's unexpected I would say 🤣 
