### PR TITLE
Fix ActionCable disconnection on Ruby 3.0

### DIFF
--- a/actioncable/lib/action_cable/remote_connections.rb
+++ b/actioncable/lib/action_cable/remote_connections.rb
@@ -45,7 +45,7 @@ module ActionCable
 
         # Uses the internal channel to disconnect the connection.
         def disconnect
-          server.broadcast internal_channel, type: "disconnect"
+          server.broadcast internal_channel, { type: "disconnect" }
         end
 
         # Returns all the identifiers that were applied to this connection.


### PR DESCRIPTION
Ruby 3.0 treats keyword arguments differently from hashes - wrap `type: "disconnect"` in a hash accordingly to stop Ruby 3.0 from thinking it's a keyword argument.

Without this, calling:

```
ActionCable.server.remote_connections.where(...).disconnect
```

blows up on Ruby 3.0 with:

```
ArgumentError (wrong number of arguments (given 1, expected 2)):
actioncable (6.0.3.3) lib/action_cable/server/broadcasting.rb:24:in `broadcast'
actioncable (6.0.3.3) lib/action_cable/remote_connections.rb:48:in `disconnect'
...
```