### PR TITLE
Make ActiveRecord::Base.logger a class_attribute

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `ActiveRecord::Base.logger` is now a `class_attribute`.
+
+    This means it can no longer be accessed directly through `@@logger`, and that setting `logger =`
+    on a subclass won't change the parent's logger.
+
+    *Jean Boussier*
+
 *   Add `.asc.nulls_first` for all databases. Unfortunately MySQL still doesn't like `nulls_last`.
 
     *Keenan Brock*

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       # Accepts a logger conforming to the interface of Log4r which is then
       # passed on to any new database connections made and which can be
       # retrieved on both a class and instance level by calling +logger+.
-      mattr_accessor :logger, instance_writer: false
+      class_attribute :logger, instance_writer: false
 
       ##
       # :singleton-method:


### PR DESCRIPTION
`cattr_accessor` rely on class variables which has terrible
performance on long ancestor chains. See https://bugs.ruby-lang.org/issues/17763
for a detailed description of the problem.

In comparison `class_attribute` on `ActiveRecord::Base` is almost 7x
faster:

```
Calculating -------------------------------------
              logger      1.700M (± 0.9%) i/s -      8.667M in   5.097595s
             clogger     11.556M (± 0.9%) i/s -     58.806M in   5.089282s

Comparison:
             clogger: 11555754.2 i/s
              logger:  1700280.4 i/s - 6.80x  (± 0.00) slower
```

This is because `ActiveRecord::Base.ancestors.size == 62`.

Other `cattr` usages on `ActiveRecord::Base` should be considered too, but `logger` is by far the biggest hostspot, so probably the best one to start the discussion.

@eileencodes @jhawthorn @tenderlove @rafaelfranca 