### PR TITLE
Add caution notes to active storage migrations

### DIFF
--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -4,9 +4,23 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
       add_column :active_storage_blobs, :service_name, :string
 
       if configured_service = ActiveStorage::Blob.service.name
+        # Fill the initial value for service_name.
+        #
+        # N.B: the database will be locked during the whole update.
+        # Depending on the number of Blob records in the database, this can be
+        # quite slow.
+        # If this is an issue for you, you should edit this migration
+        # (for instance by updating the records incrementally).
         ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
       end
 
+      # Mark the column as not nullable.
+      #
+      # N.B: any other app instances not upgraded to ActiveStorage 6.1 yet will
+      # be unable to create new Blobs until they are upgraded.
+      # If this is an issue for you, you should edit this migration
+      # (for instance by moving the non-nullable change to a separate migration,
+      # that will run after all instances are upgraded to ActiveStorage 6.1).
       change_column :active_storage_blobs, :service_name, :string, null: false
     end
   end

--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -1,31 +1,45 @@
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
   def up
     unless column_exists?(:active_storage_blobs, :service_name)
       add_column :active_storage_blobs, :service_name, :string
+    end
 
-      if configured_service = ActiveStorage::Blob.service.name
-        # Fill the initial value for service_name.
-        #
-        # N.B: the database will be locked during the whole update.
-        # Depending on the number of Blob records in the database, this can be
-        # quite slow.
-        # If this is an issue for you, you should edit this migration
-        # (for instance by updating the records incrementally).
-        ActiveStorage::Blob.unscoped.update_all(service_name: configured_service)
+    if (configured_service = ActiveStorage::Blob.service.name && blobs_without_service_name.count > 0)
+      say_with_time("backfill ActiveStorage::Blob.service.name. This could take a while…") do
+        blobs_without_service_name.in_batches do |relation|
+          relation.update_all service_name: configured_service
+          sleep(0.01) # throttle
+        end
       end
+    end
 
-      # Mark the column as not nullable.
-      #
-      # N.B: any other app instances not upgraded to ActiveStorage 6.1 yet will
-      # be unable to create new Blobs until they are upgraded.
-      # If this is an issue for you, you should edit this migration
-      # (for instance by moving the non-nullable change to a separate migration,
-      # that will run after all instances are upgraded to ActiveStorage 6.1).
-      change_column :active_storage_blobs, :service_name, :string, null: false
+    unless column_exists?(:active_storage_blobs, :service_name, null: false)
+      ActiveStorage::Blob.transaction do
+        # Ensure all service_name values are filled (in case other app instances
+        # not upgraded to ActiveStorage 6.1 yet created records with nil service_name
+        # while we where backfilling the column).
+        blobs_without_service_name.update_all service_name: configured_service
+
+        # Mark the column as not nullable.
+        #
+        # N.B: any other app instances not upgraded to ActiveStorage 6.1 yet will
+        # be unable to create new Blobs until they are upgraded.
+        # If this is an issue for you, you should edit this migration
+        # (for instance by moving the non-nullable change to a separate migration,
+        # that will run after all instances are upgraded to ActiveStorage 6.1).
+        change_column :active_storage_blobs, :service_name, :string, null: false
+      end
     end
   end
 
   def down
     remove_column :active_storage_blobs, :service_name
   end
+
+  private
+    def blobs_without_service_name
+      ActiveStorage::Blob.unscoped.where(service_name: nil)
+    end
 end


### PR DESCRIPTION
### Summary

The `service_name` migration contained in ActiveStorage 6.1 can cause downtime when run on semi-large production systems. This PR warns app maintainers about this, and suggests mitigations.

### Issues with the `add_service_name_to_active_storage_blobs` migration

I recently updated a semi-large production app to Rails 6.1, and ran into a 5 minutes downtime when running this ActiveStorage migration (plus some transcient errors until all instances were migrated).

From what I understand, there are two causes:

1. The `update_all` statement can take a long time (e.g. 1s for 100,000 records), during which the database may be entirely locked (at least on Postgres).
2. The `change_column` statement will make app instances not running on ActiveStorage 6.1 yet unable to create Blobs.

### Mitigations

This PR contains two commits:

1. **The first commit just adds comments** about the pitfalls of this migration. It makes developers aware of potential issue, and prompt them to adjust it themselves if needed.
2. **The second commit makes the migration asynchronous**, which avoids locking the database during the migration.

I guess just adding the comments to the `6-1-stable` branch would allow developers migrating to Rails 6.1 to make informed decisions. And in a second step, adding the actual mitigations could also be nice.