### PR TITLE
`update_attribute` should always apply dirty changes

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -641,6 +641,7 @@ module ActiveRecord
       name = name.to_s
       verify_readonly_attribute(name)
       public_send("#{name}=", value)
+      @_already_called[:changes_applied] = false
 
       save(validate: false)
     end

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -454,7 +454,7 @@ class PersistenceTest < ActiveRecord::TestCase
     Topic.reset_column_information
   end
 
-  def test_update_after_create
+  def test_update_attribute_after_create
     klass = Class.new(Topic) do
       def self.name; "Topic"; end
       after_create do
@@ -467,6 +467,22 @@ class PersistenceTest < ActiveRecord::TestCase
 
     topic_reloaded = Topic.find(topic.id)
     assert_equal("Another New Topic", topic_reloaded.title)
+    assert_equal("David", topic_reloaded.author_name)
+  end
+
+  def test_update_attribute_after_update
+    klass = Class.new(Topic) do
+      def self.name; "Topic"; end
+      after_update :update_author, if: :saved_change_to_title?
+      def update_author
+        update_attribute("author_name", "David")
+      end
+    end
+    topic = klass.create(title: "New Topic")
+    topic.update(title: "Another Topic")
+
+    topic_reloaded = Topic.find(topic.id)
+    assert_equal("Another Topic", topic_reloaded.title)
     assert_equal("David", topic_reloaded.author_name)
   end
 


### PR DESCRIPTION
### Summary

Update_attribute has the following documented behaviour:

> Updates all the attributes that are dirty in this object.

With ae56ecd467367e3520a5232d8c38264bfe9d173c this behaviour broke when `update_attribute` was called
in an `after_update` callback.
None of the changed attributes would get marked as changed,
resulting in a possible endless loop, as the `after_update` would
get called again by `update_attribute`.

The issue is fixed by making sure `changes_applied` isn't skipped
by setting it's `@_already_called` value to false.

Fixes the following comment: https://github.com/rails/rails/pull/41860#issuecomment-821200408