### PR TITLE
Convert Template::Types.type_klass to instance ivar

### DIFF
--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView
   class Template #:nodoc:
-    class Types
+    module Types
       class Type
         SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])
 
@@ -37,21 +37,23 @@ module ActionView
         end
       end
 
-      cattr_accessor :type_klass
+      class << self
+        attr_accessor :type_klass
 
-      def self.delegate_to(klass)
-        self.type_klass = klass
+        def delegate_to(klass)
+          self.type_klass = klass
+        end
+
+        def [](type)
+          type_klass[type]
+        end
+
+        def symbols
+          type_klass::SET.symbols
+        end
       end
 
       delegate_to Type
-
-      def self.[](type)
-        type_klass[type]
-      end
-
-      def self.symbols
-        type_klass::SET.symbols
-      end
     end
   end
 end


### PR DESCRIPTION
In the interest of making @tenderlove's keynote less accurate 😆 (like https://github.com/rails/rails/commit/8f07a124efa3303e143be402e28f9480761563dc)... and I guess for performance too.