### PR TITLE
More ruby 2.7 Syntax cleanup 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -258,9 +258,11 @@ Performance/FlatMap:
 
 Performance/MapCompact:
   Enabled: true
+  Exclude: []
 
 Performance/SelectMap:
   Enabled: true
+  Exclude: []
 
 Performance/RedundantMerge:
   Enabled: true

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1000,7 +1000,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_select_with_block
-    assert_equal [1], posts(:welcome).comments.select { |c| c.id == 1 }.map(&:id)
+    assert_equal [1], posts(:welcome).comments.filter_map { |c| c.id if c.id == 1 }
   end
 
   def test_select_with_block_and_dirty_target

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -500,7 +500,7 @@ class RelationTest < ActiveRecord::TestCase
   end
 
   def test_select_with_block
-    even_ids = Developer.all.select { |d| d.id % 2 == 0 }.map(&:id)
+    even_ids = Developer.all.filter_map { |d| d.id if d.id % 2 == 0 }
     assert_equal [2, 4, 6, 8, 10], even_ids.sort
   end
 


### PR DESCRIPTION
In addition of using ruby 2.7 syntax cleanup series.
Here are some more changes based on 
[https://blog.saeloun.com/2019/05/25/ruby-2-7-enumerable-filter-map.html](https://blog.saeloun.com/2019/05/25/ruby-2-7-enumerable-filter-map.html)