### PR TITLE
use double splat for keyword arguments

### DIFF
--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -394,7 +394,7 @@ module ActiveSupport
               modifiers[:nx] = unless_exist
               modifiers[:px] = (1000 * expires_in.to_f).ceil if expires_in
 
-              redis.with { |c| c.set key, serialized_entry, modifiers }
+              redis.with { |c| c.set key, serialized_entry, **modifiers }
             else
               redis.with { |c| c.set key, serialized_entry }
             end


### PR DESCRIPTION
Currently, `Rails 6.0.3.7` gives deprecation warning when using `Redis.write`.

```ruby
Redis.write("key", "value", expires_in: 5.seconds)
```
throws warning:
```
/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-6.0.3.7/lib/active_support/cache/redis_cache_store.rb:397: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/redis-4.2.5/lib/redis.rb:836: warning: The called method `set' is defined here
```

I just followed the change done in this commit: https://github.com/rails/rails/commit/37c19f7ebcf542af968a4983b3296b9fa283a0dc by @kamipo 

```
# Gemfile
rails (6.0.3.7)
redis (4.2.5)
```
This is my very first small attempt on contributing to rails, so do help me. I'm not sure how the releases are done related to old rails version.

 cc @morgoth 