### PR TITLE
Filter attributes in SQL logs

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Filter attributes in SQL logs
+
+    Previously, SQL queries in logs containing `ActiveRecord::Base.filter_attributes` were not filtered.
+
+    Now, the filter attributes will be masked `[FILTERED]` in the logs when `prepared_statement` is enabled.
+
+    ```
+    # Before:
+      Foo Load (0.2ms)  SELECT "foos".* FROM "foos" WHERE "foos"."passw" = ? LIMIT ?  [["passw", "hello"], ["LIMIT", 1]]
+
+    # After:
+      Foo Load (0.5ms)  SELECT "foos".* FROM "foos" WHERE "foos"."passw" = ? LIMIT ?  [["passw", "[FILTERED]"], ["LIMIT", 1]]
+    ```
+
+    *Aishwarya Subramanian*
+
 *   Add database config option `database_tasks`
 
     If you would like to connect to an external database without any database

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -51,7 +51,10 @@ module ActiveRecord
 
         binds = []
         payload[:binds].each_with_index do |attr, i|
-          binds << render_bind(attr, casted_params[i])
+          attribute_name = attr.respond_to?(:name) ? attr.name : attr[i].name
+          filtered_params = filter(attribute_name, casted_params[i])
+
+          binds << render_bind(attr, filtered_params)
         end
         binds = binds.inspect
         binds.prepend("  ")
@@ -134,6 +137,10 @@ module ActiveRecord
 
       def extract_query_source_location(locations)
         backtrace_cleaner.clean(locations.lazy).first
+      end
+
+      def filter(name, value)
+        ActiveRecord::Base.inspection_filter.filter_param(name, value)
       end
   end
 end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

SQL queries are logged when `:debug` option is used.
Previously, filter attributes were not masked in the logs.

For e.g.

```
  Foo Load (0.2ms)  SELECT "foos".* FROM "foos" WHERE "foos"."passw" = ? LIMIT ?  [["passw", "hello"], ["LIMIT", 1]]
```

`password` being one of the filter attributes, is written to disk.

With this change, filter attributes will be masked as [FILTERED] in the logs.

```
  Foo Load (0.5ms)  SELECT "foos".* FROM "foos" WHERE "foos"."passw" = ? LIMIT ?  [["passw", "[FILTERED]"], ["LIMIT", 1]]
```

The filtration is applied only when `prepared_statement` is enabled.  

Fixes https://github.com/rails/rails/issues/41896

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
