### PR TITLE
Remove unused constant from disable_joins_association_relation

### DIFF
--- a/activerecord/lib/active_record/disable_joins_association_relation.rb
+++ b/activerecord/lib/active_record/disable_joins_association_relation.rb
@@ -2,8 +2,6 @@
 
 module ActiveRecord
   class DisableJoinsAssociationRelation < Relation # :nodoc:
-    TOO_MANY_RECORDS = 5000
-
     attr_reader :ids, :key
 
     def initialize(klass, key, ids)


### PR DESCRIPTION
This removes an unused constant that was added in https://github.com/rails/rails/pull/41937