### PR TITLE
Remove ActiveModel errors deprecations

### DIFF
--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -20,11 +20,11 @@ class ActiveModelHelperTest < ActionView::TestCase
     super
 
     @post = Post.new
-    assert_deprecated { @post.errors[:author_name] << "can't be empty" }
-    assert_deprecated { @post.errors[:body] << "foo" }
-    assert_deprecated { @post.errors[:category] << "must exist" }
-    assert_deprecated { @post.errors[:published] << "must be accepted" }
-    assert_deprecated { @post.errors[:updated_at] << "bar" }
+    @post.errors.add(:author_name, "can't be empty")
+    @post.errors.add(:body, "foo")
+    @post.errors.add(:category, "must exist")
+    @post.errors.add(:published, "must be accepted")
+    @post.errors.add(:updated_at, "bar")
 
     @post.author_name = ""
     @post.body        = "Back to the hill and over it again!"

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1340,7 +1340,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_with_priority_zones_and_errors
     @firm = Firm.new("D")
     @firm.extend ActiveModel::Validations
-    assert_deprecated { @firm.errors[:time_zone] << "invalid" }
+    @firm.errors.add(:time_zone)
     zones = [ ActiveSupport::TimeZone.new("A"), ActiveSupport::TimeZone.new("D") ]
     html = time_zone_select("firm", "time_zone", zones)
     assert_dom_equal "<div class=\"field_with_errors\">" \

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -138,25 +138,6 @@ module ActiveModel
       }
     end
 
-    # Removes all errors except the given keys. Returns a hash containing the removed errors.
-    #
-    #   person.errors.keys                  # => [:name, :age, :gender, :city]
-    #   person.errors.slice!(:age, :gender) # => { :name=>["cannot be nil"], :city=>["cannot be nil"] }
-    #   person.errors.keys                  # => [:age, :gender]
-    def slice!(*keys)
-      deprecation_removal_warning(:slice!)
-
-      keys = keys.map(&:to_sym)
-
-      results = messages.dup.slice!(*keys)
-
-      @errors.keep_if do |error|
-        keys.include?(error.attribute)
-      end
-
-      results
-    end
-
     # Search for errors matching +attribute+, +type+ or +options+.
     #
     # Only supplied params will be matched.
@@ -205,7 +186,7 @@ module ActiveModel
     #   person.errors[:name]  # => ["cannot be nil"]
     #   person.errors['name'] # => ["cannot be nil"]
     def [](attribute)
-      DeprecationHandlingMessageArray.new(messages_for(attribute), self, attribute)
+      messages_for(attribute)
     end
 
     # Iterates through each error object.
@@ -213,68 +194,10 @@ module ActiveModel
     #   person.errors.add(:name, :too_short, count: 2)
     #   person.errors.each do |error|
     #     # Will yield <#ActiveModel::Error attribute=name, type=too_short,
-    #                                       options={:count=>3}>
-    #   end
-    #
-    # To be backward compatible with past deprecated hash-like behavior,
-    # when block accepts two parameters instead of one, it
-    # iterates through each error key, value pair in the error messages hash.
-    # Yields the attribute and the error for that attribute. If the attribute
-    # has more than one error message, yields once for each error message.
-    #
-    #   person.errors.add(:name, :blank, message: "can't be blank")
-    #   person.errors.each do |attribute, message|
-    #     # Will yield :name and "can't be blank"
-    #   end
-    #
-    #   person.errors.add(:name, :not_specified, message: "must be specified")
-    #   person.errors.each do |attribute, message|
-    #     # Will yield :name and "can't be blank"
-    #     # then yield :name and "must be specified"
+    #                                       options={:count=>2}>
     #   end
     def each(&block)
