### PR TITLE
Perform template glob and checks at same time

### DIFF
--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -23,16 +23,16 @@ module ActionView #:nodoc:
     end
 
     private
-      def find_candidate_template_paths(path)
-        @hash.keys.select do |fixture|
-          fixture.start_with?(path.virtual)
+      def template_glob(glob)
+        @hash.keys.select do |path|
+          File.fnmatch(glob, path)
         end.map do |fixture|
           "/#{fixture}"
         end
       end
 
       def source_for_template(template)
-        @hash[template[1..template.size]]
+        @hash[template.from(1)]
       end
   end
 


### PR DESCRIPTION
Previously we would check that our paths were safe and inside the app right before building templates. Instead we can do this, and reject directories at the same time as we perform the glob.
