### PR TITLE
Allow symbols as template identifiers

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -194,6 +194,7 @@ module ActionView
 
       # Fix when prefix is specified as part of the template name
       def normalize_name(name, prefixes)
+        name = name.to_s
         idx = name.rindex("/")
         return name, prefixes.presence || [""] unless idx
 

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -149,6 +149,10 @@ module RenderTestCases
     assert_equal "4", @view.render(inline: "(2**2).to_s", type: :ruby)
   end
 
+  def test_render_template_via_symbol_lookup
+    assert_equal "Hello from Ruby code", @view.render(template: :ruby_template)
+  end
+
   def test_render_template_with_localization_on_context_level
     old_locale, @view.locale = @view.locale, :da
     assert_equal "Hey verden", @view.render(template: "test/hello_world")


### PR DESCRIPTION
### Summary

Some [recent optimisation work](https://github.com/rails/rails/pull/42194) altered some behaviour which previously allowed a Symbol to be passed as a template identifier.

```
NoMethodError: undefined method `rindex' for :my_template:Symbol
    actionview (7.0.0.alpha.43254be) lib/action_view/lookup_context.rb:197:in `normalize_name'
```

This PR updates the `normalize_name` method to ensure it is operating on a String and adds coverage to confirm Symbol identifiers are supported.

/cc @jhawthorn 
