### PR TITLE
Make sure uniqueness validator works with case insensitive scopes.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Make sure uniqueness validator works with case insensitive scopes.
+
+    When both `case_sensitive: false` and `scope: [:some_attr]` are passed
+    to validation - it should use case insensitive comparison for scopes
+    as well as for primary attribute.
+
+    ```ruby
+    class User
+      validates_uniqueness_of(:first_name, scope: :last_name, case_sensitive: false)
+    end
+
+    User.create(first_name: 'Alexander', last_name: 'Pushkin')
+    User.create(first_name: 'Alexander', last_name: 'PUSHKIN') # this one should fail
+    ```
+
+    *Artem Kozaev*
+
 *   Ensure `has_one` autosave association callbacks get called once.
 
     Change the `has_one` autosave callback to be non cyclic as well.

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -335,6 +335,16 @@ class UniquenessValidationTest < ActiveRecord::TestCase
     assert t3.save, "Should save t3 as unique"
   end
 
+  def test_validate_case_insensitive_uniqueness_with_scope
+    Topic.validates_uniqueness_of(:title, scope: :author_name, case_sensitive: false)
+
+    topic1 = Topic.create(title: "Winter Morning", author_name: "Pushkin")
+    assert_empty topic1.errors
+
+    topic2 = Topic.create(title: "Winter Morning", author_name: "PUSHKIN")
+    assert_equal(["has already been taken"], topic2.errors[:title])
+  end
+
   def test_validate_uniqueness_by_default_database_collation
     Topic.validates_uniqueness_of(:author_email_address)
 


### PR DESCRIPTION
### Summary

When both `case_sensitive: false` and `scope: [:some_attr]` are passed
to validation - it should use case insensitive comparison for scopes
as well as for primary attribute.

```ruby
class User
  validates_uniqueness_of(:first_name, scope: :last_name, case_sensitive: false)
end

User.create(first_name: 'Alexander', last_name: 'Pushkin')
User.create(first_name: 'Alexander', last_name: 'PUSHKIN') # this one should fail
```