### PR TITLE
chore: fix spelling change `favourite` to the more used `favorite`

### DIFF
--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -50,8 +50,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
             :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors
 
   def test_eager_with_has_one_through_join_model_with_conditions_on_the_through
-    member = Member.all.merge!(includes: :favourite_club).find(members(:some_other_guy).id)
-    assert_nil member.favourite_club
+    member = Member.all.merge!(includes: :favorite_club).find(members(:some_other_guy).id)
+    assert_nil member.favorite_club
   end
 
   def test_should_work_inverse_of_with_eager_load
@@ -129,15 +129,15 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_loading_association_with_same_table_joins
     super_memberships = [memberships(:super_membership_of_boring_club)]
 
-    member = Member.joins(:favourite_memberships).first
+    member = Member.joins(:favorite_memberships).first
     assert_equal members(:groucho), member
     assert_equal super_memberships, member.super_memberships
 
-    member = Member.joins(:favourite_memberships).preload(:super_memberships).first
+    member = Member.joins(:favorite_memberships).preload(:super_memberships).first
     assert_equal members(:groucho), member
     assert_equal super_memberships, member.super_memberships
 
-    member = Member.joins(:favourite_memberships).eager_load(:super_memberships).first
+    member = Member.joins(:favorite_memberships).eager_load(:super_memberships).first
     assert_equal members(:groucho), member
     assert_equal super_memberships, member.super_memberships
   end
@@ -512,9 +512,9 @@ class EagerAssociationTest < ActiveRecord::TestCase
   end
 
   def test_eager_load_has_one_quotes_table_and_column_names
-    michael = Person.all.merge!(includes: :favourite_reference).find(people(:michael).id)
+    michael = Person.all.merge!(includes: :favorite_reference).find(people(:michael).id)
     references(:michael_unicyclist)
-    assert_no_queries { assert_equal references(:michael_unicyclist), michael.favourite_reference }
+    assert_no_queries { assert_equal references(:michael_unicyclist), michael.favorite_reference }
   end
 
   def test_eager_load_has_many_quotes_table_and_column_names

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -616,7 +616,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     person.first_name = "Naruto"
     person.references << Reference.new
     person.save!
-    assert_equal 1, person.references.update_all(favourite: true)
+    assert_equal 1, person.references.update_all(favorite: true)
   end
 
   def test_exists_respects_association_scope

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1189,7 +1189,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     member = members(:groucho)
     club   = member.clubs.create!
 
-    assert_equal true, club.reload.membership.favourite
+    assert_equal true, club.reload.membership.favorite
   end
 
   def test_deleting_from_has_many_through_a_belongs_to_should_not_try_to_update_counter
@@ -1340,11 +1340,11 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     member = Member.create!
     Membership.create!(club: club, member: member)
 
-    club.favourites << member
-    assert_equal [member], club.favourites
+    club.favorites << member
+    assert_equal [member], club.favorites
 
     club.reload
-    assert_equal [member], club.favourites
+    assert_equal [member], club.favorites
   end
 
   def test_has_many_through_unscope_default_scope
@@ -1377,9 +1377,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_through_with_scope_that_should_not_be_fully_merged
     Club.has_many :distinct_memberships, -> { distinct }, class_name: "Membership"
-    Club.has_many :special_favourites, through: :distinct_memberships, source: :member
+    Club.has_many :special_favorites, through: :distinct_memberships, source: :member
 
-    assert_nil Club.new.special_favourites.distinct_value
+    assert_nil Club.new.special_favorites.distinct_value
   end
 
   def test_has_many_through_do_not_cache_association_reader_if_the_though_method_has_default_scopes

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -706,7 +706,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_with_touch_option_on_create
     assert_queries(3) {
-      Club.create(name: "1000 Oaks", membership_attributes: { favourite: true })
+      Club.create(name: "1000 Oaks", membership_attributes: { favorite: true })
     }
   end
 

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -173,9 +173,9 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_one_through_with_conditions_eager_loading
     # conditions on the through table
-    assert_equal clubs(:moustache_club), Member.all.merge!(includes: :favourite_club).find(@member.id).favourite_club
-    memberships(:membership_of_favourite_club).update_columns(favourite: false)
-    assert_nil Member.all.merge!(includes: :favourite_club).find(@member.id).reload.favourite_club
+    assert_equal clubs(:moustache_club), Member.all.merge!(includes: :favorite_club).find(@member.id).favorite_club
+    memberships(:membership_of_favorite_club).update_columns(favorite: false)
+    assert_nil Member.all.merge!(includes: :favorite_club).find(@member.id).reload.favorite_club
 
     # conditions on the source table
     assert_equal clubs(:moustache_club), Member.all.merge!(includes: :hairy_club).find(@member.id).hairy_club

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -465,7 +465,7 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
   def test_quote_table_name
     ref = references(:michael_magician)
-    ref.favourite = !ref.favourite
+    ref.favorite = !ref.favorite
     assert ref.save
   end
 

--- a/activerecord/test/fixtures/memberships.yml
+++ b/activerecord/test/fixtures/memberships.yml
@@ -2,40 +2,40 @@ membership_of_boring_club:
   joined_on: <%= 3.weeks.ago.to_s(:db) %>
   club: boring_club
   member_id: 1
-  favourite: false
+  favorite: false
   type: CurrentMembership
 
-membership_of_favourite_club:
+membership_of_favorite_club:
   joined_on: <%= 3.weeks.ago.to_s(:db) %>
   club: moustache_club
   member_id: 1
-  favourite: true
+  favorite: true
   type: Membership
 
 other_guys_membership:
   joined_on: <%= 4.weeks.ago.to_s(:db) %>
   club: boring_club
   member_id: 2
