### PR TITLE
Remove aliases with two letter:

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -34,12 +34,9 @@ module Rails
         actions: "-a",
         orm: "-o",
         javascripts: "-j",
-        javascript_engine: "-je",
         resource_controller: "-c",
         scaffold_controller: "-c",
         stylesheets: "-y",
-        stylesheet_engine: "-se",
-        scaffold_stylesheet: "-ss",
         template_engine: "-e",
         test_framework: "-t"
       },


### PR DESCRIPTION
There a issues is use more than one character to use as aliases
https://github.com/erikhuda/thor/blob/a5cbed8/lib/thor/base.rb#L307

So, for this change the convention is remove the two letters aliases
https://github.com/rails/rails/pull/38813

