### PR TITLE
Optimize normalize_name

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -192,19 +192,20 @@ module ActionView
         end
       end
 
-      # Support legacy foo.erb names even though we now ignore .erb
-      # as well as incorrectly putting part of the path in the template
-      # name instead of the prefix.
+      # Fix when prefix is specified as part of the template name
       def normalize_name(name, prefixes)
-        prefixes = prefixes.presence
-        parts    = name.to_s.split("/")
-        parts.shift if parts.first.empty?
-        name = parts.pop
+        idx = name.rindex("/")
+        return name, prefixes.presence || [""] unless idx
 
-        return name, prefixes || [""] if parts.empty?
+        path_prefix = name[0, idx]
+        path_prefix = path_prefix.from(1) if path_prefix.start_with?("/")
+        name = name.from(idx + 1)
 
-        parts    = parts.join("/")
-        prefixes = prefixes ? prefixes.map { |p| "#{p}/#{parts}" } : [parts]
+        if !prefixes || prefixes.empty?
+          prefixes = [path_prefix]
+        else
+          prefixes = prefixes.map { |p| "#{p}/#{path_prefix}" }
+        end
 
         return name, prefixes
       end


### PR DESCRIPTION
This is called on every render or template lookup.

    lookup_context = ActionController::Base.new.lookup_context
    normalize = lookup_context.method(:normalize_name)

    Benchmark.ips do |x|
      x.report "already normalized" do
        normalize.call("show", ["users"])
      end

      x.report "without prefixes" do
        normalize.call("users/show", [])
      end

      x.report "with prefixes in both arguments" do
        normalize.call("extra/show", ["users", "application"])
      end
    end

Before:

      already normalized      2.322M (± 0.5%) i/s -     11.615M in   5.003512s
        without prefixes      1.613M (± 0.7%) i/s -      8.076M in   5.007165s
    with prefixes in both arguments
                              1.020M (± 0.7%) i/s -      5.154M in   5.054101s

After:

      already normalized      3.740M (± 0.3%) i/s -     18.715M in   5.003477s
        without prefixes      2.197M (± 0.6%) i/s -     11.089M in   5.047800s
    with prefixes in both arguments
                              1.244M (± 0.9%) i/s -      6.246M in   5.020968s

