### PR TITLE
Add network timeouts to ActionMailer SMTP

### DIFF
--- a/actionmailer/lib/action_mailer/delivery_methods.rb
+++ b/actionmailer/lib/action_mailer/delivery_methods.rb
@@ -24,6 +24,8 @@ module ActionMailer
         user_name:            nil,
         password:             nil,
         authentication:       nil,
+        open_timeout:         5,
+        read_timeout:         5,
         enable_starttls_auto: true
 
       add_delivery_method :file, Mail::FileDelivery,


### PR DESCRIPTION
The `mail` gem does not provide network timeouts by default. Rails should provide a sensible default.