### PR TITLE
ActiveSupport::SecurityUtils.secure_compare should compare bytesize instead of length

### DIFF
--- a/activesupport/lib/active_support/security_utils.rb
+++ b/activesupport/lib/active_support/security_utils.rb
@@ -31,7 +31,7 @@ module ActiveSupport
     # the secret length. This should be considered when using secure_compare
     # to compare weak, short secrets to user input.
     def secure_compare(a, b)
-      a.length == b.length && fixed_length_secure_compare(a, b)
+      a.bytesize == b.bytesize && fixed_length_secure_compare(a, b)
     end
     module_function :secure_compare
   end

--- a/activesupport/test/security_utils_test.rb
+++ b/activesupport/test/security_utils_test.rb
@@ -9,6 +9,10 @@ class SecurityUtilsTest < ActiveSupport::TestCase
     assert_not ActiveSupport::SecurityUtils.secure_compare("a", "b")
   end
 
+  def test_secure_compare_return_false_on_bytesize_mismatch
+    assert_not ActiveSupport::SecurityUtils.secure_compare("a", "\u{ff41}")
+  end
+
   def test_fixed_length_secure_compare_should_perform_string_comparison
     assert ActiveSupport::SecurityUtils.fixed_length_secure_compare("a", "a")
     assert_not ActiveSupport::SecurityUtils.fixed_length_secure_compare("a", "b")


### PR DESCRIPTION
### Summary

`ActiveSupport::SecurityUtils.secure_compare` dies with ArgumentError (string length mismatch.)
when arguments have same `length` but different `bytesize`.

```
$ bin/rails c
Loading development environment (Rails 6.1.3)
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
irb(main):001:0> ActiveSupport::SecurityUtils.secure_compare("a", "あ")
Traceback (most recent call last):
        1: from (irb):1
ArgumentError (string length mismatch.)
irb(main):002:0> ActiveSupport::SecurityUtils.secure_compare("a", "aa")
=> false
```

It should compare arguments' using `bytesize` and return false.

### Other Information

ref. #39142

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
