### PR TITLE
Allow Relation#sum to take an `init` parameters

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -83,15 +83,24 @@ module ActiveRecord
     # #calculate for examples with options.
     #
     #   Person.sum(:age) # => 4562
-    def sum(column_name = nil)
+    def sum(identity_or_column = nil, &block)
       if block_given?
-        unless column_name.nil?
-          raise ArgumentError, "Column name argument is not supported when a block is passed."
+        values = map(&block)
+        if identity_or_column.nil? && (values.first.is_a?(Numeric) || values.first(1) == [])
+          identity_or_column = 0
         end
 
-        super()
+        if identity_or_column.nil?
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Rails 7.0 has deprecated Enumerable.sum in favor of Ruby's native implementation available since 2.4.
+            Sum of non-numeric elements requires an initial argument.
+          MSG
+          values.inject(:+) || 0
+        else
+          values.sum(identity_or_column)
+        end
       else
-        calculate(:sum, column_name)
+        calculate(:sum, identity_or_column)
       end
     end
 

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -503,7 +503,15 @@ class CalculationsTest < ActiveRecord::TestCase
   end
 
   def test_should_not_overshadow_enumerable_sum
+    some_companies = companies(:rails_core).companies.order(:id)
+
     assert_equal 6, [1, 2, 3].sum(&:abs)
+    assert_equal 15, some_companies.sum(&:id)
+    assert_equal 25, some_companies.sum(10, &:id)
+    assert_deprecated do
+      assert_equal "LeetsoftJadedpixel", some_companies.sum(&:name)
+    end
+    assert_equal "companies: LeetsoftJadedpixel", some_companies.sum("companies: ", &:name)
   end
 
   def test_should_sum_scoped_field
@@ -1338,12 +1346,6 @@ class CalculationsTest < ActiveRecord::TestCase
   def test_count_with_block_and_column_name_raises_an_error
     assert_raises(ArgumentError) do
       Account.count(:firm_id) { true }
-    end
-  end
-
-  def test_sum_with_block_and_column_name_raises_an_error
-    assert_raises(ArgumentError) do
-      Account.sum(:firm_id) { 1 }
     end
   end
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/41669#issuecomment-836398720

This is needed to not prevent full use of `Enumerable#sum` on `Relation` objects.

Since https://github.com/rails/rails/pull/42080, if you are summing a list of objects that aren't `Numeric`, you need to provide an `init` value, e.g. `products.sum(Money.new(0), &:price)`.

cc @pixeltrix @alberto-mota @rafaelfranca 