### PR TITLE
Prevent double save of cyclic associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Prevent double saves in autosave of cyclic associations
+
+    Adds a @saving state which tracks if a record is currently being saved.
+    If @saving is set to true, the record won't be saved by the autosave callbacks.
+
+    *Petrik de Heus*
+
 *   Fix Float::INFINITY assignment to datetime column with postgresql adapter
 
     Before:

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -235,7 +235,16 @@ module ActiveRecord
     def reload(options = nil)
       @marked_for_destruction = false
       @destroyed_by_association = nil
+      @saving = false
       super
+    end
+
+    def save(**options) # :nodoc
+      saving { super }
+    end
+
+    def save!(**options) # :nodoc:
+      saving { super }
     end
 
     # Marks this record to be destroyed as part of the parent's save transaction.
@@ -273,7 +282,26 @@ module ActiveRecord
       new_record? || has_changes_to_save? || marked_for_destruction? || nested_records_changed_for_autosave?
     end
 
+    # Returns whether or not this record is already being saved outside of the
+    # current autosave callback
+    def saving?
+      @saving
+    end
+
+    def can_save? #:nodoc:
+      !destroyed? && !saving?
+    end
+
     private
+      # Track if this record is being saved. If it is being saved we
+      # can skip saving it in the autosave callbacks
+      def saving
+        previously_saving, @saving = @saving, true
+        yield
+      ensure
+        @saving = previously_saving
+      end
+
       # Returns the record for an association collection that should be validated
       # or saved. If +autosave+ is +false+ only new records will be returned,
       # unless the parent is/was a new record itself.
@@ -400,7 +428,7 @@ module ActiveRecord
             end
 
             records.each do |record|
-              next if record.destroyed?
+              next unless record.can_save?
 
               saved = true
 
@@ -437,7 +465,7 @@ module ActiveRecord
         association = association_instance_get(reflection.name)
         record      = association && association.load_target
 
-        if record && !record.destroyed?
+        if record&.can_save?
           autosave = reflection.options[:autosave]
 
           if autosave && record.marked_for_destruction?
@@ -482,7 +510,7 @@ module ActiveRecord
         return unless association && association.loaded? && !association.stale_target?
 
         record = association.load_target
-        if record && !record.destroyed?
+        if record&.can_save?
           autosave = reflection.options[:autosave]
 
           if autosave && record.marked_for_destruction?

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -812,6 +812,7 @@ module ActiveRecord
         @previously_new_record    = false
         @destroyed                = false
         @marked_for_destruction   = false
+        @saving                   = false
         @destroyed_by_association = nil
         @_start_transaction_state = nil
         @strict_loading           = self.class.strict_loading_by_default

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -404,6 +404,7 @@ module ActiveRecord
               attr = attr.with_value_from_user(value) if attr.value != value
               attr
             end
+            @saving = false
             @mutations_from_database = nil
             @mutations_before_last_save = nil
             if @attributes.fetch_value(@primary_key) != restore_state[:id]

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1556,7 +1556,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     fall.sections << sections
     fall.save!
     fall.reload
-    assert_equal sections, fall.sections.sort_by(&:id)
+    assert_equal sections.sort_by(&:id), fall.sections.sort_by(&:id)
   end
 
   private

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1951,3 +1951,75 @@ class TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAcceptsNe
     assert_equal "Updated", valid_project.name
   end
 end
