### PR TITLE
Improve the payload name for `delete_all` to more appropriate

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -618,7 +618,7 @@ module ActiveRecord
       stmt = arel.compile_delete(table[primary_key])
       stmt.from(source)
 
-      klass.connection.delete(stmt, "#{klass} Destroy").tap { reset }
+      klass.connection.delete(stmt, "#{klass} Delete All").tap { reset }
     end
 
     # Finds and destroys all records matching the specified conditions.

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       Book.create(name: "test book")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "SELECT"
+        if event.payload[:sql].match?("SELECT")
           assert_equal "Book Load", event.payload[:name]
         end
       end
@@ -25,7 +25,7 @@ module ActiveRecord
     def test_payload_name_on_create
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "INSERT"
+        if event.payload[:sql].match?("INSERT")
           assert_equal "Book Create", event.payload[:name]
         end
       end
@@ -37,7 +37,7 @@ module ActiveRecord
     def test_payload_name_on_update
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "UPDATE"
+        if event.payload[:sql].match?("UPDATE")
           assert_equal "Book Update", event.payload[:name]
         end
       end
@@ -50,11 +50,10 @@ module ActiveRecord
     def test_payload_name_on_update_all
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "UPDATE"
+        if event.payload[:sql].match?("UPDATE")
           assert_equal "Book Update All", event.payload[:name]
         end
       end
-      Book.create(name: "test book", format: "paperback")
       Book.update_all(format: "ebook")
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
@@ -63,7 +62,7 @@ module ActiveRecord
     def test_payload_name_on_destroy
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "DELETE"
+        if event.payload[:sql].match?("DELETE")
           assert_equal "Book Destroy", event.payload[:name]
         end
       end
@@ -73,10 +72,22 @@ module ActiveRecord
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end
 
+    def test_payload_name_on_delete_all
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+        event = ActiveSupport::Notifications::Event.new(*args)
+        if event.payload[:sql].match?("DELETE")
+          assert_equal "Book Delete All", event.payload[:name]
+        end
+      end
+      Book.delete_all
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
     def test_payload_name_on_pluck
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "SELECT"
+        if event.payload[:sql].match?("SELECT")
           assert_equal "Book Pluck", event.payload[:name]
         end
       end
@@ -88,7 +99,7 @@ module ActiveRecord
     def test_payload_name_on_count
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "SELECT"
+        if event.payload[:sql].match?("SELECT")
           assert_equal "Book Count", event.payload[:name]
         end
       end
@@ -100,7 +111,7 @@ module ActiveRecord
     def test_payload_name_on_grouped_count
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
-        if event.payload[:sql].match "SELECT"
+        if event.payload[:sql].match?("SELECT")
           assert_equal "Book Count", event.payload[:name]
         end
       end


### PR DESCRIPTION
The payload name for `delete_all` was named "Destroy" in #30619 since
`delete_all` was used in `record.destroy` at that time.

Since ea45d56, `record.destroy` no longer relies on `delete_all`, so now
we can improve the payload name for `delete_all` to more appropriate.
