### PR TITLE
Revert "un-extract the Arel visitor for SelectOptions"

### DIFF
--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -132,6 +132,12 @@ module Arel # :nodoc: all
             end
           end
 
+          visit_Arel_Nodes_SelectOptions(o, collector)
+        end
+
+        # The Oracle enhanced adapter uses this private method,
+        # see https://github.com/rsim/oracle-enhanced/issues/2186
+        def visit_Arel_Nodes_SelectOptions(o, collector)
           collector = maybe_visit o.limit, collector
           collector = maybe_visit o.offset, collector
           maybe_visit o.lock, collector


### PR DESCRIPTION
This reverts commit d803b9ae9bdfb1c8643c1b463cf9af42ad6a1cb5.

### Summary

See https://github.com/rsim/oracle-enhanced/issues/2186 for evidence
that this private method is being used by the Oracle12 sql visitor, /cc @yahonda.

This commit reverts the inlining of this method to preserve backwards compatibility.
