### PR TITLE
update tests for SecureRandom.base58 method

### DIFF
--- a/activesupport/test/core_ext/secure_random_test.rb
+++ b/activesupport/test/core_ext/secure_random_test.rb
@@ -10,6 +10,10 @@ class SecureRandomTest < ActiveSupport::TestCase
 
     assert_not_equal s1, s2
     assert_equal 16, s1.length
+    assert_match(/^[a-zA-Z0-9]+$/, s1)
+    assert_match(/^[a-zA-Z0-9]+$/, s2)
+    assert_match(/^[^0OIl]+$/, s1)
+    assert_match(/^[^0OIl]+$/, s2)
   end
 
   def test_base58_with_length
@@ -18,6 +22,10 @@ class SecureRandomTest < ActiveSupport::TestCase
 
     assert_not_equal s1, s2
     assert_equal 24, s1.length
+    assert_match(/^[a-zA-Z0-9]+$/, s1)
+    assert_match(/^[a-zA-Z0-9]+$/, s2)
+    assert_match(/^[^0OIl]+$/, s1)
+    assert_match(/^[^0OIl]+$/, s2)
   end
 
   def test_base36


### PR DESCRIPTION
### Summary

ActiveSupport's [SecureRandom.base58](https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activesupport/lib/active_support/core_ext/securerandom.rb#L6) when generating random string ignores the following characters `["0", "O", "I", "l"]`. The generated string should also fall under the following character range and number range `[a-z, A-Z, 0-9]` however the test suite for the method is not covering both the cases. This PR increases the test coverage with the above two cases.


