### PR TITLE
[skip-ci] Add documentation to HashWithIndifferentAccess#except

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -295,6 +295,10 @@ module ActiveSupport
       super(convert_key(key))
     end
 
+    # Returns a hash with indifferent access that includes everything except given keys.
+    #   hash = { a: "x", b: "y", c: 10 }.with_indifferent_access
+    #   hash.except(:a, "b") # => {c: 10}.with_indifferent_access
+    #   hash                 # => { a: "x", b: "y", c: 10 }.with_indifferent_access
     def except(*keys)
       slice(*self.keys - keys.map { |key| convert_key(key) })
     end


### PR DESCRIPTION
### Summary

https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html#method-i-except
Currently `HashWithIndifferentAccess#except` has no documentation.
Since it's behavior is different from `Hash#except`, it deserves its own documentation.

There are some other methods in HWIA without documentations, and some others which have small documentations and code examples such as `dig`.
I'm not sure if it's a good idea to document all these methods. If it is, I could add documentations to them in this PR.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

I noticed `HashWithIndifferentAccess#except` can be refactored using `super` to be able to call Ruby's own `except` method added in 3.0.
I'll send another PR to do so if it's worth. 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
