### PR TITLE
Allow to opt-in to the new TimeWithZone.name and fix XmlMini serialization

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -9,6 +9,13 @@ module ActiveSupport
 
     config.eager_load_namespaces << ActiveSupport
 
+    initializer "active_support.remove_deprecated_time_with_zone_name" do |app|
+      if app.config.active_support.remove_deprecated_time_with_zone_name
+        require "active_support/time_with_zone"
+        TimeWithZone.singleton_class.remove_method(:name)
+      end
+    end
+
     initializer "active_support.set_authenticated_message_encryption" do |app|
       config.after_initialize do
         unless app.config.active_support.use_authenticated_message_encryption.nil?

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -45,6 +45,8 @@ module ActiveSupport
       ActiveSupport::Deprecation.warn(<<~EOM)
         ActiveSupport::TimeWithZone.name has been deprecated and
         from Rails 7.1 will use the default Ruby implementation.
+        You can set `config.active_support.remove_deprecated_time_with_zone_name = true`
+        to enable thew new behavior now.
       EOM
 
       "Time"

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -50,6 +50,7 @@ module ActiveSupport
         "Hash"       => "hash"
       }
     end
+    TYPE_NAMES["ActiveSupport::TimeWithZone"] = TYPE_NAMES["Time"]
 
     FORMATTING = {
       "symbol"   => Proc.new { |symbol| symbol.to_s },

--- a/activesupport/test/xml_mini_test.rb
+++ b/activesupport/test/xml_mini_test.rb
@@ -134,6 +134,14 @@ module XmlMiniTest
       assert_xml("<b type=\"dateTime\">1993-02-24T12:00:00+09:00</b>")
     end
 
+    test "#to_tag accepts ActiveSupport::TimeWithZone types" do
+      time = ActiveSupport::TimeWithZone.new(Time.new(1993, 02, 24, 12, 0, 0, "+09:00"), ActiveSupport::TimeZone["Europe/Paris"])
+      ActiveSupport::TimeWithZone.stub(:name, "ActiveSupport::TimeWithZone") do
+        @xml.to_tag(:b, time, @options)
+        assert_xml("<b type=\"dateTime\">1993-02-24T13:00:00+01:00</b>")
+      end
+    end
+
     test "#to_tag accepts array types" do
       @xml.to_tag(:b, ["first_name", "last_name"], @options)
       assert_xml("<b type=\"array\"><b>first_name</b><b>last_name</b></b>")

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -209,6 +209,7 @@ module Rails
           if respond_to?(:active_support)
             active_support.hash_digest_class = OpenSSL::Digest::SHA256
             active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+            active_support.remove_deprecated_time_with_zone_name = true
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"


### PR DESCRIPTION
Followup on https://github.com/rails/rails/pull/41835

The problem with that deprecation IMHO is that it's not really actionable. Users will have to see it over and over again, without much to do about it.

Hence why I think we should introduce a flag to opt-in to the new behavior. Not sure if an initializer is good enough though, some code could call `TimeWithZone.name` before it is executed. If someone has a better idea, I'm interested.

Also from testing removing that method in our app, it does break XmlMini serialization, but that is easy enough to fix.

@pixeltrix what do you think?

cc @rafaelfranca 