### PR TITLE
Call #prerecord when running tests in parallel with processes

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -15,6 +15,12 @@ module ActiveSupport
           @in_flight = Concurrent::Map.new
         end
 
+        def prerecord(reporter, klass, method)
+          reporter.synchronize do
+            reporter.prerecord(klass, method)
+          end
+        end
+
         def record(reporter, result)
           raise DRb::DRbConnError if result.is_a?(DRb::DRbUnknown)
 

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -46,6 +46,8 @@ module ActiveSupport
 
           set_process_title("#{klass}##{method}")
 
+          @queue.prerecord(reporter, klass, method)
+
           result = klass.with_info_handler reporter do
             Minitest.run_one_method(klass, method)
           end

--- a/railties/test/test_unit/reporter_test.rb
+++ b/railties/test/test_unit/reporter_test.rb
@@ -18,7 +18,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(failed_test)
     @reporter.report
 
-    assert_match %r{^rails test .*test/test_unit/reporter_test\.rb:\d+$}, @output.string
+    assert_match %r{^#{Rails::TestUnitReporter.executable} .*test/test_unit/reporter_test\.rb:\d+$}, @output.string
     assert_rerun_snippet_count 1
   end
 
@@ -64,7 +64,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(failed_test)
     @reporter.report
 
-    expect = %r{\AF\n\nFailure:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nboo\n\nrails test test/test_unit/reporter_test\.rb:\d+\n\n\z}
+    expect = %r{\AF\n\nFailure:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nboo\n\n#{Rails::TestUnitReporter.executable} test/test_unit/reporter_test\.rb:\d+\n\n\z}
     assert_match expect, @output.string
   end
 
@@ -72,7 +72,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     @reporter.record(errored_test)
     @reporter.report
 
-    expect = %r{\AE\n\nError:\nTestUnitReporterTest::ExampleTest#woot:\nArgumentError: wups\n    some_test.rb:4\n\nrails test .*test/test_unit/reporter_test\.rb:\d+\n\n\z}
+    expect = %r{\AE\n\nError:\nTestUnitReporterTest::ExampleTest#woot:\nArgumentError: wups\n    some_test.rb:4\n\n#{Rails::TestUnitReporter.executable} .*test/test_unit/reporter_test\.rb:\d+\n\n\z}
     assert_match expect, @output.string
   end
 
@@ -81,7 +81,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
     verbose.record(skipped_test)
     verbose.report
 
-    expect = %r{\ATestUnitReporterTest::ExampleTest#woot = 10\.00 s = S\n\n\nSkipped:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nskipchurches, misstemples\n\nrails test test/test_unit/reporter_test\.rb:\d+\n\n\z}
+    expect = %r{\ATestUnitReporterTest::ExampleTest#woot = 10\.00 s = S\n\n\nSkipped:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nskipchurches, misstemples\n\n#{Rails::TestUnitReporter.executable} test/test_unit/reporter_test\.rb:\d+\n\n\z}
     assert_match expect, @output.string
   end
 
@@ -152,7 +152,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
       colored = Rails::TestUnitReporter.new @output, color: true, output_inline: true
       colored.record(failed_test)
 
-      expected = %r{\e\[31mF\e\[0m\n\n\e\[31mFailure:\nTestUnitReporterTest::ExampleTest#woot \[test/test_unit/reporter_test.rb:\d+\]:\nboo\n\e\[0m\n\nrails test .*test/test_unit/reporter_test.rb:\d+\n\n}
+      expected = %r{\e\[31mF\e\[0m\n\n\e\[31mFailure:\nTestUnitReporterTest::ExampleTest#woot \[[^\]]+\]:\nboo\n\e\[0m\n\n#{Rails::TestUnitReporter.executable} .*test/test_unit/reporter_test.rb:\d+\n\n}
       assert_match expected, @output.string
     end
   end
@@ -169,7 +169,7 @@ class TestUnitReporterTest < ActiveSupport::TestCase
 
   private
     def assert_rerun_snippet_count(snippet_count)
-      assert_equal snippet_count, @output.string.scan(%r{^rails test }).size
+      assert_equal snippet_count, @output.string.scan(%r{^#{Rails::TestUnitReporter.executable} }).size
     end
 
     def failed_test


### PR DESCRIPTION
### Summary

Fixes #41766

For the sake of consistency with what `Minitest` does for serial and
parallel tests with threads, some reportes may rely on this:

https://github.com/seattlerb/minitest/blob/3c6576a/lib/minitest.rb#L339-L342
https://github.com/seattlerb/minitest/blob/3c6576a/lib/minitest/parallel.rb#L32-L34

The steps are:

* Prerecord
* Run test
* Record

When running in parallel, some `prerecord` calls may arrive later than
their `record` counterparts, e.g.:

* prerecordA
* prerecordB
* recordB
* recordA

### Other Information

I fixed an error in the reporter tests file, it fails when is executed using `bin/test`:

```
railties $ bin/test test/test_unit/reporter_test.rb
```