### PR TITLE
Prevent has_one associated to be destroyed, deleted by an initialization with id

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Prevent has_one associated record to be destroyed, deleted or nullified by an initialization of
+    another record with the foreign_key of the owner.
+
+    Fixes #41692.
+
+    *Federico Aldunate*
+
 *   Allow passing SQL as `on_duplicate` value to `#upsert_all` to make it possible to use raw SQL to update columns on conflict:
 
     ```ruby

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -61,7 +61,7 @@ module ActiveRecord
             save &&= owner.persisted?
 
             transaction_if(save) do
-              remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record
+              remove_target!(options[:dependent]) if target && !target.destroyed? && assigning_another_record && owner.persisted?
 
               if record
                 set_owner_attributes(record)

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -828,6 +828,18 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_not DestroyByParentBook.exists?(book.id)
   end
 
+  test "does not destroy associated when building new record with primary_key manually set" do
+    old_author = DestroyByParentAuthor.create!(name: "Test")
+    old_book = DestroyByParentBook.create!(author: old_author)
+
+    DestroyByParentAuthor.new(
+      id: old_author.id,
+      book: DestroyByParentBook.new
+    )
+
+    assert DestroyByParentBook.exists?(old_book.id)
+  end
+
   class UndestroyableBook < ActiveRecord::Base
     self.table_name = "books"
     belongs_to :author, class_name: "DestroyableAuthor"


### PR DESCRIPTION
### Summary
Prevent has_one associated to be destroyed, deleted by a new with id.
This is related to this issue https://github.com/rails/rails/issues/41692 .

I know this is not the standard use of this, but its behavior seems counterintuitive to me.

Now this test does not work:
```ruby
test "does not destroy associated when building new record with primary_key manually set" do
    old_author = DestroyByParentAuthor.create!(name: "Test")
    old_book = DestroyByParentBook.create!(author: old_author)

    DestroyByParentAuthor.new(
      id: old_author.id,
      book: DestroyByParentBook.new
    )
    # this test does not work, Book object get's destroyed.
    assert DestroyByParentBook.exists?(old_book.id)
  end
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Note: I've only added a test for the `destroy` callback. I can add more for the other callbacks


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
