### PR TITLE
Rails 6.1.x has 7.0 deprecation horizon

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -79,13 +79,13 @@ module ActionMailbox
       def key
         if Rails.application.credentials.dig(:action_mailbox, :mailgun_api_key)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Rails.application.credentials.action_mailbox.api_key is deprecated and will be ignored in Rails 6.2.
+            Rails.application.credentials.action_mailbox.api_key is deprecated and will be ignored in Rails 7.0.
             Use Rails.application.credentials.action_mailbox.signing_key instead.
           MSG
           Rails.application.credentials.dig(:action_mailbox, :mailgun_api_key)
         elsif ENV["MAILGUN_INGRESS_API_KEY"]
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            The MAILGUN_INGRESS_API_KEY environment variable is deprecated and will be ignored in Rails 6.2.
+            The MAILGUN_INGRESS_API_KEY environment variable is deprecated and will be ignored in Rails 7.0.
             Use MAILGUN_INGRESS_SIGNING_KEY instead.
           MSG
           ENV["MAILGUN_INGRESS_API_KEY"]

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -15,7 +15,7 @@ module ActionMailer
     before_perform do
       ActiveSupport::Deprecation.warn <<~MSG.squish
         Sending mail with DeliveryJob and Parameterized::DeliveryJob
-        is deprecated and will be removed in Rails 6.2.
+        is deprecated and will be removed in Rails 7.0.
         Please use MailDeliveryJob instead.
       MSG
     end

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -150,7 +150,7 @@ module ActionMailer
               @mailer_class.name, @action.to_s, delivery_method.to_s, *@args)
           else
             ActiveSupport::Deprecation.warn(<<~EOM)
-              In Rails 6.2, Action Mailer will pass the mail arguments inside the `:args` keyword argument.
+              In Rails 7.0, Action Mailer will pass the mail arguments inside the `:args` keyword argument.
               The `perform` method of the #{job} needs to change and forward the mail arguments
               from the `args` keyword argument.
 

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -88,13 +88,13 @@ module ActionDispatch # :nodoc:
 
     def self.return_only_media_type_on_content_type=(*)
       ActiveSupport::Deprecation.warn(
-        ".return_only_media_type_on_content_type= is dreprecated with no replacement and will be removed in 6.2."
+        ".return_only_media_type_on_content_type= is dreprecated with no replacement and will be removed in 7.0."
       )
     end
 
     def self.return_only_media_type_on_content_type
       ActiveSupport::Deprecation.warn(
-        ".return_only_media_type_on_content_type is dreprecated with no replacement and will be removed in 6.2."
+        ".return_only_media_type_on_content_type is dreprecated with no replacement and will be removed in 7.0."
       )
     end
 

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -78,7 +78,7 @@ module ActionDispatch
 
       unless deprecated_response_app.nil?
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
-          `action_dispatch.hosts_response_app` is deprecated and will be ignored in Rails 6.2.
+          `action_dispatch.hosts_response_app` is deprecated and will be ignored in Rails 7.0.
           Use the Host Authorization `response_app` setting instead.
         MSG
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -597,14 +597,14 @@ module ActionDispatch
         if route.segment_keys.include?(:controller)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :controller segment in a route is deprecated and
-            will be removed in Rails 6.2.
+            will be removed in Rails 7.0.
           MSG
         end
 
         if route.segment_keys.include?(:action)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :action segment in a route is deprecated and
-            will be removed in Rails 6.2.
+            will be removed in Rails 7.0.
           MSG
         end
 

--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -25,14 +25,14 @@ module ActionDispatch
           if !self.class.file_fixture_path
             ActiveSupport::Deprecation.warn(<<~EOM)
               Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
-              In Rails 6.2, the path needs to be relative to `file_fixture_path` which you
+              In Rails 7.0, the path needs to be relative to `file_fixture_path` which you
               haven't set yet. Set `file_fixture_path` to discard this warning.
             EOM
           elsif path.exist?
             non_deprecated_path = Pathname(File.absolute_path(path)).relative_path_from(Pathname(File.absolute_path(self.class.file_fixture_path)))
             ActiveSupport::Deprecation.warn(<<~EOM)
               Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
