### PR TITLE
AnnotateTest: Updated to accomodate the SQL Server adapter

### DIFF
--- a/activerecord/test/cases/annotate_test.rb
+++ b/activerecord/test/cases/annotate_test.rb
@@ -9,7 +9,7 @@ class AnnotateTest < ActiveRecord::TestCase
   def test_annotate_wraps_content_in_an_inline_comment
     quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
 
-    assert_sql(%r{\ASELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
       posts = Post.select(:id).annotate("foo")
       assert posts.first
     end
@@ -18,22 +18,22 @@ class AnnotateTest < ActiveRecord::TestCase
   def test_annotate_is_sanitized
     quoted_posts_id, quoted_posts = regexp_escape_table_name("posts.id"), regexp_escape_table_name("posts")
 
-    assert_sql(%r{\ASELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
       posts = Post.select(:id).annotate("*/foo/*")
       assert posts.first
     end
 
-    assert_sql(%r{\ASELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/}i) do
       posts = Post.select(:id).annotate("**//foo//**")
       assert posts.first
     end
 
-    assert_sql(%r{\ASELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/ /\* bar \*/}i) do
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* foo \*/ /\* bar \*/}i) do
       posts = Post.select(:id).annotate("*/foo/*").annotate("*/bar")
       assert posts.first
     end
 
-    assert_sql(%r{\ASELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \+ MAX_EXECUTION_TIME\(1\) \*/}i) do
+    assert_sql(%r{SELECT #{quoted_posts_id} FROM #{quoted_posts} /\* \+ MAX_EXECUTION_TIME\(1\) \*/}i) do
       posts = Post.select(:id).annotate("+ MAX_EXECUTION_TIME(1)")
       assert posts.first
     end


### PR DESCRIPTION
### Summary

For the SQL Server adapter (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/) the tests in `AnnotateTest` need to be coerced and re-implemented (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/898) because the tests are expecting the SQL to start with `SELECT` but the SQL generated by the SQL Server adapter starts with `EXEC sp_executesql N'SELECT`. This PR just removes the start of string check in the regular expressions. 

These changes do not affect the purpose of the tests and removes the need coerce & re-implement the same tests in the SQL Server adapter.

The `AnnotateTest` was refactored by @kamipo in https://github.com/rails/rails/commit/7d699dad334996838dd529e4b75e1648692d56f8 to handle all adapters.