### PR TITLE
Fix validation of bi-directional accepts_nested_attributes

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -861,6 +861,7 @@ module ActiveRecord
         @previously_new_record    = false
         @destroyed                = false
         @marked_for_destruction   = false
+        @_validating              = false
         @destroyed_by_association = nil
         @_start_transaction_state = nil
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -588,6 +588,17 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_predicate molecule, :persisted?
     assert_equal 1, molecule.electrons.count
   end
+
+  def test_invalid_with_bi_directional_nested_attributes
+    pirate = FamousPirateNestedAttributes.new(famous_ship_nested_attributes_attributes: [
+      { name: "Nights Dirty Lightning" },
+      { name: nil },
+      { name: "The Black Rock" }
+    ])
+
+    assert_not_predicate pirate, :valid?
+    assert_equal ["can't be blank"], pirate.errors["famous_ship_nested_attributes.name"]
+  end
 end
 
 class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -99,6 +99,13 @@ class FamousPirate < ActiveRecord::Base
   validates_presence_of :catchphrase, on: :conference
 end
 
+class FamousPirateNestedAttributes < ActiveRecord::Base
+  self.table_name = "pirates"
+  has_many :famous_ship_nested_attributes, inverse_of: :famous_pirate_nested_attributes, foreign_key: :pirate_id
+
+  accepts_nested_attributes_for :famous_ship_nested_attributes
+end
+
 class SpacePirate < ActiveRecord::Base
   self.table_name = "pirates"
 

--- a/activerecord/test/models/ship.rb
+++ b/activerecord/test/models/ship.rb
@@ -40,3 +40,12 @@ class FamousShip < ActiveRecord::Base
   belongs_to :famous_pirate, foreign_key: :pirate_id
   validates_presence_of :name, on: :conference
 end
+
+class FamousShipNestedAttribute < ActiveRecord::Base
+  self.table_name = "ships"
+  belongs_to :famous_pirate_nested_attributes, foreign_key: :pirate_id
+
+  validates_presence_of :name
+
+  accepts_nested_attributes_for :famous_pirate_nested_attributes
+end


### PR DESCRIPTION
### Summary

When defining bi-directional `accepts_nested_attributes` the validation of a collection doesn't work well: in particular only the last record of the collection is used. This happens because each child item in the collection calls `valid?` on the parent record erasing the previous validation errors stored in the parent.

Fixes the issue by tracking the record under validation and skipping cyclic `valid?` calls.

Fixes #41811

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
