### PR TITLE
Implement an optimized Cache::Entry coder

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -93,6 +93,14 @@ module ActiveSupport
     self.test_parallelization_disabled = true unless ENV["PARALLEL_WORKERS"]
   end
 
+  def self.cache_format_version
+    Cache.format_version
+  end
+
+  def self.cache_format_version=(value)
+    Cache.format_version = value
+  end
+
   def self.to_time_preserves_timezone
     DateAndTime::Compatibility.preserve_timezone
   end

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -45,8 +45,6 @@ module ActiveSupport
         end
       end
 
-      DEFAULT_CODER = DupCoder
-
       def initialize(options = nil)
         options ||= {}
         # Disable compression by default.
@@ -144,6 +142,10 @@ module ActiveSupport
 
       private
         PER_ENTRY_OVERHEAD = 240
+
+        def default_coder
+          DupCoder
+        end
 
         def cached_size(key, payload)
           key.to_s.bytesize + payload.bytesize + PER_ENTRY_OVERHEAD

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -168,7 +168,7 @@ module ActiveSupport
       # Race condition TTL is not set by default. This can be used to avoid
       # "thundering herd" cache writes when hot cache entries are expired.
       # See <tt>ActiveSupport::Cache::Store#fetch</tt> for more.
-      def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: DEFAULT_CODER, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
+      def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: default_coder, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
         @redis_options = redis_options
 
         @max_key_bytesize = MAX_KEY_BYTESIZE
@@ -433,7 +433,10 @@ module ActiveSupport
           if entries.any?
             if mset_capable? && expires_in.nil?
               failsafe :write_multi_entries do
-                redis.with { |c| c.mapped_mset(serialize_entries(entries, **options)) }
+                payload = serialize_entries(entries, **options)
+                redis.with do |c|
+                  c.mapped_mset(payload)
+                end
               end
             else
               super

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -183,7 +183,7 @@ module CacheStoreBehavior
   end
 
   def test_nil_with_compress_low_compress_threshold
-    assert_uncompressed(nil, compress: true, compress_threshold: 1)
+    assert_uncompressed(nil, compress: true, compress_threshold: 20)
   end
 
   def test_small_string_with_default_compression_settings
@@ -243,12 +243,12 @@ module CacheStoreBehavior
   end
 
   def test_incompressible_data
-    assert_uncompressed(nil, compress: true, compress_threshold: 1)
-    assert_uncompressed(true, compress: true, compress_threshold: 1)
-    assert_uncompressed(false, compress: true, compress_threshold: 1)
-    assert_uncompressed(0, compress: true, compress_threshold: 1)
-    assert_uncompressed(1.2345, compress: true, compress_threshold: 1)
-    assert_uncompressed("", compress: true, compress_threshold: 1)
+    assert_uncompressed(nil, compress: true, compress_threshold: 30)
+    assert_uncompressed(true, compress: true, compress_threshold: 30)
+    assert_uncompressed(false, compress: true, compress_threshold: 30)
+    assert_uncompressed(0, compress: true, compress_threshold: 30)
+    assert_uncompressed(1.2345, compress: true, compress_threshold: 30)
+    assert_uncompressed("", compress: true, compress_threshold: 30)
 
     incompressible = nil
 
@@ -600,8 +600,11 @@ module CacheStoreBehavior
       actual_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "actual", {}), **{})
       uncompressed_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "uncompressed", {}), **{})
 
-      actual_size = Marshal.dump(actual_entry).bytesize
-      uncompressed_size = Marshal.dump(uncompressed_entry).bytesize
+      actual_payload = @cache.send(:serialize_entry, actual_entry, **@cache.send(:merged_options, options))
+      uncompressed_payload = @cache.send(:serialize_entry, uncompressed_entry, compress: false)
+
+      actual_size = actual_payload.bytesize
+      uncompressed_size = uncompressed_payload.bytesize
 
       if should_compress
         assert_operator actual_size, :<, uncompressed_size, "value should be compressed"

--- a/activesupport/test/cache/coder_test.rb
+++ b/activesupport/test/cache/coder_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/cache"
+
+class CacheCoderTest < ActiveSupport::TestCase
+  def test_new_coder_can_read_legacy_payloads
+    entry = ActiveSupport::Cache::Entry.new("foobar", expires_in: 1.hour, version: "v42")
+    deserialized_entry = ActiveSupport::Cache::Coders::Rails70Coder.load(
+      ActiveSupport::Cache::Coders::Rails61Coder.dump(entry),
+    )
+
+    assert_equal entry.value, deserialized_entry.value
+    assert_equal entry.version, deserialized_entry.version
+    assert_equal entry.expires_at, deserialized_entry.expires_at
+  end
+
+  def test_legacy_coder_can_read_new_payloads
+    entry = ActiveSupport::Cache::Entry.new("foobar", expires_in: 1.hour, version: "v42")
+    deserialized_entry = ActiveSupport::Cache::Coders::Rails61Coder.load(
+      ActiveSupport::Cache::Coders::Rails70Coder.dump(entry),
+    )
+
+    assert_equal entry.value, deserialized_entry.value
+    assert_equal entry.version, deserialized_entry.version
+    assert_equal entry.expires_at, deserialized_entry.expires_at
+  end
+end

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -144,3 +144,36 @@ class FileStoreTest < ActiveSupport::TestCase
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
   end
 end
