### PR TITLE
Extract and optimize virtual path building

### DIFF
--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -15,11 +15,18 @@ module ActionView
       attr_reader :name, :prefix, :partial, :virtual
       alias_method :partial?, :partial
 
+      def self.virtual(name, prefix, partial)
+        if prefix.empty?
+          "#{partial ? "_" : ""}#{name}"
+        elsif partial
+          "#{prefix}/_#{name}"
+        else
+          "#{prefix}/#{name}"
+        end
+      end
+
       def self.build(name, prefix, partial)
-        virtual = +""
-        virtual << "#{prefix}/" unless prefix.empty?
-        virtual << (partial ? "_#{name}" : name)
-        new name, prefix, partial, virtual
+        new name, prefix, partial, virtual(name, prefix, partial)
       end
 
       def initialize(name, prefix, partial, virtual)


### PR DESCRIPTION
This updates `Resolver::Path.build` to only allocate a single string when building the virtual path. Also separated into its own method so that it can be used on its own.

```
Before:  build      1.759M (± 0.4%) i/s -      8.855M in   5.034065s
After:   build      2.700M (± 0.8%) i/s -     13.584M in   5.031691s
```