### PR TITLE
Only update dirty attributes once for cyclic autosave callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Only update dirty attributes once for cyclic autosave callbacks.
+
+    Instead of calling `changes_applied` everytime `save` is called,
+    we can skip it if it has already been called once in the current saving
+    cycle.
+
+    *Petrik de Heus*
+
 *   Allow passing SQL as `on_duplicate` value to `#upsert_all` to make it possible to use raw SQL to update columns on conflict:
 
     ```ruby

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -187,7 +187,7 @@ module ActiveRecord
 
         def _update_record(attribute_names = attribute_names_for_partial_writes)
           affected_rows = super
-          changes_applied
+          changes_applied if _apply_changes?(attribute_names)
           affected_rows
         end
 
@@ -199,6 +199,10 @@ module ActiveRecord
 
         def attribute_names_for_partial_writes
           partial_writes? ? changed_attribute_names_to_save : attribute_names
+        end
+
+        def _apply_changes?(attribute_names)
+          true
         end
     end
   end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -851,9 +851,11 @@ module ActiveRecord
         @readonly                 = false
         @previously_new_record    = false
         @destroyed                = false
+        @_saving                  = false
         @marked_for_destruction   = false
         @destroyed_by_association = nil
         @_start_transaction_state = nil
+        @_already_called          = {}
 
         klass = self.class
 

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -404,6 +404,7 @@ module ActiveRecord
               attr = attr.with_value_from_user(value) if attr.value != value
               attr
             end
+            @_saving = false
             @mutations_from_database = nil
             @mutations_before_last_save = nil
             if @attributes.fetch_value(@primary_key) != restore_state[:id]

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1958,3 +1958,71 @@ class TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAcceptsNe
     assert_equal "Updated", valid_project.name
   end
 end
+
+class TestAutosaveAssociationTracksSavingState < ActiveRecord::TestCase
+  test "@_saving is set to true during multiple nested saves" do
+    autosave_saving_stack = []
+
+    ship_with_saving_stack = Class.new(Ship) do
+      before_save { autosave_saving_stack << @_saving }
+      after_save  { autosave_saving_stack << @_saving }
+    end
+
+    pirate_with_callbacks = Class.new(Pirate) do
+      after_save   { ship.save }
+      after_create { ship.save }
+      after_commit { ship.save }
+    end
+
+    child = ship_with_saving_stack.new(name: "Nights Dirty Lightning")
+    child.pirate = pirate_with_callbacks.new(catchphrase: "Aye")
+    child.save!
+    assert_equal [true] * 10, autosave_saving_stack
+    assert_not child.instance_variable_get(:@_saving)
+  end
+
+  test "@_saving is reset to false if validations fail" do
+    child = Ship.new(name: "Nights Dirty Lightning")
+    child.build_pirate
+    assert_not child.save
+    assert_not child.instance_variable_get(:@_saving)
+  end
+end
+
+class TestCyclicAutosaveAssociationsApplyDirtyChangesOnce < ActiveRecord::TestCase
+  test "dirty changes are applied once on child if child is the inverse has_one of parent" do
+    ship_reflection = Ship.reflect_on_association(:pirate)
+    pirate_reflection = Pirate.reflect_on_association(:ship)
+    assert_equal ship_reflection, pirate_reflection.inverse_of, "The pirate reflection's inverse should be the ship reflection"
+
+    child = Ship.new(name: "Nights Dirty Lightning")
+    parent = child.build_pirate(catchphrase: "Aye")
+    child.save!
+    assert_predicate child, :id_previously_changed?
+    assert_predicate parent, :id_previously_changed?
+  end
+
+  test "dirty changes are applied once on child if child is an inverse has_many of parent" do
+    child = FamousShip.new(name: "Poison Orchid")
+    parent = child.build_famous_pirate(catchphrase: "Aye")
+    child.save!
+    assert_predicate child, :id_previously_changed?
+    assert_predicate parent, :id_previously_changed?
+  end
+
+  test "dirty changes on parent are applied only once" do
+    child = Ship.new(name: "Nights Dirty Lightning")
+    parent = child.build_pirate(catchphrase: "Aye")
+    parent.save!
+    assert_predicate child, :id_previously_changed?
+    assert_predicate parent, :id_previously_changed?
+  end
+
+  test "dirty changes are applied once on child if child is an inverse has_many of parent with touch" do
+    child = LineItem.new
+    parent = child.build_invoice
+    child.save!
+    assert_predicate child, :id_previously_changed?
+    assert_predicate parent, :id_previously_changed?
+  end
+end


### PR DESCRIPTION
Only update dirty attributes once for cyclic autosaves

Calling save on records with autosave associations can cause these
records to be saved more than once. Everytime it's saved the dirty
changes are applied, causing the dirty state to be incorrect.

```ruby
class Post < ApplicationRecord
  belongs_to :message
end

class Message < ApplicationRecord
  has_one :post
end

post = Post.create!(message: Message.new(subject: "Hello, world!"))
post.id_previously_changed?
```

To prevent this we can track if the changes have already been applied
during the current save cycle.

Because callbacks can call save again

```ruby
  after_update :update_again, if: :saved_change_to_public?

  def update_again
    update_attribute :body, nil
  end
```

We fix this by considering this another save_cycle, that can have
changes applied only once as well. We track this by incrementing
@_changes_applied_index for each save_cycle.

Autosaving can also cause the @new_record and @previously_new_record to
be incorrect. These should also be changed once during a save cycle.
We can fix this by moving these to the `changes_applied_for_create` and
`changes_applied_for_update`.
