### PR TITLE
Raise ArgumentError from TimeZone.iso8601 instead of KeyError

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -383,8 +383,6 @@ module ActiveSupport
     def iso8601(str)
       parts = Date._iso8601(str)
 
-      raise ArgumentError, "invalid date" if parts.empty?
-
       time = Time.new(
         parts.fetch(:year),
         parts.fetch(:mon),
@@ -400,6 +398,9 @@ module ActiveSupport
       else
         TimeWithZone.new(nil, self, time)
       end
+
+    rescue KeyError
+      raise ArgumentError, "invalid date"
     end
 
     # Method for creating new ActiveSupport::TimeWithZone instance in time zone

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -343,6 +343,16 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Time.utc(2014, 10, 25, 22, 0, 0), zone.parse("2014-10-26T01:00:00")
   end
 
+  def test_iso8601_with_invalid_value_parseable_by_date__iso8601
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    exception = assert_raises(ArgumentError) do
+      zone.iso8601("12936")
+    end
+
+    assert_equal "invalid date", exception.message
+  end
+
   def test_parse
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     twz = zone.parse("1999-12-31 19:00:00")


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

`ActiveSupport::TimeZone.iso8601` raises `KeyError` for some invalid values instead of `ArgumentError`
This appears to be an issue with how `Date._iso8601` interprets the value as it can return an unexpectedly incomplete result.
 e.g.

```ruby
Date._iso8601('12936')
=> {:yday=>936, :year=>2012}

Time.zone.iso8601('12936')
KeyError: key not found: :mon`
```
For consistency `ActiveSupport::TimeZone.iso8601` should raise `ArgumentError` if the resulting hash from `Date._iso8601` doesn't contain the necessary date part keys.

I've raised an issue with details here https://github.com/rails/rails/issues/41763

### Other Information

Rails version: Rails 6.0.3.5

Ruby version: ruby 2.7.2p137 (2020-10-01 revision 5445e04352)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
