### PR TITLE
Convert ActiveRecord::Base.legacy_connection_handling to not use a class variable

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -2,6 +2,12 @@
 
 module ActiveRecord
   module ConnectionHandling
+    class << self
+      attr_accessor :legacy_handling, :handlers # :nodoc:
+    end
+    @legacy_handling = true
+    @handlers = {}
+
     RAILS_ENV   = -> { (Rails.env if defined?(Rails.env)) || ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence }
     DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }
 


### PR DESCRIPTION
This accessor is very frequently accessed in production, and we often see it around 1% of production runtime.

Class variable are very slow, and [even though it might get better in Ruby 3.1](https://bugs.ruby-lang.org/issues/17763), until then it is better to only use them if absolutely necessary.

Here `legacy_connection_handling` is never called on descendants, it is basically just a global, hence doesn't need the inheritance semantic of class variables.

So by moving it to be a regular instance variable of a module, it can be almost 3x faster:

```ruby
require 'benchmark/ips'
require 'active_support/all'

class CVarBase
  mattr_accessor :legacy_connection_handling, instance_writer: false, default: true

  def self.connection_handlers
    unless legacy_connection_handling
      raise NotImplementedError, "The new connection handling does not support accessing multiple connection handlers."
    end

    @@connection_handlers ||= {}
  end

  def self.connection_handlers=(handlers)
    unless legacy_connection_handling
      raise NotImplementedError, "The new connection handling does not setting support multiple connection handlers."
    end

    @@connection_handlers = handlers
  end
end

class CVarChild < CVarBase
end

class RefactorBase
  module Config
    extend self
    attr_accessor :legacy_connection_handling
    @legacy_connection_handling = true

    attr_accessor :connection_handlers
    @connection_handlers = {}
  end

  def self.legacy_connection_handling
    Config.legacy_connection_handling
  end

  def self.legacy_connection_handling=(enabled)
    if (Config.legacy_connection_handling = enabled)
      Config.connection_handlers ||= {}
    else
      Config.connection_handlers = false
    end
  end

  def self.connection_handlers
    Config.connection_handlers or raise NotImplementedError, "The new connection handling does not setting support multiple connection handlers."
  end

  def self.connection_handlers=(handlers)
    unless legacy_connection_handling
      raise NotImplementedError, "The new connection handling does not setting support multiple connection handlers."
    end

    Config.connection_handlers = handlers
  end
end

class RefactorChild < RefactorBase
end

Benchmark.ips do |x|
  x.report('cvar') { CVarChild.connection_handlers }
  x.report('const_ivar') { RefactorChild.connection_handlers }
  x.compare!
end
```

```
Warming up --------------------------------------
                cvar   547.633k i/100ms
          const_ivar     1.458M i/100ms
Calculating -------------------------------------
                cvar      5.418M (± 1.7%) i/s -     27.382M in   5.054881s
          const_ivar     14.576M (± 1.6%) i/s -     72.907M in   5.003221s

Comparison:
          const_ivar: 14576090.3 i/s
                cvar:  5418439.1 i/s - 2.69x  (± 0.00) slower
```

cc @eileencodes because cvars and connection handlers.
cc @tenderlove because we talked about this yesterday.
cc @jhawthorn @rafaelfranca just because.
