### PR TITLE
Fix SQL when using single numeric with MySQL's json

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -3,6 +3,7 @@
 require "active_record/connection_adapters/abstract_adapter"
 require "active_record/connection_adapters/statement_pool"
 require "active_record/connection_adapters/mysql/column"
+require "active_record/connection_adapters/mysql/json"
 require "active_record/connection_adapters/mysql/explain_pretty_printer"
 require "active_record/connection_adapters/mysql/quoting"
 require "active_record/connection_adapters/mysql/schema_creation"
@@ -593,6 +594,13 @@ module ActiveRecord
 
             m.register_type %r(^enum)i, Type.lookup(:string, adapter: :mysql2)
             m.register_type %r(^set)i,  Type.lookup(:string, adapter: :mysql2)
+            m.register_type(%r(^json)i) do |sql_type|
+              if /^json/.match?(sql_type)
+                MySQL::Json.new
+              else
+                Type.lookup(:string, adapter: :mysql2)
+              end
+            end
           end
 
           def register_integer_type(mapping, key, **options)

--- a/activerecord/lib/active_record/connection_adapters/mysql/json.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/json.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module MySQL
+      class Json < Type::Json # :nodoc:
+        class NumericSQLValue < ::Numeric # :nodoc:
+          attr_reader :numeric
+
+          def initialize(numeric)
+            raise ArgumentError, "expected #{numeric.inspect} to be Numeric" unless numeric.is_a?(Numeric)
+            @numeric = numeric
+          end
+
+          # MySQL adapter has no separate binds, it quotes values inline.
+          # This affects case if (and only if) we pass explicit numeric as a value for `json` column in `where`
+          #
+          # Note, the following queries are different
+          # SELECT ... WHERE `json_data_type`.`payload` = 42                 # a MySQL query in repl, finds correctly
+          # SELECT ... WHERE `json_data_type`.`payload` = CAST('42' AS json) # rendered NumericValue, finds correctly
+          #
+          # But parent Type::Json#serialize returned json-string, it gets quoted, finds nothing
+          # SELECT ... WHERE `json_data_type`.`payload` = '42'
+          #
+          # According to RFC8259 a json top level value defined as:
+          # value = false / null / true / object / array / number / string
+          # MySQL behaves correctly when making the difference
+          #
+          # Besides, we cannot return numeric value from #serialize,
+          # it breaks insertion, the following is invalid:
+          # INSERT INTO `json_data_type` (`payload`) VALUES (42)
+          #
+          # On the contrary, SQL part with `CAST` is fine
+          # i.e. if (and only if) we pass explicit numeric as a value for `json` column in `create`, we'll get
+          # INSERT INTO `json_data_type` (`payload`) VALUES (CAST('42' AS json))
+          #
+          # To run a query which properly compares a `json` field with a single integer, which is valid operation,
+          # we have to return an instance of this class and rely on `quoter` to call `to_s` on it.
+          # It does the same with `when Numeric`, see ActiveRecord::ConnectionAdapters::Mysql2Adapter#_quote(value)
+          def to_s
+            "CAST('#{@numeric}' AS json)"
+          end
+        end
+        private_constant :NumericSQLValue
+
+        def type
+          :json
+        end
+
+        def cast(value)
+          return value if numeric?(value)
+          super
+        end
+
+        def serialize(value)
+          return NumericSQLValue.new(value) if numeric?(value)
+          super
+        end
+
+        def deserialize(value)
+          return value.numeric if value.is_a?(NumericSQLValue)
+          super
+        end
+
+        private
+          def numeric?(value)
+            value.is_a?(::Integer) || value.is_a?(::Float)
+          end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -213,6 +213,18 @@ module JSONSharedTestCases
     assert_equal 1.234, json.payload
   end
 
