### PR TITLE
make Rails::Rack::Logger tag compute configurable

### DIFF
--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -26,6 +26,21 @@ module ActiveSupport
   # it easy to stamp log lines with subdomains, request ids, and anything else
   # to aid debugging of multi-user production applications.
   module TaggedLogging
+    module TagComputer
+      def self.call(request, taggers)
+        taggers.collect do |tag|
+          case tag
+          when Proc
+            tag.call(request)
+          when Symbol
+            request.send(tag)
+          else
+            tag
+          end
+        end
+      end
+    end
+
     module Formatter # :nodoc:
       # This method is invoked when a log event occurs.
       def call(severity, timestamp, progname, msg)

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Add `config.log_tag_computer` to configure the computation of tags in
+    Rails::Rack::Logger.
+
+        module StructuredTagComputer
+          def self.call(request, taggers)
+            {
+              request_id: request.request_id
+            }
+          end
+        end
+
+        config.log_tag_computer = StructuredTagComputer
+
+    The `compute_tags` method on Rails::Rack::Logger is deprecated, but its functionality
+    can be restored by passing ActiveSupport::TaggedLogging::TagComputer as the
+    third argument when adding Rails::Rack::Logger to the middleware stack:
+
+        app.middleware.use Rails::Rack::Logger, [:request_id], ActiveSupport::TaggedLogging::TagComputer
+
+    *Hartley McGuire*
+
 *   No longer add autoloaded paths to `$LOAD_PATH`.
 
     This means it won't be possible to load them with a manual `require` call, the class or module can be referenced instead.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -14,7 +14,7 @@ module Rails
                     :cache_classes, :cache_store, :consider_all_requests_local, :console,
                     :eager_load, :exceptions_app, :file_watcher, :filter_parameters,
                     :force_ssl, :helpers_paths, :hosts, :host_authorization, :logger, :log_formatter,
-                    :log_tags, :railties_order, :relative_url_root, :secret_key_base,
+                    :log_tags, :log_tag_computer, :railties_order, :relative_url_root, :secret_key_base,
                     :ssl_options, :public_file_server,
                     :session_options, :time_zone, :reload_classes_only_on_change,
                     :beginning_of_week, :filter_redirect, :x, :enable_dependency_loading,
@@ -58,6 +58,7 @@ module Rails
         @exceptions_app                          = nil
         @autoflush_log                           = true
         @log_formatter                           = ActiveSupport::Logger::SimpleFormatter.new
+        @log_tag_computer                        = ActiveSupport::TaggedLogging::TagComputer
         @eager_load                              = nil
         @secret_key_base                         = nil
         @api_only                                = false

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -48,7 +48,7 @@ module Rails
           middleware.use ::ActionDispatch::RequestId, header: config.action_dispatch.request_id_header
           middleware.use ::ActionDispatch::RemoteIp, config.action_dispatch.ip_spoofing_check, config.action_dispatch.trusted_proxies
 
-          middleware.use ::Rails::Rack::Logger, config.log_tags
+          middleware.use ::Rails::Rack::Logger, config.log_tags, config.log_tag_computer
           middleware.use ::ActionDispatch::ShowExceptions, show_exceptions_app
           middleware.use ::ActionDispatch::DebugExceptions, app, config.debug_exception_response_format
 


### PR DESCRIPTION
### Summary

For applications that use a structured/JSON logger, this is the first
change necessary to allow them to use the Tagged Logging feature in
Rails::Rack::Logger. Instead of returning an array of strings, a
configured tag computer could return a hash of fields to be merged into
a structured log.

```ruby
module StructuredTagComputer
  def self.call(request, taggers)
    {
      request_id: request.request_id
    }
  end
end

config.log_tag_computer = StructuredTagComputer
```

### Other Information

I'm interested in using the idea of Tagged Logging with Ougai, a structured/JSON logger. However, the default `TaggedLogging::Formatter` and `Rails::Rack::Logger.compute_tags` methods make assumptions that the logger will exclusively be logging strings.

This PR tackles the `compute_tags` part, making it default to the original implementation but allowing for it to be replaced with a custom callable.

In the end, I imagine the API would look like this:

```ruby
module StructuredTagFormatter
  # I'd like to extract the tagging parts of TaggedLogging::Formatter (everything except call and tags_text) 
  # in a future PR so that it can be included in custom Tagged Formatters
  include ActiveSupport::TaggedLogging::Taggable

  def call(severity, timestamp, progname, data)
    super(severity, timestamp, progname, merged_tags.merge(data))
  end
   
  private

  def merged_tags
    current_tags.reduce(:merge) || {}
  end
end

# config/environments/production.rb
config.log_tag_computer = StructuredTagComputer # see Summary

logger = Ougai::Logger.new(STDOUT)
# Passing in a custom tag formatter will be the other component of a future PR
config.logger = ActiveSupport::TaggedLogging.new(logger, StructuredTagFormatter)
```
