### PR TITLE
ActionText: Always render Action Text HTML with :html format (part 2)

### DIFF
--- a/actiontext/lib/action_text/attachments/trix_conversion.rb
+++ b/actiontext/lib/action_text/attachments/trix_conversion.rb
@@ -28,7 +28,7 @@ module ActionText
       private
         def trix_attachment_content
           if partial_path = attachable.try(:to_trix_content_attachment_partial_path)
-            ActionText::Content.render(partial: partial_path, object: self, as: model_name.element)
+            ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element)
           end
         end
     end


### PR DESCRIPTION
It looks like that the fix provided by @jonathanhefner should also be applied to trix_conversion.rb.

The original fix https://github.com/rails/rails/pull/40702 explained that: 

> 
> Since rails#40222, Action Text HTML is rendered in the context of the current
> request.  This causes the Action Text template format to default to the
> request format, which prevents the template from being resolved when the
> request format is not `:html` (e.g. `:json`).  Therefore, override the
> template format to always be `:html`. Fixes rails#40695.

When I want to pass the trix content to my react app, using json.jbuilder, I render this like:

```
json.explanation(answer.explanation.body&.to_trix_html)
```

This will eventually call the render method:
```
ActionText::Content.render(partial: partial_path, object: self, as: model_name.element)

```
This also has the problem of searching for a partial with the JSON format, instead of the HTML format that is needed here.

So I think this should be:

```
ActionText::Content.render(partial: partial_path, formats: :html, object: self, as: model_name.element)

```
