### PR TITLE
Make sure Inflector.underscore returns a String

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -94,7 +94,7 @@ module ActiveSupport
     #
     #   camelize(underscore('SSLError'))  # => "SslError"
     def underscore(camel_cased_word)
-      return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+      return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
       word = camel_cased_word.to_s.gsub("::", "/")
       word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
       word.gsub!(/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -120,7 +120,7 @@ module InflectorTestCases
     "SpecialGuest"          => "special_guest",
     "ApplicationController" => "application_controller",
     "Area51Controller"      => "area51_controller",
-    "AppCDir"               => "app_c_dir"
+    "AppCDir"               => "app_c_dir",
   }
 
   UnderscoreToLowerCamel = {
@@ -143,6 +143,7 @@ module InflectorTestCases
     "FreeBSD"               => "free_bsd",
     "HTML"                  => "html",
     "ForceXMLController"    => "force_xml_controller",
+    :product                => "product",
   }
 
   CamelWithModuleToUnderscoreWithSlash = {


### PR DESCRIPTION
If you were to pass it an underscore symbol, it would be immediately returned without modification.

I just discovered that oddity, and I think it's a bug.