### PR TITLE
Visually cap huge exception messages

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
@@ -9,7 +9,7 @@
   <p>
     Showing <i><%= @exception.file_name %></i> where line <b>#<%= @exception.line_number %></b> raised:
   </p>
-  <pre><code><%= h @exception.message %></code></pre>
+  <pre style="max-height: 1000px; overflow: auto;"><code><%= h @exception.message %></code></pre>
 
   <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Noticed that the helpful errors given by ActionDispatch in development are overwhelmingly huge on some cases. Such as a typoed variable name in .html.erb file.

This makes it a bit easier to scroll down to the `Extracted source (around line #X):` bit of the page, which is usually way more helpful on such cases.

<details>
<summary>📸 Screenshot</summary>

<img width="1229" alt="Screen Shot 2021-04-04 at 10 09 52" src="https://user-images.githubusercontent.com/7394653/113510001-d5a00380-952e-11eb-8cac-91e19051a5d7.png">

</details>

### Other Information

This is the minimal effort change I came up with, as I am not super familiar with the Rails codebase. But If someone can direct me, I can make any other necessary changes. 
Like possibly moving CSS to a specific `.css` file. Or anything else, maybe a "Expand" button instead of the overflow, ...

Also, another thing that called my attention is that on such case, the exception message is a whooping 5MB+! Which takes a couple seconds to load in full(At least on my usual setup, Mac+Docker, which is known to be kinda slow). Maybe it could be cutoff at some point (~1MB?) and have another mechanism to actually bring the full message.
But it might be a bit counterproductive, as on some extreme cases the only thing you might have to debug is this message...

*Left CHANGELOG changes to be made after I receive some feedback 😉* 
