### PR TITLE
Allow to set cache expiry as an absolute timestamp

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `expires_at` argument to `ActiveSupport::Cache` `write` and `fetch` to set a cache entry TTL as an absolute time.
+
+    ```ruby
+    Rails.cache.write(key, value, expires_at: Time.now.at_end_of_hour)
+    ```
+
+    *Jean Boussier*
+
 *   Deprecate `ActiveSupport::TimeWithZone.name` so that from Rails 7.1 it will use the default implementation.
 
     *Andrew White*

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -393,15 +393,41 @@ module CacheStoreBehavior
     time = Time.local(2008, 4, 24)
 
     Time.stub(:now, time) do
-      @cache.write("foo", "bar")
+      @cache.write("foo", "bar", expires_in: 1.minute)
+      @cache.write("egg", "spam", expires_in: 2.minute)
       assert_equal "bar", @cache.read("foo")
+      assert_equal "spam", @cache.read("egg")
     end
 
     Time.stub(:now, time + 30) do
       assert_equal "bar", @cache.read("foo")
+      assert_equal "spam", @cache.read("egg")
     end
 
     Time.stub(:now, time + 61) do
+      assert_nil @cache.read("foo")
+      assert_equal "spam", @cache.read("egg")
+    end
+
+    Time.stub(:now, time + 121) do
+      assert_nil @cache.read("foo")
+      assert_nil @cache.read("egg")
+    end
+  end
+
+  def test_expires_at
+    time = Time.local(2008, 4, 24)
+
+    Time.stub(:now, time) do
+      @cache.write("foo", "bar", expires_at: time + 15.seconds)
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 10) do
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 30) do
       assert_nil @cache.read("foo")
     end
   end

--- a/activesupport/test/cache/cache_entry_test.rb
+++ b/activesupport/test/cache/cache_entry_test.rb
@@ -9,8 +9,14 @@ class CacheEntryTest < ActiveSupport::TestCase
     assert_not entry.expired?, "entry not expired"
     entry = ActiveSupport::Cache::Entry.new("value", expires_in: 60)
     assert_not entry.expired?, "entry not expired"
-    Time.stub(:now, Time.now + 61) do
+    Time.stub(:now, Time.at(entry.expires_at + 1)) do
       assert entry.expired?, "entry is expired"
     end
+  end
+
+  def test_initialize_with_expires_at
+    entry = ActiveSupport::Cache::Entry.new("value", expires_in: 60)
+    clone = ActiveSupport::Cache::Entry.new("value", expires_at: entry.expires_at)
+    assert_equal entry.expires_at, clone.expires_at
   end
 end


### PR DESCRIPTION
I was initially going for an advanced feature, but realized the most straightforward way to implement it actually expose it as public API on `Cache#write` and `#fetch`. But it turns out it's a feature that makes sense, so I'll go with it.

### Case for `expires_at`

Sometime it can be useful to set a cache entry expiry not relative to current time, but as an absolute timestamps, e.g.:

  - If you want to cache an API token that was provided to you with a precise expiry time.
  - If you want to cache something until a precise cutoff time, e.g. `expires_at: Time.now.at_end_of_hour`
  - Probably lots of other minor uses I didn't think of.

### Aliases

`expires_in` is aliased as `expire_in` and `expired_in`. I wonder if I should implement the same aliases or to consider these as deprecated.

### Original description

Some cache backend don't Marshal the entire Entry state but instead serialize its components in a specific format.

As such they need to be able to build an Entry by passing `expires_at` instead of `expires_in`. e.g.:

```ruby
payload = MessagePack.dump([entry.value, entry.expires_at, entry.version])
entry_components = MessagePack.load(payload)
Entry.new(entry_components[0], expires_at: entry_components[1], version: entry_components[2])
```

This leaves the `@created_at` variable in a weird useless state, but this is to avoid breaking the binary format.

~~While I was at it, I replaced `Time.now.to_f` by `Process.clock_gettime` as it is about 3x faster:~~ I'll keep that to another PR, as lots of stubs would need to be updated.
