### PR TITLE
Add wharel method to query with a block

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
-      :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
+      :where, :wharel, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,

--- a/activerecord/lib/active_record/relation/queryable_table.rb
+++ b/activerecord/lib/active_record/relation/queryable_table.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class QueryableTable # :nodoc:
+    def initialize(model)
+      @model = model
+      @arel_table = model.arel_table
+      @reflections = model._reflections
+      @attribute_nodes = {}
+      define_attribute_accessors
+    end
+
+    def method_missing(name, *_args)
+      if reflections.key?(name.to_s)
+        self.class.new(reflections[name.to_s].klass)
+      else
+        super
+      end
+    end
+
+    def inspect
+      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)} @model=#{@model}>"
+    end
+
+    private
+      attr_reader :model, :arel_table, :reflections
+
+      def define_attribute_accessors
+        model.attribute_names.each do |attr|
+          define_singleton_method attr do
+            @attribute_nodes[attr] ||= Predicatable.new(arel_table[attr])
+          end
+        end
+      end
+
+      class Predicatable
+        MAPPED_METHODS = [
+          :eq,
+          :not_eq,
+          :gt,
+          :gteq,
+          :lt,
+          :lteq,
+          :in,
+          :not_in,
+          :and,
+          :or,
+          :matches,
+          :does_not_match
+        ]
+
+        def initialize(arel_node)
+          @arel_node = arel_node
+        end
+
+        MAPPED_METHODS.each do |method|
+          define_method method do |other|
+            other = other.arel_node if other.is_a?(self.class)
+            Predicatable.new(arel_node.public_send(method, other))
+          end
+        end
+
+        def to_arel
+          arel_node
+        end
+
+        protected
+          attr_reader :arel_node
+      end
+  end
+end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -63,6 +63,16 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal 1, posts.to_a.size
   end
 
+  def test_wharel
+    posts = Post.wharel { |post| post.author_id.not_eq(1).and(post.id.gt(2)) }
+    assert_equal 6, posts.to_a.size
+  end
+
+  def test_wharel_can_chain
+    posts = Post.wharel { |post| post.author_id.gteq(1) }.wharel { |post| post.id.lteq(4) }
+    assert_equal 3, posts.to_a.size
+  end
+
   def test_scoped
     topics = Topic.all
     assert_kind_of ActiveRecord::Relation, topics
@@ -510,6 +520,12 @@ class RelationTest < ActiveRecord::TestCase
 
   def test_finding_with_hash_conditions_on_joined_table
     firms = DependentFirm.joins(:account).where(name: "RailsCore", accounts: { credit_limit: 55..60 }).to_a
+    assert_equal 1, firms.size
+    assert_equal companies(:rails_core), firms.first
+  end
+
+  def tests_finding_with_block_on_joined_table
+    firms = DependentFirm.joins(:account).wharel { |firm| firm.name.eq("RailsCore").and(firm.accounts.credit_limit.in(55..60)) }.to_a
     assert_equal 1, firms.size
     assert_equal companies(:rails_core), firms.first
   end


### PR DESCRIPTION
### Summary
**TL;DR**: exposing a subset of Arel and using blocks to build queries that need to be done through prepared statements right now.

This PR is a follow-up to https://github.com/rails/rails/pull/39445 which aims to fix some of the things pointed out and give a fresh starting point without so many comments.

As a recap this PR tries to address are the two following types of queries:

```sql
SELECT posts.* FROM posts WHERE posts.views > 100 OR posts.title LIKE '%Rails%'
``` 

```sql
SELECT `authors`.* FROM `authors` INNER JOIN `posts` ON `posts`.`author_id` = `authors`.`id` WHERE `posts`.`tags_count` > 10
```

Which are solved right now using something similar to prepared statements like `Post.where("views > ? OR title LIKE ?", 100, "'%Rails%'")`. This syntax has many drawbacks:
- First of all ambiguity: this is a classic in many applications I've seen
```ruby
Post.where('created_at > ?', 1.month.ago).joins(:comments)
# run this query and you'll get an ActiveRecord::StatementInvalid (PG::AmbiguousColumn: ERROR:  column reference "created_at" is ambiguous) exception
```
The solution is to fully qualify the columns, but that can be very verbose if you have big table names
- DB specific syntax: the where blocks describe it perfectly
> While this provides the most flexibility, you can also unintentionally introduce dependencies on the underlying database
- Possible SQL injections: where an unaware developer can do something like `Post.where("title LIKE '%#{params[:query]}%'")`

The solution I've generally reach for is Arel, which allows building complex queries without having to write raw SQL or prepared statements. The issue there is that Arel is still a private API so I don't want to rely too much on it but mostly that it just doesn't feel like the Rails way.

My idea of how querying can be enhanced is simple: use a block to build the query just as if you were using `#select` or `#map`. From the previous thread, it seems like an acceptable name would be `#wharel` (I'd still rather use `#where` with a block) and could be considered as an advanced feature. Also, since there was some controversy around exposing the whole private interface I think we could just release a subset of it that allows controlling the implementation details behind it (it's a simple wrapper right now but it can be implemented in any sort of way). This can easily be expanded to fit other cases like `avg`, `min`, `max`, etc.

Replicating the queries from before it would look like
```ruby
Post.wharel { |post| post.views.gt(100).or(post.title.matches("%Rails%") }
```

And chaining with joined tables would look like
```ruby
Author.joins(:posts).wharel { |author| author.posts.tags_count.gt(10) }
```

Sorry for the length but I wanted to provide proper context as to why I'd like this change to move forward. I've also been told that maybe it'd be good if @dhh could weigh in since last time the discussion went off on a tangent.

