### PR TITLE
Internal refactor relative to previous encryption schemes

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -83,7 +83,7 @@ module ActiveRecord
           previous_types.each.with_index do |type, index|
             break type.deserialize(value)
           rescue ActiveRecord::Encryption::Errors::Base => error
-            handle_deserialize_error(error, value) if index == previous_types_without_clean_text.length - 1
+            handle_deserialize_error(error, value) if index == previous_types.length - 1
           end
         end
 

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -46,7 +46,7 @@ module ActiveRecord
             if args.is_a?(Array) && (options = args.first).is_a?(Hash)
               self.deterministic_encrypted_attributes&.each do |attribute_name|
                 type = type_for_attribute(attribute_name)
-                if !type.previous_types_including_clean_text.empty? && value = options[attribute_name]
+                if !type.previous_types.empty? && value = options[attribute_name]
                   options[attribute_name] = process_encrypted_query_argument(value, check_for_additional_values, type)
                 end
               end
@@ -72,7 +72,7 @@ module ActiveRecord
           end
 
           def additional_values_for(value, type)
-            type.previous_types_including_clean_text.collect do |additional_type|
+            type.previous_types.collect do |additional_type|
               AdditionalValue.new(value, additional_type)
             end
           end

--- a/activerecord/lib/active_record/encryption/extended_deterministic_uniqueness_validator.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_uniqueness_validator.rb
@@ -14,7 +14,7 @@ module ActiveRecord
           klass = record.class
           if klass.deterministic_encrypted_attributes&.each do |attribute_name|
             encrypted_type = klass.type_for_attribute(attribute_name)
-            [ encrypted_type, *encrypted_type.previous_types_including_clean_text ].each do |type|
+            [ encrypted_type, *encrypted_type.previous_types ].each do |type|
               encrypted_value = type.serialize(value)
               ActiveRecord::Encryption.without_encryption do
                 super(record, attribute, encrypted_value)

--- a/activerecord/test/cases/encryption/encryptable_record_api_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_api_test.rb
@@ -106,7 +106,7 @@ class ActiveRecord::Encryption::EncryptableRecordApiTest < ActiveRecord::Encrypt
 
   test "encrypt attributes encrypted with a previous encryption scheme" do
     author = EncryptedAuthor.create!(name: "david")
-    old_type = EncryptedAuthor.type_for_attribute(:name).previous_types_including_clean_text.first
+    old_type = EncryptedAuthor.type_for_attribute(:name).previous_types.first
     value_encrypted_with_old_type = old_type.serialize("dhh")
     ActiveRecord::Encryption.without_encryption do
       author.update!(name: value_encrypted_with_old_type)

--- a/activerecord/test/cases/encryption/encryption_schemes_test.rb
+++ b/activerecord/test/cases/encryption/encryption_schemes_test.rb
@@ -50,8 +50,8 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
       encrypts :name
     end
 
-    assert_equal 2, encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text.count
-    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text
+    assert_equal 2, encrypted_author_class.type_for_attribute(:name).previous_types.count
+    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_types
 
     author = ActiveRecord::Encryption.without_encryption do
       encrypted_author_class.create name: previous_type_1.serialize("1")
@@ -75,8 +75,8 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
       encrypts :name
     end
 
-    assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text.count
-    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_types_including_clean_text
+    assert_equal 3, encrypted_author_class.type_for_attribute(:name).previous_types.count
+    previous_type_1, previous_type_2 = encrypted_author_class.type_for_attribute(:name).previous_types
 
     author = ActiveRecord::Encryption.without_encryption do
       encrypted_author_class.create name: previous_type_1.serialize("1")
@@ -153,7 +153,7 @@ class ActiveRecord::Encryption::EncryptionSchemesTest < ActiveRecord::Encryption
 
     def create_author_with_name_encrypted_with_previous_scheme
       author = EncryptedAuthor.create!(name: "david")
-      old_type = EncryptedAuthor.type_for_attribute(:name).previous_types_including_clean_text.first
+      old_type = EncryptedAuthor.type_for_attribute(:name).previous_types.first
       value_encrypted_with_old_type = old_type.serialize("dhh")
       ActiveRecord::Encryption.without_encryption do
         author.update!(name: value_encrypted_with_old_type)


### PR DESCRIPTION
This is a minor refactor of the system that deals with previous encryption schemes:

It renames `#previous_types_including_clean_text` -> `#previous_types`. This private API method is used in other places and invokers are always interested in the "clean text type" (when support for unencrypted data is enabled). It makes sense to make that the default behavior. The old internal private method `#previous_types` is now `#previous_types_without_clean_text`.

This also:

- Adds tests to validate that the system launches decryption errors when all the previous encryption schemes fail to decrypt, and to validate that it returns the ciphertext when support for unencrypted text is enabled.
- Extracts method with common logic for tidying up test of previous encryption schemes.