### PR TITLE
Add Range serializer for ActiveJob

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add a Serializer for the Range class
+
+    This should allow things like `MyJob.perform_later(range: 1..100)`
+
 *   Communicate enqueue failures to callers of `perform_later`.
 
     `perform_later` can now optionally take a block which will execute after

--- a/activejob/lib/active_job/serializers.rb
+++ b/activejob/lib/active_job/serializers.rb
@@ -17,6 +17,7 @@ module ActiveJob
     autoload :TimeWithZoneSerializer
     autoload :TimeSerializer
     autoload :ModuleSerializer
+    autoload :RangeSerializer
 
     mattr_accessor :_additional_serializers
     self._additional_serializers = Set.new
@@ -61,6 +62,7 @@ module ActiveJob
       DateSerializer,
       TimeWithZoneSerializer,
       TimeSerializer,
-      ModuleSerializer
+      ModuleSerializer,
+      RangeSerializer
   end
 end

--- a/activejob/lib/active_job/serializers/range_serializer.rb
+++ b/activejob/lib/active_job/serializers/range_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveJob
+  module Serializers
+    class RangeSerializer < ObjectSerializer
+      KEYS = %w[begin end exclude_end].freeze
+
+      def serialize(range)
+        args = Arguments.serialize([range.begin, range.end, range.exclude_end?])
+        hash = KEYS.zip(args).to_h
+        super(hash)
+      end
+
+      def deserialize(hash)
+        args = Arguments.deserialize(hash.values_at(*KEYS))
+        Range.new(*args)
+      end
+
+      private
+        def klass
+          ::Range
+        end
+    end
+  end
+end

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -30,7 +30,15 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     { "a" => 1 },
     ModuleArgument,
     ModuleArgument::ClassArgument,
-    ClassArgument
+    ClassArgument,
+    1..,
+    1...,
+    1..5,
+    1...5,
+    Date.new(2001, 2, 3)..,
+    Time.new(2002, 10, 31, 2, 2, 2.123456789r, "+02:00")..,
+    DateTime.new(2001, 2, 3, 4, 5, 6.123456r, "+03:00")..,
+    ActiveSupport::TimeWithZone.new(Time.utc(1999, 12, 31, 23, 59, "59.123456789".to_r), ActiveSupport::TimeZone["UTC"])..,
   ].each do |arg|
     test "serializes #{arg.class} - #{arg.inspect} verbatim" do
       assert_arguments_unchanged arg


### PR DESCRIPTION
### Summary

This change adds an ActiveJob serializer for the core ruby Range object.

### Other Information

Missing Range support means users need to add start/finish pair of arguments instead of simply passing a Range object.

Then native ruby `as_json`/`json_create` are not used because they can't handle endless ranges.