### PR TITLE
clean up Arel::Visitors::Dot

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `Arel::Visitors::Dot` now renders a complete set of properties when visiting
+    `Arel::Nodes::SelectCore`, `SelectStatement`, `InsertStatement`, `UpdateStatement`, and
+    `DeleteStatement`, which fixes #42026. Previously, some properties were omitted.
+
+    *Mike Dalessio*
+
 *   `Arel::Visitors::Dot` now supports `Arel::Nodes::Bin`, `Case`, `CurrentRow`, `Distinct`,
     `DistinctOn`, `Else`, `Except`, `InfixOperation`, `Intersect`, `Lock`, `NotRegexp`, `Quoted`,
     `Regexp`, `UnaryOperation`, `Union`, `UnionAll`, `When`, and `With`. Previously, these node

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `Arel::Visitors::Dot` now supports `Arel::Nodes::Bin`, `Case`, `CurrentRow`, `Distinct`,
+    `DistinctOn`, `Else`, `Except`, `InfixOperation`, `Intersect`, `Lock`, `NotRegexp`, `Quoted`,
+    `Regexp`, `UnaryOperation`, `Union`, `UnionAll`, `When`, and `With`. Previously, these node
+    types caused an exception to be raised by `Arel::Visitors::Dot#accept`.
+
+    *Mike Dalessio*
+
 *   Optimize `remove_columns` to use a single SQL statement.
 
     ```ruby

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -73,26 +73,23 @@ module Arel # :nodoc: all
           visit_edge o, "wheres"
         end
 
-        def window(o)
+        def visit_Arel_Nodes_Window(o)
           visit_edge o, "partitions"
           visit_edge o, "orders"
           visit_edge o, "framing"
         end
-        alias :visit_Arel_Nodes_Window            :window
 
-        def named_window(o)
+        def visit_Arel_Nodes_NamedWindow(o)
           visit_edge o, "partitions"
           visit_edge o, "orders"
           visit_edge o, "framing"
           visit_edge o, "name"
         end
-        alias :visit_Arel_Nodes_NamedWindow       :named_window
 
-        def extract(o)
+        def visit_Arel_Nodes_Extract(o)
           visit_edge o, "expressions"
           visit_edge o, "alias"
         end
-        alias :visit_Arel_Nodes_Extract :extract
 
         def visit_Arel_Nodes_NamedFunction(o)
           visit_edge o, "name"
@@ -111,7 +108,7 @@ module Arel # :nodoc: all
           visit_edge o, "source"
           visit_edge o, "projections"
           visit_edge o, "wheres"
-          visit_edge o,  "windows"
+          visit_edge o, "windows"
         end
 
         def visit_Arel_Nodes_SelectStatement(o)
@@ -147,12 +144,11 @@ module Arel # :nodoc: all
           visit_edge o, "name"
         end
 
-        def nary(o)
-          o.children.each_with_index do |x, i|
-            edge(i) { visit x }
+        def visit_Arel_Nodes_And(o)
+          o.children.each_with_index do |child, i|
+            edge(i) { visit child }
           end
         end
-        alias :visit_Arel_Nodes_And :nary
 
         def visit_String(o)
           @node_stack.last.fields << o

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -166,22 +166,22 @@ module Arel # :nodoc: all
         alias :visit_Arel_Nodes_SqlLiteral :visit_String
 
         def visit_Arel_Nodes_BindParam(o)
-          edge("value") { visit o.value }
+          visit_edge(o, "value")
         end
 
         def visit_ActiveModel_Attribute(o)
-          edge("value_before_type_cast") { visit o.value_before_type_cast }
+          visit_edge(o, "value_before_type_cast")
         end
 
         def visit_Hash(o)
           o.each_with_index do |pair, i|
-            edge("pair_#{i}")   { visit pair }
+            edge("pair_#{i}") { visit pair }
           end
         end
 
         def visit_Array(o)
-          o.each_with_index do |x, i|
-            edge(i) { visit x }
+          o.each_with_index do |member, i|
+            edge(i) { visit member }
           end
         end
         alias :visit_Set :visit_Array

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -31,6 +31,21 @@ module Arel # :nodoc: all
       end
 
       private
+        def visit_Arel_Nodes_Function(o)
+          visit_edge o, "expressions"
+          visit_edge o, "distinct"
+          visit_edge o, "alias"
+        end
+
+        def visit_Arel_Nodes_Unary(o)
+          visit_edge o, "expr"
+        end
+
+        def visit_Arel_Nodes_Binary(o)
+          visit_edge o, "left"
+          visit_edge o, "right"
+        end
+
         def visit_Arel_Nodes_Ordering(o)
           visit_edge o, "expr"
         end
@@ -53,39 +68,10 @@ module Arel # :nodoc: all
           visit_edge o, "left"
         end
 
-        def visit_Arel_Nodes_InnerJoin(o)
-          visit_edge o, "left"
-          visit_edge o, "right"
-        end
-        alias :visit_Arel_Nodes_FullOuterJoin  :visit_Arel_Nodes_InnerJoin
-        alias :visit_Arel_Nodes_OuterJoin      :visit_Arel_Nodes_InnerJoin
-        alias :visit_Arel_Nodes_RightOuterJoin :visit_Arel_Nodes_InnerJoin
-
         def visit_Arel_Nodes_DeleteStatement(o)
           visit_edge o, "relation"
           visit_edge o, "wheres"
         end
-
-        def unary(o)
-          visit_edge o, "expr"
-        end
-        alias :visit_Arel_Nodes_Group             :unary
-        alias :visit_Arel_Nodes_Cube              :unary
-        alias :visit_Arel_Nodes_RollUp            :unary
-        alias :visit_Arel_Nodes_GroupingSet       :unary
-        alias :visit_Arel_Nodes_GroupingElement   :unary
-        alias :visit_Arel_Nodes_Grouping          :unary
-        alias :visit_Arel_Nodes_Having            :unary
-        alias :visit_Arel_Nodes_Limit             :unary
-        alias :visit_Arel_Nodes_Not               :unary
-        alias :visit_Arel_Nodes_Offset            :unary
-        alias :visit_Arel_Nodes_On                :unary
-        alias :visit_Arel_Nodes_UnqualifiedColumn :unary
-        alias :visit_Arel_Nodes_OptimizerHints    :unary
-        alias :visit_Arel_Nodes_Preceding         :unary
-        alias :visit_Arel_Nodes_Following         :unary
-        alias :visit_Arel_Nodes_Rows              :unary
-        alias :visit_Arel_Nodes_Range             :unary
 
         def window(o)
           visit_edge o, "partitions"
@@ -101,17 +87,6 @@ module Arel # :nodoc: all
           visit_edge o, "name"
         end
         alias :visit_Arel_Nodes_NamedWindow       :named_window
-
-        def function(o)
-          visit_edge o, "expressions"
-          visit_edge o, "distinct"
-          visit_edge o, "alias"
-        end
-        alias :visit_Arel_Nodes_Exists :function
-        alias :visit_Arel_Nodes_Min    :function
-        alias :visit_Arel_Nodes_Max    :function
-        alias :visit_Arel_Nodes_Avg    :function
-        alias :visit_Arel_Nodes_Sum    :function
 
         def extract(o)
           visit_edge o, "expressions"
@@ -178,30 +153,6 @@ module Arel # :nodoc: all
           end
         end
         alias :visit_Arel_Nodes_And :nary
-
-        def binary(o)
-          visit_edge o, "left"
-          visit_edge o, "right"
-        end
-        alias :visit_Arel_Nodes_As                 :binary
-        alias :visit_Arel_Nodes_Assignment         :binary
-        alias :visit_Arel_Nodes_Between            :binary
-        alias :visit_Arel_Nodes_Concat             :binary
-        alias :visit_Arel_Nodes_DoesNotMatch       :binary
-        alias :visit_Arel_Nodes_Equality           :binary
-        alias :visit_Arel_Nodes_GreaterThan        :binary
-        alias :visit_Arel_Nodes_GreaterThanOrEqual :binary
-        alias :visit_Arel_Nodes_In                 :binary
-        alias :visit_Arel_Nodes_JoinSource         :binary
-        alias :visit_Arel_Nodes_LessThan           :binary
-        alias :visit_Arel_Nodes_LessThanOrEqual    :binary
-        alias :visit_Arel_Nodes_IsNotDistinctFrom  :binary
-        alias :visit_Arel_Nodes_IsDistinctFrom     :binary
-        alias :visit_Arel_Nodes_Matches            :binary
-        alias :visit_Arel_Nodes_NotEqual           :binary
-        alias :visit_Arel_Nodes_NotIn              :binary
-        alias :visit_Arel_Nodes_Or                 :binary
-        alias :visit_Arel_Nodes_Over               :binary
 
         def visit_String(o)
           @node_stack.last.fields << o

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -46,6 +46,25 @@ module Arel # :nodoc: all
           visit_edge o, "right"
         end
 
+        def visit_Arel_Nodes_UnaryOperation(o)
+          visit_edge o, "operator"
+          visit_edge o, "expr"
+        end
+
+        def visit_Arel_Nodes_InfixOperation(o)
+          visit_edge o, "operator"
+          visit_edge o, "left"
+          visit_edge o, "right"
+        end
+
+        def visit__regexp(o)
+          visit_edge o, "left"
+          visit_edge o, "right"
+          visit_edge o, "case_sensitive"
+        end
+        alias :visit_Arel_Nodes_Regexp :visit__regexp
+        alias :visit_Arel_Nodes_NotRegexp :visit__regexp
+
         def visit_Arel_Nodes_Ordering(o)
           visit_edge o, "expr"
         end
@@ -85,6 +104,12 @@ module Arel # :nodoc: all
           visit_edge o, "framing"
           visit_edge o, "name"
         end
+
+        def visit__no_edges(o)
+          # intentionally left blank
+        end
+        alias :visit_Arel_Nodes_CurrentRow :visit__no_edges
+        alias :visit_Arel_Nodes_Distinct :visit__no_edges
 
         def visit_Arel_Nodes_Extract(o)
           visit_edge o, "expressions"
@@ -144,11 +169,13 @@ module Arel # :nodoc: all
           visit_edge o, "name"
         end
 
-        def visit_Arel_Nodes_And(o)
+        def visit__children(o)
           o.children.each_with_index do |child, i|
             edge(i) { visit child }
           end
         end
+        alias :visit_Arel_Nodes_And :visit__children
+        alias :visit_Arel_Nodes_With :visit__children
 
         def visit_String(o)
           @node_stack.last.fields << o
@@ -188,6 +215,12 @@ module Arel # :nodoc: all
 
         def visit_Arel_Nodes_Comment(o)
           visit_edge(o, "values")
+        end
+
+        def visit_Arel_Nodes_Case(o)
+          visit_edge(o, "case")
+          visit_edge(o, "conditions")
+          visit_edge(o, "default")
         end
 
         def visit_edge(o, method)

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -87,11 +87,6 @@ module Arel # :nodoc: all
           visit_edge o, "left"
         end
 
-        def visit_Arel_Nodes_DeleteStatement(o)
-          visit_edge o, "relation"
-          visit_edge o, "wheres"
-        end
-
         def visit_Arel_Nodes_Window(o)
           visit_edge o, "partitions"
           visit_edge o, "orders"
@@ -127,6 +122,7 @@ module Arel # :nodoc: all
           visit_edge o, "relation"
           visit_edge o, "columns"
           visit_edge o, "values"
+          visit_edge o, "select"
         end
 
         def visit_Arel_Nodes_SelectCore(o)
@@ -134,6 +130,11 @@ module Arel # :nodoc: all
           visit_edge o, "projections"
           visit_edge o, "wheres"
           visit_edge o, "windows"
+          visit_edge o, "groups"
+          visit_edge o, "comment"
+          visit_edge o, "havings"
+          visit_edge o, "set_quantifier"
+          visit_edge o, "optimizer_hints"
         end
 
         def visit_Arel_Nodes_SelectStatement(o)
@@ -141,12 +142,27 @@ module Arel # :nodoc: all
           visit_edge o, "limit"
           visit_edge o, "orders"
           visit_edge o, "offset"
+          visit_edge o, "lock"
+          visit_edge o, "with"
         end
 
         def visit_Arel_Nodes_UpdateStatement(o)
           visit_edge o, "relation"
           visit_edge o, "wheres"
           visit_edge o, "values"
+          visit_edge o, "orders"
+          visit_edge o, "limit"
+          visit_edge o, "offset"
+          visit_edge o, "key"
+        end
+
+        def visit_Arel_Nodes_DeleteStatement(o)
+          visit_edge o, "relation"
+          visit_edge o, "wheres"
+          visit_edge o, "orders"
+          visit_edge o, "limit"
+          visit_edge o, "offset"
+          visit_edge o, "key"
         end
 
         def visit_Arel_Table(o)

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -132,10 +132,6 @@ module Arel # :nodoc: all
             end
           end
 
-          visit_Arel_Nodes_SelectOptions(o, collector)
-        end
-
-        def visit_Arel_Nodes_SelectOptions(o, collector)
           collector = maybe_visit o.limit, collector
           collector = maybe_visit o.offset, collector
           maybe_visit o.lock, collector

--- a/activerecord/test/cases/arel/visitors/dot_test.rb
+++ b/activerecord/test/cases/arel/visitors/dot_test.rb
@@ -10,6 +10,10 @@ module Arel
         @visitor = Visitors::Dot.new
       end
 
+      def assert_edge(edge_name, dot_string)
+        assert_match(/->.*label="#{edge_name}"/, dot_string)
+      end
+
       # functions
       [
         Nodes::Sum,
@@ -64,7 +68,6 @@ module Arel
         Arel::Nodes::Or,
         Arel::Nodes::TableAlias,
         Arel::Nodes::As,
-        Arel::Nodes::DeleteStatement,
         Arel::Nodes::JoinSource,
         Arel::Nodes::Casted,
       ].each do |klass|
@@ -169,6 +172,78 @@ module Arel
         assert_edge("0", dot)
         assert_edge("1", dot)
         assert_edge("2", dot)
+      end
+
+      def test_Arel_Nodes_SelectCore
+        node = Arel::Nodes::SelectCore.new
+
+        dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value
+
+        assert_match '[label="<f0>Arel::Nodes::SelectCore"]', dot
+        assert_edge("source", dot)
+        assert_edge("projections", dot)
+        assert_edge("wheres", dot)
+        assert_edge("windows", dot)
+        assert_edge("groups", dot)
+        assert_edge("comment", dot)
+        assert_edge("havings", dot)
+        assert_edge("set_quantifier", dot)
+        assert_edge("optimizer_hints", dot)
+      end
+
+      def test_Arel_Nodes_SelectStatement
+        node = Arel::Nodes::SelectStatement.new
+
+        dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value
+
+        assert_match '[label="<f0>Arel::Nodes::SelectStatement"]', dot
+        assert_edge("cores", dot)
+        assert_edge("limit", dot)
+        assert_edge("orders", dot)
+        assert_edge("offset", dot)
+        assert_edge("lock", dot)
+        assert_edge("with", dot)
+      end
+
+      def test_Arel_Nodes_InsertStatement
+        node = Arel::Nodes::InsertStatement.new
+
+        dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value
+
+        assert_match '[label="<f0>Arel::Nodes::InsertStatement"]', dot
+        assert_edge("relation", dot)
+        assert_edge("columns", dot)
+        assert_edge("values", dot)
+        assert_edge("select", dot)
+      end
+
+      def test_Arel_Nodes_UpdateStatement
+        node = Arel::Nodes::UpdateStatement.new
+
+        dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value
+
+        assert_match '[label="<f0>Arel::Nodes::UpdateStatement"]', dot
+        assert_edge("relation", dot)
+        assert_edge("wheres", dot)
+        assert_edge("values", dot)
+        assert_edge("orders", dot)
+        assert_edge("limit", dot)
+        assert_edge("offset", dot)
+        assert_edge("key", dot)
+      end
+
+      def test_Arel_Nodes_DeleteStatement
+        node = Arel::Nodes::DeleteStatement.new
+
+        dot = @visitor.accept(node, Arel::Collectors::PlainString.new).value
+
+        assert_match '[label="<f0>Arel::Nodes::DeleteStatement"]', dot
+        assert_edge("relation", dot)
+        assert_edge("wheres", dot)
+        assert_edge("orders", dot)
+        assert_edge("limit", dot)
+        assert_edge("offset", dot)
+        assert_edge("key", dot)
       end
     end
   end


### PR DESCRIPTION
### Summary

This changeset provides some love to `Arel::Visitors::Dot`.

- `Arel::Visitors::Dot` now renders a complete set of properties when visiting
  `Arel::Nodes::SelectCore`, `SelectStatement`, `InsertStatement`, `UpdateStatement`, and
  `DeleteStatement`, which fixes #42026. Previously, some properties were omitted.
- `Arel::Visitors::Dot` now supports `Arel::Nodes::Bin`, `Case`, `CurrentRow`, `Distinct`,
  `DistinctOn`, `Else`, `Except`, `InfixOperation`, `Intersect`, `Lock`, `NotRegexp`, `Quoted`,
  `Regexp`, `UnaryOperation`, `Union`, `UnionAll`, `When`, and `With`. Previously, these node types
  caused an exception to be raised by `Arel::Visitors::Dot#accept`.