-              In Rails 6.2, the path needs to be relative to `file_fixture_path`.
+              In Rails 7.0, the path needs to be relative to `file_fixture_path`.
 
               Please modify the call from
               `fixture_file_upload("#{original_path}")` to `fixture_file_upload("#{non_deprecated_path}")`.

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -934,7 +934,7 @@ XML
   def test_fixture_file_upload_output_deprecation_when_file_fixture_path_is_not_set
     TestCaseTest.stub :fixture_path, File.expand_path("../fixtures", __dir__) do
       TestCaseTest.stub :file_fixture_path, nil do
-        assert_deprecated(/In Rails 6.2, the path needs to be relative to `file_fixture_path`/) do
+        assert_deprecated(/In Rails 7.0, the path needs to be relative to `file_fixture_path`/) do
           fixture_file_upload("multipart/ruby_on_rails.jpg", "image/jpg")
         end
       end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -46,7 +46,7 @@ module ActionView
         app.config.action_view.each do |k, v|
           if k == :raise_on_missing_translations
             ActiveSupport::Deprecation.warn \
-              "action_view.raise_on_missing_translations is deprecated and will be removed in Rails 6.2. " \
+              "action_view.raise_on_missing_translations is deprecated and will be removed in Rails 7.0. " \
               "Set i18n.raise_on_missing_translations instead. " \
               "Note that this new setting also affects how missing translations are handled in controllers."
           end

--- a/activejob/lib/active_job/callbacks.rb
+++ b/activejob/lib/active_job/callbacks.rb
@@ -186,7 +186,7 @@ module ActiveJob
 
         if !self.class.skip_after_callbacks_if_terminated && callbacks.any? { |c| c.kind == :after }
           ActiveSupport::Deprecation.warn(<<~EOM)
-            In Rails 6.2, `after_enqueue`/`after_perform` callbacks no longer run if `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
+            In Rails 7.0, `after_enqueue`/`after_perform` callbacks no longer run if `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
             To enable this behavior, uncomment the `config.active_job.skip_after_callbacks_if_terminated` config
             in the new 6.1 framework defaults initializer.
           EOM

--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -146,7 +146,7 @@ module ActiveModel
     def marshal_load(values)
       if values.is_a?(Hash)
         ActiveSupport::Deprecation.warn(<<~MSG)
-          Marshalling load from legacy attributes format is deprecated and will be removed in Rails 6.2.
+          Marshalling load from legacy attributes format is deprecated and will be removed in Rails 7.0.
         MSG
         empty_hash = {}.freeze
         initialize(empty_hash, empty_hash, empty_hash, empty_hash, values)

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -249,7 +249,7 @@ module ActiveModel
 
           You are passing a block expecting two parameters,
           so the old hash behavior is simulated. As this is deprecated,
-          this will result in an ArgumentError in Rails 6.2.
+          this will result in an ArgumentError in Rails 7.0.
         MSG
         @errors.
           sort { |a, b| a.attribute <=> b.attribute }.
@@ -325,7 +325,7 @@ module ActiveModel
 
     def to_h
       ActiveSupport::Deprecation.warn(<<~EOM)
-        ActiveModel::Errors#to_h is deprecated and will be removed in Rails 6.2.
+        ActiveModel::Errors#to_h is deprecated and will be removed in Rails 7.0.
         Please use `ActiveModel::Errors.to_hash` instead. The values in the hash
         returned by `ActiveModel::Errors.to_hash` is an array of error messages.
       EOM
@@ -583,7 +583,7 @@ module ActiveModel
       end
 
       def deprecation_removal_warning(method_name, alternative_message = nil)
-        message = +"ActiveModel::Errors##{method_name} is deprecated and will be removed in Rails 6.2."
+        message = +"ActiveModel::Errors##{method_name} is deprecated and will be removed in Rails 7.0."
         if alternative_message
           message << "\n\nTo achieve the same use:\n\n  "
           message << alternative_message

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -1177,7 +1177,7 @@ module ActiveRecord
           return owner_to_pool_manager[owner] if owner_to_pool_manager.key?(owner)
 
           if owner == "primary"
-            ActiveSupport::Deprecation.warn("Using `\"primary\"` as a `connection_specification_name` is deprecated and will be removed in Rails 6.2.0. Please use `ActiveRecord::Base`.")
+            ActiveSupport::Deprecation.warn("Using `\"primary\"` as a `connection_specification_name` is deprecated and will be removed in Rails 7.0.0. Please use `ActiveRecord::Base`.")
             owner_to_pool_manager[Base.name]
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         if value.is_a?(Base)
           ActiveSupport::Deprecation.warn(<<~MSG)
             Passing an Active Record object to `quote` directly is deprecated
