### PR TITLE
Simplify ActiveModel & ActiveRecord Type::Registry

### DIFF
--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -24,9 +24,10 @@ module ActiveModel
     class << self
       attr_accessor :registry # :nodoc:
 
-      # Add a new type to the registry, allowing it to be gotten through ActiveModel::Type#lookup
-      def register(type_name, klass = nil, **options, &block)
-        registry.register(type_name, klass, **options, &block)
+      # Add a new type to the registry, allowing it to be referenced as a
+      # symbol by {attribute}[rdoc-ref:Attributes::ClassMethods#attribute].
+      def register(type_name, klass = nil, &block)
+        registry.register(type_name, klass, &block)
       end
 
       def lookup(*args, **kwargs) # :nodoc:

--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -1,31 +1,30 @@
 # frozen_string_literal: true
 
 module ActiveModel
-  # :stopdoc:
   module Type
-    class Registry
+    class Registry # :nodoc:
       def initialize
-        @registrations = []
+        @registrations = {}
       end
 
-      def initialize_dup(other)
+      def initialize_copy(other)
         @registrations = @registrations.dup
         super
       end
 
-      def register(type_name, klass = nil, **options, &block)
+      def register(type_name, klass = nil, &block)
         unless block_given?
           block = proc { |_, *args| klass.new(*args) }
           block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
         end
-        registrations << registration_klass.new(type_name, block, **options)
+        registrations[type_name] = block
       end
 
       def lookup(symbol, *args, **kwargs)
-        registration = find_registration(symbol, *args, **kwargs)
+        registration = registrations[symbol]
 
         if registration
-          registration.call(self, symbol, *args, **kwargs)
+          registration.call(symbol, *args, **kwargs)
         else
           raise ArgumentError, "Unknown type #{symbol.inspect}"
         end
@@ -33,38 +32,6 @@ module ActiveModel
 
       private
         attr_reader :registrations
-
-        def registration_klass
-          Registration
-        end
-
-        def find_registration(symbol, *args, **kwargs)
-          registrations.find { |r| r.matches?(symbol, *args, **kwargs) }
-        end
-    end
-
-    class Registration
-      # Options must be taken because of https://bugs.ruby-lang.org/issues/10856
-      def initialize(name, block, **)
-        @name = name
-        @block = block
-      end
-
-      def call(_registry, *args, **kwargs)
-        if kwargs.any? # https://bugs.ruby-lang.org/issues/10856
-          block.call(*args, **kwargs)
-        else
-          block.call(*args)
-        end
-      end
-
-      def matches?(type_name, *args, **kwargs)
-        type_name == name
-      end
-
-      private
-        attr_reader :name, :block
     end
   end
-  # :startdoc:
 end

--- a/activemodel/test/cases/type_test.rb
+++ b/activemodel/test/cases/type_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveModel
+  class TypeTest < ActiveModel::TestCase
+    setup do
+      @old_registry = ActiveModel::Type.registry
+      ActiveModel::Type.registry = @old_registry.dup
+    end
+
+    teardown do
+      ActiveModel::Type.registry = @old_registry
+    end
+
+    test "registering a new type" do
+      type = Struct.new(:args)
+      ActiveModel::Type.register(:foo, type)
+
+      assert_equal type.new(:arg), ActiveModel::Type.lookup(:foo, :arg)
+    end
+  end
+end

--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -5,15 +5,40 @@ require "active_model/type/registry"
 module ActiveRecord
   # :stopdoc:
   module Type
-    class AdapterSpecificRegistry < ActiveModel::Type::Registry
+    class AdapterSpecificRegistry # :nodoc:
+      def initialize
+        @registrations = []
+      end
+
+      def initialize_copy(other)
+        @registrations = @registrations.dup
+        super
+      end
+
       def add_modifier(options, klass, **args)
         registrations << DecorationRegistration.new(options, klass, **args)
       end
 
-      private
-        def registration_klass
-          Registration
+      def register(type_name, klass = nil, **options, &block)
+        unless block_given?
+          block = proc { |_, *args| klass.new(*args) }
+          block.ruby2_keywords if block.respond_to?(:ruby2_keywords)
         end
