### PR TITLE
Stop checking if ruby2_keywords is defined

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -582,14 +582,13 @@ module ActionMailer
         payload[:perform_deliveries] = mail.perform_deliveries
       end
 
-      def method_missing(method_name, *args)
+      ruby2_keywords def method_missing(method_name, *args)
         if action_methods.include?(method_name.to_s)
           MessageDelivery.new(self, method_name, *args)
         else
           super
         end
       end
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
       def respond_to_missing?(method, include_all = false)
         action_methods.include?(method.to_s) || super

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -20,10 +20,9 @@ module ActionMailer
       MSG
     end
 
-    def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
+    ruby2_keywords def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
       mailer.constantize.public_send(mail_method, *args).send(delivery_method)
     end
-    ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
 
     private
       # "Deserialize" the mailer class name by hand in case another argument

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -15,7 +15,7 @@ module ActionMailer
   #   Notifier.welcome(User.first).deliver_later # enqueue email delivery as a job through Active Job
   #   Notifier.welcome(User.first).message       # a Mail::Message object
   class MessageDelivery < Delegator
-    def initialize(mailer_class, action, *args) #:nodoc:
+    ruby2_keywords def initialize(mailer_class, action, *args) #:nodoc:
       @mailer_class, @action, @args = mailer_class, action, args
 
       # The mail is only processed if we try to call any methods on it.
@@ -23,7 +23,6 @@ module ActionMailer
       @processed_mailer = nil
       @mail_message = nil
     end
-    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     # Method calls are delegated to the Mail::Message that's ready to deliver.
     def __getobj__ #:nodoc:

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -108,14 +108,13 @@ module ActionMailer
       end
 
       private
-        def method_missing(method_name, *args)
+        ruby2_keywords def method_missing(method_name, *args)
           if @mailer.action_methods.include?(method_name.to_s)
             ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, *args)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
         def respond_to_missing?(method, include_all = false)
           @mailer.respond_to?(method, include_all)
@@ -123,18 +122,16 @@ module ActionMailer
     end
 
     class DeliveryJob < ActionMailer::DeliveryJob # :nodoc:
-      def perform(mailer, mail_method, delivery_method, params, *args)
+      ruby2_keywords def perform(mailer, mail_method, delivery_method, params, *args)
         mailer.constantize.with(params).public_send(mail_method, *args).send(delivery_method)
       end
-      ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
     end
 
     class MessageDelivery < ActionMailer::MessageDelivery # :nodoc:
-      def initialize(mailer_class, action, params, *args)
+      ruby2_keywords def initialize(mailer_class, action, params, *args)
         super(mailer_class, action, *args)
         @params = params
       end
-      ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
       private
         def processed_mailer

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -83,11 +83,10 @@ module AbstractController
         file, line = location.path, location.lineno
 
         methods.each do |method|
-          _helpers_for_modification.class_eval <<-ruby_eval, file, line
-            def #{method}(*args, &block)                    # def current_user(*args, &block)
+          _helpers_for_modification.class_eval <<~ruby_eval, file, line
+            ruby2_keywords def #{method}(*args, &block)     # ruby2_keywords def current_user(*args, &block)
               controller.send(:'#{method}', *args, &block)  #   controller.send(:'current_user', *args, &block)
             end                                             # end
-            ruby2_keywords(:'#{method}') if respond_to?(:ruby2_keywords, true)
           ruby_eval
         end
       end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -88,35 +88,31 @@ module ActionDispatch
       middlewares[i]
     end
 
-    def unshift(klass, *args, &block)
+    ruby2_keywords def unshift(klass, *args, &block)
       middlewares.unshift(build_middleware(klass, args, block))
     end
-    ruby2_keywords(:unshift) if respond_to?(:ruby2_keywords, true)
 
     def initialize_copy(other)
       self.middlewares = other.middlewares.dup
     end
 
-    def insert(index, klass, *args, &block)
+    ruby2_keywords def insert(index, klass, *args, &block)
       index = assert_index(index, :before)
       middlewares.insert(index, build_middleware(klass, args, block))
     end
-    ruby2_keywords(:insert) if respond_to?(:ruby2_keywords, true)
 
     alias_method :insert_before, :insert
 
-    def insert_after(index, *args, &block)
+    ruby2_keywords def insert_after(index, *args, &block)
       index = assert_index(index, :after)
       insert(index + 1, *args, &block)
     end
-    ruby2_keywords(:insert_after) if respond_to?(:ruby2_keywords, true)
 
-    def swap(target, *args, &block)
+    ruby2_keywords def swap(target, *args, &block)
       index = assert_index(target, :before)
       insert(index, *args, &block)
       middlewares.delete_at(index + 1)
     end
-    ruby2_keywords(:swap) if respond_to?(:ruby2_keywords, true)
 
     def delete(target)
       middlewares.delete_if { |m| m.klass == target }
@@ -140,10 +136,9 @@ module ActionDispatch
       middlewares.insert(target_index + 1, source_middleware)
     end
 
