### PR TITLE
Fix case of GitHub, JavaScript, TypeScript  [ci skip]

### DIFF
--- a/actionview/test/ujs/public/vendor/qunit.js
+++ b/actionview/test/ujs/public/vendor/qunit.js
@@ -1896,7 +1896,7 @@ QUnit.equiv = (function() {
  * http://flesler.blogspot.com Licensed under BSD
  * (http://www.opensource.org/licenses/bsd-license.php) Date: 5/15/2008
  *
- * @projectDescription Advanced and extensible data dumping for Javascript.
+ * @projectDescription Advanced and extensible data dumping for JavaScript.
  * @version 1.0.0
  * @author Ariel Flesler
  * @link {http://flesler.blogspot.com/2008/05/jsdump-pretty-dump-of-any-javascript.html}
@@ -2123,7 +2123,7 @@ QUnit.jsDump = (function() {
 }());
 
 /*
- * Javascript Diff Algorithm
+ * JavaScript Diff Algorithm
  *  By John Resig (http://ejohn.org/)
  *  Modified by Chu Alan "sprite"
  *

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -29,7 +29,7 @@ NOTE: Bugs in the most recent released version of Ruby on Rails will likely get 
 
 ### Creating a Bug Report
 
-If you've found a problem in Ruby on Rails that is not a security risk, search the [Issues](https://github.com/rails/rails/issues) on Github, in case it has already been reported. If you cannot find any open GitHub issues addressing the problem you found, your next step will be to [open a new issue](https://github.com/rails/rails/issues/new). (See the next section for reporting security issues.)
+If you've found a problem in Ruby on Rails that is not a security risk, search the [Issues](https://github.com/rails/rails/issues) on GitHub, in case it has already been reported. If you cannot find any open GitHub issues addressing the problem you found, your next step will be to [open a new issue](https://github.com/rails/rails/issues/new). (See the next section for reporting security issues.)
 
 Your issue report should contain a title and a clear description of the issue at the bare minimum. You should include as much relevant information as possible and a code sample that demonstrates the issue. It would be even better to include a failing unit test that tests the expected behavior. Your goal should be to make it easy for yourself - and others - to reproduce the bug and figure out a fix.
 

--- a/guides/source/webpacker.md
+++ b/guides/source/webpacker.md
@@ -55,7 +55,7 @@ Webpacker is installed by default in Rails 6.0 and up. You can install it with a
 
 |File                    |Location                |Explanation                                                                                         |
 |------------------------|------------------------|----------------------------------------------------------------------------------------------------|
-|Javascript Folder       | `app/javascript`       |A place for your front-end source                                                                   |
+|JavaScript Folder       | `app/javascript`       |A place for your front-end source                                                                   |
 |Webpacker Configuration | `config/webpacker.yml` |Configure the Webpacker gem                                                                         |
 |Babel Configuration     | `babel.config.js`      |Configuration for the [Babel](https://babeljs.io) JavaScript Compiler                               |
 |PostCSS Configuration   | `postcss.config.js`    |Configuration for the [PostCSS](https://postcss.org) CSS Post-Processor                             |
@@ -74,14 +74,14 @@ INFO. It's possible to install frameworks not included in this list. These are b
 
 |Framework         |Install command                         |Description                                       |
 |------------------|----------------------------------------|--------------------------------------------------|
-|Angular           |`bin/rails webpacker:install:angular`   |Sets up Angular and Typescript                    |
+|Angular           |`bin/rails webpacker:install:angular`   |Sets up Angular and TypeScript                    |
 |CoffeeScript      |`bin/rails webpacker:install:coffee`    |Sets up CoffeeScript                              |
 |Elm               |`bin/rails webpacker:install:elm`       |Sets up Elm                                       |
-|ERB               |`bin/rails webpacker:install:erb`       |Sets up ERB support on your Javascript files      |
+|ERB               |`bin/rails webpacker:install:erb`       |Sets up ERB support on your JavaScript files      |
 |React             |`bin/rails webpacker:install:react`     |Sets up ReactJS                                   |
 |Stimulus          |`bin/rails webpacker:install:stimulus`  |Sets up StimulusJS                                |
 |Svelte            |`bin/rails webpacker:install:svelte`    |Sets up Svelte JS                                 |
-|TypeScript        |`bin/rails webpacker:install:typescript`|Sets up Typescript for your project using Babel's TypeScript support|
+|TypeScript        |`bin/rails webpacker:install:typescript`|Sets up TypeScript for your project using Babel's TypeScript support|
 |Vue               |`bin/rails webpacker:install:vue`       |Sets up VueJS                                     |
 
 For more information about the existing integrations, consult the [README](https://github.com/rails/webpacker#integrations).


### PR DESCRIPTION
### Summary

Changes are:

- `Github` -> `GitHub`
- `Javascript` -> `JavaScript`
- `Typescript` -> `TypeScript`