### PR TITLE
Add setting for enumerating column names in SELECT statements

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,43 @@
+*   Add setting for enumerating column names in SELECT statements.
+
+    Adding a column to a Postgres database while the application is running can
+    change the result of wildcard `SELECT *` queries, which invalidates the result
+    of cached prepared statements and raises a PreparedStatementCacheExpired error.
+
+    When truthy, ActiveRecord will avoid wildcards and always include column names
+    in `SELECT` queries, which will return consistent results and avoid prepared
+    statement errors.
+
+    Before:
+
+    ```ruby
+    Book.limit(5)
+    # SELECT * FROM books LIMIT 5
+    ```
+
+    After:
+
+    ```ruby
+    # config/application.rb
+    module MyApp
+      class Application < Rails::Application
+        config.active_record.enumerate_columns_in_select_statements = true
+      end
+    end
+
+    # or, configure per-model
+    class Book < ApplicationRecord
+      self.enumerate_columns_in_select_statements = true
+    end
+    ```
+
+    ```ruby
+    Book.limit(5)
+    # SELECT id, author_id, name, format, status, language, etc FROM books LIMIT 5
+    ```
+
+    *Matt Duszynski*
+
 *   Only update dirty attributes once for cyclic autosave callbacks.
 
     Instead of calling `changes_applied` everytime `save` is called,

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -129,6 +129,14 @@ module ActiveRecord
       # for multiple databases.
       mattr_accessor :suppress_multiple_database_warning, instance_writer: false, default: false
 
+      ##
+      # :singleton-method:
+      # Force enumeration of all columns in SELECT statements
+      # e.g. `SELECT first_name, last_name FROM ...` instead of `SELECT * FROM ...`
+      # This avoids PreparedStatementCacheExpired errors when a column is added
+      # to a Postgres database while the app is running.
+      class_attribute :enumerate_columns_in_select_statements, instance_accessor: false, default: false
+
       mattr_accessor :maintain_test_schema, instance_accessor: false
 
       class_attribute :belongs_to_required_by_default, instance_accessor: false

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1390,7 +1390,7 @@ module ActiveRecord
       def build_select(arel)
         if select_values.any?
           arel.project(*arel_columns(select_values))
-        elsif klass.ignored_columns.any?
+        elsif klass.ignored_columns.any? || klass.enumerate_columns_in_select_statements
           arel.project(*klass.column_names.map { |field| table[field] })
         else
           arel.project(table[Arel.star])

--- a/activerecord/test/cases/relation/select_test.rb
+++ b/activerecord/test/cases/relation/select_test.rb
@@ -77,5 +77,15 @@ module ActiveRecord
         tags_count indestructible_tags_count tags_with_destroy_count tags_with_nullify_count
       ), posts.first.attributes.keys
     end
+
+    def test_enumerate_columns_in_select_statements
+      original_value = Post.enumerate_columns_in_select_statements
+      Post.enumerate_columns_in_select_statements = true
+      sql = Post.all.to_sql
+      Post.column_names.each do |column_name|
+        assert_includes sql, column_name
+      end
+      Post.enumerate_columns_in_select_statements = original_value
+    end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -473,6 +473,8 @@ in controllers and views. This defaults to `false`.
 
 * `config.active_record.queues.destroy` allows specifying the Active Job queue to use for destroy jobs. When this option is `nil`, purge jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`). It defaults to `nil`.
 
+* `config.active_record.enumerate_columns_in_select_statements` when truthy, will always include column names in `SELECT` statements, and avoid wildcard `SELECT * FROM ...` queries. This avoids prepared statement cache errors when adding columns to a Postgres database. Defaults to `false`.
+
 The MySQL adapter adds one additional configuration option:
 
 * `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans` controls whether Active Record will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
### Summary

Add a new configuration setting `ActiveRecord::Base.enumerate_columns_in_select_statements`. When truthy, ActiveRecord will explicitly project all column names in `SELECT` statements, rather than a wildcard `table_name.*`.

E.g. `SELECT * FROM posts` becomes `SELECT id, title, body, created_at, updated_at FROM posts`

### Other Information

When a column is added to a Postgres table, it changes the query result for any wildcard SELECTs. This causes `PreparedStatementCacheExpired` errors when the statement occurs inside a transaction. https://github.com/rails/rails/pull/22170 cleans up the statement cache, but the error is still raised and will fail the transaction, and probably cause a 500 error, failed background job, etc.

I've seen a few different recommendations on how to handle these:
* [Disable prepared statements entirely](https://stackoverflow.com/questions/57721392/how-can-i-prevent-any-activerecordpreparedstatementcacheexpired-errors-immedia)
* [Rescue the error and explicitly retry the transaction](https://web.archive.org/web/20180429213411/http://samueldavies.net/2017/05/06/how-to-automatically-retry-transactions-instead-of-raising-on-activerecord-preparedstatementcacheexpired/)
* [Turn off prepared statements before deploy, and turn on afterwards](https://github.com/ankane/strong_migrations/issues/85#issuecomment-518977743)
* [Set a "fake" value for `ignored_columns`](https://flexport.engineering/avoiding-activerecord-preparedstatementcacheexpired-errors-4499a4f961cf)

The last option above works because setting any value for `ignored_columns` triggers the code path to project all column names instead of a wildcard, and this is what we're currently using in production.
```ruby
# app/models/application_record.rb
class ApplicationRecord
  self.ignored_columns = [:__fake_column__]
end
```

However, this feels hacky, and isn't how `ignored_columns` is supposed to be used. Adding an option to enable this behavior all the time seems cleaner, and makes it easier to opt-in on a per-model, or per-environment basis.
```ruby
# config/application.rb
module MyApp
  class Application < Rails::Application
    config.active_record.enumerate_columns_in_select_statements = true
  end
end
```

If the code looks good and is agreeable to everyone, I'll make sure to update the [docs](https://guides.rubyonrails.org/configuring.html#configuring-active-record) and add a changelog entry as well.