### PR TITLE
Stop executing perform method when retry_job is called

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Stop executing perform method when `retry_job` is called
+
+    The `perform` method can now be automatically interrupted if `retry_job`
+    is called, preventing weird states where a job continues to execute after
+    it has been re-enqueued.
+
+    *Daniel Morton*
+
 *   Communicate enqueue failures to callers of `perform_later`.
 
     `perform_later` can now optionally take a block which will execute after

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -56,6 +56,9 @@ module ActiveJob
       def _perform_job
         run_callbacks :perform do
           perform(*arguments)
+        rescue ActiveJob::Exceptions::RetryInvokedError => e
+          # Allows execution of perform to be halted but prevents RetryInvokedError from bubbling up any further
+          e.enqueue_result
         end
       end
   end

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -2,6 +2,7 @@
 
 require "helper"
 require "jobs/retry_job"
+require "jobs/halt_on_retry_job"
 require "models/person"
 require "minitest/mock"
 
@@ -323,6 +324,14 @@ class ExceptionsTest < ActiveSupport::TestCase
     end
 
     assert_equal ["Raised DefaultsError for the 5th time"], JobBuffer.values
+  end
+
+  test "job stops executing perform method after calling retry_job if configured to do so" do
+    HaltOnRetryJob.perform_later
+    assert_equal 3, JobBuffer.values.count
+    assert_equal "Executing before retry_job was called", JobBuffer.values[0]
+    assert_equal "Executing before retry_job was called", JobBuffer.values[1]
+    assert_equal "Job complete", JobBuffer.values[2]
   end
 
   private

--- a/activejob/test/jobs/halt_on_retry_job.rb
+++ b/activejob/test/jobs/halt_on_retry_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../support/job_buffer"
+
+class HaltOnRetryJob < ActiveJob::Base
+  abort_perform_on_retry true
+
+  def perform
+    JobBuffer.add("Executing before retry_job was called")
+    if executions < 2
+      retry_job
+      JobBuffer.add("Executing after retry_job was called")
+    end
+    JobBuffer.add("Job complete")
+  end
+end


### PR DESCRIPTION
While `retry_job` would normally be expected to be called by the framework
itself (in response to `retry_on` being configured for example) or possibly by
a library like `job-iteration` that breaks up jobs into smaller units of work,
it is possible that a job itself could choose to call `retry_job`. If this
call to `retry_job` is not the final statement executed by the job, the job
would enter a strange state where it has been re-enqueued for retry and also
continues to execute. The remainder of that execution could result in an
exception being raised that also could cause the job to be re-enqueued.

It seems like this is generally undesirable and unexpected.

This PR adds the ability to configure a job to abort the execution of its
`perform` method when `retry_job` is called (via raising an exception that
is caught and ignored one level above the `perform` call):

    # typed: true
    # frozen_string_literal: true
    class HaltRetryJob < ActiveJob::Base
      queue_as :low
      abort_perform_on_retry true

      def perform(params)
        execute_some_code

        retry_job

        # this will not be called if `abort_perform_on_retry true` is set
        some_other_code
      end
    end

Perhaps after a deprecation cycle, aborting the execution of the `perform`
method could become the default option rather than something that is opted-in
to.