### PR TITLE
ApplicationController HTTPS by default when config.force_ssl=true

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -40,6 +40,11 @@ module ActionController
       paths   = app.config.paths
       options = app.config.action_controller
 
+      if app.config.force_ssl
+        options.default_url_options ||= {}
+        options.default_url_options[:protocol] ||= "https"
+      end
+
       options.logger      ||= Rails.logger
       options.cache_store ||= Rails.cache
 


### PR DESCRIPTION
In a Rails application, when setting the `config.force_ssl = true`
option it is somehow expected that all requests are processed through
the HTTPS protocol. Especially, all requests handled by Rails
controllers will have the HTTPS protocol set and thus any URLs
generated by Rails route helpers (`*_url` and `*_path) will contain
the HTTPS protocol when called inside a controller or view.

However in case you are using ApplicationController renderers outside
a rack environment (in an ActiveJob for instance) you will somehow be
surprised that the generated URLs don't contain the HTTPS protocol by
default.

Similarly to what was done for ActionMailer (#17388), do you think it
makes sense to also assume
`config.action_controller.default_url_options` should have the
protocol default set to `https` when `config.force_ssl = true` is
configured too?