### PR TITLE
Set session options when initializing a basic session

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Set session options when initializing a basic session.
+
+    *Gannon McGibbon*
+
 *   Add `cache_control: {}` option to `fresh_when` and `stale?`
 
     Works as a shortcut to set `response.cache_control` with the above methods.

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -25,7 +25,9 @@ module ActionDispatch
       end
 
       def self.disabled(req)
-        new(nil, req, enabled: false)
+        new(nil, req, enabled: false).tap do
+          Session::Options.set(req, Session::Options.new(nil, { id: nil }))
+        end
       end
 
       def self.find(req)

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1381,3 +1381,17 @@ class RequestInspectTest < BaseRequestTest
     assert_match %r(#<ActionDispatch::Request POST "https://example.com/path/\?q=1" for 1.2.3.4>), request.inspect
   end
 end
+
+class RequestSession < BaseRequestTest
+  def setup
+    super
+    @request = stub_request
+  end
+
+  test "#session" do
+    @request.session
+
+    assert_not_predicate(ActionDispatch::Request::Session.find(@request), :enabled?)
+    assert_instance_of(ActionDispatch::Request::Session::Options, ActionDispatch::Request::Session::Options.find(@request))
+  end
+end


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/41932

Sets session options when setting a default basic session. Overrides `Rack::Request#session`, which is public.