### PR TITLE
Address non-deteristic CI failure of HasManyThroughDisableJoinsAssoci ationsTest

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -44,13 +44,13 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_pluck_on_disable_joins_through
-    assert_equal @author.comments.pluck(:id), @author.no_joins_comments.pluck(:id)
+    assert_equal @author.comments.pluck(:id).sort, @author.no_joins_comments.pluck(:id).sort
     assert_queries(2) { @author.no_joins_comments.pluck(:id) }
     assert_queries(1) { @author.comments.pluck(:id) }
   end
 
   def test_pluck_on_disable_joins_through_using_custom_foreign_key
-    assert_equal @author.comments_with_foreign_key.pluck(:id), @author.no_joins_comments_with_foreign_key.pluck(:id)
+    assert_equal @author.comments_with_foreign_key.pluck(:id).sort, @author.no_joins_comments_with_foreign_key.pluck(:id).sort
     assert_queries(2) { @author.no_joins_comments_with_foreign_key.pluck(:id) }
     assert_queries(1) { @author.comments_with_foreign_key.pluck(:id) }
   end
@@ -68,7 +68,7 @@ class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_to_a_on_disable_joins_through
-    assert_equal @author.comments.to_a, @author.no_joins_comments.to_a
+    assert_equal @author.comments.sort_by(&:id), @author.no_joins_comments.sort_by(&:id)
     @author.reload
     assert_queries(2) { @author.no_joins_comments.to_a }
     assert_queries(1) { @author.comments.to_a }


### PR DESCRIPTION
### Summary

This pull request addresses CI failure at https://buildkite.com/rails/rails/builds/76751#fa683e3c-b213-4474-8faf-dd37e6444b76 and modified two tests to avoid similar failures.

- `HasManyThroughDisableJoinsAssociationsTest#test_to_a_on_disable_joins_through`

```ruby
Failure:
HasManyThroughDisableJoinsAssociationsTest#test_to_a_on_disable_joins_through [/rails/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb:71]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<SpecialComment id: 11, post_id: 7, body: "go crazy", type: "SpecialComment", label: "default", tags_count: 0, children_count: 0, parent_id: nil, author_type: nil, author_id: nil, resource_id: nil, resource_type: nil, origin_id: nil, origin_type: nil, developer_id: nil, updated_at: "2021-04-19 22:54:11.359941000 +0000", deleted_at: nil, comments: nil, company: nil>, #<Comment id: 71, post_id: 65, body: "text", type: nil, label: "default", tags_count: 0, children_count: 0, parent_id: nil, author_type: nil, author_id: nil, resource_id: nil, resource_type: nil, origin_id: 70, origin_type: "Member", developer_id: nil, updated_at: "2021-04-19 22:54:12.138620000 +0000", deleted_at: nil, comments: nil, company: nil>, #<Comment id: 70, post_id: 64, body: "text", type: nil, label: "default", tags_count: 0, children_count: 0, parent_id: nil, author_type: nil, author_id: nil, resource_id: nil, resource_type: nil, origin_id: 69, origin_type: "Member", developer_id: nil, updated_at: "2021-04-19 22:54:12.131832000 +0000", deleted_at: nil, comments: nil, company: nil>]
+[#<SpecialComment id: 11, post_id: 7, body: "go crazy", type: "SpecialComment", label: "default", tags_count: 0, children_count: 0, parent_id: nil, author_type: nil, author_id: nil, resource_id: nil, resource_type: nil, origin_id: nil, origin_type: nil, developer_id: nil, updated_at: "2021-04-19 22:54:11.359941000 +0000", deleted_at: nil, comments: nil, company: nil>, #<Comment id: 70, post_id: 64, body: "text", type: nil, label: "default", tags_count: 0, children_count: 0, parent_id: nil, author_type: nil, author_id: nil, resource_id: nil, resource_type: nil, origin_id: 69, origin_type: "Member", developer_id: nil, updated_at: "2021-04-19 22:54:12.131832000 +0000", deleted_at: nil, comments: nil, company: nil>, #<Comment id: 71, post_id: 65, body: "text", type: nil, label: "default", tags_count: 0, children_count: 0, parent_id: nil, author_type: nil, author_id: nil, resource_id: nil, resource_type: nil, origin_id: 70, origin_type: "Member", developer_id: nil, updated_at: "2021-04-19 22:54:12.138620000 +0000", deleted_at: nil, comments: nil, company: nil>]
```

- `HasManyThroughDisableJoinsAssociationsTest#test_pluck_on_disable_joins_through`
Reproduced one time in local environment.

```ruby
...........F

Failure:
HasManyThroughDisableJoinsAssociationsTest#test_pluck_on_disable_joins_through [/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb:47]:
Expected: [31, 11, 32]
  Actual: [11, 31, 32]

bin/test test/cases/associations/has_many_through_disable_joins_associations_test.rb:46

```

-  `HasManyThroughDisableJoinsAssociationsTest#test_pluck_on_disable_joins_through_using_custom_foreign_key`, Not reproduced locally but it could also fail due to
non-deterministic order.


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