-      if block.arity <= 1
-        @errors.each(&block)
-      else
-        ActiveSupport::Deprecation.warn(<<~MSG)
-          Enumerating ActiveModel::Errors as a hash has been deprecated.
-          In Rails 6.1, `errors` is an array of Error objects,
-          therefore it should be accessed by a block with a single block
-          parameter like this:
-
-          person.errors.each do |error|
-            attribute = error.attribute
-            message = error.message
-          end
-
-          You are passing a block expecting two parameters,
-          so the old hash behavior is simulated. As this is deprecated,
-          this will result in an ArgumentError in Rails 7.0.
-        MSG
-        @errors.
-          sort { |a, b| a.attribute <=> b.attribute }.
-          each { |error| yield error.attribute, error.message }
-      end
-    end
-
-    # Returns all message values.
-    #
-    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
-    #   person.errors.values   # => [["cannot be nil", "must be specified"]]
-    def values
-      deprecation_removal_warning(:values, "errors.map { |error| error.message }")
-      @errors.map(&:message).freeze
-    end
-
-    # Returns all message keys.
-    #
-    #   person.errors.messages # => {:name=>["cannot be nil", "must be specified"]}
-    #   person.errors.keys     # => [:name]
-    def keys
-      deprecation_removal_warning(:keys, "errors.attribute_names")
-      keys = @errors.map(&:attribute)
-      keys.uniq!
-      keys.freeze
+      @errors.each(&block)
     end
 
     # Returns all error attribute names
@@ -283,22 +206,6 @@ module ActiveModel
     #   person.errors.attribute_names # => [:name]
     def attribute_names
       @errors.map(&:attribute).uniq.freeze
-    end
-
-    # Returns an xml formatted representation of the Errors hash.
-    #
-    #   person.errors.add(:name, :blank, message: "can't be blank")
-    #   person.errors.add(:name, :not_specified, message: "must be specified")
-    #   person.errors.to_xml
-    #   # =>
-    #   #  <?xml version=\"1.0\" encoding=\"UTF-8\"?>
-    #   #  <errors>
-    #   #    <error>name can't be blank</error>
-    #   #    <error>name must be specified</error>
-    #   #  </errors>
-    def to_xml(options = {})
-      deprecation_removal_warning(:to_xml)
-      to_a.to_xml({ root: "errors", skip_types: true }.merge!(options))
     end
 
     # Returns a Hash that can be used as the JSON representation for this
@@ -323,33 +230,20 @@ module ActiveModel
       end
     end
 
-    def to_h
-      ActiveSupport::Deprecation.warn(<<~EOM)
-        ActiveModel::Errors#to_h is deprecated and will be removed in Rails 7.0.
-        Please use `ActiveModel::Errors.to_hash` instead. The values in the hash
-        returned by `ActiveModel::Errors.to_hash` is an array of error messages.
-      EOM
-
-      to_hash.transform_values { |values| values.last }
-    end
-
     # Returns a Hash of attributes with an array of their error messages.
     #
-    # Updating this hash would still update errors state for backward
-    # compatibility, but this behavior is deprecated.
+    # Updating this hash would not update errors state.
     def messages
-      DeprecationHandlingMessageHash.new(self)
+      self
     end
 
     # Returns a Hash of attributes with an array of their error details.
     #
-    # Updating this hash would still update errors state for backward
-    # compatibility, but this behavior is deprecated.
+    # Updating this hash would not update errors state.
     def details
       hash = group_by_attribute.transform_values do |errors|
         errors.map(&:details)
       end
-      DeprecationHandlingDetailsHash.new(hash)
     end
 
     # Returns a Hash of attributes with an array of their Error objects.
@@ -589,88 +483,6 @@ module ActiveModel
           }
         }
       end
