### PR TITLE
Add `ActiveRecord::QueryMethods#in_order_of`.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Add `ActiveRecord::QueryMethods#in_order_of`.
+
+    This allows you to specify an explicit order that you'd like records
+    returned in based on a SQL expression. By default, this will be accomplished
+    using a case statement, as in:
+
+    ```ruby
+    Post.in_order_of(:id, [3, 5, 1])
+    ```
+
+    will generate the SQL:
+
+    ```sql
+    SELECT "posts".* FROM "posts" ORDER BY CASE "posts"."id" WHEN 3 THEN 1 WHEN 5 THEN 2 WHEN 1 THEN 3 ELSE 4 END ASC
+    ```
+
+    However, because this functionality is built into MySQL in the form of the
+    `FIELD` function, that connection adapter will generate the following SQL
+    instead:
+
+    ```sql
+    SELECT "posts".* FROM "posts" ORDER BY FIELD("posts"."id", 1, 5, 3) DESC
+    ```
+
+    *Kevin Newton*
+
 *   Fix `eager_loading?` when ordering with `Symbol`
 
     `eager_loading?` is triggered correctly when using `order` with symbols.
@@ -34,7 +60,7 @@
 
     *Luis Vasconcellos*, *Eileen M. Uchitelle*
 
-*   Fix `eager_loading?` when ordering with `Hash` syntax.
+*   Fix `eager_loading?` when ordering with `Hash` syntax
 
     `eager_loading?` is triggered correctly when using `order` with hash syntax
     on an outer table.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -632,6 +632,15 @@ module ActiveRecord
       def check_version # :nodoc:
       end
 
+      def field_ordered_value(column, values)
+        node = Arel::Nodes::Case.new(column)
+        values.each.with_index(1) do |value, order|
+          node.when(value).then(order)
+        end
+
+        Arel::Nodes::Ascending.new(node.else(values.length + 1))
+      end
+
       class << self
         private
           def initialize_type_map(m)

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -137,6 +137,11 @@ module ActiveRecord
         true
       end
 
+      def field_ordered_value(column, values)
+        field = Arel::Nodes::NamedFunction.new("FIELD", [column, values.reverse])
+        Arel::Nodes::Descending.new(field)
+      end
+
       def get_advisory_lock(lock_name, timeout = 0) # :nodoc:
         query_value("SELECT GET_LOCK(#{quote(lock_name.to_s)}, #{timeout})") == 1
       end

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -12,7 +12,7 @@ module ActiveRecord
       :create_or_find_by, :create_or_find_by!,
       :destroy_all, :delete_all, :update_all, :touch_all, :destroy_by, :delete_by,
       :find_each, :find_in_batches, :in_batches,
-      :select, :reselect, :order, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
+      :select, :reselect, :order, :in_order_of, :reorder, :group, :limit, :offset, :joins, :left_joins, :left_outer_joins,
       :where, :rewhere, :invert_where, :preload, :extract_associated, :eager_load, :includes, :from, :lock, :readonly,
       :and, :or, :annotate, :optimizer_hints, :extending,
       :having, :create_with, :distinct, :references, :none, :unscope, :merge, :except, :only,

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class FieldOrderedValuesTest < ActiveRecord::TestCase
+  fixtures :posts
+
+  def test_in_order_of
+    order = [3, 4, 1]
+    posts = Post.in_order_of(:id, order).limit(3)
+
+    assert_equal(order, posts.map(&:id))
+  end
+
+  def test_in_order_of_expression
+    order = [3, 4, 1]
+    posts = Post.in_order_of(Arel.sql("id * 2"), order.map { |id| id * 2 }).limit(3)
+
+    assert_equal(order, posts.map(&:id))
+  end
+
+  def test_in_order_of_after_regular_order
+    order = [3, 4, 1]
+    posts = Post.where(type: "Post").order(:type).in_order_of(:id, order).limit(3)
+
+    assert_equal(order, posts.map(&:id))
+  end
+end


### PR DESCRIPTION
### Summary

This allows you to specify an explicit order that you'd like records
returned in based on a SQL expression. By default, this will be accomplished
using a case statement, as in:

```ruby
Post.in_order_of(:id, [3, 5, 1])
```

will generate the SQL:

```sql
SELECT "posts".* FROM "posts" ORDER BY CASE "posts"."id" WHEN 3 THEN 1 WHEN 5 THEN 2 WHEN 1 THEN 3 ELSE 4 END ASC
```

However, because this functionality is built into MySQL in the form of the
`FIELD` function, that connection adapter will generate the following SQL
instead:

```sql
SELECT "posts".* FROM "posts" ORDER BY FIELD("posts"."id", 1, 5, 3) DESC
```

This work largely inspired by the new addition to Enumerable here: https://github.com/rails/rails/pull/41333. cc @dhh 