### PR TITLE
Add config to enable/disable `ActiveRecord::QueryCache` globally

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `config.active_record.enable_query_cache` to enable/disable `ActiveRecord::QueryCache` globally
+
+    Preference on the default state of `ActiveRecord::QueryCache` varies
+    from application to application based on their objectives and characteristics.
+
+    Since the release of Rails 5, `ActiveRecord::QueryCache` is enabled
+    not only in the context `ActionDispatch` but also at any user code executed
+    within `ActiveSupport::Executor.wrap` block.
+
+    This change allows applications to control the default state of the query cache
+    by `config.active_record.enable_query_cache`.
+    Defaults to `true`.
+
+    *Takumasa Ochi*
+
 *   Ensure `has_one` autosave association callbacks get called once.
 
     Change the `has_one` autosave callback to be non cyclic as well.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -31,6 +31,7 @@ module ActiveRecord
     config.active_record.check_schema_cache_dump_version = true
     config.active_record.maintain_test_schema = true
     config.active_record.has_many_inversing = false
+    config.active_record.enable_query_cache = true
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
 
@@ -239,8 +240,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
-    initializer "active_record.set_executor_hooks" do
-      ActiveRecord::QueryCache.install_executor_hooks
+    initializer "active_record.set_executor_hooks", before: "active_record.set_configs" do
+      if config.active_record.delete(:enable_query_cache)
+        ActiveRecord::QueryCache.install_executor_hooks
+      end
       ActiveRecord::AsynchronousQueriesTracker.install_executor_hooks
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -462,6 +462,14 @@ in controllers and views. This defaults to `false`.
   changes by moving the volatile information (max updated at and count) of
   the relation's cache key into the cache version to support recycling cache key.
 
+* `config.active_record.enable_query_cache` globally enables `ActiveRecord::QueryCache`
+  at user code within `ActiveSupport::Executor.wrap` block. Typically, user code within
+  a HTTP request, user code within an Active Job execution, and user code within an Action Cable
+  channel are affected by this setting.
+  See [SQL Caching](caching_with_rails.html#sql-caching) for query cache.
+  See [Threading and Code Execution in Rails](threading_and_code_execution.html) for `ActiveSupport::Executor`.
+  Defaults to `true`.
+
 * `config.active_record.has_many_inversing` enables setting the inverse record
   when traversing `belongs_to` to `has_many` associations.
 


### PR DESCRIPTION
### Summary

Preference on the default state of `ActiveRecord::QueryCache` varies from application to application based on their objectives and characteristics.

Since the release of Rails 5, `ActiveRecord::QueryCache` is enabled not only in the context `ActionDispatch` but also at any user code executed within `ActiveSupport::Executor.wrap` block.

This change allows applications to control the default state of the query cache by `config.active_record.enable_query_cache`.
Defaults to `true`.

### Other Information

One of the objectives of this feature is to help keep consistent and transparent transactions for applications with expected race conditions. Actually, we want to fix the regression caused by the undocumented removal of `ActiveRecord::QueryCache` from action dispatch middlewares, which mistakenly enabled query cache and resulted in inconsistent transactions under race conditions.

Since query cache prevents user code from executing the actual query to databases, it sometimes causes issues.
For example, the lack of `SELECT` queries invokes the following issues.

* MySQL InnoDB with SERIALIZABLE transaction isolation level
  * Lack of query invokes lack of share lock on the target record
  * It results in incomplete SERIALIZABLE transaction isolation level
* MySQL InnoDB with REPEATABLE READ transaction isolation level
  * Record fetched from cache is out of MVCC.
  * It results in inconsistent read

Although I know some workarounds (e.g., `uncached`), I prefer to provide a concise way to enable/disable the global query cache as default.

It has been a long time since `ActiveRecord::QueryCache` was removed from `config.app_middlewares`. Therefore, I think adding `config.active_record.enable_query_cache` is sufficient to fix this issue.

In order to keep backward compatibility, I set the default to `true`.

Also, I intentionally avoided adding a test. Just like `config.active_record.use_schema_cache_dump`, the code change only affects the initialization process, and the boolean value of the setting is not leaked outside of `ActiveRecord::Railtie`.