### PR TITLE
[WIP] Allow customized cookie_jar to be used

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -16,6 +16,8 @@ require "active_support/core_ext/array/conversions"
 
 module ActionDispatch
   class Request
+    cattr_accessor :cookie_jar_class, instance_writer: false
+
     include Rack::Request::Helpers
     include ActionDispatch::Http::Cache::Request
     include ActionDispatch::Http::MimeNegotiation

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -16,7 +16,7 @@ require "active_support/core_ext/array/conversions"
 
 module ActionDispatch
   class Request
-    cattr_accessor :cookie_jar_class, instance_writer: false
+    cattr_accessor :cookie_jar_class, instance_writer: false, default: ActionDispatch::Cookies::CookieJar
 
     include Rack::Request::Helpers
     include ActionDispatch::Http::Cache::Request

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -10,7 +10,7 @@ module ActionDispatch
   module RequestCookieMethods
     def cookie_jar
       fetch_header("action_dispatch.cookies") do
-        self.cookie_jar = Cookies::CookieJar.build(self, cookies)
+        self.cookie_jar = self.cookie_jar_class.build(self, cookies)
       end
     end
 

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -44,6 +44,7 @@ module ActionDispatch
       ActionDispatch::Http::URL.tld_length = app.config.action_dispatch.tld_length
 
       ActiveSupport.on_load(:action_dispatch_request) do
+        self.cookie_jar_class = app.config.action_dispatch.cookie_jar_class || ActionDispatch::Cookies::CookieJar
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_request_media_type_on_content_type
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge


### PR DESCRIPTION
### Summary
This PR introduces changes that allows developers to swap [stock `cookie_jar`](https://github.com/rails/rails/blob/fc5dd0b85189811062c85520fd70de8389b55aeb/actionpack/lib/action_dispatch/middleware/cookies.rb#L282) with custom `cookie_jar`. 

Example use cases for a custom `cookie_jar`:
- Make sure cookies are compliant with privacy regulations before sending.
- Only send cookies that are part of a cookie whitelist.
- Cookies monitoring.
