### PR TITLE
Replace `map + compact` with `filter_map`

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -246,7 +246,7 @@ module ActionCable
         # Returns messages transmitted into channel
         def transmissions
           # Return only directly sent message (via #transmit)
-          connection.transmissions.map { |data| data["message"] }.compact
+          connection.transmissions.filter_map { |data| data["message"] }
         end
 
         # Enhance TestHelper assertions to handle non-String

--- a/actioncable/lib/action_cable/connection/identification.rb
+++ b/actioncable/lib/action_cable/connection/identification.rb
@@ -26,7 +26,7 @@ module ActionCable
       # Return a single connection identifier that combines the value of all the registered identifiers into a single gid.
       def connection_identifier
         unless defined? @connection_identifier
-          @connection_identifier = connection_gid identifiers.map { |id| instance_variable_get("@#{id}") }.compact
+          @connection_identifier = connection_gid identifiers.filter_map { |id| instance_variable_get("@#{id}") }
         end
 
         @connection_identifier

--- a/actionpack/lib/abstract_controller/caching.rb
+++ b/actionpack/lib/abstract_controller/caching.rb
@@ -50,7 +50,7 @@ module AbstractController
     end
 
     def view_cache_dependencies
-      self.class._view_cache_dependencies.map { |dep| instance_exec(&dep) }.compact
+      self.class._view_cache_dependencies.filter_map { |dep| instance_exec(&dep) }
     end
 
     private

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -26,7 +26,7 @@ module ActionController
 
     # Before processing, set the request formats in current controller formats.
     def process_action(*) #:nodoc:
-      self.formats = request.formats.map(&:ref).compact
+      self.formats = request.formats.filter_map(&:ref)
       super
     end
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -955,7 +955,7 @@ module ActionController
       def each_element(object, &block)
         case object
         when Array
-          object.grep(Parameters).map { |el| yield el }.compact
+          object.grep(Parameters).filter_map { |el| yield el }
         when Parameters
           if object.nested_attributes?
             object.each_nested_attribute(&block)

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -20,7 +20,7 @@ module ActionText
       end
 
       def from_attachables(attachables)
-        Array(attachables).map { |attachable| from_attachable(attachable) }.compact
+        Array(attachables).filter_map { |attachable| from_attachable(attachable) }
       end
 
       def from_attachable(attachable, attributes = {})

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -363,7 +363,7 @@ class TemplateDigestorTest < ActionView::TestCase
 
     def tree_template_formats(template_name)
       tree = ActionView::Digestor.tree(template_name, finder)
-      tree.flatten.map(&:template).compact.map(&:format)
+      tree.flatten.filter_map { |node| node.template&.format }
     end
 
     def disable_resolver_caching

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -119,7 +119,7 @@ end
           n = ENV["BUILDKITE_PARALLEL_JOB"].to_i
           m = ENV["BUILDKITE_PARALLEL_JOB_COUNT"].to_i
 
-          test_files = test_files.each_slice(m).map { |slice| slice[n] }.compact
+          test_files = test_files.each_slice(m).filter_map { |slice| slice[n] }
         end
 
         test_files.each do |file|

--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -486,7 +486,7 @@ module ActiveRecord
         existing_records = if association.loaded?
           association.target
         else
-          attribute_ids = attributes_collection.map { |a| a["id"] || a[:id] }.compact
+          attribute_ids = attributes_collection.filter_map { |a| a["id"] || a[:id] }
           attribute_ids.empty? ? [] : association.scope.where(association.klass.primary_key => attribute_ids)
         end
 

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -96,7 +96,7 @@ module Arel # :nodoc: all
     end
 
     def froms
-      @ast.cores.map { |x| x.from }.compact
+      @ast.cores.filter_map { |x| x.from }
     end
 
     def join(relation, klass = Nodes::InnerJoin)

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -31,7 +31,7 @@ module Rails
           sslcapath: "--ssl-capath",
           sslcipher: "--ssl-cipher",
           sslkey: "--ssl-key"
-        }.map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }.compact
+        }.filter_map { |opt, arg| "#{arg}=#{config[opt]}" if config[opt] }
 
         if config[:password] && @options[:include_password]
           args << "--password=#{config[:password]}"


### PR DESCRIPTION
### Summary

Since Rails 7 requires Ruby > 2.7, I changed some recurrences of `map + compact` with `filter_map`. I took the liberty to change some occurrences in tests too.

### Other Information

Here's an article about `filter_map`: https://blog.saeloun.com/2019/05/25/ruby-2-7-enumerable-filter-map.html

### Benchmark

```ruby
N = 1_00_000
enum = 1.upto(1_000)
Benchmark.bmbm do |x|
  x.report("select + map") {N.times {enum.select { |i| i.even? }.map{|i| i +1}}}
  x.report("map + compact") {N.times {enum.map { |i| i + 1 if i.even? }.compact}}
  x.report("filter_map") {N.times {enum.filter_map { |i| i + 1 if i.even? }}}
end
#
# Rehearsal -------------------------------------------------
# select + map    8.569651   0.051319   8.620970 (  8.632449)
# map + compact   7.392666   0.133964   7.526630 (  7.538013)
# filter_map      6.923772   0.022314   6.946086 (  6.956135)
# --------------------------------------- total: 23.093686sec
# 
#                     user     system      total        real
# select + map    8.550637   0.033190   8.583827 (  8.597627)
# map + compact   7.263667   0.131180   7.394847 (  7.405570)
# filter_map      6.761388   0.018223   6.779611 (  6.790559)
```