### PR TITLE
Fixes ActiveStorage#has_many_attached re-creating destroyed attachment

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_many.rb
@@ -7,6 +7,7 @@ module ActiveStorage
     def initialize(name, record, attachables)
       @name, @record, @attachables = name, record, Array(attachables)
       blobs.each(&:identify_without_saving)
+      attachments
     end
 
     def attachments
@@ -35,13 +36,16 @@ module ActiveStorage
         ActiveStorage::Attached::Changes::CreateOneOfMany.new(name, record, attachable)
       end
 
-
       def assign_associated_attachments
-        record.public_send("#{name}_attachments=", attachments)
+        record.public_send("#{name}_attachments=", persisted_or_new_attachments)
       end
 
       def reset_associated_blobs
         record.public_send("#{name}_blobs").reset
+      end
+
+      def persisted_or_new_attachments
+        attachments.select { |attachment| attachment.persisted? || attachment.new_record? }
       end
   end
 end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -648,6 +648,24 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_match(/Cannot find variant :unknown for User#highlights_with_variants/, error.message)
   end
 
+  test "successfully attaches new blobs and destroys attachments marked for destruction via nested attributes" do
+    append_on_assign do
+      town_blob = create_blob(filename: "town.jpg")
+      @user.highlights.attach(town_blob)
+      @user.reload
+
+      racecar_blob = fixture_file_upload("racecar.jpg")
+      @user.update(
+        highlights: [racecar_blob],
+        highlights_attachments_attributes: [{ id: town_blob.id, _destroy: true }]
+      )
+
+      assert @user.reload.highlights.attached?
+      assert_equal 1, @user.highlights.count
+      assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
+    end
+  end
+
   private
     def append_on_assign
       ActiveStorage.replace_on_assign_to_many, previous = false, ActiveStorage.replace_on_assign_to_many

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -128,6 +128,8 @@ class User < ActiveRecord::Base
   has_many_attached :highlights_with_variants do |attachable|
     attachable.variant :thumb, resize: "100x100"
   end
+
+  accepts_nested_attributes_for :highlights_attachments, allow_destroy: true
 end
 
 class Group < ActiveRecord::Base


### PR DESCRIPTION
fixes #41862

ActiveStorage#has_many_attached with `config.active_storage.replace_on_assign_to_many = false`
flag set to flase always appends new attachments to the association.
As mentioned in the issue, if you use nested attributes along with
flag disabled and mark some of the attachment to be `destroyed?`.
The attachment is destroyed but get re-created without blob upload.
This also results in `ActiveStorage#purge_job` failing with rollback.

This PR intends to resolve the issue by checking if the attachment is
persisted when `#save` is invoked. Only persisted and attachment
records are saved which patches the issues.
