### PR TITLE
Fix spelling in CoffeeScript and JavaScript files [ci skip]

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs.coffee
@@ -32,8 +32,8 @@
   # Form file input elements
   fileInputSelector: 'input[name][type=file]:not([disabled])'
 
-  # Link onClick disable selector with possible reenable after remote submission
+  # Link onClick disable selector with possible re-enable after remote submission
   linkDisableSelector: 'a[data-disable-with], a[data-disable]'
 
-  # Button onClick disable selector with possible reenable after remote submission
+  # Button onClick disable selector with possible re-enable after remote submission
   buttonDisableSelector: 'button[data-remote][data-disable-with], button[data-remote][data-disable]'

--- a/actionview/test/ujs/public/vendor/jquery-2.2.0.js
+++ b/actionview/test/ujs/public/vendor/jquery-2.2.0.js
@@ -5265,7 +5265,7 @@ function domManip( collection, args, callback, ignored ) {
 			if ( hasScripts ) {
 				doc = scripts[ scripts.length - 1 ].ownerDocument;
 
-				// Reenable scripts
+				// Re-enable scripts
 				jQuery.map( scripts, restoreScript );
 
 				// Evaluate executable scripts on first document insertion


### PR DESCRIPTION
### Summary

Changed `reenable` to the more used `re-enable`