+
+class TestCyclicAutosaveAssociationsOnlySaveOnce < ActiveRecord::TestCase
+  teardown do
+    $autosave_saving_stack = []
+  end
+
+  test "child is saved only once if child is the inverse has_one of parent" do
+    ship_reflection = Ship.reflect_on_association(:pirate)
+    pirate_reflection = Pirate.reflect_on_association(:ship)
+    assert_equal ship_reflection, pirate_reflection.inverse_of, "The pirate reflection's inverse should be the ship reflection"
+
+    child = Ship.new(name: "Nights Dirty Lightning")
+    parent = child.build_pirate(catchphrase: "Aye")
+    child.save!
+    assert child.previously_new_record?
+    assert parent.previously_new_record?
+  end
+
+  test "child is saved only once if child is an inverse has_many of parent" do
+    child = FamousShip.new(name: "Poison Orchid")
+    parent = child.build_famous_pirate(catchphrase: "Aye")
+    child.save!
+    assert child.previously_new_record?
+    assert parent.previously_new_record?
+  end
+
+  test "similar children are saved in the autosave" do
+    child1 = FamousShip.new(name: "Poison Orchid")
+    parent = child1.build_famous_pirate(catchphrase: "Aye")
+    child2 = parent.famous_ships.build(name: "Red Messenger")
+    child1.save!
+    assert child2.persisted?
+    assert child1.previously_new_record?
+    assert parent.previously_new_record?
+    assert_equal [child2, child1], parent.reload.famous_ships
+  end
+
+  test "parent is saved only once" do
+    child = Ship.new(name: "Nights Dirty Lightning")
+    parent = child.build_pirate(catchphrase: "Aye")
+    parent.save!
+    assert child.previously_new_record?
+    assert parent.previously_new_record?
+  end
+
+  test "saving? is reset to false if validations fail" do
+    child = Ship.new(name: "Nights Dirty Lightning")
+    child.build_pirate
+    assert_not child.save
+    assert_not_predicate child, :saving?
+  end
+
+  test "saving? is set to false after multiple nested saves" do
+    ship_with_saving_stack = Class.new(Ship) do
+      before_save { $autosave_saving_stack << saving? }
+      after_save  { $autosave_saving_stack << saving? }
+    end
+
+    pirate_with_callbacks = Class.new(Pirate) do
+      after_save   { ship.save }
+      after_create { ship.save }
+      after_commit { ship.save }
+    end
+
+    child = ship_with_saving_stack.new(name: "Nights Dirty Lightning")
+    child.pirate = pirate_with_callbacks.new(catchphrase: "Aye")
+    $autosave_saving_stack = []
+    child.save!
+    assert_equal [true] * 8, $autosave_saving_stack
+    assert_equal false, child.saving?
+  end
+end


### PR DESCRIPTION
### Summary

Autosave will double save records with cyclic associations.

For example: a child record with a parent association.
If save is called on the child before the parent has been saved,
the child will be saved twice.
The double save of the child will clear the mutation tracker on
the child record resulting in an incorrect dirty state.

```
    # pirate has_one ship
    ship = Ship.new(name: "Nights Dirty Lightning")
    pirate = ship.build_pirate(catchphrase: "Aye")
    ship.save!
    ship.previous_changes # => returns {} but this should contain the changes.
```

When saving ship currently the following happens:
1. the `before_save` callbacks of the **ship** are called
2. the callbacks call `autosave_associated_records_for_pirate`
3. `autosave_associated_records_for_pirate` saves the **pirate**
4. the `after_save` callbacks of the **pirate** are called
5. the callbacks call `autosave_associated_records_for_ship`
6. `autosave_associated_records_for_ship` saves the **ship**
7. the **ship** is saved again by the original save

`autosave_associated_records_for_ship` saves the ship because the ship
association is set by inverse_of in a `has_one` on the pirate. This does
not happen with a `has_many` by default because the inverse is not set.
If setting the inverse on the `has_many` the problem occurs as well.

This commit adds a `@saving` state which tracks if a record is currently being saved.
If `@saving` is set to true, the record won't be saved by the autosave callbacks.

With this commit the following happens when saving a ship:
1. `@saving` is set to true on **ship**
2. the `before_save` callbacks of the **ship** are called
3. the callbacks call `autosave_associated_records_for_pirate`
5. `autosave_associated_records_for_pirate` saves the **pirate**
6. the `after_save` callbacks of the **pirate** are called
6. `autosave_associated_records_for_ship` skips saving the **ship**
8. the **ship** is saved.
9. `@saving` is set to false on ship

### Other Information

When the child is not saved in the autosave, similar children could be autosaved.
This could result in unexpected order when creating new records, as similar
children will be saved first.

Fixes #35597.
This is a reopening of #36362 which was closed but can't be reopened
because the `master` branch no longer exists.
