### PR TITLE
Add regression test for #41714

### DIFF
--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1505,6 +1505,13 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   def test_should_not_load_the_associated_model
     assert_queries(1) { @ship.name = "The Vile Insanity"; @ship.save! }
   end
+
+  def test_should_save_with_non_nullable_foreign_keys
+    parent = Post.new title: "foo", body: "..."
+    child = parent.comments.build body: "..."
+    child.save!
+    assert_equal child.reload.post, parent.reload
+  end
 end
 
 module AutosaveAssociationOnACollectionAssociationTests


### PR DESCRIPTION
Commit a1a5d37749964b1e1a23914ef13da327403e34cb tried to fix doubles saves in autosaved associations.
However, it didn't work properly for non-nullable foreign_keys and had
to be reverted.

To prevent this in the future, add a regression test.