### PR TITLE
Revert overwriting test_order

### DIFF
--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -91,12 +91,6 @@ module ActiveSupport
         Minitest.parallel_executor = executor
 
         parallelize_me!
-
-        # `Minitest::Test.parallelize_me!` will try to change `test_order` to return
-        # `:parallel`. However, since `ActiveSupport::TestCase` is already overriding it,
-        # in some inheritance situations, it will have precedence over the `Minitest` one.
-        # For this reason, it needs to be updated by hand.
-        self.test_order = :parallel
       end
 
       # Set up hook for parallel testing. This can be used if you have multiple

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -547,17 +547,17 @@ module ApplicationTests
 
         class ParallelTest < ActiveSupport::TestCase
           def test_verify_test_order
-            puts "Test order: \#{self.class.test_order}"
+            puts "Test parallelization disabled: \#{ActiveSupport.test_parallelization_disabled}"
           end
         end
       RUBY
 
       output = run_test_command(file_name)
 
-      assert_match "Test order: random", output
+      assert_match "Test parallelization disabled: true", output
     end
 
-    def test_random_order_is_enabled_when_multiple_files_are_run
+    def test_parallel_is_enabled_when_multiple_files_are_run
       exercise_parallelization_regardless_of_machine_core_count(with: :processes, force: false)
 
       file_1 = app_file "test/unit/parallel_test_first.rb", <<-RUBY
@@ -565,7 +565,7 @@ module ApplicationTests
 
         class ParallelTestFirst < ActiveSupport::TestCase
           def test_verify_test_order
-            puts "Test order (file 1): \#{self.class.test_order}"
+            puts "Test parallelization disabled (file 1): \#{ActiveSupport.test_parallelization_disabled}"
           end
         end
       RUBY
@@ -575,18 +575,18 @@ module ApplicationTests
 
         class ParallelTestSecond < ActiveSupport::TestCase
           def test_verify_test_order
-            puts "Test order (file 2): \#{self.class.test_order}"
+            puts "Test parallelization disabled (file 2): \#{ActiveSupport.test_parallelization_disabled}"
           end
         end
       RUBY
 
       output = run_test_command([file_1, file_2].join(" "))
 
-      assert_match "Test order (file 1): random", output
-      assert_match "Test order (file 2): random", output
+      assert_match "Test parallelization disabled (file 1): false", output
+      assert_match "Test parallelization disabled (file 2): false", output
     end
 
-    def test_random_order_is_enabled_when_PARALLEL_WORKERS_is_set
+    def test_parallel_is_enabled_when_PARALLEL_WORKERS_is_set
       @old = ENV["PARALLEL_WORKERS"]
       ENV["PARALLEL_WORKERS"] = "5"
 
@@ -597,14 +597,14 @@ module ApplicationTests
 
         class ParallelTest < ActiveSupport::TestCase
           def test_verify_test_order
-            puts "Test order: \#{self.class.test_order}"
+            puts "Test parallelization disabled: \#{ActiveSupport.test_parallelization_disabled}"
           end
         end
       RUBY
 
       output = run_test_command(file_name)
 
-      assert_match "Test order: random", output
+      assert_match "Test parallelization disabled: false", output
     ensure
       ENV["PARALLEL_WORKERS"] = @old
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -557,7 +557,7 @@ module ApplicationTests
       assert_match "Test order: random", output
     end
 
-    def test_parallel_is_enabled_when_multiple_files_are_run
+    def test_random_order_is_enabled_when_multiple_files_are_run
       exercise_parallelization_regardless_of_machine_core_count(with: :processes, force: false)
 
       file_1 = app_file "test/unit/parallel_test_first.rb", <<-RUBY
@@ -582,11 +582,11 @@ module ApplicationTests
 
       output = run_test_command([file_1, file_2].join(" "))
 
-      assert_match "Test order (file 1): parallel", output
-      assert_match "Test order (file 2): parallel", output
+      assert_match "Test order (file 1): random", output
+      assert_match "Test order (file 2): random", output
     end
 
-    def test_parallel_is_enabled_when_PARALLEL_WORKERS_is_set
+    def test_random_order_is_enabled_when_PARALLEL_WORKERS_is_set
       @old = ENV["PARALLEL_WORKERS"]
       ENV["PARALLEL_WORKERS"] = "5"
 
@@ -604,7 +604,7 @@ module ApplicationTests
 
       output = run_test_command(file_name)
 
-      assert_match "Test order: parallel", output
+      assert_match "Test order: random", output
     ensure
       ENV["PARALLEL_WORKERS"] = @old
     end


### PR DESCRIPTION
Reverts a change from https://github.com/rails/rails/commit/2327ebfdc6791ce95e6628884ec7b18b73e22bba which can overwrite `test_order` that was manually set by the user in config. This leads to a situation where the user is depending on a particular `test_order` but is unknowingly forced into another.