### PR TITLE
Directly delegate `constantize` to `Object.const_get`

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -277,38 +277,7 @@ module ActiveSupport
     # NameError is raised when the name is not in CamelCase or the constant is
     # unknown.
     def constantize(camel_cased_word)
-      if camel_cased_word.blank? || !camel_cased_word.include?("::")
-        Object.const_get(camel_cased_word)
-      else
-        names = camel_cased_word.split("::")
-
-        # Trigger a built-in NameError exception including the ill-formed constant in the message.
-        Object.const_get(camel_cased_word) if names.empty?
-
-        # Remove the first blank element in case of '::ClassName' notation.
-        names.shift if names.size > 1 && names.first.empty?
-
-        names.inject(Object) do |constant, name|
-          if constant == Object
-            constant.const_get(name)
-          else
-            candidate = constant.const_get(name)
-            next candidate if constant.const_defined?(name, false)
-            next candidate unless Object.const_defined?(name)
-
-            # Go down the ancestors to check if it is owned directly. The check
-            # stops when we reach Object or the end of ancestors tree.
-            constant = constant.ancestors.inject(constant) do |const, ancestor|
-              break const    if ancestor == Object
-              break ancestor if ancestor.const_defined?(name, false)
-              const
-            end
-
-            # owner is in Object, so raise
-            constant.const_get(name, false)
-          end
-        end
-      end
+      Object.const_get(camel_cased_word)
     end
 
     # Tries to find a constant with the name specified in the argument string.


### PR DESCRIPTION
All the complexity of that method was to work around various problems caused by Ruby's constant lookup semantic as well as the classic autoloader shortcommings.

Now that Rails require Ruby 2.7 I don't think we need anything more than just `Object.const_get`.

```ruby
require 'benchmark/ips'
require 'active_support/all'

module Foo
  module Bar
    module Baz
    end
  end
end

def patched_constantize(name)
  Object.const_get(name)
end

Benchmark.ips do |x|
  x.report('orig') { ActiveSupport::Inflector.constantize("Foo::Bar::Baz") }
  x.report('patched') { patched_constantize("Foo::Bar::Baz") }
  x.compare!
end
```

```
Warming up --------------------------------------
                orig    69.668k i/100ms
             patched   391.385k i/100ms
Calculating -------------------------------------
                orig    705.027k (± 1.9%) i/s -      3.553M in   5.041486s
             patched      3.935M (± 1.1%) i/s -     19.961M in   5.072912s

Comparison:
             patched:  3935235.5 i/s
                orig:   705027.2 i/s - 5.58x  (± 0.00) slower
```

cc @fxn @pixeltrix am I overlooking something?