### PR TITLE
Use a NullFlash object when the session is disabled

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -45,6 +45,7 @@ module ActionDispatch
       # read a notice you put there or <tt>flash["notice"] = "hello"</tt>
       # to put a new one.
       def flash
+        return Flash::NullFlash unless session.respond_to?(:loaded?)
         flash = flash_hash
         return flash if flash
         self.flash = Flash::FlashHash.from_session_value(session["flash"])
@@ -76,6 +77,20 @@ module ActionDispatch
       def reset_session # :nodoc:
         super
         self.flash = nil
+      end
+    end
+
+    module NullFlash #:nodoc:
+      class << self
+        def []=(k, v); end
+
+        def [](k); end
+
+        def alert=(message); end
+
+        def notice=(message); end
+
+        def empty?; end
       end
     end
 

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -67,10 +67,10 @@ module Rails
               config.session_options[:secure] = true
             end
             middleware.use config.session_store, config.session_options
-            middleware.use ::ActionDispatch::Flash
           end
 
           unless config.api_only
+            middleware.use ::ActionDispatch::Flash
             middleware.use ::ActionDispatch::ContentSecurityPolicy::Middleware
             middleware.use ::ActionDispatch::PermissionsPolicy::Middleware
           end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -582,6 +582,23 @@ module ApplicationTests
       end
     end
 
+    test "EtagWithFlash module doesn't break when the session store is disabled" do
+      make_basic_app do |application|
+        application.config.session_store :disabled
+      end
+
+      class ::OmgController < ActionController::Base
+        def index
+          stale?(weak_etag: "something")
+          render plain: "else"
+        end
+      end
+
+      get "/"
+
+      assert last_response.ok?
+    end
+
     test "Use key_generator when secret_key_base is set" do
       make_basic_app do |application|
         application.secrets.secret_key_base = "b3c631c314c0bbca50c1b2843150fe33"


### PR DESCRIPTION
### Summary
Fixes #42165

This etagger (introduced in #26250) uses flash. However, when the
session store is not set (or disabled), it will raise an error because
the flash middleware is included only if a session store is present.

### Other Information
I'm not completely sure if this is the right way to check application
settings in a base class. Any help would be appreciated.
