### PR TITLE
Refactor routes to make them lazily defined

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -334,7 +334,7 @@ module ActionDispatch
       attr_accessor :formatter, :set, :named_routes, :default_scope, :router
       attr_accessor :disable_clear_and_finalize, :resources_path_names
       attr_accessor :default_url_options, :draw_paths
-      attr_reader :env_key, :polymorphic_mappings
+      attr_reader :env_key, :polymorphic_mappings, :source_paths
 
       alias :routes :set
 
@@ -373,11 +373,17 @@ module ActionDispatch
         @disable_clear_and_finalize = false
         @finalized                  = false
         @env_key                    = "ROUTES_#{object_id}_SCRIPT_NAME"
+        @source_paths               = []
 
         @set    = Journey::Routes.new
         @router = Journey::Router.new @set
         @formatter = Journey::Formatter.new self
         @polymorphic_mappings = {}
+      end
+
+      def load
+        source_paths.each { |path| Kernel.load(path) }
+        finalize!
       end
 
       def eager_load!
@@ -476,6 +482,7 @@ module ActionDispatch
       end
 
       def url_helpers(supports_path = true)
+        load
         if supports_path
           @url_helpers_with_paths ||= generate_url_helpers(true)
         else

--- a/railties/lib/rails/application/routes_reloader.rb
+++ b/railties/lib/rails/application/routes_reloader.rb
@@ -21,9 +21,6 @@ module Rails
 
       def reload!
         clear!
-        load_paths
-        finalize!
-        route_sets.each(&:eager_load!) if eager_load
       ensure
         revert
       end
@@ -46,17 +43,8 @@ module Rails
         end
       end
 
-      def load_paths
-        paths.each { |path| load(path) }
-        run_after_load_paths.call
-      end
-
       def run_after_load_paths
         @run_after_load_paths ||= -> { }
-      end
-
-      def finalize!
-        route_sets.each(&:finalize!)
       end
 
       def revert

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -603,7 +603,7 @@ module Rails
       routes.draw_paths.concat(external_paths)
 
       if routes? || routing_paths.any?
-        app.routes_reloader.paths.unshift(*routing_paths)
+        app.routes.source_paths.unshift(*routing_paths)
         app.routes_reloader.route_sets << routes
         app.routes_reloader.external_routes.unshift(*external_paths)
       end


### PR DESCRIPTION
This is a very early draft. All sorts of things are likely broken.

### Context

Right now routes are eagerly loaded on boot by the `RoutesReloader` object. And then when necessary it clears them out, and load them again. If you don't plan to use the routes (e.g. you are running a simple model test), then it's a waste.

And even if you use the routes, it's not that big of a win.

### This change

This is a rough draft of trying to make the `RouteSet` object responsible for loading it's associated `routes.rb` files. This way it could do it when it's actually needed. The `RoutesReloader` would only be responsible for "unloading" the routes.
