### PR TITLE
Add example for proc-based route to Routing guide [ci skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -920,6 +920,8 @@ As long as `MyRackApp` responds to `call` and returns a `[status, headers, body]
 
 NOTE: For the curious, `'articles#index'` actually expands out to `ArticlesController.action(:index)`, which returns a valid Rack application.
 
+NOTE: Since procs/lambdas are objects that happen to respond to `call` you can implement very simple routes (e.g. for health checks) inline:<br>`get '/health', to: ->(env) { [204, {}, ''] }`
+
 If you specify a Rack application as the endpoint for a matcher, remember that
 the route will be unchanged in the receiving application. With the following
 route your Rack application should expect the route to be `/admin`:


### PR DESCRIPTION
### Summary

Add a small example of how the routing to Rack apps functionality can be used with procs/lambdas in the Routing guide.
