### PR TITLE
Cleanups to Resolver/UnboundTemplate details

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -252,16 +252,17 @@ module ActionView
       end
 
       def build_unbound_template(template, virtual_path)
-        handler, format, variant = extract_handler_and_format_and_variant(template)
+        details = @path_parser.parse(template)
         source = source_for_template(template)
 
         UnboundTemplate.new(
           source,
           template,
-          handler,
+          details.handler,
           virtual_path: virtual_path,
-          format: format,
-          variant: variant,
+          locale: details.locale,
+          format: details.format,
+          variant: details.variant,
         )
       end
 
@@ -281,20 +282,6 @@ module ActionView
 
       def escape_entry(entry)
         entry.gsub(/[*?{}\[\]]/, '\\\\\\&')
-      end
-
-      # Extract handler, formats and variant from path. If a format cannot be found neither
-      # from the path, or the handler, we should return the array of formats given
-      # to the resolver.
-      def extract_handler_and_format_and_variant(path)
-        details = @path_parser.parse(path)
-
-        handler = Template.handler_for_extension(details.handler)
-        format = details.format || handler.try(:default_format)
-        variant = details.variant
-
-        # Template::Types[format] and handler.default_format can return nil
-        [handler, format, variant]
       end
 
       def find_template_paths_from_details(path, details)

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -236,11 +236,11 @@ module ActionView
         template_paths.map do |template|
           unbound_template =
             if cache
-              @unbound_templates.compute_if_absent([template, path.virtual]) do
-                build_unbound_template(template, path.virtual)
+              @unbound_templates.compute_if_absent(template) do
+                build_unbound_template(template)
               end
             else
-              build_unbound_template(template, path.virtual)
+              build_unbound_template(template)
             end
 
           unbound_template.bind_locals(locals)
@@ -251,15 +251,15 @@ module ActionView
         Template::Sources::File.new(template)
       end
 
-      def build_unbound_template(template, virtual_path)
-        details = @path_parser.parse(template)
+      def build_unbound_template(template)
+        details = @path_parser.parse(template.from(@path.size + 1))
         source = source_for_template(template)
 
         UnboundTemplate.new(
           source,
           template,
           details.handler,
-          virtual_path: virtual_path,
+          virtual_path: details.path.virtual,
           locale: details.locale,
           format: details.format,
           variant: details.variant,

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -4,11 +4,17 @@ require "concurrent/map"
 
 module ActionView
   class UnboundTemplate
-    def initialize(source, identifier, handler, options)
+    attr_reader :handler, :format, :variant, :locale, :virtual_path
+
+    def initialize(source, identifier, handler, format:, variant:, locale:, virtual_path:)
       @source = source
       @identifier = identifier
       @handler = handler
-      @options = options
+
+      @format = format
+      @variant = variant
+      @locale = locale
+      @virtual_path = virtual_path
 
       @templates = Concurrent::Map.new(initial_capacity: 2)
     end
@@ -19,12 +25,19 @@ module ActionView
 
     private
       def build_template(locals)
-        options = @options.merge(locals: locals)
+        handler = Template.handler_for_extension(@handler)
+        format = @format || handler.try(:default_format)
+
         Template.new(
           @source,
           @identifier,
-          @handler,
-          **options
+          handler,
+
+          format: format,
+          variant: @variant,
+          virtual_path: @virtual_path,
+
+          locals: locals
         )
       end
   end


### PR DESCRIPTION
This PR includes cleanup of parsed details handling the towards a redo of https://github.com/rails/rails/pull/39362, which I never completed.

* Introduces a Struct to store the parsed details instead of using a hash (as suggested in #39362).
* Parses and stores the full set of details on `UnboundTemplate` instead of treating it as just an options hash to pass to `Template`. This will allow filtering later.
* Determines `virtual_path` from the filesystem instead of from the requested path
