### PR TITLE
More detailed docs on singular routing + `form_with`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1306,6 +1306,16 @@ module ActionDispatch
         #   DELETE    /profile
         #   POST      /profile
         #
+        # If you want instances of a model to work with this resource via
+        # record identification (eg. in +form_with+ or +redirect_to+), you
+        # will need to call resolve[rdoc-ref:CustomUrls#resolve]:
+        #
+        #   resource :profile
+        #   resolve('Profile') { [:profile] }
+        #
+        #   # Enables this to work with singular routes:
+        #   form_with(model: @profile) {}
+        #
         # === Options
         # Takes same options as resources[rdoc-ref:#resources]
         def resource(*resources, &block)

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -271,7 +271,7 @@ resources :articles
 
 TIP: Declaring a resource has a number of side effects. See [Rails Routing from the Outside In](routing.html#resource-routing-the-rails-default) guide for more information on setting up and using resources.
 
-When dealing with RESTful resources, calls to `form_with` can get significantly easier if you rely on **record identification**. In short, you can just pass the model instance and have Rails figure out model name and the rest:
+When dealing with RESTful resources, calls to `form_with` can get significantly easier if you rely on **record identification**. In short, you can just pass the model instance and have Rails figure out model name and the rest. In both of these examples, the long and short style have the same outcome:
 
 ```ruby
 ## Creating a new article
@@ -288,6 +288,13 @@ form_with(model: @article)
 ```
 
 Notice how the short-style `form_with` invocation is conveniently the same, regardless of the record being new or existing. Record identification is smart enough to figure out if the record is new by asking `record.persisted?`. It also selects the correct path to submit to, and the name based on the class of the object.
+
+If you have a [singular resource](routing.html#singular-resources), you will need to call `resource` and `resolve` for it to work with `form_with`:
+
+```ruby
+resource :geocoder
+resolve('Geocoder') { [:geocoder] }
+```
 
 WARNING: When you're using STI (single-table inheritance) with your models, you can't rely on record identification on a subclass if only their parent class is declared a resource. You will have to specify `:url`, and `:scope` (the model name) explicitly.
 

--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -198,6 +198,8 @@ A singular resourceful route generates these helpers:
 * `edit_geocoder_path` returns `/geocoder/edit`
 * `geocoder_path` returns `/geocoder`
 
+NOTE: The call to `resolve` is necessary for converting instances of the `Geocoder` to routes through [record identification](form_helpers.html#relying-on-record-identification).
+
 As with plural resources, the same helpers ending in `_url` will also include the host, port, and path prefix.
 
 ### Controller Namespaces and Routing


### PR DESCRIPTION
Updates docs in 3 places:

- https://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resource
- https://guides.rubyonrails.org/form_helpers.html#relying-on-record-identification
- https://guides.rubyonrails.org/routing.html#singular-resources

To consistently explain how singular routes using `resources` should be set up, so they can work with `form_with`, `redirect_to`, and anything else that uses record identification.

(There's lots of comments below because my original suggestion was to remove the call to `resolve` from the docs, when it turns out it is necessary.)