### PR TITLE
Command format for multiple args to custom tasks

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -649,6 +649,7 @@ Invocation of the tasks will look like:
 ```bash
 $ bin/rails task_name
 $ bin/rails "task_name[value 1]" # entire argument string should be quoted
+$ bin/rails "task_name[value 1,value2,value3]" # separate multiple args with a comma
 $ bin/rails db:nothing
 ```
 


### PR DESCRIPTION
### Summary

I think it helps to document that multiple args are comma separated, as this isn't quite intuitive IMO.