### PR TITLE
chore: remove redundant MIME type from HTML script tag

### DIFF
--- a/actionpack/lib/action_dispatch/journey/visualizer/index.html.erb
+++ b/actionpack/lib/action_dispatch/journey/visualizer/index.html.erb
@@ -8,7 +8,7 @@
         <%= style %>
       <% end %>
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.8/d3.min.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.8/d3.min.js"></script>
   </head>
   <body>
     <div id="wrapper">

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb
@@ -25,7 +25,7 @@
     </div>
   <% end %>
 
-  <script type="text/javascript">
+  <script>
     (function() {
       var traceFrames = document.getElementsByClassName('trace-frames-<%= error_index %>');
       var selectedFrame, currentSource = document.getElementById('frame-source-<%= error_index %>-0');

--- a/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/routes/_table.html.erb
@@ -95,7 +95,7 @@
   </tbody>
 </table>
 
-<script type='text/javascript'>
+<script>
   // support forEach iterator on NodeList
   NodeList.prototype.forEach = Array.prototype.forEach;
 

--- a/actionview/test/ujs/views/layouts/application.html.erb
+++ b/actionview/test/ujs/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title><%= @title %></title>
     <%= csp_meta_tag %>
     <link href="/vendor/qunit.css" media="screen" rel="stylesheet" type="text/css" media="screen, projection" />
-    <script src="/vendor/jquery-2.2.0.js" type="text/javascript"></script>
+    <script src="/vendor/jquery-2.2.0.js"></script>
     <%= javascript_tag nonce: true do %>
       // This is for test in override.js.
       // Must go before rails-ujs.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script

### Summary

<img width="772" alt="Screen Shot 2021-04-12 at 6 54 21 am" src="https://user-images.githubusercontent.com/418747/114321143-8f652880-9b5c-11eb-9e33-cfcf6c3c5192.png">
