### PR TITLE
Fix test `EncryptableFixtureTest` that fails intermittently

### DIFF
--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -242,7 +242,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
 
   # Only run for adapters that add a default string limit when not provided (MySQL, 255)
   if EncryptedAuthor.columns_hash["name"].limit
-    # No column limits in SQLLite
+    # No column limits in SQLite
     test "validate column sizes" do
       assert EncryptedAuthor.new(name: "jorge").valid?
       assert_not EncryptedAuthor.new(name: "a" * 256).valid?

--- a/activerecord/test/cases/encryption/encrypted_fixtures_test.rb
+++ b/activerecord/test/cases/encryption/encrypted_fixtures_test.rb
@@ -4,6 +4,8 @@ require "cases/encryption/helper"
 require "models/book_encrypted"
 
 class ActiveRecord::Encryption::EncryptableFixtureTest < ActiveRecord::EncryptionTestCase
+  self.use_transactional_tests = false
+
   fixtures :encrypted_books, :encrypted_book_that_ignores_cases
 
   test "fixtures get encrypted automatically" do


### PR DESCRIPTION
### Summary

Reference:

https://buildkite.com/rails/rails/builds/76506#f42a5ab3-1923-4a9f-b843-56c4098b6bef
https://buildkite.com/rails/rails/builds/76590#04721d73-9505-4c29-82bf-0a1be1f41649
https://buildkite.com/rails/rails/builds/76556#aa284ad0-0eab-48e9-a50b-60e3b5c7ccac

Apparently when loading different fixtures that reference the same
table, the files that are loaded last run a `DELETE FROM` statement
that removes previous data.

Reproduction command using `minitest_bisect`:

```
activerecord $ bin/test -a mysql2 --seed 22031 -n "/^(?:ActiveRecord::Encryption::EncryptableRecordTest#(?:test_when_downcase:_true_it_creates_content_downcased)|ActiveRecord::Encryption::EncryptableFixtureTest#(?:test_fixtures_get_encrypted_automatically))$/"
```