### PR TITLE
remove unecessary sufix

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -44,7 +44,7 @@ views.
 #### Create the Mailer
 
 ```bash
-$ bin/rails generate mailer UserMailer
+$ bin/rails generate mailer User
 create  app/mailers/user_mailer.rb
 create  app/mailers/application_mailer.rb
 invoke  erb


### PR DESCRIPTION
Removing the unnecessary suffix from the documentation, if used it will create with the duplicate name mailer in the folder views, example:

app/views/user_mailer_mailer