-    def use(klass, *args, &block)
+    ruby2_keywords def use(klass, *args, &block)
       middlewares.push(build_middleware(klass, args, block))
     end
-    ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
 
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -422,7 +422,7 @@ module ActionDispatch
       end
 
       # Delegate unhandled messages to the current session instance.
-      def method_missing(method, *args, &block)
+      ruby2_keywords def method_missing(method, *args, &block)
         if integration_session.respond_to?(method)
           integration_session.public_send(method, *args, &block).tap do
             copy_session_variables!
@@ -431,7 +431,6 @@ module ActionDispatch
           super
         end
       end
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
   end
 

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -74,11 +74,10 @@ module ActionView
         def helper_method(*methods)
           # Almost a duplicate from ActionController::Helpers
           methods.flatten.each do |method|
-            _helpers_for_modification.module_eval <<-end_eval, __FILE__, __LINE__ + 1
-              def #{method}(*args, &block)                    # def current_user(*args, &block)
+            _helpers_for_modification.module_eval <<~end_eval, __FILE__, __LINE__ + 1
+              ruby2_keywords def #{method}(*args, &block)     # ruby2_keywords def current_user(*args, &block)
                 _test_case.send(:'#{method}', *args, &block)  #   _test_case.send(:'current_user', *args, &block)
               end                                             # end
-              ruby2_keywords(:'#{method}') if respond_to?(:ruby2_keywords, true)
             end_eval
           end
         end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2120,7 +2120,7 @@ class FormWithActsLikeFormForTest < FormWithTest
         end
       RUBY_EVAL
     end
-    ruby2_keywords(:fields) if respond_to?(:ruby2_keywords, true)
+    ruby2_keywords(:fields)
   end
 
   def test_form_with_with_labelled_builder

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -81,10 +81,10 @@ module ActiveJob
                 _ruby2_keywords_hash(**hash)
               end
 
-              private def _ruby2_keywords_hash(*args)
-                args.last
-              end
-              ruby2_keywords(:_ruby2_keywords_hash) if respond_to?(:ruby2_keywords, true)
+              private
+                ruby2_keywords def _ruby2_keywords_hash(*args)
+                  args.last
+                end
             end
           end
         }

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -88,7 +88,7 @@ module ActiveJob
 
     # Creates a new job instance. Takes the arguments that will be
     # passed to the perform method.
-    def initialize(*arguments)
+    ruby2_keywords def initialize(*arguments)
       @arguments  = arguments
       @job_id     = SecureRandom.uuid
       @queue_name = self.class.queue_name
@@ -97,7 +97,6 @@ module ActiveJob
       @exception_executions = {}
       @timezone   = Time.zone&.name
     end
-    ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
     # Returns a hash with the job data that can safely be passed to the
     # queuing adapter.

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -35,10 +35,9 @@ module ActiveJob
       end
 
       private
-        def job_or_instantiate(*args) # :doc:
+        ruby2_keywords def job_or_instantiate(*args) # :doc:
           args.first.is_a?(self) ? args.first : new(*args)
         end
-        ruby2_keywords(:job_or_instantiate) if respond_to?(:ruby2_keywords, true)
     end
 
     # Enqueues the job to be performed by the queue adapter.

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -424,7 +424,7 @@ module ActiveModel
             defn <<
             body <<
             "end" <<
-            "ruby2_keywords(:'#{name}') if respond_to?(:ruby2_keywords, true)"
+            "ruby2_keywords(:'#{name}')"
         end
 
         class AttributeMethodMatcher #:nodoc:
@@ -461,7 +461,7 @@ module ActiveModel
     # It's also possible to instantiate related objects, so a <tt>Client</tt>
     # class belonging to the +clients+ table with a +master_id+ foreign key
     # can instantiate master through <tt>Client#master</tt>.
-    def method_missing(method, *args, &block)
+    ruby2_keywords def method_missing(method, *args, &block)
       if respond_to_without_attributes?(method, true)
         super
       else
@@ -469,7 +469,6 @@ module ActiveModel
         match ? attribute_missing(match, *args, &block) : super
       end
     end
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     # +attribute_missing+ is like +method_missing+, but for attributes. When
     # +method_missing+ is called we check to see if there is a matching

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -656,10 +656,9 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *args, &block) #:nodoc:
+      ruby2_keywords def method_missing(name, *args, &block) #:nodoc:
         nearest_delegate.send(name, *args, &block)
       end
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
       def migrate(direction)
         new.migrate direction
@@ -914,7 +913,7 @@ module ActiveRecord
       @connection || ActiveRecord::Base.connection
     end
 
-    def method_missing(method, *arguments, &block)
+    ruby2_keywords def method_missing(method, *arguments, &block)
       arg_list = arguments.map(&:inspect) * ", "
 
       say_with_time "#{method}(#{arg_list})" do
@@ -931,7 +930,6 @@ module ActiveRecord
         connection.send(method, *arguments, &block)
       end
     end
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     def copy(destination, sources, options = {})
       copied = []

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -112,7 +112,7 @@ module ActiveRecord
             record(:"#{method}", args, &block)  #   record(:create_table, args, &block)
           end                                   # end
         EOV
