### PR TITLE
Make Active Record adapters connections lazy

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -519,6 +519,7 @@ module ActiveRecord
       # This is done under the hood by calling #active?. If the connection
       # is no longer active, then this method will reconnect to the database.
       def verify!
+        return if @connection.nil?
         reconnect! unless active?
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -530,7 +530,7 @@ module ActiveRecord
       # PostgreSQL's lo_* methods.
       def raw_connection
         disable_lazy_transactions!
-        @connection
+        connection
       end
 
       def default_uniqueness_comparison(attribute, value, klass) # :nodoc:
@@ -589,6 +589,13 @@ module ActiveRecord
       end
 
       private
+        def connection
+          @connection || @lock.synchronize do
+            connect
+            @connection
+          end
+        end
+
         def type_map
           @type_map ||= Type::TypeMap.new.tap do |mapping|
             initialize_type_map(mapping)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -45,7 +45,7 @@ module ActiveRecord
 
           # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
           # made since we established the connection
-          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
+          connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
 
           super
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -27,7 +27,7 @@ module ActiveRecord
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.execute(sql)
+              connection.execute(sql)
             end
           end
         end
@@ -45,7 +45,7 @@ module ActiveRecord
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
               # Don't cache statements if they are not prepared
               unless prepare
-                stmt = @connection.prepare(sql)
+                stmt = connection.prepare(sql)
                 begin
                   cols = stmt.columns
                   unless without_prepared_statement?(binds)
@@ -56,7 +56,7 @@ module ActiveRecord
                   stmt.close
                 end
               else
-                stmt = @statements[sql] ||= @connection.prepare(sql)
+                stmt = @statements[sql] ||= connection.prepare(sql)
                 cols = stmt.columns
                 stmt.reset!
                 stmt.bind_params(type_casted_binds)
@@ -70,7 +70,7 @@ module ActiveRecord
 
         def exec_delete(sql, name = "SQL", binds = [])
           exec_query(sql, name, binds)
-          @connection.changes
+          connection.changes
         end
         alias :exec_update :exec_delete
 
@@ -78,22 +78,22 @@ module ActiveRecord
           raise TransactionIsolationError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted
           raise StandardError, "You need to enable the shared-cache mode in SQLite mode before attempting to change the transaction isolation level" unless shared_cache?
 
-          Thread.current.thread_variable_set("read_uncommitted", @connection.get_first_value("PRAGMA read_uncommitted"))
-          @connection.read_uncommitted = true
+          Thread.current.thread_variable_set("read_uncommitted", connection.get_first_value("PRAGMA read_uncommitted"))
+          connection.read_uncommitted = true
           begin_db_transaction
         end
 
         def begin_db_transaction #:nodoc:
-          log("begin transaction", "TRANSACTION") { @connection.transaction }
+          log("begin transaction", "TRANSACTION") { connection.transaction }
         end
 
         def commit_db_transaction #:nodoc:
-          log("commit transaction", "TRANSACTION") { @connection.commit }
+          log("commit transaction", "TRANSACTION") { connection.commit }
           reset_read_uncommitted
         end
 
         def exec_rollback_db_transaction #:nodoc:
-          log("rollback transaction", "TRANSACTION") { @connection.rollback }
+          log("rollback transaction", "TRANSACTION") { connection.rollback }
           reset_read_uncommitted
         end
 
@@ -102,7 +102,7 @@ module ActiveRecord
             read_uncommitted = Thread.current.thread_variable_get("read_uncommitted")
             return unless read_uncommitted
 
-            @connection.read_uncommitted = read_uncommitted
+            connection.read_uncommitted = read_uncommitted
           end
 
           def execute_batch(statements, name = nil)
@@ -116,13 +116,13 @@ module ActiveRecord
 
             log(sql, name) do
               ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                @connection.execute_batch2(sql)
+                connection.execute_batch2(sql)
               end
             end
           end
 
           def last_inserted_id(result)
-            @connection.last_insert_row_id
+            connection.last_insert_row_id
           end
 
           def build_fixture_statements(fixture_set)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module SQLite3
       module Quoting # :nodoc:
         def quote_string(s)
