### PR TITLE
ActiveRecord: Fix cache_key for a relation with .group

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -371,12 +371,14 @@ module ActiveRecord
         if collection.has_limit_or_offset?
           query = collection.select("#{column} AS collection_cache_key_timestamp")
           query._select!(table[Arel.star]) if distinct_value && collection.select_values.empty?
+          query.group!("collection_cache_key_timestamp") if collection.group_values.any?
           subquery_alias = "subquery_for_cache_key"
           subquery_column = "#{subquery_alias}.collection_cache_key_timestamp"
           arel = query.build_subquery(subquery_alias, select_values % subquery_column)
         else
           query = collection.unscope(:order)
           query.select_values = [select_values % column]
+          query._select!(collection.select_values) if collection.group_values.any?
           arel = query.arel
         end
 

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -174,6 +174,21 @@ module ActiveRecord
       assert_not_predicate developers, :loaded?
     end
 
+    test "cache_key with a relation having group and limit" do
+      developers = Developer.select("max(id) as id", "firm_id")
+                            .group(:firm_id)
+                            .limit(5)
+
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+    end
+
+    test "cache_key with a relation having group with column alias" do
+      developers = Developer.select("max(id) as id", "firm_id as my_firm")
+                            .group("my_firm")
+
+      assert_match(/\Adevelopers\/query-(\h+)-(\d+)-(\d+)\z/, developers.cache_key)
+    end
+
     test "cache_key with a relation having custom select and order" do
       developers = Developer.select("name AS dev_name").order("dev_name DESC").limit(5)
 


### PR DESCRIPTION
This PR fixes a bug when using relation with the `.group` and `.cache_key`. 

```ruby
Developer.select("max(id) as id", "firm_id as my_firm").group('my_firm').cache_key
# => ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column "my_firm" does not exist

Developer.select("max(id) as id", "firm_id").group(:firm_id).limit(5)
#=> ActiveRecord::StatementInvalid: PG::GroupingError: ERROR:  column "developers.legacy_updated_at" must appear in the GROUP BY
```