### PR TITLE
Fixes Action Text specs on Rails 6.1 stable failing after backporting a commit

### DIFF
--- a/actiontext/test/fixtures/action_text/rich_texts.yml
+++ b/actiontext/test/fixtures/action_text/rich_texts.yml
@@ -1,3 +1,8 @@
+hello_alice_message_content:
+  record: hello_alice (Message)
+  name: content
+  body: <p>Hello, <%= ActionText::FixtureSet.attachment("people", :alice) %></p>
+
 hello_world_review_content:
   record: hello_world (Review)
   name: content

--- a/actiontext/test/fixtures/messages.yml
+++ b/actiontext/test/fixtures/messages.yml
@@ -1,2 +1,5 @@
+hello_alice:
+  subject: "A message to Alice"
+
 hello_world:
   subject: "A greeting"

--- a/actiontext/test/fixtures/people.yml
+++ b/actiontext/test/fixtures/people.yml
@@ -1,0 +1,2 @@
+alice:
+  name: "Alice"


### PR DESCRIPTION
PR fixes the test cases failing on Rails 6-1 stable failing after backporting a feature. Related discussion: https://github.com/rails/rails/pull/41284#issuecomment-803842194