### PR TITLE
Derive foreign key from model name in `has_many` associations

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -665,7 +665,7 @@ module ActiveRecord
           elsif options[:as]
             "#{options[:as]}_id"
           else
-            active_record.name.foreign_key
+            active_record.model_name.to_s.foreign_key
           end
         end
 

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -421,6 +421,10 @@ class ReflectionTest < ActiveRecord::TestCase
     assert_equal "category_id", Post.reflect_on_association(:categorizations).foreign_key.to_s
   end
 
+  def test_foreign_key_is_inferred_from_model_name
+    assert_equal "post_id", PostRecord.reflect_on_association(:comments).foreign_key.to_s
+  end
+
   def test_symbol_for_class_name
     assert_equal Client, Firm.reflect_on_association(:unsorted_clients_with_symbol).klass
   end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -384,6 +384,8 @@ class Postesque < ActiveRecord::Base
 end
 
 class PostRecord < ActiveRecord::Base
+  has_many :comments
+
   class << self
     def model_name
       ActiveModel::Name.new(self, nil, "Post")


### PR DESCRIPTION
Currently Active Record derives the foreign key name for `has_many` associations based on the Active Record Base `name. Sometimes when using additional conventions for class names, such as with class name suffixes and prefixes, it makes sense to be able to further customize the foreign key logic to account for a different pattern.

Similar to what was done in the [case of table names](https://github.com/rails/rails/pull/42213), as Active Record Base extends Active Model Naming, we have already a `model_name` at the class-level that behaves similarly to `name` while at the same time giving more flexibility by allowing specifying a custom name and namespacing.

This commit changes the foreign key computation in Reflections to infer its value based on the Active Record's `model_name` object instead of its class `name`. This allows customization of the foreign key pattern since a distinct instance of `ActiveModel::Name` can be used instead.

For example, to use `post_id` as foreign key for a `PostRecord` class in a `has_many` association:

```ruby
 class PostRecord < ActiveRecord::Base
   has_many :comments

   class << self
     def model_name
       ActiveModel::Name.new(self, nil, "Post")
     end
   end
 end

 PostRecord.reflect_on_association(:comments).foreign_key
 # => "post_id"
```
