### PR TITLE
Add more methods to NullPool

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -26,9 +26,10 @@ module ActiveRecord
 
       attr_accessor :schema_cache
 
-      def connection_klass
-        nil
-      end
+      def connection_klass; end
+      def checkin(_); end
+      def remove(_); end
+      def async_executor; end
     end
 
     # Connection pool base class for managing Active Record database

--- a/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
+++ b/activerecord/test/cases/connection_adapters/standalone_connection_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class StandaloneConnectionTest < ActiveRecord::TestCase
+      def setup
+        super
+
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
+        @connection = ActiveRecord::Base.public_send(db_config.adapter_method, db_config.configuration_hash)
+      end
+
+      def test_can_query
+        result = @connection.select_all("SELECT 1")
+        assert_equal [[1]], result.rows
+      end
+
+      def test_silently_ignore_async
+        result = @connection.select_all("SELECT 1", async: true)
+        assert_equal [[1]], result.rows
+      end
+
+      def test_can_throw_away
+        @connection.throw_away!
+        assert_not @connection.active?
+      end
+
+      def test_can_close
+        @connection.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds more empty methods to a connection pool.

In normal usage, a connection is always be associated with a pool, but for testing (we do this a few places in the AR test suite) it can be convenient to build a connection and use it without associating a pool.

In most cases, this worked fine, but there were a few corner cases which would hit `NoMethodError` on the `NullPool`. In particular in some cases raising in a transaction would error in `connection.throw_away!`.

To make these "standalone" or "pool-less" connections work consistently, this commit adds the methods which a connection could call on it's pool (but not any other of `ConnectionPool`'s public interface).

I feel like these methods being empty (returning `nil`) makes sense:
* `async_executor` - `nil` means we haven't configured or don't support async, which is the perfect behaviour for when we don't have a pool!
* `remove` - Called by `throw_away!` to tell the pool to no longer manage this connection. Since `NullPool` doesn't manage the connection anyways and won't reuse it, we don't need to do anything 😌
* `checkin` - Called by `close`, this returns the connection to the pool to be reused. I was less sure about this. I could see an argument being made to call `disconnect!` on the connection in that case (knowing we'll never reuse it) or raising an exception telling the user they should be calling `disconnect!`, but doing nothing also seems completely appropriate so that's what I went with.

cc @eileencodes @dinahshi @HParker 