-
-      def deprecation_removal_warning(method_name, alternative_message = nil)
-        message = +"ActiveModel::Errors##{method_name} is deprecated and will be removed in Rails 7.0."
-        if alternative_message
-          message << "\n\nTo achieve the same use:\n\n  "
-          message << alternative_message
-        end
-        ActiveSupport::Deprecation.warn(message)
-      end
-
-      def deprecation_rename_warning(old_method_name, new_method_name)
-        ActiveSupport::Deprecation.warn("ActiveModel::Errors##{old_method_name} is deprecated. Please call ##{new_method_name} instead.")
-      end
-  end
-
-  class DeprecationHandlingMessageHash < SimpleDelegator
-    def initialize(errors)
-      @errors = errors
-      super(prepare_content)
-    end
-
-    def []=(attribute, value)
-      ActiveSupport::Deprecation.warn("Calling `[]=` to an ActiveModel::Errors is deprecated. Please call `ActiveModel::Errors#add` instead.")
-
-      @errors.delete(attribute)
-      Array(value).each do |message|
-        @errors.add(attribute, message)
-      end
-
-      __setobj__ prepare_content
-    end
-
-    def delete(attribute)
-      ActiveSupport::Deprecation.warn("Calling `delete` to an ActiveModel::Errors messages hash is deprecated. Please call `ActiveModel::Errors#delete` instead.")
-
-      @errors.delete(attribute)
-    end
-
-    private
-      def prepare_content
-        content = @errors.to_hash
-        content.each do |attribute, value|
-          content[attribute] = DeprecationHandlingMessageArray.new(value, @errors, attribute)
-        end
-        content.default_proc = proc do |hash, attribute|
-          hash = hash.dup
-          hash[attribute] = DeprecationHandlingMessageArray.new([], @errors, attribute)
-          __setobj__ hash.freeze
-          hash[attribute]
-        end
-        content.freeze
-      end
-  end
-
-  class DeprecationHandlingMessageArray < SimpleDelegator
-    def initialize(content, errors, attribute)
-      @errors = errors
-      @attribute = attribute
-      super(content.freeze)
-    end
-
-    def <<(message)
-      ActiveSupport::Deprecation.warn("Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.")
-
-      @errors.add(@attribute, message)
-      __setobj__ @errors.messages_for(@attribute)
-      self
-    end
-
-    def clear
-      ActiveSupport::Deprecation.warn("Calling `clear` to an ActiveModel::Errors message array in order to delete all errors is deprecated. Please call `ActiveModel::Errors#delete` instead.")
-
-      @errors.delete(@attribute)
-    end
-  end
-
-  class DeprecationHandlingDetailsHash < SimpleDelegator
-    def initialize(details)
-      details.default = []
-      details.freeze
-      super(details)
-    end
   end
 
   # Raised when a validation cannot be corrected by end users and are considered

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -234,7 +234,9 @@ module ActiveModel
     #
     # Updating this hash would not update errors state.
     def messages
-      self
+      hash = to_hash
+      hash.default = []
+      hash
     end
 
     # Returns a Hash of attributes with an array of their error details.
@@ -244,6 +246,8 @@ module ActiveModel
       hash = group_by_attribute.transform_values do |errors|
         errors.map(&:details)
       end
+      hash.default = []
+      hash
     end
 
     # Returns a Hash of attributes with an array of their Error objects.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -185,8 +185,12 @@ module ActiveModel
     #
     #   person.errors[:name]  # => ["cannot be nil"]
     #   person.errors['name'] # => ["cannot be nil"]
-    def [](attribute)
-      messages_for(attribute)
+    def [](index_or_attribute)
+      if index_or_attribute.is_a?(Integer)
+        @errors[index_or_attribute]
+      else
+        messages_for(index_or_attribute)
+      end
     end
 
     # Iterates through each error object.

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -39,7 +39,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   def test_include?
     errors = ActiveModel::Errors.new(Person.new)
-    assert_deprecated { errors[:foo] << "omg" }
+    errors.add(:foo, "omg")
     assert_includes errors, :foo, "errors should include :foo"
     assert_includes errors, "foo", "errors should include 'foo' as :foo"
   end
@@ -108,15 +108,6 @@ class ErrorsTest < ActiveModel::TestCase
 
     assert_equal 1, person.errors.count
     person.errors.clear
-    assert_empty person.errors
-  end
-
-  test "clear errors by key" do
-    person = Person.new
-    person.validate!
-
-    assert_equal 1, person.errors.count
-    assert_deprecated { person.errors[:name].clear }
     assert_empty person.errors
   end
 
@@ -599,15 +590,6 @@ class ErrorsTest < ActiveModel::TestCase
       },
       errors.details
     )
-  end
-
-  test "messages delete (deprecated)" do
-    person = Person.new
-    person.validate!
-
-    assert_equal 1, person.errors.count
-    assert_deprecated { person.errors.messages.delete(:name) }
-    assert_empty person.errors
   end
 
   test "group_by_attribute" do

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -127,14 +127,6 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["omg"], errors["name"]
   end
 
-  test "[]= overrides values" do
-    errors = ActiveModel::Errors.new(self)
-    assert_deprecated { errors.messages[:foo] = "omg" }
-    assert_deprecated { errors.messages[:foo] = "zomg" }
-
-    assert_equal ["zomg"], errors[:foo]
-  end
-
   test "attribute_names returns the error attributes" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:foo, "omg")
