### PR TITLE
Ignore file fixtures on `db:fixtures:load`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ignore file fixtures on `db:fixtures:load`
+
+    *Kevin Sjöberg*
+
 *   Fix ActionController::Live controller test deadlocks by removing the body buffer size limit for tests.
 
     *Dylan Thacker-Smith*

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -385,8 +385,9 @@ db_namespace = namespace :db do
       fixture_files = if ENV["FIXTURES"]
         ENV["FIXTURES"].split(",")
       else
-        # The use of String#[] here is to support namespaced fixtures.
-        Dir["#{fixtures_dir}/**/*.yml"].map { |f| f[(fixtures_dir.size + 1)..-5] }
+        files = Dir[File.join(fixtures_dir, "**/*.{yml}")]
+        files.reject! { |f| f.start_with?(File.join(fixtures_dir, "files")) }
+        files.map! { |f| f[fixtures_dir.to_s.size..-5].delete_prefix("/") }
       end
 
       ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

In commit, https://github.com/rails/rails/commit/8ec085bf1804770a547894967fcdee24087fda87, support for namespaced fixtures where introduced. When file fixtures where introduced their default path was set to `test/fixtures/files`. This caused any `.yml` file placed in `test/fixtures/files` to be treated as a test fixture. This was addressed in https://github.com/rails/rails/pull/36884. However, we're still unconditionally loading everything within `test/fixtures` when you run `rake db:fixtures:load`.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

The current solution is fairly naive, but I thought it's good enough as a starting point. I can iterate on the solution based on feedback. Some thoughts:

- Do we want to support an environment variable such as `FILE_FIXTURES_DIR` given we're already supporting `FIXTURES_DIR`?
- The default value for the fixtures directory is fetched from `ActiveRecord::Tasks::DatabaseTasks.fixtures_path`. Does it make sense to define a `file_fixtures_path` as well?
