### PR TITLE
Add support for ordinal date values in AS::TimeZone.iso8601

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `TimeZone.iso8601` now accepts valid ordinal values similar to Ruby's `Date._iso8601` method.
+    A valid ordinal value will be converted to an instance of `TimeWithZone` using the `:year`
+    and `:yday` fragments returned from `Date._iso8601`.
+
+    ```ruby
+    twz = ActiveSupport::TimeZone["Eastern Time (US & Canada)"].iso8601("21087")
+    twz.to_a[0, 6] == [0, 0, 0, 28, 03, 2021]
+    ```
+
+    *Steve Laing*
+
 *   `Time#change` and methods that call it (eg. `Time#advance`) will now
     return a `Time` with the timezone argument provided, if the caller was
     initialized with a timezone argument.

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -387,10 +387,21 @@ module ActiveSupport
     def iso8601(str)
       parts = Date._iso8601(str)
 
+      year = parts.fetch(:year)
+
+      if parts.key?(:yday)
+        ordinal_date = Date.ordinal(year, parts.fetch(:yday))
+        month = ordinal_date.month
+        day = ordinal_date.day
+      else
+        month = parts.fetch(:mon)
+        day = parts.fetch(:mday)
+      end
+
       time = Time.new(
-        parts.fetch(:year),
-        parts.fetch(:mon),
-        parts.fetch(:mday),
+        year,
+        month,
+        day,
         parts.fetch(:hour, 0),
         parts.fetch(:min, 0),
         parts.fetch(:sec, 0) + parts.fetch(:sec_fraction, 0),
@@ -403,7 +414,7 @@ module ActiveSupport
         TimeWithZone.new(nil, self, time)
       end
 
-    rescue KeyError
+    rescue Date::Error, KeyError
       raise ArgumentError, "invalid date"
     end
 

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -365,11 +365,19 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Time.utc(2014, 10, 25, 22, 0, 0), zone.parse("2014-10-26T01:00:00")
   end
 
-  def test_iso8601_with_invalid_value_parseable_by_date__iso8601
+  def test_iso8601_with_ordinal_date_value
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    twz = zone.iso8601("21087")
+    assert_equal Time.utc(2021, 3, 28, 0, 0, 0), twz.time
+    assert_equal zone, twz.time_zone
+  end
+
+  def test_iso8601_with_invalid_ordinal_date_value
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
 
     exception = assert_raises(ArgumentError) do
-      zone.iso8601("12936")
+      zone.iso8601("21367")
     end
 
     assert_equal "invalid date", exception.message


### PR DESCRIPTION
### Summary

`Date._iso8601` will attempt to parse certain values as ordinal date strings eg. `'21087'` is parsed as 28th March 2021.
`ActiveSupport::TimeZone.iso8601` should provide similar support for ordinal values as Ruby stdlib in `Date._iso8601`.

Add support for values which parse as year and day of year eg. `{ year: 2021, yday: 87 }`  and attempt to generate a valid date with `Date.ordinal`. This will sanitize the `:yday` part of the parsed value for the corresponding year.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

See https://github.com/rails/rails/pull/41764#issuecomment-808863720 for suggestion which led to this PR.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
