### PR TITLE
feat(ActiveRecord): Allow disabling negative scopes

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -217,7 +217,11 @@ module ActiveRecord
             end
           end
         end
-        detect_negative_enum_conditions!(value_method_names) if scopes
+
+        if scopes || scopes.is_a?(Hash) && scopes[:negatives] != false
+          detect_negative_enum_conditions!(value_method_names)
+        end
+
         enum_values.freeze
       end
 
@@ -244,8 +248,10 @@ module ActiveRecord
               klass.send(:detect_enum_conflict!, name, value_method_name, true)
               klass.scope value_method_name, -> { where(name => value) }
 
-              klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
-              klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              unless scopes.is_a?(Hash) && scopes[:negatives] == false
+                klass.send(:detect_enum_conflict!, name, "not_#{value_method_name}", true)
+                klass.scope "not_#{value_method_name}", -> { where.not(name => value) }
+              end
             end
           end
       end

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -725,6 +725,15 @@ class EnumTest < ActiveRecord::TestCase
     assert_raises(NoMethodError) { klass.proposed }
   end
 
+  test "negative scopes can be disabled by :_scopes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum status: [:proposed, :written], _scopes: { negatives: false }
+    end
+
+    assert_raises(NoMethodError) { klass.not_proposed }
+  end
+
   test "overloaded default by :default" do
     klass = Class.new(ActiveRecord::Base) do
       self.table_name = "books"
@@ -741,6 +750,15 @@ class EnumTest < ActiveRecord::TestCase
     end
 
     assert_raises(NoMethodError) { klass.proposed }
+  end
+
+  test "negative scopes can be disabled by :scopes" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = "books"
+      enum :status, [:proposed, :written], scopes: { negatives: false }
+    end
+
+    assert_raises(NoMethodError) { klass.not_proposed }
   end
 
   test "query state by predicate with :prefix" do


### PR DESCRIPTION
### Summary

This PR allows disabling the automatic generation of negative scopes with the enum definition.

Currently, scopes can only be disabled as a whole during the enum definition like so

```rb
enum :status, [:proposed, :written], scopes: false
```

This PR provides the possibility of disabling only negative scopes


```rb
enum :status, [:proposed, :written], scopes: { negatives: false }
```

#### Why?

Automatic generation of negative scopes is not necessary in some cases and might just be confusing in others.

I am currently working on an app that has a lot of enum values defined with the `:not_*` prefix, and disabling the generation for these would be helpful, and would also disable the related warning message.