### PR TITLE
 Update docs for `ActiveRecord::Middleware::DatabaseSelector`

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -22,6 +22,7 @@ module ActiveRecord
     # To use the DatabaseSelector in your application with default settings add
     # the following options to your environment config:
     #
+    #   # This require is only necessary when using `rails new app --minimal`
     #   require "active_support/core_ext/integer/time"
     #
     #   class Application < Rails::Application

--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -22,9 +22,13 @@ module ActiveRecord
     # To use the DatabaseSelector in your application with default settings add
     # the following options to your environment config:
     #
-    #   config.active_record.database_selector = { delay: 2.seconds }
-    #   config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-    #   config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    #   require "active_support/core_ext/integer/time"
+    #
+    #   class Application < Rails::Application
+    #     config.active_record.database_selector = { delay: 2.seconds }
+    #     config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    #     config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+    #   end
     #
     # New applications will include these lines commented out in the production.rb.
     #


### PR DESCRIPTION
### Summary

The docs for the database selector middleware indicate that you can
set a delay that can be a duration (eg. `2.seconds`)

https://api.rubyonrails.org/v6.1/classes/ActiveRecord/Middleware/DatabaseSelector.html

In normal apps, this works fine without an explicit require because
the extension is required through other libs. However, when creating a
minimal app, this results in an undefined method error.

```
test_app/config/application.rb:38:in `<class:Application>': undefined method `seconds' for 2:Integer (NoMethodError)
```

Reproduction steps (Rails 6.1.3.2 and `main`)

1. Create a new app.

```
rails _6.1.3.2_ new test_app --minimal
```

2. Edit `config/application.rb` and add the lines from the docs:

```
config.active_record.database_selector = { delay: 2.seconds }
config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
```

3. Start `bin/rails server` or `bin/rails console`.