### PR TITLE
Batch queries that are the same but are using different extension

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -15,11 +15,11 @@ module ActiveRecord
           def eql?(other)
             association_key_name == other.association_key_name &&
               scope.table_name == other.scope.table_name &&
-              scope.values == other.scope.values
+              scope.values_for_queries == other.scope.values_for_queries
           end
 
           def hash
-            [association_key_name, scope.table_name, scope.values].hash
+            [association_key_name, scope.table_name, scope.values_for_queries].hash
           end
 
           def records_for(loaders)

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -776,6 +776,10 @@ module ActiveRecord
       @values.dup
     end
 
+    def values_for_queries # :nodoc:
+      @values.except(:extending, :skip_query_cache, :strict_loading)
+    end
+
     def inspect
       subject = loaded? ? records : annotate("loading for inspect")
       entries = subject.take([limit_value, 11].compact.min).map!(&:inspect)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -530,6 +530,27 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_groups_queries_with_same_sql_at_second_level
+    author = nil
+
+    # Expected
+    #   SELECT FROM authors ...
+    #   SELECT FROM posts ... (thinking)
+    #   SELECT FROM posts ... (welcome)
+    #   SELECT FROM comments ... (comments for both welcome and thinking)
+    assert_queries(4) do
+      author = Author
+        .where(name: "David")
+        .includes(thinking_posts: :comments, welcome_posts: :comments_with_extending)
+        .first
+    end
+
+    assert_no_queries do
+      author.thinking_posts.map(&:comments)
+      author.welcome_posts.map(&:comments_with_extending)
+    end
+  end
+
   def test_preload_with_grouping_sets_inverse_association
     mary = authors(:mary)
     bob = authors(:bob)

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -85,6 +85,8 @@ class Post < ActiveRecord::Base
     end
   end
 
+  has_many :comments_with_extending, -> { extending(NamedExtension) }, class_name: "Comment", foreign_key: "post_id"
+
   has_many :comments_with_extend_2, extend: [NamedExtension, NamedExtension2], class_name: "Comment", foreign_key: "post_id"
 
   has_many :author_favorites, through: :author


### PR DESCRIPTION
If an association scope would generate the same query but have different values for `extending`, `skip_query_cache` or `strict_loading` we should consider them the same for the purpose of generating the preload batches.