### PR TITLE
Fix: use previous encryption schemes when support_unencrypted_data is on

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
       attr_reader :scheme, :cast_type
 
-      delegate :key_provider, :downcase?, :deterministic?, :with_context, :fixed?, to: :scheme
+      delegate :key_provider, :downcase?, :deterministic?, :previous_schemes, :with_context, :fixed?, to: :scheme
 
       # === Options
       #
@@ -43,30 +43,28 @@ module ActiveRecord
         old_value != new_value
       end
 
-      def previous_encrypted_types(include_clear: true) # :nodoc:
-        @previous_encrypted_types ||= {} # Memoizing on support_unencrypted_data so that we can tweak it during tests
-        @previous_encrypted_types["#{support_unencrypted_data?} #{include_clear}"] ||= previous_schemes(include_clear: include_clear).collect do |scheme|
-          EncryptedAttributeType.new(scheme: scheme, previous_type: true)
-        end
+      def previous_types_including_clean_text # :nodoc:
+        @previous_types_including_clean_text ||= {} # Memoizing on support_unencrypted_data so that we can tweak it during tests
+        @previous_types_including_clean_text[support_unencrypted_data?] ||= build_previous_types_for(previous_schemes_including_clean_text)
       end
 
       private
+        def previous_schemes_including_clean_text
+          previous_schemes.including((clean_text_scheme if support_unencrypted_data?)).compact
+        end
+
+        def previous_types
+          @previous_types ||= build_previous_types_for(previous_schemes)
+        end
+
+        def build_previous_types_for(schemes)
+          schemes.collect do |scheme|
+            EncryptedAttributeType.new(scheme: scheme, previous_type: true)
+          end
+        end
+
         def previous_type?
           @previous_type
-        end
-
-        def serialize_with_oldest?
-          @serialize_with_oldest ||= fixed? && previous_encrypted_types(include_clear: false).present?
-        end
-
-        def serialize_with_oldest(value)
-          previous_encrypted_types.first.serialize(value)
-        end
-
-        def serialize_with_current(value)
-          casted_value = cast_type.serialize(value)
-          casted_value = casted_value&.downcase if downcase?
-          encrypt(casted_value.to_s) unless casted_value.nil?
         end
 
         def decrypt(value)
@@ -74,7 +72,7 @@ module ActiveRecord
             encryptor.decrypt(value, **decryption_options) unless value.nil?
           end
         rescue ActiveRecord::Encryption::Errors::Base => error
-          if previous_encrypted_types.blank?
+          if previous_types.blank?
             handle_deserialize_error(error, value)
           else
             try_to_deserialize_with_previous_encrypted_types(value)
@@ -82,10 +80,10 @@ module ActiveRecord
         end
 
         def try_to_deserialize_with_previous_encrypted_types(value)
-          previous_encrypted_types.each.with_index do |type, index|
+          previous_types_including_clean_text.each.with_index do |type, index|
             break type.deserialize(value)
           rescue ActiveRecord::Encryption::Errors::Base => error
-            handle_deserialize_error(error, value) if index == previous_encrypted_types(include_clear: true).length - 1
+            handle_deserialize_error(error, value) if index == previous_types.length - 1
           end
         end
 
@@ -97,12 +95,18 @@ module ActiveRecord
           end
         end
 
-        def previous_schemes(include_clear: true)
-          scheme.previous_schemes.including((clean_text_scheme if include_clear && support_unencrypted_data?)).compact
+        def serialize_with_oldest?
+          @serialize_with_oldest ||= fixed? && previous_types.present?
         end
 
-        def support_unencrypted_data?
-          ActiveRecord::Encryption.config.support_unencrypted_data && !previous_type?
+        def serialize_with_oldest(value)
+          previous_types_including_clean_text.first.serialize(value)
+        end
+
+        def serialize_with_current(value)
+          casted_value = cast_type.serialize(value)
+          casted_value = casted_value&.downcase if downcase?
+          encrypt(casted_value.to_s) unless casted_value.nil?
         end
 
         def encrypt(value)
@@ -113,6 +117,10 @@ module ActiveRecord
 
         def encryptor
           ActiveRecord::Encryption.encryptor
+        end
+
+        def support_unencrypted_data?
+          ActiveRecord::Encryption.config.support_unencrypted_data && !previous_type?
         end
 
         def encryption_options

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -46,7 +46,7 @@ module ActiveRecord
             if args.is_a?(Array) && (options = args.first).is_a?(Hash)
               self.deterministic_encrypted_attributes&.each do |attribute_name|
                 type = type_for_attribute(attribute_name)
-                if !type.previous_encrypted_types.empty? && value = options[attribute_name]
+                if !type.previous_types_including_clean_text.empty? && value = options[attribute_name]
                   options[attribute_name] = process_encrypted_query_argument(value, check_for_additional_values, type)
                 end
               end
@@ -72,7 +72,7 @@ module ActiveRecord
           end
 
           def additional_values_for(value, type)
-            type.previous_encrypted_types.collect do |additional_type|
+            type.previous_types_including_clean_text.collect do |additional_type|
               AdditionalValue.new(value, additional_type)
             end
           end

--- a/activerecord/lib/active_record/encryption/extended_deterministic_uniqueness_validator.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_uniqueness_validator.rb
@@ -14,7 +14,7 @@ module ActiveRecord
           klass = record.class
           if klass.deterministic_encrypted_attributes&.each do |attribute_name|
             encrypted_type = klass.type_for_attribute(attribute_name)
-            [ encrypted_type, *encrypted_type.previous_encrypted_types ].each do |type|
+            [ encrypted_type, *encrypted_type.previous_types_including_clean_text ].each do |type|
               encrypted_value = type.serialize(value)
               ActiveRecord::Encryption.without_encryption do
                 super(record, attribute, encrypted_value)

