### PR TITLE
More flexible action_on_unpermitted_parameters configuration

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Enhance `ActionController::Parameters.action_on_unpermitted_parameters` to support arbitrary behavior:
+
+    ```ruby
+    # application.rb
+    config.action_controller.action_on_unpermitted_parameters = 'HandleUnpermittedParamsTestHandler'
+
+    # app/controller/concerns/handle_unpermitted_params_test_handler.rb
+    class HandleUnpermittedParamsTestHandler
+      def self.handle_unpermitted_parameters(params:, unpermitted_keys:, request:)
+        # Anything you want!
+      end
+    end
+    ```
+
+    *bbuchalter*
+
 *   Add `ActionController::Live#send_stream` that makes it more convenient to send generated streams:
 
     ```ruby

--- a/actionpack/test/controller/parameters/handle_unpermitted_params_test.rb
+++ b/actionpack/test/controller/parameters/handle_unpermitted_params_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "action_controller/metal/strong_parameters"
+
+class HandleUnpermittedParamsTest < ActiveSupport::TestCase
+  class HandleUnpermittedParamsTestHandler
+    def self.handle_unpermitted_parameters(params:, unpermitted_keys:, request:)
+      raise ActionController::UnpermittedParameters.new(unpermitted_keys)
+    end
+  end
+
+  def setup
+    ActionController::Parameters.action_on_unpermitted_parameters = "HandleUnpermittedParamsTestHandler"
+  end
+
+  def teardown
+    ActionController::Parameters.action_on_unpermitted_parameters = false
+  end
+
+  test "raises on unexpected params" do
+    params = ActionController::Parameters.new(
+      book: { pages: 65 },
+      fishing: "Turnips")
+
+    assert_raises(ActionController::UnpermittedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
+
+  test "raises on unexpected nested params" do
+    params = ActionController::Parameters.new(
+      book: { pages: 65, title: "Green Cats and where to find then." })
+
+    assert_raises(ActionController::UnpermittedParameters) do
+      params.permit(book: [:pages])
+    end
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -524,7 +524,11 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.
 
-* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
+* `config.action_controller.action_on_unpermitted_parameters` controls behavior when parameters that are not explicitly permitted are found. The default value is `:log` in test and development environments, `false` otherwise. The values can be:
+    * `false` to take no action
+    * `:log` to emit an `ActiveSupport::Notifications.instrument` on the `unpermitted_parameters.action_controller` topic
+    * `:raise` to raise a `ActionController::UnpermittedParameters` exception
+    * A string which references a class which implements a class method with the signature `handle_unpermitted_parameters(params:, unpermitted_keys:, request:)`
 
 * `config.action_controller.always_permitted_parameters` sets a list of permitted parameters that are permitted by default. The default values are `['controller', 'action']`.
 


### PR DESCRIPTION
This PR gives more control over the behavior of Rails when an unpermitted parameter is encountered. The primary use case for this is to allow for synchronous use of the Rails logger; currently the :log option does not provide enough details about the controller to make the events emitted via ActiveSupport::Notifications actionable. While this could be modified, for backwards compatibility and ultimate flexibility, we can simply allow the user to specify the behavior they desire.