### PR TITLE
[ci skip] Fix SQL result of `Book.joins(reviews: :customer)` query example 

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1254,8 +1254,8 @@ This produces:
 
 ```sql
 SELECT books.* FROM books
-  INNER JOIN reviews ON reviews.book_id = book.id
-  INNER JOIN customer ON customers.id = reviews.id
+  INNER JOIN reviews ON reviews.book_id = books.id
+  INNER JOIN customers ON customers.id = reviews.customer_id
 ```
 
 Or, in English: "return all books that have a review by a customer."


### PR DESCRIPTION
### Summary

The SQL example for `Book.joins(reviews: :customer)` on the documentation is incorrect.
https://guides.rubyonrails.org/active_record_querying.html#joining-nested-associations-single-level

It should be 
```SQL
SELECT books.* FROM books
  INNER JOIN reviews ON reviews.book_id = books.id
  INNER JOIN customers ON customers.id = reviews.customer_id
```

## Test

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
# require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :reviews, force: true do |t|
    t.belongs_to :book
    t.belongs_to :customer
  end

  create_table :books, force: true do |t|
  end

  create_table :customers, force: true do |t|
  end
end

class Review < ActiveRecord::Base
  belongs_to :book
  belongs_to :customer
end

class Customer < ActiveRecord::Base
  has_many :reviews
end

class Book < ActiveRecord::Base
  has_many :reviews
end

puts Book.joins(reviews: :customer).to_sql
# => SELECT "books".* FROM "books" INNER JOIN "reviews" ON "reviews"."book_id" = "books"."id" INNER JOIN "customers" ON "customers"."id" = "reviews"."customer_id"
```