### PR TITLE
Encapsulate "details" into TemplateDetails

### DIFF
--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -44,6 +44,7 @@ module ActionView
     autoload :Rendering
     autoload :RoutingUrlFor
     autoload :Template
+    autoload :TemplateDetails
     autoload :TemplatePath
     autoload :UnboundTemplate
     autoload :ViewPaths

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module ActionView
+  class TemplateDetails # :nodoc:
+    class Requested
+      attr_reader :locale, :handlers, :formats, :variants
+
+      def initialize(locale:, handlers:, formats:, variants:)
+        @locale = locale
+        @handlers = handlers
+        @formats = formats
+        @variants = variants
+      end
+    end
+
+    attr_reader :locale, :handler, :format, :variant
+
+    def initialize(locale, handler, format, variant)
+      @locale = locale
+      @handler = handler
+      @format = format
+      @variant = variant
+    end
+
+    def matches?(requested)
+      return if format && !requested.formats.include?(format)
+      return if locale && !requested.locale.include?(locale)
+      unless requested.variants == :any
+        return if variant && !requested.variants.include?(variant)
+      end
+      return if handler && !requested.handlers.include?(handler)
+
+      true
+    end
+
+    def sort_key_for(requested)
+      locale_match = details_match_sort_key(locale, requested.locale)
+      format_match = details_match_sort_key(format, requested.formats)
+      variant_match =
+        if requested.variants == :any
+          variant ? 1 : 0
+        else
+          details_match_sort_key(variant, requested.variants)
+        end
+      handler_match = details_match_sort_key(handler, requested.handlers)
+
+      [locale_match, format_match, variant_match, handler_match]
+    end
+
+    def handler_class
+      Template.handler_for_extension(handler)
+    end
+
+    def format_or_default
+      format || handler_class.try(:default_format)
+    end
+
+    private
+      def details_match_sort_key(have, want)
+        if have
+          want.index(have)
+        else
+          want.size
+        end
+      end
+  end
+end

--- a/actionview/lib/action_view/unbound_template.rb
+++ b/actionview/lib/action_view/unbound_template.rb
@@ -4,16 +4,13 @@ require "concurrent/map"
 
 module ActionView
   class UnboundTemplate
-    attr_reader :handler, :format, :variant, :locale, :virtual_path
+    attr_reader :virtual_path, :details
+    delegate :locale, :format, :variant, :handler, to: :@details
 
-    def initialize(source, identifier, handler, format:, variant:, locale:, virtual_path:)
+    def initialize(source, identifier, details:, virtual_path:)
       @source = source
       @identifier = identifier
-      @handler = handler
-
-      @format = format
-      @variant = variant
-      @locale = locale
+      @details = details
       @virtual_path = virtual_path
 
       @templates = Concurrent::Map.new(initial_capacity: 2)
@@ -25,16 +22,13 @@ module ActionView
 
     private
       def build_template(locals)
-        handler = Template.handler_for_extension(@handler)
-        format = @format || handler.try(:default_format)
-
         Template.new(
           @source,
           @identifier,
-          handler,
+          details.handler_class,
 
-          format: format,
-          variant: @variant,
+          format: details.format_or_default,
+          variant: variant&.to_s,
           virtual_path: @virtual_path,
 
           locals: locals


### PR DESCRIPTION
@seejohnrun and I wrote this together live on Twitch https://www.twitch.tv/videos/1019394918. Thanks to everyone who tuned in ❤️

When dealing with the "details" for a template: `locale`, `format`, `variant`, and `handler`, previously we would store these in an ad-hoc way every place we did. Often as a hash or as separate instance variables on a class.

This PR attempts to simplify this by encapsulating known details on a template in a new `ActionView::TemplateDetails` class, and requested details in `ActionView::TemplateDetails::Requested`.

This allowed extracting and simplifying filtering and sorting logic from the `Resolver` class as well as extracting default format logic from `UnboundTemplate`.

As well as reducing complexity, in the future this should make it possible to provide suggestions on missing template errors due to mismatched details, and might allow improved performance.

At least for now these new classes are private (:nodoc)