### PR TITLE
Move field into `USING` fields

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -401,12 +401,11 @@ module ActiveRecord
                  rc.delete_rule AS 'on_delete'
           FROM information_schema.referential_constraints rc
           JOIN information_schema.key_column_usage fk
-          USING (constraint_schema, constraint_name)
+          USING (constraint_schema, constraint_name,  table_name)
           WHERE fk.referenced_column_name IS NOT NULL
             AND fk.table_schema = #{scope[:schema]}
             AND fk.table_name = #{scope[:name]}
             AND rc.constraint_schema = #{scope[:schema]}
-            AND rc.table_name = #{scope[:name]}
         SQL
 
         fk_info.map do |row|


### PR DESCRIPTION
### Summary

The previous query filtered to `fk.table_name = #{scope[:name]} AND rc.table_name = #{scope[:name]}` which is logically equivalent to `fk.table_name = rc.table_name AND fk.table_name = #{scope[:name]}`. This modification to the SQL allows the query to run on [vitess](https://github.com/vitessio/vitess) databases. The previous query would fail on these databases with an error of "two predicates for table_name not supported".

I was not 100% sure how to test this. Adding vitess to the testing matrix seemed heavy handed, and having a test make assertions about the SQL query being executed seemed too brittle... So I landed with no tests. Definitely happy to add them, though, if folks have suggestions!