### PR TITLE
Clear `@cache_keys` cache after `update_all`, `delete_all`, `destroy_all`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -488,7 +488,7 @@ module ActiveRecord
       stmt = arel.compile_update(values, table[primary_key])
       stmt.table(source)
 
-      klass.connection.update(stmt, "#{klass} Update All")
+      klass.connection.update(stmt, "#{klass} Update All").tap { reset }
     end
 
     def update(id = :all, attributes) # :nodoc:
@@ -616,10 +616,7 @@ module ActiveRecord
       stmt = arel.compile_delete(table[primary_key])
       stmt.from(source)
 
-      affected = klass.connection.delete(stmt, "#{klass} Destroy")
-
-      reset
-      affected
+      klass.connection.delete(stmt, "#{klass} Destroy").tap { reset }
     end
 
     # Finds and destroys all records matching the specified conditions.
@@ -701,6 +698,7 @@ module ActiveRecord
       @delegate_to_klass = false
       @to_sql = @arel = @loaded = @should_eager_load = nil
       @offsets = @take = nil
+      @cache_keys = nil
       @records = nil
       self
     end

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -7,6 +7,7 @@ require "models/project"
 require "models/topic"
 require "models/post"
 require "models/comment"
+require "models/ship"
 
 module ActiveRecord
   class CollectionCacheKeyTest < ActiveRecord::TestCase
@@ -99,6 +100,33 @@ module ActiveRecord
     test "cache_key for loaded relation with includes" do
       comments = Comment.includes(:post).where("posts.type": "Post").load
       assert_match(/\Acomments\/query-(\h+)-(\d+)-(\d+)\z/, comments.cache_key)
+    end
+
+    test "update_all will update cache_key" do
+      developers = Developer.where(name: "David")
+      cache_key = developers.cache_key
+
+      developers.update_all(updated_at: Time.now.utc)
+
+      assert_not_equal cache_key, developers.cache_key
+    end
+
+    test "delete_all will update cache_key" do
+      developers = Developer.where(name: "David")
+      cache_key = developers.cache_key
+
+      developers.delete_all
+
+      assert_not_equal cache_key, developers.cache_key
+    end
+
+    test "destroy_all will update cache_key" do
+      developers = Developer.where(name: "David")
+      cache_key = developers.cache_key
+
+      developers.destroy_all
+
+      assert_not_equal cache_key, developers.cache_key
     end
 
     test "it triggers at most one query" do


### PR DESCRIPTION
The calculated cache key is cached on a relation, but there is no way to
re-calculation even if mutation to collection on a relation is happened.

The `@cache_keys` cache should be cleared at least after `update_all`,
`delete_all`, `destroy_all`.

Related to #41784.
