### PR TITLE
Make sure not to generate Link headers longer than 8kiB

### DIFF
--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -529,6 +529,17 @@ class AssetTagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_should_generate_links_under_the_max_size
+    with_preload_links_header do
+      100.times do |i|
+        stylesheet_link_tag("http://example.com/style.css?#{i}")
+        javascript_include_tag("http://example.com/all.js?#{i}")
+      end
+      lines = @response.headers["Link"].split("\n")
+      assert_equal 2, lines.size
+    end
+  end
+
   def test_should_not_preload_links_with_defer
     with_preload_links_header do
       javascript_include_tag("http://example.com/all.js", defer: true)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/39939

So apparently I overlooked that some browser and proxies have a max header size limit. For most of them it seems to be at least 8kiB.

So to avoid issues, we can try to split the `Link` headers into 8kiB or less lines. Unless I'm mistaken Rack convert multi-line headers into repeated headers.