+
+class OptimizedFileStoreTest < FileStoreTest
+  def setup
+    @previous_format = ActiveSupport::Cache.format_version
+    ActiveSupport::Cache.format_version = 7.0
+    super
+  end
+
+  def forward_compatibility
+    previous_format = ActiveSupport::Cache.format_version
+    ActiveSupport::Cache.format_version = 6.1
+    @old_store = lookup_store
+    ActiveSupport::Cache.format_version = previous_format
+
+    @old_store.write("foo", "bar")
+    assert_equal "bar", @cache.read("foo")
+  end
+
+  def forward_compatibility
+    previous_format = ActiveSupport::Cache.format_version
+    ActiveSupport::Cache.format_version = 6.1
+    @old_store = lookup_store
+    ActiveSupport::Cache.format_version = previous_format
+
+    @cache.write("foo", "bar")
+    assert_equal "bar", @old_store.read("foo")
+  end
+
+  def teardown
+    super
+    ActiveSupport::Cache.format_version = @previous_format
+  end
+end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -209,6 +209,39 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     end
   end
 
+  class OptimizedRedisCacheStoreCommonBehaviorTest < RedisCacheStoreCommonBehaviorTest
+    def before_setup
+      @previous_format = ActiveSupport::Cache.format_version
+      ActiveSupport::Cache.format_version = 7.0
+      super
+    end
+
+    def forward_compatibility
+      previous_format = ActiveSupport::Cache.format_version
+      ActiveSupport::Cache.format_version = 6.1
+      @old_store = lookup_store
+      ActiveSupport::Cache.format_version = previous_format
+
+      @old_store.write("foo", "bar")
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    def forward_compatibility
+      previous_format = ActiveSupport::Cache.format_version
+      ActiveSupport::Cache.format_version = 6.1
+      @old_store = lookup_store
+      ActiveSupport::Cache.format_version = previous_format
+
+      @cache.write("foo", "bar")
+      assert_equal "bar", @old_store.read("foo")
+    end
+
+    def after_teardown
+      super
+      ActiveSupport::Cache.format_version = @previous_format
+    end
+  end
+
   class ConnectionPoolBehaviourTest < StoreTest
     include ConnectionPoolBehavior
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -865,6 +865,8 @@ There are a few configuration options available in Active Support:
 
 * `config.active_support.use_authenticated_message_encryption` specifies whether to use AES-256-GCM authenticated encryption as the default cipher for encrypting messages instead of AES-256-CBC.
 
+* `config.active_support.cache_format_version` specifies which version of the cache serializer to use. Possible values are `6.1` and `7.0`. Defaults to `6.1`.
+
 * `ActiveSupport::Logger.silencer` is set to `false` to disable the ability to silence logging in a block. The default is `true`.
 
 * `ActiveSupport::Cache::Store.logger` specifies the logger to use within cache store operations.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -210,6 +210,7 @@ module Rails
             active_support.hash_digest_class = OpenSSL::Digest::SHA256
             active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
             active_support.remove_deprecated_time_with_zone_name = true
+            active_support.cache_format_version = 7.0
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/40412
Ref: https://github.com/rails/rails/issues/9494

Active Support's cache have for long been limited because of its format. It directly serialize its `Entry` object with `Marshal`, so any internal change might break the format.
    
The current shortcomings are:
    
  - The minimum entry overhead is quite ridiculous:  `Marshal.dump(ActiveSupport::Cache::Entry.new("")).bytesize # => 107`
  - Only the internal `value` is compressed, but unless it's a String, to do so it first need to be serialized. So we end up with `Marshal.dump(Zlib.deflate(Marshal.dump(value)))` which is wasteful.
 - Overall the format can't be evolved which prevent many refactorings.

I previously submitted https://github.com/rails/rails/pull/40412 which went quite far to have a compact header, etc. But ultimately I think the extra complexity isn't quite justified, the only prefix we need is a single byte to know the format. Right now it uses `0` for uncompressed payloads and `1` for `gziped` ones. But that leaves over 200 other prefixes for future extensions.

This change is supposed to be fully backward and forward compatible, as long as Rails 7.0 with `load_defaults '6.1'` is deployed first, and then set to `load_defaults '7.0'` in a later deploy.

### Performance

Overall this new implementation is substantially faster than the old one, and also always produce smaller payloads. Of course the larger the cached values, the smaller the difference matters.

But more importantly it opens the door to further improvements, thanks to the version prefix.

