### PR TITLE
Include code to hide archived comments

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1772,6 +1772,21 @@ Then, in our `index` action template (`app/views/articles/index.html.erb`) we wo
 <%= link_to "New Article", new_article_path %>
 ```
 
+Similarly, in our comment partial view (`app/views/comments/_comment.html.erb`) we would used the `archived?` method to avoid displaying any comment that is archived:
+```html+erb
+<% unless comment.archived? %>
+  <p>
+    <strong>Commenter:</strong>
+    <%= comment.commenter %>
+  </p>
+
+  <p>
+    <strong>Comment:</strong>
+    <%= comment.body %>
+  </p>
+<% end %>
+```
+
 However, if you look again at our models now, you can see that the logic is duplicated. If in the future we increase the functionality of our blog - to include private messages, for instance -  we might find ourselves duplicating the logic yet again. This is where concerns come in handy.
 
 A concern is only responsible for a focused subset of the model's responsibility; the methods in our concern will all be related to the visibility of a model. Let's call our new concern (module) `Visible`. We can create a new file inside `app/models/concerns` called `visible.rb` , and store all of the status methods that were duplicated in the models.

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1773,6 +1773,7 @@ Then, in our `index` action template (`app/views/articles/index.html.erb`) we wo
 ```
 
 Similarly, in our comment partial view (`app/views/comments/_comment.html.erb`) we would used the `archived?` method to avoid displaying any comment that is archived:
+
 ```html+erb
 <% unless comment.archived? %>
   <p>


### PR DESCRIPTION
Added code to only show non-archived comments, since we allow them to have archived as a status

### Summary

I added a section that shows the code to be added to ensure that only comments that don't have a status of `archived` will be shown, similar to only showing non-archived articles. Without this statement, if I create a comment with a status of `archived`, the comment still shows upon creation.
