### PR TITLE
Adds documentation for strict_loading_n_plus_one_only? [ci skip]

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -769,7 +769,8 @@ module ActiveRecord
       @strict_loading_mode = mode
     end
 
-    def strict_loading_n_plus_one_only? # :nodoc:
+    # Returns +true+ if the record uses strict_loading with +:n_plus_one_only+ mode enabled.
+    def strict_loading_n_plus_one_only?
       @strict_loading_mode == :n_plus_one_only
     end
 


### PR DESCRIPTION
While adding test case for #41839, found that `strict_loading_n_plus_one_only?` is marked as `nodoc`. Didn't find any reason why would we want to hide it so wrote small doc and for it.