### PR TITLE
Add notification for ActiveSupport::Messages::Rotator#run_rotations

### DIFF
--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -47,7 +47,10 @@ module ActiveSupport
         def run_rotations(on_rotation)
           @rotations.find do |rotation|
             if message = yield(rotation) rescue next
-              on_rotation&.call
+              ActiveSupport::Notifications.instrument("rotation.active_support") do
+                on_rotation&.call
+              end
+
               return message
             end
           end

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -517,6 +517,16 @@ INFO. Cache stores may add their own keys
 }
 ```
 
+#### rotation.active_support
+
+| Key            | Value                                             |
+| -------------- | ------------------------------------------------- |
+|                |                                                   |
+
+```ruby
+{}
+```
+
 ### Active Job
 
 #### enqueue_at.active_job


### PR DESCRIPTION
Adds the ability to easily monitor rotations. With the ability to know which cookies are impacted.
The goal is to know when a rotation can be safely removed.

This is an extraction of what we use at Doctolib, when we rotate some secrets.