### PR TITLE
chore: fix spelling in `test/dispatch/debug_exceptions_test.rb`

### DIFF
--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -26,8 +26,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
   class Boomer
     attr_accessor :closed
 
-    class NilAnnotedSourceCodeError < StandardError
-      def annoted_source_code
+    class NilAnnotatedSourceCodeError < StandardError
+      def annotated_source_code
         nil
       end
     end
@@ -60,8 +60,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    def method_that_raises_nil_annoted_source_code
-      raise NilAnnotedSourceCodeError, "nil annoted_source_code"
+    def method_that_raises_nil_annotated_source_code
+      raise NilAnnotatedSourceCodeError, "nil annotated_source_code"
     end
 
     def call(env)
@@ -123,8 +123,8 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
         raise_nested_exceptions
       when %r{/actionable_error}
         raise CustomActionableError
-      when %r{/nil_annoted_source_code_error}
-        method_that_raises_nil_annoted_source_code
+      when %r{/nil_annotated_source_code_error}
+        method_that_raises_nil_annotated_source_code
       when "/utf8_template_error"
         begin
           eval "“fancy string”"
@@ -744,17 +744,17 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_match "ActionController::BadRequest", body
   end
 
-  test "debug exceptions with misbehaving Exception#annoted_source_code" do
+  test "debug exceptions with misbehaving Exception#annotated_source_code" do
     @app = DevelopmentApp
 
     io = StringIO.new
     logger = ActiveSupport::Logger.new(io)
 
-    get "/nil_annoted_source_code_error", headers: { "action_dispatch.show_exceptions" => true, "action_dispatch.logger" => logger }
+    get "/nil_annotated_source_code_error", headers: { "action_dispatch.show_exceptions" => true, "action_dispatch.logger" => logger }
 
-    assert_select "header h1", /DebugExceptionsTest::Boomer::NilAnnotedSourceCodeError/
+    assert_select "header h1", /DebugExceptionsTest::Boomer::NilAnnotatedSourceCodeError/
     assert_select "#container div.exception-message" do
-      assert_select "div", /nil annoted_source_code/
+      assert_select "div", /nil annotated_source_code/
     end
   end
 


### PR DESCRIPTION
### Summary

One word fixed 10 times 2 variations