### PR TITLE
Fix seemingly wrong require "lib"

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "openssl"
-require "zip"
+require "zlib"
 require "active_support/core_ext/numeric"
 
 module ActiveRecord

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -10,9 +10,8 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
 
   test "Finds records when data is unencrypted" do
     ActiveRecord::Encryption.without_encryption { Book.create! name: "Dune" }
-    puts EncryptedBook.where(name: "Dune").to_sql
     assert EncryptedBook.find_by(name: "Dune") # core
-    # assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
+    assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
   end
 
   test "Finds records when data is encrypted" do


### PR DESCRIPTION
### Summary

Running `rake test` in `guides/` is failing:

https://buildkite.com/rails/rails/builds/76198#de7db4af-b8ca-46de-986f-0db34b1d4ddc

This library is used [here](https://github.com/rails/rails/blob/1251703/activerecord/lib/active_record/encryption/encryptor.rb#L121) and [here](https://github.com/rails/rails/blob/1251703/activerecord/lib/active_record/encryption/encryptor.rb#L135).

The test suite should be green again once this one is merged. It's failing because of the bug report files that are pointing to `main` (`guides/bug_report_templates/*_main.rb`).

### Other Information

I removed a print statement and uncommented an assertion, I can revert it back if needed.