### PR TITLE
Remove some dependencies on an active connection to eager load models

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/primary_key.rb
+++ b/activerecord/lib/active_record/attribute_methods/primary_key.rb
@@ -93,7 +93,7 @@ module ActiveRecord
               base_name.foreign_key
             else
               if ActiveRecord::Base != self && table_exists?
-                pk = connection.schema_cache.primary_keys(table_name)
+                pk = schema_cache.primary_keys(table_name)
                 suppress_composite_primary_key(pk)
               else
                 "id"

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -468,8 +468,7 @@ module ActiveRecord
 
             columns.map do |name, column|
               if fixture.key?(name)
-                type = lookup_cast_type_from_column(column)
-                with_yaml_fallback(type.serialize(fixture[name]))
+                with_yaml_fallback(column.cast_type.serialize(fixture[name]))
               else
                 default_insert_value(column)
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -468,7 +468,8 @@ module ActiveRecord
 
             columns.map do |name, column|
               if fixture.key?(name)
-                with_yaml_fallback(column.cast_type.serialize(fixture[name]))
+                type = lookup_cast_type_from_column(column)
+                with_yaml_fallback(type.serialize(fixture[name]))
               else
                 default_insert_value(column)
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1475,6 +1475,7 @@ module ActiveRecord
           cast_type = lookup_cast_type(sql_type)
           SqlTypeMetadata.new(
             sql_type: sql_type,
+            cast_type: cast_type,
             type: cast_type.type,
             limit: cast_type.limit,
             precision: cast_type.precision,

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
       attr_reader :name, :default, :sql_type_metadata, :null, :default_function, :collation, :comment
 
-      delegate :precision, :scale, :limit, :type, :sql_type, to: :sql_type_metadata, allow_nil: true
+      delegate :precision, :scale, :limit, :type, :sql_type, :cast_type, to: :sql_type_metadata, allow_nil: true
 
       # Instantiates a new column in the table.
       #

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -679,6 +679,7 @@ module ActiveRecord
             cast_type = get_oid_type(oid, fmod, column_name, sql_type)
             simple_type = SqlTypeMetadata.new(
               sql_type: sql_type,
+              cast_type: cast_type,
               type: cast_type.type,
               limit: cast_type.limit,
               precision: cast_type.precision,

--- a/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
+++ b/activerecord/lib/active_record/connection_adapters/sql_type_metadata.rb
@@ -8,19 +8,21 @@ module ActiveRecord
     class SqlTypeMetadata
       include Deduplicable
 
-      attr_reader :sql_type, :type, :limit, :precision, :scale
+      attr_reader :sql_type, :cast_type, :type, :limit, :precision, :scale
 
-      def initialize(sql_type: nil, type: nil, limit: nil, precision: nil, scale: nil)
+      def initialize(sql_type: nil, cast_type: nil, type: nil, limit: nil, precision: nil, scale: nil)
         @sql_type = sql_type
         @type = type
         @limit = limit
         @precision = precision
         @scale = scale
+        @cast_type = cast_type
       end
 
       def ==(other)
         other.is_a?(SqlTypeMetadata) &&
           sql_type == other.sql_type &&
+          cast_type == other.cast_type &&
           type == other.type &&
           limit == other.limit &&
           precision == other.precision &&
@@ -31,6 +33,7 @@ module ActiveRecord
       def hash
         SqlTypeMetadata.hash ^
           sql_type.hash ^
+          cast_type.hash ^
           type.hash ^
           limit.hash ^
           precision.hash >> 1 ^

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -378,7 +378,7 @@ module ActiveRecord
 
       # Indicates whether the table associated with this class exists
       def table_exists?
-        connection.schema_cache.data_source_exists?(table_name)
+        schema_cache.data_source_exists?(table_name)
       end
 
       def attributes_builder # :nodoc:
@@ -523,6 +523,10 @@ module ActiveRecord
         end
 
       private
+        def schema_cache
+          connection_pool.schema_cache || connection.schema_cache
+        end
+
         def inherited(child_class)
           super
           child_class.initialize_load_schema_monitor
@@ -551,7 +555,7 @@ module ActiveRecord
             raise ActiveRecord::TableNotSpecified, "#{self} has no table configured. Set one with #{self}.table_name="
           end
 
-          columns_hash = connection.schema_cache.columns_hash(table_name)
+          columns_hash = schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
           @columns_hash.each do |name, column|

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -555,7 +555,7 @@ module ActiveRecord
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
           @columns_hash.each do |name, column|
-            type = connection.lookup_cast_type_from_column(column)
+            type = column.cast_type || connection.lookup_cast_type_from_column(column)
             type = _convert_type_from_options(type)
             warn_if_deprecated_type(column)
             define_attribute(

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -113,7 +113,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     Topic.reset_column_information
 
-    Topic.connection.stub(:lookup_cast_type_from_column, ->(_) { raise "Some Error" }) do
+    Topic.connection.stub(:type_map, -> { raise "Some Error" }) do
       assert_raises RuntimeError do
         Topic.columns_hash
       end

--- a/activerecord/test/cases/migration/change_schema_test.rb
+++ b/activerecord/test/cases/migration/change_schema_test.rb
@@ -70,8 +70,8 @@ module ActiveRecord
         five = columns.detect { |c| c.name == "five" } unless mysql
 
         assert_equal "hello", one.default
-        assert_equal true, connection.lookup_cast_type_from_column(two).deserialize(two.default)
-        assert_equal false, connection.lookup_cast_type_from_column(three).deserialize(three.default)
+        assert_equal true, two.cast_type.deserialize(two.default)
+        assert_equal false, three.cast_type.deserialize(three.default)
         assert_equal "1", four.default
         assert_equal "hello", five.default unless mysql
       end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -195,7 +195,7 @@ module ActiveRecord
 
         old_columns = connection.columns(TestModel.table_name)
         assert old_columns.find { |c|
-          default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
 
@@ -203,11 +203,11 @@ module ActiveRecord
         new_columns = connection.columns(TestModel.table_name)
 
         assert_not new_columns.find { |c|
-          default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == true
         }
         assert new_columns.find { |c|
-          default = connection.lookup_cast_type_from_column(c).deserialize(c.default)
+          default = c.cast_type.deserialize(c.default)
           c.name == "approved" && c.type == :boolean && default == false
         }
         change_column :test_models, :approved, :boolean, default: true

--- a/activerecord/test/cases/schema_loading_test.rb
+++ b/activerecord/test/cases/schema_loading_test.rb
@@ -42,6 +42,19 @@ class SchemaLoadingTest < ActiveRecord::TestCase
     assert_equal 2, klass.load_schema_calls
   end
 
+  def test_load_with_schema_cache_without_connecting
+    model_one = define_model
+    model_one.define_attribute_methods
+
+    model_two = define_model
+    assert_not_nil model_two.connection_pool.schema_cache
+    model_two.connection_pool.schema_cache.stub(:connection, :no_connection) do
+      ActiveRecord::Base.stub(:connection, :no_connection) do
+        model_two.define_attribute_methods
+      end
+    end
+  end
+
   private
     def define_model
       Class.new(ActiveRecord::Base) do

--- a/activerecord/test/cases/unconnected_test.rb
+++ b/activerecord/test/cases/unconnected_test.rb
@@ -34,7 +34,7 @@ class TestUnconnectedAdapter < ActiveRecord::TestCase
 
   def test_error_message_when_connection_not_established
     error = assert_raise(ActiveRecord::ConnectionNotEstablished) do
-      TestRecord.find(1)
+      TestRecord.connection
     end
 
     assert_equal "No connection pool for 'ActiveRecord::Base' found.", error.message


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/42077

### Context

For resiliency reasons, it is paramount that Rails is able to boot even if it can't connect to the database, right now it is achieved by skipping Active Record attribute methods definition if an error happens (Ref: https://github.com/rails/rails/pull/40119).

That's better than crashing, but it's far from ideal. I would like to refactor Active Record enough, that if you have a proper schema cache the entire eager loading can happen without connecting to the database at all.

This PR attempt to get us closer to that goal.

### This change

By looking up the schema cache on the `connection_pool` we avoid eagerly connecting to the database.

I'm not certain this is correct yet, as the schema cache is supposed to hold a connection to fallback on querying the database. So I might need to refactor the schema cache a bit more first. Or maybe even to refactor the adapters to not eagerly connect.
