### PR TITLE
chore: fix i.e. typos in Markdown and Ruby [ci-skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -469,7 +469,7 @@
 
 *   Add option to run `default_scope` on all queries.
 
-    Previously, a `default_scope` would only run on select or insert queries. In some cases, like non-Rails tenant sharding solutions, it may be desirable to run `default_scope` on all queries in order to ensure queries are including a foreign key for the shard (ie `blog_id`).
+    Previously, a `default_scope` would only run on select or insert queries. In some cases, like non-Rails tenant sharding solutions, it may be desirable to run `default_scope` on all queries in order to ensure queries are including a foreign key for the shard (i.e. `blog_id`).
 
     Now applications can add an option to run on all queries including select, insert, delete, and update by adding an `all_queries` option to the default scope definition.
 

--- a/activerecord/lib/active_record/database_configurations/url_config.rb
+++ b/activerecord/lib/active_record/database_configurations/url_config.rb
@@ -19,7 +19,7 @@ module ActiveRecord
     #
     # ==== Options
     #
-    # * <tt>:env_name</tt> - The Rails environment, ie "development".
+    # * <tt>:env_name</tt> - The Rails environment, i.e. "development".
     # * <tt>:name</tt> - The db config name. In a standard two-tier
     #   database configuration this will default to "primary". In a multiple
     #   database three-tier database configuration this corresponds to the name

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -415,7 +415,7 @@ the handler. Call `connection_handler.all_connection_pools` to use this. In most
 you'll want writing or reading pools with `connection_handler.connection_pool_list(:writing)` or
 `connection_handler.connection_pool_list(:reading)`.
 * If you turn off `legacy_connection_handling` in your application, any method that's unsupported
-will raise an error (ie `connection_handlers=`).
+will raise an error (i.e. `connection_handlers=`).
 
 ## Granular Database Connection Switching
 

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -344,7 +344,7 @@ The following middlewares, used for session management, are excluded from API ap
 The trick to adding these back in is that, by default, they are passed `session_options`
 when added (including the session key), so you can't just add a `session_store.rb` initializer, add
 `use ActionDispatch::Session::CookieStore` and have sessions functioning as usual.  (To be clear: sessions
-may work, but your session options will be ignored - i.e the session key will default to `_session_id`)
+may work, but your session options will be ignored - i.e. the session key will default to `_session_id`)
 
 Instead of the initializer, you'll have to set the relevant options somewhere before your middleware is
 built (like `config/application.rb`) and pass them to your preferred middleware, like this:


### PR DESCRIPTION
i.e. is the customary abbreviation for "that is." It is derived from the Latin term "id est."

### Summary

Fixed two variations `i.e` and `ie`




