### PR TITLE
feat(activesupport): extract lock_file to File.lock

### DIFF
--- a/activesupport/lib/active_support/core_ext/file.rb
+++ b/activesupport/lib/active_support/core_ext/file.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/file/lock"
 require "active_support/core_ext/file/atomic"

--- a/activesupport/lib/active_support/core_ext/file/lock.rb
+++ b/activesupport/lib/active_support/core_ext/file/lock.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class File
+  # Lock a file for a block so only one process can modify it at a time.
+  def self.lock(file_name, &block)
+    if exist?(file_name)
+      open(file_name, "r+") do |f|
+        f.flock LOCK_EX
+        yield
+      ensure
+        f.flock LOCK_UN
+      end
+    else
+      yield
+    end
+  end
+end


### PR DESCRIPTION
This pull request extracts private method `lock_file`  from `FileStore` class to `File` as a public method. This is a low-hanging fruit feature that should be available just like `atomic_write`. Both methods are usually used together anyway.