### PR TITLE
Add draw_routes config option to ActionMailbox

### DIFF
--- a/actionmailbox/config/routes.rb
+++ b/actionmailbox/config/routes.rb
@@ -22,4 +22,4 @@ Rails.application.routes.draw do
 
     post ":inbound_email_id/reroute" => "reroutes#create", as: :rails_conductor_inbound_email_reroute
   end
-end
+end if ActionMailbox.draw_routes

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -14,4 +14,5 @@ module ActionMailbox
   mattr_accessor :incinerate, default: true
   mattr_accessor :incinerate_after, default: 30.days
   mattr_accessor :queues, default: {}
+  mattr_accessor :draw_routes, default: true
 end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -27,6 +27,7 @@ module ActionMailbox
         ActionMailbox.incinerate_after = app.config.action_mailbox.incinerate_after || 30.days
         ActionMailbox.queues = app.config.action_mailbox.queues || {}
         ActionMailbox.ingress = app.config.action_mailbox.ingress
+        ActionMailbox.draw_routes = app.config.action_mailbox.draw_routes != false
       end
     end
   end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -757,6 +757,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_mailbox.queues.routing` accepts a symbol indicating the Active Job queue to use for routing jobs. When this option is `nil`, routing jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).
 
+* `config.active_storage.draw_routes` can be used to toggle Action Mailbox route generation. The default is `true`.
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:
@@ -1118,6 +1120,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_job.skip_after_callbacks_if_terminated`: `false`
 - `config.action_mailbox.queues.incineration`: `:action_mailbox_incineration`
 - `config.action_mailbox.queues.routing`: `:action_mailbox_routing`
+- `config.action_mailbox.draw_routes`: `true`
 - `config.action_mailer.deliver_later_queue_name`: `:mailers`
 - `config.active_record.collection_cache_versioning`: `false`
 - `config.active_record.cache_versioning`: `false`

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2874,6 +2874,31 @@ module ApplicationTests
       assert_equal ActionMailer::MailDeliveryJob, ActionMailer::Base.delivery_job
     end
 
+    test "ActionMailbox.draw_routes can be configured via config.action_mailbox.draw_routes" do
+      routes = %w(
+        rails_postmark_inbound_emails rails_relay_inbound_emails rails_sendgrid_inbound_emails
+        rails_mandrill_inbound_health_check rails_mandrill_inbound_emails
+        rails_mailgun_inbound_emails
+        rails_conductor_inbound_emails new_rails_conductor_inbound_email_source rails_conductor_inbound_email_sources rails_conductor_inbound_email_reroute
+      )
+
+      output = rails("routes")
+      routes.each do |route|
+        assert_includes(output, route)
+      end
+
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_mailbox.draw_routes = false
+        end
+      RUBY
+
+      output = rails("routes")
+      routes.each do |route|
+        assert_not_includes(output, route)
+      end
+    end
+
     test "ActionMailer::Base.delivery_job is ActionMailer::DeliveryJob in the 5.x defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
       add_to_config 'config.load_defaults "5.2"'


### PR DESCRIPTION
Adds a draw_routes config option to ActionMailbox to draw the action_mailbox application routes or not.  Mirrors the ActiveStorage draw_routes option.

### Summary

ActiveStorage has a draw_routes config option which allows you to set whether the application routes for active_storage are generated or not.  This pull request adds a draw_routes config option to ActionMailbox that accomplishes the same thing to set whether ActionMailbox routes are generated for the application or not.

The option for ActiveStorage is `config.active_storage.draw_routes` and likewise the option for ActionMailbox is `config.action_mailbox.draw_routes`

### Other Information

None