### PR TITLE
Deprecate ActiveSupport::TimeWithZone.name

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Deprecate `ActiveSupport::TimeWithZone.name` so that from Rails 7.1 it will use the default implementation.
+
+    *Andrew White*
+
 *   Tests parallelization is now disabled when running individual files to prevent the setup overhead.
 
     It can still be enforced if the environment variable `PARALLEL_WORKERS` is present and set to a value greater than 1.

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -40,6 +40,11 @@ module ActiveSupport
   class TimeWithZone
     # Report class name as 'Time' to thwart type checking.
     def self.name
+      ActiveSupport::Deprecation.warn(<<~EOM)
+        ActiveSupport::TimeWithZone.name has been deprecated and
+        from Rails 7.1 will use the default Ruby implementation.
+      EOM
+
       "Time"
     end
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -585,12 +585,15 @@ class HashToXmlTest < ActiveSupport::TestCase
   end
 
   def test_timezoned_attributes
-    xml = {
-      created_at: Time.utc(1999, 2, 2),
-      local_created_at: Time.utc(1999, 2, 2).in_time_zone("Eastern Time (US & Canada)")
-    }.to_xml(@xml_options)
-    assert_match %r{<created-at type="dateTime">1999-02-02T00:00:00Z</created-at>}, xml
-    assert_match %r{<local-created-at type="dateTime">1999-02-01T19:00:00-05:00</local-created-at>}, xml
+    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated") do
+      xml = {
+        created_at: Time.utc(1999, 2, 2),
+        local_created_at: Time.utc(1999, 2, 2).in_time_zone("Eastern Time (US & Canada)")
+      }.to_xml(@xml_options)
+
+      assert_match %r{<created-at type="dateTime">1999-02-02T00:00:00Z</created-at>}, xml
+      assert_match %r{<local-created-at type="dateTime">1999-02-01T19:00:00-05:00</local-created-at>}, xml
+    end
   end
 
   def test_multiple_records_from_xml_with_attributes_other_than_type_ignores_them_without_exploding

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -186,7 +186,9 @@ class TimeWithZoneTest < ActiveSupport::TestCase
       time: 1999-12-31 19:00:00.000000000 Z
     EOF
 
-    assert_equal(yaml, @twz.to_yaml)
+    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated") do
+      assert_equal(yaml, @twz.to_yaml)
+    end
   end
 
   def test_ruby_to_yaml
@@ -199,7 +201,9 @@ class TimeWithZoneTest < ActiveSupport::TestCase
         time: 1999-12-31 19:00:00.000000000 Z
     EOF
 
-    assert_equal(yaml, { "twz" => @twz }.to_yaml)
+    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated") do
+      assert_equal(yaml, { "twz" => @twz }.to_yaml)
+    end
   end
 
   def test_yaml_load
@@ -567,7 +571,9 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_class_name
-    assert_equal "Time", ActiveSupport::TimeWithZone.name
+    assert_deprecated("ActiveSupport::TimeWithZone.name has been deprecated") do
+      assert_equal "Time", ActiveSupport::TimeWithZone.name
+    end
   end
 
   def test_method_missing_with_time_return_value


### PR DESCRIPTION
In c00f2d2 the `name` method was overridden to return 'Time' instead of the real class name 'ActiveSupport::TimeWithZone'. The reasoning for this is unclear and it can cause confusion for developers assuming that name is returning the real class name. Since we don't know why this was added, we're deprecating the method first to give developers a chance to provide us with feedback and look to fix any issues that arise.
