### PR TITLE
Make ActiveRecord::Relation #one? and #many? work with .group() queries

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Make ActiveRecord::Relation #one? and #many? work with .group() queries
+
+    If a query contains a group(), #one? and #many? are now determined by the
+    number of groups returned, which matches the number of records returned
+    and the result of length().
+
+    For example, if there is a single post, even with multiple comments:
+
+    ```ruby
+      Post.joins(:comments).group('posts.id').one? # true
+      Post.joins(:comments).group('posts.id').many? # false
+    ```
+
+    If there are multiple posts:
+
+    ```ruby
+      Post.joins(:comments).group('posts.id').one? # false
+      Post.joins(:comments).group('posts.id').many? # true
+    ```
+
+    See #41870 for more examples.
+
+    *Michael Nacos*
+
 *   Accept optional transaction args to `ActiveRecord::Locking::Pessimistic#with_lock`
 
     `#with_lock` now accepts transaction options like `requires_new:`,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -296,15 +296,25 @@ module ActiveRecord
     def one?
       return super if block_given?
       return records.one? if limit_value || loaded?
-      limited_count == 1
+      group_safe_count(limited_count) == 1
     end
 
     # Returns true if there is more than one record.
     def many?
       return super if block_given?
       return records.many? if limit_value || loaded?
-      limited_count > 1
+      group_safe_count(limited_count) > 1
     end
+
+    # Counts the number of keys when count_result is a Hash
+    #
+    # This occurs when our query includes a group() section.
+    # The number of keys in this Hash matches the number of groups returned,
+    # the number of records in the result set, and the behavior of #length.
+    def group_safe_count(count_result)
+      count_result.is_a?(Hash) ? count_result.length : count_result
+    end
+    private :group_safe_count
 
     # Returns a stable cache key that can be used to identify this query.
     # The cache key is built with a fingerprint of the SQL query.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1180,6 +1180,12 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_predicate posts.limit(1), :many?
   end
 
+  def test_many_with_group
+    posts = Post.all
+
+    assert_predicate posts.group(:id), :many?
+  end
+
   def test_none?
     posts = Post.all
     assert_queries(1) do
@@ -1210,6 +1216,13 @@ class RelationTest < ActiveRecord::TestCase
     end
 
     assert_predicate posts, :loaded?
+  end
+
+  def test_one_with_group
+    posts = Developer.where(name: "David")
+
+    assert_equal 1, posts.size
+    assert_equal true, posts.group(:id).one?
   end
 
   def test_to_a_should_dup_target


### PR DESCRIPTION
### Summary

These methods rely on #size, which sometimes performs a #count, but #count on a query containing a .group() clause returns a Hash, e.g. {1=>1} if the query contains exactly one result.

Currently, if #size returns a Hash:
- #one? returns false for a single record, when it should say true
- #many? throws a `TypeError: no implicit conversion of Integer into Hash`

Grouping is often used to obtain unique records from joins instead of using `.distinct`, for performance reasons. For example:

```ruby
  relation = Post.joins(:comments).group('posts.id')
  relation.one? # returns false if the above query returns a single record
  relation.many? # throws TypeError: no implicit conversion of Integer into Hash
```

### Other Information

Fixes https://github.com/rails/rails/issues/41870