@@ -473,17 +465,6 @@ class ErrorsTest < ActiveModel::TestCase
     person.errors.add(:name, "cannot be blank")
     person.errors.add(:name, "cannot be nil")
     assert_equal ["name cannot be blank", "name cannot be nil"], person.errors.to_a
-  end
-
-  test "to_h is deprecated" do
-    person = Person.new
-    person.errors.add(:name, "cannot be blank")
-    person.errors.add(:name, "too long")
-
-    expected_deprecation = "ActiveModel::Errors#to_h is deprecated"
-    assert_deprecated(expected_deprecation) do
-      assert_equal({ name: "too long" }, person.errors.to_h)
-    end
   end
 
   test "to_hash returns the error messages hash" do

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -127,52 +127,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal ["omg"], errors["name"]
   end
 
-  test "values returns an array of messages" do
-    errors = ActiveModel::Errors.new(Person.new)
-    assert_deprecated { errors.messages[:foo] = "omg" }
-    assert_deprecated { errors.messages[:baz] = "zomg" }
-
-    assert_deprecated do
-      assert_equal ["omg", "zomg"], errors.values
-    end
-  end
-
   test "[]= overrides values" do
     errors = ActiveModel::Errors.new(self)
     assert_deprecated { errors.messages[:foo] = "omg" }
     assert_deprecated { errors.messages[:foo] = "zomg" }
 
     assert_equal ["zomg"], errors[:foo]
-  end
-
-  test "values returns an empty array after try to get a message only" do
-    errors = ActiveModel::Errors.new(Person.new)
-    errors.messages[:foo]
-    errors.messages[:baz]
-
-    assert_deprecated do
-      assert_equal [], errors.values
-    end
-  end
-
-  test "keys returns the error keys" do
-    errors = ActiveModel::Errors.new(Person.new)
-    assert_deprecated { errors.messages[:foo] << "omg" }
-    assert_deprecated { errors.messages[:baz] << "zomg" }
-
-    assert_deprecated do
-      assert_equal [:foo, :baz], errors.keys
-    end
-  end
-
-  test "keys returns an empty array after try to get a message only" do
-    errors = ActiveModel::Errors.new(Person.new)
-    errors.messages[:foo]
-    errors.messages[:baz]
-
-    assert_deprecated do
-      assert_equal [], errors.keys
-    end
   end
 
   test "attribute_names returns the error attributes" do
@@ -763,30 +723,6 @@ class ErrorsTest < ActiveModel::TestCase
 
     assert(person.errors.added?(:name, :invalid))
     assert(person.errors.added?(:name, :blank))
-  end
-
-  test "slice! removes all errors except the given keys" do
-    person = Person.new
-    person.errors.add(:name, "cannot be nil")
-    person.errors.add(:age, "cannot be nil")
-    person.errors.add(:gender, "cannot be nil")
-    person.errors.add(:city, "cannot be nil")
-
-    assert_deprecated { person.errors.slice!(:age, "gender") }
-
-    assert_equal [:age, :gender], assert_deprecated { person.errors.keys }
-  end
-
-  test "slice! returns the deleted errors" do
-    person = Person.new
-    person.errors.add(:name, "cannot be nil")
-    person.errors.add(:age, "cannot be nil")
-    person.errors.add(:gender, "cannot be nil")
-    person.errors.add(:city, "cannot be nil")
-
-    removed_errors = assert_deprecated { person.errors.slice!(:age, "gender") }
-
-    assert_equal({ name: ["cannot be nil"], city: ["cannot be nil"] }, removed_errors)
   end
 
   test "errors are marshalable" do

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -49,16 +49,6 @@ class ValidationsTest < ActiveModel::TestCase
     assert_equal 2, r.errors.count
   end
 
-  def test_single_error_per_attr_iteration
-    r = Reply.new
-    r.valid?
-
-    errors = assert_deprecated { r.errors.collect { |attr, messages| [attr.to_s, messages] } }
-
-    assert_includes errors, ["title", "is Empty"]
-    assert_includes errors, ["content", "is Empty"]
-  end
-
   def test_multiple_errors_per_attr_iteration_with_full_error_composition
     r = Reply.new
     r.title   = ""
@@ -74,7 +64,7 @@ class ValidationsTest < ActiveModel::TestCase
 
   def test_errors_on_nested_attributes_expands_name
     t = Topic.new