-            and will be no longer quoted as id value in Rails 6.2.
+            and will be no longer quoted as id value in Rails 7.0.
           MSG
           value = value.id_for_database
         end
@@ -27,14 +27,14 @@ module ActiveRecord
         if value.is_a?(Base)
           ActiveSupport::Deprecation.warn(<<~MSG)
             Passing an Active Record object to `type_cast` directly is deprecated
-            and will be no longer type casted as id value in Rails 6.2.
+            and will be no longer type casted as id value in Rails 7.0.
           MSG
           value = value.id_for_database
         end
 
         if column
           ActiveSupport::Deprecation.warn(<<~MSG)
-            Passing a column to `type_cast` is deprecated and will be removed in Rails 6.2.
+            Passing a column to `type_cast` is deprecated and will be removed in Rails 7.0.
           MSG
           type = lookup_cast_type_from_column(column)
           value = type.serialize(value)

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -135,7 +135,7 @@ module ActiveRecord
     #     Dog.first # finds first Dog record stored on the shard one replica
     #   end
     #
-    # The database kwarg is deprecated and will be removed in 6.2.0 without replacement.
+    # The database kwarg is deprecated and will be removed in 7.0.0 without replacement.
     def connected_to(database: nil, role: nil, shard: nil, prevent_writes: false, &blk)
       if legacy_connection_handling
         if self != Base
@@ -154,7 +154,7 @@ module ActiveRecord
       if database && (role || shard)
         raise ArgumentError, "`connected_to` cannot accept a `database` argument with any other arguments."
       elsif database
-        ActiveSupport::Deprecation.warn("The database key in `connected_to` is deprecated. It will be removed in Rails 6.2.0 without replacement.")
+        ActiveSupport::Deprecation.warn("The database key in `connected_to` is deprecated. It will be removed in Rails 7.0.0 without replacement.")
 
         if database.is_a?(Hash)
           role, database = database.first

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -278,11 +278,11 @@ module ActiveRecord
       end
 
       def self.allow_unsafe_raw_sql # :nodoc:
-        ActiveSupport::Deprecation.warn("ActiveRecord::Base.allow_unsafe_raw_sql is deprecated and will be removed in Rails 6.2")
+        ActiveSupport::Deprecation.warn("ActiveRecord::Base.allow_unsafe_raw_sql is deprecated and will be removed in Rails 7.0")
       end
 
       def self.allow_unsafe_raw_sql=(value) # :nodoc:
-        ActiveSupport::Deprecation.warn("ActiveRecord::Base.allow_unsafe_raw_sql= is deprecated and will be removed in Rails 6.2")
+        ActiveSupport::Deprecation.warn("ActiveRecord::Base.allow_unsafe_raw_sql= is deprecated and will be removed in Rails 7.0")
       end
 
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new

--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -40,7 +40,7 @@ module ActiveRecord
     def configs_for(env_name: nil, spec_name: nil, name: nil, include_replicas: false)
       if spec_name
         name = spec_name
-        ActiveSupport::Deprecation.warn("The kwarg `spec_name` is deprecated in favor of `name`. `spec_name` will be removed in Rails 6.2")
+        ActiveSupport::Deprecation.warn("The kwarg `spec_name` is deprecated in favor of `name`. `spec_name` will be removed in Rails 7.0")
       end
 
       env_name ||= default_env if name

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       end
 
       def config
-        ActiveSupport::Deprecation.warn("DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys")
+        ActiveSupport::Deprecation.warn("DatabaseConfig#config will be removed in 7.0.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys")
         configuration_hash.stringify_keys
       end
 

--- a/activerecord/lib/active_record/legacy_yaml_adapter.rb
+++ b/activerecord/lib/active_record/legacy_yaml_adapter.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       else
         ActiveSupport::Deprecation.warn(<<-MSG.squish)
           YAML loading from legacy format older than Rails 5.0 is deprecated
-          and will be removed in Rails 6.2.
+          and will be removed in Rails 7.0.
         MSG
         if coder["attributes"].is_a?(ActiveModel::AttributeSet)
           Rails420.convert(klass, coder)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -630,7 +630,7 @@ module ActiveRecord
           if column.sql_type.start_with?("interval")
             precision_arguments = column.precision.presence && ", precision: #{column.precision}"
             ActiveSupport::Deprecation.warn(<<~WARNING)
