### PR TITLE
Active Storage environments

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Active Storage now supports an `environment` key in the `storage.yml` file. When set,
+    a service cannot be accessed unless the `Rails.env` matches the given environment.
+
+    ```yml
+    # config/storage.yml
+
+    local:
+      service: Disk
+      environment: development
+      # ...
+
+    amazon:
+      service: S3
+      environment:
+        - production
+        - staging
+      # ...
+    ```
+
+    This can prevent [data loss](https://github.com/rails/rails/issues/42186) from bad blob data.
+
+    *Alex Ghiculescu*
+
 *   `ActiveStorage::PreviewError` is raised when a previewer is unable to generate a preview image.
 
     *Alex Robbin*

--- a/activestorage/lib/active_storage/errors.rb
+++ b/activestorage/lib/active_storage/errors.rb
@@ -26,4 +26,12 @@ module ActiveStorage
 
   # Raised when a Previewer is unable to generate a preview image.
   class PreviewError < Error; end
+
+  class EnvironmentMismatchError < Error
+    def initialize(name, permitted_env)
+      msg = +"You are attempting to access the `#{name}` Active Storage service that can only be accessed in the `#{permitted_env}` environment.\n"
+      msg << "If the `#{name}` service should work in the `#{Rails.env}` environment, set it as the `environment` in config/storage.yml."
+      super(msg)
+    end
+  end
 end

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -17,12 +17,13 @@ module ActiveStorage
       :url_for_direct_upload, :headers_for_direct_upload, :path_for, to: :primary
 
     # Stitch together from named services.
-    def self.build(primary:, mirrors:, name:, configurator:, **options) #:nodoc:
+    def self.build(primary:, mirrors:, environment: nil, name:, configurator:, **options) #:nodoc:
       new(
         primary: configurator.build(primary),
         mirrors: mirrors.collect { |mirror_name| configurator.build mirror_name }
       ).tap do |service_instance|
         service_instance.name = name
+        service_instance.environment = environment
       end
     end
 

--- a/activestorage/lib/active_storage/service/registry.rb
+++ b/activestorage/lib/active_storage/service/registry.rb
@@ -14,12 +14,13 @@ module ActiveStorage
         else
           if block_given?
             yield key
+            nil
           else
             raise KeyError, "Missing configuration for the #{key} Active Storage service. " \
               "Configurations available for the #{configurations.keys.to_sentence} services."
           end
         end
-      end
+      end.tap { |service| service&.check_if_environment_is_permitted! }
     end
 
     private

--- a/activestorage/test/service/registry_test.rb
+++ b/activestorage/test/service/registry_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "service/shared_service_tests"
+
+class ActiveStorage::Service::RegistryTest < ActiveSupport::TestCase
+  test "disallows access to service in incorrect environment" do
+    assert_raise ActiveStorage::EnvironmentMismatchError do
+      ActiveStorage::Service::Registry.new(foo: { service: "disk", environment: "production", root: "path" }).fetch(:foo)
+    end
+  end
+
+  test "disallows access to service in incorrect environment with multiple environments listed" do
+    assert_raise ActiveStorage::EnvironmentMismatchError do
+      ActiveStorage::Service::Registry.new(foo: { service: "disk", environment: ["production", "staging"], root: "path" }).fetch(:foo)
+    end
+  end
+
+  test "allows access to service in correct environment" do
+    with_rails_env("production") do
+      assert_nothing_raised do
+        ActiveStorage::Service::Registry.new(foo: { service: "disk", environment: "production", root: "path" }).fetch(:foo)
+        ActiveStorage::Service::Registry.new(foo: { service: "disk", environment: ["production", "staging"], root: "path" }).fetch(:foo)
+        ActiveStorage::Service::Registry.new(foo: { service: "disk", environment: ["staging", "production"], root: "path" }).fetch(:foo)
+      end
+    end
+  end
+
+  test "allows access to service that doesn't restrict environment" do
+    with_rails_env("production") do
+      assert_nothing_raised do
+        ActiveStorage::Service::Registry.new(foo: { service: "disk", environment: "", root: "path" }).fetch(:foo)
+        ActiveStorage::Service::Registry.new(foo: { service: "disk", root: "path" }).fetch(:foo)
+      end
+    end
+  end
+
+  test "configures registry from config file" do
+    with_rails_env("development") do
+      configs = YAML.load(config_file_contents)
+      registry = ActiveStorage::Service::Registry.new(configs)
+
+      assert_raise ActiveStorage::EnvironmentMismatchError do
+        registry.fetch(:amazon)
+      end
+
+      assert_nothing_raised do
+        registry.fetch(:local)
+      end
+    end
+  end
+
+  private
+    def with_rails_env(env)
+      old_rails_env = Rails.env
+      Rails.env = env
+      yield
+    ensure
+      Rails.env = old_rails_env
+    end
+
+    def config_file_contents
+      <<~YML
+local:
+  service: Disk
+  root: "/tmp/foo"
+  environment: development
+amazon:
+  service: S3
+  bucket: foo
+  region: us-east-1
+  access_key_id: foo
+  secret_access_key: bar
+  environment:
+    - production
+    - staging
+      YML
+    end
+end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -33,6 +33,7 @@ require "tmpdir"
 Rails.configuration.active_storage.service_configurations = SERVICE_CONFIGURATIONS.merge(
   "local" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests") },
   "local_public" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests"), "public" => true },
+  "local_developent_only" => { "service" => "Disk", "environment" => "development", "root" => Dir.mktmpdir("active_storage_tests") },
   "disk_mirror_1" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests_1") },
   "disk_mirror_2" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests_2") },
   "disk_mirror_3" => { "service" => "Disk", "root" => Dir.mktmpdir("active_storage_tests_3") },

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -70,7 +70,7 @@ amazon:
 ```
 
 The `environment` configuration is optional, but makes Active Storage more secure
-by preventing access to the specified except when Rails is running in the specified environment.
+by preventing access to the specified service except when Rails is running in the stated environment.
 
 Tell Active Storage which service to use by setting
 `Rails.application.config.active_storage.service`. Because each environment will

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -52,19 +52,25 @@ below declares three services named `local`, `test`, and `amazon`:
 ```yaml
 local:
   service: Disk
+  environment: development
   root: <%= Rails.root.join("storage") %>
 
 test:
   service: Disk
+  environment: test
   root: <%= Rails.root.join("tmp/storage") %>
 
 amazon:
   service: S3
+  environment: production
   access_key_id: ""
   secret_access_key: ""
   bucket: ""
   region: "" # e.g. 'us-east-1'
 ```
+
+The `environment` configuration is optional, but makes Active Storage more secure
+by preventing access to the specified except when Rails is running in the specified environment.
 
 Tell Active Storage which service to use by setting
 `Rails.application.config.active_storage.service`. Because each environment will

--- a/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
@@ -9,6 +9,7 @@ local:
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3
+#   environment: production
 #   access_key_id: <%%= Rails.application.credentials.dig(:aws, :access_key_id) %>
 #   secret_access_key: <%%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
 #   region: us-east-1
@@ -17,6 +18,7 @@ local:
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS
+#   environment: production
 #   project: your_project
 #   credentials: <%%= Rails.root.join("path/to/gcs.keyfile") %>
 #   bucket: your_own_bucket-<%%= Rails.env %>
@@ -24,11 +26,13 @@ local:
 # Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
 # microsoft:
 #   service: AzureStorage
+#   environment: production
 #   storage_account_name: your_account_name
 #   storage_access_key: <%%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
 #   container: your_container_name-<%%= Rails.env %>
 
 # mirror:
 #   service: Mirror
+#   environment: production
 #   primary: local
 #   mirrors: [ amazon, google, microsoft ]


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/42186

The Active Storage `config.yml` file now supports an `environment` key for each service. If set, the service can only be accessed in that environment.

It's already possible to set the Active Storage service on a per-environment basis (using `Rails.application.config.active_storage.service`), but individual blobs can bypass this because the `service_name` column can be any string. This PR adds an additional layer of protection; now, if you try to interact with a file that is connected to a not-permitted service, you an `ActiveStorage::EnvironmentMismatchError` will be raised.

Here's an example! Given this config:

```yml

local:
  service: Disk
  environment: development

amazon:
  service: S3
  environment: production,staging

universal:
  service: S3
```

A user whose Rails.env is development will be able to interact with files from the `local` and `universal` services, but not  the `amazon` service.

```ruby
Rails.env = "development"
ActiveStorage::Blob.find_by(service_name: "local").purge # works fine because environments match
ActiveStorage::Blob.find_by(service_name: "universal").purge # works fine because no environment restrictions set (current case for all Rails apps)
ActiveStorage::Blob.find_by(service_name: "amazon").purge # raises ActiveStorage::EnvironmentMismatchError
```

The implementation was inspired by https://github.com/rails/rails/pull/22967
