### PR TITLE
Allow loading nested locales in engines

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -345,7 +345,7 @@ All these configuration options are delegated to the `I18n` library.
 
 * `config.i18n.enforce_available_locales` ensures that all locales passed through i18n must be declared in the `available_locales` list, raising an `I18n::InvalidLocale` exception when setting an unavailable locale. Defaults to `true`. It is recommended not to disable this option unless strongly required, since this works as a security measure against setting any invalid locale from user input.
 
-* `config.i18n.load_path` sets the path Rails uses to look for locale files. Defaults to `config/locales/*.{yml,rb}`.
+* `config.i18n.load_path` sets the path Rails uses to look for locale files. Defaults to `config/locales/**/*.{yml,rb}`.
 
 * `config.i18n.raise_on_missing_translations` determines whether an error should be raised for missing translations
 in controllers and views. This defaults to `false`.

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow loading nested locales in engines.
+
+    *Gannon McGibbon*
+
 *   Ensure `Rails.application.config_for` always cast hashes to `ActiveSupport::OrderedOptions`.
 
     *Jean Boussier*

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -33,7 +33,7 @@ module Rails
   # Then ensure that this file is loaded at the top of your <tt>config/application.rb</tt>
   # (or in your +Gemfile+) and it will automatically load models, controllers and helpers
   # inside +app+, load routes at <tt>config/routes.rb</tt>, load locales at
-  # <tt>config/locales/*</tt>, and load tasks at <tt>lib/tasks/*</tt>.
+  # <tt>config/locales/**/*</tt>, and load tasks at <tt>lib/tasks/**/*</tt>.
   #
   # == Configuration
   #

--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -57,7 +57,7 @@ module Rails
           paths.add "config"
           paths.add "config/environments", glob: "#{Rails.env}.rb"
           paths.add "config/initializers", glob: "**/*.rb"
-          paths.add "config/locales",      glob: "*.{rb,yml}"
+          paths.add "config/locales",      glob: "**/*.{rb,yml}"
           paths.add "config/routes.rb"
           paths.add "config/routes",       glob: "**/*.rb"
 

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -390,6 +390,37 @@ module RailtiesTest
       assert $executed
     end
 
+    test "locales can be nested" do
+      app_file "config/locales/en/models.yml", <<~YAML
+        en:
+          foo: "1"
+      YAML
+
+      app_file "config/locales/en/dates.yml", <<~YAML
+        en:
+          bar: "1"
+      YAML
+
+      app_file "config/locales/extra/nested/folder/en.yml", <<~YAML
+        en:
+          baz: "1"
+      YAML
+
+      boot_rails
+
+      expected_locales = %W(
+        #{app_path}/config/locales/en/models.yml
+        #{app_path}/config/locales/en/dates.yml
+        #{app_path}/config/locales/extra/nested/folder/en.yml
+      ).map { |path| File.expand_path(path) }
+
+      actual_locales = I18n.load_path.map { |path| File.expand_path(path) }
+
+      expected_locales.each do |expected_locale|
+        assert_includes(actual_locales, expected_locale)
+      end
+    end
+
     test "i18n files have lower priority than application ones" do
       add_to_config <<-RUBY
         config.i18n.load_path << "#{app_path}/app/locales/en.yml"


### PR DESCRIPTION
### Summary

Allows loading of nested locales for better organization in larger apps. Eg. `config/locales/en/models.yml` and `config/locales/en/dates.yml`.