### PR TITLE
Don't clear view cache during concurrent requests

### DIFF
--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -4,49 +4,63 @@ module ActionView
   class CacheExpiry
     class Executor
       def initialize(watcher:)
-        @cache_expiry = CacheExpiry.new(watcher: watcher)
-      end
-
-      def before(target)
-        @cache_expiry.clear_cache_if_necessary
-      end
-    end
-
-    def initialize(watcher:)
-      @watched_dirs = nil
-      @watcher_class = watcher
-      @watcher = nil
-      @mutex = Mutex.new
-    end
-
-    def clear_cache_if_necessary
-      @mutex.synchronize do
-        watched_dirs = dirs_to_watch
-        return if watched_dirs.empty?
-
-        if watched_dirs != @watched_dirs
-          @watched_dirs = watched_dirs
-          @watcher = @watcher_class.new([], watched_dirs) do
-            clear_cache
-          end
-          @watcher.execute
-        else
-          @watcher.execute_if_updated
+        @execution_lock = Concurrent::ReadWriteLock.new
+        @cache_expiry = ViewModificationWatcher.new(watcher: watcher) do
+          clear_cache
         end
       end
-    end
 
-    def clear_cache
-      ActionView::LookupContext::DetailsKey.clear
-    end
-
-    private
-      def dirs_to_watch
-        all_view_paths.grep(FileSystemResolver).map!(&:path).tap(&:uniq!).sort!
+      def run
+        ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+          @cache_expiry.execute_if_updated
+          @execution_lock.acquire_read_lock
+        end
       end
 
-      def all_view_paths
-        ActionView::ViewPaths.all_view_paths.flat_map(&:paths)
+      def complete(_)
+        @execution_lock.release_read_lock
       end
+
+      private
+        def clear_cache
+          @execution_lock.with_write_lock do
+            ActionView::LookupContext::DetailsKey.clear
+          end
+        end
+    end
+
+    class ViewModificationWatcher
+      def initialize(watcher:, &block)
+        @watched_dirs = nil
+        @watcher_class = watcher
+        @watcher = nil
+        @mutex = Mutex.new
+        @block = block
+      end
+
+      def execute_if_updated
+        @mutex.synchronize do
+          watched_dirs = dirs_to_watch
+          return if watched_dirs.empty?
+
+          if watched_dirs != @watched_dirs
+            @watched_dirs = watched_dirs
+            @watcher = @watcher_class.new([], watched_dirs, &@block)
+            @watcher.execute
+          else
+            @watcher.execute_if_updated
+          end
+        end
+      end
+
+      private
+        def dirs_to_watch
+          all_view_paths.grep(FileSystemResolver).map!(&:path).tap(&:uniq!).sort!
+        end
+
+        def all_view_paths
+          ActionView::ViewPaths.all_view_paths.flat_map(&:paths)
+        end
+    end
   end
 end

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -98,7 +98,7 @@ module ActionView
       end
 
       unless enable_caching
-        app.executor.to_run ActionView::CacheExpiry::Executor.new(watcher: app.config.file_watcher)
+        app.executor.register_hook ActionView::CacheExpiry::Executor.new(watcher: app.config.file_watcher)
       end
     end
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/rails/rails/issues/40613, where when there are concurrent requests and reloading is enabled it's possible for the template cache to be cleared at the same time that a request is running. 

This PR updates `ActionView::CacheExpiry` to hold a lock while inside the executor (ie. inside a request) and to only clear caches when that is done.

This is done using `Concurrent::ReadWriteLock`. This allows any number of parallel requests to hold the read lock, but once we detect a change and begin to acquire the write lock, all future requests will be blocked.

I don't know that this is safe to do 😓 (though it at least doesn't affect production environments). If there was for example a long running request this could block future requests when reloading occurs until that request finished, but I don't know what guarantees we expect to provide developers w/r/t that. If this isn't acceptable, the lock could maybe be somewhere more granular, but it would be ideal if it worked here.

cc @fxn @matthewd for reloading/concurrency advice 🙇‍♂️