### PR TITLE
Error page CSS and a11y improvements

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Remove inline styles and address basic accessibilty issues on rescue templates.
+
+    *Jacob Herrington*
+
 *   Add support for 'private, no-store' Cache-Control headers.
 
     Previously, 'no-store' was exclusive; no other directives could be specified.

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/.#layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/.#layout.erb
@@ -1,0 +1,1 @@
+jacob@localhost.localdomain.464253:1617581131

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/.#layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/.#layout.erb
@@ -1,1 +1,0 @@
-jacob@localhost.localdomain.464253:1617581131

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb
@@ -11,7 +11,7 @@
     <b>Did you mean?</b>
     <ul>
     <% corrections.each do |correction| %>
-      <li style="list-style-type: none"><%= h correction %></li>
+      <li class="correction"><%= h correction %></li>
     <% end %>
     </ul>
   <% end %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb
@@ -1,17 +1,17 @@
-<h2 style="margin-top: 30px">Request</h2>
+<h2 class="request-heading">Request</h2>
 <% if params_valid? %>
   <p><b>Parameters</b>:</p> <pre><%= debug_params(@request.filtered_parameters) %></pre>
 <% end %>
 
 <div class="details">
   <div class="summary"><a href="#" onclick="return toggleSessionDump()">Toggle session dump</a></div>
-  <div id="session_dump" style="display:none"><pre><%= debug_hash @request.session %></pre></div>
+  <div id="session_dump" class="hidden"><pre><%= debug_hash @request.session %></pre></div>
 </div>
 
 <div class="details">
   <div class="summary"><a href="#" onclick="return toggleEnvDump()">Toggle env dump</a></div>
-  <div id="env_dump" style="display:none"><pre><%= debug_hash @request.env.slice(*@request.class::ENV_METHODS) %></pre></div>
+  <div id="env_dump" class="hidden"><pre><%= debug_hash @request.env.slice(*@request.class::ENV_METHODS) %></pre></div>
 </div>
 
-<h2 style="margin-top: 30px">Response</h2>
+<h2 class="response-heading">Response</h2>
 <p><b>Headers</b>:</p> <pre><%= debug_headers(defined?(@response) ? @response.headers : {}) %></pre>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
@@ -14,7 +14,7 @@
 
   <% traces.each do |name, trace| %>
     <div id="<%= "#{name.gsub(/\s/, '-')}-#{error_index}" %>" style="display: <%= (name == trace_to_show) ? 'block' : 'none' %>;">
-      <code style="font-size: 11px;">
+      <code class="traces">
         <% trace.each do |frame| %>
           <a class="trace-frames trace-frames-<%= error_index %>" data-exception-object-id="<%= frame[:exception_object_id] %>" data-frame-id="<%= frame[:id] %>" href="#">
             <%= frame[:trace] %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
@@ -1,7 +1,7 @@
 <header>
   <h1>Blocked host: <%= @host %></h1>
 </header>
-<div id="container">
+<main role="main" id="container">
   <h2>To allow requests to <%= @host %>, add the following to your environment configuration:</h2>
   <pre>config.hosts &lt;&lt; "<%= @host %>"</pre>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -20,12 +20,12 @@
 
   <% @exception_wrapper.wrapped_causes.each.with_index(1) do |wrapper, index| %>
     <div class="details">
-      <a class="summary" href="#" style="color: #F0F0F0; text-decoration: none; background: #C52F24; border-bottom: none;" onclick="return toggle(<%= wrapper.exception.object_id %>)">
+      <a class="summary" href="#" onclick="return toggle(<%= wrapper.exception.object_id %>)">
         <%= wrapper.exception.class.name %>: <%= h wrapper.exception.message %>
       </a>
     </div>
 