```ruby
# frozen_string_literal: true

require 'benchmark/ips'
require 'active_support/all'
require 'zlib'

sizes = if ENV['SIZES']
  ENV['SIZES'].split(',').map(&:to_i)
else
  [0, 10, 2_000]
end

sizes.each do |bytesize|
  puts "================ #{bytesize} bytes ================"

  if bytesize == 0
    entry_marshal = Marshal.dump(ActiveSupport::Cache::Entry.new(''))
    entry_pack = ActiveSupport::Cache::EntryCoder.dump(ActiveSupport::Cache::Entry.new('', compress: false))
  else
    string = ('A'..'z').cycle.take(bytesize).join
    entry_marshal = Marshal.dump(ActiveSupport::Cache::Entry.new(string, expires_in: 1.hour, version: "v42").compressed(1_024))
    entry_pack = ActiveSupport::Cache::EntryCoder.dump_compressed(ActiveSupport::Cache::Entry.new(string, expires_in: 1.hour, version: "v42", compress: false), 1_024)
  end

  puts "Marshal.dump.bytesize: #{entry_marshal.bytesize}"
  puts "EntryCoder.dump.bytesize: #{entry_pack.bytesize}"
  puts

  Benchmark.ips do |x|
    x.report('Marshal.dump') { Marshal.dump(ActiveSupport::Cache::Entry.new(string, expires_in: 1.hour, version: "v42").compressed(1_024)) }
    x.report('EntryCoder.dump') { ActiveSupport::Cache::EntryCoder.dump_compressed(ActiveSupport::Cache::Entry.new(string, expires_in: 1.hour, version: "v42", compress: false), 1_024) }
    x.compare!
  end

  puts
  Benchmark.ips do |x|
    x.report('Marshal.load') { Marshal.load(entry_marshal).value }
    x.report('EntryCoder.load') { ActiveSupport::Cache::EntryCoder.load(entry_pack).value }
    x.compare!
  end
  puts
  puts
end
```

```
================ 0 bytes ================
Marshal.dump.bytesize: 90
EntryCoder.dump.bytesize: 13

Warming up --------------------------------------
        Marshal.dump    17.030k i/100ms
     EntryCoder.dump    20.436k i/100ms
Calculating -------------------------------------
        Marshal.dump    168.942k (± 1.0%) i/s -    851.500k in   5.040696s
     EntryCoder.dump    205.791k (± 1.3%) i/s -      1.042M in   5.065456s

Comparison:
     EntryCoder.dump:   205790.5 i/s
        Marshal.dump:   168942.0 i/s - 1.22x  (± 0.00) slower


Warming up --------------------------------------
        Marshal.load    35.907k i/100ms
     EntryCoder.load    50.413k i/100ms
Calculating -------------------------------------
        Marshal.load    357.504k (± 2.2%) i/s -      1.795M in   5.024558s
     EntryCoder.load    501.540k (± 0.8%) i/s -      2.521M in   5.026151s

Comparison:
     EntryCoder.load:   501539.7 i/s
        Marshal.load:   357504.0 i/s - 1.40x  (± 0.00) slower



================ 10 bytes ================
Marshal.dump.bytesize: 128
EntryCoder.dump.bytesize: 52

Warming up --------------------------------------
        Marshal.dump    14.352k i/100ms
     EntryCoder.dump    19.461k i/100ms
Calculating -------------------------------------
        Marshal.dump    144.208k (± 0.8%) i/s -    731.952k in   5.075996s
     EntryCoder.dump    194.288k (± 0.8%) i/s -    973.050k in   5.008606s

Comparison:
     EntryCoder.dump:   194287.7 i/s
        Marshal.dump:   144208.3 i/s - 1.35x  (± 0.00) slower


Warming up --------------------------------------
        Marshal.load    28.966k i/100ms
     EntryCoder.load    40.911k i/100ms
Calculating -------------------------------------
        Marshal.load    289.728k (± 0.7%) i/s -      1.477M in   5.099033s
     EntryCoder.load    406.628k (± 0.7%) i/s -      2.046M in   5.030772s

Comparison:
     EntryCoder.load:   406628.0 i/s
        Marshal.load:   289727.6 i/s - 1.40x  (± 0.00) slower



================ 2000 bytes ================
Marshal.dump.bytesize: 221
EntryCoder.dump.bytesize: 128

Warming up --------------------------------------
        Marshal.dump     3.940k i/100ms
     EntryCoder.dump     3.999k i/100ms
Calculating -------------------------------------
        Marshal.dump     39.468k (± 0.9%) i/s -    200.940k in   5.091648s
     EntryCoder.dump     39.909k (± 0.9%) i/s -    199.950k in   5.010555s

Comparison:
     EntryCoder.dump:    39909.0 i/s
        Marshal.dump:    39467.7 i/s - same-ish: difference falls within error


Warming up --------------------------------------
        Marshal.load    10.632k i/100ms
     EntryCoder.load    13.317k i/100ms
Calculating -------------------------------------
        Marshal.load    105.531k (± 1.0%) i/s -    531.600k in   5.037931s
     EntryCoder.load    134.306k (± 1.3%) i/s -    679.167k in   5.057798s

Comparison:
     EntryCoder.load:   134305.7 i/s
        Marshal.load:   105531.0 i/s - 1.27x  (± 0.00) slower
```