### PR TITLE
Using filter_map for performance appraisal

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -246,7 +246,7 @@ module ActionCable
         # Returns messages transmitted into channel
         def transmissions
           # Return only directly sent message (via #transmit)
-          connection.transmissions.map { |data| data["message"] }.compact
+          connection.transmissions.filter_map { |data| data["message"] }
         end
 
         # Enhance TestHelper assertions to handle non-String

--- a/actioncable/lib/action_cable/connection/identification.rb
+++ b/actioncable/lib/action_cable/connection/identification.rb
@@ -26,7 +26,7 @@ module ActionCable
       # Return a single connection identifier that combines the value of all the registered identifiers into a single gid.
       def connection_identifier
         unless defined? @connection_identifier
-          @connection_identifier = connection_gid identifiers.map { |id| instance_variable_get("@#{id}") }.compact
+          @connection_identifier = connection_gid identifiers.filter_map { |id| instance_variable_get("@#{id}") }
         end
 
         @connection_identifier

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -952,7 +952,7 @@ module ActionController
       def each_element(object, &block)
         case object
         when Array
-          object.grep(Parameters).map { |el| yield el }.compact
+          object.grep(Parameters).filter_map { |el| yield el }
         when Parameters
           if object.nested_attributes?
             object.each_nested_attribute(&block)

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -486,7 +486,7 @@ module ActiveRecord
         existing_records = if association.loaded?
           association.target
         else
-          attribute_ids = attributes_collection.map { |a| a["id"] || a[:id] }.compact
+          attribute_ids = attributes_collection.filter_map { |a| a["id"] || a[:id] }
           attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
         end
 

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -96,7 +96,7 @@ module Arel # :nodoc: all
     end
 
     def froms
-      @ast.cores.map { |x| x.from }.compact
+      @ast.cores.filter_map { |x| x.from }
     end
 
     def join(relation, klass = Nodes::InnerJoin)


### PR DESCRIPTION
Using ``filter_map`` instead of map and compact. 
Added these changes for performance appraisal. 

```
N = 1_00_000
enum = 1.upto(1_000)
Benchmark.bmbm do |x|
  x.report("select + map") {N.times {enum.select { |i| i.even? }.map{|i| i +1}}}
  x.report("map + compact") {N.times {enum.map { |i| i + 1 if i.even? }.compact}}
  x.report("filter_map") {N.times {enum.filter_map { |i| i + 1 if i.even? }}}
end
#
# Rehearsal -------------------------------------------------
# select + map    8.569651   0.051319   8.620970 (  8.632449)
# map + compact   7.392666   0.133964   7.526630 (  7.538013)
# filter_map      6.923772   0.022314   6.946086 (  6.956135)
# --------------------------------------- total: 23.093686sec
# 
#                     user     system      total        real
# select + map    8.550637   0.033190   8.583827 (  8.597627)
# map + compact   7.263667   0.131180   7.394847 (  7.405570)
# filter_map      6.761388   0.018223   6.779611 (  6.790559)
```