### PR TITLE
Use stable branch for --edge option when not alpha

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -270,7 +270,7 @@ module Rails
             GemfileEntry.path("rails", Rails::Generators::RAILS_DEV_PATH)
           ]
         elsif options.edge?
-          edge_branch = Rails.gem_version.prerelease? ? "main" : [*Rails.gem_version.segments.first(2), "stable"].join("-")
+          edge_branch = Rails.version.end_with?("alpha") ? "main" : [*Rails.gem_version.segments.first(2), "stable"].join("-")
           [
             GemfileEntry.github("rails", "rails/rails", edge_branch)
           ]
@@ -361,9 +361,9 @@ module Rails
       def exec_bundle_command(bundle_command, command, env)
         full_command = %Q["#{Gem.ruby}" "#{bundle_command}" #{command}]
         if options[:quiet]
-          system(env, full_command, out: File::NULL)
+          system(env, full_command, out: File::NULL, exception: true)
         else
-          system(env, full_command)
+          system(env, full_command, exception: true)
         end
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -856,23 +856,28 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_edge_option
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0")) do
-      generator([destination_root], edge: true, skip_webpack_install: true)
-      run_generator_instance
-    end
+    %w[2.1.0.beta1 2.1.0.rc1 2.1.0 2.1.1.rc1].each do |version|
+      Rails.stub(:version, version) do
+        prepare_destination
+        run_generator [destination_root, "--edge"]
+      end
 
-    assert_equal 1, @bundle_commands.count("install")
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']2-1-stable["']$}
+      assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']\d+-\d+-stable["']$}
+    end
   end
 
   def test_edge_option_during_alpha
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0.alpha")) do
-      generator([destination_root], edge: true, skip_webpack_install: true)
-      run_generator_instance
+    Rails.stub(:version, "2.1.0.alpha") do
+      run_generator [destination_root, "--edge"]
     end
 
-    assert_equal 1, @bundle_commands.count("install")
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
+  end
+
+  def test_edge_option_runs_bundle_install
+    generator([destination_root], edge: true, skip_webpack_install: true)
+    run_generator_instance
+    assert_equal 1, @bundle_commands.count("install")
   end
 
   def test_master_option

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -250,23 +250,28 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_edge_option
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0")) do
-      generator([destination_root], edge: true)
-      run_generator_instance
-    end
+    %w[2.1.0.beta1 2.1.0.rc1 2.1.0 2.1.1.rc1].each do |version|
+      Rails.stub(:version, version) do
+        prepare_destination
+        run_generator [destination_root, "--edge"]
+      end
 
-    assert_empty @bundle_commands
-    assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']2-1-stable["']$}
+      assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']\d+-\d+-stable["']$}
+    end
   end
 
   def test_edge_option_during_alpha
-    Rails.stub(:gem_version, Gem::Version.new("2.1.0.alpha")) do
-      generator([destination_root], edge: true)
-      run_generator_instance
+    Rails.stub(:version, "2.1.0.alpha") do
+      run_generator [destination_root, "--edge"]
     end
 
-    assert_empty @bundle_commands
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
+  end
+
+  def test_edge_option_does_not_run_bundle_install
+    generator([destination_root], edge: true, skip_webpack_install: true)
+    run_generator_instance
+    assert_empty @bundle_commands
   end
 
   def test_generation_does_not_run_bundle_install_with_full_and_mountable


### PR DESCRIPTION
Follow-up to #41568.

If a user runs `rails new --edge` with an `x.y.0.betaN` or `x.y.z.rcN` version, they most likely want to track the `x-y-stable` branch rather than `main` branch.  In some cases, the `x-y-stable` branch may not exist yet.  In those cases, it is better to raise an error when `bundle install` fails, so that the user knows that the branch is not available.
