### PR TITLE
chore: fix case of CSS and JavaScript

### DIFF
--- a/actiontext/test/dummy/config/webpacker.yml
+++ b/actiontext/test/dummy/config/webpacker.yml
@@ -16,7 +16,7 @@ default: &default
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false
 
-  # Extract and emit a css file
+  # Extract and emit a CSS file
   extract_css: false
 
   static_assets_extensions:
@@ -88,7 +88,7 @@ production:
   # Production depends on precompilation of packs prior to booting for performance.
   compile: false
 
-  # Extract and emit a css file
+  # Extract and emit a CSS file
   extract_css: true
 
   # Cache manifest.json for performance

--- a/actionview/app/assets/javascripts/rails-ujs/utils/dom.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/dom.coffee
@@ -9,8 +9,8 @@ m = Element.prototype.matches or
 # element::
 #   native DOM element
 # selector::
-#   css selector string or
-#   a javascript object with `selector` and `exclude` properties
+#   CSS selector string or
+#   a JavaScript object with `selector` and `exclude` properties
 #   Examples: "form", { selector: "form", exclude: "form[data-remote='true']"}
 Rails.matches = (element, selector) ->
   if selector.exclude?

--- a/actionview/app/assets/javascripts/rails-ujs/utils/event.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/event.coffee
@@ -54,7 +54,7 @@ Rails.stopEverything = (e) ->
 # element::
 #   parent element that will listen for events e.g. document
 # selector::
-#   css selector; or an object that has `selector` and `exclude` properties (see: Rails.matches)
+#   CSS selector; or an object that has `selector` and `exclude` properties (see: Rails.matches)
 # eventType::
 #   string representing the event e.g. 'submit', 'click'
 # handler::

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1060,7 +1060,7 @@ module ActionView
           (content_tag("select", select_html.html_safe, select_options) + "\n").html_safe
         end
 
-        # Builds the css class value for the select element
+        # Builds the CSS class value for the select element
         #  css_class_attribute(:year, 'date optional', { year: 'my-year' })
         #  => "date optional my-year"
         def css_class_attribute(type, html_options_class, options) # :nodoc:

--- a/actionview/test/ujs/public/vendor/jquery-2.2.0.js
+++ b/actionview/test/ujs/public/vendor/jquery-2.2.0.js
@@ -340,7 +340,7 @@ jQuery.extend( {
 		}
 	},
 
-	// Convert dashed to camelCase; used by the css and data modules
+	// Convert dashed to camelCase; used by the CSS and data modules
 	// Support: IE9-11+
 	// Microsoft forgot to hump their vendor prefix (#9572)
 	camelCase: function( string ) {
@@ -5869,7 +5869,7 @@ var
 	cssPrefixes = [ "Webkit", "O", "Moz", "ms" ],
 	emptyStyle = document.createElement( "div" ).style;
 
-// Return a css property mapped to a potentially vendor prefixed property
+// Return a CSS property mapped to a potentially vendor prefixed property
 function vendorPropName( name ) {
 
 	// Shortcut for names that are not vendor prefixed
@@ -5971,7 +5971,7 @@ function getWidthOrHeight( elem, name, extra ) {
 	// MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
 	if ( val <= 0 || val == null ) {
 
-		// Fall back to computed then uncomputed css if necessary
+		// Fall back to computed then uncomputed CSS if necessary
 		val = curCSS( elem, name, styles );
 		if ( val < 0 || val == null ) {
 			val = elem.style[ name ];
@@ -9686,7 +9686,7 @@ jQuery.each( { scrollLeft: "pageXOffset", scrollTop: "pageYOffset" }, function( 
 // Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
 // Blink bug: https://code.google.com/p/chromium/issues/detail?id=229280
 // getComputedStyle returns percent when specified for top/left/bottom/right;
-// rather than make the css module depend on the offset module, just check for it here
+// rather than make the CSS module depend on the offset module, just check for it here
 jQuery.each( [ "top", "left" ], function( i, prop ) {
 	jQuery.cssHooks[ prop ] = addGetHookIf( support.pixelPosition,
 		function( elem, computed ) {

--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -192,7 +192,7 @@ Action Pack
 
     Rails will use `layouts/single_car` when a request comes in `:show` action, and use `layouts/application` (or `layouts/cars`, if exists) when a request comes in for any other actions.
 
-* `form_for` is changed to use `#{action}_#{as}` as the css class and id if `:as` option is provided. Earlier versions used `#{as}_#{action}`.
+* `form_for` is changed to use `#{action}_#{as}` as the CSS class and id if `:as` option is provided. Earlier versions used `#{as}_#{action}`.
 
 * `ActionController::ParamsWrapper` on Active Record models now only wrap `attr_accessible` attributes if they were set. If not, only the attributes returned by the class method `attribute_names` will be wrapped. This fixes the wrapping of nested attributes by adding them to `attr_accessible`.
 

--- a/guides/source/development_dependencies_install.md
+++ b/guides/source/development_dependencies_install.md
@@ -211,7 +211,7 @@ If you're using another database, check the file `activerecord/test/config.yml` 
 
 ### Install JavaScript dependencies
 
-If you installed Yarn, you will need to install the javascript dependencies:
+If you installed Yarn, you will need to install the JavaScript dependencies:
 
 ```bash
 $ yarn install

--- a/guides/source/layouts_and_rendering.md
+++ b/guides/source/layouts_and_rendering.md
@@ -1079,7 +1079,7 @@ The result of rendering this page into the supplied layout would be this HTML:
 </html>
 ```
 
-The `content_for` method is very helpful when your layout contains distinct regions such as sidebars and footers that should get their own blocks of content inserted. It's also useful for inserting tags that load page-specific JavaScript or css files into the header of an otherwise generic layout.
+The `content_for` method is very helpful when your layout contains distinct regions such as sidebars and footers that should get their own blocks of content inserted. It's also useful for inserting tags that load page-specific JavaScript or CSS files into the header of an otherwise generic layout.
 
 ### Using Partials
 


### PR DESCRIPTION
### Summary

Fixed `JavaScript` twice and the rest was `CSS`

