### PR TITLE
Allow preloader to load in parallel using load_async

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -118,8 +118,8 @@ module ActiveRecord
         associations.nil? || records.length == 0
       end
 
-      def call
-        Batch.new([self], available_records: @available_records).call
+      def call(async: false)
+        Batch.new([self], available_records: @available_records, async: async).call
 
         loaders
       end

--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -4,9 +4,10 @@ module ActiveRecord
   module Associations
     class Preloader
       class Batch # :nodoc:
-        def initialize(preloaders, available_records:)
+        def initialize(preloaders, async: false, available_records:)
           @preloaders = preloaders.reject(&:empty?)
           @available_records = available_records.flatten.group_by(&:class)
+          @async = async
         end
 
         def call
@@ -42,7 +43,8 @@ module ActiveRecord
 
           def group_and_load_similar(loaders)
             loaders.grep_v(ThroughAssociation).group_by(&:loader_query).each_pair do |query, similar_loaders|
-              query.load_records_in_batch(similar_loaders)
+              result = query.load_records_in_batch(similar_loaders)
+              result.load_async if @async
             end
           end
       end

--- a/activerecord/test/cases/async_preloader_test.rb
+++ b/activerecord/test/cases/async_preloader_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+require "models/post"
+require "models/author"
+
+class AsyncPreloaderTest < ActiveRecord::TestCase
+  self.use_transactional_tests = false
+
+  fixtures :authors, :posts
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+  end
+
+  def test_async_select_all
+    ActiveRecord::Base.asynchronous_queries_tracker.start_session
+
+    author = authors(:david)
+    preloader = ActiveRecord::Associations::Preloader.new(records: [author], associations: [:thinking_posts, :welcome_posts])
+
+    payloads = []
+    callback = lambda do |name, started, finished, unique_id, payload|
+      next if payload[:name].nil? || payload[:name] == "SCHEMA"
+      payloads << payload
+    end
+    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+      preloader.call(async: true)
+    end
+
+    assert_equal 2, payloads.size
+
+    assert_no_queries do
+      author.thinking_posts.to_a
+      author.welcome_posts.to_a
+    end
+
+  ensure
+    ActiveRecord::Base.asynchronous_queries_tracker.finalize_session
+  end
+end


### PR DESCRIPTION
Still WIP, but interested in thoughts

This adds the ability for the Preloader to load associations in parallel. This is done by calling `load_async` on each grouped query at each iteration of the `Preloader::Batch`. We then `run` each loader, which will end up waiting on each of the queries. This allows queries at the same "level" (loosely defined) to run in parallel.

There are some limitations to this currently:
* There's a synchronization point at each level
* Currently this only available through the private API
* Ideally we would enable enable `async` for *all* preloads, but that isn't necessarily safe depending on app
* "`async`" might be misleading as an argument because the call to Preloader blocks until the full preload is finished (it just uses async to run in parallel)

cc @eileencodes @byroot @rafaelfranca 