### PR TITLE
Avoid running async queries on null relations

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -56,8 +56,8 @@ module ActiveRecord
     end
 
     private
-      def exec_queries
-        @records = [].freeze
+      def exec_main_query(async: false)
+        [].freeze
       end
   end
 end

--- a/activerecord/test/cases/null_relation_test.rb
+++ b/activerecord/test/cases/null_relation_test.rb
@@ -28,6 +28,12 @@ class NullRelationTest < ActiveRecord::TestCase
     end
   end
 
+  def test_async_query_on_null_relation
+    assert_no_queries do
+      assert_equal [], Developer.none.load_async.load
+    end
+  end
+
   def test_none_chained_to_methods_firing_queries_straight_to_db
     assert_no_queries do
       assert_equal [],    Developer.none.pluck(:id, :name)


### PR DESCRIPTION
Calling `load_async` on a null relation was executing the fallback `WHERE 1=0` query, since it doesn't go through `exec_queries`.

Since https://github.com/rails/rails/pull/41372, `exec_queries` is implemented in terms of `exec_main_query`, so we only need to override that one method.

We can also stop assigning `@records`, as that now happens in `load` since https://github.com/rails/rails/pull/37926.