-              The behavior of the `:interval` type will be changing in Rails 6.2
+              The behavior of the `:interval` type will be changing in Rails 7.0
               to return an `ActiveSupport::Duration` object. If you'd like to keep
               the old behavior, you can add this line to #{self.name} model:
 

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -463,7 +463,7 @@ db_namespace = namespace :db do
 
     task load_if_ruby: ["db:create", :environment] do
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        Using `bin/rails db:schema:load_if_ruby` is deprecated and will be removed in Rails 6.2.
+        Using `bin/rails db:schema:load_if_ruby` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :ruby` to use `schema.rb` and run `bin/rails db:schema:load` instead.
       MSG
       db_namespace["schema:load"].invoke if ActiveRecord::Base.schema_format == :ruby
@@ -526,7 +526,7 @@ db_namespace = namespace :db do
     desc "Dumps the database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
     task dump: :load_config do
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        Using `bin/rails db:structure:dump` is deprecated and will be removed in Rails 6.2.
+        Using `bin/rails db:structure:dump` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:schema:dump` instead.
       MSG
 
@@ -537,7 +537,7 @@ db_namespace = namespace :db do
     desc "Recreates the databases from the structure.sql file"
     task load: [:load_config, :check_protected_environments] do
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        Using `bin/rails db:structure:load` is deprecated and will be removed in Rails 6.2.
+        Using `bin/rails db:structure:load` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:schema:load` instead.
       MSG
       db_namespace["schema:load"].invoke
@@ -545,7 +545,7 @@ db_namespace = namespace :db do
 
     task load_if_sql: ["db:create", :environment] do
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        Using `bin/rails db:structure:load_if_sql` is deprecated and will be removed in Rails 6.2.
+        Using `bin/rails db:structure:load_if_sql` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:schema:load` instead.
       MSG
       db_namespace["schema:load"].invoke if ActiveRecord::Base.schema_format == :sql
@@ -556,7 +556,7 @@ db_namespace = namespace :db do
         desc "Dumps the #{name} database structure to db/structure.sql. Specify another file with SCHEMA=db/my_structure.sql"
         task name => :load_config do
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Using `bin/rails db:structure:dump:#{name}` is deprecated and will be removed in Rails 6.2.
+            Using `bin/rails db:structure:dump:#{name}` is deprecated and will be removed in Rails 7.0.
             Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:schema:dump:#{name}` instead.
           MSG
           db_namespace["schema:dump:#{name}"].invoke
@@ -570,7 +570,7 @@ db_namespace = namespace :db do
         desc "Recreates the #{name} database from the structure.sql file"
         task name => :load_config do
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Using `bin/rails db:structure:load:#{name}` is deprecated and will be removed in Rails 6.2.
+            Using `bin/rails db:structure:load:#{name}` is deprecated and will be removed in Rails 7.0.
             Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:schema:load:#{name}` instead.
           MSG
           db_namespace["schema:load:#{name}"].invoke
@@ -602,7 +602,7 @@ db_namespace = namespace :db do
     # desc "Recreate the test database from an existent structure.sql file"
     task load_structure: %w(db:test:purge) do
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        Using `bin/rails db:test:load_structure` is deprecated and will be removed in Rails 6.2.
+        Using `bin/rails db:test:load_structure` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:test:load_schema` instead.
       MSG
       db_namespace["test:load_schema"].invoke
@@ -649,7 +649,7 @@ db_namespace = namespace :db do
       namespace :load_structure do
         task name => "db:test:purge:#{name}" do
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Using `bin/rails db:test:load_structure:#{name}` is deprecated and will be removed in Rails 6.2.
+            Using `bin/rails db:test:load_structure:#{name}` is deprecated and will be removed in Rails 7.0.
             Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:test:load_structure:#{name}` instead.
           MSG
           db_namespace["test:load_schema:#{name}"].invoke

