### PR TITLE
Clarify that ActionDispatch::DebugLocks is accessible via HTTP

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -9,9 +9,9 @@ module ActionDispatch
   #     config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
   #
   # After restarting the application and re-triggering the deadlock condition,
-  # <tt>/rails/locks</tt> will show a summary of all threads currently known to
-  # the interlock, which lock level they are holding or awaiting, and their
-  # current backtrace.
+  # the route <tt>/rails/locks</tt> will show a summary of all threads currently
+  # known to the interlock, which lock level they are holding or awaiting, and
+  # their current backtrace.
   #
   # Generally a deadlock will be caused by the interlock conflicting with some
   # other external lock or blocking I/O call. These cannot be automatically


### PR DESCRIPTION
### Summary

I just spent more time than I am willing to admit to search for a file at `/rails/locks` (among other paths that I added as an argument) in my filesystem because I observed that the deadlocked server wouldn't handle any "normal" requests and assumed the mentioned path therefore must be in my filesystem. Granted `/rails` is a very non-standard path and the documentation somewhat hints at this by saying "insert it near the top of the middleware stack", but nevertheless I would have preferred to have this explicitly.
