### PR TITLE
Used #filter_map directly to remove nil entries (ruby 2.7).

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -119,7 +119,7 @@ end
           n = ENV["BUILDKITE_PARALLEL_JOB"].to_i
           m = ENV["BUILDKITE_PARALLEL_JOB_COUNT"].to_i
 
-          test_files = test_files.each_slice(m).map { |slice| slice[n] }.compact
+          test_files = test_files.each_slice(m).filter_map { |slice| slice[n] }
         end
 
         test_files.each do |file|

--- a/activerecord/lib/active_record/associations/preloader/branch.rb
+++ b/activerecord/lib/active_record/associations/preloader/branch.rb
@@ -46,9 +46,9 @@ module ActiveRecord
 
         def likely_reflections
           parent_classes = parent.target_classes
-          parent_classes.map do |parent_klass|
+          parent_classes.filter_map do |parent_klass|
             parent_klass._reflect_on_association(@association)
-          end.compact
+          end
         end
 
         def root?

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -498,10 +498,10 @@ module ActiveRecord
         end
 
         def build_fixture_statements(fixture_set)
-          fixture_set.map do |table_name, fixtures|
+          fixture_set.filter_map do |table_name, fixtures|
             next if fixtures.empty?
             build_fixture_sql(fixtures, table_name)
-          end.compact
+          end
         end
 
         def build_truncate_statement(table_name)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -917,9 +917,7 @@ module ActiveRecord
             WHERE t.typname IN (%s)
           SQL
           coders = execute_and_clear(query, "SCHEMA", []) do |result|
-            result
-              .map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
-              .compact
+            result.filter_map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
           end
 
           map = PG::TypeMapByOid.new

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -196,11 +196,11 @@ module ActiveRecord
         end
 
         def touch_model_timestamps_unless(&block)
-          model.timestamp_attributes_for_update_in_model.map do |column_name|
+          model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
             if touch_timestamp_attribute?(column_name)
               "#{column_name}=(CASE WHEN (#{updatable_columns.map(&block).join(" AND ")}) THEN #{model.quoted_table_name}.#{column_name} ELSE CURRENT_TIMESTAMP END),"
             end
-          end.compact.join
+          end.join
         end
 
         def raw_update_sql

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1159,13 +1159,13 @@ module ActiveRecord
     def migrations_status # :nodoc:
       db_list = schema_migration.normalized_versions
 
-      file_list = migration_files.map do |file|
+      file_list = migration_files.filter_map do |file|
         version, name, scope = parse_migration_filename(file)
         raise IllegalMigrationNameError.new(file) unless version
         version = schema_migration.normalize_migration_number(version)
         status = db_list.delete(version) ? "up" : "down"
         [status, version, (name + scope).humanize]
-      end.compact
+      end
 
       db_list.map! do |version|
         ["up", version, "********** NO FILE **********"]

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -486,7 +486,7 @@ module ActiveRecord
         existing_records = if association.loaded?
           association.target
         else
-          attribute_ids = attributes_collection.map { |a| a["id"] || a[:id] }.compact
+          attribute_ids = attributes_collection.filter_map { |a| a["id"] || a[:id] }
           attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
         end
 

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -94,7 +94,7 @@ module ActiveRecord
             sslcapath: "--ssl-capath",
             sslcipher: "--ssl-cipher",
             sslkey:    "--ssl-key"
-          }.map { |opt, arg| "#{arg}=#{configuration_hash[opt]}" if configuration_hash[opt] }.compact
+          }.filter_map { |opt, arg| "#{arg}=#{configuration_hash[opt]}" if configuration_hash[opt] }
 
           args
         end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -148,8 +148,7 @@ module ActiveRecord
 
     def max_updated_column_timestamp
       timestamp_attributes_for_update_in_model
-        .map { |attr| self[attr]&.to_time }
-        .compact
+        .filter_map { |attr| self[attr]&.to_time }
         .max
     end
 


### PR DESCRIPTION
### Summary

Since Rails 7 supports ruby 2.7.0+, used #filter_map which got introduced in ruby 2.7.
The `filter_map` method is faster than normal `map + compact` combination.