--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -321,8 +321,8 @@ module ActiveRecord
 
         unless group_fields == group_values
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            `#{operation}` with group by duplicated fields does no longer affect to result in Rails 6.2.
-            To migrate to Rails 6.2's behavior, use `uniq!(:group)` to deduplicate group fields
+            `#{operation}` with group by duplicated fields does no longer affect to result in Rails 7.0.
+            To migrate to Rails 7.0's behavior, use `uniq!(:group)` to deduplicate group fields
             (`#{klass.name&.tableize || klass.table_name}.uniq!(:group).#{operation}(#{column_name.inspect})`).
           MSG
           group_fields = group_values

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -369,7 +369,7 @@ module ActiveRecord
           blank_value = order_values.first
           ActiveSupport::Deprecation.warn(<<~MSG.squish)
             `.reorder(#{blank_value.inspect})` with `.first` / `.first!` no longer
-            takes non-deterministic result in Rails 6.2.
+            takes non-deterministic result in Rails 7.0.
             To continue taking non-deterministic result, use `.take` / `.take!` instead.
           MSG
         end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1157,8 +1157,8 @@ module ActiveRecord
           annotates = annotates.uniq if annotates.size > 1
           unless annotates == annotate_values
             ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Duplicated query annotations are no longer shown in queries in Rails 6.2.
-              To migrate to Rails 6.2's behavior, use `uniq!(:annotate)` to deduplicate query annotations
+              Duplicated query annotations are no longer shown in queries in Rails 7.0.
+              To migrate to Rails 7.0's behavior, use `uniq!(:annotate)` to deduplicate query annotations
               (`#{klass.name&.tableize || klass.table_name}.uniq!(:annotate)`).
             MSG
             annotates = annotate_values

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -168,8 +168,8 @@ module ActiveRecord
             else
               ActiveSupport::Deprecation.warn(<<-MSG.squish)
                 Merging (#{node.to_sql}) and (#{ref.to_sql}) no longer maintain
-                both conditions, and will be replaced by the latter in Rails 6.2.
-                To migrate to Rails 6.2's behavior, use `relation.merge(other, rewhere: true)`.
+                both conditions, and will be replaced by the latter in Rails 7.0.
+                To migrate to Rails 7.0's behavior, use `relation.merge(other, rewhere: true)`.
               MSG
               false
             end

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -340,7 +340,7 @@ module ActiveRecord
         db_config = resolve_configuration(configuration)
 
         if environment || name
-          ActiveSupport::Deprecation.warn("`environment` and `name` will be removed as parameters in 6.2.0, you may now pass an ActiveRecord::DatabaseConfigurations::DatabaseConfig as `configuration` instead.")
+          ActiveSupport::Deprecation.warn("`environment` and `name` will be removed as parameters in 7.0.0, you may now pass an ActiveRecord::DatabaseConfigurations::DatabaseConfig as `configuration` instead.")
         end
 
         name ||= db_config.name

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -140,8 +140,8 @@ class CalculationsTest < ActiveRecord::TestCase
       [9, 9] => 53
     }
     message = <<-MSG.squish
-      `maximum` with group by duplicated fields does no longer affect to result in Rails 6.2.
-      To migrate to Rails 6.2's behavior, use `uniq!(:group)` to deduplicate group fields
+      `maximum` with group by duplicated fields does no longer affect to result in Rails 7.0.
+      To migrate to Rails 7.0's behavior, use `uniq!(:group)` to deduplicate group fields
       (`accounts.uniq!(:group).maximum(:credit_limit)`).
     MSG
     assert_deprecated(message) do
@@ -156,8 +156,8 @@ class CalculationsTest < ActiveRecord::TestCase
       [9, 9, 9, 9] => 53
     }
     message = <<-MSG.squish
-      `minimum` with group by duplicated fields does no longer affect to result in Rails 6.2.
-      To migrate to Rails 6.2's behavior, use `uniq!(:group)` to deduplicate group fields
+      `minimum` with group by duplicated fields does no longer affect to result in Rails 7.0.
+      To migrate to Rails 7.0's behavior, use `uniq!(:group)` to deduplicate group fields
       (`accounts.uniq!(:group).minimum(:credit_limit)`).
     MSG
     assert_deprecated(message) do

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -365,8 +365,8 @@ class RelationMergingTest < ActiveRecord::TestCase
     end
 
     message = <<-MSG.squish
