### PR TITLE
Support `<form>` elements without `[action]`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Support rendering `<form>` elements _without_ `[action]` attributes by:
+
+    * `form_with url: false` or `form_with ..., html: { action: false }`
+    * `form_for ..., url: false` or `form_for ..., html: { action: false }`
+    * `form_tag false` or `form_tag ..., action: false`
+    * `button_to "...", false` or `button_to(false) { ... }`
+
+    *Sean Doyle*
+
 *   Add `:day_format` option to `date_select`
 
         date_select("article", "written_on", day_format: ->(day) { day.ordinalize })

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -62,6 +62,9 @@ module ActionView
       #
       #   <%= form_tag('/posts', remote: true) %>
       #   # => <form action="/posts" method="post" data-remote="true">
+
+      #   form_tag(false, method: :get)
+      #   # => <form method="get">
       #
       #   form_tag('http://far.away.com/form', authenticity_token: false)
       #   # form without authenticity token
@@ -875,7 +878,11 @@ module ActionView
             html_options["enctype"] = "multipart/form-data" if html_options.delete("multipart")
             # The following URL is unescaped, this is just a hash of options, and it is the
             # responsibility of the caller to escape all the values.
-            html_options["action"]  = url_for(url_for_options)
+            if url_for_options == false || html_options["action"] == false
+              html_options.delete("action")
+            else
+              html_options["action"] = url_for(url_for_options)
+            end
             html_options["accept-charset"] = "UTF-8"
 
             html_options["data-remote"] = true if html_options.delete("remote")

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -238,7 +238,15 @@ module ActionView
       # HTTP verb via the +:method+ option within +html_options+.
       #
       # ==== Options
-      # The +options+ hash accepts the same options as +url_for+.
+      # The +options+ hash accepts the same options as +url_for+. To generate a
+      # <tt><form></tt> element without an <tt>[action]</tt> attribute, pass
+      # <tt>false</tt>:
+      #
+      #   <%= button_to "New", false %>
+      #   # => "<form method="post" class="button_to">
+      #   #      <button type="submit">New</button>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
+      #   #    </form>"
       #
       # Most values in +html_options+ are passed through to the button element,
       # but there are a few special options:
@@ -324,11 +332,15 @@ module ActionView
       #   #
       def button_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options = options, name if block_given?
-        options      ||= {}
         html_options ||= {}
         html_options = html_options.stringify_keys
 
-        url    = options.is_a?(String) ? options : url_for(options)
+        url =
+          case options
+          when FalseClass then nil
+          else url_for(options)
+          end
+
         remote = html_options.delete("remote")
         params = html_options.delete("params")
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -53,7 +53,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     method = method.to_s == "get" ? "get" : "post"
 
-    txt =  +%{<form accept-charset="UTF-8" action="#{action}"}
+    txt =  +%{<form accept-charset="UTF-8"} + (action ? %{ action="#{action}"} : "")
     txt << %{ enctype="multipart/form-data"} if enctype
     txt << %{ data-remote="true"} unless local
     txt << %{ class="#{html_class}"} if html_class
@@ -104,6 +104,22 @@ class FormWithActsLikeFormTagTest < FormWithTest
     actual = form_with(method: :delete)
 
     expected = whole_form("http://www.example.com", method: :delete)
+    assert_dom_equal expected, actual
+  end
+
+  def test_form_with_false_url
+    actual = form_with(url: false)
+
+    expected = whole_form(false)
+
+    assert_dom_equal expected, actual
+  end
+
+  def test_form_with_false_action
+    actual = form_with(html: { action: false })
+
+    expected = whole_form(false)
+
     assert_dom_equal expected, actual
   end
 
@@ -441,6 +457,22 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123") do
       '<input type="text" name="no_model_to_back_this_badboy" id="no_model_to_back_this_badboy" >'
     end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_false_url
+    form_with(url: false)
+
+    expected = whole_form(false)
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_model_and_false_url
+    form_with(model: Post.new, url: false)
+
+    expected = whole_form(false)
 
     assert_dom_equal expected, output_buffer
   end
