### PR TITLE
Deprecate Kernel#concern in favor of extending ActiveSupport::Concern

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `Kernel#concern`
+
+    *Rafael Sales*
+
 *   Tests parallelization is now disabled when running individual files to prevent the setup overhead.
 
     It can still be enforced if the environment variable `PARALLEL_WORKERS` is present and set to a value greater than 1.

--- a/activesupport/lib/active_support/core_ext/kernel/concern.rb
+++ b/activesupport/lib/active_support/core_ext/kernel/concern.rb
@@ -9,6 +9,24 @@ module Kernel
   #
   # See Module::Concerning for more.
   def concern(topic, &module_definition)
+    ActiveSupport::Deprecation.warn(<<~EOM)
+      Defining toplevel concern via Kernel#concern is deprecated.
+      Please define a module and extend ActiveSupport::Concern instead.
+
+      For example, instead of:
+
+      concern :Foo do
+        ...
+      end
+
+      Define the module manually:
+
+      module Foo
+        extend ActiveSupport::Concern
+        ...
+      end
+    EOM
+
     Object.concern topic, &module_definition
   end
 end

--- a/activesupport/test/core_ext/kernel/concern_test.rb
+++ b/activesupport/test/core_ext/kernel/concern_test.rb
@@ -5,10 +5,12 @@ require "active_support/core_ext/kernel/concern"
 
 class KernelConcernTest < ActiveSupport::TestCase
   def test_may_be_defined_at_toplevel
-    mod = ::TOPLEVEL_BINDING.eval "concern(:ToplevelConcern) { }"
-    assert_equal mod, ::ToplevelConcern
-    assert_kind_of ActiveSupport::Concern, ::ToplevelConcern
-    assert_not Object.ancestors.include?(::ToplevelConcern), mod.ancestors.inspect
+    assert_deprecated do
+      mod = ::TOPLEVEL_BINDING.eval "concern(:ToplevelConcern) { }"
+      assert_equal mod, ::ToplevelConcern
+      assert_kind_of ActiveSupport::Concern, ::ToplevelConcern
+      assert_not Object.ancestors.include?(::ToplevelConcern), mod.ancestors.inspect
+    end
   ensure
     Object.send :remove_const, :ToplevelConcern
   end


### PR DESCRIPTION
**Problem:** Defining a toplevel concern using `Kernel#concern` exposes nested constants to the global Ruby namespace.

Example:

```ruby
concern :Foo do
  BAR = 'BAR'
end

class SomeFoo
  include Foo
end

> BAR
=> "BAR"

> Foo::BAR
NameError (uninitialized constant Foo::BAR)

> SomeFoo::BAR
NameError (uninitialized constant SomeFoo::BAR)
```

**Solution:** Deprecate `Kernel#concern` so that developers are forced to use a safer definition of concerns using `module` + `extend ActiveSupport::Concern`.

Example:

```ruby
module Foo
  extend ActiveSupport::Concern

  BAR = 'BAR'
end

class SomeFoo
  include Foo
end

> BAR
NameError (uninitialized constant BAR)

> Foo::BAR
=> "BAR"

> SomeFoo::BAR
=> "BAR"
```


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
