### PR TITLE
Make ActionMailer::MailDeliveryJob easily subclassable

### DIFF
--- a/actionmailer/lib/action_mailer/mail_delivery_job.rb
+++ b/actionmailer/lib/action_mailer/mail_delivery_job.rb
@@ -17,14 +17,12 @@ module ActionMailer
       @mailer_class = params ? mailer.constantize.with(params) : mailer.constantize
       @mail_method = mail_method
       @delivery_method = delivery_method
-      @args = args
-      @kwargs = kwargs
 
-      send_message
+      send_message(args, kwargs)
     end
 
-    def send_message
-      message.send(@delivery_method)
+    def send_message(args, kwargs)
+      message(args, kwargs).send(@delivery_method)
     end
 
     private
@@ -36,11 +34,11 @@ module ActionMailer
         end
       end
 
-      def message
-        @message ||= if @kwargs
-          @mailer_class.public_send(@mail_method, *@args, **@kwargs)
+      def message(args, kwargs)
+        if kwargs.present?
+          @mailer_class.public_send(@mail_method, *args, **kwargs)
         else
-          @mailer_class.public_send(@mail_method, *@args)
+          @mailer_class.public_send(@mail_method, *args)
         end
       end
 


### PR DESCRIPTION
### Summary

`ActionMailer` allows mailers to set a custom job to process messages scheduled to `deliver_later`. (https://edgeapi.rubyonrails.org/classes/ActionMailer/MessageDelivery.html#method-i-deliver_later)

However the arguments passed to this custom job are the same as those passed to `ActionMailer::MailDeliveryJob` and would require some metaprogramming to actually send the message. The metaprogramming logic would likely be a copy->paste from `ActionMailer::MailDeliveryJob`; so I thought if we extracted the actual sending of the message into its own method, `ActionMailer::MailDeliveryJob` can easily be subclassed and any additional logic can be added by overriding the new `send_message` method.

I reckon one of the most common use cases to use a custom delivery job would be to conditionally send an email (eg: Send a trial ending reminder only if the user hasn't bought a subscription). This would now be very simple by subclassing `ActionMailer::MailDeliveryJob` and overriding `send_message` to include the conditional logic.


### Other Information

I've just opened this PR to check if if my reasoning for this change is sound or if I've overlooked something that would make this change unviable. I know this needs more work, so if this change is valid then I'll update the docs and add a test and anything else that needs doing to get this into shape to merge!