### PR TITLE
Fix Float::INFINITY assignment to datetime attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Fix Float::INFINITY assignment to datetime column with postgresql adapter
+
+    Before:
+
+    ```ruby
+    # With this config
+    ActiveRecord::Base.time_zone_aware_attributes = true
+
+    # and the following schema:
+    create_table "postgresql_infinities" do |t|
+      t.datetime "datetime"
+    end
+
+    # This test fails
+    record = PostgresqlInfinity.create!(datetime: Float::INFINITY)
+    assert_equal Float::INFINITY, record.datetime # record.datetime gets nil
+    ```
+
+    After this commit, `record.datetime` gets `Float::INFINITY` as expected.
+
+    *Shunichi Ikegami*
+
 *   Type cast enum values by the original attribute type.
 
     The notable thing about this change is that unknown labels will no longer match 0 on MySQL.

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -19,6 +19,8 @@ module ActiveRecord
 
           if value.is_a?(Hash)
             set_time_zone_without_conversion(super)
+          elsif value == ::Float::INFINITY || value == -::Float::INFINITY
+            value
           elsif value.respond_to?(:in_time_zone)
             begin
               super(user_input_in_time_zone(value)) || super

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -72,7 +72,14 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
 
   test "assigning 'infinity' on a datetime column with TZ aware attributes" do
     in_time_zone "Pacific Time (US & Canada)" do
+      # reset_column_information should be called to recrate types with TimeZoneConverter
+      PostgresqlInfinity.reset_column_information
+
       record = PostgresqlInfinity.create!(datetime: "infinity")
+      assert_equal Float::INFINITY, record.datetime
+      assert_equal record.datetime, record.reload.datetime
+
+      record = PostgresqlInfinity.create!(datetime: Float::INFINITY)
       assert_equal Float::INFINITY, record.datetime
       assert_equal record.datetime, record.reload.datetime
     end


### PR DESCRIPTION
### Summary

After assigning string `"infinity"` to datetime attribute with postgresql adapter, reading it back gets `Float::INFINITY`.
But assigning `Float::INFINITY` to datetime attribute results in getting `nil` value when `ActiveRecord::Base.time_zone_aware_attributes` is true.
This is due to `TimeZoneConverter` not handling `Float::INFINITY` appropriately.

```ruby
# With this config
ActiveRecord::Base.time_zone_aware_attributes = true

# and the following schema:
create_table "postgresql_infinities" do |t|
  t.datetime "datetime"
end

# This test fails
record = PostgresqlInfinity.create!(datetime: Float::INFINITY)
assert_equal Float::INFINITY, record.datetime # record.datetime gets nil
```

### Other Information

Before this commit, the timezone aware infinity test was executed without `TimeZoneConverter` and it does not test anything.
So I added `reset_column_information` to recreate types with `TimeZoneConverter`.
