### PR TITLE
Use a regular flash object if session store is disabled

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -199,6 +199,10 @@ module ActionController #:nodoc:
             def exists?
               true
             end
+
+            def enabled?
+              false
+            end
           end
 
           class NullCookieJar < ActionDispatch::Cookies::CookieJar #:nodoc:

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -211,6 +211,10 @@ module ActionController
       @data.fetch(key.to_s, *args, &block)
     end
 
+    def enabled?
+      true
+    end
+
     private
       def load!
         @id

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -244,7 +244,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
   SessionKey = "_myapp_session"
   Generator = ActiveSupport::CachingKeyGenerator.new(
     ActiveSupport::KeyGenerator.new("b3c631c314c0bbca50c1b2843150fe33", iterations: 1000)
- )
+  )
   Rotations = ActiveSupport::Messages::RotationConfiguration.new
   SIGNED_COOKIE_SALT = "signed cookie"
 


### PR DESCRIPTION
### Summary

After #42167, all apps (except api only ones) have access to the flash
module. If the session store is disabled, then an empty flash object
is used.

The old null flash was removed because of the maintenance costs.

cc/ @byroot 