### PR TITLE
docs: fix e.g. typo in debugging_rails_applications.md [ci-skip]

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -819,7 +819,7 @@ deleted when that breakpoint is reached.
 * `finish [n]`: execute until the selected stack frame returns. If no frame
 number is given, the application will run until the currently selected frame
 returns. The currently selected frame starts out the most-recent frame or 0 if
-no frame positioning (e.g up, down, or frame) has been performed. If a frame
+no frame positioning (e.g. up, down, or frame) has been performed. If a frame
 number is given it will run until the specified frame returns.
 
 ### Editing


### PR DESCRIPTION
e.g. is the abbreviation for the Latin phrase exempli gratia, meaning “for example.” This abbreviation is typically used to introduce one or more examples of something mentioned previously in the sentence and can be used interchangeably with “for example” or “such as.”

### Summary

Fixed one typo.