### PR TITLE
use ruby 2.7's filter_map instead of select + map

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -259,6 +259,9 @@ Performance/FlatMap:
 Performance/MapCompact:
   Enabled: true
 
+Performance/SelectMap:
+  Enabled: true
+
 Performance/RedundantMerge:
   Enabled: true
 

--- a/actionview/lib/action_view/testing/resolvers.rb
+++ b/actionview/lib/action_view/testing/resolvers.rb
@@ -24,10 +24,8 @@ module ActionView #:nodoc:
 
     private
       def template_glob(glob)
-        @hash.keys.select do |path|
-          File.fnmatch(glob, path)
-        end.map do |fixture|
-          "/#{fixture}"
+        @hash.keys.filter_map do |path|
+          "/#{path}" if File.fnmatch(glob, path)
         end
       end
 

--- a/guides/rails_guides/kindle.rb
+++ b/guides/rails_guides/kindle.rb
@@ -17,7 +17,7 @@ module Kindle
       puts "=> Arranging html pages in document order"
       toc = File.read("toc.ncx")
       doc = Nokogiri::XML(toc).xpath("//ncx:content", "ncx" => "http://www.daisy.org/z3986/2005/ncx/")
-      html_pages = doc.select { |c| c[:src] }.map { |c| c[:src] }.uniq
+      html_pages = doc.filter_map { |c| c[:src] }.uniq
 
       generate_front_matter(html_pages)
 

--- a/railties/lib/rails/info_controller.rb
+++ b/railties/lib/rails/info_controller.rb
@@ -34,9 +34,7 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
 
   private
     def match_route
-      _routes.routes.select { |route|
-        yield route.path
-      }.map { |route| route.path.spec.to_s }
+      _routes.routes.filter_map { |route| route.path.spec.to_s if yield route.path }
     end
 
     def with_leading_slash(path)

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -63,7 +63,9 @@ module Rails
         private
           def extract_filters(argv)
             # Extract absolute and relative paths but skip -n /.*/ regexp filters.
-            argv.select { |arg| path_argument?(arg) && !regexp_filter?(arg) }.map do |path|
+            argv.filter_map do |path|
+              next unless path_argument?(path) && !regexp_filter?(path)
+
               path = path.tr("\\", "/")
               case
               when /(:\d+)+$/.match?(path)


### PR DESCRIPTION
Related: c3d7794, bbbc861

### Summary

Like #42053, ruby 2.7 allows us to use `filter_map` instead of `select + map`, and I enabled the rubocop check for it as well

### Benchmark

From https://blog.saeloun.com/2019/05/25/ruby-2-7-enumerable-filter-map.html

```ruby
N = 1_00_000
enum = 1.upto(1_000)
Benchmark.bmbm do |x|
  x.report("select + map") {N.times {enum.select { |i| i.even? }.map{|i| i +1}}}
  x.report("map + compact") {N.times {enum.map { |i| i + 1 if i.even? }.compact}}
  x.report("filter_map") {N.times {enum.filter_map { |i| i + 1 if i.even? }}}
end
#
# Rehearsal -------------------------------------------------
# select + map    8.569651   0.051319   8.620970 (  8.632449)
# map + compact   7.392666   0.133964   7.526630 (  7.538013)
# filter_map      6.923772   0.022314   6.946086 (  6.956135)
# --------------------------------------- total: 23.093686sec
# 
#                     user     system      total        real
# select + map    8.550637   0.033190   8.583827 (  8.597627)
# map + compact   7.263667   0.131180   7.394847 (  7.405570)
# filter_map      6.761388   0.018223   6.779611 (  6.790559)
```