### PR TITLE
Fix prepending/including concernable modules

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -34,6 +34,40 @@
 
     *Jean Boussier*
 
+*   Fix including/prepending modules that both extend `ActiveSupport::Concern`
+
+    ```ruby
+    module A
+      extend ActiveSupport::Concern
+    end
+
+    module B
+      extend ActiveSupport::Concern
+    end
+    ```
+
+    Before:
+
+    ```ruby
+    A.include(B)
+    A.ancestors # => [A]
+
+    A.prepend(B)
+    A.ancestors # => [A]
+    ```
+
+    After:
+
+    ```ruby
+    A.include(B)
+    A.ancestors # => [A, B]
+
+    A.prepend(B)
+    A.ancestors # => [B, A]
+    ```
+
+    *Igor Drozdov*
+
 *   Add `Enumerable#sole`, per `ActiveRecord::FinderMethods#sole`.  Returns the
     sole item of the enumerable, raising if no items are found, or if more than
     one is.

--- a/activesupport/lib/active_support/concern.rb
+++ b/activesupport/lib/active_support/concern.rb
@@ -127,6 +127,8 @@ module ActiveSupport
     def append_features(base) #:nodoc:
       if base.instance_variable_defined?(:@_dependencies)
         base.instance_variable_get(:@_dependencies) << self
+        super
+
         false
       else
         return false if base < self
@@ -140,6 +142,8 @@ module ActiveSupport
     def prepend_features(base) #:nodoc:
       if base.instance_variable_defined?(:@_dependencies)
         base.instance_variable_get(:@_dependencies).unshift self
+        super
+
         false
       else
         return false if base < self

--- a/activesupport/test/concern_test.rb
+++ b/activesupport/test/concern_test.rb
@@ -210,4 +210,16 @@ class ConcernTest < ActiveSupport::TestCase
 
     assert_equal @klass.foo, [:included, :class, :prepended]
   end
+
+  def test_prepending_concernable_modules
+    actual_module = Module.new.extend(ActiveSupport::Concern)
+
+    actual_module.prepend Baz
+
+    assert_equal actual_module.ancestors, [Baz, actual_module]
+  end
+
+  def test_including_concernable_modules
+    assert_equal Foo.ancestors, [Foo, Bar, Baz]
+  end
 end


### PR DESCRIPTION
When both modules extend `ActiveSupport::Concern`, it's not possible to prepend/include one into another.

```ruby
module A
  extend ActiveSupport::Concern
end

module B
  extend ActiveSupport::Concern
end
```

Before:

```ruby
A.include(B)
A.ancestors # => [A]

A.prepend(B)
A.ancestors # => [A]
```

It happens because ActiveSupport::Concern overrides prepend_features/append_features and doesn't call `super` when `@_dependencies` are defined in a module.

Let's fix it by calling `super` method to call original Ruby's implementation of this method in order to perform the necessary logic that puts a module into ancestors.

After:

```ruby
A.include(B)
A.ancestors # => [A, B]

A.prepend(B)
A.ancestors # => [B, A]
```