### PR TITLE
Private process action

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -35,14 +35,6 @@ module AbstractController
                        skip_after_callbacks_if_terminated: true
     end
 
-    # Override <tt>AbstractController::Base#process_action</tt> to run the
-    # <tt>process_action</tt> callbacks around the normal behavior.
-    def process_action(*)
-      run_callbacks(:process_action) do
-        super
-      end
-    end
-
     module ClassMethods
       # If +:only+ or +:except+ are used, convert the options into the
       # +:if+ and +:unless+ options of ActiveSupport::Callbacks.
@@ -220,5 +212,14 @@ module AbstractController
         alias_method :"append_#{callback}_action", :"#{callback}_action"
       end
     end
+
+    private
+      # Override <tt>AbstractController::Base#process_action</tt> to run the
+      # <tt>process_action</tt> callbacks around the normal behavior.
+      def process_action(*)
+        run_callbacks(:process_action) do
+          super
+        end
+      end
   end
 end

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -46,64 +46,64 @@ module ActionController
       end
     end
 
-  private
-    def process_action(*)
-      raw_payload = {
-        controller: self.class.name,
-        action: action_name,
-        request: request,
-        params: request.filtered_parameters,
-        headers: request.headers,
-        format: request.format.ref,
-        method: request.request_method,
-        path: request.fullpath
-      }
+    private
+      def process_action(*)
+        raw_payload = {
+          controller: self.class.name,
+          action: action_name,
+          request: request,
+          params: request.filtered_parameters,
+          headers: request.headers,
+          format: request.format.ref,
+          method: request.request_method,
+          path: request.fullpath
+        }
 
-      ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload)
+        ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload)
 
-      ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
-        result = super
-        payload[:response] = response
-        payload[:status]   = response.status
-        result
-      rescue => error
-        payload[:status] = ActionDispatch::ExceptionWrapper.status_code_for_exception(error.class.name)
-        raise
-      ensure
-        append_info_to_payload(payload)
+        ActiveSupport::Notifications.instrument("process_action.action_controller", raw_payload) do |payload|
+          result = super
+          payload[:response] = response
+          payload[:status]   = response.status
+          result
+        rescue => error
+          payload[:status] = ActionDispatch::ExceptionWrapper.status_code_for_exception(error.class.name)
+          raise
+        ensure
+          append_info_to_payload(payload)
+        end
       end
-    end
 
-    # A hook invoked every time a before callback is halted.
-    def halted_callback_hook(filter, _)
-      ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)
-    end
-
-    # A hook which allows you to clean up any time, wrongly taken into account in
-    # views, like database querying time.
-    #
-    #   def cleanup_view_runtime
-    #     super - time_taken_in_something_expensive
-    #   end
-    def cleanup_view_runtime # :doc:
-      yield
-    end
-
-    # Every time after an action is processed, this method is invoked
-    # with the payload, so you can add more information.
-    def append_info_to_payload(payload) # :doc:
-      payload[:view_runtime] = view_runtime
-    end
-
-    module ClassMethods
-      # A hook which allows other frameworks to log what happened during
-      # controller process action. This method should return an array
-      # with the messages to be added.
-      def log_process_action(payload) #:nodoc:
-        messages, view_runtime = [], payload[:view_runtime]
-        messages << ("Views: %.1fms" % view_runtime.to_f) if view_runtime
-        messages
+      # A hook invoked every time a before callback is halted.
+      def halted_callback_hook(filter, _)
+        ActiveSupport::Notifications.instrument("halted_callback.action_controller", filter: filter)
       end
-    end
+
+      # A hook which allows you to clean up any time, wrongly taken into account in
+      # views, like database querying time.
+      #
+      #   def cleanup_view_runtime
+      #     super - time_taken_in_something_expensive
+      #   end
+      def cleanup_view_runtime # :doc:
+        yield
+      end
+
+      # Every time after an action is processed, this method is invoked
+      # with the payload, so you can add more information.
+      def append_info_to_payload(payload) # :doc:
+        payload[:view_runtime] = view_runtime
+      end
+
+      module ClassMethods
+        # A hook which allows other frameworks to log what happened during
+        # controller process action. This method should return an array
+        # with the messages to be added.
+        def log_process_action(payload) #:nodoc:
+          messages, view_runtime = [], payload[:view_runtime]
+          messages << ("Views: %.1fms" % view_runtime.to_f) if view_runtime
+          messages
+        end
+      end
   end
 end

--- a/actionpack/lib/action_controller/metal/params_wrapper.rb
+++ b/actionpack/lib/action_controller/metal/params_wrapper.rb
@@ -242,14 +242,14 @@ module ActionController
       end
     end
 
-    # Performs parameters wrapping upon the request. Called automatically
-    # by the metal call stack.
-    def process_action(*)
-      _perform_parameter_wrapping if _wrapper_enabled?
-      super
-    end
-
     private
+      # Performs parameters wrapping upon the request. Called automatically
+      # by the metal call stack.
+      def process_action(*)
+        _perform_parameter_wrapping if _wrapper_enabled?
+        super
+      end
+
       # Returns the wrapper key which will be used to store wrapped parameters.
       def _wrapper_key
         _wrapper_options.name

--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -24,12 +24,6 @@ module ActionController
       end
     end
 
-    # Before processing, set the request formats in current controller formats.
-    def process_action(*) #:nodoc:
-      self.formats = request.formats.filter_map(&:ref)
-      super
-    end
-
     # Check for double render errors and set the content_type after rendering.
     def render(*args) #:nodoc:
       raise ::AbstractController::DoubleRenderError if response_body
@@ -53,6 +47,12 @@ module ActionController
     end
 
     private
+      # Before processing, set the request formats in current controller formats.
+      def process_action(*) #:nodoc:
+        self.formats = request.formats.filter_map(&:ref)
+        super
+      end
+
       def _process_variant(options)
         if defined?(request) && !request.nil? && request.variant.present?
           options[:variant] = request.variant


### PR DESCRIPTION
### Summary

`AbstractController::Base` defines `process_action` as private, but modules included after redefine it as a public method.

I also fixed the indentation in actionpack/lib/action_controller/metal/instrumentation.rb, I kept it separate for easier review but I can squash it.

### Other Information

Doing this removes `process_action` from the docs (there's still [ActionController::LogSubscriber#process_action](https://api.rubyonrails.org/v6.1.3/classes/ActionController/LogSubscriber.html#method-i-process_action)).

Maybe we should make it visible to the documentation in `AbstractController::Base`, given the comment and the fact that it's then overridden by things outside actionpack like `ActiveRecord::Railties::ControllerRuntime`:
https://github.com/rails/rails/blob/75ac626c4e21129d8296d4206a1960563cc3d4aa/actionpack/lib/abstract_controller/base.rb#L221-L223

cc @rafaelfranca @byroot