### PR TITLE
Fix invalid statement template compile error

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb
@@ -6,6 +6,7 @@
 <%= @exception.message %>
 <% if defined?(ActiveStorage) && @exception.message.match?(%r{#{ActiveStorage::Blob.table_name}|#{ActiveStorage::Attachment.table_name}}) %>
 To resolve this issue run: bin/rails active_storage:install
+<% end %>
 <% if defined?(ActionMailbox) && @exception.message.match?(%r{#{ActionMailbox::InboundEmail.table_name}}) %>
 To resolve this issue run: bin/rails action_mailbox:install
 <% end %>


### PR DESCRIPTION
### Summary

In the view `actionpack/lib/action_dispatch/middleware/templates/rescues/invalid_statement.text.erb` there is a missing `end`, causing a compile error with the template. 

