### PR TITLE
Action Text: forward form: option to hidden input

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add support for passing `form:` option to `rich_text_area_tag` and
+    `rich_text_area` helpers to specify the `<input type="hidden" form="...">`
+    value.
+
+    *Sean Doyle*
+
 *   Add `config.action_text.attachment_tag_name`, to specify the HTML tag that contains attachments.
 
     *Mark VanLandingham*

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -20,6 +20,7 @@ module ActionText
     #   # <trix-editor id="content" input="trix_input_post_1" class="trix-content" ...></trix-editor>
     def rich_text_area_tag(name, value = nil, options = {})
       options = options.symbolize_keys
+      form = options.delete(:form)
 
       options[:input] ||= "trix_input_#{ActionText::TagHelper.id += 1}"
       options[:class] ||= "trix-content"
@@ -29,7 +30,7 @@ module ActionText
       options[:data][:blob_url_template] = main_app.rails_service_blob_url(":signed_id", ":filename")
 
       editor_tag = content_tag("trix-editor", "", options)
-      input_tag = hidden_field_tag(name, value.try(:to_trix_html) || value, id: options[:input])
+      input_tag = hidden_field_tag(name, value.try(:to_trix_html) || value, id: options[:input], form: form)
 
       input_tag + editor_tag
     end

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -140,4 +140,18 @@ class ActionText::FormHelperTest < ActionView::TestCase
       "</form>",
       output_buffer
   end
+
+  test "form with rich text area with form attribute" do
+    form_with model: Message.new, scope: :message do |form|
+      form.rich_text_area :title, form: "other_form"
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" form="other_form" />' \
+        '<trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
 end


### PR DESCRIPTION
Trix's `<trix-editor>` doesn't support the [form][] property like
`<textarea>` or other form fields.

For example, consider the following HTML and event listener:

```html
<form action="/articles" method="post">
  <textarea name="content"></textarea>

  <button type="submit">Save</button>
</form>

<script>
  addEventListener("keydown", ({ key, metaKey, target }) => {
    if (target.form && key == "Enter" && (metaKey || ctrlKey)) {
      form.requestSubmit()
    }
  })
</script>
```

The `target` (an instance of `HTMLTextAreaElement` relies on the
[HTMLTextAreaElement.form][] property for access to its associated
`<form>`. While it's usually equivalent to `target.closest("form")`,
that isn't always the case. Declaring a `[form]` attribute with another
`<form>` element's `[id]` value can associate a field to a `<form>` that
is _not an ancestor_. That means that the event listener from above
would continue to work with this HTML:

```html
<textarea name="content" form="new_article"></textarea>

<!-- elsewhere -->
<form id="new_article" action="/articles" method="post">
  <button type="submit">Save</button>
</form>
```

Unfortunately, if the `<textarea>` element were replaced with a
`<trix-editor>`, the event listener's reliance on accessing the form as
a property would break, since the `<trix-editor>` custom element doesn't
declare that property. There is currently a pull request
([basecamp/trix#899][]) to add support for accessing the `form` as a
property of the `<trix-editor>` element.

The [feedback][] provided on that pull request suggests that we
implement the `form` property by delegating to the `<input
type="hidden">` element. Currently, `<input type="hidden">` elements
constructed by Action Text helpers cannot declare the `[form]`
attribute.

This commit adds support by special-casing the `options[:form]` key
within `ActionText::TagHelper#rich_text_area_tag`.

[form]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement#properties
[basecamp/trix#899]: https://github.com/basecamp/trix/pull/899#discussion_r618543357
[feedback]: https://github.com/basecamp/trix/pull/899#discussion_r618543357

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
