### PR TITLE
Stop checking for Process.pid and trust the `fork` decorators

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -53,15 +53,9 @@ module ActiveRecord
     # about the model. The model needs to pass a connection specification name to the handler,
     # in order to look up the correct connection pool.
     class ConnectionHandler
-      FINALIZER = lambda { |_| ActiveSupport::ForkTracker.check! }
-      private_constant :FINALIZER
-
       def initialize
         # These caches are keyed by pool_config.connection_specification_name (PoolConfig#connection_specification_name).
         @owner_to_pool_manager = Concurrent::Map.new(initial_capacity: 2)
-
-        # Backup finalizer: if the forked child skipped Kernel#fork the early discard has not occurred
-        ObjectSpace.define_finalizer self, FINALIZER
       end
 
       def prevent_writes # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -36,8 +36,6 @@ module ActiveRecord
       end
 
       def disconnect!
-        ActiveSupport::ForkTracker.check!
-
         return unless @pool
 
         synchronize do
@@ -51,8 +49,6 @@ module ActiveRecord
       end
 
       def pool
-        ActiveSupport::ForkTracker.check!
-
         @pool || synchronize { @pool ||= ConnectionAdapters::ConnectionPool.new(self) }
       end
 


### PR DESCRIPTION
`Process.pid` is not cached on Linux and is surprisingly expensive. These checks are in hotspots, so the cost is not negligible.

In https://github.com/rails/rails/pull/37296#discussion_r330222303 we established that it's pretty much impossible to bypass `Process.fork` / `Kernel#fork`.

We still added the checks to protect against user defined `after_fork` hooks that would use the connection. But I don't think the cost is worth this extra safety.

At the same time [I'll try to push for Ruby to expose a native `after_fork` callback](https://bugs.ruby-lang.org/issues/5446#note-35), but of course even if it works it might take a while before Rails can use it.

@matthewd What do you think? Do you still feel strongly about this extra check?