### PR TITLE
Add new "encrypted_books" table to the schema

### DIFF
--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -102,7 +102,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   test "deterministic ciphertexts remain constant" do
     # We need to make sure these don't change or existing apps will stop working
     ciphertext = "{\"p\":\"DIohhw==\",\"h\":{\"iv\":\"wEPaDcJP3VNIxaiz\",\"at\":\"X7+2xvvcu1k1if6Dy28Esw==\"}}"
-    book = Book.create name: ciphertext
+    book = UnencryptedBook.create name: ciphertext
 
     book = EncryptedBook.find(book.id)
     assert_equal "Dune", book.name

--- a/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
+++ b/activerecord/test/cases/encryption/extended_deterministic_queries_test.rb
@@ -9,13 +9,13 @@ class ActiveRecord::Encryption::ExtendedDeterministicQueriesTest < ActiveRecord:
   end
 
   test "Finds records when data is unencrypted" do
-    ActiveRecord::Encryption.without_encryption { Book.create! name: "Dune" }
+    ActiveRecord::Encryption.without_encryption { UnencryptedBook.create! name: "Dune" }
     assert EncryptedBook.find_by(name: "Dune") # core
     assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
   end
 
   test "Finds records when data is encrypted" do
-    Book.create! name: "Dune"
+    UnencryptedBook.create! name: "Dune"
     assert EncryptedBook.find_by(name: "Dune") # core
     assert EncryptedBook.where("id > 0").find_by(name: "Dune") # relation
   end

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -70,7 +70,7 @@ module ActiveRecord::Encryption
 
         # Skip type casting to simulate an upcase value. Not supported in AR without using private apis
         EncryptedBookThatIgnoresCase.connection.execute <<~SQL
-          UPDATE books SET name = '#{name}' WHERE id = #{book.id};
+          UPDATE encrypted_books SET name = '#{name}' WHERE id = #{book.id};
         SQL
 
         book.reload

--- a/activerecord/test/fixtures/encrypted_book_that_ignores_cases.yml
+++ b/activerecord/test/fixtures/encrypted_book_that_ignores_cases.yml
@@ -3,5 +3,3 @@ rfr:
   id: 2
   name: "Ruby for Rails"
   format: "ebook"
-  status: "proposed"
-  last_read: "reading"

--- a/activerecord/test/fixtures/encrypted_books.yml
+++ b/activerecord/test/fixtures/encrypted_books.yml
@@ -3,11 +3,3 @@ awdr:
   id: 1
   name: "Agile Web Development with Rails"
   format: "paperback"
-  status: :published
-  last_read: :read
-  language: :english
-  author_visibility: :visible
-  illustrator_visibility: :visible
-  font_size: :medium
-  difficulty: :medium
-  boolean_status: :enabled

--- a/activerecord/test/models/book_encrypted.rb
+++ b/activerecord/test/models/book_encrypted.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-require "models/book"
+class UnencryptedBook < ActiveRecord::Base
+  self.table_name = "encrypted_books"
+end
 
 class EncryptedBook < ActiveRecord::Base
-  self.table_name = "books"
+  self.table_name = "encrypted_books"
 
   encrypts :name, deterministic: true
 end
 
 class EncryptedBookWithDowncaseName < ActiveRecord::Base
-  self.table_name = "books"
+  self.table_name = "encrypted_books"
 
   validates :name, uniqueness: true
   encrypts :name, deterministic: true, downcase: true
 end
 
 class EncryptedBookThatIgnoresCase < ActiveRecord::Base
-  self.table_name = "books"
+  self.table_name = "encrypted_books"
 
   encrypts :name, deterministic: true, ignore_case: true
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -124,6 +124,16 @@ ActiveRecord::Schema.define do
     t.date :updated_on
   end
 
+  create_table :encrypted_books, id: :integer, force: true do |t|
+    t.references :author
+    t.string :format
+    t.column :name, :string
+    t.column :original_name, :string
+
+    t.datetime :created_at
+    t.datetime :updated_at
+  end
+
   create_table :booleans, force: true do |t|
     t.boolean :value
     t.boolean :has_fun, null: false, default: false


### PR DESCRIPTION
### Summary

Reusing the "books" one could cause interferences when fixtures are
loaded in a very specific order such as:

https://buildkite.com/rails/rails/builds/76217#ee4ce591-e6c1-4a0d-a7db-1f83647d141e

Reproduction command using minitest-bisect:

```
activerecord $ bin/test -v --seed 23607 -n "/^(?:EagerAssociationTest#(?:test_preloading_a_regular_association_with_a_typo_through_a_polymorphic_association_still_raises)|ActiveRecord::Encryption::EncryptableFixtureTest#(?:test_fixtures_get_encrypted_automatically)|ViewWithoutPrimaryKeyTest#(?:test_attributes|test_reading))$/"
```