### PR TITLE
Avoid sending preload links for `data:` URLs

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -98,7 +98,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_javascript(source, path_options)
-          if preload_links_header && !options["defer"]
+          if preload_links_header && !options["defer"] && href.present? && !href.start_with?("data:")
             preload_link = "<#{href}>; rel=#{rel}; as=script"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
@@ -178,7 +178,7 @@ module ActionView
 
         sources_tags = sources.uniq.map { |source|
           href = path_to_stylesheet(source, path_options)
-          if preload_links_header
+          if preload_links_header && href.present? && !href.start_with?("data:")
             preload_link = "<#{href}>; rel=preload; as=style"
             preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
             preload_link += "; integrity=#{integrity}" unless integrity.nil?
@@ -543,6 +543,8 @@ module ActionView
 
         MAX_HEADER_SIZE = 8_000 # Some HTTP client and proxies have a 8kiB header limit
         def send_preload_links_header(preload_links, max_header_size: MAX_HEADER_SIZE)
+          return if preload_links.empty?
+
           if respond_to?(:request) && request
             request.send_early_hints("Link" => preload_links.join("\n"))
           end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -537,6 +537,14 @@ class AssetTagHelperTest < ActionView::TestCase
     end
   end
 
+  def test_should_not_set_preload_links_for_data_url
+    with_preload_links_header do
+      stylesheet_link_tag("data:text/css;base64,YWxlcnQoIkhlbGxvIik7")
+      javascript_include_tag("data:text/javascript;base64,YWxlcnQoIkhlbGxvIik7")
+      assert_nil @response.headers["Link"]
+    end
+  end
+
   def test_should_generate_links_under_the_max_size
     with_preload_links_header do
       100.times do |i|
@@ -551,7 +559,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_should_not_preload_links_with_defer
     with_preload_links_header do
       javascript_include_tag("http://example.com/all.js", defer: true)
-      assert_equal "", @response.headers["Link"]
+      assert_nil @response.headers["Link"]
     end
   end
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/39939#issuecomment-836802840 reported by @mjtko 

Sending a preload for `data:` URLs make no sense, it was just an oversight.