-          @connection.class.quote(s)
+          ::SQLite3::Database.quote(s)
         end
 
         def quote_table_name_for_assignment(table, attr)

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -66,10 +66,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_quote_after_disconnect
     @connection.disconnect!
-
-    assert_raise(Mysql2::Error) do
-      @connection.quote("string")
-    end
+    @connection.quote("string")
   end
 
   def test_active_after_disconnect

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -111,9 +111,12 @@ module ActiveRecord
 
       def test_bad_timeout
         assert_raises(TypeError) do
-          Base.sqlite3_connection database: ":memory:",
-                                  adapter: "sqlite3",
-                                  timeout: "usa"
+          adapter = Base.sqlite3_connection(
+            database: ":memory:",
+            adapter: "sqlite3",
+            timeout: "usa",
+          )
+          adapter.raw_connection
         end
       end
 
@@ -279,6 +282,7 @@ module ActiveRecord
       end
 
       def test_tables_logs_name
+        @conn.raw_connection
         sql = <<~SQL
           SELECT name FROM sqlite_master WHERE name <> 'sqlite_sequence' AND type IN ('table')
         SQL
@@ -558,14 +562,16 @@ module ActiveRecord
         db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
         db = ::SQLite3::Database.new(db_config.database)
 
-        statement = ::SQLite3::Statement.new(db,
-                                           "CREATE TABLE statement_test (number integer not null)")
-        statement.stub(:step, -> { raise ::SQLite3::BusyException.new("busy") }) do
-          assert_called(statement, :columns, returns: []) do
-            assert_called(statement, :close) do
-              ::SQLite3::Statement.stub(:new, statement) do
-                assert_raises ActiveRecord::StatementInvalid do
-                  @conn.exec_query "select * from statement_test"
+        @conn.stub(:connection, db) do
+          statement = ::SQLite3::Statement.new(db,
+                                             "CREATE TABLE statement_test (number integer not null)")
+          statement.stub(:step, -> { raise ::SQLite3::BusyException.new("busy") }) do
+            assert_called(statement, :columns, returns: []) do
+              assert_called(statement, :close) do
+                ::SQLite3::Statement.stub(:new, statement) do
+                  assert_raises ActiveRecord::StatementInvalid do
+                    @conn.exec_query "select * from statement_test"
+                  end
                 end
               end
             end

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
@@ -12,6 +12,7 @@ module ActiveRecord
           @conn = Base.sqlite3_connection database: dir.join("db/foo.sqlite3"),
                                adapter: "sqlite3",
                                timeout: 100
+          @conn.raw_connection
 
           assert Dir.exist? dir.join("db")
           assert File.exist? dir.join("db/foo.sqlite3")

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -86,7 +86,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
   test "set the read_uncommitted PRAGMA to its previous value" do
     with_connection(flags: shared_cache_flags) do |conn|
       conn.transaction(joinable: false, isolation: :read_uncommitted) do
-        conn.instance_variable_get(:@connection).read_uncommitted = true
+        conn.send(:connection).read_uncommitted = true
         assert(read_uncommitted?(conn))
         conn.transaction_manager.materialize_transactions
         assert(read_uncommitted?(conn))
@@ -98,7 +98,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
 
   private
     def read_uncommitted?(conn)
-      conn.instance_variable_get(:@connection).get_first_value("PRAGMA read_uncommitted") != 0
+      conn.send(:connection).get_first_value("PRAGMA read_uncommitted") != 0
     end
 
     def shared_cache_flags
@@ -115,6 +115,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
         options[:database] ||= db_config.database
       end
       conn = ActiveRecord::Base.sqlite3_connection(options)
+      conn.send(:connection)
 
       yield(conn)
     ensure


### PR DESCRIPTION
### Context

This is a rebase of an old branch: https://github.com/Shopify/rails/tree/lazy-connection.

Related: https://github.com/rails/rails/pull/42085

For resiliency reasons, it is paramount that Rails is able to boot even if it can't connect to the database, right now it is achieved by skipping Active Record attribute methods definition if an error happens (Ref: https://github.com/rails/rails/pull/40119).

But for historical reason, lots of important data is held by the `Adapter` and accessed through `ActiveRecord::Base.connection`, and that later does eagerly connect to the database.

If the `Adapter` would only connect when necessary, it would make it much easier to initialize the application without having a dependency on the database.