### PR TITLE
Fix: assign previous encryption schemes via previous: config option

### DIFF
--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -27,7 +27,7 @@ module ActiveRecord
           properties.each do |name, value|
             [:context, :config].each do |configurable_object_name|
               configurable_object = ActiveRecord::Encryption.send(configurable_object_name)
-              configurable_object.send "#{name}=", value if configurable_object.respond_to?(name)
+              configurable_object.send "#{name}=", value if configurable_object.respond_to?("#{name}=")
             end
           end
         end

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -9,6 +9,23 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
     assert_equal ActiveRecord::Encryption.key_provider, ActiveRecord::Encryption.context.key_provider
   end
 
+  test ".configure configures initial config properties" do
+    previous_key_provider = ActiveRecord::Encryption::DerivedSecretKeyProvider.new("some secret")
+
+    ActiveRecord::Encryption.configure \
+      primary_key: "the primary key",
+      deterministic_key: "the deterministic key",
+      key_derivation_salt: "the salt",
+      previous: [{ key_provider: previous_key_provider }]
+
+    config = ActiveRecord::Encryption.config
+
+    assert_equal "the primary key", config.primary_key
+    assert_equal "the deterministic key", config.deterministic_key
+    assert_equal "the salt", config.key_derivation_salt
+    assert_equal previous_key_provider, config.previous_schemes.first.key_provider
+  end
+
   test "can add listeners that will get invoked when declaring encrypted attributes" do
     @klass, @attribute_name = nil
     ActiveRecord::Encryption.on_encrypted_attribute_declared do |declared_klass, declared_attribute_name|

--- a/activerecord/test/fixtures/encrypted_book_that_ignores_cases.yml
+++ b/activerecord/test/fixtures/encrypted_book_that_ignores_cases.yml
@@ -1,5 +1,4 @@
 rfr:
   author_id: 1
-  id: 2
   name: "Ruby for Rails"
   format: "ebook"

--- a/activerecord/test/fixtures/encrypted_books.yml
+++ b/activerecord/test/fixtures/encrypted_books.yml
@@ -1,5 +1,4 @@
 awdr:
   author_id: 1
-  id: 1
   name: "Agile Web Development with Rails"
   format: "paperback"


### PR DESCRIPTION
The [`previous:` config option](https://edgeguides.rubyonrails.org/active_record_encryption.html#global-previous-encryption-schemes) was being skipped at initialization time because it was checking the existence of a reader method instead of the accessor itself.

This also adds a test for the `.configure` method that was missing.

cc @georgeclaghorn @jeremy 
