### PR TITLE
Add note regarding "trix-content" class. [ci-skip]

### DIFF
--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -11,7 +11,8 @@ module ActionText
     # that Trix will write to on changes, so the content will be sent on form submissions.
     #
     # ==== Options
-    # * <tt>:class</tt> - Defaults to "trix-content" which ensures default styling is applied.
+    # * <tt>:class</tt> - Defaults to "trix-content" so that default styles will be applied.
+    #   Setting this to a different value will prevent default styles from being applied.
     #
     # ==== Example
     #

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -85,7 +85,7 @@ end
 
 **Note:** you don't need to add a `content` field to your `messages` table.
 
-Then refer to this field in the form for the model:
+Then use [`rich_text_area`] to refer to this field in the form for the model:
 
 ```erb
 <%# app/views/messages/_form.html.erb %>
@@ -113,6 +113,8 @@ class MessagesController < ApplicationController
   end
 end
 ```
+
+[`rich_text_area`]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-rich_text_area
 
 ## Rendering Rich Text content
 


### PR DESCRIPTION
### Summary

Passing custom classes into the `rich_text_area` form helper removes the `trix-content` class. [This class is needed for default styling](https://github.com/rails/rails/blob/adc5eb66f861a98da32f7c682155360d5b9a4a52/actiontext/app/helpers/action_text/tag_helper.rb#L14). This can lead developers to think their styles are broken, when in fact all that is missing is the correct class.

Although this is documented in the [Trix README](https://github.com/basecamp/trix#styling-formatted-content), it's not highlighted in the official Rails Guides.

#### Example

`<%= form.rich_text_area :content %>` will render `<trix-editor id="content" input="trix_input_post_1" class="trix-content" ...></trix-editor>`


`<%= form.rich_text_area :content, class: "foo" %>` will render `<trix-editor id="content" input="trix_input_post_1" class="foo" ...></trix-editor>`. Note how the `trix-content` no longer renders.

### Other Information

[Related Tweet](https://twitter.com/stevepolitodsgn/status/1380143439480819712)
