### PR TITLE
Add support for defining default values as option for ActiveSupport::Configurable accessors

### DIFF
--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -94,17 +94,19 @@ module ActiveSupport
       #   User.new.allowed_access = true # => NoMethodError
       #   User.new.allowed_access        # => NoMethodError
       #
-      # Also you can pass a block to set up the attribute with a default value.
+      # Also you can pass <tt>default</tt> or a block to set up the attribute with a default value.
       #
       #   class User
       #     include ActiveSupport::Configurable
+      #     config_accessor :allowed_access, default: false
       #     config_accessor :hair_colors do
       #       [:brown, :black, :blonde, :red]
       #     end
       #   end
       #
+      #   User.allowed_access # => false
       #   User.hair_colors # => [:brown, :black, :blonde, :red]
-      def config_accessor(*names, instance_reader: true, instance_writer: true, instance_accessor: true) # :doc:
+      def config_accessor(*names, instance_reader: true, instance_writer: true, instance_accessor: true, default: nil) # :doc:
         names.each do |name|
           raise NameError.new("invalid config attribute name") unless /\A[_A-Za-z]\w*\z/.match?(name)
 
@@ -118,7 +120,8 @@ module ActiveSupport
             class_eval reader, __FILE__, reader_line if instance_reader
             class_eval writer, __FILE__, writer_line if instance_writer
           end
-          send("#{name}=", yield) if block_given?
+
+          send("#{name}=", block_given? ? yield : default)
         end
       end
       private :config_accessor

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -50,7 +50,7 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert_not_respond_to instance, :baz=
   end
 
-  test "configuration accessors can take a default value" do
+  test "configuration accessors can take a default value as a block" do
     parent = Class.new do
       include ActiveSupport::Configurable
       config_accessor :hair_colors, :tshirt_colors do
@@ -60,6 +60,15 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
 
     assert_equal [:black, :blue, :white], parent.hair_colors
     assert_equal [:black, :blue, :white], parent.tshirt_colors
+  end
+
+  test "configuration accessors can take a default value as an option" do
+    parent = Class.new do
+      include ActiveSupport::Configurable
+      config_accessor :foo, default: :bar
+    end
+
+    assert_equal :bar, parent.foo
   end
 
   test "configuration hash is available on instance" do


### PR DESCRIPTION
### Summary
Sometimes it can be very strange or long have to define default values for config accessors as blocks, specially for simple values. This commit adds the ability to specify those values by just passing a ` default` option when defining the accessor.



