### PR TITLE
Fix Typo

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -79,7 +79,7 @@ a class `Book`, you should have a database table called **books**. The Rails
 pluralization mechanisms are very powerful, being capable of pluralizing (and
 singularizing) both regular and irregular words. When using class names composed
 of two or more words, the model class name should follow the Ruby conventions,
-using the CamelCase form, while the table name must use the snake_case form. Examples:
+using the PascalCase form, while the table name must use the snake_case form. Examples:
 
 * Model Class - Singular with the first letter of each word capitalized (e.g.,
 `BookClub`).

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -110,7 +110,7 @@ Migrations are stored as files in the `db/migrate` directory, one for each
 migration class. The name of the file is of the form
 `YYYYMMDDHHMMSS_create_products.rb`, that is to say a UTC timestamp
 identifying the migration followed by an underscore followed by the name
-of the migration. The name of the migration class (CamelCased version)
+of the migration. The name of the migration class (PascalCased version)
 should match the latter part of the file name. For example
 `20080906120000_create_products.rb` should define class `CreateProducts` and
 `20080906120001_add_details_to_products.rb` should define


### PR DESCRIPTION
### Summary

Fix a typo in rails guides `BookClub` is `PascalCase` not `camelCase`


### Other Information
