### PR TITLE
Fix keyword args delegation in ForkTracker (6.1 backport)

### DIFF
--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -16,6 +16,7 @@ module ActiveSupport
           pid
         end
       end
+      ruby2_keywords(:fork) if respond_to?(:ruby2_keywords, true)
     end
 
     module CoreExtPrivate
@@ -25,6 +26,7 @@ module ActiveSupport
         def fork(*)
           super
         end
+        ruby2_keywords(:fork) if respond_to?(:ruby2_keywords, true)
     end
 
     @pid = Process.pid


### PR DESCRIPTION
This is the 6.1 backport of https://github.com/rails/rails/pull/41737

We're using https://github.com/ko1/nakayoshi_fork which redefine `fork` to take keyword arguments.

So the current `*` signature cause problem on Ruby 3.0.

```
gems/nakayoshi_fork-0.0.4/lib/nakayoshi_fork.rb:5:in `fork': wrong number of arguments (given 1, expected 0) (ArgumentError)
    from bundler/gems/rails-62958da8a41c/activesupport/lib/active_support/fork_tracker.rb:8:in `fork'
    from bundler/gems/rails-62958da8a41c/activesupport/lib/active_support/fork_tracker.rb:26:in `fork'
```

cc @rafaelfranca @kamipo @etiennebarrie 