### PR TITLE
Escape route params

### DIFF
--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -176,14 +176,24 @@ module ActionDispatch
                 missing_keys << key
               end
             else
-              escaped_key_value = Regexp.escape(parts[key])
-              unless tests[key].match?(escaped_key_value)
+              unless valid_key?(tests[key], parts[key])
                 missing_keys ||= []
                 missing_keys << key
               end
             end
           }
           missing_keys
+        end
+
+        def valid_key?(test, value)
+          test.match?(value) ||
+          test.match?(escape_value(value))
+        end
+
+        def escape_value(value)
+          return if value.nil?
+
+          Regexp.escape(value)
         end
 
         def possibles(cache, options, depth = 0)

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -176,7 +176,8 @@ module ActionDispatch
                 missing_keys << key
               end
             else
-              unless tests[key].match?(parts[key])
+              escaped_key_value = Regexp.escape(parts[key])
+              unless tests[key].match?(escaped_key_value)
                 missing_keys ||= []
                 missing_keys << key
               end

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -149,6 +149,22 @@ module ActionDispatch
         assert_equal "/users/1.json", url_helpers.user_path(1, :json)
       end
 
+      test "escape new line for dynamic params" do
+        draw do
+          get "/wildcard/:dynamic_segment", to: SimpleApp.new("foo#index"), as: :dynamic
+        end
+
+        assert_equal "/wildcard/a%0Anewline", url_helpers.dynamic_path(dynamic_segment: "a\nnewline")
+      end
+
+      test "escape new line for wildcard params" do
+        draw do
+          get "/wildcard/*wildcard_segment", to: SimpleApp.new("foo#index"), as: :wildcard
+        end
+
+        assert_equal "/wildcard/a%0Anewline", url_helpers.wildcard_path(wildcard_segment: "a\nnewline")
+      end
+
       private
         def draw(&block)
           @set.draw(&block)


### PR DESCRIPTION
### Summary

Fixes this issue: https://github.com/rails/rails/issues/39103

The wildcard route params are not handled the same way as the others, it uses a regex by default to identify missing params. You may find this code in `ActionDispatch::Routing::Mapper line 138`, and the regex use in `ActionDispatch::Journey::Formatter line 179`.

Due that, the regex wasn't matching the route value with special characters such as `\n`, because it wasn't being handled as literal, so we need to "escape". This PR implements this fix.