-      Duplicated query annotations are no longer shown in queries in Rails 6.2.
-      To migrate to Rails 6.2's behavior, use `uniq!(:annotate)` to deduplicate query annotations
+      Duplicated query annotations are no longer shown in queries in Rails 7.0.
+      To migrate to Rails 7.0's behavior, use `uniq!(:annotate)` to deduplicate query annotations
       (`posts.uniq!(:annotate)`).
     MSG
     assert_deprecated(message) do

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -61,7 +61,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal [mary, bob],   mary_and_bob
 
     author_id = Regexp.escape(Author.connection.quote_table_name("authors.id"))
-    message = %r/Merging \(#{author_id} BETWEEN (\?|\W?\w?\d) AND \g<1>\) and \(#{author_id} (?:= \g<1>|IN \(\g<1>, \g<1>\))\) no longer maintain both conditions, and will be replaced by the latter in Rails 6\.2\./
+    message = %r/Merging \(#{author_id} BETWEEN (\?|\W?\w?\d) AND \g<1>\) and \(#{author_id} (?:= \g<1>|IN \(\g<1>, \g<1>\))\) no longer maintain both conditions, and will be replaced by the latter in Rails 7\.0\./
 
     assert_deprecated(message) do
       assert_equal [mary], david_and_mary.merge(Author.where(id: mary))
@@ -80,7 +80,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     end
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]), rewhere: true)
 