--- a/activerecord/test/cases/encryption/encryptable_record_api_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_api_test.rb
@@ -106,7 +106,7 @@ class ActiveRecord::Encryption::EncryptableRecordApiTest < ActiveRecord::Encrypt
 
   test "encrypt attributes encrypted with a previous encryption scheme" do
     author = EncryptedAuthor.create!(name: "david")
-    old_type = EncryptedAuthor.type_for_attribute(:name).previous_encrypted_types.first
+    old_type = EncryptedAuthor.type_for_attribute(:name).previous_types_including_clean_text.first
     value_encrypted_with_old_type = old_type.serialize("dhh")
     ActiveRecord::Encryption.without_encryption do
       author.update!(name: value_encrypted_with_old_type)

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -64,6 +64,50 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
     assert_equal "1", author.reload.name
   end
 
+  test "use global previous schemes to decrypt data encrypted with previous schemes with unencrypted data" do
+    ActiveRecord::Encryption.config.support_unencrypted_data = true
+    ActiveRecord::Encryption.config.previous = [ { encryptor: TestEncryptor.new("0" => "1") }, { encryptor: TestEncryptor.new("1" => "2") } ]
+
+    # We want to evaluate .encrypts *after* tweaking the config property
+    encrypted_author_class = Class.new(Author) do
+      self.table_name = "authors"
+
+      encrypts :name
+    end
+
+    assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_encrypted_types.count
+    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_encrypted_types
+
+    author = ActiveRecord::Encryption.without_encryption do
+      encrypted_author_class.create name: previous_type_1.serialize("1")
+    end
+    assert_equal "0", author.reload.name
+
+    author = ActiveRecord::Encryption.without_encryption do
+      encrypted_author_class.create name: previous_type_2.serialize("2")
+    end
+    assert_equal "1", author.reload.name
+  end
+
+  # test "try all the previous encryption schemes when decrypting data" do
+  #   ActiveRecord::Encryption.config.support_unencrypted_data = false
+  #   ActiveRecord::Encryption.config.previous = [ { encryptor: TestEncryptor.new("0" => "1") }, { encryptor: TestEncryptor.new("1" => "2") } ]
+  #
+  #   encrypted_author_class = Class.new(Author) do
+  #     self.table_name = "authors"
+  #
+  #     encrypts :name, previous: { encryptor: TestEncryptor.new("2" => "3") }
+  #   end
+  #
+  #   assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_encrypted_types.count
+  #   previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_encrypted_types
+  #
+  #   author = ActiveRecord::Encryption.without_encryption do
+  #     encrypted_author_class.create name: previous_type_1.serialize("3")
+  #   end
+  #   assert_equal "2", author.reload.name
+  # end
+
   test "deterministic encryption is fixed by default: it will always use the oldest scheme to encrypt data" do
     ActiveRecord::Encryption.config.support_unencrypted_data = false
     ActiveRecord::Encryption.config.deterministic_key = "12345"

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -50,8 +50,8 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
       encrypts :name
     end
 
-    assert_equal 2, encrypted_author_class.type_for_attribute(:name).previous_encrypted_types.count
-    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_encrypted_types
+    assert_equal 2, encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text.count
+    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text
 
     author = ActiveRecord::Encryption.without_encryption do
       encrypted_author_class.create name: previous_type_1.serialize("1")
@@ -75,8 +75,8 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
       encrypts :name
     end
 
-    assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_encrypted_types.count
-    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_encrypted_types
+    assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text.count
+    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text
 
     author = ActiveRecord::Encryption.without_encryption do
       encrypted_author_class.create name: previous_type_1.serialize("1")
@@ -88,25 +88,6 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
     end
     assert_equal "1", author.reload.name
   end
-
-  # test "try all the previous encryption schemes when decrypting data" do
-  #   ActiveRecord::Encryption.config.support_unencrypted_data = false
-  #   ActiveRecord::Encryption.config.previous = [ { encryptor: TestEncryptor.new("0" => "1") }, { encryptor: TestEncryptor.new("1" => "2") } ]
-  #
-  #   encrypted_author_class = Class.new(Author) do
-  #     self.table_name = "authors"
-  #
-  #     encrypts :name, previous: { encryptor: TestEncryptor.new("2" => "3") }
-  #   end
-  #
-  #   assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_encrypted_types.count
-  #   previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_encrypted_types
-  #
-  #   author = ActiveRecord::Encryption.without_encryption do
-  #     encrypted_author_class.create name: previous_type_1.serialize("3")
-  #   end
-  #   assert_equal "2", author.reload.name
-  # end
 
   test "deterministic encryption is fixed by default: it will always use the oldest scheme to encrypt data" do
     ActiveRecord::Encryption.config.support_unencrypted_data = false
@@ -172,7 +153,7 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
 
     def create_author_with_name_encrypted_with_previous_scheme
       author = EncryptedAuthor.create!(name: "david")
-      old_type = EncryptedAuthor.type_for_attribute(:name).previous_encrypted_types.first
+      old_type = EncryptedAuthor.type_for_attribute(:name).previous_types_including_clean_text.first
       value_encrypted_with_old_type = old_type.serialize("dhh")
       ActiveRecord::Encryption.without_encryption do
         author.update!(name: value_encrypted_with_old_type)


### PR DESCRIPTION
This fixes a bug where previous encryption schemes were not properly tried beyond the first one when `config. support_unencrypted_data` was on.

With the previous implementation it was never raising encryption errors when checking previous types, so it always returned the result from applying the first previous type.

This also refactors the internal API for fetching previous encrypted types to improve clarity. It splits it into 2 separated methods instead of reusing the same method with a flag param.