### PR TITLE
Corrects #to_sentence documentation for :words_connector [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -16,12 +16,12 @@ class Array
   #
   # ==== Options
   #
-  # * <tt>:words_connector</tt> - The sign or word used to join the elements
-  #   in arrays with two or more elements (default: ", ").
-  # * <tt>:two_words_connector</tt> - The sign or word used to join the elements
-  #   in arrays with two elements (default: " and ").
+  # * <tt>:words_connector</tt> - The sign or word used to join all but the last
+  #   element in arrays with three or more elements (default: ", ").
   # * <tt>:last_word_connector</tt> - The sign or word used to join the last element
   #   in arrays with three or more elements (default: ", and ").
+  # * <tt>:two_words_connector</tt> - The sign or word used to join the elements
+  #   in arrays with two elements (default: " and ").
   # * <tt>:locale</tt> - If +i18n+ is available, you can set a locale and use
   #   the connector options defined on the 'support.array' namespace in the
   #   corresponding dictionary file.


### PR DESCRIPTION
### Summary

When using `#to_sentence`, the `:words_connector` argument is only used on arrays with three or more elements.

This change fixes a small mistake in the documentation which claimed that `:words_connector` would be used for arrays of two or more elements.

The small discrepancy can cause a developer a short minute or two fumbling with the arguments to achieve the desired result. Hopefully this change will make the intended usage more clear.

### Other Information

This also shifts the `:words_connector` information to come after the `:two_words_connector` and `:last_word_connector` for a better logical grouping of the entries (array sizings: [2,3,3]; values: [and, and, comma]) now that the correction is in place.