### PR TITLE
Ensure variables are set in case enlist_fixture_connections is called

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -111,12 +111,11 @@ module ActiveRecord
       @fixture_connections = []
       @@already_loaded_fixtures ||= {}
       @connection_subscriber = nil
+      @legacy_saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
+      @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
 
       # Load fixtures once and begin transaction.
       if run_in_transaction?
-        @legacy_saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
-        @saved_pool_configs = Hash.new { |hash, key| hash[key] = {} }
-
         if @@already_loaded_fixtures[self.class]
           @loaded_fixtures = @@already_loaded_fixtures[self.class]
         else


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/40384 Introduced a change which broke our tests at GitHub. We call `enlist_fixture_connections` when loading fixtures.

The current Rails code uses `enlist_fixture_connections` when the context is `run_in_transasction?`. However if
`enlist_fixture_connections` is called outside of that context the code fails since these variables are not defined. This ensures the code can still be executed without side effects. 

I wasn't sure how to or whether I should write a test for this since enlist_fixture_connections is a private method so feedback is appreciated.

### Other Information

/cc @eugeneius as the original PR author


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
