### PR TITLE
Ensure modules are preloaded correctly using rel=modulepreload.

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -94,11 +94,12 @@ module ActionView
         crossorigin = options.delete("crossorigin")
         crossorigin = "anonymous" if crossorigin == true
         integrity = options["integrity"]
+        rel = options["type"] == "module" ? "modulepreload" : "preload"
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
           if preload_links_header && !options["defer"]
-            preload_link = "<#{href}>; rel=preload; as=script"
+            preload_link = "<#{href}>; rel=#{rel}; as=script"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
             preload_link += "; nopush" if nopush

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -554,6 +554,14 @@ class AssetTagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_should_set_preload_links_with_rel_modulepreload
+    with_preload_links_header do
+      javascript_include_tag("http://example.com/all.js", type: "module")
+      expected = "<http://example.com/all.js>; rel=modulepreload; as=script; nopush"
+      assert_equal expected, @response.headers["Link"]
+    end
+  end
+
   def test_should_set_preload_links_with_integrity_hashes
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")


### PR DESCRIPTION
### Summary 

This pull request fixes response hints for [`module` scripts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).

It modifies `javascript_include_tag` to check for `type: module`, in which case it will use <kbd>[rel: modulepreload](developer.mozilla.org/en-US/docs/Web/HTML/Link_types/modulepreload)</kbd> instead.

### Background 📜

Previously, the response hint sent in `javascript_include_tag` was using <kbd>rel=preload</kbd> for all scripts, including [`module` scripts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).

```
Link <http://example.com/module.js>; rel=preload; as=script; crossorigin=anonymous; nopush"
```

Browsers will __ignore the pre-loaded resource__ because the types don't match (preloaded a script, but included a module).

### Screenshots 📷 

<img width="1438" alt="Screen Shot 2021-03-18 at 16 12 12" src="https://user-images.githubusercontent.com/1158253/111685545-ce76b700-8806-11eb-8732-ca0ea1a96570.png">

### References 🔗

- https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
- https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/modulepreload
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
