### PR TITLE
Fix current_page? with kwargs

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -388,7 +388,8 @@ module ActionView
       #        end
       #     %>
       def link_to_unless_current(name, options = {}, html_options = {}, &block)
-        link_to_unless current_page?(options), name, options, html_options, &block
+        is_current_page = options.is_a?(Hash) ? current_page?(**options) : current_page?(options)
+        link_to_unless is_current_page, name, options, html_options, &block
       end
 
       # Creates a link tag of the given +name+ using a URL created by the set of

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -550,20 +550,20 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_current_page_with_http_head_method
     @request = request_for_url("/", method: :head)
-    assert current_page?(url_hash)
+    assert current_page?(**url_hash)
     assert current_page?("http://www.example.com/")
   end
 
   def test_current_page_with_simple_url
     @request = request_for_url("/")
-    assert current_page?(url_hash)
+    assert current_page?(**url_hash)
     assert current_page?("http://www.example.com/")
   end
 
   def test_current_page_ignoring_params
     @request = request_for_url("/?order=desc&page=1")
 
-    assert current_page?(url_hash)
+    assert current_page?(**url_hash)
     assert current_page?("http://www.example.com/")
   end
 
@@ -571,7 +571,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     @request = request_for_url("/?order=desc&page=1")
 
     assert_not current_page?(url_hash, check_parameters: true)
-    assert_not current_page?(url_hash.merge(check_parameters: true))
+    assert_not current_page?(**url_hash.merge(check_parameters: true))
     assert_not current_page?(ActionController::Parameters.new(url_hash.merge(check_parameters: true)).permit!)
     assert_not current_page?("http://www.example.com/", check_parameters: true)
   end
@@ -591,7 +591,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_with_params_that_match
     @request = request_for_url("/?order=desc&page=1")
 
-    assert current_page?(hash_for(order: "desc", page: "1"))
+    assert current_page?(**hash_for(order: "desc", page: "1"))
     assert current_page?("http://www.example.com/?order=desc&page=1")
   end
 
@@ -604,13 +604,13 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_with_escaped_params
     @request = request_for_url("/category/administra%c3%a7%c3%a3o")
 
-    assert current_page?({ controller: "foo", action: "category", category: "administração" })
+    assert current_page?(controller: "foo", action: "category", category: "administração")
   end
 
   def test_current_page_with_escaped_params_with_different_encoding
     @request = request_for_url("/")
     @request.stub(:path, (+"/category/administra%c3%a7%c3%a3o").force_encoding(Encoding::ASCII_8BIT)) do
-      assert current_page?({ controller: "foo", action: "category", category: "administração" })
+      assert current_page?(controller: "foo", action: "category", category: "administração")
       assert current_page?("http://www.example.com/category/administra%c3%a7%c3%a3o")
     end
   end
@@ -618,7 +618,7 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_current_page_with_double_escaped_params
     @request = request_for_url("/category/administra%c3%a7%c3%a3o?callback_url=http%3a%2f%2fexample.com%2ffoo")
 
-    assert current_page?({ controller: "foo", action: "category", category: "administração", callback_url: "http://example.com/foo" })
+    assert current_page?(controller: "foo", action: "category", category: "administração", callback_url: "http://example.com/foo")
   end
 
   def test_current_page_with_trailing_slash


### PR DESCRIPTION
### Summary

The following warnings in the test log have been suppressed

```
rails/actionview/test/template/url_helper_test.rb:574: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:607: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:559: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:553: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:566: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:594: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/lib/action_view/helpers/url_helper.rb:391: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:621: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
rails/actionview/test/template/url_helper_test.rb:613: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails/actionview/lib/action_view/helpers/url_helper.rb:548: warning: The called method `current_page?' is defined here
```