### PR TITLE
Add `ActiveRecord::Relation#structurally_compatible?`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `ActiveRecord::Relation#structurally_compatible?`.
+
+    Adds a query method by which a user can tell if the relation that they're
+    about to use for `#or` or `#and` is structurally compatible with the
+    receiver.
+
+    *Kevin Newton*
+
 *   Fix `eager_loading?` when ordering with `Symbol`
 
     `eager_loading?` is triggered correctly when using `order` with symbols.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -731,6 +731,21 @@ module ActiveRecord
       self
     end
 
+    # Checks whether the given relation is structurally compatible with this relation, to determine
+    # if it's possible to use the #and and #or methods without raising an error. Structurally
+    # compatible is defined as: they must be scoping the same model, and they must differ only by
+    # #where (if no #group has been defined) or #having (if a #group is present).
+    #
+    #    Post.where("id = 1").structurally_compatible?(Post.where("author_id = 3"))
+    #    # => true
+    #
+    #    Post.joins(:comments).structurally_compatible?(Post.where("id = 1"))
+    #    # => false
+    #
+    def structurally_compatible?(other)
+      structurally_incompatible_values_for(other).empty?
+    end
+
     # Returns a new relation, which is the logical intersection of this relation and the one passed
     # as an argument.
     #

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -50,7 +50,7 @@ module ActiveRecord
       ActiveRecord::FinderMethods.public_instance_methods(false) - [:include?, :member?, :raise_record_not_found_exception!] +
       ActiveRecord::SpawnMethods.public_instance_methods(false) - [:spawn, :merge!] +
       ActiveRecord::QueryMethods.public_instance_methods(false).reject { |method|
-        method.end_with?("=", "!", "value", "values", "clause")
+        method.end_with?("=", "!", "?", "value", "values", "clause")
       } - [:reverse_order, :arel, :extensions, :construct_join_dependency] + [
         :any?, :many?, :none?, :one?,
         :first_or_create, :first_or_create!, :first_or_initialize,

--- a/activerecord/test/cases/relation/structural_compatibility_test.rb
+++ b/activerecord/test/cases/relation/structural_compatibility_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+module ActiveRecord
+  class StructuralCompatibilityTest < ActiveRecord::TestCase
+    fixtures :posts
+
+    def test_compatible_values
+      left = Post.where(id: 1)
+      right = Post.where(id: 2)
+
+      assert left.structurally_compatible?(right)
+    end
+
+    def test_incompatible_single_value_relations
+      left = Post.distinct.where("id = 1")
+      right = Post.where(id: [2, 3])
+
+      assert_not left.structurally_compatible?(right)
+    end
+
+    def test_incompatible_multi_value_relations
+      left = Post.order("body asc").where("id = 1")
+      right = Post.order("id desc").where(id: [2, 3])
+
+      assert_not left.structurally_compatible?(right)
+    end
+
+    def test_incompatible_unscope
+      left = Post.order("body asc").where("id = 1").unscope(:order)
+      right = Post.order("body asc").where("id = 2")
+
+      assert_not left.structurally_compatible?(right)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Adds a query method by which a user can tell if the relation that they're  about to use for `#or` or `#and` is structurally compatible with the receiver.

### Other Information

Previously you either needed to iterate over the values of the relation or just catch the ArgumentError thrown by `#or` or `#and` in order to determine if two relations were structurally compatible.

As for my use case: I have filters coming in from query parameters that are transformed into `ActiveRecord::Relation` objects. Those objects are then joined together using `or` and `and` to get to one single relation at the end. The issue is, if a developer adds a join into any of the transformations, then all of the sudden we've got structurally incompatible relations and some filters can't be used with others. What I'd like to do in this case is:

```ruby
relations = [...]
relations.drop(1).inject(relations.first) do |current, other|
  if current.structurally_compatible?(other)
    current.or(other)
  else
    Model.where(id: current).or(Model.where(id: other))
  end
end
```

or something to that effect, so that I don't have to catch any errors and devs can use whatever grouping/joins they want to to get the filters working correctly.