@@ -2398,7 +2430,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     def form_text(action = "/", id = nil, html_class = nil, local = nil, multipart = nil, method = nil)
-      txt =  +%{<form accept-charset="UTF-8" action="#{action}"}
+      txt =  +%{<form accept-charset="UTF-8"} + (action ? %{ action="#{action}"} : "")
       txt << %{ enctype="multipart/form-data"} if multipart
       txt << %{ data-remote="true"} unless local
       txt << %{ class="#{html_class}"} if html_class

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1617,6 +1617,24 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_false_url
+    form_for(Post.new, url: false) do |form|
+    end
+
+    expected = whole_form(false, "new_post", "new_post")
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_false_action
+    form_for(Post.new, html: { action: false }) do |form|
+    end
+
+    expected = whole_form(false, "new_post", "new_post")
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_field_id_with_model
     value = field_id(Post.new, :title)
 
@@ -3738,7 +3756,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     def form_text(action = "/", id = nil, html_class = nil, remote = nil, multipart = nil, method = nil)
-      txt =  +%{<form accept-charset="UTF-8" action="#{action}"}
+      txt =  +%{<form accept-charset="UTF-8"} + (action ? %{ action="#{action}"} : "")
       txt << %{ enctype="multipart/form-data"} if multipart
       txt << %{ data-remote="true"} if remote
       txt << %{ class="#{html_class}"} if html_class

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -42,7 +42,7 @@ class FormTagHelperTest < ActionView::TestCase
 
     method = method.to_s == "get" ? "get" : "post"
 
-    txt =  +%{<form accept-charset="UTF-8" action="#{action}"}
+    txt =  +%{<form accept-charset="UTF-8"} + (action ? %{ action="#{action}"} : "")
     txt << %{ enctype="multipart/form-data"} if enctype
     txt << %{ data-remote="true"} if remote
     txt << %{ class="#{html_class}"} if html_class
@@ -135,6 +135,20 @@ class FormTagHelperTest < ActionView::TestCase
     actual = form_tag({}, { remote: false })
 
     expected = whole_form
+    assert_dom_equal expected, actual
+  end
+
+  def test_form_tag_with_false_url_for_options
+    actual = form_tag(false)
+
+    expected = whole_form(false)
+    assert_dom_equal expected, actual
+  end
+
+  def test_form_tag_with_false_action
+    actual = form_tag({}, action: false)
+
+    expected = whole_form(false)
     assert_dom_equal expected, actual
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -161,6 +161,20 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_button_to_with_false_url
+    assert_dom_equal(
+      %{<form method="post" class="button_to"><button type="submit">Hello</button></form>},
+      button_to("Hello", false)
+    )
+  end
+
+  def test_button_to_with_false_url_and_block
+    assert_dom_equal(
+      %{<form method="post" class="button_to"><button type="submit">Hello</button></form>},
+      button_to(false) { "Hello" }
+    )
+  end
+
   def test_button_to_with_straight_url_and_request_forgery
     self.request_forgery = true
 


### PR DESCRIPTION
Some background
---

By default, when a `<form>` is declared without an `[action]` attribute,
browsers will encode a `<form>`'s fields into the _current_ URL.

This can be useful for a `<form method="get">` that operates on the
current page. For example, when filtering search results, a form that
sorts:

```html
<form method="get">
  <button name="sort" value="desc">Most to least</button>
  <button name="sort" value="asc">Least to most</button>
</form>
```

can operate on a page that is filtered in another way by merging the
`?sort=asc` or `?sort=desc` values _into_ the existing page, which might
have the `?q=...` string set elsewhere.

The problem
---

Prior to this commit, none of the `<form>` construction variations
supported declaring a `<form>` without an `[action]` attribute.
`form_with`, `form_for`, and `form_tag` all default to `url_for({})`
when a `url:` or `action:` option is omitted.

The solution
---

Treat `url: false`, or `action: false` as an escape hatch to signal to
Action View that we don't need to transform the `model:` option or
argument into a Rails route.

