### PR TITLE
Expand gemspec files within gem directory

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/%name%.gemspec.tt
@@ -20,7 +20,9 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
   spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
 
-  spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  end
 
   <%= '# ' if options.dev? || options.edge? || options.main? -%>spec.add_dependency "rails", "<%= Array(rails_version_specifier).join('", "') %>"
 end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -535,7 +535,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
   def test_creating_gemspec
     run_generator
     assert_file "bukkits.gemspec", /spec\.name\s+= "bukkits"/
-    assert_file "bukkits.gemspec", /spec\.files = Dir\["\{app,config,db,lib\}\/\*\*\/\*", "MIT-LICENSE", "Rakefile", "README\.md"\]/
+    assert_file "bukkits.gemspec", /spec\.files = Dir.chdir\(File\.expand_path\(__dir__\)\)\s+do\s+Dir\["\{app,config,db,lib\}\/\*\*\/\*", "MIT-LICENSE", "Rakefile", "README\.md"\]\s+end/
     assert_file "bukkits.gemspec", /spec\.version\s+ = Bukkits::VERSION/
   end
 


### PR DESCRIPTION
### Summary
The value of `spec.files` within a new plugin's gemspec is incorrect when that plugin is installed in a Rails application via a local git mapping. Bundler resolves the `spec.files` assignment within the path of the rails application instead of the path of the gem which breaks things like `bundle binstubs foo` and possibly other tools too.

The problem can be seen when inspecting the gem from a console in the rails application:
```
bundle exec irb
x = Bundler.definition.specs.find {|s| s.name == 'foobar'}
x.files
```

This update introduces a `chdir` to ensure that the `spec.files` assignment is evaluated within the gem's directory. This change mirrors what you would find in a newly generated gem's gemspec when running `bundle gem foo`.

**Ruby version:** ruby 2.7.2p137 (2020-10-01 revision 5445e04352)
**Bundler version:** 2.2.16 (2021-04-09 commit 3d7bfaff25)
**Rails version:** 6.1.3.1
