### PR TITLE
Remove unjustified use of class variables in actionpack

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/class/attribute"
 require "action_dispatch/http/filter_redirect"
 require "action_dispatch/http/cache"
 require "monitor"
@@ -83,8 +83,8 @@ module ActionDispatch # :nodoc:
     LOCATION     = "Location"
     NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304]
 
-    cattr_accessor :default_charset, default: "utf-8"
-    cattr_accessor :default_headers
+    class_attribute :default_charset, instance_predicate: false, default: "utf-8"
+    class_attribute :default_headers, instance_predicate: false
 
     def self.return_only_media_type_on_content_type=(*)
       ActiveSupport::Deprecation.warn(

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -418,7 +418,10 @@ module ActionDispatch
         end
       end
 
-      mattr_accessor :always_write_cookie, default: false
+      class << self
+        attr_accessor :always_write_cookie
+      end
+      @always_write_cookie = false
 
       private
         def escape(string)
@@ -439,7 +442,7 @@ module ActionDispatch
         end
 
         def write_cookie?(cookie)
-          request.ssl? || !cookie[:secure] || always_write_cookie
+          request.ssl? || !cookie[:secure] || self.class.always_write_cookie
         end
 
         def handle_options(options)

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -4,8 +4,11 @@ require "active_support/core_ext/hash/indifferent_access"
 
 module ActionDispatch
   class Request
-    class Utils # :nodoc:
-      mattr_accessor :perform_deep_munge, default: true
+    module Utils # :nodoc:
+      class << self
+        attr_accessor :perform_deep_munge
+      end
+      @perform_deep_munge = true
 
       def self.each_param_value(params, &block)
         case params

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -458,12 +458,12 @@ class CookiesTest < ActionController::TestCase
   end
 
   def test_setting_cookie_with_secure_when_always_write_cookie_is_true
-    old_cookie, @request.cookie_jar.always_write_cookie = @request.cookie_jar.always_write_cookie, true
+    old_cookie, @request.cookie_jar.class.always_write_cookie = @request.cookie_jar.class.always_write_cookie, true
     get :authenticate_with_secure
     assert_cookie_header "user_name=david; path=/; secure; SameSite=Lax"
     assert_equal({ "user_name" => "david" }, @response.cookies)
   ensure
-    @request.cookie_jar.always_write_cookie = old_cookie
+    @request.cookie_jar.class.always_write_cookie = old_cookie
   end
 
   def test_not_setting_cookie_with_secure


### PR DESCRIPTION
I feel that in many cases, `cattr_accessor` / `mattr_accessor` is used even though a class instance variable would work just as well. 

Class variables have two downsides:
  - They are generally slower (sometimes way slower). [Assuming Eileen's and Aaron's patch](https://bugs.ruby-lang.org/issues/17763) is merged, that might no longer hold on ruby 3.1, but that's a long way out.
  - In many cases instance accessors are leaked even though they aren't useful.

