### PR TITLE
Optimize the HStore parser

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -291,6 +291,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
 
   def test_backslash
     assert_cycle('a\\b' => 'b\\ar', '1"foo' => "2")
+    assert_cycle('a\\"' => 'b\\ar', '1"foo' => "2")
   end
 
   def test_comma

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -111,8 +111,8 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
   def test_type_cast_hstore
     assert_equal({ "1" => "2" }, @type.deserialize("\"1\"=>\"2\""))
     assert_equal({}, @type.deserialize(""))
-    assert_equal({ "key" => nil }, @type.deserialize("key => NULL"))
-    assert_equal({ "c" => "}", '"a"' => 'b "a b' }, @type.deserialize(%q(c=>"}", "\"a\""=>"b \"a b")))
+    assert_cycle("key" => nil)
+    assert_cycle("c" => "}", '"a"' => 'b "a b')
   end
 
   def test_with_store_accessors
@@ -198,48 +198,36 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
     assert_not_predicate hstore, :changed?
   end
 
-  def test_gen1
-    assert_equal('" "=>""', @type.serialize(" " => ""))
+  def test_spaces
+    assert_cycle(" " => " ")
   end
 
-  def test_gen2
-    assert_equal('","=>""', @type.serialize("," => ""))
+  def test_commas
+    assert_cycle("," => "")
   end
 
-  def test_gen3
-    assert_equal('"="=>""', @type.serialize("=" => ""))
+  def test_signs
+    assert_cycle("=" => ">")
   end
 
-  def test_gen4
-    assert_equal('">"=>""', @type.serialize(">" => ""))
+  def test_various_null
+    assert_cycle({ "a" => nil, "b" => nil, "c" => "NuLl", "null" => "c" })
   end
 
-  def test_parse1
-    assert_equal({ "a" => nil, "b" => nil, "c" => "NuLl", "null" => "c" }, @type.deserialize('a=>null,b=>NuLl,c=>"NuLl",null=>c'))
-  end
-
-  def test_parse2
-    assert_equal({ " " => " " },  @type.deserialize("\\ =>\\ "))
-  end
-
-  def test_parse3
-    assert_equal({ "=" => ">" },  @type.deserialize("==>>"))
-  end
-
-  def test_parse4
-    assert_equal({ "=a" => "q=w" },   @type.deserialize('\=a=>q=w'))
+  def test_equal_signs
+    assert_cycle("=a" => "q=w")
   end
 
   def test_parse5
-    assert_equal({ "=a" => "q=w" },   @type.deserialize('"=a"=>q\=w'))
+    assert_cycle("=a" => "q=w")
   end
 
   def test_parse6
-    assert_equal({ "\"a" => "q>w" },  @type.deserialize('"\"a"=>q>w'))
+    assert_cycle("\"a" => "q>w")
   end
 
   def test_parse7
-    assert_equal({ "\"a" => "q\"w" }, @type.deserialize('\"a=>q"w'))
+    assert_cycle("\"a" => "q\"w")
   end
 
   def test_rewrite


### PR DESCRIPTION
### Context

I saw some people reporting poor Hstore performance on Reddit, and after taking a quick look, it indeed seems that the parser is quite wasteful.

### Compatibility

A good part of the extra performance is at the cost of making the parser less tolerant. Maybe extra tests based on the postgres documentation were added by @joelhoffman in https://github.com/rails/rails/pull/4896, but from my understanding, the documentation states what postgres will accept, not what it will produce.

e.g. unquoted `NULL` is case insensitive, so postgress will accept `NuLL` instead, but will always return `NULL`.

I'm not experienced with postgresql though, so I'm might be totally off.

### Performance

Test string from taken from the the test suite: `"\"a\\\\b\"=>\"b\\\\ar\", \"1\\\"foo\"=>\"2\""`

Bench:

```
Warming up --------------------------------------
            original     6.896k i/100ms
             patched    15.787k i/100ms
Calculating -------------------------------------
            original     68.176k (± 1.2%) i/s -    344.800k in   5.058270s
             patched    157.786k (± 1.0%) i/s -    789.350k in   5.003144s

Comparison:
             patched:   157786.0 i/s
            original:    68176.1 i/s - 2.31x  (± 0.00) slower

```

Memory before: allocated 4376 bytes (55 objects)
Memory after: allocated: 1880 bytes (23 objects)
