### PR TITLE
Make Module#duplicable? return false

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+++ b/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
@@ -16,7 +16,7 @@ class Hash
   #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
   #   # => { a: 100, b: 450, c: { c1: 300 } }
   def deep_merge(other_hash, &block)
-    deep_dup.deep_merge!(other_hash, &block)
+    deep_dup.deep_merge!(other_hash.deep_dup, &block)
   end
 
   # Same as +deep_merge+, but modifies +self+.

--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -53,7 +53,16 @@ require "singleton"
 module Singleton
   # Singleton instances are not duplicable:
   #
-  # Class.new.include(Singleton).instance.dup # TypeError (can't dup instance of singleton
+  # Class.new.include(Singleton).instance.dup # => TypeError (can't dup instance of singleton
+  def duplicable?
+    false
+  end
+end
+
+class Module
+  # Module and Class are duplicable, however the copy will be anonymous which can have consequences.
+  #
+  # Object.dup # => #<Class:0x00007f8834c15778>
   def duplicable?
     false
   end

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -310,6 +310,25 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal("foo", hash_1[:a][:b])
   end
 
+  def test_deep_merge_dup_received_hash
+    hash_1 = { d: "bar" }
+    hash_2 = { a: { b: "foo" } }
+
+    new_hash = hash_1.deep_merge(hash_2)
+    new_hash[:a][:b] = "baz"
+
+    assert_equal("foo", hash_2[:a][:b])
+  end
+
+  def test_deep_merge_only_dup_hashes
+    hash_1 = { a: { b: Object } }
+    hash_2 = { d: "bar" }
+
+    new_hash = hash_1.deep_merge(hash_2)
+
+    assert_equal(Object, new_hash[:a][:b])
+  end
+
   def test_reverse_merge
     defaults = { d: 0, a: "x", b: "y", c: 10 }.freeze
     options  = { a: 1, b: 2 }


### PR DESCRIPTION
This is an alternative to https://github.com/rails/rails/pull/41946

Module and Class are technically duplicable, however the copy will be anonymous which can have consequences.

Also improve https://github.com/rails/rails/pull/41931 to also protect the merged hash from mutation.

cc @rafaelfranca @MarcelEeken