### PR TITLE
Precompute Inheritance.base_class

### DIFF
--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -215,6 +215,19 @@ module ActiveRecord
         super
       end
 
+      def dup # :nodoc:
+        # `initialize_dup` / `initialize_copy` don't work when defined
+        # in the `singleton_class`.
+        other = super
+        other.set_base_class
+        other
+      end
+
+      def initialize_clone(other) # :nodoc:
+        super
+        set_base_class
+      end
+
       protected
         # Returns the class type of the record using the current module as a prefix. So descendants of
         # MyApp::Business::Account would appear as MyApp::Business::AccountSubclass.

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -190,8 +190,9 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_base_class_activerecord_error
-    klass = Class.new { include ActiveRecord::Inheritance }
-    assert_raise(ActiveRecord::ActiveRecordError) { klass.base_class }
+    assert_raise(ActiveRecord::ActiveRecordError) do
+      Class.new { include ActiveRecord::Inheritance }
+    end
   end
 
   def test_a_bad_type_column


### PR DESCRIPTION
I was surprised to see `Module#<` show up on some production profiles (just a bit more than `1ms` but still).

I think `base_class` can be entirely precomputed  from the `inherited` hook.

I initially wasn't sure it could be precomputed, in case the `abstract_class = true` of the parent would be delayed somehow, But I don't think it's a realistic concern.

cc @kamipo I think you are interested in this area?