### PR TITLE
add foreign keys in bulk change_table

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add and drop foreign keys in bulk change_table
+
+    Previously, foreign keys each generated their own ALTER TABLE
+    statement.
+
+    *Cody Cutrer*
+
 *   `Arel::Visitors::Dot` now renders a complete set of properties when visiting
     `Arel::Nodes::SelectCore`, `SelectStatement`, `InsertStatement`, `UpdateStatement`, and
     `DeleteStatement`, which fixes #42026. Previously, some properties were omitted.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -22,8 +22,8 @@ module ActiveRecord
         def visit_AlterTable(o)
           sql = +"ALTER TABLE #{quote_table_name(o.name)} "
           sql << o.adds.map { |col| accept col }.join(" ")
-          sql << o.foreign_key_adds.map { |fk| visit_AddForeignKey fk }.join(" ")
-          sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
+          sql << o.foreign_key_adds.map { |fk| accept AddForeignKey.new(fk) }.join(" ")
+          sql << o.foreign_key_drops.map { |fk| accept DropForeignKey.new(fk) }.join(" ")
           sql << o.check_constraint_adds.map { |con| visit_AddCheckConstraint con }.join(" ")
           sql << o.check_constraint_drops.map { |con| visit_DropCheckConstraint con }.join(" ")
         end
@@ -81,11 +81,11 @@ module ActiveRecord
         end
 
         def visit_AddForeignKey(o)
-          "ADD #{accept(o)}"
+          "ADD #{accept(o.foreign_key_definition)}"
         end
 
-        def visit_DropForeignKey(name)
-          "DROP CONSTRAINT #{quote_column_name(name)}"
+        def visit_DropForeignKey(o)
+          "DROP CONSTRAINT #{quote_column_name(o.foreign_key_name)}"
         end
 
         def visit_CreateIndexDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -131,6 +131,10 @@ module ActiveRecord
         end
     end
 
+    AddForeignKey = Struct.new(:foreign_key_definition)
+
+    DropForeignKey = Struct.new(:foreign_key_name)
+
     CheckConstraintDefinition = Struct.new(:table_name, :expression, :options) do
       def name
         options[:name]

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1629,6 +1629,21 @@ module ActiveRecord
           remove_columns_for_alter(table_name, :updated_at, :created_at)
         end
 
+        def add_foreign_key_for_alter(from_table, to_table, **options)
+          return unless supports_foreign_keys?
+
+          options = foreign_key_options(from_table, to_table, options)
+          schema_creation.accept(AddForeignKey.new(ForeignKeyDefinition.new(from_table, to_table, options)))
+        end
+
+        def remove_foreign_key_for_alter(from_table, to_table = nil, **options)
+          return unless supports_foreign_keys?
+
+          fk_name_to_delete = foreign_key_for!(from_table, to_table: to_table, **options).name
+
+          schema_creation.accept(DropForeignKey.new(fk_name_to_delete))
+        end
+
         def insert_versions_sql(versions)
           sm_table = quote_table_name(schema_migration.table_name)
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -10,7 +10,7 @@ module ActiveRecord
           end
 
           def visit_AddForeignKey(o)
-            super.dup.tap { |sql| sql << " NOT VALID" unless o.validate? }
+            super.dup.tap { |sql| sql << " NOT VALID" unless o.foreign_key_definition.validate? }
           end
 
           def visit_CheckConstraintDefinition(o)


### PR DESCRIPTION
### Summary

Just a minor SQL cleanup.

### Other Information

Both PostgreSQL and MySQL (the two adapters that support bulk ALTER TABLE) support foreign keys, so there shouldn't be any problems here.
