### PR TITLE
feat(CI): add the GitHub Super Linter

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,24 @@
+# https://github.com/igorshubovych/markdownlint-cli
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+# markdownlint -c .github/linters/.markdown-lint.yml .
+
+MD001: false
+MD003: false
+MD004: false
+MD007: false
+MD012: false
+MD013: false
+MD014: false
+MD022: false
+MD024: false
+MD025: false
+MD026: false
+MD030: false
+MD031: false
+MD032: false
+MD033: false
+MD034: false
+MD036: false
+MD040: false
+MD041: false
+MD046: false

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,23 @@
+---
+
+# https://yamllint.readthedocs.io/en/stable/index.html
+# yamllint --strict -c .github/linters/.yaml-lint.yml .
+
+extends: default
+
+ignore: |
+  **/test/
+
+rules:
+  braces: disable
+  colons: disable
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines: disable
+  indentation: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: disable
+  trailing-spaces: disable
+  truthy: disable

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,15 @@
+name: Lint Code Base
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: github/super-linter@v3
+        env:
+          VALIDATE_MARKDOWN: true
+          VALIDATE_YAML: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -312,7 +312,7 @@ Action Pack
 
 #### Deprecations
 
-* Passing formats or handlers to render :template and friends like `render :template => "foo.html.erb"` is deprecated. Instead, you can provide :handlers and :formats directly as options: ` render :template => "foo", :formats => [:html, :js], :handlers => :erb`.
+* Passing formats or handlers to render :template and friends like `render :template => "foo.html.erb"` is deprecated. Instead, you can provide :handlers and :formats directly as options: `render :template => "foo", :formats => [:html, :js], :handlers => :erb`.
 
 ### Sprockets
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -284,7 +284,7 @@ message, to allow future contributors to easily verify your findings and
 determine if they are still relevant. (For example, future optimizations in the
 Ruby VM might render certain optimizations unnecessary.)
 
-When optimizing for a specific scenario that you care about, it is easy to 
+When optimizing for a specific scenario that you care about, it is easy to
 regress performance for other common cases.
 Therefore, you should test your change against a list of representative
 scenarios, ideally extracted from real-world production applications.

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -236,7 +236,7 @@ Cross-Site Request Forgery (CSRF)
 
 This attack method works by including malicious code or a link in a page that accesses a web application that the user is believed to have authenticated. If the session for that web application has not timed out, an attacker may execute unauthorized commands.
 
-![](images/security/csrf.png)
+![Cross-Site Request Forgery](images/security/csrf.png)
 
 In the [session chapter](#sessions) you have learned that most Rails applications use cookie-based sessions. Either they store the session ID in the cookie and have a server-side session hash, or the entire session hash is on the client-side. In either case the browser will automatically send along the cookie on every request to a domain, if it can find a cookie for that domain. The controversial point is that if the request comes from a site of a different domain, it will also send the cookie. Let's start with an example:
 
@@ -373,7 +373,7 @@ def sanitize_filename(filename)
 end
 ```
 
-A significant disadvantage of synchronous processing of file uploads (as the attachment_fu plugin may do with images), is its _vulnerability to denial-of-service attacks_. An attacker can synchronously start image file uploads from many computers which increases the server load and may eventually crash or stall the server.
+A significant disadvantage of synchronous processing of file uploads (as the `attachment_fu` plugin may do with images), is its _vulnerability to denial-of-service attacks_. An attacker can synchronously start image file uploads from many computers which increases the server load and may eventually crash or stall the server.
 
 The solution to this is best to _process media files asynchronously_: Save the media file and schedule a processing request in the database. A second process will handle the processing of the file in the background.
 
@@ -405,7 +405,7 @@ raise if basename !=
 send_file filename, disposition: 'inline'
 ```
 
-Another (additional) approach is to store the file names in the database and name the files on the disk after the ids in the database. This is also a good approach to avoid possible code in an uploaded file to be executed. The attachment_fu plugin does this in a similar way.
+Another (additional) approach is to store the file names in the database and name the files on the disk after the ids in the database. This is also a good approach to avoid possible code in an uploaded file to be executed. The `attachment_fu` plugin does this in a similar way.
 
 Intranet and Admin Security
 ---------------------------


### PR DESCRIPTION
Lint Markdown and YAML.
For this PR no YAML was changed.
Three Markdown files were linted for four rules.

https://github.com/igorshubovych/markdownlint-cli
https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
https://yamllint.readthedocs.io/
https://github.com/github/super-linter
https://github.com/marketplace/actions/super-linter

Run locally with:

 yamllint --strict -c .github/linters/.yaml-lint.yml .

markdownlint -c .github/linters/.markdown-lint.yml .

And we can improve this more later as there are more rules to lint for and also the GitHub Super Linter supports more languages too.

### Summary

The GitHub Super Linter is a robust tool and well supported.

### Other Information

Run Super-Linter locally to test your branch of code. 

https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md
