### PR TITLE
Use leading arguments with `...` instead of `ruby2_keywords` when possible

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -582,14 +582,13 @@ module ActionMailer
         payload[:perform_deliveries] = mail.perform_deliveries
       end
 
-      def method_missing(method_name, *args)
+      def method_missing(method_name, ...)
         if action_methods.include?(method_name.to_s)
-          MessageDelivery.new(self, method_name, *args)
+          MessageDelivery.new(self, method_name, ...)
         else
           super
         end
       end
-      ruby2_keywords(:method_missing)
 
       def respond_to_missing?(method, include_all = false)
         action_methods.include?(method.to_s) || super

--- a/actionmailer/lib/action_mailer/delivery_job.rb
+++ b/actionmailer/lib/action_mailer/delivery_job.rb
@@ -20,10 +20,9 @@ module ActionMailer
       MSG
     end
 
-    def perform(mailer, mail_method, delivery_method, *args) #:nodoc:
-      mailer.constantize.public_send(mail_method, *args).send(delivery_method)
+    def perform(mailer, mail_method, delivery_method, ...)
+      mailer.constantize.public_send(mail_method, ...).send(delivery_method)
     end
-    ruby2_keywords(:perform)
 
     private
       # "Deserialize" the mailer class name by hand in case another argument

--- a/actionmailer/lib/action_mailer/parameterized.rb
+++ b/actionmailer/lib/action_mailer/parameterized.rb
@@ -108,14 +108,13 @@ module ActionMailer
       end
 
       private
-        def method_missing(method_name, *args)
+        def method_missing(method_name, ...)
           if @mailer.action_methods.include?(method_name.to_s)
-            ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, *args)
+            ActionMailer::Parameterized::MessageDelivery.new(@mailer, method_name, @params, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
 
         def respond_to_missing?(method, include_all = false)
           @mailer.respond_to?(method, include_all)
@@ -123,18 +122,16 @@ module ActionMailer
     end
 
     class DeliveryJob < ActionMailer::DeliveryJob # :nodoc:
-      def perform(mailer, mail_method, delivery_method, params, *args)
-        mailer.constantize.with(params).public_send(mail_method, *args).send(delivery_method)
+      def perform(mailer, mail_method, delivery_method, params, ...)
+        mailer.constantize.with(params).public_send(mail_method, ...).send(delivery_method)
       end
-      ruby2_keywords(:perform)
     end
 
     class MessageDelivery < ActionMailer::MessageDelivery # :nodoc:
-      def initialize(mailer_class, action, params, *args)
-        super(mailer_class, action, *args)
+      def initialize(mailer_class, action, params, ...)
+        super(mailer_class, action, ...)
         @params = params
       end
-      ruby2_keywords(:initialize)
 
       private
         def processed_mailer

--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -84,10 +84,9 @@ module AbstractController
 
         methods.each do |method|
           _helpers_for_modification.class_eval <<~ruby_eval, file, line
-            def #{method}(*args, &block)                    # def current_user(*args, &block)
-              controller.send(:'#{method}', *args, &block)  #   controller.send(:'current_user', *args, &block)
-            end                                             # end
-            ruby2_keywords(:'#{method}')
+            def #{method}(...)                    # def current_user(...)
+              controller.send(:'#{method}', ...)  #   controller.send(:'current_user', ...)
+            end                                   # end
           ruby_eval
         end
       end

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -39,7 +39,7 @@ module ActionController
       EXCLUDE = ->(list, action) { !list.include? action }
       NULL    = ->(list, action) { true }
 
-      def build_middleware(klass, args, block)
+      def build_middleware(klass, *args, &block)
         options = args.extract_options!
         only   = Array(options.delete(:only)).map(&:to_s)
         except = Array(options.delete(:except)).map(&:to_s)
@@ -58,6 +58,7 @@ module ActionController
 
         Middleware.new(klass, args, list, strategy, block)
       end
+      ruby2_keywords(:build_middleware)
   end
 
   # <tt>ActionController::Metal</tt> is the simplest possible controller, providing a

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -99,35 +99,30 @@ module ActionDispatch
       middlewares[i]
     end
 
-    def unshift(klass, *args, &block)
-      middlewares.unshift(build_middleware(klass, args, block))
+    def unshift(klass, ...)
+      middlewares.unshift(build_middleware(klass, ...))
     end
-    ruby2_keywords(:unshift)
 
     def initialize_copy(other)
       self.middlewares = other.middlewares.dup
     end
 
-    def insert(index, klass, *args, &block)
+    def insert(index, klass, ...)
       index = assert_index(index, :before)
-      middlewares.insert(index, build_middleware(klass, args, block))
+      middlewares.insert(index, build_middleware(klass, ...))
     end
-    ruby2_keywords(:insert)
+    alias :insert_before :insert
 
-    alias_method :insert_before, :insert
-
-    def insert_after(index, *args, &block)
+    def insert_after(index, klass, ...)
       index = assert_index(index, :after)
-      insert(index + 1, *args, &block)
+      insert(index + 1, klass, ...)
     end
-    ruby2_keywords(:insert_after)
 
-    def swap(target, *args, &block)
+    def swap(target, klass, ...)
       index = assert_index(target, :before)
-      insert(index, *args, &block)
+      insert(index, klass, ...)
       middlewares.delete_at(index + 1)
     end
-    ruby2_keywords(:swap)
 
     def delete(target)
       middlewares.delete_if { |m| m.klass == target }
@@ -140,8 +135,7 @@ module ActionDispatch
       target_index = assert_index(target, :before)
       middlewares.insert(target_index, source_middleware)
     end
-
-    alias_method :move_before, :move
+    alias :move_before :move
 
     def move_after(target, source)
       source_index = assert_index(source, :after)
@@ -151,10 +145,9 @@ module ActionDispatch
       middlewares.insert(target_index + 1, source_middleware)
     end
 
-    def use(klass, *args, &block)
-      middlewares.push(build_middleware(klass, args, block))
+    def use(klass, ...)
+      middlewares.push(build_middleware(klass, ...))
     end
-    ruby2_keywords(:use)
 
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)
@@ -174,11 +167,12 @@ module ActionDispatch
         i
       end
 
