### PR TITLE
ActionDispatch::Routing::RouteSet.url_for, only merge params if params is a hash

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -823,7 +823,7 @@ module ActionDispatch
         params = route_with_params.params
 
         if options.key? :params
-          params.merge! options[:params]
+          params.merge! options[:params] if options[:params].is_a?(Hash)
         end
 
         options[:path]        = path


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

If an arbitrary parameter structure is passed into a rails request with a nested `params` that isn't a hash, a
```
TypeError:
       no implicit conversion of String into Hash
```
exception is raised. For example:

```
food = {
  "foo" => "bar",
  "tacos" => {
    "ingredients" => [[
      "shell",
      "meat",
      "lettuce",
      "cheese"
    ]],
    "no" => "sour cream"
  }
}

post :create, :params => { resturant: resturant_uuid, params: food.to_json }
```
(sorry for the rspec example)

will raise the aforementioned exception.

### Other Information

I know this still needs a test, and if people think it's worth merging, pointing me to the file I should write one in would be super helpful.
