### PR TITLE
Fix NullRelation#to_sql to return an actual query

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -38,10 +38,6 @@ module ActiveRecord
       false
     end
 
-    def to_sql
-      ""
-    end
-
     def calculate(operation, _column_name)
       case operation
       when :count, :sum

--- a/activerecord/test/cases/null_relation_test.rb
+++ b/activerecord/test/cases/null_relation_test.rb
@@ -51,7 +51,7 @@ class NullRelationTest < ActiveRecord::TestCase
   end
 
   def test_null_relation_metadata_methods
-    assert_equal "", Developer.none.to_sql
+    assert_includes Developer.none.to_sql, " WHERE (1=0)"
     assert_equal({}, Developer.none.where_values_hash)
   end
 


### PR DESCRIPTION
Fix: #42229

It is unclear why it was defined to return an empty string in #5809.

But returning the query that will actually be generated if the NullRelation is executed makes more sense.

cc @bf4 