-      def build_middleware(klass, args, block)
+      def build_middleware(klass, *args, &block)
         @rack_runtime_deprecated = false if klass == Rack::Runtime
 
         Middleware.new(klass, args, block)
       end
+      ruby2_keywords(:build_middleware)
 
       def index_of(index)
         raise "ActionDispatch::MiddlewareStack::FakeRuntime can not be referenced in middleware operations" if index == FakeRuntime

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -422,16 +422,15 @@ module ActionDispatch
       end
 
       # Delegate unhandled messages to the current session instance.
-      def method_missing(method, *args, &block)
+      def method_missing(method, ...)
         if integration_session.respond_to?(method)
-          integration_session.public_send(method, *args, &block).tap do
+          integration_session.public_send(method, ...).tap do
             copy_session_variables!
           end
         else
           super
         end
       end
-      ruby2_keywords(:method_missing)
     end
   end
 

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -75,10 +75,9 @@ module ActionView
           # Almost a duplicate from ActionController::Helpers
           methods.flatten.each do |method|
             _helpers_for_modification.module_eval <<~end_eval, __FILE__, __LINE__ + 1
-              def #{method}(*args, &block)                    # def current_user(*args, &block)
-                _test_case.send(:'#{method}', *args, &block)  #   _test_case.send(:'current_user', *args, &block)
-              end                                             # end
-              ruby2_keywords(:'#{method}')
+              def #{method}(...)                    # def current_user(...)
+                _test_case.send(:'#{method}', ...)  #   _test_case.send(:'current_user', ...)
+              end                                   # end
             end_eval
           end
         end

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2115,12 +2115,11 @@ class FormWithActsLikeFormForTest < FormWithTest
   class LabelledFormBuilder < ActionView::Helpers::FormBuilder
     (field_helpers - %w(hidden_field)).each do |selector|
       class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-        def #{selector}(field, *args, &proc)
+        def #{selector}(field, ...)
           ("<label for='\#{field}'>\#{field.to_s.humanize}:</label> " + super + "<br/>").html_safe
         end
       RUBY_EVAL
     end
