### PR TITLE
chore: fix spelling in `test/cases/migration/index_test.rb`

### DIFF
--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -164,7 +164,7 @@ module ActiveRecord
 
       def test_valid_index_options
         assert_raise ArgumentError do
-          connection.add_index :testings, :foo, unqiue: true
+          connection.add_index :testings, :foo, unique: true
         end
       end
 


### PR DESCRIPTION
### Summary

Fixed one typo.

Changed `unqiue` to `unique`.