### PR TITLE
[ci skip] fix on guides mailer_basics avoid ActiveModel::ForbiddenAttributesError 

### DIFF
--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -195,10 +195,11 @@ waiting for the send to complete.
 
 ```ruby
 class UsersController < ApplicationController
-  # POST /users
-  # POST /users.json
+  # ...
+
+  # POST /users or /users.json
   def create
-    @user = User.new(params[:user])
+    @user = User.new(user_params)
 
     respond_to do |format|
       if @user.save
@@ -213,6 +214,8 @@ class UsersController < ApplicationController
       end
     end
   end
+
+  # ...
 end
 ```
 


### PR DESCRIPTION
### Summary

Update Mailer Basics docs, following the guide in the section **2.1.4 Calling the Mailer** after copy the code snippet 
this line:
```ruby
@user = User.new(params[:user])
```
raise the exception:
`
ActiveModel::ForbiddenAttributesError
`
