### PR TITLE
Backport "Quote the arguments passed to the Contains/Overlaps Arel nodes"

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Changed Arel predications `contains` and `overlaps` to use
+    `quoted_node` so that PostgreSQL arrays are quoted properly.
+
+    *Bradley Priest*
+
+
 ## Rails 6.1.3.1 (March 26, 2021) ##
 
 *   No changes.

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -207,11 +207,11 @@ module Arel # :nodoc: all
     end
 
     def contains(other)
-      Arel::Nodes::Contains.new(self, other)
+      Arel::Nodes::Contains.new self, quoted_node(other)
     end
 
     def overlaps(other)
-      Arel::Nodes::Overlaps.new(self, other)
+      Arel::Nodes::Overlaps.new self, quoted_node(other)
     end
 
     def quoted_array(others)

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -1046,15 +1046,13 @@ module Arel
       describe "#contains" do
         it "should create a Contains node" do
           relation = Table.new(:products)
-          query = Nodes.build_quoted("{foo,bar}")
-          _(relation[:tags].contains(query)).must_be_kind_of Nodes::Contains
+          _(relation[:tags].contains(["foo", "bar"])).must_be_kind_of Nodes::Contains
         end
 
         it "should generate @> in sql" do
-          relation = Table.new(:products)
+          relation = Table.new(:products, type_caster: fake_pg_caster)
           mgr = relation.project relation[:id]
-          query = Nodes.build_quoted("{foo,bar}")
-          mgr.where relation[:tags].contains(query)
+          mgr.where relation[:tags].contains(["foo", "bar"])
           _(mgr.to_sql).must_be_like %{ SELECT "products"."id" FROM "products" WHERE "products"."tags" @> '{foo,bar}' }
         end
       end
@@ -1062,15 +1060,13 @@ module Arel
       describe "#overlaps" do
         it "should create an Overlaps node" do
           relation = Table.new(:products)
-          query = Nodes.build_quoted("{foo,bar}")
-          _(relation[:tags].overlaps(query)).must_be_kind_of Nodes::Overlaps
+          _(relation[:tags].overlaps(["foo", "bar"])).must_be_kind_of Nodes::Overlaps
         end
 
         it "should generate && in sql" do
-          relation = Table.new(:products)
+          relation = Table.new(:products, type_caster: fake_pg_caster)
           mgr = relation.project relation[:id]
-          query = Nodes.build_quoted("{foo,bar}")
-          mgr.where relation[:tags].overlaps(query)
+          mgr.where relation[:tags].overlaps(["foo", "bar"])
           _(mgr.to_sql).must_be_like %{ SELECT "products"."id" FROM "products" WHERE "products"."tags" && '{foo,bar}' }
         end
       end
@@ -1130,6 +1126,19 @@ module Arel
             end: Nodes::Quoted.new(end_val),
             exclude_end?: exclude,
           )
+        end
+
+        # Mimic PG::TextDecoder::Array casting
+        def fake_pg_caster
+          Object.new.tap do |caster|
+            def caster.type_cast_for_database(attr_name, value)
+              if attr_name == "tags"
+                "{#{value.join(",")}}"
+              else
+                value
+              end
+            end
+          end
         end
     end
   end


### PR DESCRIPTION
This is a backport of #41640 as we're having to [monkey-patch this in 6.1 apps][1].

[1]: https://github.com/ScottishParliament/e-petitions/commit/75263d2166e6852262e2afff81b2cfc2988f4d7f