### PR TITLE
Generate the `Permissions-Policy` header

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Change `ActionDispatch::PermissionsPolicy` to generate both the
+    `Permissions-Policy` header and the `Feature-Policy` header.
+
+    This also adds the `interest-cohort` directive to the list of supported directives,
+    to allow for opting out of FLoC (https://web.dev/floc/#how-can-websites-opt-out-of-the-floc-computation).
+
+    *Rasmus Bang Grouleff*
+
 *   Expand search field on `rails/info/routes` to also search **route name**, **http verb** and **controller#action**.
 
     *Jason Kotchoff*

--- a/railties/test/application/permissions_policy_test.rb
+++ b/railties/test/application/permissions_policy_test.rb
@@ -34,6 +34,7 @@ module ApplicationTests
       app("development")
 
       get "/"
+      assert_nil last_response.headers["Permissions-Policy"]
       assert_nil last_response.headers["Feature-Policy"]
     end
 
@@ -61,7 +62,8 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_policy "geolocation 'none'"
+      assert_feature_policy "geolocation 'none'"
+      assert_permissions_policy "geolocation=()"
     end
 
     test "override permissions policy using same directive in a controller" do
@@ -92,7 +94,8 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_policy "geolocation https://example.com"
+      assert_feature_policy "geolocation https://example.com"
+      assert_permissions_policy "geolocation=(\"https://example.com\")"
     end
 
     test "override permissions policy by unsetting a directive in a controller" do
@@ -125,6 +128,7 @@ module ApplicationTests
       get "/"
       assert_equal 200, last_response.status
       assert_nil last_response.headers["Feature-Policy"]
+      assert_nil last_response.headers["Permissions-Policy"]
     end
 
     test "override permissions policy using different directives in a controller" do
@@ -157,7 +161,8 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_policy "payment https://secure.example.com; autoplay 'none'"
+      assert_feature_policy "payment https://secure.example.com; autoplay 'none'"
+      assert_permissions_policy "payment=(\"https://secure.example.com\"), autoplay=()"
     end
 
     test "global permissions policy added to rack app" do
@@ -179,13 +184,19 @@ module ApplicationTests
       app("development")
 
       get "/"
-      assert_policy "payment 'none'"
+      assert_feature_policy "payment 'none'"
+      assert_permissions_policy "payment=()"
     end
 
     private
-      def assert_policy(expected)
+      def assert_feature_policy(expected)
         assert_equal 200, last_response.status
         assert_equal expected, last_response.headers["Feature-Policy"]
+      end
+
+      def assert_permissions_policy(expected)
+        assert_equal 200, last_response.status
+        assert_equal expected, last_response.headers["Permissions-Policy"]
       end
   end
 end


### PR DESCRIPTION
### Summary

This changes the `ActionDispatch::PermissionsPolicy` to generate the
`Permissions-Policy` header instead of the `Feature-Policy` header.
Besides renaming the header, the header value is now a structured field value
instead of a semicolon separated list.

Furthermore the list of supported directives now includes `interest-cohort`
though it is not a part of the list of available directives from W3C.
This is to enable opting out of FLoC (https://web.dev/floc/#how-can-websites-opt-out-of-the-floc-computation).

This is the required change mentioned in #40652.