### PR TITLE
Fix user-defined `self.default_scope` to respect table alias

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -146,9 +146,7 @@ module ActiveRecord
             if default_scope_override
               # The user has defined their own default scope method, so call that
               evaluate_default_scope do
-                if scope = default_scope
-                  relation.merge!(scope)
-                end
+                relation.scoping { default_scope }
               end
             elsif default_scopes.any?
               evaluate_default_scope do


### PR DESCRIPTION
If a model which has a user-defined `self.default_scope` is joined with
table alias, a user-defined `self.default_scope` ignores table alias.

This problem has potentially existed for a long time, but it has not
become apparent because it is difficult to meet this condition.

Since #40106, table alias is easily used if association names are used
in `where`.

So user-defined `self.default_scope` should be evaluated in the current
aliased relation.

Fixes #41857.
