### PR TITLE
Expand path of user provided file in runner

### DIFF
--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -38,8 +38,9 @@ module Rails
         if code_or_file == "-"
           eval($stdin.read, TOPLEVEL_BINDING, "stdin")
         elsif File.exist?(code_or_file)
-          $0 = code_or_file
-          Kernel.load code_or_file
+          expanded_file_path = File.expand_path code_or_file
+          $0 = expanded_file_path
+          Kernel.load expanded_file_path
         else
           begin
             eval(code_or_file, TOPLEVEL_BINDING, __FILE__, __LINE__)

--- a/railties/test/commands/runner_test.rb
+++ b/railties/test/commands/runner_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rails/command"
+require "rails/commands/runner/runner_command"
+
+class Rails::RunnerTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  setup :build_app
+  teardown :teardown_app
+
+  def test_rails_runner_with_stdin
+    command_output = `echo "puts 'Hello world'" | #{app_path}/bin/rails runner -`
+
+    assert_equal <<~OUTPUT, command_output
+      Hello world
+    OUTPUT
+  end
+
+  def test_rails_runner_with_file
+    # We intentionally define a file with a name that matches the one of the
+    # script that we want to run to ensure that runner executes the latter one.
+    app_file "lib/foo.rb", "# Lib file"
+
+    app_file "foo.rb", <<-RUBY
+    puts "Hello world"
+    RUBY
+
+    assert_equal <<~OUTPUT, run_runner_command("foo.rb")
+      Hello world
+    OUTPUT
+  end
+
+  def test_rails_runner_with_ruby_code
+    assert_equal <<~OUTPUT, run_runner_command('puts "Hello world"')
+      Hello world
+    OUTPUT
+  end
+
+  def test_rails_runner_with_syntax_error_in_ruby_code
+    command_output = run_runner_command("This is not ruby code", allow_failure: true)
+
+    assert_match(/Please specify a valid ruby command/, command_output)
+    assert_equal 1, $?.exitstatus
+  end
+
+  def test_rails_runner_with_name_error_in_ruby_code
+    assert_raise(NameError) { IDoNotExist }
+
+    command_output = run_runner_command("IDoNotExist.new", allow_failure: true)
+
+    assert_match(/Please specify a valid ruby command/, command_output)
+    assert_equal 1, $?.exitstatus
+  end
+
+  private
+    def run_runner_command(argument, allow_failure: false)
+      rails "runner", argument, allow_failure: allow_failure
+    end
+end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Rails `runner` uses the `Kernel.load` method to execute code written in a file.
> If the filename is an absolute path (e.g. starts with ‘/’), the file will be loaded directly using the absolute path.
> 
> If the filename is an explicit relative path (e.g. starts with ‘./’ or ‘../’), the file will be loaded using the relative path from the current directory.
> 
> Otherwise, the file will be searched for in the library directories listed in $LOAD_PATH ($:). If the file is found in a directory, it will attempt to load the file relative to that directory. If the file is not found in any of the directories in $LOAD_PATH, the file will be loaded using the relative path from the current directory.
> https://ruby-doc.org/core-3.0.0/Kernel.html#method-i-load

If a user provides a file without an absolute or explicit relative path and a file with the same path exists in any directory of the `$LOAD_PATH`, `runner` will execute the latter one instead of the intended one.

---

Expanding the path of the file forces Kernel to load the correct file using its absolute path.

Fixes #42007
