### PR TITLE
Fixed typo in new framework default template [ci skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -30,7 +30,7 @@
 
 # Change the format of the cache entry.
 # Changing this default means that all new cache entries added to the cache
-# will have a different format that is not support by Rails 6.1 applications.
+# will have a different format that is not supported by Rails 6.1 applications.
 # Only change this value after your application is fully deployed to Rails 7.0
 # and you have no plans to rollback.
 # config.active_support.cache_format_version = 7.0


### PR DESCRIPTION
Just checking if this is a typo in the new framework default template file for rails 7.0 