- Simplify the implementation by taking advantage of the fact that `Arel::Visitors::Visitor#visit`
  falls back to ancestors' visitor methods.
- Eliminate needless aliases and extra methods

Also, the unused private method `Arel::Visitors::ToSql#visit_Arel_Nodes_SelectOptions` has been
removed. It is not needed since a2040ee removed the Oracle12 visitor. This essentially reverses the
Oracle prefactor from 8d04c28.


### Other Information

Here are some pretty pictures for some of the nodes that are now supported:

__SelectCore__
![select_core](https://user-images.githubusercontent.com/8207/116834860-fe4b0580-ab8d-11eb-8ce3-cb341a786503.png)

__Case__
![case_and_friends](https://user-images.githubusercontent.com/8207/116834881-128f0280-ab8e-11eb-9ffb-a443328c8f7c.png)

__Regexp__
![regexp](https://user-images.githubusercontent.com/8207/116834889-1884e380-ab8e-11eb-8d1e-019929b628e5.png)

__InfixOperation__
![infix_operator](https://user-images.githubusercontent.com/8207/116834898-1de22e00-ab8e-11eb-8cbc-bb19fe8bc2a3.png)

__UnaryOperation__
![unary_operation](https://user-images.githubusercontent.com/8207/116834903-233f7880-ab8e-11eb-84da-021300f47659.png)


### Things I suspect you might want me to do differently

Do you want me to squash these commits? I left them as a series of simple transformations.

Should I document in the CHANGELOG the removal of the private method
`Arel::Visitors::ToSql#visit_Arel_Nodes_SelectOptions`? I had assumed since it was private that I
wouldn't need to.

