### PR TITLE
Add support for check_constraints with the same name on different tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -427,7 +427,7 @@ module ActiveRecord
         if supports_check_constraints?
           scope = quoted_scope(table_name)
 
-          chk_info = exec_query(<<~SQL, "SCHEMA")
+          sql = <<~SQL
             SELECT cc.constraint_name AS 'name',
                   cc.check_clause AS 'expression'
             FROM information_schema.check_constraints cc
@@ -437,6 +437,9 @@ module ActiveRecord
               AND tc.table_name = #{scope[:name]}
               AND cc.constraint_schema = #{scope[:schema]}
           SQL
+          sql += " AND cc.table_name = #{scope[:name]}" if mariadb?
+
+          chk_info = exec_query(sql, "SCHEMA")
 
           chk_info.map do |row|
             options = {

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -54,6 +54,15 @@ def supports_default_expression?
   end
 end
 
+def supports_non_unique_constraint_name?
+  if current_adapter?(:Mysql2Adapter)
+    conn = ActiveRecord::Base.connection
+    conn.mariadb?
+  else
+    false
+  end
+end
+
 %w[
   supports_savepoints?
   supports_partial_index?

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -18,10 +18,16 @@ if ActiveRecord::Base.connection.supports_check_constraints?
             t.integer :price
             t.integer :quantity
           end
+
+          @connection.create_table "purchases", force: true do |t|
+            t.integer :price
+            t.integer :quantity
+          end
         end
 
         teardown do
           @connection.drop_table "trades", if_exists: true rescue nil
+          @connection.drop_table "purchases", if_exists: true rescue nil
         end
 
         def test_check_constraints
@@ -53,6 +59,25 @@ if ActiveRecord::Base.connection.supports_check_constraints?
             assert_equal "`quantity` > 0", constraint.expression
           else
             assert_equal "quantity > 0", constraint.expression
+          end
+        end
+
+        if supports_non_unique_constraint_name?
+          def test_add_constraint_with_same_name_to_different_table
+            @connection.add_check_constraint :trades, "quantity > 0", name: "greater_than_zero"
+            @connection.add_check_constraint :purchases, "quantity > 0", name: "greater_than_zero"
+
+            trades_check_constraints = @connection.check_constraints("trades")
+            assert_equal 1, trades_check_constraints.size
+            trade_constraint = trades_check_constraints.first
+            assert_equal "trades", trade_constraint.table_name
+            assert_equal "greater_than_zero", trade_constraint.name
+
+            purchases_check_constraints = @connection.check_constraints("purchases")
+            assert_equal 1, purchases_check_constraints.size
+            purchase_constraint = purchases_check_constraints.first
+            assert_equal "purchases", purchase_constraint.table_name
+            assert_equal "greater_than_zero", purchase_constraint.name
           end
         end
 


### PR DESCRIPTION
### Summary

MariaDB does not follow the SQL standard when it comes to CHECK_CONSTRAINTS naming. MariaDB allows multiple check constraints to have the same name as long as they are on different tables. To handle this, they have added another column to information_schema.check_constraints to store the table name.

Here you can see the difference in how MariaDB defines this table vs MySQL
https://mariadb.com/kb/en/information-schema-check_constraints-table/
https://dev.mysql.com/doc/refman/8.0/en/information-schema-check-constraints-table.html

Fixes: #41773 