### PR TITLE
Propose a way to add validation on the enum attribute

### DIFF
--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -506,13 +506,36 @@ class EnumTest < ActiveRecord::TestCase
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Book"; end
       enum status: [:proposed, :written]
-      validates_inclusion_of :status, in: ["written"]
+      validates_inclusion_of :status, in: ["proposed"]
     end
-    klass.delete_all
-    invalid_book = klass.new(status: "proposed")
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: "written")
     assert_not_predicate invalid_book, :valid?
+
+    invalid_book = klass.new(status: nil)
+    assert_not_predicate invalid_book, :valid?
+  end
+
+  test "enum with :validate" do
+    klass = Class.new(ActiveRecord::Base) do
+      def self.name; "Book"; end
+      enum :status, [:proposed, :written], validate: true
+    end
+
+    valid_book = klass.new(status: "proposed")
+    assert_predicate valid_book, :valid?
+
     valid_book = klass.new(status: "written")
     assert_predicate valid_book, :valid?
+
+    invalid_book = klass.new(status: nil)
+    assert_not_predicate invalid_book, :valid?
+
+    invalid_book = klass.new(status: "unknown")
+    assert_not_predicate invalid_book, :valid?
   end
 
   test "enums are distinct per class" do


### PR DESCRIPTION
Last year, I heard about the inconveniences of ActiveRecord Enum and got
some feedback (one of those is #40456).

Some people have reported that in practice they are using enums for user
input and it is inconvenient to not be able to handle invalid input with
validation like other attributes.

Actually, a former colleague was overriding the attribute writer for
validation, and they had wished this inconvenience to be resolved in the
Rails.

So I propose a way to add validation on the enum attribute. This allows
people to no longer need to override the attribute writer.

Before:

```ruby
class Book < ActiveRecord::Base
  enum :status, [:proposed, :written]

  validates_inclusion_of :status, in: statuses.keys

  def status=(value)
    super
  rescue ArgumentError
    @attributes.write_cast_value("status", value)
  end
end
```

After:

```ruby
class Book < ActiveRecord::Base
  enum :status, [:proposed, :written], validate: true
end
```

Resolves #13971.
