### PR TITLE
Probe with :array? instead of :oid

### DIFF
--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -619,7 +619,7 @@ module ActiveRecord
 
         def warn_if_deprecated_type(column)
           return if attributes_to_define_after_schema_loads.key?(column.name)
-          return unless column.respond_to?(:oid)
+          return unless column.respond_to?(:array?)
 
           if column.array?
             array_arguments = ", array: true"


### PR DESCRIPTION
### Summary

`Column#array?` is only defined by the PostgreSQL adapter. If an adapter (such as https://github.com/kwent/activerecord6-redshift-adapter) defines `oid` but not `array?`, the check breaks. It seems safer to probe for `array?` directly.
