### PR TITLE
allow adding a foreign key in the same statement as adding the column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add foreign key in the same statement as adding a column.
+
+    ```ruby
+    add_reference :astronauts, :myrocket, foreign_key: { to_table: :rockets }
+    ```
+
+    will generate
+
+    ```SQL
+    ALTER TABLE "astronauts" ADD "myrocket_id" integer CONSTRAINT "fk_rails_1286abb657" REFERENCES "rockets" ("id")
+    ```
+
+    In Postgres, this allows completely skipping of the foreign key validate,
+    and in SQLite3 it allows adding a column and a foreign key without rewriting
+    the table.
+
 *   Add attribute encryption support.
 
     Encrypted attributes are declared at the model level. These

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1599,7 +1599,9 @@ module ActiveRecord
         def add_column_for_alter(table_name, column_name, type, **options)
           td = create_table_definition(table_name)
           cd = td.new_column_definition(column_name, type, **options)
-          schema_creation.accept(AddColumnDefinition.new(cd))
+          schema = schema_creation
+          schema.set_table_context(table_name)
+          schema.accept(AddColumnDefinition.new(cd))
         end
 
         def rename_column_sql(table_name, column_name, new_column_name)

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -359,6 +359,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support foreign key constraints defined inline with the column?
+      def supports_foreign_key_as_column_constraint?
+        false
+      end
+
       # Does this adapter support creating invalid constraints?
       def supports_validate_constraints?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -177,6 +177,10 @@ module ActiveRecord
         true
       end
 
+      def supports_foreign_key_as_column_constraint?
+        true
+      end
+
       def supports_check_constraints?
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -127,6 +127,10 @@ module ActiveRecord
         true
       end
 
+      def supports_foreign_key_as_column_constraint?
+        true
+      end
+
       def supports_check_constraints?
         true
       end

--- a/activerecord/test/cases/migration/references_statements_test.rb
+++ b/activerecord/test/cases/migration/references_statements_test.rb
@@ -132,6 +132,15 @@ module ActiveRecord
         assert_not column_exists?(table_name, :supplier_id, :integer)
       end
 
+      def test_combines_foreign_key_with_column
+        @table = Minitest::Mock.new
+        @table.expect :column, nil, ["user_id", :bigint, { foreign_key: { column: "user_id", to_table: "users" } }]
+        @table.expect :supports_foreign_key_as_column_constraint?, true
+        rd = ConnectionAdapters::ReferenceDefinition.new(:user, foreign_key: true, index: false)
+        rd.add_to(@table)
+        @table.verify
+      end
+
       private
         def with_polymorphic_column
           add_column table_name, :supplier_type, :string


### PR DESCRIPTION
### Summary

This patch adds foreign keys inline with the column, when using add_reference (and other methods that chain to it).

### Other Information

I did not check all adapters. PostgreSQL and SQLite3 are implemented and tested. I explicitly did not do MySQL - while MySQL has _a_ syntax for doing it, it does not support naming the constraint when doing so. I'm also unaware if there's a performance benefit to doing so.

While the additional test seems surprisingly small, all functionality is tested by various existing tests that add foreign keys and references.
