### PR TITLE
Allow access to nested secrets by method calls

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Allow nested access to keys on `Rails.application.credentials`
+
+    Previously only top level keys in `credentials.yml.enc` could be accessed with method calls. Now any key can.
+
+    For example, given these secrets:
+
+    ```yml
+    aws:
+       access_key_id: 123
+       secret_access_key: 345
+    ```
+
+    `Rails.application.credentials.aws.access_key_id` will now return the same thing as `Rails.application.credentials.aws[:access_key_id]`
+
+    *Alex Ghiculescu*
+
 *   Added a faster and more compact `ActiveSupport::Cache` serialization format.
 
     It can be enabled with `config.active_support.cache_format_version = 7.0` or

--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -34,8 +34,12 @@ module ActiveSupport
     end
 
     private
+      def deep_transform(hash)
+        hash.transform_values { |value| value.is_a?(Hash) ? ActiveSupport::InheritableOptions.new(deep_transform(value)) : value }
+      end
+
       def options
-        @options ||= ActiveSupport::InheritableOptions.new(config)
+        @options ||= ActiveSupport::InheritableOptions.new(deep_transform(config))
       end
 
       def deserialize(config)

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -37,9 +37,14 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
   end
 
   test "reading configuration by key file" do
-    @credentials.write({ something: { good: true } }.to_yaml)
+    @credentials.write({ something: { good: true, bad: false, nested: { foo: "bar" } } }.to_yaml)
 
     assert @credentials.something[:good]
+    assert_not @credentials.something[:bad]
+    assert @credentials.something.good
+    assert_not @credentials.something.bad
+    assert_equal "bar", @credentials.dig(:something, :nested, :foo)
+    assert_equal "bar", @credentials.something.nested.foo
   end
 
   test "reading comment-only configuration" do

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1163,9 +1163,11 @@ For example, with the following decrypted `config/credentials.yml.enc`:
 ```yaml
 secret_key_base: 3b7cd72...
 some_api_key: SOMEKEY
+system:
+  access_key_id: 1234AB
 ```
 
-`Rails.application.credentials.some_api_key` returns `"SOMEKEY"`.
+`Rails.application.credentials.some_api_key` returns `"SOMEKEY"`. `Rails.application.credentials.system.access_key_id` returns `"1234AB"`.
 
 If you want an exception to be raised when some key is blank, you can use the bang
 version:


### PR DESCRIPTION
In a new Rails app, the generated credentials file contains an example of some [nested secrets](https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/railties/lib/rails/generators/rails/credentials/credentials_generator.rb#L46).

Currently you can't access them nicely the way you would top level secrets:

```
2.7.3 :001 > Rails.application.credentials.aws
 => {:access_key_id=>123, :secret_access_key=>345}
2.7.3 :002 > Rails.application.credentials.aws.access_key_id
Traceback (most recent call last):
        1: from (irb):2
NoMethodError (undefined method `access_key_id' for {:access_key_id=>123, :secret_access_key=>345}:Hash)
```

It would make secrets easier to use if you could, so this PR adds support for that. `Rails.application.credentials.aws.access_key_id` will now return `123` in the above example.

The old method of hash access remains unchanged.