### PR TITLE
Add CHANGELOG entry for #41640

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Changed Arel predications `contains` and `overlaps` to use
+    `quoted_node` so that PostgreSQL arrays are quoted properly.
+
+    *Bradley Priest*
+
 *   Add mode argument to record level `strict_loading!`
 
     This argument can be used when enabling strict loading for a single record


### PR DESCRIPTION
There was no CHANGELOG entry for the original methods being added but that ship has sailed (unlike the ship in the Suez Canal).