### PR TITLE
Correct misspelling in as-twz-deprecation message [ci skip]

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -46,7 +46,7 @@ module ActiveSupport
         ActiveSupport::TimeWithZone.name has been deprecated and
         from Rails 7.1 will use the default Ruby implementation.
         You can set `config.active_support.remove_deprecated_time_with_zone_name = true`
-        to enable thew new behavior now.
+        to enable the new behavior now.
       EOM
 
       "Time"


### PR DESCRIPTION
This corrects a minor misspelling in the deprecation message of ActiveSupport::TimeWithZone.

