### PR TITLE
Only change @previously_new_record once for cyclic autosave callbacks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Only change `@previously_new_record` once during cyclic autosave callbacks.
+
+    Cyclic autosave callbacks could incorrectly set `@previously_new_record` to
+    false when creating a new record. This can be prevented by only allowing it
+    to be set once in the current saving cycle.
+
+    *Petrik de Heus*
+
 *   Only update dirty attributes once for cyclic autosave callbacks.
 
     Instead of calling `changes_applied` everytime `save` is called,

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -291,7 +291,10 @@ module ActiveRecord
         yield
       ensure
         @_saving = previously_saving
-        @_already_called[:changes_applied] = false unless @_saving
+        unless @_saving
+          @_already_called[:changes_applied] = false
+          @_already_called[:_set_previously_new_record] = false
+        end
       end
 
       # Returns the record for an association collection that should be validated
@@ -538,6 +541,13 @@ module ActiveRecord
       # Call +changes_applied+ at least once or if attributes changed
       def _apply_changes?(attribute_names)
         !@_already_called[:changes_applied] || attribute_names.present?
+      end
+
+      def _set_previously_new_record(value)
+        unless @_already_called[:_set_previously_new_record]
+          super
+          @_already_called[:_set_previously_new_record] = true
+        end
       end
   end
 end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -959,7 +959,7 @@ module ActiveRecord
         @_trigger_update_callback = affected_rows == 1
       end
 
-      @previously_new_record = false
+      _set_previously_new_record(false)
 
       yield(self) if block_given?
 
@@ -978,7 +978,7 @@ module ActiveRecord
       self.id ||= new_id if @primary_key
 
       @new_record = false
-      @previously_new_record = true
+      _set_previously_new_record(true)
 
       yield(self) if block_given?
 
@@ -1011,6 +1011,10 @@ module ActiveRecord
     # +:touch+ option is used.
     def belongs_to_touch_method
       :touch
+    end
+
+    def _set_previously_new_record(value)
+      @previously_new_record = value
     end
   end
 end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -2000,6 +2000,8 @@ class TestCyclicAutosaveAssociationsApplyDirtyChangesOnce < ActiveRecord::TestCa
     child.save!
     assert_predicate child, :id_previously_changed?
     assert_predicate parent, :id_previously_changed?
+    assert_predicate child, :previously_new_record?
+    assert_predicate parent, :previously_new_record?
   end
 
   test "dirty changes are applied once on child if child is an inverse has_many of parent" do
@@ -2008,6 +2010,8 @@ class TestCyclicAutosaveAssociationsApplyDirtyChangesOnce < ActiveRecord::TestCa
     child.save!
     assert_predicate child, :id_previously_changed?
     assert_predicate parent, :id_previously_changed?
+    assert_predicate child, :previously_new_record?
+    assert_predicate parent, :previously_new_record?
   end
 
   test "dirty changes on parent are applied only once" do
@@ -2016,6 +2020,8 @@ class TestCyclicAutosaveAssociationsApplyDirtyChangesOnce < ActiveRecord::TestCa
     parent.save!
     assert_predicate child, :id_previously_changed?
     assert_predicate parent, :id_previously_changed?
+    assert_predicate child, :previously_new_record?
+    assert_predicate parent, :previously_new_record?
   end
 
   test "dirty changes are applied once on child if child is an inverse has_many of parent with touch" do
@@ -2024,5 +2030,7 @@ class TestCyclicAutosaveAssociationsApplyDirtyChangesOnce < ActiveRecord::TestCa
     child.save!
     assert_predicate child, :id_previously_changed?
     assert_predicate parent, :id_previously_changed?
+    assert_predicate child, :previously_new_record?
+    assert_predicate parent, :previously_new_record?
   end
 end


### PR DESCRIPTION
### Summary

Calling save on a record with cyclic autosave callbacks, can call other
callbacks and hooks multiple times. This can lead to unexpected
behaviour of `previously_new_record?`.

For example `save` gets called twice on Post in the following example.
This results in `_create_record` and `_update_record` both getting
called. The first one setting `@previously_new_record` to true, the second
one setting it to false.

     class Post < ApplicationRecord
       belongs_to :postable, polymorphic: true, inverse_of: :post
     end

     class Message < ApplicationRecord
       has_one :post, as: :postable
     end

     post = Post.create!(postable: Message.new(subject: "Hello, world!"))
     # the following would return false when true is expected
     post.previously_new_record?

`save` gets called twice because Post autosaves Message, which
autosaves Post again.

By adding a method for setting the @previously_new_record, we can skip
executing this method for autosave if the method has already been called
once in the current saving cycle.

### Other Information

This is a followup to  #41860 and fixes another case for #41701
