### PR TITLE
Active Storage: don't crash if mini_mime doesn't recognize content_type

### DIFF
--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -113,7 +113,7 @@ module ActiveStorage::Blob::Representable
       if filename.extension.present? && MiniMime.lookup_by_extension(filename.extension)&.content_type == content_type
         filename.extension
       else
-        MiniMime.lookup_by_content_type(content_type).extension
+        MiniMime.lookup_by_content_type(content_type)&.extension
       end
     end
 

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -187,6 +187,20 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
   end
 
+  test "doesn't crash content_type not recognized by mini_mime" do
+    blob = create_file_blob(filename: "racecar.jpg")
+
+    # image/jpg is not recognised by mini_mime (image/jpeg is correct)
+    blob.update(content_type: "image/jpg")
+
+    assert_nothing_raised do
+      blob.variant(resize: "100x100")
+    end
+
+    assert_nil blob.send(:format)
+    assert_equal :png, blob.send(:default_variant_format)
+  end
+
   private
     def process_variants_with(processor)
       previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, processor


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/41777

Since there is no format recognised for the invalid content_type, we fall back to treating it as a `png`. This was also the behavior with mimemagic.

Note this is a regression in 6.1.3.1. Would be good to backport to https://github.com/rails/rails/tree/6-1-stable