### PR TITLE
Improve `did_you_mean` partial name correction

### DIFF
--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -626,13 +626,27 @@ module RenderTestCases
   if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
     def test_render_partial_provides_spellcheck
       e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/partail") }
-      assert_match %r{Did you mean\?  test/_partial\n *test/_partialhtml}, e.message
+      assert_match %r{Did you mean\?  test/partial\n *test/partialhtml}, e.message
     end
 
     def test_spellcheck_doesnt_list_directories
       e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/directory") }
       assert_match %r{Did you mean\?}, e.message
-      assert_no_match %r{Did you mean\?  test/_directory\n}, e.message # test/hello is a directory
+      assert_no_match %r{Did you mean\?  test/directory\n}, e.message # test/hello is a directory
+    end
+
+    def test_spellcheck_only_lists_templates
+      e = assert_raises(ActionView::MissingTemplate) { @view.render(template: "test/partial") }
+
+      assert_match %r{Did you mean\?}, e.message
+      assert_no_match %r{Did you mean\?  test/partial\n}, e.message
+    end
+
+    def test_spellcheck_only_lists_partials
+      e = assert_raises(ActionView::MissingTemplate) { @view.render(partial: "test/template") }
+
+      assert_match %r{Did you mean\?}, e.message
+      assert_no_match %r{Did you mean\?  test/template\n}, e.message
     end
   end
 


### PR DESCRIPTION
Before this change `did_you_mean` shows partial paths like `animals/_partial`, but adding that to your render call in a view like `<%= render 'animals/_partial' %>` will still be missing as rails will search for the template `animals/__partial` (note the double underscore). we can provide the user a easier copy/paste correction if we don't show them about the underscore.

This changes from:
```
Missing partial explores/__explore, application/__explore with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}.

Searched in:
  * "/Users/adamhess/code/ruby_explorer/app/views"
  * "/Users/adamhess/code/rails/actiontext/app/views"
  * "/Users/adamhess/code/rails/actionmailbox/app/views"

Did you mean?  explores/_explore
               explores/_error
               explores/_fake
               explores/index
               active_storage/blobs/_blob
               layouts/application
```


to:
```
Missing partial explores/__explore, application/__explore with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :jbuilder]}.

Searched in:
  * "/Users/adamhess/code/ruby_explorer/app/views"
  * "/Users/adamhess/code/rails/actiontext/app/views"
  * "/Users/adamhess/code/rails/actionmailbox/app/views"

Did you mean?  explores/explore
               explores/error
               explores/fake
               explores/index
               active_storage/blobs/blob
               layouts/application
````

CC: @jhawthorn @seejohnrun 