### PR TITLE
[ci skip] Redis adapter SSL/TLS connection information ( action cable  docs).

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -723,7 +723,7 @@ The Redis adapter requires users to provide a URL pointing to the Redis server.
 Additionally, a `channel_prefix` may be provided to avoid channel name collisions
 when using the same Redis server for multiple applications. See the [Redis PubSub documentation](https://redis.io/topics/pubsub#database-amp-scoping) for more details.
 
-The Redis adapter also support SSL/TLS connections. The required SSL/TLS parameters can be be passed in `ssl_params` key in the configuration yaml file.
+The Redis adapter also supports SSL/TLS connections. The required SSL/TLS parameters can be be passed in `ssl_params` key in the configuration yaml file.
 
 ```
 production:
@@ -735,20 +735,12 @@ production:
   }
 ```
 
-The options given to `ssl_params` are passed directly to the OpenSSL::SSL::SSLContext#set_params method and can be any valid attribute of the SSL context.
-Please see [OpenSSL::SSL::SSLContext documentation](https://ruby-doc.org/stdlib-2.7.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html) for other available
-attributes. If you are using self signed certificates for redis adapter under a firewall and opt to skip certificate check, then the ssl `verify_mode` should be
-set as OpenSSL::SSL::VERIFY_NONE.
+The options given to `ssl_params` are passed directly to the `OpenSSL::SSL::SSLContext#set_params` method and can be any valid attribute of the SSL context.
+Please refer to the [OpenSSL::SSL::SSLContext documentation](https://docs.ruby-lang.org/en/master/OpenSSL/SSL/SSLContext.html) for other available attributes.
 
-```
-production:
-  adapter: redis
-  url: rediss://10.10.3.153:tls_port
-  channel_prefix: appname_production
-  ssl_params: {
-    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
-  }
-```
+If you are using self-signed certificates for redis adapter behind a firewall and opt to skip certificate check, then the ssl `verify_mode` should be set as `OpenSSL::SSL::VERIFY_NONE`.
+
+WARNING: It is not recommended to use `VERIFY_NONE` in production unless you absolutely understand the security implications. In order to set this option for the Redis adapter, the config should be `ssl_params: { <%= OpenSSL::SSL::VERIFY_NONE %> }`.
 
 ##### PostgreSQL Adapter
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -723,6 +723,33 @@ The Redis adapter requires users to provide a URL pointing to the Redis server.
 Additionally, a `channel_prefix` may be provided to avoid channel name collisions
 when using the same Redis server for multiple applications. See the [Redis PubSub documentation](https://redis.io/topics/pubsub#database-amp-scoping) for more details.
 
+The Redis adapter also support SSL/TLS connections. The required SSL/TLS parameters can be be passed in `ssl_params` key in the configuration yaml file.
+
+```
+production:
+  adapter: redis
+  url: rediss://10.10.3.153:tls_port
+  channel_prefix: appname_production
+  ssl_params: {
+    ca_file: "/path/to/ca.crt"
+  }
+```
+
+The options given to `ssl_params` are passed directly to the OpenSSL::SSL::SSLContext#set_params method and can be any valid attribute of the SSL context.
+Please see [OpenSSL::SSL::SSLContext documentation](https://ruby-doc.org/stdlib-2.7.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html) for other available
+attributes. If you are using self signed certificates for redis adapter under a firewall and opt to skip certificate check, then the ssl `verify_mode` should be
+set as OpenSSL::SSL::VERIFY_NONE.
+
+```
+production:
+  adapter: redis
+  url: rediss://10.10.3.153:tls_port
+  channel_prefix: appname_production
+  ssl_params: {
+    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
+  }
+```
+
 ##### PostgreSQL Adapter
 
 The PostgreSQL adapter uses Active Record's connection pool, and thus the


### PR DESCRIPTION
### Summary

Followup for [this comment](https://github.com/rails/rails/issues/42036#issuecomment-830644874) to add redis adapter ssl_params documentaiton.

Redis 6 requires TLS to connect. However, Heroku support explained that they manage requests from the router level to the application level involving Self Signed Certs. Turns out, Heroku terminates SSL at the router level and requests are forwarded from there to the application via HTTP while everything is behind Heroku's Firewall and security measures.

When Redis adapter is used for action cable, we can pass ssl_params to skip certificate check. Also there are more valid attributes which can be passed in ssl_params. Added these informations to action cable configuration doc section.

### Other Information

[Heroku documentation](https://devcenter.heroku.com/articles/securing-heroku-redis#using-ruby)

cc: @pixeltrix @zzak 