### PR TITLE
Use latest stable gem version for bug report templates

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.1.0"
+  gem "rails", "6.1.3"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.1.0"
+  gem "rails", "6.1.3"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_job_gem.rb
+++ b/guides/bug_report_templates/active_job_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activejob", "6.1.0"
+  gem "activejob", "6.1.3"
 end
 
 require "minitest/autorun"

--- a/guides/bug_report_templates/active_record_gem.rb
+++ b/guides/bug_report_templates/active_record_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "6.1.0"
+  gem "activerecord", "6.1.3"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_record_migrations_gem.rb
+++ b/guides/bug_report_templates/active_record_migrations_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activerecord", "6.1.0"
+  gem "activerecord", "6.1.3"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.1.0"
+  gem "rails", "6.1.3"
   gem "sqlite3"
 end
 

--- a/guides/bug_report_templates/generic_gem.rb
+++ b/guides/bug_report_templates/generic_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "activesupport", "6.1.0"
+  gem "activesupport", "6.1.3"
 end
 
 require "active_support"


### PR DESCRIPTION
Using the latest stable gem version which is 6.1.3 in bug report templates. 
or Can we use `Rails.gem_version`