### PR TITLE
Add a public writer for `ActiveStorage::Service::DiskService#root`

### DIFF
--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -9,7 +9,7 @@ module ActiveStorage
   # Wraps a local disk path as an Active Storage service. See ActiveStorage::Service for the generic API
   # documentation that applies to all services.
   class Service::DiskService < Service
-    attr_reader :root
+    attr_accessor :root
 
     def initialize(root:, public: false, **options)
       @root = root

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -26,4 +26,17 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   test "headers_for_direct_upload generation" do
     assert_equal({ "Content-Type" => "application/json" }, @service.headers_for_direct_upload(@key, content_type: "application/json"))
   end
+
+  test "root" do
+    assert_equal tmp_config.dig(:tmp, :root), @service.root
+  end
+
+  test "can change root" do
+    tmp_path_2 = File.join(Dir.tmpdir, "active_storage_2")
+    @service.root = tmp_path_2
+
+    assert_equal tmp_path_2, @service.root
+  ensure
+    @service.root = tmp_config.dig(:tmp, :root)
+  end
 end


### PR DESCRIPTION
Extracted from https://github.com/rails/rails/pull/41543. In that PR, I introduce docs on how to test Active Storage in a variety of scenarios. One specific case is when you're doing parallel tests. To avoid the files uploaded / deleted in your tests from clashing with each other, you should have each test run with a separate storage directory.

Currently `ActiveStorage::Service::DiskService#root` is readonly, which means that to do that you need to change it using `instance_variable_set`. This isn't very elegant. Given parallel tests and Active Storage are both turned on by default in Rails I think it makes sense to have a nice API for this.

This PR just changes the `attr_reader` to an `attr_accessor`. With this change, the [code sample here](https://github.com/rails/rails/pull/41543/files#diff-e61fcdded4b6112b041ff388609c7032d09b8212ce209d67a7debc32f230d77aR1059-R1061) works.

@gmcgibbon suggested I extract this change out to another PR, and so here we are 👍 