### PR TITLE
Disable parallel testing when running individual files

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Tests parallelization is now disabled when running individual files to prevent the setup overhead.
+
+    It can still be enforced if the environment variable `PARALLEL_WORKERS` is present and set to a value greater than 1.
+
+    *Ricardo Díaz*
+
 *   Fix proxying keyword arguments in `ActiveSupport::CurrentAttributes`.
 
     *Marcin Kołodziej*

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -87,6 +87,11 @@ module ActiveSupport
   end
 
   cattr_accessor :test_order # :nodoc:
+  cattr_accessor :test_parallelization_disabled, default: false # :nodoc:
+
+  def self.disable_test_parallelization!
+    self.test_parallelization_disabled = true unless ENV["PARALLEL_WORKERS"]
+  end
 
   def self.to_time_preserves_timezone
     DateAndTime::Compatibility.preserve_timezone

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -75,7 +75,7 @@ module ActiveSupport
         workers = Concurrent.physical_processor_count if workers == :number_of_processors
         workers = ENV["PARALLEL_WORKERS"].to_i if ENV["PARALLEL_WORKERS"]
 
-        return if workers <= 1
+        return if workers <= 1 || ActiveSupport.test_parallelization_disabled
 
         executor = case with
                    when :processes
@@ -91,6 +91,12 @@ module ActiveSupport
         Minitest.parallel_executor = executor
 
         parallelize_me!
+
+        # `Minitest::Test.parallelize_me!` will try to change `test_order` to return
+        # `:parallel`. However, since `ActiveSupport::TestCase` is already overriding it,
+        # in some inheritance situations, it will have precedence over the `Minitest` one.
+        # For this reason, it needs to be updated by hand.
+        self.test_order = :parallel
       end
 
       # Set up hook for parallel testing. This can be used if you have multiple

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -3,6 +3,7 @@
 require "shellwords"
 require "method_source"
 require "rake/file_list"
+require "active_support"
 require "active_support/core_ext/module/attribute_accessors"
 
 module Rails
@@ -46,7 +47,8 @@ module Rails
 
           tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]
           tests.exclude(default_test_exclude_glob) if patterns.empty?
-
+          # Disable parallel testing if there's only one test file to run.
+          ActiveSupport.disable_test_parallelization! if tests.size <= 1
           tests.to_a.each { |path| require File.expand_path(path) }
         end
 


### PR DESCRIPTION
### Summary

Fixes #41473

Setting up the parallel workers could be an overhead when running
individual files.

This patch disables that process in case the number of files to run
is less than one.

Results running a sample file:

Before:

```
actionpack $ bin/test test/controller/parameters/accessors_test.rb
Run options: --seed 48261

........................................................................

Finished in 0.211923s, 339.7460 runs/s, 552.0873 assertions/s.
72 runs, 117 assertions, 0 failures, 0 errors, 0 skips
```

After

```
actionpack $ bin/test test/controller/parameters/accessors_test.rb

Run options: --seed 5461

........................................................................

Finished in 0.008411s, 8560.2189 runs/s, 13910.3557 assertions/s.
72 runs, 117 assertions, 0 failures, 0 errors, 0 skips
```

Of course this improvement doesn't apply to all cases, so the environment
variable `PARALLEL_WORKERS` can still be used to enforce parallelization. 