### PR TITLE
Support USE INDEX index hints API

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Support USE INDEX index hints API
+
+    Index hints give the optimizer information about how to choose indexes during query processing.
+    Whilst USE INDEX supports both SELECT/UPDATE statement for now only SELECT statament is handled.
+    Please note that this is a MySQL/MariaDB only feature.
+
+    ```ruby
+    Post.use_index(:index_on_comment_id, for: :join).load
+    # SELECT `posts`.* FROM `posts` USE INDEX FOR JOIN (`index_on_comment_id`)
+    ```
+
+    See also:
+    * https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
+    * https://mariadb.com/kb/en/index-hints-how-to-force-query-plans/#use-index-use-a-limited-set-of-indexes
+
+    *Jacopo Beschi*
+
 *   Add `ActiveRecord::Base#attributes_for_database`
 
     Returns attributes with values for assignment to the database.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -441,6 +441,10 @@ module ActiveRecord
         true
       end
 
+      def supports_use_index_hints?
+        false
+      end
+
       def async_enabled? # :nodoc:
         supports_concurrent_connections? &&
           !Base.async_query_executor.nil? && !pool.async_executor.nil?

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -79,6 +79,10 @@ module ActiveRecord
         true
       end
 
+      def supports_use_index_hints?
+        true
+      end
+
       # HELPER METHODS ===========================================
 
       def each_hash(result) # :nodoc:

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       :find_each, :find_in_batches, :in_batches,
       :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
-      :and, :or, :annotate, :optimizer_hints, :extending,
+      :and, :or, :annotate, :optimizer_hints, :use_index, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,
       :count, :average, :minimum, :maximum, :sum, :calculate,
       :pluck, :pick, :ids, :strict_loading, :excluding, :without

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -5,7 +5,7 @@ module ActiveRecord
   class Relation
     MULTI_VALUE_METHODS  = [:includes, :eager_load, :preload, :select, :group,
                             :order, :joins, :left_outer_joins, :references,
-                            :extending, :unscope, :optimizer_hints, :annotate]
+                            :extending, :unscope, :optimizer_hints, :annotate, :use_index]
 
     SINGLE_VALUE_METHODS = [:limit, :offset, :lock, :readonly, :reordering, :strict_loading,
                             :reverse_order, :distinct, :create_with, :skip_query_cache]

--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -54,7 +54,8 @@ module ActiveRecord
       NORMAL_VALUES = Relation::VALUE_METHODS - Relation::CLAUSE_METHODS -
                       [
                         :select, :includes, :preload, :joins, :left_outer_joins,
-                        :order, :reverse_order, :lock, :create_with, :reordering
+                        :order, :reverse_order, :lock, :create_with, :reordering,
+                        :use_index
                       ]
 
       def merge
@@ -76,6 +77,7 @@ module ActiveRecord
         merge_preloads
         merge_joins
         merge_outer_joins
+        merge_use_indexes
 
         relation
       end
@@ -186,6 +188,12 @@ module ActiveRecord
         def replace_from_clause?
           relation.from_clause.empty? && !other.from_clause.empty? &&
             relation.klass.base_class == other.klass.base_class
+        end
+
+        def merge_use_indexes
+          return if other.use_index_values.empty?
+
+          relation.use_index_values.concat(other.use_index_values)
         end
     end
   end

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -24,6 +24,7 @@ require "arel/nodes/ascending"
 require "arel/nodes/descending"
 require "arel/nodes/unqualified_column"
 require "arel/nodes/with"
+require "arel/nodes/use_index"
 
 # binary
 require "arel/nodes/binary"

--- a/activerecord/lib/arel/nodes/select_core.rb
+++ b/activerecord/lib/arel/nodes/select_core.rb
@@ -4,7 +4,7 @@ module Arel # :nodoc: all
   module Nodes
     class SelectCore < Arel::Nodes::Node
       attr_accessor :projections, :wheres, :groups, :windows, :comment
-      attr_accessor :havings, :source, :set_quantifier, :optimizer_hints
+      attr_accessor :havings, :source, :set_quantifier, :optimizer_hints, :use_indexes
 
       def initialize(relation = nil)
         super()
@@ -13,6 +13,7 @@ module Arel # :nodoc: all
         # https://ronsavage.github.io/SQL/sql-92.bnf.html#set%20quantifier
         @set_quantifier  = nil
         @optimizer_hints = nil
+        @use_indexes     = []
         @projections     = []
         @wheres          = []
         @groups          = []
@@ -45,7 +46,7 @@ module Arel # :nodoc: all
       def hash
         [
           @source, @set_quantifier, @projections, @optimizer_hints,
-          @wheres, @groups, @havings, @windows, @comment
+          @use_indexes, @wheres, @groups, @havings, @windows, @comment
         ].hash
       end
 