-    assert_deprecated { t.errors["replies.name"] << "can't be blank" }
+    t.errors.add("replies.name", "can't be blank")
     assert_equal ["Replies name can't be blank"], t.errors.full_messages
   end
 
@@ -222,11 +212,6 @@ class ValidationsTest < ActiveModel::TestCase
     t = Topic.new
     assert_predicate t, :invalid?
 
-    xml = assert_deprecated { t.errors.to_xml }
-    assert_match %r{<errors>}, xml
-    assert_match %r{<error>Title can't be blank</error>}, xml
-    assert_match %r{<error>Content can't be blank</error>}, xml
-
     hash = {}
     hash[:title] = ["can't be blank"]
     hash[:content] = ["can't be blank"]
@@ -239,7 +224,8 @@ class ValidationsTest < ActiveModel::TestCase
 
     t = Topic.new("title" => "")
     assert_predicate t, :invalid?
-    assert_equal "can't be blank", t.errors["title"].first
+    assert_equal :blank, t.errors.first.type
+
     Topic.validates_presence_of :title, :author_name
     Topic.validate { errors.add("author_email_address", "will never be valid") }
     Topic.validates_length_of :title, :content, minimum: 2
@@ -247,15 +233,26 @@ class ValidationsTest < ActiveModel::TestCase
     t = Topic.new title: ""
     assert_predicate t, :invalid?
 
-    assert_equal :title, key = assert_deprecated { t.errors.keys[0] }
-    assert_equal "can't be blank", t.errors[key][0]
-    assert_equal "is too short (minimum is 2 characters)", t.errors[key][1]
-    assert_equal :author_name, key = assert_deprecated { t.errors.keys[1] }
-    assert_equal "can't be blank", t.errors[key][0]
-    assert_equal :author_email_address, key = assert_deprecated { t.errors.keys[2] }
-    assert_equal "will never be valid", t.errors[key][0]
-    assert_equal :content, key = assert_deprecated { t.errors.keys[3] }
-    assert_equal "is too short (minimum is 2 characters)", t.errors[key][0]
+    t.errors[0].tap do |error|
+      assert_equal :title, error.attribute
+      assert_equal :blank, error.type
+    end
+    t.errors[1].tap do |error|
+      assert_equal :title, error.attribute
+      assert_equal :too_short, error.type
+    end
+    t.errors[3].tap do |error|
+      assert_equal :author_name, error.attribute
+      assert_equal :blank, error.type
+    end
+    t.errors[4].tap do |error|
+      assert_equal :author_email_address, error.attribute
+      assert_equal "will never be valid", error.message
+    end
+    t.errors[6].tap do |error|
+      assert_equal :content, error.attribute
+      assert_equal :too_short, error.type
+    end
   end
 
   def test_validation_with_if_and_on

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -7,7 +7,6 @@ require "models/reply"
 require "models/custom_reader"
 
 require "active_support/json"
-require "active_support/xml_mini"
 
 class ValidationsTest < ActiveModel::TestCase
   class CustomStrictValidationException < StandardError; end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -759,7 +759,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_push_with_invalid_join_record
     repair_validations(Contract) do
-      Contract.validate { |r| r.errors[:base] << "Invalid Contract" }
+      Contract.validate { |r| r.errors.add(:base, "Invalid Contract") }
 
       firm = companies(:first_firm)
       lifo = Developer.new(name: "lifo")
@@ -1213,7 +1213,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_create_should_not_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       assert_deprecated { Category.create(name: "Fishing", authors: [Author.first]) }
     end
   end
@@ -1225,7 +1225,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_create_bang_should_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       assert_raises(ActiveRecord::RecordInvalid) do
         assert_deprecated { Category.create!(name: "Fishing", authors: [Author.first]) }
       end
@@ -1234,7 +1234,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_save_bang_should_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       c = Category.new(name: "Fishing", authors: [Author.first])
       assert_raises(ActiveRecord::RecordInvalid) do
         assert_deprecated { c.save! }
@@ -1244,7 +1244,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_save_returns_falsy_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       c = Category.new(name: "Fishing", authors: [Author.first])
       assert_deprecated { assert_not c.save }
     end


### PR DESCRIPTION
### Summary

After the transition of Rails 6.1's ActiveModel errors as objects, we can safely remove deprecation related logic.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
