### PR TITLE
Look yarnpkg in $PATH other than yarn

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/yarn.tt
@@ -2,7 +2,7 @@ APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
   yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
     select { |dir| File.expand_path(dir) != __dir__ }.
-    product(["yarn", "yarn.cmd", "yarn.ps1"]).
+    product(["yarn", "yarnpkg", "yarn.cmd", "yarn.ps1"]).
     map { |dir, file| File.expand_path(file, dir) }.
     find { |file| File.executable?(file) }
 


### PR DESCRIPTION
This is defined as an issue in #37558; however, we take advantage of Debian `yarnpkg` package. With that, `yarnpkg` users from Debian can use `bin/yarn` and `yarn` package provided from Yarn community will not be affected because `yarn` is executed first.

### Other Information

Pull request is not here to start a debate of whether support distribution specific path or program names. I see value in this PR because previous `bin/yarn` did not have choice other than `yarn` or `yarnpkg`. Yes, we are adding our own patches if we start in a new project, yet I wanted to share this simple change.