### PR TITLE
Improve error logs for websocket runtime errors

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Improved error formatting for runtime errors when handling websocket
+    requests.
+
+    *Elias Fatsi*
+
 *   The Action Cable client now includes safeguards to prevent a "thundering
     herd" of client reconnects after server connectivity loss:
 

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -22,7 +22,14 @@ module ActionCable
         end
       rescue Exception => e
         @connection.rescue_with_handler(e)
-        logger.error "Could not execute command from (#{data.inspect}) [#{e.class} - #{e.message}]: #{e.backtrace.first(5).join(" | ")}"
+
+        logger.error ""
+        logger.error "\e[31m#{e.class} - #{e.message}\e[0m"
+        logger.error "Request data: \e[34m#{data.inspect}\e[0m"
+
+        e.backtrace.each do |trace_line|
+          logger.error trace_line
+        end
       end
 
       def add(data)


### PR DESCRIPTION
### Summary

Improve the legibility of runtime errors logged when ActionCable
is handling a websocket request.

I wrote a blog post about the monkey patch that I toyed with
initially to get better logging in one of my applications -
https://www.viget.com/articles/better-actioncable-errors/