### PR TITLE
Ensure has_one autosave association callbacks get called once

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+* Ensure has_one autosave association callbacks get called once.
+
+    Change the `has_one` autosave callback to be non cyclic as well.
+    By doing this the autosave callback are made more consistent for
+    all 3 cases: `has_many`, `has_one` and `belongs_to`.
+
+    *Petrik de Heus*
+
 *   Only update dirty attributes once for cyclic autosave callbacks.
 
     Instead of calling `changes_applied` everytime `save` is called,

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -196,7 +196,7 @@ module ActiveRecord
             after_create save_method
             after_update save_method
           elsif reflection.has_one?
-            define_method(save_method) { save_has_one_association(reflection) } unless method_defined?(save_method)
+            define_non_cyclic_method(save_method) { save_has_one_association(reflection) }
             # Configures two callbacks instead of a single after_save so that
             # the model may rely on their execution order relative to its
             # own callbacks.


### PR DESCRIPTION
### Summary

When saving a record, autosave adds callbacks to save its' associations.
Since the associations can have similar callbacks for the inverse,
endless loops could occur.

To prevent these endless loops, the callbacks for `has_many` and
`belongs_to` are defined as methods that only execute once.
This is implemented in the `define_non_cyclic_method` method.
However, this wasn't used for the `has_one` callbacks.
The callbacks are basically defined as follows:

```ruby
if reflection.collection?
  define_non_cyclic_method(save_method) { save_collection_association(reflection) }
  after_create save_method
  after_update save_method
elsif reflection.has_one?
  define_method(save_method) { save_has_one_association(reflection) } unless method_defined?(save_method)
  after_create save_method
  after_update save_method
else
  define_non_cyclic_method(save_method) { throw(:abort) if save_belongs_to_association(reflection) == false }
  before_save save_method
end
```

While `has_one` association callbacks didn't result in endless loops,
they could execute multiple times.
For example for a bidirectional `has_one` with autosave enabled,
the `save_has_one_association` gets called twice:

```ruby
class Pirate < ActiveRecord::Base
  has_one :ship, autosave: true

  def save_has_one_association(reflection)
    @count ||= 0
    @count += 1 if reflection.name == :ship
    super
  end
end

class Ship < ActiveRecord::Base
  belongs_to :pirate, autosave: true
end

pirate = Pirate.new(catchphrase: "Aye")
pirate.build_ship(name: "Nights Dirty Lightning")
pirate.save!
# this returns 2 instead of 1.
assert_equal 1, pirate.instance_variable_get(:@count)
```

This commit changes `has_one` autosave callbacks to be non-cyclic as
well. By doing this the autosave callbacks are made more consistent for
all 3 cases: `has_many`, `has_one` and `belongs_to`.




