### PR TITLE
Replace `gsub` with `tr`

### DIFF
--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -207,7 +207,7 @@ module ActiveRecord
         end
 
         types.each do |type|
-          scope_name = type.tableize.gsub("/", "_")
+          scope_name = type.tableize.tr("/", "_")
           singular   = scope_name.singularize
           query      = "#{singular}?"
 


### PR DESCRIPTION
### Summary

Replaces `gsub` with `tr` because it's faster and it is a drop-in replacement in this context.

### Other Information

https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancestringreplacement