### PR TITLE
Only dup hashes in Hash#deep_merge

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -16,12 +16,12 @@ class Hash
   #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
   #   # => { a: 100, b: 450, c: { c1: 300 } }
   def deep_merge(other_hash, &block)
-    deep_dup.deep_merge!(other_hash, &block)
+    deep_dup_hashes(self).deep_merge!(other_hash, &block)
   end
 
   # Same as +deep_merge+, but modifies +self+.
   def deep_merge!(other_hash, &block)
-    merge!(other_hash) do |key, this_val, other_val|
+    merge!(deep_dup_hashes(other_hash)) do |key, this_val, other_val|
       if this_val.is_a?(Hash) && other_val.is_a?(Hash)
         this_val.deep_merge(other_val, &block)
       elsif block_given?
@@ -31,4 +31,13 @@ class Hash
       end
     end
   end
+
+  private
+    def deep_dup_hashes(object)
+      return object unless object.is_a?(Hash)
+
+      copy = object.transform_keys { |k| deep_dup_hashes(k) }
+      copy.transform_values! { |v| deep_dup_hashes(v) }
+      copy
+    end
 end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -310,6 +310,25 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal("foo", hash_1[:a][:b])
   end
 
+  def test_deep_merge_dup_received_hash
+    hash_1 = { d: "bar" }
+    hash_2 = { a: { b: "foo" } }
+
+    new_hash = hash_1.deep_merge(hash_2)
+    new_hash[:a][:b] = "baz"
+
+    assert_equal("foo", hash_2[:a][:b])
+  end
+
+  def test_deep_merge_only_dup_hashes
+    hash_1 = { a: { b: Object } }
+    hash_2 = { d: "bar" }
+
+    new_hash = hash_1.deep_merge(hash_2)
+
+    assert_equal(Object, new_hash[:a][:b])
+  end
+
   def test_reverse_merge
     defaults = { d: 0, a: "x", b: "y", c: 10 }.freeze
     options  = { a: 1, b: 2 }


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/41931

That PR caused issue for us because we have some modules/classes in hashes being deep merged, and while duping a class works, it makes it anonymous:

```ruby
>> {foo: Object}.deep_merge({})
=> {:foo=>#<Class:0x00007f8f96a66da0>}
```

I'm really not satisfied with this patch because:

  - Adding a private method for internal use on `Hash` seems dirty.
  - This really increase allocations, and likely negatively impact performance (I haven't benched though)

So I'm not too sure what to do. Maybe an alternative would be for `deep_dup` to not dup `Module` and `Class`?

cc @rafaelfranca @MarcelEeken 