### PR TITLE
Do not autoload in initializer in example code

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -423,6 +423,7 @@ by default has been mixed into Active Record classes.
 You can extend the list of supported argument types. You just need to define your own serializer:
 
 ```ruby
+# app/serializers/money_serializer.rb
 class MoneySerializer < ActiveJob::Serializers::ObjectSerializer
   # Checks if an argument should be serialized by this serializer.
   def serialize?(argument)
@@ -449,7 +450,20 @@ end
 and add this serializer to the list:
 
 ```ruby
+# config/initializer/custom_serializers.rb
 Rails.application.config.active_job.custom_serializers << MoneySerializer
+```
+
+Note that auto-loading reloadable code during initialization is not supported. Thus it is recommended
+to set-up serializers to be loaded only once, e.g. by amending `config/application.rb` like this:
+
+```ruby
+# config/application.rb
+module YourApp
+  class Application < Rails::Application
+    config.autoload_once_paths << Rails.root.join('app', 'serializers')
+  end
+end
 ```
 
 Exceptions


### PR DESCRIPTION
### Summary

Performing autoloading during initialization is not supported by Rails and will result in a detailed deprecation warning.
Following the proposed fix in the deprecation warning will not work with the given piece of code however.

According to https://github.com/rails/rails/issues/37690 the new example code is a supported workaround for the given problem.

This PR should at least address the documentation concerns mentioned by @fxn in that issue.

### Other Information

The afforementioned issue also mentions proposals on how to improve the way that serializers are loaded in general, including the idea to pass class names as strings instead of immediately looking them up during initialization. Investigating those options would IMO still be viable, but probably takes longer to discuss and implement than documenting a preferred way to work around this issue.
