### PR TITLE
chore: remove unneeded blank lines from YAML

### DIFF
--- a/actionmailbox/test/dummy/config/webpacker.yml
+++ b/actionmailbox/test/dummy/config/webpacker.yml
@@ -47,7 +47,6 @@ development:
     watch_options:
       ignored: /node_modules/
 
-
 test:
   <<: *default
   compile: true

--- a/actiontext/test/dummy/config/webpacker.yml
+++ b/actiontext/test/dummy/config/webpacker.yml
@@ -74,7 +74,6 @@ development:
     watch_options:
       ignored: '**/node_modules/**'
 
-
 test:
   <<: *default
   compile: true

--- a/activerecord/test/fixtures/funny_jokes.yml
+++ b/activerecord/test/fixtures/funny_jokes.yml
@@ -7,4 +7,3 @@ another_joke:
   name: |
        The \n Aristocrats
        Ate the candy
-

--- a/activestorage/test/dummy/config/webpacker.yml
+++ b/activestorage/test/dummy/config/webpacker.yml
@@ -54,7 +54,6 @@ development:
     watch_options:
       ignored: /node_modules/
 
-
 test:
   <<: *default
   compile: true


### PR DESCRIPTION
### Summary

Removed 4 blank lines one from each YAML file.

Makes it consistent.