### PR TITLE
Fix compatibility with Psych 4

### DIFF
--- a/activesupport/lib/active_support/configuration_file.rb
+++ b/activesupport/lib/active_support/configuration_file.rb
@@ -19,7 +19,12 @@ module ActiveSupport
     end
 
     def parse(context: nil, **options)
-      YAML.load(render(context), **options) || {}
+      source = render(context)
+      begin
+        YAML.load(source, aliases: true, **options) || {}
+      rescue ArgumentError
+        YAML.load(source, **options) || {}
+      end
     rescue Psych::SyntaxError => error
       raise "YAML syntax error occurred while parsing #{@content_path}. " \
             "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \


### PR DESCRIPTION
Psych 4 load in safe mode by default: https://github.com/ruby/psych/pull/487

So aliases need to be explicitly allowed.

cc @tenderlove.

~~Since Rails main branch targets Ruby 2.7+ the patch is simple. However if we wish to backport it to older versions, we'll have to assume `aliases:` might not exist like in webpacker: https://github.com/rails/webpacker/pull/3024~~

Actually even 3.0 ships with a Psych that doesn't accept `load(aliases: true)`