### PR TITLE
Allow expires_in for ActiveStorage signed ids

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `expires_in` for ActiveStorage signed ids.
+
+    *aki77*
+
 *   Allow to purge an attachment when record is not persisted for `has_one_attached`
 
     *Jacopo Beschi*

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -151,7 +151,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   end
 
   # Returns a signed ID for this blob that's suitable for reference on the client-side without fear of tampering.
-  def signed_id(purpose: :blob_id)
+  def signed_id(purpose: :blob_id, expires_in: nil)
     super
   end
 

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -100,6 +100,23 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id, purpose: :custom_purpose)
   end
 
+  test "getting a signed blob ID from an attachment with a expires_in" do
+    blob = create_blob
+    @user.avatar.attach(blob)
+
+    signed_id = @user.avatar.signed_id(expires_in: 1.minute)
+    assert_equal blob, ActiveStorage::Blob.find_signed!(signed_id)
+  end
+
+  test "fail to find blob within expiration date" do
+    blob = create_blob
+    @user.avatar.attach(blob)
+
+    signed_id = @user.avatar.signed_id(expires_in: 1.minute)
+    travel 2.minutes
+    assert_nil ActiveStorage::Blob.find_signed(signed_id)
+  end
+
   test "signed blob ID backwards compatibility" do
     blob = create_blob
     @user.avatar.attach(blob)


### PR DESCRIPTION
This commit allows passing a `expires_in`: keyword argument to signed_id.
This matches the signature of the `super` methods in ActiveRecord.

This is useful for generating expiring URLs.

Related Issues: #38843