### PR TITLE
Fix ReDOS in SourceAnnotationExtractor

### DIFF
--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -44,7 +44,7 @@ module Rails
 
       register_extensions("builder", "rb", "rake", "yml", "yaml", "ruby") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }
       register_extensions("css", "js") { |tag| /\/\/\s*(#{tag}):?\s*(.*)$/ }
-      register_extensions("erb") { |tag| /<%\s*#\s*(#{tag}):?\s*(.*?)\s*%>/ }
+      register_extensions("erb") { |tag| /<%\s*#\s*(#{tag}):?\s*+(.*\S)\s*%>/ }
 
       # Returns a representation of the annotation that looks like this:
       #


### PR DESCRIPTION
### Summary

The regular expression in [source_annotation_extractor.rb](https://github.com/rails/rails/blob/a295612ebf87dbe853155a8a11082a647ee8636a/railties/lib/rails/source_annotation_extractor.rb#L47) is vulnerable to ReDOS, can cause high CPU usage with a crafted file.

### Other Information

Reproduce with a rails project

```
rails new example
cd example
python -c 'print("<%#TODO"+" "*10000)' >> app/views/layouts/application.html.erb
rails notes
```

Reproduce with command line

```
$ time ruby -e 'puts ("<%# TODO:"+" "*10000).match?(/<%\s*#\s*(TODO):?\s*(.*?)\s*%>/)'
false

real    36m17.131s
user    36m14.137s
sys     0m0.027s

$ time ruby -e 'puts ("<%# TODO:"+" "*10000).match?(/<%\s*#\s*(TODO):?\s*+(.*\S)\s*%>/)'
false

real    0m0.091s
user    0m0.080s
sys     0m0.011s
```