### PR TITLE
Improve performance for #one? and #many?

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Improve performance of `one?` and `many?` by limiting the generated count query to 2 results.
+
+    *Gonzalo Riestra*
+
 *   Don't check type when using `if_not_exists` on `add_column`.
 
     Previously, if a migration called `add_column` with the `if_not_exists` option set to true

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -2278,6 +2278,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_no_queries { assert firm.clients.many? }
   end
 
+  def test_subsequent_calls_to_many_should_not_use_query
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients.many?
+      firm.clients.many?
+    end
+  end
+
   def test_calling_many_should_defer_to_collection_if_using_a_block
     firm = companies(:first_firm)
     assert_queries(1) do
@@ -2352,6 +2360,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     firm = companies(:first_firm)
     firm.clients.load  # force load
     assert_no_queries { assert_not firm.clients.one? }
+  end
+
+  def test_subsequent_calls_to_one_should_not_use_query
+    firm = companies(:first_firm)
+    assert_queries(1) do
+      firm.clients.one?
+      firm.clients.one?
+    end
   end
 
   def test_calling_one_should_defer_to_collection_if_using_a_block


### PR DESCRIPTION
`ActiveRecord::Relation` methods `one?` and `many?` generate a query like `SELECT COUNT(*) FROM posts` under the hood, and then compare if the result is equal (or greater) to 1. That count operation can be really slow for large tables or complex conditions, but there's no need to count all the records in these cases. It's much faster just by adding a limit, like `SELECT COUNT(count_column) FROM (SELECT 1 AS count_column FROM posts LIMIT 2)`. Other methods like `any?` do use a limit.

This is happening in all the Rails versions.

I've run some benchmarks and with 100M rows, the speed boost is more than 1300x.

<details>
  <summary>Benchmark code</summary>

```

# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "v6.1.3.1"
  gem "sqlite3"
  gem "benchmark-ips"
end

require "active_record"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "benchmark.sqlite3")

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.boolean :posted
  end
end

class Post < ActiveRecord::Base
  def self.fast_one?
    Post.limit(2).count(:all) == 1
  end
end

def benchmark
  puts
  puts "Benchmark with #{Post.count} rows"
  Benchmark.ips do |x|
    x.report("one?")        { Post.one? }
    x.report("fast_one?")   { Post.fast_one? }
    x.compare!
  end
end

print "Populating database"
names = [{ posted: true }] * 100_000
100.times do
  Post.insert_all(names)
  print "."
end

benchmark
Post.where('id > 10000000').delete_all
benchmark
Post.where('id > 1000000').delete_all
benchmark
Post.where('id > 100000').delete_all
benchmark


```

</details>

<details>
  <summary>Benchmark results</summary>

```
Benchmark with 100,000,000 rows
Warming up --------------------------------------
                one?     1.000  i/100ms
           fast_one?   518.000  i/100ms
Calculating -------------------------------------
                one?      3.832  (± 0.0%) i/s -     20.000  in   5.219749s
           fast_one?      5.084k (± 7.4%) i/s -     25.900k in   5.129227s

Comparison:
           fast_one?:     5084.1 i/s
                one?:        3.8 i/s - 1326.68x  (± 0.00) slower


Benchmark with 10,000,000 rows
Warming up --------------------------------------
                one?     3.000  i/100ms
           fast_one?   470.000  i/100ms
Calculating -------------------------------------
                one?     32.466  (±15.4%) i/s -    159.000  in   5.053688s
           fast_one?      4.466k (± 6.9%) i/s -     22.560k in   5.076130s

Comparison:
           fast_one?:     4466.3 i/s
                one?:       32.5 i/s - 137.57x  (± 0.00) slower


Benchmark with 1,000,000 rows
Warming up --------------------------------------
                one?    31.000  i/100ms
           fast_one?   402.000  i/100ms
Calculating -------------------------------------
                one?    375.534  (±13.3%) i/s -      1.860k in   5.067453s
           fast_one?      4.402k (±16.9%) i/s -     21.306k in   5.021693s

Comparison:
           fast_one?:     4401.5 i/s
                one?:      375.5 i/s - 11.72x  (± 0.00) slower


Benchmark with 100,000 rows
Warming up --------------------------------------
                one?   479.000  i/100ms
           fast_one?   447.000  i/100ms
Calculating -------------------------------------
                one?      5.479k (±14.0%) i/s -     27.303k in   5.106124s
           fast_one?      4.460k (± 6.2%) i/s -     22.350k in   5.033595s

Comparison:
                one?:     5479.4 i/s
           fast_one?:     4459.8 i/s - same-ish: difference falls within error

```

</details>
