### PR TITLE
Lint Markdown blank lines around headings [ci-skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -708,6 +708,7 @@ production:
   url: redis://10.10.3.153:6381
   channel_prefix: appname_production
 ```
+
 #### Adapter Configuration
 
 Below is a list of the subscription adapters available for end users.

--- a/guides/source/action_view_helpers.md
+++ b/guides/source/action_view_helpers.md
@@ -415,6 +415,7 @@ end
 Sanitizes a block of CSS code.
 
 #### strip_links(html)
+
 Strips all link tags from text leaving just the link text.
 
 ```ruby

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -147,6 +147,7 @@ end
 ```
 
 #### Jbuilder
+
 [Jbuilder](https://github.com/rails/jbuilder) is a gem that's
 maintained by the Rails team and included in the default Rails `Gemfile`.
 It's similar to Builder, but is used to generate JSON, instead of XML.

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -190,6 +190,7 @@ class Article
   encrypts :title, deterministic: true, previous: { deterministic: false }
 end
 ```
+
 #### Encryption schemes and deterministic attributes
 
 When adding previous encryption schemes:

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1444,6 +1444,7 @@ NOTE: If an association is eager loaded as part of a join, any fields from a cus
 This is because it is ambiguous whether they should appear on the parent record, or the child.
 
 ### preload
+
 With `preload`, Active record ensures that loaded using a query for every specified association.
 
 Revisiting the case where N + 1 was occurred using the `preload` method, we could rewrite `Book.limit(10)` to authors:
@@ -1468,6 +1469,7 @@ SELECT `authors`.* FROM `authors`
 NOTE: The `preload` method using an array, hash, or a nested hash of array/hash in the same way as the includes method to load any number of associations with a single `Model.find` call. However, unlike the `includes` method, it is not possible to specify conditions for eager loaded associations.
 
 ### eager_load
+
 With `eager_load`, Active record ensures that force eager loading by using　`LEFT OUTER JOIN` for all specified associations.
 
 Revisiting the case where N + 1 was occurred using the `eager_load` method, we could rewrite `Book.limit(10)` to authors:

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1005,6 +1005,7 @@ side of the association.
 Counter cache columns are added to the containing model's list of read-only attributes through `attr_readonly`.
 
 ##### `:dependent`
+
 If you set the `:dependent` option to:
 
 * `:destroy`, when the object is destroyed, `destroy` will be called on its

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1050,6 +1050,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 `config.load_defaults` sets new defaults up to and including the version passed. Such that passing, say, `6.0` also gets the new defaults from every version before it.
 
 #### For '7.0', defaults from previous versions below and:
+
 - `config.action_view.button_to_generates_button_tag`: `true`
 - `config.action_view.apply_stylesheet_media_default` : `false`
 - `config.active_support.key_generator_hash_digest_class`: `OpenSSL::Digest::SHA256`

--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -962,6 +962,7 @@ For further information on how to install Valgrind and use with Ruby, refer to
 by Evan Weaver.
 
 ### Find a Memory Leak
+
 There is an excellent article about detecting and fixing memory leaks at Derailed, [which you can read here](https://github.com/schneems/derailed_benchmarks#is-my-app-leaking-memory).
 
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -941,6 +941,7 @@ We will be redirected back to the articles index page and there we assert
 that the text from the new article's title is on the articles index page.
 
 #### Testing for multiple screen sizes
+
 If you want to test for mobile sizes on top of testing for desktop,
 you can create another class that inherits from SystemTestCase and use in your
 test suite. In this example a file called `mobile_system_test_case.rb` is created


### PR DESCRIPTION
### Summary

One blank line added to most files.

Makes it consistent like all the other docs.