### PR TITLE
Revert "Refactor LocalCache to avoid calling Marshal.dump as much"

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -858,10 +858,6 @@ module ActiveSupport
         end
       end
 
-      def compressed? # :nodoc:
-        defined?(@compressed)
-      end
-
       # Duplicates the value in a class. This is used by cache implementations that don't natively
       # serialize entries to protect against accidental cache modifications.
       def dup_value!
@@ -895,6 +891,10 @@ module ActiveSupport
               @compressed = true
             end
           end
+        end
+
+        def compressed?
+          defined?(@compressed)
         end
 
         def uncompress(value)

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -35,65 +35,6 @@ module ActiveSupport
         # Simple memory backed cache. This cache is not thread safe and is intended only
         # for serving as a temporary memory cache for a single thread.
         class LocalStore < Store
-          class Entry # :nodoc:
-            class << self
-              def build(cache_entry)
-                return if cache_entry.nil?
-                return cache_entry if cache_entry.compressed?
-
-                value = cache_entry.value
-                if value.is_a?(String)
-                  DupableEntry.new(cache_entry)
-                elsif !value || value == true || value.is_a?(Numeric)
-                  new(cache_entry)
-                else
-                  MutableEntry.new(cache_entry)
-                end
-              end
-            end
-
-            attr_reader :value, :version, :expires_at
-
-            def initialize(cache_entry)
-              @value = cache_entry.value
-              @expires_at = cache_entry.expires_at
-              @version = cache_entry.version
-            end
-
-            def mismatched?(version)
-              @version && version && @version != version
-            end
-
-            def expired?
-              expires_at && expires_at <= Time.now.to_f
-            end
-          end
-
-          class DupableEntry < Entry # :nodoc:
-            def initialize(_cache_entry)
-              super
-              unless @value.frozen?
-                @value = @value.dup.freeze
-              end
-            end
-
-            def value
-              @value.dup
-            end
-          end
-
-          class MutableEntry < Entry # :nodoc:
-            def initialize(cache_entry)
-              @payload = Marshal.dump(cache_entry.value)
-              @expires_at = cache_entry.expires_at
-              @version = cache_entry.version
-            end
-
-            def value
-              Marshal.load(@payload)
-            end
-          end
-
           def initialize
             super
             @data = {}
@@ -124,7 +65,8 @@ module ActiveSupport
           end
 
           def write_entry(key, entry, **options)
-            @data[key] = Entry.build(entry)
+            entry.dup_value!
+            @data[key] = entry
             true
           end
 
@@ -133,7 +75,10 @@ module ActiveSupport
           end
 
           def fetch_entry(key, options = nil) # :nodoc:
-            @data.fetch(key) { @data[key] = Entry.build(yield) }
+            entry = @data.fetch(key) { @data[key] = yield }
+            dup_entry = entry.dup
+            dup_entry&.dup_value!
+            dup_entry
           end
         end
 
@@ -186,12 +131,12 @@ module ActiveSupport
           def read_entry(key, **options)
             if cache = local_cache
               hit = true
-              entry = cache.fetch_entry(key) do
+              value = cache.fetch_entry(key) do
                 hit = false
                 super
               end
               options[:event][:store] = cache.class.name if hit && options[:event]
-              entry
+              value
             else
               super
             end


### PR DESCRIPTION
Reverts rails/rails#41882

`Store#handle_expired_entry` has the potential to sending a local Entry back in the cache, which wasn't expected and isn't desirable. This refactor would need to rebuild a regular `Entry`.

I might try another approach for this performance patch but in the meantime I'll revert and add a test case to prevent such regression in the future.