### PR TITLE
Fix a type error that occurred when there is a params key

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -823,7 +823,7 @@ module ActionDispatch
         params = route_with_params.params
 
         if options.key? :params
-          params.merge! options[:params]
+          params.merge! options[:params] if options[:params].is_a?(Hash)
         end
 
         options[:path]        = path


### PR DESCRIPTION
### Summary

When there is a params key in the request parameter and the key value type is not Hash, a type error occurs.

example test
```ruby
it 'foo' do
    post :bar, params: { params: "foo" }
    expect(response).to have_http_status(:success)
 end
```


this request has params key
In the url_for function, params.merge! is executed and the string type cannot be merged, a type error occurs of course. 
It would be better to run only if options[:params] is a hash.