### PR TITLE
Ensure `Rails.application.config_for` always cast hashes to `ActiveSupport::OrderedOptions`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ensure `Rails.application.config_for` always cast hashes to `ActiveSupport::OrderedOptions`.
+
+    *Jean Boussier*
+
 *   Remove Rack::Runtime from the default middleware stack and deprecate
     referencing it in middleware operations without adding it back
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -246,11 +246,18 @@ module Rails
         all_configs    = ActiveSupport::ConfigurationFile.parse(yaml).deep_symbolize_keys
         config, shared = all_configs[env.to_sym], all_configs[:shared]
 
-        if config.is_a?(Hash)
-          ActiveSupport::OrderedOptions.new.update(shared&.deep_merge(config) || config)
-        else
-          config || shared
+        if shared
+          config = {} if config.nil?
+          if config.is_a?(Hash)
+            config = shared.deep_merge(config)
+          end
         end
+
+        if config.is_a?(Hash)
+          config = ActiveSupport::OrderedOptions.new.update(config)
+        end
+
+        config
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2106,10 +2106,10 @@ module ApplicationTests
     end
 
     test "config_for containing ERB tags should evaluate" do
-      set_custom_config <<~RUBY
+      set_custom_config <<~YAML
         development:
           key: <%= 'custom key' %>
-      RUBY
+      YAML
 
       app "development"
 
@@ -2152,6 +2152,28 @@ module ApplicationTests
       YAML.stub :load, { "development" => { "key" => "value" } } do
         assert_equal({ key: "value" }, Rails.application.config_for(:custom))
       end
+    end
+
+    test "config_for returns a ActiveSupport::OrderedOptions" do
+      app_file "config/custom.yml", <<~YAML
+        shared:
+          some_key: default
+
+        development:
+          some_key: value
+
+        test:
+      YAML
+
+      app "development"
+
+      config = Rails.application.config_for(:custom)
+      assert_instance_of ActiveSupport::OrderedOptions, config
+      assert_equal "value", config.some_key
+
+      config = Rails.application.config_for(:custom, env: :test)
+      assert_instance_of ActiveSupport::OrderedOptions, config
+      assert_equal "default", config.some_key
     end
 
     test "api_only is false by default" do


### PR DESCRIPTION
Fix: #42037

Opening a PR just to make sure CI passes. I'll merge on green.

I'll also backport it to 6-1-stable.