### PR TITLE
Add documentation around nested_attrs edge case

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -236,6 +236,24 @@ module ActiveRecord
     # of hashes can be used with hashes generated from HTTP/HTML parameters,
     # where there may be no natural way to submit an array of hashes.
     #
+    # === Updating a Collection and Its Attributes
+    # If you are passing a set of ids with your nested attributes, the
+    # attributes are executed in the order they're passed. The new
+    # records in the collection can be updated by your nested_attributes,
+    # as long as the ids are passed before the nested attributes are set.
+    #
+    #   Member.create(
+    #     name: 'rachael',
+    #     post_ids: [1],
+    #     posts_attributes: [
+    #       { id: 1, title: 'Foo' },
+    #       { title: 'Bar' }
+    #     ]
+    #   )
+    #
+    # Note: If the nested attributes are passed before the ids are set,
+    # then the ids will override all attribute changes.
+    #
     # === Saving
     #
     # All changes to models, including the destruction of those marked for


### PR DESCRIPTION
### Summary
#41986 discovered an interesting edge case in nested_attributes.

When nested_attributes, and collection ids are passed in the same update
or create, order impacts the outcome of the call.

If the collection ids are passed first, then the nested_attributes
update those ids, and create any records without ids that were passed.

If the nested_attributes are passed first, they are quashed by the ids
being passed.

## Solution
The only way I can think of to make this easier on developers is reordering the attributes
or making update_attribute aware of other attributes passed in update_attributes.

Both of which feel like big changes that need a lot of conversation.

Instead, this PR documents and adds tests around the behavior.
