### PR TITLE
Fix build on Ruby 3.0.1

### DIFF
--- a/activerecord/test/cases/validations/numericality_validation_test.rb
+++ b/activerecord/test/cases/validations/numericality_validation_test.rb
@@ -111,9 +111,10 @@ class NumericalityValidationTest < ActiveRecord::TestCase
 
     subject = model_class.new(virtual_decimal_number: 123.455)
 
-    if RUBY_VERSION > "3.0.0"
+    if 123.455.to_d(5) == BigDecimal("123.46")
       # BigDecimal's to_d behavior changed in BigDecimal 3.0.1, see https://github.com/ruby/bigdecimal/issues/70
-      # TODO: replace this with a check against BigDecimal::VERSION
+      # TODO: replace this with a check against BigDecimal::VERSION, currently
+      # we just check the behaviour because both versions of BigDecimal report "3.0.0"
       assert_not_predicate subject, :valid?
     else
       assert_predicate subject, :valid?


### PR DESCRIPTION
Ruby 3.0.1 was released yesterday and is breaking the build because `RUBY_VERSION > "3.0.0"`.

Because both versions of BigDecimal have `BigDecimal::VERSION == "3.0.0"` and guessing at what future Ruby version has which BigDecimal hasn't been successful 😅 this replaces the guard with a test of the specific changed behaviour.

<img width="1196" alt="Screen Shot 2021-04-06 at 11 17 13 AM" src="https://user-images.githubusercontent.com/131752/113759211-aeca0480-96c9-11eb-9b2c-5c9a2e37a6eb.png">

Opening this PR to double check that all versions behave correctly (it seemed to work locally).