### PR TITLE
Adds option `extname` to stylesheet_link_tag to exclude automatically  appended `.css` extension

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Adds option `extname` to `stylesheet_link_tag` to skip default
+    `.css` extension appended to the stylesheet path.
+
+    Before:
+    ```ruby
+    stylesheet_link_tag "style.less"
+    # <link href="/stylesheets/style.less.scss" rel="stylesheet">
+    ```
+
+    After:
+    ```ruby
+    stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less"
+    # <link href="/stylesheets/style.less" rel="stylesheet/less">
+    ```
+
+    *Abhay Nikam*
+
 *   Deprecate `render` locals to be assigned to instance variables.
 
     *Petrik de Heus*

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -122,12 +122,29 @@ module ActionView
         sources_tags
       end
 
-      # Returns a stylesheet link tag for the sources specified as arguments. If
-      # you don't specify an extension, <tt>.css</tt> will be appended automatically.
+      # Returns a stylesheet link tag for the sources specified as arguments.
+      #
+      # When passing paths, the <tt>.css</tt> extension is optional.
+      # If you don't specify an extension, <tt>.css</tt> will be appended automatically.
+      # If you do not want <tt>.css</tt> appended to the path,
+      # set <tt>extname: false</tt> in the options.
       # You can modify the link attributes by passing a hash as the last argument.
       #
       # If the server supports Early Hints header links for these assets will be
       # automatically pushed.
+      #
+      # ==== Options
+      #
+      # * <tt>:extname</tt>  - Append an extension to the generated URL unless the extension
+      #   already exists. This only applies for relative URLs.
+      # * <tt>:protocol</tt>  - Sets the protocol of the generated URL. This option only
+      #   applies when a relative URL and +host+ options are provided.
+      # * <tt>:host</tt>  - When a relative URL is provided the host is added to the
+      #   that path.
+      # * <tt>:skip_pipeline</tt>  - This option is used to bypass the asset pipeline
+      #   when it is set to true.
+      #
+      # ==== Examples
       #
       #   stylesheet_link_tag "style"
       #   # => <link href="/assets/style.css" rel="stylesheet" />
@@ -137,6 +154,9 @@ module ActionView
       #
       #   stylesheet_link_tag "http://www.example.com/style.css"
       #   # => <link href="http://www.example.com/style.css" rel="stylesheet" />
+      #
+      #   stylesheet_link_tag "style.less", extname: false, skip_pipeline: true, rel: "stylesheet/less"
+      #   # => <link href="/stylesheets/style.less" rel="stylesheet/less">
       #
       #   stylesheet_link_tag "style", media: "all"
       #   # => <link href="/assets/style.css" media="all" rel="stylesheet" />
@@ -149,7 +169,7 @@ module ActionView
       #   #    <link href="/css/stylish.css" rel="stylesheet" />
       def stylesheet_link_tag(*sources)
         options = sources.extract_options!.stringify_keys
-        path_options = options.extract!("protocol", "host", "skip_pipeline").symbolize_keys
+        path_options = options.extract!("protocol", "extname", "host", "skip_pipeline").symbolize_keys
         preload_links = []
         crossorigin = options.delete("crossorigin")
         crossorigin = "anonymous" if crossorigin == true

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -515,6 +515,14 @@ class AssetTagHelperTest < ActionView::TestCase
     ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default = original_default_media
   end
 
+  def test_stylesheet_link_tag_without_default_extension_applied
+    assert_dom_equal %(<link href="/stylesheets/wellington.less" rel="stylesheet" />), stylesheet_link_tag("wellington.less", extname: false)
+  end
+
+  def test_javascript_include_tag_without_default_extension_applied
+    assert_dom_equal %(<script src="/javascripts/foo.jsx"></script>), javascript_include_tag("foo.jsx", extname: false)
+  end
+
   def test_javascript_include_tag_without_request
     @request = nil
     assert_dom_equal %(<script src="/javascripts/foo.js"></script>), javascript_include_tag("foo.js")


### PR DESCRIPTION
Fixes: #41918

This PR adds the option `extname` to `stylesheet_link_tag`.
Previously, `stylesheet_link_tag` automatically added `.css`.

The change is similar to `javascript_include_tag` with `extname` option.