### PR TITLE
Handle duplicate migration names in multi db

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1044,7 +1044,9 @@ module ActiveRecord
       end
 
       def load_migration
-        require(File.expand_path(filename))
+        Object.send(:remove_const, name) rescue nil
+
+        load(File.expand_path(filename))
         name.constantize.new(name, version)
       end
   end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -15,6 +15,12 @@ require MIGRATIONS_ROOT + "/rename/1_we_need_things"
 require MIGRATIONS_ROOT + "/rename/2_rename_things"
 require MIGRATIONS_ROOT + "/decimal/1_give_me_big_numbers"
 
+class ValidPeopleHaveLastNames < ActiveRecord::Migration::Current
+  def change
+    drop_table :people
+  end
+end
+
 class BigNumber < ActiveRecord::Base
   unless current_adapter?(:PostgreSQLAdapter, :SQLite3Adapter)
     attribute :value_of_e, :integer
@@ -106,6 +112,14 @@ class MigrationTest < ActiveRecord::TestCase
 
     ActiveRecord::SchemaMigration.create!(version: 3)
     assert_equal true, migrator.needs_migration?
+  end
+
+  def test_name_collision_across_dbs
+    migrations_path = MIGRATIONS_ROOT + "/valid"
+    migrator = ActiveRecord::MigrationContext.new(migrations_path)
+    migrator.up
+
+    assert_column Person, :last_name
   end
 
   def test_migration_detection_without_schema_migration_table


### PR DESCRIPTION
### Summary

In a multidatabse setup, migrations live in seperate directories.
The check for duplicate migration names, does not take this into account.

So you _can_ end up having multiple migrations with the same name.
This can lead to situations, where migrations from one database carries over to the other database with severe consequences.

To illustrate the situation, look at these two migrations.

```ruby
# db/migrate/1_clean_up_things.rb

class CleanUpThings < ActiveRecord::Migration::Current
  def change
    drop_table :things
  end
end
```
and
```ruby
# db/migrate_other_database/1_clean_up_things.rb

class CleanUpThings < ActiveRecord::Migration::Current
  def up
    remove_column :things, :stuff
  end
end
```

As they live in separate directories no `ActiveRecord::DuplicateMigrationNameError` will be thrown.

When running `rails db:migrate` we can end up in a situation where `CleanUpThings` from `db/migrate` is loaded _before_ `CleanUpThings` from `db/migrate_other_database`.

Now, when loading `db/migrate_other_database/1_clean_up_things.rb`, what happens is, that `CleanUpThings` both have the `up` and the `change` functions.

If we do not remove the lingering `CleanUpThings`, we end up dropping the table `things` in the database loading migrations from `db/migrate_other_database`, when what we wanted was just to remove a column from that database.

In this situation we must ensure that the lingering `CleanUpThings` is removed, so we don't end up dropping the table `things` in the database with migrations in `/db/migrate_other_database`.

This is what this PR does.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

I'm not 100% sure that we need to change `require` to `load`.  I had some situations, that I'm not able to reproduce consistently, where `require` didn't work. So I've opted for `load`.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
