### PR TITLE
Associations in `insert_all` attributes including polymorphic

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -151,7 +151,7 @@ module ActiveRecord
         end
 
         def attributes(object)
-          { @reflection.foreign_key => object.id }
+          { @reflection.foreign_key => object.public_send(@reflection.association_primary_key) }
         end
       end
 
@@ -165,7 +165,8 @@ module ActiveRecord
         end
 
         def attributes(object)
-          { @reflection.foreign_key => object.id, @reflection.foreign_type => object.class.polymorphic_name }
+          { @reflection.foreign_key => object.public_send(@reflection.association_primary_key(object.class)),
+            @reflection.foreign_type => object.class.polymorphic_name }
         end
       end
 

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       reflection_keys = @keys & model._reflections.keys
       reflection_keys.each do |key|
         reflection = model._reflections[key]
-        extender = reflection.polymorphic? ? PolymorphicRelationExtender.new(reflection) : CommonRelationExtender.new(reflection)
+        extender = reflection.polymorphic? ? PolymorphicAssociationExtender.new(reflection) : CommonAssociationExtender.new(reflection)
         @extenders[key] = extender
         @keys |= extender.keys
       end
@@ -141,7 +141,7 @@ module ActiveRecord
         end
       end
 
-      class CommonRelationExtender
+      class CommonAssociationExtender
         def initialize(reflection)
           @reflection = reflection
         end
@@ -155,7 +155,7 @@ module ActiveRecord
         end
       end
 
-      class PolymorphicRelationExtender
+      class PolymorphicAssociationExtender
         def initialize(reflection)
           @reflection = reflection
         end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -128,6 +128,11 @@ module ActiveRecord
       #     { id: 1, title: "Rework" },
       #     { id: 2, title: "Eloquent Ruby" }
       #   ])
+      #
+      #   # insert_all works with associations in attributes including polymorphic
+      #
+      #   Author.create!(name: "David")
+      #   Book.insert_all!([{ author: author, name: "Rework" }])
       def insert_all(attributes, returning: nil, unique_by: nil)
         InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
       end

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -439,7 +439,7 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_insert_all_on_polymorphic_relation_2
+  def test_insert_all_on_polymorphic_relation_in_attributes
     pirate = Pirate.create!(catchphrase: "Yar!")
 
     assert_difference "pirate.treasures.count", +1 do

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -3,6 +3,8 @@
 require "cases/helper"
 require "models/author"
 require "models/book"
+require "models/pirate"
+require "models/treasure"
 require "models/cart"
 require "models/speedometer"
 require "models/subscription"
@@ -418,6 +420,30 @@ class InsertAllTest < ActiveRecord::TestCase
 
     assert_difference "author.books.count", +1 do
       author.books.insert_all!([{ name: "My little book", isbn: "1974522598", author_id: second_author.id }])
+    end
+  end
+
+  def test_insert_all_on_relation_in_attributes
+    author = Author.create!(name: "Jimmy")
+
+    assert_difference "author.books.count", +1 do
+      Book.insert_all!([{ author: author, name: "My little book", isbn: "1974522598" }])
+    end
+  end
+
+  def test_insert_all_on_polymorphic_relation
+    pirate = Pirate.create!(catchphrase: "Yar!")
+
+    assert_difference "pirate.treasures.count", +1 do
+      pirate.treasures.insert_all!([{ name: "gold coins" }])
+    end
+  end
+
+  def test_insert_all_on_polymorphic_relation_2
+    pirate = Pirate.create!(catchphrase: "Yar!")
+
+    assert_difference "pirate.treasures.count", +1 do
+      Treasure.insert_all!([{ looter: pirate, name: "gold coins" }])
     end
   end
 


### PR DESCRIPTION
### Summary

Sometimes this is useful to have associations in `insert_all`/`upsert_all` how we can do it in `create`. We can inline the SQL columns and the object values to get valid attributes for these methods but we already have this info in models and it looks like logic duplication.

It works 
```ruby
pirate = Pirate.create!(catchphrase: "Yar!")
pirate.treasures.insert_all!([{ name: "gold coins" }])
```

But following code have not worked and this PR adds this way
```ruby
Treasure.insert_all!([{ looter: pirate, name: "gold coins" }])
```