-  favourite: false
+  favorite: false
   type: CurrentMembership
 
 blarpy_winkup_crazy_club:
   joined_on: <%= 4.weeks.ago.to_s(:db) %>
   club: crazy_club
   member_id: 3
-  favourite: false
+  favorite: false
   type: CurrentMembership
 
 super_membership_of_boring_club:
   joined_on: <%= 3.weeks.ago.to_s(:db) %>
   club: boring_club
   member_id: 1
-  favourite: false
+  favorite: false
   type: SuperMembership
 
 selected_membership_of_boring_club:
   joined_on: <%= 3.weeks.ago.to_s(:db) %>
   club: boring_club
   member_id: 1
-  favourite: false
+  favorite: false
   type: SelectedMembership

--- a/activerecord/test/fixtures/references.yml
+++ b/activerecord/test/fixtures/references.yml
@@ -2,16 +2,16 @@ michael_magician:
   id: 1
   person_id: 1
   job_id: 3
-  favourite: false
+  favorite: false
 
 michael_unicyclist:
   id: 2
   person_id: 1
   job_id: 1
-  favourite: true
+  favorite: true
 
 david_unicyclist:
   id: 3
   person_id: 2
   job_id: 1
-  favourite: false
+  favorite: false

--- a/activerecord/test/models/club.rb
+++ b/activerecord/test/models/club.rb
@@ -8,7 +8,7 @@ class Club < ActiveRecord::Base
   has_one :sponsored_member, through: :sponsor, source: :sponsorable, source_type: :Member
   belongs_to :category
 
-  has_many :favourites, -> { where(memberships: { favourite: true }) }, through: :memberships, source: :member
+  has_many :favorites, -> { where(memberships: { favorite: true }) }, through: :memberships, source: :member
 
   scope :general, -> { left_joins(:category).where(categories: { name: "General" }).unscope(:limit) }
 

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -6,7 +6,7 @@ class Member < ActiveRecord::Base
   has_one :membership
   has_one :club, through: :current_membership
   has_one :selected_club, through: :selected_membership, source: :club
-  has_one :favourite_club, -> { where "memberships.favourite = ?", true }, through: :membership, source: :club
+  has_one :favorite_club, -> { where "memberships.favorite = ?", true }, through: :membership, source: :club
   has_one :hairy_club, -> { where clubs: { name: "Moustache and Eyebrow Fancier Club" } }, through: :membership, source: :club
   has_one :sponsor, as: :sponsorable
   has_one :sponsor_club, through: :sponsor
@@ -27,13 +27,13 @@ class Member < ActiveRecord::Base
   has_one :general_club, -> { general }, through: :current_membership, source: :club
 
   has_many :super_memberships
-  has_many :favourite_memberships, -> { where(favourite: true) }, class_name: "Membership"
-  has_many :clubs, through: :favourite_memberships
+  has_many :favorite_memberships, -> { where(favorite: true) }, class_name: "Membership"
+  has_many :clubs, through: :favorite_memberships
 
   has_many :tenant_memberships
   has_many :tenant_clubs, through: :tenant_memberships, class_name: "Club", source: :club
 
-  has_one :club_through_many, through: :favourite_memberships, source: :club
+  has_one :club_through_many, through: :favorite_memberships, source: :club
 
   belongs_to :admittable, polymorphic: true
   has_one :premium_club, through: :admittable

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -17,8 +17,8 @@ class Person < ActiveRecord::Base
 
   has_many :references
   has_many :bad_references
-  has_many :fixed_bad_references, -> { where favourite: true }, class_name: "BadReference"
-  has_one  :favourite_reference, -> { where "favourite=?", true }, class_name: "Reference"
+  has_many :fixed_bad_references, -> { where favorite: true }, class_name: "BadReference"
+  has_one  :favorite_reference, -> { where "favorite=?", true }, class_name: "Reference"
   has_many :posts_with_comments_sorted_by_comment_id, -> { includes(:comments).order("comments.id") }, through: :readers, source: :post
   has_many :first_posts, -> { where(id: [1, 2]) }, through: :readers
 

--- a/activerecord/test/models/reference.rb
+++ b/activerecord/test/models/reference.rb
@@ -21,5 +21,5 @@ end
 
 class BadReference < ActiveRecord::Base
   self.table_name = "references"
-  default_scope { where(favourite: false) }
+  default_scope { where(favorite: false) }
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -614,7 +614,7 @@ ActiveRecord::Schema.define do
   create_table :memberships, force: true do |t|
     t.datetime :joined_on
     t.integer :club_id, :member_id
-    t.boolean :favourite, default: false
+    t.boolean :favorite, default: false
     t.integer :type
     t.datetime :created_at
     t.datetime :updated_at
@@ -909,7 +909,7 @@ ActiveRecord::Schema.define do
   create_table :references, force: true do |t|
     t.integer :person_id
     t.integer :job_id
-    t.boolean :favourite
+    t.boolean :favorite
     t.integer :lock_version, default: 0
   end
 

--- a/guides/source/2_2_release_notes.md
+++ b/guides/source/2_2_release_notes.md
@@ -55,7 +55,7 @@ If you want to generate these guides locally, inside your application:
 $ rake doc:guides
 ```
 
-This will put the guides inside `Rails.root/doc/guides` and you may start surfing straight away by opening `Rails.root/doc/guides/index.html` in your favourite browser.
+This will put the guides inside `Rails.root/doc/guides` and you may start surfing straight away by opening `Rails.root/doc/guides/index.html` in your favorite browser.
 
 * Major contributions from [Xavier Noria](http://advogato.org/person/fxn/diary.html) and [Hongli Lai](http://izumi.plan99.net/blog/).
 * More information:


### PR DESCRIPTION
### Summary

`favorite` was used more before this.
