### PR TITLE
Turn ActiveSupport::TimeWithZone into a subclass of Time

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -513,14 +513,14 @@ module ActiveSupport
     def utc_to_local(time)
       tzinfo.utc_to_local(time).yield_self do |t|
         ActiveSupport.utc_to_local_returns_utc_offset_times ?
-          t : Time.utc(t.year, t.month, t.day, t.hour, t.min, t.sec, t.sec_fraction)
+          t : Time.utc(t.year, t.month, t.day, t.hour, t.min, t.sec, t.sec_fraction * 1_000_000)
       end
     end
 
     # Adjust the given time to the simultaneous time in UTC. Returns a
     # Time.utc() instance.
     def local_to_utc(time, dst = true)
-      tzinfo.local_to_utc(time, dst)
+      tzinfo.local_to_utc(time, dst) { |periods| periods.last }
     end
 
     # Available so that TimeZone instances respond like TZInfo::Timezone

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -658,12 +658,6 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal 500000000, twz.nsec
   end
 
-  def test_utc_to_local_conversion_saves_period_in_instance_variable
-    assert_nil @twz.instance_variable_get("@period")
-    @twz.time
-    assert_kind_of TZInfo::TimezonePeriod, @twz.instance_variable_get("@period")
-  end
-
   def test_instance_created_with_local_time_returns_correct_utc_time
     twz = ActiveSupport::TimeWithZone.new(nil, @time_zone, Time.utc(1999, 12, 31, 19))
     assert_equal Time.utc(2000), twz.utc


### PR DESCRIPTION
When this feature was introduced it could either wrap a DateTime or a Time instance due to the limited range that Time supported in Ruby 1.8. Now that Time takes a timezone object and Rails 7.0 drops support for Ruby 2.5 we can refactor it to be a proper subclass and avoid duck-typing hacks like overriding `name` and `is_a?`.

This is a WIP - we're caching a UTC Time instance that represents the time in UTC and also a UTC Time instance that represents the time in the local timezone - it should be possible to remove the latter and use `self`.

(It also includes a bug fix for ActiveSupport::TimeZone#utc_to_local which needs filing separately)