### PR TITLE
Display a help message if `rails new` is called without a path

### DIFF
--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -38,6 +38,7 @@ module Rails
         end
 
         command_name, namespace = "help", "help" if command_name.blank? || HELP_MAPPINGS.include?(command_name)
+        command_name, namespace, args = "application", "application", ["--help"] if rails_new_with_no_path?(args)
         command_name, namespace = "version", "version" if %w( -v --version ).include?(command_name)
 
         original_argv = ARGV.dup
@@ -91,6 +92,10 @@ module Rails
       private
         COMMANDS_IN_USAGE = %w(generate console server test test:system dbconsole new)
         private_constant :COMMANDS_IN_USAGE
+
+        def rails_new_with_no_path?(args)
+          args == ["new"]
+        end
 
         def commands
           lookup!

--- a/railties/test/command/application_test.rb
+++ b/railties/test/command/application_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "rails/command"
+
+class Rails::Command::ApplicationTest < ActiveSupport::TestCase
+  test "rails new without path prints help" do
+    output = capture(:stdout) do
+      Rails::Command.invoke(:application, %w[new])
+    end
+
+    # Doesn't include the default thor error message:
+    assert_not output.start_with?("No value provided for required arguments")
+
+    # Includes contents of ~/railties/lib/rails/generators/rails/app/USAGE:
+    assert output.include?("The 'rails new' command creates a new Rails application with a default
+    directory structure and configuration at the path you specify.")
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/42196

Previously calling `rails new` without an app path displayed an error message that wasn't very friendly.

Not it will display the same usage message that `rails` and `rails help new` does.

To test (copied from https://github.com/rails/rails/pull/39282):

- Pull this branch
- Uninstall your local rails copy using `gem uninstall rails`
- Move into the root directory where you pulled down the rails code, then install: `rake install`
- In another directory run `rails new`