### PR TITLE
Active Storage: encourage `Rails.env` in bucket names

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
@@ -12,21 +12,21 @@ local:
 #   access_key_id: <%%= Rails.application.credentials.dig(:aws, :access_key_id) %>
 #   secret_access_key: <%%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
 #   region: us-east-1
-#   bucket: your_own_bucket
+#   bucket: your_own_bucket-<%%= Rails.env %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS
 #   project: your_project
 #   credentials: <%%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket
+#   bucket: your_own_bucket-<%%= Rails.env %>
 
 # Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
 # microsoft:
 #   service: AzureStorage
 #   storage_account_name: your_account_name
 #   storage_access_key: <%%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name
+#   container: your_container_name-<%%= Rails.env %>
 
 # mirror:
 #   service: Mirror


### PR DESCRIPTION
https://github.com/rails/rails/issues/42186 outlined a problem I've seen in the wild before (with AS, but also with other gems like papertrail) where developers interact with production data locally and inadvertently destroy it.

A simple way to prevent this in the Active Storage case is to make the `bucket` name for services be based on `Rails.env`. This way, if you pull a production database copy and call `purge` on a blob for it, AS will try and destroy the file from the `your_own_bucket-development` bucket. But the file doesn't live there - it lives in the `your_own_bucket-production` bucket.

This is just a suggestion and people who know what they are doing can name their buckets whatever they want. But for first time Active Storage users I think this removes an unnecessarily sharp knife.
