### PR TITLE
Generate OrderedOptions accessors on first access

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -71,12 +71,6 @@ module ActionMailer
       end
     end
 
-    initializer "action_mailer.compile_config_methods" do
-      ActiveSupport.on_load(:action_mailer) do
-        config.compile_methods! if config.respond_to?(:compile_methods!)
-      end
-    end
-
     initializer "action_mailer.eager_load_actions" do
       ActiveSupport.on_load(:after_initialize) do
         ActionMailer::Base.descendants.each(&:action_methods) if config.eager_load

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -66,12 +66,6 @@ module ActionController
       end
     end
 
-    initializer "action_controller.compile_config_methods" do
-      ActiveSupport.on_load(:action_controller) do
-        config.compile_methods! if config.respond_to?(:compile_methods!)
-      end
-    end
-
     initializer "action_controller.request_forgery_protection" do |app|
       ActiveSupport.on_load(:action_controller_base) do
         if app.config.action_controller.default_protect_from_forgery

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Generate `ActiveSupport::OrderedOptions` accessors on first access.
+
+    Getter and setter methods on `ActiveSupport::OrderedOptions` are now
+    generated on each instance the first time an accessor method is called.
+
+    This fixes a bug where methods on `Hash` would mask keys with the same
+    name on `ActiveSupport::OrderedOptions` and by extension
+    `ActiveSupport::Configurable` (e.g. `Rails.application.config`).
+
+    This change also increases the read performance of
+    `ActiveSupport::OrderedOptions` and removes the need for
+    `ActiveSupport::Configurable::Configuration#compile_methods!`.
+
+    *Malcolm Locke*
+
 *   Deprecate `ActiveSupport::SafeBuffer`'s incorrect implicit conversion of objects into string.
 
     Except for a few methods like `String#%`, objects must implement `#to_str`

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -10,18 +10,6 @@ module ActiveSupport
     extend ActiveSupport::Concern
 
     class Configuration < ActiveSupport::InheritableOptions
-      def compile_methods!
-        self.class.compile_methods!(keys)
-      end
-
-      # Compiles reader methods so we don't have to go through method_missing.
-      def self.compile_methods!(keys)
-        keys.reject { |m| method_defined?(m) }.each do |key|
-          class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def #{key}; _get(#{key.inspect}); end
-          RUBY
-        end
-      end
     end
 
     module ClassMethods

--- a/activesupport/test/configurable_test.rb
+++ b/activesupport/test/configurable_test.rb
@@ -72,24 +72,6 @@ class ConfigurableActiveSupport < ActiveSupport::TestCase
     assert_equal :bar, Parent.config.foo
   end
 
-  test "configuration is crystalizeable" do
-    parent = Class.new { include ActiveSupport::Configurable }
-    child  = Class.new(parent)
-
-    parent.config.bar = :foo
-    assert_method_not_defined parent.config, :bar
-    assert_method_not_defined child.config, :bar
-    assert_method_not_defined child.new.config, :bar
-
-    parent.config.compile_methods!
-    assert_equal :foo, parent.config.bar
-    assert_equal :foo, child.new.config.bar
-
-    assert_method_defined parent.config, :bar
-    assert_method_defined child.config, :bar
-    assert_method_defined child.new.config, :bar
-  end
-
   test "should raise name error if attribute name is invalid" do
     assert_raises NameError do
       Class.new do

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -125,4 +125,10 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
     assert_equal "#<ActiveSupport::OrderedOptions {:foo=>:bar, :baz=>:quz}>", a.inspect
   end
+
+  def test_methods_are_not_masked_by_hash
+    a = ActiveSupport::OrderedOptions.new
+    a.count = 99
+    assert_equal 99, a.count
+  end
 end


### PR DESCRIPTION
### Summary

Changes `ActiveSupport::OrderedOptions` to generate accessor methods for
each key on first access.

For the given key `:foo` 3 methods are generated: `#foo`, `#foo!` and `#foo=`

This change removes the requirement for
`ActiveSupport::Configuration#compile_methods!` as these methods no longer
need to be explicitly compiled.

Fixes #42140 

### Other Information

Chief motivation for this is as a bug fix for the fact that any keys on `ActiveSupport::OrderedOptions` are masked by methods on `Hash` when a method with the same name exists on `Hash`

```ruby
oo = ActiveSupport::OrderedOptions.new
oo.count = 99
oo.count # => 1
```

As a side effect of this change, speed is greatly improved in read and write method invocations as `method_missing` is bypassed.

```ruby
# frozen_string_literal: true

require "active_support"
require "active_support/ordered_options"
require "benchmark/ips"

oo = ActiveSupport::OrderedOptions.new

oo.foo = 1
oo.bar = "two"

Benchmark.ips do |x|
  x.report("write") { oo.baz = "three" }
  x.report("read")  { oo.foo ; oo.bar ; oo.not_found }
  x.report("read!")  { oo.foo! ; oo.bar! }
end
```
Before:
```
               write      1.355M (± 2.3%) i/s -      6.838M in   5.050324s
                read    485.645k (± 0.8%) i/s -      2.445M in   5.034469s
               read!    497.287k (± 0.6%) i/s -      2.519M in   5.066502s
```
After:
```
              write      3.148M (± 2.0%) i/s -     15.869M in   5.042414s
                read      1.298M (± 1.6%) i/s -      6.513M in   5.018765s
               read!    943.126k (± 6.3%) i/s -      4.752M in   5.064580s
```