### PR TITLE
Use triple-dot delegation in ForkTracker

### DIFF
--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -3,7 +3,7 @@
 module ActiveSupport
   module ForkTracker # :nodoc:
     module CoreExt
-      def fork(*)
+      def fork(...)
         if block_given?
           super do
             ForkTracker.check!
@@ -22,7 +22,7 @@ module ActiveSupport
       include CoreExt
 
       private
-        def fork(*)
+        def fork(...)
           super
         end
     end


### PR DESCRIPTION
We're using https://github.com/ko1/nakayoshi_fork which redefine `fork` to take keyword arguments.

So the current `*` signature cause problem on Ruby 3.0.

```
gems/nakayoshi_fork-0.0.4/lib/nakayoshi_fork.rb:5:in `fork': wrong number of arguments (given 1, expected 0) (ArgumentError)
    from bundler/gems/rails-62958da8a41c/activesupport/lib/active_support/fork_tracker.rb:8:in `fork'
    from bundler/gems/rails-62958da8a41c/activesupport/lib/active_support/fork_tracker.rb:26:in `fork'
```

cc @rafaelfranca @kamipo @etiennebarrie 