### PR TITLE
ActiveRecord#strict_loading! should return boolean instead of current mode set.

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -765,8 +765,8 @@ module ActiveRecord
         raise ArgumentError, "The :mode option must be one of [:all, :n_plus_one_only]."
       end
 
-      @strict_loading = value
       @strict_loading_mode = mode
+      @strict_loading = value
     end
 
     def strict_loading_n_plus_one_only? # :nodoc:

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -19,19 +19,22 @@ class StrictLoadingTest < ActiveRecord::TestCase
     developer = Developer.first
     assert_not_predicate developer, :strict_loading?
 
-    developer.strict_loading!
+    assert developer.strict_loading!
     assert_predicate developer, :strict_loading?
 
     assert_raises ActiveRecord::StrictLoadingViolationError do
       developer.audit_logs.to_a
     end
 
-    developer.strict_loading!(false)
+    assert_not developer.strict_loading!(false)
     assert_not_predicate developer, :strict_loading?
 
     assert_nothing_raised do
       developer.audit_logs.to_a
     end
+
+    assert developer.strict_loading!(mode: :n_plus_one_only)
+    assert developer.strict_loading_n_plus_one_only?
   end
 
   def test_strict_loading_n_plus_one_only_mode


### PR DESCRIPTION
The return type was changed in the PR #41704 after addition of mode
option. The current documentation is misleading since
documentation propose strict_loading! would return boolean whereas
it returns the current mode set.

I came across this issue while debugging: #41827 and thought
this should be brought to the attention.

PR fixes the issue and would always return boolean based on
strict_loading is enabled or disabled.

```
user.strict_loading! # => true
user.strict_loading!(false) # => false
user.strict_loading!(mode: :n_plus_one_only) # => true
```