### PR TITLE
Resolve wildcard depends using all_template_paths

### DIFF
--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -159,10 +159,14 @@ module ActionView
 
         def resolve_directories(wildcard_dependencies)
           return [] unless @view_paths
+          return [] if wildcard_dependencies.empty?
 
-          wildcard_dependencies.flat_map { |query, templates|
-            @view_paths.find_all_with_query(query).map do |template|
-              "#{File.dirname(query)}/#{File.basename(template).split('.').first}"
+          # Remove trailing "*"
+          prefixes = wildcard_dependencies.map { |query| query[0..-2] }
+
+          @view_paths.flat_map(&:all_template_paths).uniq.select { |path|
+            prefixes.any? do |prefix|
+              path.start_with?(prefix) && !path.index("/", prefix.size)
             end
           }.sort
         end

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -56,15 +56,6 @@ module ActionView #:nodoc:
       find_all(path, prefixes, *args).any?
     end
 
-    def find_all_with_query(query) # :nodoc:
-      paths.each do |resolver|
-        templates = resolver.find_all_with_query(query)
-        return templates unless templates.empty?
-      end
-
-      []
-    end
-
     private
       def _find_all(path, prefixes, args)
         prefixes = [prefixes] if String === prefixes

--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -93,16 +93,16 @@ module ActionView
       def corrections
         path = @error.path
         prefixes = @error.prefixes
-        candidates = @error.paths.flat_map(&:template_paths_for_suggestions).uniq
+        candidates = @error.paths.flat_map(&:all_template_paths).uniq
 
         # Group by possible prefixes
         files_by_dir = candidates.group_by do |x|
           File.dirname(x)
         end.transform_values do |files|
           files.map do |file|
-            # Remove template extensions
-            File.basename(file).split(".", 2)[0]
-          end.uniq
+            # Remove directory
+            File.basename(file)
+          end
         end
 
         # No suggestions if there's an exact match, but wrong details

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -160,7 +160,7 @@ module ActionView
       @cache.cache_query(query) { find_template_paths(File.join(@path, query)) }
     end
 
-    def template_paths_for_suggestions # :nodoc:
+    def all_template_paths # :nodoc:
       # Not implemented by default
       []
     end
@@ -343,8 +343,13 @@ module ActionView
     end
     alias :== :eql?
 
-    def template_paths_for_suggestions # :nodoc:
-      Dir.glob("**/*", base: path)
+    def all_template_paths # :nodoc:
+      paths = Dir.glob("**/*", base: @path)
+      paths.reject do |filename|
+        File.directory?(File.join(@path, filename))
+      end.map do |filename|
+        filename.gsub(/\.[^\/]*\z/, "")
+      end.uniq
     end
   end
 

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -89,11 +89,10 @@ module ActionView
 
       def initialize
         @data = SmallCache.new(&KEY_BLOCK)
-        @query_cache = SmallCache.new
       end
 
       def inspect
-        "#{to_s[0..-2]} keys=#{@data.size} queries=#{@query_cache.size}>"
+        "#{to_s[0..-2]} keys=#{@data.size}>"
       end
 
       # Cache the templates returned by the block
@@ -101,13 +100,8 @@ module ActionView
         @data[key][name][prefix][partial][locals] ||= canonical_no_templates(yield)
       end
 
-      def cache_query(query) # :nodoc:
-        @query_cache[query] ||= canonical_no_templates(yield)
-      end
-
       def clear
         @data.clear
-        @query_cache.clear
       end
 
       # Get the cache size. Do not call this
@@ -124,7 +118,7 @@ module ActionView
           end
         end
 
-        size + @query_cache.size
+        size
       end
 
       private
@@ -154,10 +148,6 @@ module ActionView
       cached(key, [name, prefix, partial], details, locals) do
         _find_all(name, prefix, partial, details, key, locals)
       end
-    end
-
-    def find_all_with_query(query) # :nodoc:
-      @cache.cache_query(query) { find_template_paths(File.join(@path, query)) }
     end
 
     def all_template_paths # :nodoc:

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -635,6 +635,12 @@ module RenderTestCases
       e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/partail") }
       assert_match %r{Did you mean\?  test/_partial\n *test/_partialhtml}, e.message
     end
+
+    def test_spellcheck_doesnt_list_directories
+      e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/directory") }
+      assert_match %r{Did you mean\?}, e.message
+      assert_no_match %r{Did you mean\?  test/_directory\n}, e.message # test/hello is a directory
+    end
   end
 
   def test_render_partial_wrong_details_no_spellcheck

--- a/actionview/test/template/resolver_cache_test.rb
+++ b/actionview/test/template/resolver_cache_test.rb
@@ -5,6 +5,6 @@ require "abstract_unit"
 class ResolverCacheTest < ActiveSupport::TestCase
   def test_inspect_shields_cache_internals
     ActionView::LookupContext::DetailsKey.clear
-    assert_match %r(#<ActionView::Resolver:0x[0-9a-f]+ @cache=#<ActionView::Resolver::Cache:0x[0-9a-f]+ keys=0 queries=0>>), ActionView::Resolver.new.inspect
+    assert_match %r(#<ActionView::Resolver:0x[0-9a-f]+ @cache=#<ActionView::Resolver::Cache:0x[0-9a-f]+ keys=0>>), ActionView::Resolver.new.inspect
   end
 end


### PR DESCRIPTION
This refactors the (private API) `template_paths_for_suggestions` method introduced in #41845 to be more generally useful as "`all_template_paths`". It now returns all virtual paths available within a resolver.

This also re-implements explicit wildcard template dependencies using `all_template_paths`, which allows removing `find_all_with_query`. This is slightly less powerful than the previous implementation, which would have technically supported any glob which ended in a "*", but this supports the only case which was documented and tested (`"foo/*"`). I think it's best to stick with that (though if someone was using `**/*`, we could add that).