### PR TITLE
Allow overriding button_to authenticity token

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Allow `ActionView::Helpers::UrlHelper#button_to` to render with a
+    custom authenticity token, or render without an authenticity
+    token when `authenticity_token: false` is passed.
+
+        <%= button_to "New", "https://example.com", authenticity_token: false %>
+        <%# => <form class="button_to" method="post" action="https://example.com">
+            =>   <button type="submit">External Resource</button>
+            => </form>
+        %>
+
+    *Jacob Herrington*
+
 *   Deprecate `render` locals to be assigned to instance variables.
 
     *Petrik de Heus*

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -242,6 +242,8 @@ module ActionView
       # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
       #   be placed
       # * <tt>:params</tt> - \Hash of parameters to be rendered as hidden fields within the form.
+      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form. Override with a custom
+      #   authenticity token or pass false to skip the authenticity token field altogether.
       #
       # ==== Data attributes
       #
@@ -263,6 +265,11 @@ module ActionView
       #   # => "<form method="post" action="/articles/new" class="button_to">
       #   #      <button type="submit">New</button>
       #   #    </form>"
+      #
+      #   <%= button_to "New", "https://example.com", authenticity_token: false %>
+      #   #=> <form class="button_to" method="post" action="https://example.com">
+      #   #     <button type="submit">External Resource</button>
+      #   #   </form>
       #
       #   <%= button_to [:make_happy, @user] do %>
       #     Make happy <strong><%= @user.name %></strong>
@@ -309,9 +316,10 @@ module ActionView
         html_options ||= {}
         html_options = html_options.stringify_keys
 
-        url    = options.is_a?(String) ? options : url_for(options)
-        remote = html_options.delete("remote")
-        params = html_options.delete("params")
+        url                = options.is_a?(String) ? options : url_for(options)
+        remote             = html_options.delete("remote")
+        params             = html_options.delete("params")
+        authenticity_token = html_options.delete("authenticity_token")
 
         method     = html_options.delete("method").to_s
         method_tag = BUTTON_TAG_METHOD_VERBS.include?(method) ? method_tag(method) : "".html_safe
@@ -325,7 +333,7 @@ module ActionView
 
         request_token_tag = if form_method == "post"
           request_method = method.empty? ? "post" : method
-          token_tag(nil, form_options: { action: url, method: request_method })
+          token_tag(authenticity_token, form_options: { action: url, method: request_method })
         else
           ""
         end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This change allows developers to pass an `authenticity_token` argument to `button_to` that mimics the behavior in the form generating methods.

For example:
```erb
<%= button_to "New", "https://example.com", authenticity_token: false %>
<%# => <form class="button_to" method="post" action="https://example.com">
    =>   <button type="submit">External Resource</button>
    => </form>
%>
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

This may be a solution to https://github.com/rails/rails/issues/41820.
