### PR TITLE
Disable MemCacheStore compression and rely on Dalli instead

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Disable `ActiveSupport::Cache::MemCacheStore` own compression and
+    instead translate the compression configuration to enable it in Dalli.
+
+    *Jean Boussier*
+
 *   Add `Enumerable#sole`, per `ActiveRecord::FinderMethods#sole`.  Returns the
     sole item of the enumerable, raising if no items are found, or if more than
     one is.

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -213,11 +213,11 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def test_large_string_with_default_compression_settings
-    assert_compressed(LARGE_STRING)
+    assert_uncompressed(LARGE_STRING) # Rely on Dalli for compression
   end
 
   def test_large_object_with_default_compression_settings
-    assert_compressed(LARGE_OBJECT)
+    assert_uncompressed(LARGE_OBJECT) # Rely on Dalli for compression
   end
 
   private


### PR DESCRIPTION
See previous discussion in https://github.com/rails/rails/pull/39747

I'd like to get back on my Cache refactor to eliminate the double marshaling, this is an early cleanup to make it simpler.

cc @maxgurewitz @eugeneius 