-    <div id="<%= wrapper.exception.object_id %>" style="display: none;">
+    <div id="<%= wrapper.exception.object_id %>" class="hidden">
       <%= render "rescues/source", source_extracts: wrapper.source_extracts, show_source_idx: wrapper.source_to_show_id, error_index: index %>
       <%= render "rescues/trace", traces: wrapper.traces, trace_to_show: wrapper.trace_to_show, error_index: index %>
     </div>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb
@@ -7,7 +7,7 @@
   </h1>
 </header>
 
-<div id="container">
+<main role="main" id="container">
   <%= render "rescues/message_and_suggestions", exception: @exception %>
   <%= render "rescues/actions", exception: @exception, request: @request %>
 
@@ -32,4 +32,4 @@
   <% end %>
 
   <%= render template: "rescues/_request_and_response" %>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header role="banner">
   <h1>
     <%= @exception.class.to_s %>
     <% if @request.parameters['controller'] %>
@@ -7,7 +7,7 @@
   </h1>
 </header>
 
-<div id="container">
+<main role="main" id="container">
   <h2>
     <%= h @exception.message %>
     <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
@@ -21,4 +21,4 @@
   <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show %>
   <%= render template: "rescues/_request_and_response" %>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -241,8 +241,7 @@
 
   <script>
     var toggle = function(id) {
-      var s = document.getElementById(id).style;
-      s.display = s.display == 'none' ? 'block' : 'none';
+      document.getElementById(id).classList.toggle('hidden');
       return false;
     }
     var show = function(id) {

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -191,6 +191,7 @@
       overflow-wrap: break-word;
     }
     a:hover, a.trace-frames.selected { color: #C00; }
+    a.summary:hover { color: #FFF; }
 
     @media (prefers-color-scheme: dark) {
       body {

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -129,7 +129,7 @@
 
     .source .data .line_numbers {
       background-color: #ECECEC;
-      color: #AAA;
+      color: #555;
       padding: 1em .5em;
       border-right: 1px solid #DDD;
       text-align: right;
@@ -261,7 +261,7 @@
 </head>
 <body>
 
-<%= yield %>
+  <%= yield %>
 
 </body>
 </html>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -53,7 +53,7 @@
       padding: 8px 0;
     }
 
-    .exception-message .message{
+    .exception-message .message {
       margin-bottom: 8px;
       line-height: 25px;
       font-size: 1.5em;
@@ -172,8 +172,7 @@
       color: #666;
       overflow-wrap: break-word;
     }
-    a:hover { color: #C00; }
-    a.trace-frames.selected { color: #C00 }
+    a:hover, a.trace-frames.selected { color: #C00; }
 
     @media (prefers-color-scheme: dark) {
       body {
@@ -181,11 +180,7 @@
         color: #ECECEC;
       }
 
-      .details {
-        border-color: #666;
-      }
-
-      .summary {
+      .details, .summary {
         border-color: #666;
       }
 
@@ -220,8 +215,7 @@
 
       a { color: #C00; }
       a.trace-frames { color: #999; }
-      a:hover { color: #E9382B; }
-      a.trace-frames.selected { color: #E9382B; }
+      a:hover, a.trace-frames.selected { color: #E9382B; }
     }
 
     <%= yield :style %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/layout.erb
@@ -49,6 +49,14 @@
       line-height: 25px;
     }
 
+    code.traces {
+      font-size: 11px;
+    }
+
+    .response-heading, .request-heading {
+      margin-top: 30px;
+    }
+
     .exception-message {
       padding: 8px 0;
     }
@@ -73,6 +81,13 @@
       padding: 8px 15px;
       border-bottom: 1px solid #D0D0D0;
       display: block;
+    }
+
+    a.summary {
+      color: #F0F0F0;
+      text-decoration: none;
+      background: #C52F24;
+      border-bottom: none;
     }
 
     .details pre {
@@ -143,6 +158,10 @@
       display: none;
     }
 
+    .correction {
+      list-style-type: none;
+    }
+
     input[type="submit"] {
       color: white;
       background-color: #C00;
@@ -164,7 +183,6 @@
       box-shadow: 0 2px #F99;
       transform: translateY(1px)
     }
-
 
     a { color: #980905; }
     a:visited { color: #666; }

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_exact_template.html.erb
@@ -1,8 +1,8 @@
-<header>
+<header role="banner">
   <h1>No template for interactive request</h1>
 </header>
 
-<div id="container">
+<main id="container">
   <h2><%= h @exception.message %></h2>
 
   <p class="summary">
@@ -16,4 +16,4 @@
     since we expect an HTML template
     to be rendered for such requests. If that's the case, carry on.
   </p>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/missing_template.html.erb
@@ -1,11 +1,11 @@
-<header>
+<header role="banner">
   <h1>Template is missing</h1>
 </header>
 
-<div id="container">
+<main role="main" id="container">
   <h2><%= h @exception.message %></h2>
 
   <%= render "rescues/source", source_extracts: @source_extracts, show_source_idx: @show_source_idx %>
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show %>
   <%= render template: "rescues/_request_and_response" %>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/routing_error.html.erb
@@ -1,7 +1,7 @@
-<header>
+<header role="banner">
   <h1>Routing Error</h1>
 </header>
-<div id="container">
+<main role="main" id="container">
   <h2><%= h @exception.message %></h2>
   <% unless @exception.failures.empty? %>
     <p>
@@ -29,4 +29,4 @@
   <% end %>
 
   <%= render template: "rescues/_request_and_response" %>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb
@@ -1,11 +1,11 @@
-<header>
+<header role="banner">
   <h1>
     <%= @exception.cause.class.to_s %> in
     <%= @request.parameters["controller"].camelize if @request.parameters["controller"] %>#<%= @request.parameters["action"] %>
   </h1>
 </header>
 
-<div id="container">
+<main role="main" id="container">
   <p>
     Showing <i><%= @exception.file_name %></i> where line <b>#<%= @exception.line_number %></b> raised:
   </p>
@@ -17,4 +17,4 @@
 
   <%= render "rescues/trace", traces: @traces, trace_to_show: @trace_to_show %>
   <%= render template: "rescues/_request_and_response" %>
-</div>
+</main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/unknown_action.html.erb
@@ -1,6 +1,6 @@
-<header>
+<header role="banner">
   <h1>Unknown action</h1>
 </header>
-<div id="container">
+<main role="main" id="container">
   <%= render "rescues/message_and_suggestions", exception: @exception %>
-</div>
+</main>


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

There are two main parts of this pull request:

**1. Improvements to the existing CSS and removing inline styles**

I noticed that there are quite a few inline styles in these templates.

Of course, that's not inherently wrong, but it does make it a little hard to find the CSS if you spot a bug and can cause bugs.

In order to make maintaining these templates a bit easier, I removed as many inline styles as possible (those which are not relying on erb). I believe this change fixes at least one styling bug where inline styles were competing with the styles defined in the layout.

Additionally, I eliminated a couple of unnecessary rules and tweaked a JS function so that it should behave more consistently.

**2. Addressing (really, really) basic accessibility issues**

I intentionally tried not to change any selectors that folks might be making assumptions about on this page, to avoid breaking any tools that might be floating around. However, the container `div`s became `main`s to address a lack of landmark elements.

There are only two visible UI changes in this PR.

Line numbers were darkened slightly to increase color contrast (a11y):
![image](https://user-images.githubusercontent.com/11466782/113966765-54c65d80-97f5-11eb-9aa3-96d95bd1d960.png)

An extremely light hover effect was applied to this link to indicate interactivity:
![image](https://user-images.githubusercontent.com/11466782/113966877-8808ec80-97f5-11eb-8ea3-5265be762a6d.png)

I'd like to make more drastic changes in support of making these pages more friendly to assistive technologies, but I don't want to invest the time if that's something the maintainers aren't willing to merge in the name of stability (as some changes might significantly modify the page).

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
