### PR TITLE
Added more regression for activejob Range serializer.

### DIFF
--- a/activejob/lib/active_job/serializers/range_serializer.rb
+++ b/activejob/lib/active_job/serializers/range_serializer.rb
@@ -7,13 +7,11 @@ module ActiveJob
 
       def serialize(range)
         args = Arguments.serialize([range.begin, range.end, range.exclude_end?])
-        hash = KEYS.zip(args).to_h
-        super(hash)
+        super(KEYS.zip(args).to_h)
       end
 
       def deserialize(hash)
-        args = Arguments.deserialize(hash.values_at(*KEYS))
-        Range.new(*args)
+        klass.new(*Arguments.deserialize(hash.values_at(*KEYS)))
       end
 
       private

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -35,9 +35,14 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     1...,
     1..5,
     1...5,
+    "a".."z",
+    "A".."Z",
     Date.new(2001, 2, 3)..,
+    10.days.ago..Date.today,
     Time.new(2002, 10, 31, 2, 2, 2.123456789r, "+02:00")..,
+    10.hours.ago..Time.current,
     DateTime.new(2001, 2, 3, 4, 5, 6.123456r, "+03:00")..,
+    (DateTime.current - 4.weeks)..DateTime.current,
     ActiveSupport::TimeWithZone.new(Time.utc(1999, 12, 31, 23, 59, "59.123456789".to_r), ActiveSupport::TimeZone["UTC"])..,
   ].each do |arg|
     test "serializes #{arg.class} - #{arg.inspect} verbatim" do


### PR DESCRIPTION
### Summary

ActiveJob Range serializer support has been added with this [pull request](https://github.com/rails/rails/pull/42219).

Ruby range also supports alphabet ranges. I have added more regressions to the ActiveJob range serializer. I have also updated the code as per [this comment ](https://github.com/rails/rails/pull/42219/files#r632952685) from @pixeltrix .
