### PR TITLE
[6-0-stable] Backport Upgrade-safe URL-safe CSRF tokens #39076

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,15 +1,22 @@
-*   Accept and default to base64_urlsafe CSRF tokens.
+*   Accept base64_urlsafe CSRF tokens to make forward compatible.
 
     Base64 strict-encoded CSRF tokens are not inherently websafe, which makes
     them difficult to deal with. For example, the common practice of sending
     the CSRF token to a browser in a client-readable cookie does not work properly
     out of the box: the value has to be url-encoded and decoded to survive transport.
 
-    Now, we generate Base64 urlsafe-encoded CSRF tokens, which are inherently safe
-    to transport. Validation accepts both urlsafe tokens, and strict-encoded tokens
-    for backwards compatibility.
+    In Rails 6.1, we generate Base64 urlsafe-encoded CSRF tokens, which are inherently
+    safe to transport. Validation accepts both urlsafe tokens, and strict-encoded
+    tokens for backwards compatibility.
 
-    *Scott Blum*
+    In Rails 5.2.5, the CSRF token format is accidentally changed to urlsafe-encoded.
+    If you upgrade apps from 5.2.5, set the config `urlsafe_csrf_tokens = true`.
+
+    ```ruby
+    Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+    ```
+
+    *Scott Blum*, *Étienne Barrié*
 
 *   Signed and encrypted cookies can now store `false` as their value when
     `action_dispatch.use_cookies_with_metadata` is enabled.

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Accept and default to base64_urlsafe CSRF tokens.
+
+    Base64 strict-encoded CSRF tokens are not inherently websafe, which makes
+    them difficult to deal with. For example, the common practice of sending
+    the CSRF token to a browser in a client-readable cookie does not work properly
+    out of the box: the value has to be url-encoded and decoded to survive transport.
+
+    Now, we generate Base64 urlsafe-encoded CSRF tokens, which are inherently safe
+    to transport.  Validation accepts both urlsafe tokens, and strict-encoded tokens
+    for backwards compatibility.
+
+    *Scott Blum*
+
 *   Signed and encrypted cookies can now store `false` as their value when
     `action_dispatch.use_cookies_with_metadata` is enabled.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -6,7 +6,7 @@
     out of the box: the value has to be url-encoded and decoded to survive transport.
 
     Now, we generate Base64 urlsafe-encoded CSRF tokens, which are inherently safe
-    to transport.  Validation accepts both urlsafe tokens, and strict-encoded tokens
+    to transport. Validation accepts both urlsafe tokens, and strict-encoded tokens
     for backwards compatibility.
 
     *Scott Blum*

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -329,7 +329,7 @@ module ActionController #:nodoc:
         end
 
         begin
-          masked_token = Base64.strict_decode64(encoded_masked_token)
+          masked_token = Base64.urlsafe_decode64(encoded_masked_token)
         rescue ArgumentError # encoded_masked_token is invalid Base64
           return false
         end
@@ -367,7 +367,7 @@ module ActionController #:nodoc:
         one_time_pad = SecureRandom.random_bytes(AUTHENTICITY_TOKEN_LENGTH)
         encrypted_csrf_token = xor_byte_strings(one_time_pad, raw_token)
         masked_token = one_time_pad + encrypted_csrf_token
-        Base64.strict_encode64(masked_token)
+        Base64.urlsafe_encode64(masked_token, padding: false)
       end
 
       def compare_with_real_token(token, session) # :doc:
@@ -393,8 +393,8 @@ module ActionController #:nodoc:
       end
 
       def real_csrf_token(session) # :doc:
-        session[:_csrf_token] ||= SecureRandom.base64(AUTHENTICITY_TOKEN_LENGTH)
-        Base64.strict_decode64(session[:_csrf_token])
+        session[:_csrf_token] ||= SecureRandom.urlsafe_base64(AUTHENTICITY_TOKEN_LENGTH, padding: false)
+        Base64.urlsafe_decode64(session[:_csrf_token])
       end
 
       def per_form_csrf_token(session, action_path, method) # :doc:

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -175,12 +175,15 @@ end
 # common test methods
 module RequestForgeryProtectionTests
   def setup
+    @old_urlsafe_csrf_tokens = ActionController::Base.urlsafe_csrf_tokens
+    ActionController::Base.urlsafe_csrf_tokens = true
     @token = Base64.urlsafe_encode64("railstestrailstestrailstestrails")
     @old_request_forgery_protection_token = ActionController::Base.request_forgery_protection_token
     ActionController::Base.request_forgery_protection_token = :custom_authenticity_token
   end
 
   def teardown
+    ActionController::Base.urlsafe_csrf_tokens = @old_urlsafe_csrf_tokens
     ActionController::Base.request_forgery_protection_token = @old_request_forgery_protection_token
   end
 
@@ -378,10 +381,25 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_allow_post_with_strict_encoded_token
-    session[:_csrf_token] = Base64.strict_encode64("railstestrailstestrailstestrails")
-    @controller.stub :form_authenticity_token, @token do
-      assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
+    token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
+    token_including_url_unsafe_chars = "+/".ljust(token_length, "A")
+    session[:_csrf_token] = token_including_url_unsafe_chars
+    @controller.stub :form_authenticity_token, token_including_url_unsafe_chars do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_unsafe_chars } }
     end
+  end
+
+  def test_should_allow_post_with_urlsafe_token_when_migrating
+    config_before = ActionController::Base.urlsafe_csrf_tokens
+    ActionController::Base.urlsafe_csrf_tokens = false
+    token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
+    token_including_url_safe_chars = "-_".ljust(token_length, "A")
+    session[:_csrf_token] = token_including_url_safe_chars
+    @controller.stub :form_authenticity_token, token_including_url_safe_chars do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_safe_chars } }
+    end
+  ensure
+    ActionController::Base.urlsafe_csrf_tokens = config_before
   end
 
   def test_should_allow_patch_with_token

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -486,6 +486,8 @@ The schema dumper adds two additional configuration options:
 
 * `config.action_controller.default_protect_from_forgery` determines whether forgery protection is added on `ActionController:Base`. This is false by default.
 
+* `config.action_controller.urlsafe_csrf_tokens` configures whether generated CSRF tokens are URL-safe. Defaults to `false`.
+
 * `config.action_controller.relative_url_root` can be used to tell Rails that you are [deploying to a subdirectory](configuring.html#deploy-to-a-subdirectory-relative-url-root). The default is `ENV['RAILS_RELATIVE_URL_ROOT']`.
 
 * `config.action_controller.permit_all_parameters` sets all the parameters for mass assignment to be permitted by default. The default value is `false`.


### PR DESCRIPTION
This is the backport of #39076 to make apps upgrade-safe from Rails 5.2.5.

I've made a PR #41805 to make CSRF tokens forward compatible, that is enough for 6.0.x -> 6.0.next.

But for 5.2.4.x and 5.2.5. #39076 is required to make apps upgrade-safe both 5.2.4.x -> 5.2.next (skip 5.2.5) and 5.2.5 -> 5.2.next.

If this way is preferable, I'll merge this and backport to 5-2-stable (with making this Ruby 2.2 compatible).