### PR TITLE
Cache and reuse generated attribute methods

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Cache and re-use generated attibute methods.
+
+    Generated methods with identical implementations will now share their instruction sequences
+    leading to reduced memory retention, and sligtly faster load time.
+
+    *Jean Boussier*
+
 *   Add `in: range`  parameter to `numericality` validator.
 
     *Michal Papis*

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -208,11 +208,33 @@ module ActiveModel
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
-        CodeGenerator.batch(self, __FILE__, __LINE__) do |owner|
+        CodeGenerator.batch(self, __FILE__, __LINE__) do |code_generator|
           attribute_method_matchers.each do |matcher|
-            matcher_new = matcher.method_name(new_name).to_s
-            matcher_old = matcher.method_name(old_name).to_s
-            define_proxy_call(owner, matcher_new, matcher_old, matcher.parameters)
+            method_name = matcher.method_name(new_name).to_s
+            target_name = matcher.method_name(old_name).to_s
+            parameters = matcher.parameters
+
+            mangled_name = target_name
+            unless NAME_COMPILABLE_REGEXP.match?(target_name)
+              mangled_name = "__temp__#{target_name.unpack1("h*")}"
+            end
+
+            code_generator.define_cached_method(method_name, as: mangled_name, namespace: :alias_attribute) do |batch|
+              body = if CALL_COMPILABLE_REGEXP.match?(target_name)
+                "self.#{target_name}(#{parameters || ''})"
+              else
+                call_args = [":'#{target_name}'"]
+                call_args << parameters if parameters
+                "send(#{call_args.join(", ")})"
+              end
+
+              modifier = matcher.parameters == FORWARD_PARAMETERS ? "ruby2_keywords " : ""
+
+              batch <<
+                "#{modifier}def #{mangled_name}(#{parameters || ''})" <<
+                body <<
+                "end"
+            end
           end
         end
       end
@@ -297,7 +319,7 @@ module ActiveModel
               if respond_to?(generate_method, true)
                 send(generate_method, attr_name.to_s, owner: owner)
               else
-                define_proxy_call(owner, method_name, matcher.target, matcher.parameters, attr_name.to_s)
+                define_proxy_call(owner, method_name, matcher.target, matcher.parameters, attr_name.to_s, namespace: :active_model)
               end
             end
           end
@@ -336,7 +358,37 @@ module ActiveModel
       end
 
       private
-        class CodeGenerator
+        class CodeGenerator # :nodoc:
+          class MethodSet
+            METHOD_CACHES = Hash.new { |h, k| h[k] = Module.new }
+
+            def initialize(namespace)
+              @cache = METHOD_CACHES[namespace]
+              @sources = []
+              @methods = {}
+            end
+
+            def define_cached_method(name, as: name)
+              name = name.to_sym
+              as = as.to_sym
+              @methods.fetch(name) do
+                unless @cache.method_defined?(as)
+                  yield @sources
+                end
+                @methods[name] = as
+              end
+            end
+
+            def apply(owner, path, line)
+              unless @sources.empty?
+                @cache.module_eval("# frozen_string_literal: true\n" + @sources.join(";"), path, line)
+              end
+              @methods.each do |name, as|
+                owner.define_method(name, @cache.instance_method(as))
+              end
+            end
+          end
+
           class << self
             def batch(owner, path, line)
               if owner.is_a?(CodeGenerator)
@@ -354,23 +406,16 @@ module ActiveModel
             @owner = owner
             @path = path
             @line = line
-            @sources = ["# frozen_string_literal: true\n"]
-            @renames = {}
+            @namespaces = Hash.new { |h, k| h[k] = MethodSet.new(k) }
           end
 
-          def <<(source_line)
-            @sources << source_line
-          end
-
-          def rename_method(old_name, new_name)
-            @renames[old_name] = new_name
+          def define_cached_method(name, namespace:, as: name, &block)
+            @namespaces[namespace].define_cached_method(name, as: as, &block)
           end
 
           def execute
-            @owner.module_eval(@sources.join(";"), @path, @line - 1)
-            @renames.each do |old_name, new_name|
-              @owner.alias_method new_name, old_name
-              @owner.undef_method old_name
+            @namespaces.each_value do |method_set|
+              method_set.apply(@owner, @path, @line - 1)
             end
           end
         end
@@ -404,37 +449,31 @@ module ActiveModel
         end
 
         # Define a method `name` in `mod` that dispatches to `send`
-        # using the given `extra` args. This falls back on `define_method`
-        # and `send` if the given names cannot be compiled.
-        def define_proxy_call(code_generator, name, target, parameters, *call_args)
+        # using the given `extra` args. This falls back on `send`
+        # if the called name cannot be compiled.
+        def define_proxy_call(code_generator, name, target, parameters, *call_args, namespace:)
           mangled_name = name
           unless NAME_COMPILABLE_REGEXP.match?(name)
             mangled_name = "__temp__#{name.unpack1("h*")}"
           end
 
