### PR TITLE
Expand payload unpermitted_parameters.action_controller

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Expand payload of `unpermitted_parameters.action_controller` instrumentation to allow subscribers to
+    know which controller action received unpermitted parameters.
+
+    *bbuchalter*
+
 *   Add `ActionController::Live#send_stream` that makes it more convenient to send generated streams:
 
     ```ruby

--- a/actionpack/lib/action_controller/metal/instrumentation_payload.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation_payload.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ActionController
+  # Encasulates logic needed to contruct payload for controller events.
+  module InstrumentationPayload
+    private
+      # The payload data used by the following instrumented events:
+      # * start_processing.action_controller
+      # * process_action.action_controller
+      def controller_instrumentation_payload
+        {
+          controller: self.class.name,
+          action: action_name,
+          request: request,
+          params: request.filtered_parameters,
+          headers: request.headers,
+          format: request.format.ref,
+          method: request.request_method,
+          path: request.fullpath
+        }
+      end
+  end
+end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -280,9 +280,17 @@ INFO. Additional keys may be added by the caller.
 
 ### unpermitted_parameters.action_controller
 
-| Key     | Value            |
-| ------- | ---------------- |
-| `:keys` | Unpermitted keys |
+| Key             | Value                                                     |
+| --------------- | --------------------------------------------------------- |
+| `:keys`         | Unpermitted keys                                          |
+| `:controller`   | The controller name                                       |
+| `:action`       | The action                                                |
+| `:params`       | Hash of request parameters without any filtered parameter |
+| `:headers`      | Request headers                                           |
+| `:format`       | html/js/json/xml etc                                      |
+| `:method`       | HTTP request verb                                         |
+| `:path`         | Request path                                              |
+| `:request`      | The `ActionDispatch::Request`                             |
 
 Action Dispatch
 ---------------

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -526,7 +526,10 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.
 
-* `config.action_controller.action_on_unpermitted_parameters` enables logging or raising an exception if parameters that are not explicitly permitted are found. Set to `:log` or `:raise` to enable. The default value is `:log` in development and test environments, and `false` in all other environments.
+* `config.action_controller.action_on_unpermitted_parameters` controls behavior when parameters that are not explicitly permitted are found. The default value is `:log` in test and development environments, `false` otherwise. The values can be:
+    * `false` to take no action
+    * `:log` to emit an `ActiveSupport::Notifications.instrument` event on the `unpermitted_parameters.action_controller` topic
+    * `:raise` to raise a `ActionController::UnpermittedParameters` exception
 
 * `config.action_controller.always_permitted_parameters` sets a list of permitted parameters that are permitted by default. The default values are `['controller', 'action']`.
 


### PR DESCRIPTION
Previously, when emitting the event, the payload did not include enough information to know which controller action recieved the unpermitted paramaters. This limits the usefulness of the events. This PR expands the payload of the event to include everything provided by the start_processing.action_controller event.