### PR TITLE
Remove unused constant `FileSystemResolver::EXTENSIONS`

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -189,8 +189,6 @@ module ActionView
 
   # A resolver that loads files from the filesystem.
   class FileSystemResolver < Resolver
-    EXTENSIONS = { locale: ".", formats: ".", variants: "+", handlers: "." }
-
     attr_reader :path
 
     def initialize(path)


### PR DESCRIPTION
### Summary

Following up #42004, this constant seems to be no longer used.