-          call_args.map!(&:inspect)
-          call_args << parameters if parameters
+          code_generator.define_cached_method(name, as: mangled_name, namespace: namespace) do |batch|
+            call_args.map!(&:inspect)
+            call_args << parameters if parameters
 
-          body = if CALL_COMPILABLE_REGEXP.match?(target)
-            "self.#{target}(#{call_args.join(", ")})"
-          else
-            call_args.unshift(":'#{target}'")
-            "send(#{call_args.join(", ")})"
-          end
+            body = if CALL_COMPILABLE_REGEXP.match?(target)
+              "self.#{target}(#{call_args.join(", ")})"
+            else
+              call_args.unshift(":'#{target}'")
+              "send(#{call_args.join(", ")})"
+            end
 
-          code_generator <<
-            "def #{mangled_name}(#{parameters || ''})" <<
-            body <<
-            "end"
+            modifier = parameters == FORWARD_PARAMETERS ? "ruby2_keywords " : ""
 
-          if parameters == FORWARD_PARAMETERS
-            code_generator << "ruby2_keywords(:'#{mangled_name}')"
-          end
-
-          if mangled_name != name
-            code_generator <<
-              "alias_method(:'#{name}', :'#{mangled_name}')" <<
-              "remove_method(:'#{mangled_name}')"
+            batch <<
+              "#{modifier}def #{mangled_name}(#{parameters || ''})" <<
+              body <<
+              "end"
           end
         end
 
@@ -533,10 +572,6 @@ module ActiveModel
 
         # We want to generate the methods via module_eval rather than
         # define_method, because define_method is slower on dispatch.
-        # Evaluating many similar methods may use more memory as the instruction
-        # sequences are duplicated and cached (in MRI).  define_method may
-        # be slower on dispatch, but if you're careful about the closure
-        # created, then define_method will consume much less memory.
         #
         # But sometimes the database might return columns with
         # characters that are not allowed in normal method names (like
@@ -560,7 +595,6 @@ module ActiveModel
             temp_method_name = "__temp__#{safe_name}#{'=' if writer}"
             attr_name_expr = "::ActiveModel::AttributeMethods::AttrNames::#{const_name}"
             yield temp_method_name, attr_name_expr
-            owner.rename_method(temp_method_name, method_name)
           end
         end
       end

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -47,10 +47,12 @@ module ActiveModel
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
             owner, name, writer: true,
           ) do |temp_method_name, attr_name_expr|
-            owner <<
-              "def #{temp_method_name}(value)" <<
-              "  _write_attribute(#{attr_name_expr}, value)" <<
-              "end"
+            owner.define_cached_method("#{name}=", as: temp_method_name, namespace: :active_model) do |batch|
+              batch <<
+                "def #{temp_method_name}(value)" <<
+                "  _write_attribute(#{attr_name_expr}, value)" <<
+                "end"
+            end
           end
         end
 

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -11,10 +11,12 @@ module ActiveRecord
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
               owner, name
             ) do |temp_method_name, attr_name_expr|
-              owner <<
-                "def #{temp_method_name}" <<
-                "  _read_attribute(#{attr_name_expr}) { |n| missing_attribute(n, caller) }" <<
-                "end"
+              owner.define_cached_method(name, as: temp_method_name, namespace: :active_record) do |batch|
+                batch <<
+                  "def #{temp_method_name}" <<
+                  "  _read_attribute(#{attr_name_expr}) { |n| missing_attribute(n, caller) }" <<
+                  "end"
+              end
             end
           end
       end

--- a/activerecord/lib/active_record/attribute_methods/write.rb
+++ b/activerecord/lib/active_record/attribute_methods/write.rb
@@ -15,10 +15,12 @@ module ActiveRecord
             ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(
               owner, name, writer: true,
             ) do |temp_method_name, attr_name_expr|
-              owner <<
-                "def #{temp_method_name}(value)" <<
-                "  _write_attribute(#{attr_name_expr}, value)" <<
-                "end"
+              owner.define_cached_method("#{name}=", as: temp_method_name, namespace: :active_record) do |batch|
+                batch <<
+                  "def #{temp_method_name}(value)" <<
+                  "  _write_attribute(#{attr_name_expr}, value)" <<
+                  "end"
+              end
             end
           end
       end


### PR DESCRIPTION
### Context

By experimenting with https://github.com/rails/rails/pull/42085, I was able to better profile our application, which made me realize that `define_attribute_methods` was responsible for about `140MB` of total resident memory as well as for `~15%` of boot time in our app. Of course you mileage may vary based on the size of the app.

