### PR TITLE
Improve _blob.html.erb

### DIFF
--- a/actiontext/app/views/active_storage/blobs/_blob.html.erb
+++ b/actiontext/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,16 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
     <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% elsif blob.image? %>
+    <%= image_tag blob, width: "200px" %>
+  <% elsif blob.audio? %>
+    <audio controls>
+      <source src="<%= rails_blob_url(blob) %>" type="<%= blob.content_type %>"></source>
+    </audio>
+  <% elsif blob.video? %>
+    <video controls width="480">
+      <source src="<%= rails_blob_url(blob) %>" type="<%= blob.content_type %>"></source>
+    </video>
   <% end %>
 
   <figcaption class="attachment__caption">


### PR DESCRIPTION
Current behavior: 
* only images are represented, and only when `gem 'image_processing'` is installed.
New behavior:
* displays image or video or audio in any case. HTML5 audio and video tags

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
