### PR TITLE
Upgrade sdoc to 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.0.4"
+  gem "sdoc", ">= 2.1.0"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (2.0.4)
+    sdoc (2.1.0)
       rdoc (>= 5.0)
     selenium-webdriver (4.0.0.alpha7)
       childprocess (>= 0.5, < 5.0)
@@ -615,7 +615,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails
-  sdoc (>= 2.0.4)
+  sdoc (>= 2.1.0)
   selenium-webdriver (>= 4.0.0.alpha7)
   sequel
   sidekiq


### PR DESCRIPTION
### Summary

Sdoc 2.1.0 works better on mobile and has improvements for SEO and Lighthouse.

On small screens we hide the panel and show a top menu bar.

![image](https://user-images.githubusercontent.com/28561/113133796-5b1a6f80-9220-11eb-83a4-53d939c268df.png)

The panel can be toggled by clicking the "menu" and "close" labels.

![image](https://user-images.githubusercontent.com/28561/113133826-666d9b00-9220-11eb-9534-75404c43c79e.png)


@MikeRogers0 Improved the Lighthouse score:
![image](https://user-images.githubusercontent.com/28561/113134418-0c210a00-9221-11eb-9a85-37e5c633c98b.png)

![image](https://user-images.githubusercontent.com/28561/113133613-28707700-9220-11eb-83ac-d62c785d1c3e.png)

Changelog:
* Make panel responsive for mobile.
* Add viewport metatag to views for improved Lighthouse score.
* Use semantic headers for better SEO.

