### PR TITLE
Restore implicit `to_s` for `content_for` and `provide`

### DIFF
--- a/actionview/lib/action_view/flows.rb
+++ b/actionview/lib/action_view/flows.rb
@@ -17,12 +17,12 @@ module ActionView
 
     # Called by each renderer object to set the layout contents.
     def set(key, value)
-      @content[key] = ActiveSupport::SafeBuffer.new(value)
+      @content[key] = ActiveSupport::SafeBuffer.new(value.to_s)
     end
 
     # Called by content_for
     def append(key, value)
-      @content[key] << value
+      @content[key] << value.to_s
     end
     alias_method :append!, :append
   end

--- a/actionview/test/template/capture_helper_test.rb
+++ b/actionview/test/template/capture_helper_test.rb
@@ -51,14 +51,14 @@ class CaptureHelperTest < ActionView::TestCase
   def test_content_for_with_multiple_calls
     assert_not content_for?(:title)
     content_for :title, "foo"
-    content_for :title, "bar"
+    content_for :title, :bar
     assert_equal "foobar", content_for(:title)
   end
 
   def test_content_for_with_multiple_calls_and_flush
     assert_not content_for?(:title)
     content_for :title, "foo"
-    content_for :title, "bar", flush: true
+    content_for :title, :bar, flush: true
     assert_equal "bar", content_for(:title)
   end
 
@@ -172,7 +172,7 @@ class CaptureHelperTest < ActionView::TestCase
     assert_equal "hi&lt;p&gt;title&lt;/p&gt;", content_for(:title)
 
     @view_flow = ActionView::OutputFlow.new
-    provide :title, "hi"
+    provide :title, :hi
     provide :title, raw("<p>title</p>")
     assert_equal "hi<p>title</p>", content_for(:title)
   end


### PR DESCRIPTION
### Summary

In #42123, implicit coercion was removed from StringBuffer. As a side-effect, the implicit conversion was removed from `content_for` and `provide`. That's because they use `SafeBuffer#<<` which no longer coerces:
https://github.com/rails/rails/blob/226f22e8433eb9bd781e4063a2e6d4f4ace2d093/actionview/lib/action_view/flows.rb#L25  via https://github.com/rails/rails/blob/226f22e8433eb9bd781e4063a2e6d4f4ace2d093/actionview/lib/action_view/helpers/capture_helper.rb#L162 and https://github.com/rails/rails/blob/226f22e8433eb9bd781e4063a2e6d4f4ace2d093/actionview/lib/action_view/helpers/capture_helper.rb#L177

`content_for` with `flush: true` didn't support implicit coercion because it used `SafeBuffer.new` directly so I also fixed this inconsistency.
https://github.com/rails/rails/blob/226f22e8433eb9bd781e4063a2e6d4f4ace2d093/actionview/lib/action_view/flows.rb#L20

### Other Information

I fixed it in the `OutputFlow` class instead of in `CaptureHelper`, but this class is only used from these helpers anyway.
For the tests I just changed some existing ones to use Symbols, which don't coerce with `to_str,` but only with `to_s`, to show the issue. The `flush: true` one fails but the two other one don't, they just show a deprecation warning. Should we run the test with deprecation warnings to raise by default?

@byroot