### PR TITLE
Fix args for rake tasks

### DIFF
--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -16,7 +16,7 @@ module Rails
           require_rake
 
           test_task = rake_tasks.find { |t| t.name == task } if task.start_with?("test:")
-          
+
           Rake.with_application do |rake|
             rake_init_args = test_task ? [] : [task, *args]
             rake.init("rails", rake_init_args)

--- a/railties/lib/rails/commands/rake/rake_command.rb
+++ b/railties/lib/rails/commands/rake/rake_command.rb
@@ -36,18 +36,18 @@ module Rails
         end
 
         private
-        def rake_tasks
-          require_rake
+          def rake_tasks
+            require_rake
 
-          return @rake_tasks if defined?(@rake_tasks)
+            return @rake_tasks if defined?(@rake_tasks)
 
-          require_application!
+            require_application!
 
-          Rake::TaskManager.record_task_metadata = true
-          Rake.application.instance_variable_set(:@name, "rails")
-          load_tasks
-          @rake_tasks = Rake.application.tasks.select(&:comment)
-        end
+            Rake::TaskManager.record_task_metadata = true
+            Rake.application.instance_variable_set(:@name, "rails")
+            load_tasks
+            @rake_tasks = Rake.application.tasks.select(&:comment)
+          end
 
           def formatted_rake_tasks
             rake_tasks.map { |t| [ t.name_with_args, t.comment ] }

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -29,35 +29,35 @@ namespace :test do
     success || exit(false)
   end
 
-  def test_paths(paths)
+  def run_tests_in_paths(paths)
     Rails::TestUnit::Runner.rake_run([*paths, *ARGV])
   end
 
   ["models", "helpers", "channels", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
     task name => "test:prepare" do
-      test_paths(["test/#{name}"])
+      run_tests_in_paths(["test/#{name}"])
     end
   end
 
   desc "Runs all tests, including system tests"
   task all: "test:prepare" do
-    test_paths(["test/**/*_test.rb"])
+    run_tests_in_paths(["test/**/*_test.rb"])
   end
 
   task generators: "test:prepare" do
-    test_paths(["test/lib/generators"])
+    run_tests_in_paths(["test/lib/generators"])
   end
 
   task units: "test:prepare" do
-    test_paths(["test/models", "test/helpers", "test/unit"])
+    run_tests_in_paths(["test/models", "test/helpers", "test/unit"])
   end
 
   task functionals: "test:prepare" do
-    test_paths(["test/controllers", "test/mailers", "test/functional"])
+    run_tests_in_paths(["test/controllers", "test/mailers", "test/functional"])
   end
 
   desc "Run system tests only"
   task system: "test:prepare" do
-    test_paths(["test/system"])
+    run_tests_in_paths(["test/system"])
   end
 end

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -29,31 +29,35 @@ namespace :test do
     success || exit(false)
   end
 
+  def test_paths(paths)
+    Rails::TestUnit::Runner.rake_run([*paths, *ARGV])
+  end
+
   ["models", "helpers", "channels", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
     task name => "test:prepare" do
-      Rails::TestUnit::Runner.rake_run(["test/#{name}"])
+      test_paths(["test/#{name}"])
     end
   end
 
   desc "Runs all tests, including system tests"
   task all: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/**/*_test.rb"])
+    test_paths(["test/**/*_test.rb"])
   end
 
   task generators: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/lib/generators"])
+    test_paths(["test/lib/generators"])
   end
 
   task units: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/models", "test/helpers", "test/unit"])
+    test_paths(["test/models", "test/helpers", "test/unit"])
   end
 
   task functionals: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/controllers", "test/mailers", "test/functional"])
+    test_paths(["test/controllers", "test/mailers", "test/functional"])
   end
 
   desc "Run system tests only"
   task system: "test:prepare" do
-    Rails::TestUnit::Runner.rake_run(["test/system"])
+    test_paths(["test/system"])
   end
 end


### PR DESCRIPTION
### Summary

When passing flags and options to rake tasks using the `rails ...` command like `rails test:system -p`, the options were being parsed as options for Rails and not for the rake task. Depending on whether the options are recognized or not by rails the result is different, it can go from working by coincidence (like with -v) or displaying the wrong output (like with -h), to different exceptions (like with -p or --seed=XXX).

Since `rails test -p` (for example) uses the options for the test runner, I think the expected behavior is for `rails test:system -p` to do the same.

In this PR I changed the initialization of the rake app to ignore the args if `task` is a known rake task. I also adapted the rake tasks inside the `:test` namespace to actually execute the test runner with the provided args.

I reported the issue here https://github.com/rails/rails/issues/41976

I tried different ways to refactor this code and this option is the one that fixes the bug without changing any output or breaking other commands, but I'm open to any correction or to provide clarification if something looks off.

EDIT: I had to make this only affect the `test:...` tasks because the `app:template` command was failing (that one needs the initialization of the rake app with the arguments

I'm not sure if there's a cleaner way to do this. I thought about modifying TestCommand but it would require a lot of duplication to support all the `test:...` tasks.