### PR TITLE
Stop implicitly coercing objects to string in Safebuffer

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2610,7 +2610,9 @@ module ActionView
               else
                 options[:child_index] = nested_child_index(name)
               end
-              output << fields_for_nested_model("#{name}[#{options[:child_index]}]", child, options, block)
+              if content = fields_for_nested_model("#{name}[#{options[:child_index]}]", child, options, block)
+                output << content
+              end
             end
             output
           elsif association

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -923,7 +923,7 @@ module ActionView
 
         def form_tag_with_body(html_options, content)
           output = form_tag_html(html_options)
-          output << content
+          output << content.to_s if content
           output.safe_concat("</form>")
         end
 

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Deprecate `ActiveSupport::SafeBuffer`'s incorrect implicit conversion of objects into string.
+
+    Except for a few methods like `String#%`, objects must implement `#to_str`
+    to be implictly converted to a String in string operations. In some
+    circumstances `ActiveSupport::SafeBuffer` was incorrectly calling the
+    explicit conversion method (`#to_s`) on them. This behavior is now
+    deprecated.
+
+    *Jean Boussier*
+
 *   Allow nested access to keys on `Rails.application.credentials`
 
     Previously only top level keys in `credentials.yml.enc` could be accessed with method calls. Now any key can.


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/22947

Interestingly enough there's a test for that behavior, but I still think it's unintentional. Not sure if we should go through a deprecation cycle first, but what's certain is that calling `to_s` is wrong. When doing implicit conversions like this we should call `to_str`.