@@ -54,6 +55,7 @@ module Arel # :nodoc: all
           self.source == other.source &&
           self.set_quantifier == other.set_quantifier &&
           self.optimizer_hints == other.optimizer_hints &&
+          self.use_indexes == other.use_indexes &&
           self.projections == other.projections &&
           self.wheres == other.wheres &&
           self.groups == other.groups &&

--- a/activerecord/lib/arel/nodes/use_index.rb
+++ b/activerecord/lib/arel/nodes/use_index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class UseIndex < Unary
+      def indexes
+        expr[0]
+      end
+
+      FOR_OPTIONS = { join: "JOIN", order: "ORDER BY", group: "GROUP BY" }.freeze
+      private_constant :FOR_OPTIONS
+      def for
+        FOR_OPTIONS[expr[1].to_sym] if expr[1].respond_to?(:to_sym)
+      end
+    end
+  end
+end

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -151,6 +151,13 @@ module Arel # :nodoc: all
       self
     end
 
+    def use_index(*indexes)
+      unless indexes.empty?
+        @ctx.use_indexes = indexes.map { |x| Arel::Nodes::UseIndex.new(x) }
+      end
+      self
+    end
+
     def distinct(value = true)
       if value
         @ctx.set_quantifier = Arel::Nodes::Distinct.new

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -135,6 +135,7 @@ module Arel # :nodoc: all
           visit_edge o, "havings"
           visit_edge o, "set_quantifier"
           visit_edge o, "optimizer_hints"
+          visit_edge o, "use_indexes"
         end
 
         def visit_Arel_Nodes_SelectStatement(o)

--- a/activerecord/lib/arel/visitors/mysql.rb
+++ b/activerecord/lib/arel/visitors/mysql.rb
@@ -39,6 +39,15 @@ module Arel # :nodoc: all
           collector
         end
 
+        def visit_Arel_Nodes_UseIndex(o, collector)
+          hints = +"USE INDEX"
+          hints += " FOR #{o.for}" if o.for
+          indexes = o.indexes.map { |idx| quote_index_name(idx) }.join(", ")
+          hints += " (#{indexes})"
+
+          collector << hints
+        end
+
         def visit_Arel_Nodes_IsNotDistinctFrom(o, collector)
           collector = visit o.left, collector
           collector << " <=> "

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -156,6 +156,7 @@ module Arel # :nodoc: all
             collector = visit o.source, collector
           end
 
+          collect_nodes_for o.use_indexes, collector, " ", " "
           collect_nodes_for o.wheres, collector, " WHERE ", " AND "
           collect_nodes_for o.groups, collector, " GROUP BY "
           collect_nodes_for o.havings, collector, " HAVING ", " AND "
@@ -167,6 +168,10 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_OptimizerHints(o, collector)
           hints = o.expr.map { |v| sanitize_as_sql_comment(v) }.join(" ")
           collector << "/*+ #{hints} */"
+        end
+
+        def visit_Arel_Nodes_UseIndex(o, collector)
+          raise NotImplementedError, "USE INDEX not implemented for this db"
         end
 
         def visit_Arel_Nodes_Comment(o, collector)
@@ -798,6 +803,7 @@ module Arel # :nodoc: all
           return name if Arel::Nodes::SqlLiteral === name
           @connection.quote_column_name(name)
         end
+        alias :quote_index_name :quote_column_name
 
         def sanitize_as_sql_comment(value)
           return value if Arel::Nodes::SqlLiteral === value

