### PR TITLE
Change default `X-XSS-Protection` header to '0'

### DIFF
--- a/actionpack/test/controller/base_test.rb
+++ b/actionpack/test/controller/base_test.rb
@@ -133,7 +133,7 @@ class ControllerInstanceTests < ActiveSupport::TestCase
     ActionDispatch::Response.default_headers = {
       "X-Frame-Options" => "DENY",
       "X-Content-Type-Options" => "nosniff",
-      "X-XSS-Protection" => "1;"
+      "X-XSS-Protection" => "0"
     }
 
     response_headers = SimpleController.action("hello").call(

--- a/actionpack/test/controller/metal_test.rb
+++ b/actionpack/test/controller/metal_test.rb
@@ -15,7 +15,7 @@ class MetalControllerInstanceTests < ActiveSupport::TestCase
     ActionDispatch::Response.default_headers = {
       "X-Frame-Options" => "DENY",
       "X-Content-Type-Options" => "nosniff",
-      "X-XSS-Protection" => "1;"
+      "X-XSS-Protection" => "0"
     }
 
     response_headers = SimpleController.action("hello").call(

--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -339,7 +339,7 @@ class ResponseTest < ActiveSupport::TestCase
       ActionDispatch::Response.default_headers = {
         "X-Frame-Options" => "DENY",
         "X-Content-Type-Options" => "nosniff",
-        "X-XSS-Protection" => "1;",
+        "X-XSS-Protection" => "0",
         "X-Download-Options" => "noopen",
         "X-Permitted-Cross-Domain-Policies" => "none",
         "Referrer-Policy" => "strict-origin-when-cross-origin"
@@ -351,7 +351,7 @@ class ResponseTest < ActiveSupport::TestCase
 
       assert_equal("DENY", resp.headers["X-Frame-Options"])
       assert_equal("nosniff", resp.headers["X-Content-Type-Options"])
-      assert_equal("1;", resp.headers["X-XSS-Protection"])
+      assert_equal("0", resp.headers["X-XSS-Protection"])
       assert_equal("noopen", resp.headers["X-Download-Options"])
       assert_equal("none", resp.headers["X-Permitted-Cross-Domain-Policies"])
       assert_equal("strict-origin-when-cross-origin", resp.headers["Referrer-Policy"])

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -898,7 +898,7 @@ Is a hash with HTTP headers that are set by default in each response. By default
 ```ruby
 config.action_dispatch.default_headers = {
   'X-Frame-Options' => 'SAMEORIGIN',
-  'X-XSS-Protection' => '1; mode=block',
+  'X-XSS-Protection' => '0',
   'X-Content-Type-Options' => 'nosniff',
   'X-Download-Options' => 'noopen',
   'X-Permitted-Cross-Domain-Policies' => 'none',
@@ -1681,6 +1681,16 @@ Accepts a string for the HTML tag used to wrap attachments. Defaults to `"action
 - `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 - `config.active_record.verify_foreign_keys_for_fixtures`: `true`
 - `config.active_storage.variant_processor`: `:vips`
+- `config.action_dispatch.default_headers`:
+
+    {
+      "X-Frame-Options" => "SAMEORIGIN",
+      "X-XSS-Protection" => "0",
+      "X-Content-Type-Options" => "nosniff",
+      "X-Download-Options" => "noopen",
+      "X-Permitted-Cross-Domain-Policies" => "none",
+      "Referrer-Policy" => "strict-origin-when-cross-origin"
+    }
 
 #### For '6.1', defaults from previous versions below and:
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1024,7 +1024,7 @@ Every HTTP response from your Rails application receives the following default s
 ```ruby
 config.action_dispatch.default_headers = {
   'X-Frame-Options' => 'SAMEORIGIN',
-  'X-XSS-Protection' => '1; mode=block',
+  'X-XSS-Protection' => '0',
   'X-Content-Type-Options' => 'nosniff',
   'X-Download-Options' => 'noopen',
   'X-Permitted-Cross-Domain-Policies' => 'none',
@@ -1050,7 +1050,7 @@ config.action_dispatch.default_headers.clear
 Here is a list of common headers:
 
 * **X-Frame-Options:** _`SAMEORIGIN` in Rails by default_ - allow framing on same domain. Set it to 'DENY' to deny framing at all or remove this header completely if you want to allow framing on all websites.
-* **X-XSS-Protection:** _`1; mode=block` in Rails by default_ - use XSS Auditor and block page if XSS attack is detected. Set it to '0;' if you want to switch XSS Auditor off(useful if response contents scripts from request parameters)
+* **X-XSS-Protection:** _`0` in Rails by default_ - [deprecated legacy header](https://owasp.org/www-project-secure-headers/#x-xss-protection), set to '0' to disable problematic legacy XSS auditors.
 * **X-Content-Type-Options:** _`nosniff` in Rails by default_ - stops the browser from guessing the MIME type of a file.
 * **X-Content-Security-Policy:** [A powerful mechanism for controlling which sites certain content types can be loaded from](https://w3c.github.io/webappsec-csp/)
 * **Access-Control-Allow-Origin:** Used to control which sites are allowed to bypass same origin policies and send cross-origin requests.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Change default `X-XSS-Protection` header to disable XSS auditor
+
+    This header has been deprecated and the XSS auditor it triggered
+    has been removed from all major modern browsers (in favour of
+    Content Security Policy) that implemented this header to begin with
+    (Firefox never did).
+
+    [OWASP](https://owasp.org/www-project-secure-headers/#x-xss-protection)
+    suggests setting this header to '0' to disable the default behaviour
+    on old browsers as it can introduce additional security issues.
+
+    Added the new behaviour as a framework default from Rails 7.0.
+
+    *Christian Sutter*
+
 *   New applications get a dependency on the new `debug` gem, replacing `byebug`.
 
     *Xavier Noria*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -198,6 +198,14 @@ module Rails
           load_defaults "6.1"
 
           if respond_to?(:action_dispatch)
+            action_dispatch.default_headers = {
+              "X-Frame-Options" => "SAMEORIGIN",
+              "X-XSS-Protection" => "0",
+              "X-Content-Type-Options" => "nosniff",
+              "X-Download-Options" => "noopen",
+              "X-Permitted-Cross-Domain-Policies" => "none",
+              "Referrer-Policy" => "strict-origin-when-cross-origin"
+            }
             action_dispatch.return_only_request_media_type_on_content_type = false
           end
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -70,3 +70,13 @@
 # operations. See the upgrading guide for detail on the changes required.
 # The `:mini_magick` option is not deprecated; it's fine to keep using it.
 # Rails.application.config.active_storage.variant_processor = :vips
+
+# Change the default headers to disable browsers' flawed legacy XSS protection
+# Rails.application.config.action_dispatch.default_headers = {
+#   "X-Frame-Options" => "SAMEORIGIN",
+#   "X-XSS-Protection" => "0",
+#   "X-Content-Type-Options" => "nosniff",
+#   "X-Download-Options" => "noopen",
+#   "X-Permitted-Cross-Domain-Policies" => "none",
+#   "Referrer-Policy" => "strict-origin-when-cross-origin"
+# }


### PR DESCRIPTION
### Summary

This header has been deprecated and the XSS auditor it triggered has been removed from all major modern browsers (in favour of Content Security Policy) that implemented this header to begin with (Firefox never did).

[OWASP](https://owasp.org/www-project-secure-headers/#x-xss-protection) suggest setting this header to '0' to disable the default behaviour on old browsers as it can introduce additional security issues.

Added the new behaviour as a framework default from Rails 7.0.

Some other resources discussing this header and why it should be set to '0':
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
* https://scotthelme.co.uk/security-headers-updates/#removing-the-x-xss-protection-header
* https://stackoverflow.com/questions/9090577/what-is-the-http-header-x-xss-protection#answer-57802070

