### PR TITLE
Updated actiontext package file to use latest version

### DIFF
--- a/actiontext/package.json
+++ b/actiontext/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rails/activestorage": "^6.0.0"
+    "@rails/activestorage": "7.0.0-alpha"
   },
   "peerDependencies": {
     "trix": "^1.2.0"


### PR DESCRIPTION
Since we are upgrading to rails 7, The action text file contains a dependency of active storage while is on version 6.0.0
This PR updated the actiontext package file to use the latest alpha release of activestorage