### PR TITLE
Raise when setting masked keys in OrderedOptions

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Disallow setting keys with the names of `Hash` methods on `ActiveSupport::OrderedOptions`
+
+    Attempting to set a key on an instance `ActiveSupport::OrderedOptions` of
+    with the name of any instance method that is present on `Hash` will now
+    raise a `NameError`. This is because the corresponding accessor method
+    would be masked by the `Hash` method.
+
+    For example:
+
+    ```ruby
+    require "active_support"
+
+    oo = ActiveSupport::OrderedOptions.new
+
+    oo.count = 999
+    puts oo.count
+    # => 1
+    ```
+
+    *Malcolm Locke*
+
 *   Deprecate `ActiveSupport::SafeBuffer`'s incorrect implicit conversion of objects into string.
 
     Except for a few methods like `String#%`, objects must implement `#to_str`

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -33,6 +33,7 @@ module ActiveSupport
     protected :_get # make it protected
 
     def []=(key, value)
+      raise_if_hash_method(key)
       super(key.to_sym, value)
     end
 
@@ -43,6 +44,7 @@ module ActiveSupport
     def method_missing(name, *args)
       name_string = +name.to_s
       if name_string.chomp!("=")
+        raise_if_hash_method(name_string)
         self[name_string] = args.first
       else
         bangs = name_string.chomp!("!")
@@ -66,6 +68,13 @@ module ActiveSupport
     def inspect
       "#<#{self.class.name} #{super}>"
     end
+
+    private
+      def raise_if_hash_method(method_name)
+        if Hash.method_defined?(method_name.to_sym)
+          raise(NameError, "invalid key name #{method_name} would be masked by Hash method with the same name")
+        end
+      end
   end
 
   # +InheritableOptions+ provides a constructor to build an +OrderedOptions+

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -125,4 +125,16 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
     assert_equal "#<ActiveSupport::OrderedOptions {:foo=>:bar, :baz=>:quz}>", a.inspect
   end
+
+  def test_hash_method_names
+    a = ActiveSupport::OrderedOptions.new
+
+    assert_raises(NameError) do
+      a.keys = "value"
+    end
+
+    assert_raises(NameError) do
+      a[:select] = "value"
+    end
+  end
 end


### PR DESCRIPTION
This is only one of a few potential solutions to this issue.  It's fairly blunt but I think is the simplest solution so can serve as a starting point.  Happy to work on alternative solutions if required.

### Summary

If setting a key on `OrderedOptions` with the same name as a `Hash` method the corresponding reader method will be masked by the `Hash` implementation.

E.g.
```ruby
require "active_support"

oo = ActiveSupport::OrderedOptions.new

oo.count = 999
puts oo.count
# => 1
```

This change prevents setting keys on `OrderedOptions` with the names of `Hash` methods to avoid any confusion.

Fixes #42140 

As an aside, I feel like `ActiveSupport::OrderedOptions` could potentially use a name change.  Any historical vestige of ordering seems to be gone and this class now only serves to provide method access to hash keys.