### PR TITLE
Active Storage: upgrade to mini_mime 1.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       activerecord (= 7.0.0.alpha)
       activesupport (= 7.0.0.alpha)
       marcel (~> 1.0.0)
-      mini_mime (~> 1.0.2)
+      mini_mime (>= 1.1.0)
     activesupport (7.0.0.alpha)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -224,6 +224,9 @@ GEM
       tzinfo
     event_emitter (0.2.6)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-java)
+    eventmachine (1.2.7-x64-mingw32)
+    eventmachine (1.2.7-x86-mingw32)
     execjs (2.7.0)
     faraday (1.3.0)
       faraday-net_http (~> 1.0)
@@ -290,12 +293,14 @@ GEM
     hiredis (0.6.3)
     hiredis (0.6.3-java)
     http_parser.rb (0.6.0)
+    http_parser.rb (0.6.0-java)
     httpclient (2.8.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    jar-dependencies (0.4.1)
     jdbc-mysql (5.1.47)
     jdbc-postgres (42.2.14)
     jdbc-sqlite3 (3.28.0)
@@ -307,6 +312,7 @@ GEM
       mustache
       nokogiri
     libxml-ruby (3.2.1)
+    libxml-ruby (3.2.1-x64-mingw32)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -319,7 +325,7 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_magick (4.11.0)
-    mini_mime (1.0.2)
+    mini_mime (1.1.0)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     minitest-bisect (1.5.1)
@@ -368,6 +374,8 @@ GEM
     pg (1.2.3-x64-mingw32)
     pg (1.2.3-x86-mingw32)
     psych (3.3.0)
+    psych (3.3.0-java)
+      jar-dependencies (>= 0.1.7)
     public_suffix (4.0.6)
     puma (5.1.1)
       nio4r (~> 2.0)
@@ -636,4 +644,4 @@ DEPENDENCIES
   websocket-client-simple!
 
 BUNDLED WITH
-   2.2.3
+   2.2.15

--- a/activestorage/activestorage.gemspec
+++ b/activestorage/activestorage.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord",  version
 
   s.add_dependency "marcel",    "~> 1.0.0"
-  s.add_dependency "mini_mime", "~> 1.0.2"
+  s.add_dependency "mini_mime", ">= 1.1.0"
 end

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -89,7 +89,7 @@ class ActiveStorage::Variant
   end
 
   def filename
-    ActiveStorage::Filename.new "#{blob.filename.base}.#{variation.format}"
+    ActiveStorage::Filename.new "#{blob.filename.base}.#{variation.format.downcase}"
   end
 
   alias_method :content_type_for_serving, :content_type

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -33,7 +33,7 @@ class ActiveStorage::VariantWithRecord
     def transform_blob
       blob.open do |input|
         variation.transform(input) do |output|
-          yield io: output, filename: "#{blob.filename.base}.#{variation.format}",
+          yield io: output, filename: "#{blob.filename.base}.#{variation.format.downcase}",
             content_type: variation.content_type, service_name: blob.service.name
         end
       end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -122,9 +122,17 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
-  test "PNG variation of JPEG blob" do
+  test "PNG variation of JPEG blob with lowercase format" do
     blob = create_file_blob(filename: "racecar.jpg")
     variant = blob.variant(format: :png).processed
+    assert_equal "racecar.png", variant.filename.to_s
+    assert_equal "image/png", variant.content_type
+    assert_equal "PNG", read_image(variant).type
+  end
+
+  test "PNG variation of JPEG blob with uppercase format" do
+    blob = create_file_blob(filename: "racecar.jpg")
+    variant = blob.variant(format: "PNG").processed
     assert_equal "racecar.png", variant.filename.to_s
     assert_equal "image/png", variant.content_type
     assert_equal "PNG", read_image(variant).type


### PR DESCRIPTION
Fix validating uppercase variant formats. Closes #41796.