### PR TITLE
Fix BigDecimal.new warning in duplicable.rb

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/duplicable.rb
+++ b/activesupport/lib/active_support/core_ext/object/duplicable.rb
@@ -108,7 +108,7 @@ class BigDecimal
   # raises TypeError exception. Checking here on the runtime whether BigDecimal
   # will allow dup or not.
   begin
-    BigDecimal.new('4.56').dup
+    BigDecimal('4.56').dup
 
     def duplicable?
       true


### PR DESCRIPTION
Fix deprecation warning.

### Summary

BigDecimal has deprecated the usage of its new function so let's use the current function call instead.

### Other Information

A very minor change which makes using a newer Ruby version less noise in the log files.