### PR TITLE
Simplify Time.find_timezone! logic

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -80,24 +80,9 @@ class Time
     #   Time.find_zone! false              # => false
     #   Time.find_zone! "NOT-A-TIMEZONE"   # => ArgumentError: Invalid Timezone: NOT-A-TIMEZONE
     def find_zone!(time_zone)
-      if !time_zone || time_zone.is_a?(ActiveSupport::TimeZone)
-        time_zone
-      else
-        # Look up the timezone based on the identifier (unless we've been
-        # passed a TZInfo::Timezone)
-        unless time_zone.respond_to?(:period_for_local)
-          time_zone = ActiveSupport::TimeZone[time_zone] || TZInfo::Timezone.get(time_zone)
-        end
+      return time_zone unless time_zone
 
-        # Return if a TimeZone instance, or wrap in a TimeZone instance if a TZInfo::Timezone
-        if time_zone.is_a?(ActiveSupport::TimeZone)
-          time_zone
-        else
-          ActiveSupport::TimeZone.create(time_zone.name, nil, time_zone)
-        end
-      end
-    rescue TZInfo::InvalidTimezoneIdentifier
-      raise ArgumentError, "Invalid Timezone: #{time_zone}"
+      ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid Timezone: #{time_zone}")
     end
 
     # Returns a TimeZone instance matching the time zone provided.

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -229,12 +229,16 @@ module ActiveSupport
       # Returns +nil+ if no such time zone is known to the system.
       def [](arg)
         case arg
+        when self
+          arg
         when String
           begin
             @lazy_zones_map[arg] ||= create(arg)
           rescue TZInfo::InvalidTimezoneIdentifier
             nil
           end
+        when TZInfo::Timezone
+          @lazy_zones_map[arg.name] ||= create(arg.name, nil, arg)
         when Numeric, ActiveSupport::Duration
           arg *= 3600 if arg.abs <= 13
           all.find { |z| z.utc_offset == arg.to_i }

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1243,9 +1243,19 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
   end
 
   def test_find_zone_with_bang_raises_if_time_zone_can_not_be_found
-    assert_raise(ArgumentError) { Time.find_zone!("No such timezone exists") }
-    assert_raise(ArgumentError) { Time.find_zone!(-15.hours) }
-    assert_raise(ArgumentError) { Time.find_zone!(Object.new) }
+    error = assert_raise(ArgumentError) { Time.find_zone!("No such timezone exists") }
+    assert_equal "Invalid Timezone: No such timezone exists", error.message
+
+    error = assert_raise(ArgumentError) { Time.find_zone!(-15.hours) }
+    assert_equal "Invalid Timezone: -54000", error.message
+
+    error = assert_raise(ArgumentError) { Time.find_zone!(Object.new) }
+    assert_match "invalid argument to TimeZone[]", error.message
+  end
+
+  def test_find_zone_with_bang_doesnt_raises_with_nil_and_false
+    assert_nil Time.find_zone!(nil)
+    assert_equal false, Time.find_zone!(false)
   end
 
   def test_time_zone_setter_with_find_zone_without_bang

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -69,6 +69,12 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone[-480.minutes] # PST
   end
 
+  def test_from_tzinfo_to_map
+    tzinfo = TZInfo::Timezone.get("Europe/London")
+    assert_instance_of ActiveSupport::TimeZone, ActiveSupport::TimeZone[tzinfo]
+    assert_same ActiveSupport::TimeZone[tzinfo], ActiveSupport::TimeZone[tzinfo]
+  end
+
   ActiveSupport::TimeZone.all.each do |zone|
     name = zone.name.downcase.gsub(/[^a-z]/, "_")
     define_method("test_from_#{name}_to_map") do


### PR DESCRIPTION
By pushing the checks for TZInfo::Timezone and ActiveSupport::TimeZone down into the case statement inside the `[]` method we can radically simplify the logic inside of the `find_timezone!` method.

There's an edge case where passing an invalid argument to `[]` via the `find_timezone!` method generates a slightly different message for the `ArgumentError` exception and this is maintained in the unlikely case someone was relying on the difference.