-    message = %r/Merging \(#{author_id} BETWEEN (\?|\W?\w?\d) AND \g<1>\) and \(#{author_id} BETWEEN \g<1> AND \g<1>\) no longer maintain both conditions, and will be replaced by the latter in Rails 6\.2\./
+    message = %r/Merging \(#{author_id} BETWEEN (\?|\W?\w?\d) AND \g<1>\) and \(#{author_id} BETWEEN \g<1> AND \g<1>\) no longer maintain both conditions, and will be replaced by the latter in Rails 7\.0\./
 
     assert_deprecated(message) do
       assert_equal [mary], david_and_mary.merge(mary_and_bob)
@@ -114,7 +114,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal [mary, bob],   mary_and_bob
 
     author_id = Regexp.escape(Author.connection.quote_table_name("authors.id"))
-    message = %r/Merging \(\(#{author_id} = (\?|\W?\w?\d) OR #{author_id} = \g<1>\)\) and \(#{author_id} (?:= \g<1>|IN \(\g<1>, \g<1>\))\) no longer maintain both conditions, and will be replaced by the latter in Rails 6\.2\./
+    message = %r/Merging \(\(#{author_id} = (\?|\W?\w?\d) OR #{author_id} = \g<1>\)\) and \(#{author_id} (?:= \g<1>|IN \(\g<1>, \g<1>\))\) no longer maintain both conditions, and will be replaced by the latter in Rails 7\.0\./
 
     assert_deprecated(message) do
       assert_equal [mary], david_and_mary.merge(Author.where(id: mary))
@@ -133,7 +133,7 @@ class RelationMergingTest < ActiveRecord::TestCase
     end
     assert_equal [david, bob], mary_and_bob.merge(Author.where(id: [david, bob]), rewhere: true)
 
-    message = %r/Merging \(\(#{author_id} = (\?|\W?\w?\d) OR #{author_id} = \g<1>\)\) and \(\(#{author_id} = \g<1> OR #{author_id} = \g<1>\)\) no longer maintain both conditions, and will be replaced by the latter in Rails 6\.2\./
+    message = %r/Merging \(\(#{author_id} = (\?|\W?\w?\d) OR #{author_id} = \g<1>\)\) and \(\(#{author_id} = \g<1> OR #{author_id} = \g<1>\)\) no longer maintain both conditions, and will be replaced by the latter in Rails 7\.0\./
 
     assert_deprecated(message) do
       assert_equal [mary], david_and_mary.merge(mary_and_bob)

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1775,7 +1775,7 @@ class RelationTest < ActiveRecord::TestCase
     sql_log = capture_sql do
       message = <<~MSG.squish
         `.reorder(nil)` with `.first` / `.first!` no longer
-        takes non-deterministic result in Rails 6.2.
+        takes non-deterministic result in Rails 7.0.
         To continue taking non-deterministic result, use `.take` / `.take!` instead.
       MSG
       assert_deprecated(message) do

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -20,7 +20,7 @@ module URI
   class << self
     def parser
       ActiveSupport::Deprecation.warn(<<-MSG.squish)
-        URI.parser is deprecated and will be removed in Rails 6.2.
+        URI.parser is deprecated and will be removed in Rails 7.0.
         Use `URI::DEFAULT_PARSER` instead.
       MSG
       URI::DEFAULT_PARSER

--- a/activesupport/lib/active_support/deprecation.rb
+++ b/activesupport/lib/active_support/deprecation.rb
@@ -38,7 +38,7 @@ module ActiveSupport
     # and the second is a library name.
     #
     #   ActiveSupport::Deprecation.new('2.0', 'MyLibrary')
-    def initialize(deprecation_horizon = "6.2", gem_name = "Rails")
+    def initialize(deprecation_horizon = "7.0", gem_name = "Rails")
       self.gem_name = gem_name
       self.deprecation_horizon = deprecation_horizon
       # By default, warnings are not silenced and debugging is off.

--- a/activesupport/lib/active_support/multibyte/unicode.rb
+++ b/activesupport/lib/active_support/multibyte/unicode.rb
@@ -10,13 +10,13 @@ module ActiveSupport
 
       def default_normalization_form
         ActiveSupport::Deprecation.warn(
-          "ActiveSupport::Multibyte::Unicode.default_normalization_form is deprecated and will be removed in Rails 6.2."
+          "ActiveSupport::Multibyte::Unicode.default_normalization_form is deprecated and will be removed in Rails 7.0."
         )
       end
 
       def default_normalization_form=(_)
         ActiveSupport::Deprecation.warn(
-          "ActiveSupport::Multibyte::Unicode.default_normalization_form= is deprecated and will be removed in Rails 6.2."
+          "ActiveSupport::Multibyte::Unicode.default_normalization_form= is deprecated and will be removed in Rails 7.0."
         )
       end
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -87,7 +87,7 @@ module ActiveSupport
         if app.config.active_support.use_sha1_digests
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             config.active_support.use_sha1_digests is deprecated and will
-            be removed from Rails 6.2. Use
+            be removed from Rails 7.0. Use
             config.active_support.hash_digest_class = ::Digest::SHA1 instead.
           MSG
           ActiveSupport::Digest.hash_digest_class = ::Digest::SHA1

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -489,7 +489,7 @@ module ApplicationTests
         test "db:structure:#{command} is deprecated" do
           add_to_config("config.active_support.deprecation = :stderr")
           stderr_output = capture(:stderr) { rails("db:structure:#{command}", stderr: true, allow_failure: true) }
-          assert_match(/DEPRECATION WARNING: Using `bin\/rails db:structure:#{command}` is deprecated and will be removed in Rails 6.2/, stderr_output)
+          assert_match(/DEPRECATION WARNING: Using `bin\/rails db:structure:#{command}` is deprecated and will be removed in Rails 7.0/, stderr_output)
         end
       end
 
@@ -606,7 +606,7 @@ module ApplicationTests
       test "db:test:load_structure is deprecated" do
         add_to_config("config.active_support.deprecation = :stderr")
         stderr_output = capture(:stderr) { rails("db:test:load_structure", stderr: true, allow_failure: true) }
-        assert_match(/DEPRECATION WARNING: Using `bin\/rails db:test:load_structure` is deprecated and will be removed in Rails 6.2/, stderr_output)
+        assert_match(/DEPRECATION WARNING: Using `bin\/rails db:test:load_structure` is deprecated and will be removed in Rails 7.0/, stderr_output)
       end
 
       test "db:setup loads schema and seeds database" do

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -476,7 +476,7 @@ module ApplicationTests
 
           add_to_config("config.active_support.deprecation = :stderr")
           stderr_output = capture(:stderr) { rails("db:structure:#{command}:animals", stderr: true, allow_failure: true) }
-          assert_match(/DEPRECATION WARNING: Using `bin\/rails db:structure:#{command}:animals` is deprecated and will be removed in Rails 6.2/, stderr_output)
+          assert_match(/DEPRECATION WARNING: Using `bin\/rails db:structure:#{command}:animals` is deprecated and will be removed in Rails 7.0/, stderr_output)
         end
       end
 


### PR DESCRIPTION
### Summary

There are no plans to release Rails6.2 (at least as far as I
understand!).

This updates the default `deprecation_horizon` from `6.2` to `7.0` as
well as updating some custom deprecation messages.

Opening against `6-1-stable` as `main` is already updated to a `7.1`
deprecation horizon!

Is it correct to set the horizon for 7.0 or should these deprecations target 7.1 instead?
