### PR TITLE
Refactor LocalCache to avoid calling Marshal.dump as much

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -527,6 +527,10 @@ module ActiveSupport
         end
       end
 
+      def new_entry(value, options = nil) # :nodoc:
+        Entry.new(value, **merged_options(options))
+      end
+
       # Deletes all entries with keys matching the pattern.
       #
       # Options are passed to the underlying cache implementation.
@@ -858,6 +862,14 @@ module ActiveSupport
         end
       end
 
+      def compressed? # :nodoc:
+        defined?(@compressed)
+      end
+
+      def local?
+        false
+      end
+
       # Duplicates the value in a class. This is used by cache implementations that don't natively
       # serialize entries to protect against accidental cache modifications.
       def dup_value!
@@ -891,10 +903,6 @@ module ActiveSupport
               @compressed = true
             end
           end
-        end
-
-        def compressed?
-          defined?(@compressed)
         end
 
         def uncompress(value)


### PR DESCRIPTION
Second attempt at: https://github.com/rails/rails/pull/41882

The local cache need to protect against mutations of both the initial received value, and the value returned.

See:

  - https://github.com/rails/rails/pull/36656
  - https://github.com/rails/rails/pull/37587

Because of this, the overhead of the local cache end up being quite significant. On a single read, the value will be deep duped twice. So unless the value is one of the type benefiting from a fast path, we'll have to do two `Marshal.load(Marshal.dump(value))` roundtrips, which for large values can be very expensive.

<img width="1266" alt="Capture d’écran, le 2021-04-19 à 10 37 58" src="https://user-images.githubusercontent.com/19192189/115206865-577d5880-a0fb-11eb-8c1f-f9ada73d42c5.png">


By using a specialized `LocalEntry` type instead, we can store the `Marshal` payload rather than the original value. This way the overhead is reduced to a single `Marshal.dump` on writes and a single `Marshal.load` on reads.

One downside however it increased complexity, mostly because `handle_expired_entry` can pass a local entry directly to `write_entry`, so in such case we need to rebuild a regular `Cache::Entry`.