### PR TITLE
Stop internationalizing Duration#inspect

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -66,7 +66,7 @@ class Array
       two_words_connector: " and ",
       last_word_connector: ", and "
     }
-    if defined?(I18n)
+    if options[:locale] != false && defined?(I18n)
       i18n_connectors = I18n.translate(:'support.array', locale: options[:locale], default: {})
       default_connectors.merge!(i18n_connectors)
     end

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -446,7 +446,7 @@ module ActiveSupport
       @parts.
         sort_by { |unit,  _ | PARTS.index(unit) }.
         map     { |unit, val| "#{val} #{val == 1 ? unit.to_s.chop : unit.to_s}" }.
-        to_sentence(locale: ::I18n.default_locale)
+        to_sentence(locale: false)
     end
 
     def as_json(options = nil) #:nodoc:

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -113,11 +113,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "3600 seconds",                    (1.day / 24).inspect
   end
 
-  def test_inspect_locale
+  def test_inspect_ignores_locale
     current_locale = I18n.default_locale
     I18n.default_locale = :de
     I18n.backend.store_translations(:de, support: { array: { last_word_connector: " und " } })
-    assert_equal "10 years, 1 month und 1 day", (10.years + 1.month + 1.day).inspect
+    assert_equal "10 years, 1 month, and 1 day", (10.years + 1.month + 1.day).inspect
   ensure
     I18n.default_locale = current_locale
   end


### PR DESCRIPTION
This can cause infinite recursions if you do have a complex i18n backend that calls `Duration#inspect`.

There is not really any point making `inspect` internationalized anyway, as most apps will have `:en` as default locale.

cc @rafaelfranca @XrXr 