### PR TITLE
Give precedence to the DatabaseTasks registered last

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -537,7 +537,7 @@ module ActiveRecord
         end
 
         def class_for_adapter(adapter)
-          _key, task = @tasks.each_pair.detect { |pattern, _task| adapter[pattern] }
+          _key, task = @tasks.reverse_each.detect { |pattern, _task| adapter[pattern] }
           unless task
             raise DatabaseNotSupported, "Rake tasks not supported by '#{adapter}' adapter"
           end

--- a/activerecord/test/cases/tasks/database_tasks_test.rb
+++ b/activerecord/test/cases/tasks/database_tasks_test.rb
@@ -185,6 +185,21 @@ module ActiveRecord
       end
     end
 
+    def test_register_task_precedence
+      klazz = Class.new do
+        def initialize(*arguments); end
+        def structure_dump(filename); end
+      end
+      instance = klazz.new
+
+      klazz.stub(:new, instance) do
+        assert_called_with(instance, :structure_dump, ["awesome-file.sql", nil]) do
+          ActiveRecord::Tasks::DatabaseTasks.register_task(/custom_mysql/, klazz)
+          ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :custom_mysql }, "awesome-file.sql")
+        end
+      end
+    end
+
     def test_unregistered_task
       assert_raise(ActiveRecord::Tasks::DatabaseNotSupported) do
         ActiveRecord::Tasks::DatabaseTasks.structure_dump({ "adapter" => :bar }, "awesome-file.sql")


### PR DESCRIPTION
Custom adapters can register their own tasks, however if their name include on of the existing tasks name matchers (`mysql/postgres/sqlite`), the first one to be registered wins.

So for instance, if your custom adapter is named `superdupermysql`, `DatabaseTasks.register_task(/superdupermysql/, "Blah")` won't work, because `/mysql/` will be tested first and will match.

I believe it makes sense that the matchers registered last would have precedence.

cc @rafaelfranca @etiennebarrie @alexrs 