### PR TITLE
Deep duplicate in `deep_merge` so no references remain to the original hash in the result

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix issue in `Hash#deep_merge` where it did not properly duplicate a nested `Hash`
+
+    *Marcel Eeken*
+
 *   Add `expires_at` argument to `ActiveSupport::Cache` `write` and `fetch` to set a cache entry TTL as an absolute time.
 
     ```ruby

--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -16,7 +16,7 @@ class Hash
   #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
   #   # => { a: 100, b: 450, c: { c1: 300 } }
   def deep_merge(other_hash, &block)
-    dup.deep_merge!(other_hash, &block)
+    deep_dup.deep_merge!(other_hash, &block)
   end
 
   # Same as +deep_merge+, but modifies +self+.

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -300,6 +300,16 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal expected, hash_1
   end
 
+  def test_deep_merge_with_nested_hash_returning_full_new_hash
+    hash_1 = { a: { b: "foo" } }
+    hash_2 = { d: "bar" }
+
+    new_hash = hash_1.deep_merge(hash_2)
+    new_hash[:a][:b] = "baz"
+
+    assert_equal("foo", hash_1[:a][:b])
+  end
+
   def test_reverse_merge
     defaults = { d: 0, a: "x", b: "y", c: 10 }.freeze
     options  = { a: 1, b: 2 }


### PR DESCRIPTION
### Summary

The documentation for `deep_merge` says that a new hash is returned. But when deep merging a `Hash` with a nested `Hash`, the nested `Hash` is actually a reference to the original nested `Hash`, only a shallow copy is created.

This can lead to unexpected modifications when the nested `Hash` of the merged result gets modified.

```ruby
  x = { a: { b: "foo" } }
  y = { d: { e: "bar" } }

  z = x.deep_merge(y)
  # z => { a: { b: "foo" }, d: { e: "bar" } }

  z[:a][:b] = "baz"
  # z => { a: { b: "baz" }, d: { e: "bar" } }
  # x => { a: { b: "baz" } }
```

### Other Information

Reproduce case:
```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  # gem "activesupport", "6.1.0"
  gem "rails", github: "rails/rails", branch: "main"
end

require "active_support"
require "active_support/core_ext/object/blank"
require "minitest/autorun"

class BugTest < Minitest::Test
  def test_stuff
    x = { a: { b: "foo" } }
    y = { d: { e: "bar" } }

    z = x.deep_merge(y)
    z[:a][:b] = "baz"

    assert_equal "foo", x[:a][:b], "Changing 'z' should not change 'x'"
  end
end
```
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