The main bulk of the extra memory is from `CodeGenerator`:

```
retained memory by file
-----------------------------------
...
 125.79 MB  rails-5e55ac69d843/activemodel/lib/active_model/attribute_methods.rb
```


A quick digging session shows that we have `238k` attribute methods, but only `50k (21%)` of them are unique:
```ruby
>> attr_methods = ActiveRecord::Base.descendants.flat_map { |m| m.send(:generated_attribute_methods).public_instance_methods(false) }; nil
=> nil
>> attr_methods.size
=> 238818
>> attr_methods.uniq.size
=> 50707
```

So if we were to be able to re-use them, we could theoretically cut that resident memory by `~80%`, so cut our total memory usage by `~88MB` (on the totally wrong assumption that sharing a method has no overhead, but it's just for napkin math needs).

Looking at the detail of the duplicated methods, it's pretty clear what going on:
```ruby
>> attr_methods.group_by(&:itself).transform_values(&:size).sort_by(&:last).reverse.take(20)
=> [[:clear_id_change, 875],
 [:id_previously_was, 875],
 [:id_previous_change, 875],
 [:id_previously_changed?, 875],
 [:id_changed?, 875],
 [:id_change, 875],
 [:id_will_change!, 875],
 [:saved_change_to_id?, 875],
 [:id_change_to_be_saved, 875],
 [:will_save_change_to_id?, 875],
 [:id_before_last_save, 875],
 [:saved_change_to_id, 875],
 [:id_came_from_user?, 875],
 [:restore_id!, 875],
 [:created_at_was, 859],
 [:created_at_will_change!, 859],
 [:created_at, 859],
 [:created_at_change, 859],
 [:will_save_change_to_created_at?, 859],
 [:created_at_change_to_be_saved, 859]]
```

Just from that you can easily infer that we have 875 `ActiveRecord::Base` descendants, and that the vast majority of them have a `created_at` and `updated_at` column. Then we have a long tail of other popular column names across models, some fairly specific to our usage, such as `shop_id (817)`, but many that shouldn't be too uncommon in most apps such as `type (250)`, `deleted_at (171)`, `name (141)`, `title (72)`, etc.

Overall I think it's fair to assume attribute names are not random, and that it's common for an attribute name to be shared across multiple models.

### micro benchmarks

Based on the above analysis I wondered wether we could use `define_method(name, UnboundMethod)` to share the MRI `InstructionSequence` between these similar methods, and wether it's effective:

```ruby
# frozen_string_literal: true
require 'heap-profiler'

class GeneratedAttributeMethods < Module
end

cache = GeneratedAttributeMethods.new

CACHE = {}
50_000.times do |i|
  meth_name = "foo_#{i}"
  cache.module_eval("def #{meth_name}; 42; end")
  CACHE[meth_name] = cache.instance_method(meth_name)
end

mods = 5.times.map { GeneratedAttributeMethods.new }

$names = 25.times.map { |i| "foo_#{i}" }

if ARGV.first == 'cache'
  def def_methods(mod)
    $names.each do |name|
      mod.define_method(name, CACHE[name])
    end
  end
else
  def def_methods(mod)
    mod.module_eval($names.map { |m| "def #{m}; 42; end" }.join(";"))
  end
end

HeapProfiler.report("/tmp/heap-prof-#{ARGV.first || 'orig'}") do
  mods.each { |m| def_methods(m) }
end
```

```bash
$ heap-profiler /tmp/heap-prof-orig/ | grep 'Total retained'
Total retained: 59.67 kB (391 objects)
$ heap-profiler /tmp/heap-prof-cache/ | grep 'Total retained'
Total retained: 6.44 kB (136 objects)
```

Answer, looks like yes.

### This patch

So once the above is laid out, I believe the change is quite straightforward. Rather than directly generating the method code in each `generated_attribute_methods` modules, we first define them in a central "cache" module, and then copy them from the cache into the final module.

### Actual effect

I tried this patch against our app, the retained memory reduction was about `80MB`, so not far off from the napkin math.

```
retained memory by file
-----------------------------------
...
  46.35 MB  rails-88a98efb114b/activemodel/lib/active_model/attribute_methods.rb
```

### Backward compatibility

Unfortunately at this stage there's one backward incompatibility issue that might break gems using the `define_method_attribute*` API, such as my own `frozen_record`: https://github.com/byroot/frozen_record/blob/42e41eb60d17df6a692e2e18e2ea7af6a28265b9/lib/frozen_record/compact.rb#L29-L31

This whole caching strategy assumes that two attribute methods with the same name will have the same source code. The ability for subclasses to define `define_method_attribute*` breaks this assumption. 

So I need to find a way to handle this. 
