### PR TITLE
Don't check `type` on `add_column` via column_exists?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -604,7 +604,7 @@ module ActiveRecord
       #  # Ignores the method call if the column exists
       #  add_column(:shapes, :triangle, 'polygon', if_not_exists: true)
       def add_column(table_name, column_name, type, **options)
-        return if options[:if_not_exists] == true && column_exists?(table_name, column_name, type)
+        return if options[:if_not_exists] == true && column_exists?(table_name, column_name)
 
         at = create_alter_table table_name
         at.add_column(column_name, type, **options)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -341,7 +341,37 @@ class MigrationTest < ActiveRecord::TestCase
     end
   end
 
-  def test_add_column_with_if_not_exists_set_to_true_still_raises_if_type_is_different
+  def test_add_column_with_casted_type_if_not_exists_set_to_true
+    migration_a = Class.new(ActiveRecord::Migration::Current) {
+      def version; 100 end
+      def migrate(x)
+        type = current_adapter?(:PostgreSQLAdapter) ? :char : :blob
+        add_column "people", "last_name", type
+      end
+    }.new
+
+    migration_b = Class.new(ActiveRecord::Migration::Current) {
+      def version; 101 end
+      def migrate(x)
+        type = current_adapter?(:PostgreSQLAdapter) ? :char : :blob
+        add_column "people", "last_name", type, if_not_exists: true
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
+    assert_column Person, :last_name, "migration_a should have created the last_name column on people"
+
+    assert_nothing_raised do
+      ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
+    end
+  ensure
+    Person.reset_column_information
+    if Person.column_names.include?("last_name")
+      Person.connection.remove_column("people", "last_name")
+    end
+  end
+
+  def test_add_column_with_if_not_exists_set_to_true_does_not_raise_if_type_is_different
     migration_a = Class.new(ActiveRecord::Migration::Current) {
       def version; 100 end
       def migrate(x)
@@ -359,7 +389,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::Migrator.new(:up, [migration_a], @schema_migration, 100).migrate
     assert_column Person, :last_name, "migration_a should have created the last_name column on people"
 
-    assert_raises do
+    assert_nothing_raised do
       ActiveRecord::Migrator.new(:up, [migration_b], @schema_migration, 101).migrate
     end
   ensure


### PR DESCRIPTION
I originally added the `type` to the `column_exists?` check in
`add_column` because I thought it would be useful to still raise if you
tried to add a column with a different type. It seemed bad to silently
ignore.

The `type` check works fine for standard, non-type casted types like
`string`, but migrations that use types like `blob` in mysql/sqlite3 or
`char` in postgres cast these to other types. When `c.type ==
type.to_sym` is called in those cases they won't match. For example
`c.type` for a `blob` column will return `binary` so the comparison
won't match. I attempted to cast the `type` passed in but that's error
prone because for dbs like postgres we need _a lot_ more information
than just a type to determine how to cast it. I also tried going the
other way but the column doesn't store the original type, just the type
casted type (as type) and the sql type which is a string representation
of type that doesn't always match the original.

This functionality was originally extracted from GitHub and when I
looked back at our old implementation I found that we originally weren't
passing type. This came up in a migration for enterprise that wasn't
properly handling the `if_not_exists` because our `type` check was
comparing `binary` to `mediumblob`. I think it makes the most sense to
leave the public `column_exists?` method as is and remove the `type`
check from `column_exists?` in the `add_column` method.