### PR TITLE
Use `...` argument forwarding instead of ruby2_keywords when possible

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -219,10 +219,9 @@ module ActionController
     class << self
       # Pushes the given Rack middleware and its arguments to the bottom of the
       # middleware stack.
-      def use(*args, &block)
-        middleware_stack.use(*args, &block)
+      def use(...)
+        middleware_stack.use(...)
       end
-      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
     end
 
     # Alias for +middleware_stack+.

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -103,11 +103,10 @@ module ActionDispatch
         include(*_url_for_modules) if respond_to?(:_url_for_modules)
       end
 
-      def initialize(*)
+      def initialize(...)
         @_routes = nil
         super
       end
-      ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
       # Hook overridden in controller to add request information
       # with +default_url_options+. Application logic should not

--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -7,14 +7,12 @@ module ActiveJob
       @job_class = job_class
     end
 
-    def perform_now(*args)
-      @job_class.new(*args).perform_now
+    def perform_now(...)
+      @job_class.new(...).perform_now
     end
-    ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 
-    def perform_later(*args)
-      @job_class.new(*args).enqueue @options
+    def perform_later(...)
+      @job_class.new(...).enqueue @options
     end
-    ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
   end
 end

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -25,15 +25,14 @@ module ActiveJob
       # Job#arguments or false if the enqueue did not succeed.
       #
       # After the attempted enqueue, the job will be yielded to an optional block.
-      def perform_later(*args)
-        job = job_or_instantiate(*args)
+      def perform_later(...)
+        job = job_or_instantiate(...)
         enqueue_result = job.enqueue
 
         yield job if block_given?
 
         enqueue_result
       end
-      ruby2_keywords(:perform_later) if respond_to?(:ruby2_keywords, true)
 
       private
         def job_or_instantiate(*args) # :doc:

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -14,10 +14,9 @@ module ActiveJob
       #
       #   MyJob.perform_now("mike")
       #
-      def perform_now(*args)
-        job_or_instantiate(*args).perform_now
+      def perform_now(...)
+        job_or_instantiate(...).perform_now
       end
-      ruby2_keywords(:perform_now) if respond_to?(:ruby2_keywords, true)
 
       def execute(job_data) #:nodoc:
         ActiveJob::Callbacks.run_callbacks(:execute) do

--- a/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/active_schema_test.rb
@@ -196,8 +196,7 @@ class Mysql2ActiveSchemaTest < ActiveRecord::Mysql2TestCase
       end
     end
 
-    def method_missing(method_symbol, *arguments)
-      ActiveRecord::Base.connection.public_send(method_symbol, *arguments)
+    def method_missing(...)
+      ActiveRecord::Base.connection.public_send(...)
     end
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 end

--- a/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/active_schema_test.rb
@@ -106,8 +106,7 @@ class PostgresqlActiveSchemaTest < ActiveRecord::PostgreSQLTestCase
   end
 
   private
-    def method_missing(method_symbol, *arguments)
-      ActiveRecord::Base.connection.public_send(method_symbol, *arguments)
+    def method_missing(...)
+      ActiveRecord::Base.connection.public_send(...)
     end
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 end

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -49,46 +49,41 @@ module Rails
         @delete_operations = delete_operations
       end
 
-      def insert_before(*args, &block)
-        @operations << -> middleware { middleware.insert_before(*args, &block) }
+      def insert_before(...)
+        @operations << -> middleware { middleware.insert_before(...) }
       end
-      ruby2_keywords(:insert_before) if respond_to?(:ruby2_keywords, true)
 
       alias :insert :insert_before
 
-      def insert_after(*args, &block)
-        @operations << -> middleware { middleware.insert_after(*args, &block) }
-      end
-      ruby2_keywords(:insert_after) if respond_to?(:ruby2_keywords, true)
-
-      def swap(*args, &block)
-        @operations << -> middleware { middleware.swap(*args, &block) }
-      end
-      ruby2_keywords(:swap) if respond_to?(:ruby2_keywords, true)
-
-      def use(*args, &block)
-        @operations << -> middleware { middleware.use(*args, &block) }
-      end
-      ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
-
-      def delete(*args, &block)
-        @delete_operations << -> middleware { middleware.delete(*args, &block) }
+      def insert_after(...)
+        @operations << -> middleware { middleware.insert_after(...) }
       end
 
-      def move_before(*args, &block)
-        @delete_operations << -> middleware { middleware.move_before(*args, &block) }
+      def swap(...)
+        @operations << -> middleware { middleware.swap(...) }
+      end
+
+      def use(...)
+        @operations << -> middleware { middleware.use(...) }
+      end
+
+      def delete(...)
+        @delete_operations << -> middleware { middleware.delete(...) }
+      end
+
+      def move_before(...)
+        @delete_operations << -> middleware { middleware.move_before(...) }
       end
 
       alias :move :move_before
 
-      def move_after(*args, &block)
-        @delete_operations << -> middleware { middleware.move_after(*args, &block) }
+      def move_after(...)
+        @delete_operations << -> middleware { middleware.move_after(...) }
       end
 
-      def unshift(*args, &block)
-        @operations << -> middleware { middleware.unshift(*args, &block) }
+      def unshift(...)
+        @operations << -> middleware { middleware.unshift(...) }
       end
-      ruby2_keywords(:unshift) if respond_to?(:ruby2_keywords, true)
 
       def merge_into(other) #:nodoc:
         (@operations + @delete_operations).each do |operation|


### PR DESCRIPTION
Now that Rails 7.0 target Ruby 2.7, there are some cases were `...` can be used. It's still a very limited language feature, as it can only forward all the parameters (it's a bit improved in 3.0) and only in `def` methods (no `define_methods`).

cc @kamipo since you introduced most of the `ruby2_keywords` calls.

@rafaelfranca @etiennebarrie @adrianna-chang-shopify 

As for the other uses of `ruby2_keywords`, I believe they could be removed as well since when you target 2.7+ `**kwargs` is no longer ambiguous. 