### PR TITLE
Improve guide of Command Line Injection [ci skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -876,13 +876,42 @@ If you use the [in_place_editor plugin](https://rubygems.org/gems/in_place_editi
 
 NOTE: _Use user-supplied command line parameters with caution._
 
-If your application has to execute commands in the underlying operating system, there are several methods in Ruby: `exec(command)`, `syscall(command)`, `system(command)` and `command`. You will have to be especially careful with these functions if the user may enter the whole command, or a part of it. This is because in most shells, you can execute another command at the end of the first one, concatenating them with a semicolon (`;`) or a vertical bar (`|`).
+If your application has to execute commands in the underlying operating system, there are several methods in Ruby: `system(command)`, `exec(command)`, `spawn(command)` and `` `command` ``. You will have to be especially careful with these functions if the user may enter the whole command, or a part of it. This is because in most shells, you can execute another command at the end of the first one, concatenating them with a semicolon (`;`) or a vertical bar (`|`).
+
+```ruby
+user_input = "hello; rm *"
+system("/bin/echo #{user_input}")
+# prints "hello", and deletes files in the current directory
+```
 
 A countermeasure is to _use the `system(command, parameters)` method which passes command line parameters safely_.
 
 ```ruby
 system("/bin/echo","hello; rm *")
 # prints "hello; rm *" and does not delete files
+```
+
+#### Kernel#open's vulnerability
+
+`Kernel#open` executes OS command if the argument starts with a vertical bar (`|`).
+
+```ruby
+open('| ls') { |f| f.read }
+# returns file list as a String via `ls` command
+```
+
+Countermeasures are to use `File.open`, `IO.open` or `URI#open` instead. They don't execute an OS command.
+
+```ruby
+File.open('| ls') { |f| f.read }
+# doesn't execute `ls` command, just opens `| ls` file if it exists
+
+IO.open(0) { |f| f.read }
+# opens stdin. doesn't accept a String as the argument
+
+require 'open-uri'
+URI('https://example.com').open { |f| f.read }
+# opens the URI. `URI()` doesn't accept `| ls`
 ```
 
 ### Header Injection


### PR DESCRIPTION
This pull request improves the guide of Command Line Injection section on the security page.


I made four changes.


## Remove `syscall`

The document mentioned `syscall` method to list methods that execute OS command. But it is not appropriate. `syscall` method's main feature is executing a system call, but not executing an OS command.
It is possible to execute a command with a vulnerability if it executes a shell with `execve` syscall, but it is a super rare case.
So I replaced `syscall` with `spawn` method, and reordered the list.


## Fix markdown of the backtick method


The method list also includes the backtick method, but it conflicted with the markdown notation.
So I surrounded it with double-backtick to avoid conflict.

before

![210502130131](https://user-images.githubusercontent.com/4361134/116801632-91f8e380-ab46-11eb-982a-fa9ad5442ba0.png)


after

![210502130138](https://user-images.githubusercontent.com/4361134/116801633-932a1080-ab46-11eb-940c-6254f35a062a.png)



The `command` means backtick method because previously the `command` is only surrounded by backticks. https://github.com/rails/rails/pull/38610/files#diff-c0f0426bb88e0814669f4262e038f0c9a99a72e1c6b4808ffb3c69aceda0065eL905

## Add a vulnerable example


The document has a countermeasure example, but it doesn't describe vulnerable code.
So I added a vulnerable example to clear the problem. 

## Add a section of `Kernel#open` method


`Kernel#open` method is one of the most common causes of OS command injection,  but the document doesn't mention the method.
So I added a section to describe `Kernel#open` method.

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/Open
https://blog.heroku.com/identifying-ruby-ftp-cve