### PR TITLE
Exclude encryption performance tests from *:isolated_test tasks

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -112,7 +112,7 @@ end
         test_options = ENV["TESTOPTS"].to_s.split(/[\s]+/)
 
         test_files = (Dir["test/cases/**/*_test.rb"].reject {
-          |x| x.include?("/adapters/")
+          |x| x.include?("/adapters/") || x.include?("/encryption/performance")
         } + Dir["test/cases/adapters/#{adapter_short}/**/*_test.rb"]).sort
 
         if ENV["BUILDKITE_PARALLEL_JOB_COUNT"]


### PR DESCRIPTION
Encryption performance tests are meant to be excluded from CI builds, and be executed via specific rake tasks instead. However they were being included when running `*:isolated_test` tasks for active record adapters.

cc @fxn, this made [this commit](https://github.com/rails/rails/commit/af27a25f1996f44d5bd173ccaac19cd7f1455cfb) build fail.
