### PR TITLE
Revert "Merge pull request #42088 from yahonda/use_beaneater10"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ group :job do
   gem "sneakers", require: false
   gem "que", require: false
   gem "backburner", require: false
-  gem "beaneater", "=1.0.0", require: false
   gem "delayed_job_active_record", require: false
   gem "sequel", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,7 +578,6 @@ DEPENDENCIES
   azure-storage-blob
   backburner
   bcrypt (~> 3.1.11)
-  beaneater (= 1.0.0)
   benchmark-ips
   blade
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
### Summary
This pull request reverts #42088 because the newer version of beaneater 1.1.1 has been released including https://github.com/beanstalkd/beaneater/pull/80

- Command to revert the merge commit.
```
 git revert -m 1  0184a01
```
`