-    ruby2_keywords(:fields)
   end
 
   def test_form_with_with_labelled_builder

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -69,28 +69,6 @@ module ActiveJob
       private_constant :PERMITTED_TYPES, :RESERVED_KEYS, :GLOBALID_KEY,
         :SYMBOL_KEYS_KEY, :RUBY2_KEYWORDS_KEY, :WITH_INDIFFERENT_ACCESS_KEY
 
-      unless Hash.respond_to?(:ruby2_keywords_hash?) && Hash.respond_to?(:ruby2_keywords_hash)
-        using Module.new {
-          refine Hash do
-            class << Hash
-              def ruby2_keywords_hash?(hash)
-                !new(*[hash]).default.equal?(hash)
-              end
-
-              def ruby2_keywords_hash(hash)
-                _ruby2_keywords_hash(**hash)
-              end
-
-              private
-                def _ruby2_keywords_hash(*args)
-                  args.last
-                end
-                ruby2_keywords(:_ruby2_keywords_hash)
-            end
-          end
-        }
-      end
-
       def serialize_argument(argument)
         case argument
         when *PERMITTED_TYPES

--- a/activemodel/test/cases/attribute_methods_test.rb
+++ b/activemodel/test/cases/attribute_methods_test.rb
@@ -279,7 +279,7 @@ class AttributeMethodsTest < ActiveModel::TestCase
     m = ModelWithAttributes2.new
     m.attributes = { "foo" => "bar" }
 
-    def m.attribute_missing(match, *args, &block)
+    def m.attribute_missing(match, ...)
       match
     end
 

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -656,10 +656,9 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *args, &block) #:nodoc:
-        nearest_delegate.send(name, *args, &block)
+      def method_missing(name, ...) #:nodoc:
+        nearest_delegate.send(name, ...)
       end
-      ruby2_keywords(:method_missing)
 
       def migrate(direction)
         new.migrate direction

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -279,14 +279,13 @@ module ActiveRecord
         end
 
         # Forwards any missing method call to the \target.
-        def method_missing(method, *args, &block)
+        def method_missing(method, ...)
           if delegate.respond_to?(method)
-            delegate.public_send(method, *args, &block)
+            delegate.public_send(method, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
     end
   end
 end

--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -299,9 +299,9 @@ class Module
         #{target}.respond_to?(name) || super
       end
 
-      def method_missing(method, *args, &block)
+      def method_missing(method, ...)
         if #{target}.respond_to?(method)
-          #{target}.public_send(method, *args, &block)
+          #{target}.public_send(method, ...)
         else
           begin
             super
@@ -318,7 +318,6 @@ class Module
           end
         end
       end
-      ruby2_keywords(:method_missing)
     RUBY
   end
 end

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -156,15 +156,14 @@ module ActiveSupport
           @current_instances_key ||= name.to_sym
         end
 
-        def method_missing(name, *args, &block)
+        def method_missing(name, ...)
           # Caches the method definition as a singleton method of the receiver.
           #
           # By letting #delegate handle it, we avoid an enclosure that'll capture args.
           singleton_class.delegate name, to: :instance
 
-          send(name, *args, &block)
+          public_send(name, ...)
         end
-        ruby2_keywords(:method_missing)
 
         def respond_to_missing?(name, _)
           super || instance.respond_to?(name)

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -202,14 +202,13 @@ module Rails
 
         # If the class method does not have a method, then send the method call
         # to the Railtie instance.
-        def method_missing(name, *args, &block)
+        def method_missing(name, ...)
           if instance.respond_to?(name)
-            instance.public_send(name, *args, &block)
+            instance.public_send(name, ...)
           else
             super
           end
         end
-        ruby2_keywords(:method_missing)
 
         # receives an instance variable identifier, set the variable value if is
         # blank and append given block to value, which will be used later in


### PR DESCRIPTION
This cannot be applied to the codebase since Rails 7.0 supports Ruby 2.7.0+ for now, so this is an experiment on how much code can be cleaned up.

Ruby 2.7.3 supports leading arguments together with `...`:

https://bugs.ruby-lang.org/issues/16378

Actually this is a new feature, but has been backported to Ruby 2.7.3 to
mitigate the pain of kwargs migration.
