### PR TITLE
"Smart" ActiveRecord Preloader batching

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -40,6 +40,8 @@ module ActiveRecord
           end
         end
 
+        attr_reader :klass
+
         def initialize(klass, owners, reflection, preload_scope, associate_by_default = true)
           @klass         = klass
           @owners        = owners.uniq(&:__id__)
@@ -50,8 +52,20 @@ module ActiveRecord
           @run = false
         end
 
-        def already_loaded?
-          @already_loaded ||= owners.all? { |o| o.association(reflection.name).loaded? }
+        def table_name
+          @klass.table_name
+        end
+
+        def data_available?
+          already_loaded?
+        end
+
+        def future_classes
+          if run? || already_loaded?
+            []
+          else
+            [@klass]
+          end
         end
 
         def runnable_loaders
@@ -149,7 +163,11 @@ module ActiveRecord
         end
 
         private
-          attr_reader :owners, :reflection, :preload_scope, :model, :klass
+          attr_reader :owners, :reflection, :preload_scope, :model
+
+          def already_loaded?
+            @already_loaded ||= owners.all? { |o| o.association(reflection.name).loaded? }
+          end
 
           def fetch_from_preloaded_records
             @records_by_owner = owners.index_with do |owner|

--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -13,11 +13,20 @@ module ActiveRecord
           until branches.empty?
             loaders = branches.flat_map(&:runnable_loaders)
 
-            already_loaded, loaders = loaders.partition(&:already_loaded?)
-            already_loaded.each(&:run)
+            already_loaded = loaders.select(&:data_available?)
+            if already_loaded.any?
+              already_loaded.each(&:run)
+            elsif loaders.any?
+              future_tables = branches.flat_map do |branch|
+                branch.future_classes - branch.runnable_loaders.map(&:klass)
+              end.map(&:table_name).uniq
 
-            group_and_load_similar(loaders)
-            loaders.each(&:run)
+              target_loaders = loaders.reject { |l| future_tables.include?(l.table_name)  }
+              target_loaders = loaders if target_loaders.empty?
+
+              group_and_load_similar(target_loaders)
+              target_loaders.each(&:run)
+            end
 
             finished, in_progress = branches.partition(&:done?)
 

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -15,6 +15,40 @@ module ActiveRecord
           @associate_by_default = associate_by_default
 
           @children = build_children(children)
+          @loaders = nil
+        end
+
+        def future_classes
+          (immediate_future_classes + children.flat_map(&:future_classes)).uniq
+        end
+
+        def immediate_future_classes
+          if parent.done?
+            loaders.flat_map(&:future_classes).uniq
+          else
+            likely_reflections.reject(&:polymorphic?).flat_map do |reflection|
+              reflection.
+                chain.
+                map(&:klass)
+            end.uniq
+          end
+        end
+
+        def target_classes
+          if done?
+            preloaded_records.map(&:klass).uniq
+          elsif parent.done?
+            loaders.map(&:klass).uniq
+          else
+            likely_reflections.reject(&:polymorphic?).map(&:klass).uniq
+          end
+        end
+
+        def likely_reflections
+          parent_classes = parent.target_classes
+          parent_classes.map do |parent_klass|
+            parent_klass._reflect_on_association(@association)
+          end.compact
         end
 
         def root?
@@ -30,7 +64,7 @@ module ActiveRecord
         end
 
         def done?
-          loaders.all?(&:run?)
+          root? || (@loaders && @loaders.all?(&:run?))
         end
 
         def runnable_loaders


### PR DESCRIPTION
This examines all the association branches we are being asked to preload and will delay loading an association if it's likely that we find a similar association later and can batch them together.

For example, when loading

    Author.preload(:posts, favorite_authors: :posts).first

The preloader now knows to delay loading the top level posts so that it can load both the top level :posts and the :posts from the favourite authors associations together.

As mentioned in https://github.com/rails/rails/pull/41596#issuecomment-797844522 previously the groupings we had were somewhat arbitrary and we just hoped that they would end up at the same "depth" in the preload. This groups by table name and delays loading in order to try to find matching associations.

A few methods are not efficiently implemented (`target_classes`/`future_classes`) and repeat work, but I think this won't be an issue because they are run per-association rather than per-record. I did not see a difference in benchmarks.

Co-authored-by: Dinah Shi <dinahshi@github.com>

cc @eileencodes @HParker 
cc @rafaelfranca @byroot 