### PR TITLE
Allows ActiveStorage multiple attach within transaction

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -72,9 +72,9 @@ module ActiveStorage
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
 
-        after_save { attachment_changes[name.to_s]&.save }
-
-        after_commit(on: %i[ create update ]) { attachment_changes.delete(name.to_s).try(:upload) }
+        after_save do
+          attachment_changes[name.to_s]&.save && attachment_changes.delete(name.to_s).try(:upload)
+        end
 
         reflection = ActiveRecord::Reflection.create(
           :has_one_attached,
@@ -168,9 +168,9 @@ module ActiveStorage
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachments": :blob) }
 
-        after_save { attachment_changes[name.to_s]&.save }
-
-        after_commit(on: %i[ create update ]) { attachment_changes.delete(name.to_s).try(:upload) }
+        after_save do
+          attachment_changes[name.to_s]&.save && attachment_changes.delete(name.to_s).try(:upload)
+        end
 
         reflection = ActiveRecord::Reflection.create(
           :has_many_attached,


### PR DESCRIPTION
Fixes #41661, #41903, #40630

`ActiveStorage#has_many_attached` and `ActiveStorage#has_one attached`
use `after_commit` callback to upload the blob to the service.
When multiple attachments are attached within a transactions
the after_commit callback is invoked only once. This is
expected callback behavior but since after commit on
first callback was not invoked, the blob was not uploaded to the
service.

This PR aims to resolve the issue by removing the after_commit
callback and uploads the blob as soon as Attachment is created.

This PR also resolves #40630 which failed to upload the
attachment on `reload` within transaction

I could not see any side-effects of these changes introduced in
this PR but I may be wrong as well. Please feel to correct me :)

Secondly, after_commit callbacks where registered on every create/update
commit on ActiveRecord object regardless the changes were related to
ActiveStorage. This never harmed anyone as `attachment_changes` would be
nil and nothing happened but it feels weird that we leave it unconditional.