### PR TITLE
Special case SafeBuffer#concat(nil) to avoid the bulk of deprecations

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -184,7 +184,10 @@ module ActiveSupport #:nodoc:
     end
 
     def concat(value)
-      super(implicit_html_escape_interpolated_argument(value))
+      unless value.nil?
+        super(implicit_html_escape_interpolated_argument(value))
+      end
+      self
     end
     alias << concat
 


### PR DESCRIPTION
After trying out https://github.com/rails/rails/pull/42123 it appears that the bulk of the deprecations are for cases such as:

```ruby
output << some_helper
```

Where `some_helper` happens to sometime return `nil`.

While a regular String would indeed raise a `TypeError` on such case, I wonder if it wouldn't be worth to special case this specific scenario as it is quite harmless and would drastically reduce the amount of deprecated code.

@pixeltrix @rafaelfranca any thoughts on this?
