### PR TITLE
Refactor Cache::Entry compression handling

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -73,7 +73,7 @@ module ActiveSupport
       private
         def read_entry(key, **options)
           if File.exist?(key)
-            entry = File.open(key) { |f| deserialize_entry(f.read) }
+            entry = deserialize_entry(File.binread(key))
             entry if entry.is_a?(Cache::Entry)
           end
         rescue => e
@@ -84,7 +84,8 @@ module ActiveSupport
         def write_entry(key, entry, **options)
           return false if options[:unless_exist] && File.exist?(key)
           ensure_cache_path(File.dirname(key))
-          File.atomic_write(key, cache_path) { |f| f.write(serialize_entry(entry)) }
+          payload = serialize_entry(entry, **options)
+          File.atomic_write(key, cache_path) { |f| f.write(payload) }
           true
         end
 

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -148,7 +148,7 @@ module ActiveSupport
         # Write an entry to the cache.
         def write_entry(key, entry, **options)
           method = options[:unless_exist] ? :add : :set
-          value = options[:raw] ? entry.value.to_s : serialize_entry(entry)
+          value = options[:raw] ? entry.value.to_s : serialize_entry(entry, **options)
           expires_in = options[:expires_in].to_i
           if options[:race_condition_ttl] && expires_in > 0 && !options[:raw]
             # Set the memcache expire a few minutes in the future to support race condition ttls on read
@@ -198,7 +198,7 @@ module ActiveSupport
 
         def deserialize_entry(payload)
           entry = super
-          entry = Entry.new(entry, compress: false) if entry && !entry.is_a?(Entry)
+          entry = Entry.new(entry) if entry && !entry.is_a?(Entry)
           entry
         end
 

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -25,17 +25,23 @@ module ActiveSupport
     # MemoryStore is thread-safe.
     class MemoryStore < Store
       module DupCoder # :nodoc:
-        class << self
-          def load(entry)
-            entry = entry.dup
-            entry.dup_value!
-            entry
-          end
+        extend self
 
-          def dump(entry)
-            entry.dup_value!
-            entry
-          end
+        def dump(entry)
+          entry.dup_value! unless entry.compressed?
+          entry
+        end
+
+        def dump_compressed(entry, threshold)
+          entry = entry.compressed(threshold)
+          entry.dup_value! unless entry.compressed?
+          entry
+        end
+
+        def load(entry)
+          entry = entry.dup
+          entry.dup_value!
+          entry
         end
       end
 
@@ -156,7 +162,7 @@ module ActiveSupport
         end
 
         def write_entry(key, entry, **options)
-          payload = serialize_entry(entry)
+          payload = serialize_entry(entry, **options)
           synchronize do
             return false if options[:unless_exist] && @data.key?(key)
 

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -77,7 +77,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     cache = lookup_store(raw: true)
     cache.write("foo", 2)
 
-    assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compress! do
+    assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compressed do
       cache.read("foo")
     end
   end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -329,7 +329,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     test "does not compress values read with \"raw\" enabled" do
       @cache.write("foo", "bar", raw: true)
 
-      assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compress! do
+      assert_not_called_on_instance_of ActiveSupport::Cache::Entry, :compressed do
         @cache.read("foo", raw: true)
       end
     end


### PR DESCRIPTION
I extracted this out of https://github.com/rails/rails/pull/42025 to make its review easier.

Rather than immediately compressing the cache value in the constructor, this operation is delayed until we need to serialize the entry. This help us making compression a `coder` responsibility while retaining serialized format compatibility.


