### PR TITLE
Add 'inquirable' as an option for enum.

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -190,7 +190,6 @@ module ActiveRecord
         end
 
         if inquirable
-          # def status() StringInquirer.new(self[:status]) end
           define_method("#{name}") { ActiveSupport::StringInquirer.new(self[name]) }
         end
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -964,4 +964,14 @@ class EnumTest < ActiveRecord::TestCase
   ensure
     ActiveRecord::Base.logger = old_logger
   end
+
+  test "enum can return a string inquirer instead of a string" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum status: [:proposed, :written], _inquirable: true
+    end
+
+    status = klass.create!(status: 0).status
+    assert status.proposed?
+  end
 end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -971,7 +971,10 @@ class EnumTest < ActiveRecord::TestCase
       enum status: [:proposed, :written], _inquirable: true
     end
 
-    status = klass.create!(status: 0).status
-    assert status.proposed?
+    klass = klass.create!(status: 0)
+    assert klass.status.proposed?
+
+    klass.update!(status: 1)
+    assert klass.status.written?
   end
 end


### PR DESCRIPTION
### Summary
Enum provides various helpful methods, including a method ending in `?` for each value. 

However, when the attribute is assigned to a variable, this method no longer works. This forces the developer to instead use the normal equality operator `==` which increases chance of error if they forget they should compare with a String instead of a Symbol.

This PR adds the option `inquirable`, which forces the enum to return a `StringInquirer` instead of a normal string. This makes the `?` method work, and does not break other ways to test the value

```
klass = Class.new(ActiveRecord::Base) do
  self.table_name = "books"
  enum status: [:proposed, :written], _inquirable: true
end

status = klass.create!(status: 0).status
status.proposed?
=> true

%w[proposed].include? status
=> true
/proposed/ === status
=>  true
"proposed" == status
=> true
:proposed == status.to_sym
=> true
```