### PR TITLE
ActiveRecord: Optimize cache_key computation

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -369,9 +369,8 @@ module ActiveRecord
         select_values = "COUNT(*) AS #{connection.quote_column_name("size")}, MAX(%s) AS timestamp"
 
         if collection.has_limit_or_offset?
-          query = collection.spawn
-          query = query.select(table[Arel.star]) if distinct_value && query.select_values.empty?
-          query = query.select("#{column} AS collection_cache_key_timestamp")
+          query = collection.select("#{column} AS collection_cache_key_timestamp")
+          query._select!(table[Arel.star]) if distinct_value && collection.select_values.empty?
           subquery_alias = "subquery_for_cache_key"
           subquery_column = "#{subquery_alias}.collection_cache_key_timestamp"
           arel = query.build_subquery(subquery_alias, select_values % subquery_column)

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -171,6 +171,7 @@ module ActiveRecord
       developers = Developer.distinct.order(:salary).limit(5)
 
       assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+      assert_not_predicate developers, :loaded?
     end
 
     test "cache_key with a relation having custom select and order" do


### PR DESCRIPTION
While a request optimization, we added a cache, but it wasn't as fast as we hoped. It turned out that queries with `distinct_value` are executed while cache key computation. This PR addresses this performance issue.