### PR TITLE
Use beaneater 1.0.0 to workardound `ArgumentError: wrong number of arguments` error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :job do
   gem "sneakers", require: false
   gem "que", require: false
   gem "backburner", require: false
+  gem "beaneater", "=1.0.0", require: false
   gem "delayed_job_active_record", require: false
   gem "sequel", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,7 @@ DEPENDENCIES
   azure-storage-blob
   backburner
   bcrypt (~> 3.1.11)
+  beaneater (= 1.0.0)
   benchmark-ips
   blade
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
### Summary

This commit addresses Rails CI `ArgumentError: wrong number of arguments (given 2, expected 1)`
errors at https://buildkite.com/rails/rails/builds/76966#8aea460d-a196-4a38-a7dc-b41af5187d9a/1485-1518
by locking `beaneater` version to 1.0.0. Because `backburner` gem depends on `beaneater`.
and `beaneater` 1.1.0 has been released which triggers this error.

- Errors are reported at Rails CI
https://buildkite.com/rails/rails/builds/76966#8aea460d-a196-4a38-a7dc-b41af5187d9a/1485-1518

- Steps to reproduce
```ruby
git clone https://github.com/rails/rails
cd rails
rm Gemfile.lock
bundle install
cd activejob
bundle exec rake test:integration:backburner
```

- Expected behavior
It should pass.

- Actual behavior
ArgumentError: wrong number of arguments (given 2, expected 1)

This workaround can be removed once the newer versions of `beaneater` released including this pull request or similar fix.
https://github.com/beanstalkd/beaneater/pull/80

