### PR TITLE
ActiveStorage: Pass `useCapture` to UJS listener

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -864,7 +864,7 @@
     if (!started) {
       started = true;
       document.addEventListener("click", didClick, true);
-      document.addEventListener("submit", didSubmitForm);
+      document.addEventListener("submit", didSubmitForm, true);
       document.addEventListener("ajax:before", didSubmitRemoteElement);
     }
   }

--- a/activestorage/app/javascript/activestorage/ujs.js
+++ b/activestorage/app/javascript/activestorage/ujs.js
@@ -9,7 +9,7 @@ export function start() {
   if (!started) {
     started = true
     document.addEventListener("click", didClick, true)
-    document.addEventListener("submit", didSubmitForm)
+    document.addEventListener("submit", didSubmitForm, true)
     document.addEventListener("ajax:before", didSubmitRemoteElement)
   }
 }


### PR DESCRIPTION
Closes [@hotwired/turbo#243][].

Set the `useCapture` parameter of [addEventListener][] to `true` so that
cancelling the event occurs early enough in the process so that the
resulting upload is cancelled.

[@hotwired/turbo#243]: https://github.com/hotwired/turbo/issues/243#issuecomment-818792129
[addEventListener]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters

Co-authored-by: Javan Makhmali <javan@basecamp.com>