+  def test_select_by_integer_value
+    json = klass.create!(payload: 42)
+    x = klass.where(payload: 42).first
+    assert_equal(json, x)
+  end
+
+  def test_select_by_float_value
+    json = klass.create!(payload: 1.234)
+    x = klass.where(payload: 1.234).first
+    assert_equal(json, x)
+  end
+
   def test_assigning_boolean
     json = klass.create!(payload: true)
     assert_equal true, json.payload


### PR DESCRIPTION
### Summary

Currently when you insert a plain integer into a json field in mysql (which is a valid value according to rfc)
you cannot fetch this row by this value again. Happens only:
- on mysql, only with integers and floats, only inside json column: this is fixed
- on postgresql, only with integers and floats, only inside json column (**NOT** jsonb): workaround shown in tests

```ruby
numeric_value = 42
Model.create(json_column: numeric_value) # ok
Model.where(json_column: numeric_value)  # empty
```

### Current workaround

```ruby
Model.where("json_column = ?", numeric_value)  # ok + you have to rubocop:disable Rails/WhereEquals
```

### Tests

Added proper tests for all json-able databases, relevant runs for this PR
```sh
bundle exec rake test:sqlite3 TEST=test/cases/adapters/sqlite3/json_test.rb
bundle exec rake test:postgresql TEST=test/cases/adapters/postgresql/json_test.rb
bundle exec rake test:mysql2 TEST=test/cases/adapters/mysql2/json_test.rb
bundle exec rake test:mysql2 TEST=test/cases/json_attribute_test.rb
```

without this PR the newly added test fail like this:

```diff
cd activerecord; bundle exec rake test:mysql2 TEST=./test/cases/adapters/mysql2/json_test.rb

Failure:
Mysql2JSONTest#test_select_by_float_value [activerecord/test/cases/json_shared_test_cases.rb:224]:
--- expected
+++ actual
@@ -1 +1 @@
-#<JSONSharedTestCases::JsonDataType id: 1, payload: 1.234, settings: nil>
+nil

rails test activerecord/test/cases/json_shared_test_cases.rb:221

Failure:
Mysql2JSONTest#test_select_by_integer_value [activerecord/test/cases/json_shared_test_cases.rb:218]:
--- expected
+++ actual
@@ -1 +1 @@
-#<JSONSharedTestCases::JsonDataType id: 1, payload: 42, settings: nil>
+nil

rails test activerecord/test/cases/json_shared_test_cases.rb:215

27 runs, 55 assertions, 2 failures, 0 errors, 0 skips
```

<details>
<summary>Very detailed explanation what happens</summary>

MySQL adapter has no separate binds, it quotes values inline.
This affects case if (and only if) we pass explicit numeric as a value for `json` column in `where`

Note, the following queries are different

```sql
SELECT ... WHERE `json_data_type`.`payload` = 42                 -- a MySQL query in repl, finds correctly
SELECT ... WHERE `json_data_type`.`payload` = CAST('42' AS json) -- rendered NumericValue, finds correctly
```

But parent `Type::Json#serialize` returned json-string, it gets quoted
```sql
SELECT ... WHERE `json_data_type`.`payload` = '42' -- finds nothing
```

According to [RFC8259](https://datatracker.ietf.org/doc/html/rfc8259#section-3) a json top level value defined as:

> value = false / null / true / object / array / number / string

MySQL behaves correctly when making the difference

Besides, we cannot return numeric value from `#serialize`,
it breaks insertion, the following is invalid:

```sql
INSERT INTO `json_data_type` (`payload`) VALUES (42)
```

On the contrary, SQL part with `CAST` is fine
i.e. if (and only if) we pass explicit numeric as a value for `json` column in `create`, we'll get

```sql
INSERT INTO `json_data_type` (`payload`) VALUES (CAST('42' AS json))
```

To run a query that properly compares a `json` field with a single integer, which is valid operation,
we have to return an instance of this class and rely on `quoter` to call `to_s` on it.
It does the same with `when Numeric`, see `ActiveRecord::ConnectionAdapters::Mysql2Adapter#_quote(value)`
</details>