### PR TITLE
Always show blocked host in case we have it blocked instead of `request.host` (confusing error message)

### DIFF
--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -152,7 +152,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: 127.0.0.1", response.body
+    assert_match "Blocked host: www.example.com", response.body
   end
 
   test "does not consider IP addresses in X-FORWARDED-HOST spoofed when disabled" do
@@ -176,7 +176,7 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     }
 
     assert_response :forbidden
-    assert_match "Blocked host: localhost", response.body
+    assert_match "Blocked host: www.example.com", response.body
   end
 
   test "forwarded hosts should be permitted" do


### PR DESCRIPTION
### Summary

I found a very confusing error message when setting up my rails app behind an nginx proxy.

```
upstream api {
  server api:3000;
}

location /api {
  proxy_set_header X-Forwarded-Host $host;
  proxy_pass http://api;
}
```

When I open localhost:3000/api I get an error "Blocked host: localhost" which is very confusing since "localhost" is allowed by default in development. My first intention was to add `config.hosts << "localhost"` which didn't help.

The problem is that we always show `request.host` in the error message which equals to `X-Forwarded-Host` if it's present.

I think we should show the actual host that we block in order to avoid confusion. E.g. in my example above it would say "Blocked host: api" which is much easier to debug.

### Workaround

nginx uses `$proxy_host` for `Host` header by default. We can change it to `$host` (`proxy_set_header Host $host;`) to fix the error.

However, my intention was not to change the behavior but to improve the error message for developers.

### Other Information

I'm in doubt about adding `action_dispatch.blocked_host` to the request header but I found no other solutions. My first intention was to pass `blocked_host` to the `@response_app` in addition to `env` but I think it's not backward compatible since people may provide custom response app.