### PR TITLE
Implement convenience method async to integrate Active Record with Active Job

### DIFF
--- a/activerecord/app/jobs/active_record/async_job.rb
+++ b/activerecord/app/jobs/active_record/async_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # Runs an instance method from a model as an asynchronous operation,
+  # without having to create a job just for that
+  class AsyncJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(record, method_name, *args)
+      record.public_send(method_name, *args)
+    end
+  end
+end

--- a/activerecord/lib/active_record/async_execution.rb
+++ b/activerecord/lib/active_record/async_execution.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module AsyncExecution
+    def async(method_name, *args)
+      validate_record_persistence!
+      validate_method_existence!(method_name)
+      validate_method_arity!(method_name, args.length)
+      ActiveRecord::AsyncJob.perform_later(self, method_name.to_s, *args)
+    end
+
+    private
+
+    def validate_record_persistence!
+      unless persisted?
+        raise ArgumentError, "only persisted records can use #async!"
+      end
+    end
+
+    def validate_method_existence!(method_name)
+      unless respond_to?(method_name)
+        raise ArgumentError, "there is no public method `#{method_name}` for #{self}"
+      end
+    end
+
+    # Suggetions for a better way to do some sanity checks are welcome
+    def validate_method_arity!(method_name, arguments_length)
+      arity = method(method_name).arity
+      min = (arity >= 0) ? arity : (- 1 - arity)
+      max = (arity >= 0) ? arity : Float::Infinity
+
+      unless (n = arguments_length).in?(min..max)
+        range = (min == max) ? min : max.finite? ? "#{min}..#{max}" : "#{min}.."
+        interpolation = "`#{method_name}` - (given #{n}, expected #{range})"
+        raise ArgumentError, "wrong number of arguments for #{interpolation}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This is a feature extracted from the codebase I'm working on that provides a convenient integration between Active Record and Active Job. A typical use case is when you have a long running method in your User model, for example:

```ruby
user = User.find(123)
user.perform_long_running_operation!(arg0, arg1, ...)
```

If you want to make this method run asynchronously, you can use Active Job for that, but first you would have to create a job.
To avoid needing to do that, this implementation adds the convenient `async` method:
```ruby
user.async(:perform_long_running_operation!, arg0, arg1, ...)
```

The result is the same, a job is enqueued in Active Job. There are also some basic checks to see if the method exists, and if the right amount of arguments is passed (or at least tries to, as I couldn't find a simple way to deal with all cases).

### Other Information

In our codebase we also have an `await` method, which uses Postgres LISTEN/NOTIFY to allow another thread to subscribe to the response of the method that ran asynchronously. But it is very database specific and the implementation is a bit fragile, so I'll leave it for another time, if the Rails core team is interested in it.

Also, this is a first draft of the implementation, so please don't judge the code yet.
Before investing time in making it polished I would like to know if it is aligned with the objectives of the Rails core team. If that is not the case, please just close the PR.

If you are interested in it, please guide me on making the changes necessary (how to create tests for it?) to have it merged.
