### PR TITLE
Replace MimeMagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       activerecord (= 7.0.0.alpha)
       activesupport (= 7.0.0.alpha)
       marcel (~> 0.3.1)
-      mimemagic (~> 0.3.2)
+      mime-types (~> 3.3.1)
     activesupport (7.0.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -107,17 +107,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activerecord-jdbc-adapter (61.0-java)
-      activerecord (~> 6.1.0)
-    activerecord-jdbcmysql-adapter (61.0-java)
-      activerecord-jdbc-adapter (= 61.0)
-      jdbc-mysql (~> 5.1.36, < 9)
-    activerecord-jdbcpostgresql-adapter (61.0-java)
-      activerecord-jdbc-adapter (= 61.0)
-      jdbc-postgres (>= 9.4, < 43)
-    activerecord-jdbcsqlite3-adapter (61.0-java)
-      activerecord-jdbc-adapter (= 61.0)
-      jdbc-sqlite3 (~> 3.8, < 3.30)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     amq-protocol (2.3.2)
@@ -296,9 +285,6 @@ GEM
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    jdbc-mysql (5.1.47)
-    jdbc-postgres (42.2.14)
-    jdbc-sqlite3 (3.28.0)
     jmespath (1.4.0)
     json (2.5.1)
     json (2.5.1-java)
@@ -319,6 +305,9 @@ GEM
       mimemagic (~> 0.3.2)
     memoist (0.16.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.5)
     mini_magick (4.11.0)
     mini_mime (1.0.2)
@@ -369,7 +358,6 @@ GEM
     pg (1.2.3)
     pg (1.2.3-x64-mingw32)
     pg (1.2.3-x86-mingw32)
-    psych (3.3.0)
     public_suffix (4.0.6)
     puma (5.1.1)
       nio4r (~> 2.0)
@@ -518,8 +506,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2020.6)
-      tzinfo (>= 1.0.0)
     uber (0.1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -531,7 +517,6 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.6)
       rexml (~> 3.2)
-    wdm (0.1.1)
     webdrivers (4.5.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -638,4 +623,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   2.2.3
+   2.2.15

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord",  version
 
   s.add_dependency "marcel",    "~> 0.3.1"
-  s.add_dependency "mimemagic", "~> 0.3.2"
+  s.add_dependency "mime-types", "~> 3.3.1"
 end

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -110,7 +110,7 @@ module ActiveStorage::Blob::Representable
     end
 
     def format
-      if filename.extension.present? && ::MIME::Types.type_for(filename.extension)&.to_s == content_type
+      if filename.extension.present? && ::MIME::Types.type_for(filename.extension).first&.to_s == content_type
         filename.extension
       else
         ::MIME::Types[content_type].first.extensions.first

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "mimemagic"
+require "mime/types"
 
 module ActiveStorage::Blob::Representable
   extend ActiveSupport::Concern
@@ -110,10 +110,10 @@ module ActiveStorage::Blob::Representable
     end
 
     def format
-      if filename.extension.present? && MimeMagic.by_extension(filename.extension)&.to_s == content_type
+      if filename.extension.present? && ::MIME::Types.type_for(filename.extension)&.to_s == content_type
         filename.extension
       else
-        MimeMagic.new(content_type).extensions.first
+        ::Mime::Types[content_type].first.extensions.first
       end
     end
 

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -113,7 +113,7 @@ module ActiveStorage::Blob::Representable
       if filename.extension.present? && ::MIME::Types.type_for(filename.extension)&.to_s == content_type
         filename.extension
       else
-        ::Mime::Types[content_type].first.extensions.first
+        ::MIME::Types[content_type].first.extensions.first
       end
     end
 

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "mimemagic"
+require "mime/types"
 
 # A set of transformations that can be applied to a blob to create a variant. This class is exposed via
 # the ActiveStorage::Blob#variant method and should rarely be used directly.
@@ -59,14 +59,14 @@ class ActiveStorage::Variation
 
   def format
     transformations.fetch(:format, :png).tap do |format|
-      if MimeMagic.by_extension(format).nil?
+      if ::MIME::Types.type_for(format).nil?
         raise ArgumentError, "Invalid variant format (#{format.inspect})"
       end
     end
   end
 
   def content_type
-    MimeMagic.by_extension(format).to_s
+    ::MIME::Types.type_for(format).to_s
   end
 
   # Returns a signed key for all the +transformations+ that this variation was instantiated with.

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -59,14 +59,14 @@ class ActiveStorage::Variation
 
   def format
     transformations.fetch(:format, :png).tap do |format|
-      if ::MIME::Types.type_for(format).nil?
+      if ::MIME::Types.type_for(format.to_s).blank?
         raise ArgumentError, "Invalid variant format (#{format.inspect})"
       end
     end
   end
 
   def content_type
-    ::MIME::Types.type_for(format).to_s
+    ::MIME::Types.type_for(format.to_s).map(&:simplified).first
   end
 
   # Returns a signed key for all the +transformations+ that this variation was instantiated with.


### PR DESCRIPTION
## Description
Rails depends on this gem for it's mime-type logic when handling files.
This gem however was never MIT compliant and is supposed to be released under the GPL.
Combined with versions being yanked and released as GPL, this is not a viable path for Rails, or downstream services to follow.

For the discussion see: https://github.com/rails/rails/issues/41750

This pull request removes the dependency from Rails directly, and uses another MIT licenses gem to replace the logic where appropriate. The only issue remaining is the `marcel` gem, another dependency that also requires this gem.
I've linked the issue inside the ongoing discussion for that gem [here](https://github.com/basecamp/marcel/issues/23)

So this PR is only viable when `marcel` either finds a MIT viable solution for their own gem, or follows the same approach and ditches the offending gem somehow and releases a new version.