+        registrations << Registration.new(type_name, block, **options)
+      end
+
+      def lookup(symbol, *args, **kwargs)
+        registration = find_registration(symbol, *args, **kwargs)
+
+        if registration
+          registration.call(self, symbol, *args, **kwargs)
+        else
+          raise ArgumentError, "Unknown type #{symbol.inspect}"
+        end
+      end
+
+      private
+        attr_reader :registrations
 
         def find_registration(symbol, *args, **kwargs)
           registrations
@@ -22,7 +47,7 @@ module ActiveRecord
         end
     end
 
-    class Registration
+    class Registration # :nodoc:
       def initialize(name, block, adapter: nil, override: nil)
         @name = name
         @block = block
@@ -89,7 +114,7 @@ module ActiveRecord
         end
     end
 
-    class DecorationRegistration < Registration
+    class DecorationRegistration < Registration # :nodoc:
       def initialize(options, klass, adapter: nil)
         @options = options
         @klass = klass
@@ -120,7 +145,7 @@ module ActiveRecord
     end
   end
 
-  class TypeConflictError < StandardError
+  class TypeConflictError < StandardError # :nodoc:
   end
   # :startdoc:
 end


### PR DESCRIPTION
ActiveRecord::Type::Registry doesn't need to inherit from ActiveModel::Type::Registry, and it simplifies both classes.

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>

### Summary

`ActiveModel::Type::Registry` was extracted from `ActiveRecord::Type::AdapterSpecificRegistry` in 56a8b40b400169fd9d96856721d0bbb01dbfaa64 and while a lot of it was simplified, we found that we didn't really need inheritance to reuse the few bits of shared behavior:
* In Active Model, lookup only cares about the name so we can use a Hash keyed by name instead. https://github.com/rails/rails/blob/c6ee8c5c4f5555f9500f12830b7e93eac17b858e/activemodel/lib/active_model/type/registry.rb#L61-L63
   This change also allows overriding types, which was ignored before because the first type matching was used https://github.com/rails/rails/blob/c6ee8c5c4f5555f9500f12830b7e93eac17b858e/activemodel/lib/active_model/type/registry.rb#L42
  * Let me know if this is something we'd rather not support, I can raise when the type is overridden instead. I just realized `ActiveRecord::Type.register` has an `override` option, maybe we want to bring this here as well (e.g. a new registration with an existing name raises when no override, overrides the existing type with `override: true` and is ignored with `override: false`).
* Options could be passed to `register` but were silently dropped when the `Registration` was initialized. This was only necessary to support inheritance of Registry, while `ActiveModel::Type::Registration` and `ActiveRecord::Type::Registration` were unrelated they needed the same API. So we removed the `options` parameter from `register` (resulting in an early error instead of a silently ignoring arguments).

### Other Information

`initialize_dup` was really only necessary for `ActiveRecord::Type::Registry` at first because `dup` is used in a test: https://github.com/rails/rails/blob/c6ee8c5c4f5555f9500f12830b7e93eac17b858e/activerecord/test/cases/serialized_attribute_test.rb#L444

But then by adding a test for `ActiveModel::Type` we had the same need, so it adds a bit of duplication but I think that's fair.
We changed it `initialize_copy` instead of `initialize_dup` because it's a bit more correct (used by both `clone` and `dup`).

We also cleaned up the documentation to remove:
* https://api.rubyonrails.org/v6.1.3.1/classes/ActiveModel/Type/Registration.html
* https://api.rubyonrails.org/v6.1.3.1/classes/ActiveModel/Type/Registry.html
* https://api.rubyonrails.org/v6.1.3.1/classes/ActiveRecord/Type/Registration.html
* https://api.rubyonrails.org/v6.1.3.1/classes/ActiveRecord/Type/AdapterSpecificRegistry.html
* https://api.rubyonrails.org/v6.1.3.1/classes/ActiveRecord/TypeConflictError.html
* https://api.rubyonrails.org/v6.1.3.1/classes/ActiveRecord/Type/DecorationRegistration.html

Not sure why the `:stopdoc:` still documents the classes.

Overall I think this goes in the same direction of 4590d7729e241cb7f66e018a2a9759cb3baa36e5, removing things from Active Model that are only needed by Active Record. 

@rafaelfranca @byroot 
cc @adrianna-chang-shopify 