-        ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
+        ruby2_keywords(method)
       end
       alias :add_belongs_to :add_reference
       alias :remove_belongs_to :remove_reference
@@ -279,14 +279,13 @@ module ActiveRecord
         end
 
         # Forwards any missing method call to the \target.
-        def method_missing(method, *args, &block)
+        ruby2_keywords def method_missing(method, *args, &block)
           if delegate.respond_to?(method)
             delegate.public_send(method, *args, &block)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
   end
 end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -70,7 +70,7 @@ module ActiveRecord
             define_method(method) do |*args, &block|
               scoping { klass.public_send(method, *args, &block) }
             end
-            ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
+            ruby2_keywords(method)
           end
         end
       end
@@ -101,7 +101,7 @@ module ActiveRecord
       end
 
       private
-        def method_missing(method, *args, &block)
+        ruby2_keywords def method_missing(method, *args, &block)
           if @klass.respond_to?(method)
             @klass.generate_relation_method(method)
             scoping { @klass.public_send(method, *args, &block) }
@@ -109,7 +109,6 @@ module ActiveRecord
             super
           end
         end
-        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     end
 
     module ClassMethods # :nodoc:

--- a/activerecord/lib/active_record/scoping/named.rb
+++ b/activerecord/lib/active_record/scoping/named.rb
@@ -184,7 +184,7 @@ module ActiveRecord
               scope
             end
           end
-          singleton_class.send(:ruby2_keywords, name) if respond_to?(:ruby2_keywords, true)
+          singleton_class.send(:ruby2_keywords, name)
 
           generate_relation_method(name)
         end

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -299,7 +299,7 @@ class Module
         #{target}.respond_to?(name) || super
       end
 
-      def method_missing(method, *args, &block)
+      ruby2_keywords def method_missing(method, *args, &block)
         if #{target}.respond_to?(method)
           #{target}.public_send(method, *args, &block)
         else
@@ -318,7 +318,6 @@ class Module
           end
         end
       end
-      ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
     RUBY
   end
 end

--- a/activesupport/lib/active_support/core_ext/object/try.rb
+++ b/activesupport/lib/active_support/core_ext/object/try.rb
@@ -4,7 +4,7 @@ require "delegate"
 
 module ActiveSupport
   module Tryable #:nodoc:
-    def try(method_name = nil, *args, &b)
+    ruby2_keywords def try(method_name = nil, *args, &b)
       if method_name.nil? && block_given?
         if b.arity == 0
           instance_eval(&b)
@@ -15,9 +15,8 @@ module ActiveSupport
         public_send(method_name, *args, &b)
       end
     end
-    ruby2_keywords(:try) if respond_to?(:ruby2_keywords, true)
 
-    def try!(method_name = nil, *args, &b)
+    ruby2_keywords def try!(method_name = nil, *args, &b)
       if method_name.nil? && block_given?
         if b.arity == 0
           instance_eval(&b)
@@ -28,7 +27,6 @@ module ActiveSupport
         public_send(method_name, *args, &b)
       end
     end
-    ruby2_keywords(:try!) if respond_to?(:ruby2_keywords, true)
   end
 end
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -156,7 +156,7 @@ module ActiveSupport
           @current_instances_key ||= name.to_sym
         end
 
-        def method_missing(name, *args, &block)
+        ruby2_keywords def method_missing(name, *args, &block)
           # Caches the method definition as a singleton method of the receiver.
           #
           # By letting #delegate handle it, we avoid an enclosure that'll capture args.
@@ -164,7 +164,6 @@ module ActiveSupport
 
           send(name, *args, &block)
         end
-        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
         def respond_to_missing?(name, _)
           super || instance.respond_to?(name)

--- a/activesupport/lib/active_support/deprecation/method_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/method_wrappers.rb
@@ -64,7 +64,7 @@ module ActiveSupport
                 deprecator.deprecation_warning(method_name, message)
                 method.bind_call(self, *args, &block)
               end
-              ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
+              ruby2_keywords(method_name)
             end
           else
             mod ||= Module.new
@@ -73,7 +73,7 @@ module ActiveSupport
                 deprecator.deprecation_warning(method_name, message)
                 super(*args, &block)
               end
-              ruby2_keywords(method_name) if respond_to?(:ruby2_keywords, true)
+              ruby2_keywords(method_name)
             end
           end
         end

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -202,14 +202,13 @@ module Rails
 
         # If the class method does not have a method, then send the method call
         # to the Railtie instance.
-        def method_missing(name, *args, &block)
+        ruby2_keywords def method_missing(name, *args, &block)
           if instance.respond_to?(name)
             instance.public_send(name, *args, &block)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
         # receives an instance variable identifier, set the variable value if is
         # blank and append given block to value, which will be used later in


### PR DESCRIPTION
Now that Ruby 2.7+ is required, we can assume `ruby2_keywords` is available.

cc @kamipo 