### PR TITLE
Record the cast_type in the schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1475,6 +1475,7 @@ module ActiveRecord
           cast_type = lookup_cast_type(sql_type)
           SqlTypeMetadata.new(
             sql_type: sql_type,
+            cast_type: cast_type,
             type: cast_type.type,
             limit: cast_type.limit,
             precision: cast_type.precision,

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       attr_reader :name, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
 
-      delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
+      delegate :precision, :scale, :limit, :type, :sql_type, :cast_type, to: :sql_type_metadata, allow_nil: true
 
       # Instantiates a new column in the table.
       #

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -679,6 +679,7 @@ module ActiveRecord
             cast_type = get_oid_type(oid, fmod, column_name, sql_type)
             simple_type = SqlTypeMetadata.new(
               sql_type: sql_type,
+              cast_type: cast_type,
               type: cast_type.type,
               limit: cast_type.limit,
               precision: cast_type.precision,

--- a/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
@@ -8,19 +8,21 @@ module ActiveRecord
     class SqlTypeMetadata
       include Deduplicable
 
-      attr_reader :sql_type, :type, :limit, :precision, :scale
+      attr_reader :sql_type, :cast_type, :type, :limit, :precision, :scale
 
-      def initialize(sql_type: nil, type: nil, limit: nil, precision: nil, scale: nil)
+      def initialize(sql_type: nil, cast_type: nil, type: nil, limit: nil, precision: nil, scale: nil)
         @sql_type = sql_type
         @type = type
         @limit = limit
         @precision = precision
         @scale = scale
+        @cast_type = cast_type
       end
 
       def ==(other)
         other.is_a?(SqlTypeMetadata) &&
           sql_type == other.sql_type &&
+          cast_type == other.cast_type &&
           type == other.type &&
           limit == other.limit &&
           precision == other.precision &&
@@ -31,6 +33,7 @@ module ActiveRecord
       def hash
         SqlTypeMetadata.hash ^
           sql_type.hash ^
+          cast_type.hash ^
           type.hash ^
           limit.hash ^
           precision.hash >> 1 ^

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -555,7 +555,7 @@ module ActiveRecord
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
           @columns_hash.each do |name, column|
-            type = connection.lookup_cast_type_from_column(column)
+            type = column.cast_type || connection.lookup_cast_type_from_column(column)
             type = _convert_type_from_options(type)
             warn_if_deprecated_type(column)
             define_attribute(

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -113,7 +113,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     Topic.reset_column_information
 
-    Topic.connection.stub(:lookup_cast_type_from_column, ->(_) { raise "Some Error" }) do
+    Topic.connection.stub(:type_map, -> { raise "Some Error" }) do
       assert_raises RuntimeError do
         Topic.columns_hash
       end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -70,8 +70,8 @@ module ActiveRecord
         five = columns.detect { |c| c.name == "five" } unless mysql
 
         assert_equal "hello", one.default
-        assert_equal true, connection.lookup_cast_type_from_column(two).deserialize(two.default)
-        assert_equal false, connection.lookup_cast_type_from_column(three).deserialize(three.default)
+        assert_equal true, two.cast_type.deserialize(two.default)
+        assert_equal false, three.cast_type.deserialize(three.default)
         assert_equal "1", four.default
         assert_equal "hello", five.default unless mysql
       end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -195,7 +195,7 @@ module ActiveRecord
 
         old_columns = connection.columns(TestModel.table_name)
         assert old_columns.find { |c|
-          default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
 
@@ -203,11 +203,11 @@ module ActiveRecord
         new_columns = connection.columns(TestModel.table_name)
 
         assert_not new_columns.find { |c|
-          default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
         assert new_columns.find { |c|
-          default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == false
         }
         change_column :test_models, :approved, :boolean, default: true


### PR DESCRIPTION
### Context

For resiliency reasons, it is paramount that Rails is able to boot even if it can't connect to the database, right now it is achieved by skipping Active Record attribute methods definition if an error happens (Ref: https://github.com/rails/rails/pull/40119).

That's better than crashing, but it's far from ideal. I would like to refactor Active Record enough, that if you have a proper schema cache the entire eager loading can happen without connecting to the database at all.

This PR is the first of several in that direction.

### This change

Right now `define_attribute_methods` access the connection for the sole purpose of looking up the "cast_type" of each column: https://github.com/rails/rails/blob/0beae875eea321143ec4208df93e43fa3ebf39be/activerecord/lib/active_record/model_schema.rb#L558

I believe this could be stored in the `Column` object, hence part of the schema cache as well.

### Backward compatibility

It's important that Rails is able to read schema caches from the previous version, otherwise it would be very hard to regenerate the schema cache for an update. Because of this the code assumes `column.cast_type` might be `nil` and fallback to the old code.

Once Rails 7.0 is out we can remove `lookup_cast_type_from_column` entirely.