### PR TITLE
Allow PostgreSQL::Quoting to match schema namespaced table names

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -90,8 +90,8 @@ module ActiveRecord
           \A
           (
             (?:
-              # "table_name"."column_name"::type_name | function(one or no argument)::type_name
-              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
+              # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
+              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
             )
             (?:(?:\s+AS)?\s+(?:\w+|"\w+"))?
           )
@@ -103,8 +103,8 @@ module ActiveRecord
           \A
           (
             (?:
-              # "table_name"."column_name"::type_name | function(one or no argument)::type_name
-              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
+              # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
+              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
             )
             (?:\s+ASC|\s+DESC)?
             (?:\s+NULLS\s+(?:FIRST|LAST))?

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -158,6 +158,8 @@ class SchemaTest < ActiveRecord::PostgreSQLTestCase
     song = Song.create
     album = song.albums.create
     assert_equal song, Song.includes(:albums).where("albums.id": album.id).first
+    assert_equal [album.id], Song.joins(:albums).pluck("albums.id")
+    assert_equal [album.id], Song.joins(:albums).pluck("music.albums.id")
   ensure
     ActiveRecord::Base.connection.drop_schema "music", if_exists: true
   end


### PR DESCRIPTION
### Summary

A common reason for needing schema namespaces in Postgres is that two schemas may have conflicting table names. In AR, you might have two schemas that have a table with the same name, and a relationship between them. When plucking a column, you would want to be able to distinguish between them with a fully namespaced table and column. Right now, the regex used will match `table.column` but not `schema.table.column` as a valid column string. This change corrects that and adds tests to verify it.
