### PR TITLE
Freeze ActiveSupport::Duration#parts hash

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Freeze `ActiveSupport::Duration#parts` and remove writer methods.
+
+    Durations are meant to be value objects and should not be mutated.
+
+    *Andrew White*
+
 *   Fix `ActiveSupport::TimeZone#utc_to_local` with fractional seconds.
 
     When `utc_to_local_returns_utc_offset_times` is false and the time

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -576,7 +576,7 @@ module ActiveSupport
       end
 
       def duration_of_variable_length?(obj)
-        ActiveSupport::Duration === obj && obj.parts.any? { |p| [:years, :months, :weeks, :days].include?(p[0]) }
+        ActiveSupport::Duration === obj && obj.variable?
       end
 
       def wrap_with_time_zone(time)

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -734,6 +734,22 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "can't build an ActiveSupport::Duration from a NilClass", error.message
   end
 
+  def test_variable
+    assert_not 12.seconds.variable?
+    assert_not 12.minutes.variable?
+    assert_not 12.hours.variable?
+
+    assert 12.days.variable?
+    assert 12.weeks.variable?
+    assert 12.months.variable?
+    assert 12.years.variable?
+
+    assert_not (12.hours + 12.minutes).variable?
+
+    assert (12.hours + 1.day).variable?
+    assert (1.day + 12.hours).variable?
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
Durations are meant to be value objects and should not be mutated.

By doing this we can cache whether a duration is variable and give the `+` and `-` methods on `ActiveSupport::Duration` a performance boost. It also avoids two array allocations by avoiding the `any?` and the inline array definition. It's not going to make a big performance difference to apps but it makes the `duration_of_variable_length?` method 2.5 times faster:

```
Warming up --------------------------------------
             current   325.663k i/100ms
                 new   828.177k i/100ms
Calculating -------------------------------------
             current      3.274M (± 2.9%) i/s -     16.609M in   5.076744s
                 new      8.337M (± 1.9%) i/s -     42.237M in   5.067887s

Comparison:
                 new:  8337279.2 i/s
             current:  3274297.7 i/s - 2.55x  (± 0.00) slower
```

I've removed the `parts=` and `value=` methods since these should never be used on a duration.

I've also made `parts` return a copy of the frozen hash and added a `_parts` reader so that we can access the parts internally without paying the tax of the `dup`.