### PR TITLE
Add accepts_nested_attributes_for support for delegated_type

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Add nested_attributes_for support for `delegated_type`
+
+    ```ruby
+    class Entry < ApplicationRecord
+      delegated_type :entryable, types: %w[ Message Comment ]
+      accepts_nested_attributes_for :entryable
+    end
+
+    entry = Entry.create(entryable_type: 'Message', entryable_attributes: { content: 'Hello world' })
+    # => #<Entry:0x00>
+    # id: 1
+    # entryable_id: 1,
+    # entryable_type: 'Message'
+    # ...>
+
+    entry.entryable
+    # => #<Message:0x01>
+    # id: 1
+    # content: 'Hello world'
+    # ...>
+    ```
+
+    Previously it would raise an error:
+
+    ```ruby
+    Entry.create(entryable_type: 'Message', entryable_attributes: { content: 'Hello world' })
+    # ArgumentError: Cannot build association `entryable'. Are you trying to build a polymorphic one-to-one association?
+    ```
+
+    *Sjors Baltus*
+
 *   Use subquery for DELETE with GROUP_BY and HAVING clauses.
 
     Prior to this change, deletes with GROUP_BY and HAVING were returning an error.

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -137,6 +137,21 @@ module ActiveRecord
   #   end
   #
   # Now you can list a bunch of entries, call +Entry#title+, and polymorphism will provide you with the answer.
+  #
+  # == Nested Attributes
+  #
+  # Enabling nested attributes on a delegated_type association allows you to
+  # create the entry and message in one go:
+  #
+  #   class Entry < ApplicationRecord
+  #     delegated_type :entryable, types: %w[ Message Comment ]
+  #     accepts_nested_attributes_for :entryable
+  #   end
+  #
+  #   params = { entry: { entryable_type: 'Message', entryable_attributes: { subject: 'Smiling' } } }
+  #   entry = Entry.create(params[:entry])
+  #   entry.entryable.id # => 2
+  #   entry.entryable.subject # => 'Smiling'
   module DelegatedType
     # Defines this as a class that'll delegate its type for the passed +role+ to the class references in +types+.
     # That'll create a polymorphic +belongs_to+ relationship to that +role+, and it'll add all the delegated
@@ -205,6 +220,10 @@ module ActiveRecord
 
         define_method "#{role}_name" do
           public_send("#{role}_class").model_name.singular.inquiry
+        end
+
+        define_method "build_#{role}" do |*params|
+          public_send("#{role}=", public_send("#{role}_class").new(*params))
         end
 
         types.each do |type|

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -72,4 +72,9 @@ class DelegatedTypeTest < ActiveRecord::TestCase
     assert_equal @uuid_entry_with_comment.entryable_uuid, @uuid_entry_with_comment.uuid_comment_uuid
     assert_nil @uuid_entry_with_comment.uuid_message_uuid
   end
+
+  test "builder method" do
+    assert_respond_to Entry.new, :build_entryable
+    assert_equal Message, Entry.new(entryable_type: "Message").build_entryable.class
+  end
 end

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -11,6 +11,8 @@ require "models/human"
 require "models/interest"
 require "models/owner"
 require "models/pet"
+require "models/entry"
+require "models/message"
 require "active_support/hash_with_indifferent_access"
 
 class TestNestedAttributesInGeneral < ActiveRecord::TestCase
@@ -1115,5 +1117,17 @@ class TestNestedAttributesWithExtend < ActiveRecord::TestCase
     pirate = Pirate.create!(catchphrase: "Don' botharrr talkin' like one, savvy?")
     pirate.treasures_attributes = [{ id: nil }]
     assert_equal "from extension", pirate.treasures[0].name
+  end
+end
+
+class TestNestedAttributesForDelegatedType < ActiveRecord::TestCase
+  setup do
+    Entry.accepts_nested_attributes_for :entryable
+    @entry = Entry.new(entryable_type: "Message", entryable_attributes: { subject: "Hello world!" })
+  end
+
+  def test_should_build_a_new_record_based_on_the_delegated_type
+    assert_not_predicate @entry.entryable, :persisted?
+    assert_equal "Hello world!", @entry.entryable.subject
   end
 end


### PR DESCRIPTION
### Summary

This PR adds `nested_attributes_for` support to `delegated_type`, this allows a developer to create and update records easily without needing to write specific methods like:

```ruby
class Entry < ApplicationRecord
  delegated_type :entryable, types: %w[ Message Comment ]

  def self.create_with_comment(content, creator: Current.user)
    create! entryable: Comment.new(content: content), creator: creator
  end
end
```

Using `nested_attributes_for` allows to execute the following:

```ruby
class Entry < ApplicationRecord
  delegated_type :entryable, types: %w[ Message Comment ]
  accepts_nested_attributes_for :entryable
end

params = { entry: { entryable_type: 'Comment', entryable_attributes: { content: 'Smiling' } } }
entry = Entry.create(params[:entry])
```

### Why

Nested forms based on `accepts_nested_attributes_for` are very powerful and this is the last piece missing to also be able to use it on Delegated Types.

### Question

Since this is a polymorphic `belongs_to` relationship, what other tests would we like to have? As it is already tested in `TestNestedAttributesOnABelongsToAssociation`