### PR TITLE
Fix LogSubscriber for buffered event w/ nil logger

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -114,9 +114,13 @@ module ActiveSupport
     def finish(name, id, payload)
       super if logger
     rescue => e
-      if logger
-        logger.error "Could not log #{name.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
-      end
+      log_exception(name, e)
+    end
+
+    def publish_event(event)
+      super if logger
+    rescue => e
+      log_exception(event.name, e)
     end
 
   private
@@ -137,6 +141,12 @@ module ActiveSupport
       color = self.class.const_get(color.upcase) if color.is_a?(Symbol)
       bold  = bold ? BOLD : ""
       "#{bold}#{color}#{text}#{CLEAR}"
+    end
+
+    def log_exception(name, e)
+      if logger
+        logger.error "Could not log #{name.inspect} event. #{e.class}: #{e.message} #{e.backtrace}"
+      end
     end
   end
 end

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -107,6 +107,17 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     end
   end
 
+  def test_does_not_send_buffered_events_if_logger_is_nil
+    ActiveSupport::LogSubscriber.logger = nil
+    assert_not_called(@log_subscriber, :some_event) do
+      ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+      buffer = ActiveSupport::Notifications.instrumenter.buffer
+      buffer.instrument "some_event.my_log_subscriber"
+      buffer.flush
+      wait
+    end
+  end
+
   def test_does_not_fail_with_non_namespaced_events
     ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
     instrument "whatever"


### PR DESCRIPTION
`LogSubscriber` overrides start/finish to avoid instrumenting when its logger is `nil`. In order to support buffered notification events, as used by async queries, we need to apply a similar override to `LogSubscriber#publish_event`.