### PR TITLE
Specify rails --version check should be in a new terminal

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -154,7 +154,7 @@ $ gem install rails
 ```
 
 To verify that you have everything installed correctly, you should be able to
-run the following:
+run the following in a new terminal:
 
 ```bash
 $ rails --version


### PR DESCRIPTION
### Summary

After doing gem install rails, your environment won't pick up the fact you have rails installed unless you create a new terminal window for it. This can trip people up, so adding a few words to the guide will prevent people from having to search for [why Rails is needing to be installed as root](https://stackoverflow.com/questions/7788946/rails-keeps-telling-me-that-its-not-currently-installed). Worse, without that guidance, many people will install rails as root, when that is unnecessary.

