### PR TITLE
Simplify `Session.sweep` method example in security doc [ci skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -211,15 +211,11 @@ Another countermeasure is to _save user-specific properties in the session_, ver
 
 NOTE: _Sessions that never expire extend the time-frame for attacks such as cross-site request forgery (CSRF), session hijacking, and session fixation._
 
-One possibility is to set the expiry time-stamp of the cookie with the session ID. However the client can edit cookies that are stored in the web browser so expiring sessions on the server is safer. Here is an example of how to _expire sessions in a database table_. Call `Session.sweep("20 minutes")` to expire sessions that were used longer than 20 minutes ago.
+One possibility is to set the expiry time-stamp of the cookie with the session ID. However the client can edit cookies that are stored in the web browser so expiring sessions on the server is safer. Here is an example of how to _expire sessions in a database table_. Call `Session.sweep(20.minutes)` to expire sessions that were used longer than 20 minutes ago.
 
 ```ruby
 class Session < ApplicationRecord
   def self.sweep(time = 1.hour)
-    if time.is_a?(String)
-      time = time.split.inject { |count, unit| count.to_i.send(unit) }
-    end
-
     where("updated_at < ?", time.ago.to_s(:db)).delete_all
   end
 end


### PR DESCRIPTION

This pull request simplifies `Session.sweep` method implementation example in the security guide. 
I removed the String to Time conversion of `Session.sweep` method.

I think removing the conversion introduces two benefits.


First, the method will focus on the main feature, which is expiring old sessions, by this change.
The conversion is not required to understand how to expire sessions. And the implementation is a bit difficult. So it will be easy to understand by removing it, but it still describes the main feature.


Second, the conversion introduces security issues.
It uses `Kernel.#send` method, so any methods of Integer are callable via the argument. For example, `Session.sweep('42 sleep')` sleeps forever.
Actually, it doesn't become a problem rarely. But I think the potential problem is not appropriate for the "security" document.


