### PR TITLE
Allow test parallelization with processes to fail fast

### DIFF
--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -49,6 +49,10 @@ module ActiveSupport
           @active_workers.size > 0
         end
 
+        def interrupt
+          @queue.clear
+        end
+
         def shutdown
           # Wait for initial queue to drain
           while @queue.length != 0

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -69,6 +69,9 @@ module ActiveSupport
               Minitest::UnexpectedError.new(error)
             end
             @queue.record(reporter, result)
+          rescue Interrupt
+            @queue.interrupt
+            raise
           end
 
           set_process_title("(idle)")


### PR DESCRIPTION
### Summary

Running tests in parallel with processes wasn't failing fast when the
option was enabled. The problem was that even when the reporter raised
the `Interrupt` exception, the queue was not emptied, so workers keep
processing jobs as if nothing happened.

This patch basically intercepts the `Interrupt` exception that may
come from the reporter, and tells the server to clear the jobs queue,
so that it can continue the shutdown process as usual. The exception
must then continue its journey so that the backtrace is displayed.

Fixes #41336