### PR TITLE
Fix merging nested param string when named params

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -822,7 +822,7 @@ module ActionDispatch
         path = route_with_params.path(method_name)
         params = route_with_params.params
 
-        if options.key?(:params) && options[:params].is_a?(Hash)
+        if options[:params].is_a?(Hash)
           params.merge! options[:params]
         end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -822,7 +822,7 @@ module ActionDispatch
         path = route_with_params.path(method_name)
         params = route_with_params.params
 
-        if options.key? :params
+        if options.key?(:params) && options[:params].is_a?(Hash)
           params.merge! options[:params]
         end
 

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -373,6 +373,14 @@ XML
     assert_equal "/test_case_test/test/test_uri/7", @response.body
   end
 
+  def test_process_with_request_uri_with_params_nested
+    process :test_uri,
+            method: "GET",
+            params: { id: 7, params: "string" }
+
+    assert_equal "/test_case_test/test/test_uri/7?params=string", @response.body
+  end
+
   def test_process_with_request_uri_with_params_with_explicit_uri
     @request.env["PATH_INFO"] = "/explicit/uri"
     process :test_uri, method: "GET", params: { id: 7 }


### PR DESCRIPTION
### Summary

RouteSet is trying to merge a nested parameter into the root params hash, even if that parameter is a string.

I originally encountered this issue while upgrading to 6.1. I filed an issue with [rails-controller-testing](https://github.com/rails/rails-controller-testing/issues/68), but this is the root cause.




