### PR TITLE
Describe unsafe usage of `invert_where` method [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -710,6 +710,18 @@ module ActiveRecord
     #
     #   User.active.invert_where
     #   # WHERE NOT (`accepted` = 1 AND `locked` = 0)
+    #
+    # Be careful because this inverts all conditions before `invert_where` call.
+    #
+    #   class User
+    #     scope :active, -> { where(accepted: true, locked: false) }
+    #     scope :inactive, -> { active.invert_where } # Do not attempt it
+    #   end
+    #
+    #   # It also inverts `where(role: 'admin')` unexpectedly.
+    #   User.where(role: 'admin').inactive
+    #   # WHERE NOT (`role` = 'admin' AND `accepted` = 1 AND `locked` = 0)
+    #
     def invert_where
       spawn.invert_where!
     end


### PR DESCRIPTION
`invert_where` method has been added by #40249.
This pull request adds documentation of unsafe usage of `invert_where`.




As https://github.com/rails/rails/pull/40249#issuecomment-826881180, this method is dangerous.
Because it inverts all conditions before `invert_where` call.

For example


```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "activerecord", github: 'rails/rails', ref: 'be630f7d1d948c274bbb67ab6ed2148c539c9b8c'
  gem "activemodel", github: 'rails/rails', ref: 'be630f7d1d948c274bbb67ab6ed2148c539c9b8c'
  gem "activesupport", github: 'rails/rails', ref: 'be630f7d1d948c274bbb67ab6ed2148c539c9b8c'
  gem "sqlite3"
end

require "active_record"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

ActiveRecord::Schema.define do
  create_table :users, force: true do |t|
    t.string :role
    t.boolean :accepted
    t.boolean :locked
  end
end

class User < ActiveRecord::Base
  scope :active, -> { where(accepted: true, locked: false) }
  scope :inactive, -> { active.invert_where } # Do not attempt it
end
                                                                  
puts User.where(role: 'admin').inactive.to_sql
# SELECT "users".* FROM "users" WHERE NOT ("users"."role" = 'admin' AND "users"."accepted" = 1 AND "users"."locked" = 0)
```


On the last line, `User.where(role: 'admin').inactive` inverts `where(role: 'admin')` unexpectedly.


But the current documentation only describes a single `where` method call case. So we can understand how `where(...).invert_where` works, but cannot understand how `where(...).where(...).invert_where` works from the document.

This behavior can become a bug, so the documentation should describe the behavior.


---


By the way, I'm wondering if adding it should be reverted. Because it is too dangerous IMO. I will not use this method for my project to avoid problems.
But I think it needs the document to describe the risk at least.


I also opened an issue to rubocop-rails for this method. https://github.com/rubocop/rubocop-rails/issues/470
