### PR TITLE
Move @inspection_filter to the class to avoid marshal dumping it

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -466,7 +466,21 @@ module ActiveRecord
       end
 
       # Specifies columns which shouldn't be exposed while calling +#inspect+.
-      attr_writer :filter_attributes
+      def filter_attributes=(filter_attributes)
+        @inspection_filter = nil
+        @filter_attributes = filter_attributes
+      end
+
+      def inspection_filter # :nodoc:
+        if defined?(@filter_attributes)
+          @inspection_filter ||= begin
+            mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
+            ActiveSupport::ParameterFilter.new(@filter_attributes, mask: mask)
+          end
+        else
+          superclass.inspection_filter
+        end
+      end
 
       # Returns a string like 'Post(id:integer, title:string, body:text)'
       def inspect # :nodoc:
@@ -835,10 +849,7 @@ module ActiveRecord
       private_constant :InspectionMask
 
       def inspection_filter
-        @inspection_filter ||= begin
-          mask = InspectionMask.new(ActiveSupport::ParameterFilter::FILTERED)
-          ActiveSupport::ParameterFilter.new(self.class.filter_attributes, mask: mask)
-        end
+        self.class.inspection_filter
       end
   end
 end

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -63,6 +63,13 @@ class FilterAttributesTest < ActiveRecord::TestCase
     assert_includes account.inspect, 'name: "slangis73"'
   end
 
+  test "proc filter_attributes don't prevent marshal dump" do
+    ActiveRecord::Base.filter_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
+    account = Admin::Account.new(name: "37signals")
+    account.inspect
+    Marshal.dump(account)
+  end
+
   test "filter_attributes could be overwritten by models" do
     Admin::Account.all.each do |account|
       assert_includes account.inspect, "name: [FILTERED]"

--- a/activerecord/test/cases/filter_attributes_test.rb
+++ b/activerecord/test/cases/filter_attributes_test.rb
@@ -65,9 +65,9 @@ class FilterAttributesTest < ActiveRecord::TestCase
 
   test "proc filter_attributes don't prevent marshal dump" do
     ActiveRecord::Base.filter_attributes = [ lambda { |key, value| value.reverse! if key == "name" } ]
-    account = Admin::Account.new(name: "37signals")
+    account = Admin::Account.new(id: 123, name: "37signals")
     account.inspect
-    Marshal.dump(account)
+    assert_equal account, Marshal.load(Marshal.dump(account))
   end
 
   test "filter_attributes could be overwritten by models" do


### PR DESCRIPTION
### Problem

When using a Proc in the filter_attributes for an Active Record model, calling `inspect` on an instance (e.g. as done implicitly from the rails console) will cause a Marshal.dump of the record to get the error `TypeError: no _dump_data is defined for class Proc`.

The reason for the error is that the call to `inspect` causes `@inspection_filter` to be set on the instance, which contains the filter_attributes Proc.

This can also be demonstrated with the included regression test without the corresponding change to the code under test, which results in the error

```
FilterAttributesTest#test_proc_filter_attributes_don't_prevent_marshal_dump:
TypeError: no _dump_data is defined for class Proc
    test/cases/filter_attributes_test.rb:70:in `dump'
    test/cases/filter_attributes_test.rb:70:in `block in <class:FilterAttributesTest>'
```

### Solution

The `@inspection_filter` value doesn't have anything that is specific to the instance, so we may as well store it on the class.  That will also make the memoization more effective and avoid bloating the marshal dump of the record in the case where it doesn't contain a Proc.