### PR TITLE
Raise a meaningful error if ActiveStorage::Current.host is blank

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -124,6 +124,10 @@ module ActiveStorage
           purpose: :blob_key
         )
 
+        if current_host.blank?
+          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.host."
+        end
+
         current_uri = URI.parse(current_host)
 
         url_helpers.rails_disk_service_url(verified_key_with_expiration,

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -23,6 +23,16 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "URL generation without ActiveStorage::Current.host set" do
+    ActiveStorage::Current.host = nil
+
+    error = assert_raises ArgumentError do
+      @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
+    end
+
+    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.host.", error.message)
+  end
+
   test "headers_for_direct_upload generation" do
     assert_equal({ "Content-Type" => "application/json" }, @service.headers_for_direct_upload(@key, content_type: "application/json"))
   end


### PR DESCRIPTION
### Summary

It's very hard to understand what happens with the following exception

```
URI::InvalidURIError:
  bad URI(is not URI?): nil
```

that is raised when trying to generate a URL for Disk service without setting the `ActiveStorage::Current.host` first.

This can happen when the `ActiveStorage::SetCurrent` is not included in a controller, or when testing URL generation outside of the controllers layer (eg. testing URL generation in a model).

cc @elia @filippoliverani

