### PR TITLE
Fix ActiveStorage intermittent test

### DIFF
--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -655,9 +655,10 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
       @user.reload
 
       racecar_blob = fixture_file_upload("racecar.jpg")
+      attachment_id = town_blob.attachments.find_by!(record: @user).id
       @user.update(
         highlights: [racecar_blob],
-        highlights_attachments_attributes: [{ id: town_blob.id, _destroy: true }]
+        highlights_attachments_attributes: [{ id: attachment_id, _destroy: true }]
       )
 
       assert @user.reload.highlights.attached?


### PR DESCRIPTION
The `main` branch is failing https://buildkite.com/rails/rails/builds/77422 since https://github.com/rails/rails/pull/42224 was merged. The problem is that the test needs to use the `ActiveStorage::Attachment` `id` not the `ActiveStorage::Blob` `id`. 

The intermittency is there because sometimes the `id` of both match. In order to consistently reproduce the failure (before this PR) you can run: `bundle exec rake TESTOPTS="--seed=26565"`

cc: @eileencodes 