--- a/activerecord/test/cases/adapters/mysql2/use_index_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/use_index_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+if supports_use_index_hints?
+  class Mysql2UseIndexTest < ActiveRecord::Mysql2TestCase
+    fixtures :posts
+
+    def test_use_index
+      assert_sql(/\ASELECT COUNT\(count_column\) FROM \(SELECT `posts`\.`id` AS count_column FROM `posts` USE INDEX \(`index_posts_on_type`\) WHERE/) do
+        posts = Post.use_index("index_posts_on_type")
+        posts = posts.select(:id).where(author_id: [0, 1]).limit(5)
+        assert_equal 5, posts.count
+      end
+    end
+
+    def test_use_index_symbol
+      assert_sql(/\ASELECT `posts`\.`id` FROM `posts` USE INDEX \(`index_posts_on_type`\)/) do
+        Post.use_index(:index_posts_on_type).select(:id).load
+      end
+    end
+
+    def test_use_index_multiple_indexes
+      assert_sql(/\ASELECT `posts`\.`id` FROM `posts` USE INDEX \(`index_posts_on_type`, `index_posts_on_author_id`\)/) do
+        Post.use_index("index_posts_on_type", "index_posts_on_author_id").select(:id).load
+      end
+    end
+
+    def test_use_index_multiple_calls
+      assert_sql(/\ASELECT `posts`\.`id` FROM `posts` USE INDEX \(`index_posts_on_type`\) USE INDEX \(`index_posts_on_author_id`\)/) do
+        Post.use_index("index_posts_on_type").use_index("index_posts_on_author_id").select(:id).load
+      end
+    end
+
+    def test_use_index_multiple_indexes_with_scope
+      [[:join, "JOIN"], ["join", "JOIN"], [:order, "ORDER BY"], [:group, "GROUP BY"]].each do |scope, expected_for|
+        assert_sql(/\ASELECT `posts`\.`id` FROM `posts` USE INDEX FOR #{expected_for} \(`index_posts_on_type`, `index_posts_on_author_id`\)/) do
+          Post.use_index("index_posts_on_type", "index_posts_on_author_id", scope: scope).select(:id).load
+        end
+      end
+    end
+
+    def test_use_index_multiple_indexes_with_invalid_scope
+      assert_sql(/\ASELECT `posts`\.`id` FROM `posts` USE INDEX \(`index_posts_on_type`, `index_posts_on_author_id`\)/) do
+        Post.use_index("index_posts_on_type", "index_posts_on_author_id", scope: :foo).select(:id).load
+      end
+    end
+
+    def test_use_index_with_blank_values
+      assert_sql(/\ASELECT `posts`.`id` FROM `posts`\z/) do
+        Post.use_index("").select(:id).load
+      end
+    end
+
+    def test_use_index_when_merging_two_relations
+      assert_sql(/\ASELECT `posts`\.`id` FROM `posts` USE INDEX \(`index_posts_on_type`\) USE INDEX \(`index_posts_on_author_id`\)/) do
+        Post.use_index("index_posts_on_type").merge(Post.use_index("index_posts_on_author_id").select(:id)).load
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -36,7 +36,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure
@@ -66,7 +66,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
 
@@ -81,7 +81,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure
@@ -105,7 +105,7 @@ module ActiveRecord
         cache.connection = @connection
 
         assert_queries :any, ignore_none: true do
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
         end
       end
 
@@ -178,7 +178,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       end
@@ -200,7 +200,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure
@@ -224,7 +224,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
 
@@ -237,7 +237,7 @@ module ActiveRecord
           assert_equal 12, cache.columns_hash("posts").size
           assert cache.data_sources("posts")
           assert_equal "id", cache.primary_keys("posts")
-          assert_equal 1, cache.indexes("posts").size
+          assert_equal 2, cache.indexes("posts").size
           assert_equal @database_version.to_s, cache.database_version.to_s
         end
       ensure

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -74,6 +74,7 @@ end
   supports_insert_conflict_target?
   supports_optimizer_hints?
   supports_datetime_with_precision?
+  supports_use_index_hints?
 ].each do |method_name|
   define_method method_name do
     ActiveRecord::Base.connection.public_send(method_name)

--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -5,7 +5,7 @@ require "models/post"
 
 module ActiveRecord
   class RelationMutationTest < ActiveRecord::TestCase
-    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select]).each do |method|
+    (Relation::MULTI_VALUE_METHODS - [:extending, :order, :unscope, :select, :use_index]).each do |method|
       test "##{method}!" do
         assert relation.public_send("#{method}!", :foo).equal?(relation)
         assert_equal [:foo], relation.public_send("#{method}_values")
@@ -135,6 +135,16 @@ module ActiveRecord
     test "skip_preloading!" do
       relation.skip_preloading!
       assert relation.skip_preloading_value
+    end
+
+    test "use_index!" do
+      assert relation.use_index!(:foo).equal?(relation)
+      assert_equal [[[:foo], nil]], relation.use_index_values
+    end
+
+    test "use_index! with scope" do
+      assert relation.use_index!(:foo, scope: :join).equal?(relation)
+      assert_equal [[[:foo], :join]], relation.use_index_values
     end
 
     private

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -836,6 +836,7 @@ ActiveRecord::Schema.define do
     t.integer :indestructible_tags_count, default: 0
     t.integer :tags_with_destroy_count, default: 0
     t.integer :tags_with_nullify_count, default: 0
+    t.index :type
   end
 
   create_table :postesques, force: true do |t|


### PR DESCRIPTION
### Summary

Index hints give the optimizer information about how to choose indexes during query processing.
Whilst USE INDEX supports both SELECT/UPDATE statement for now only SELECT statament is handled.
Please note that this is a MySQL/MariaDB only feature.

Example:

```ruby
Post.use_index(:index_on_comment_id, for: :join).load
# SELECT `posts`.* FROM `posts` USE INDEX FOR JOIN (`index_on_comment_id`)
```

Closes #27110

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
