### PR TITLE
Fix ActiveStorage has_one_attached when blob or record are not persisted

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow to purge an attachment when record is not persisted for `has_one_attached`
+
+    *Jacopo Beschi*
+
 *   Add a load hook called `active_storage_variant_record` (providing `ActiveStorage::VariantRecord`)
     to allow for overriding aspects of the `ActiveStorage::VariantRecord` class. This makes
     `ActiveStorage::VariantRecord` consistent with `ActiveStorage::Blob` and `ActiveStorage::Attachment`

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -23,7 +23,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   def purge
     transaction do
       delete
-      record&.touch
+      record.touch if record&.persisted?
     end
     blob&.purge
   end
@@ -32,7 +32,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   def purge_later
     transaction do
       delete
-      record&.touch
+      record.touch if record&.persisted?
     end
     blob&.purge_later
   end

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -293,8 +293,9 @@ class ActiveStorage::Blob < ActiveStorage::Record
   # blobs. Note, though, that deleting the file off the service will initiate an HTTP connection to the service, which may
   # be slow or prevented, so you should not use this method inside a transaction or in callbacks. Use #purge_later instead.
   def purge
+    previously_persisted = persisted?
     destroy
-    delete
+    delete if previously_persisted
   rescue ActiveRecord::InvalidForeignKey
   end
 

--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -16,6 +16,10 @@ module ActiveStorage
       def change
         record.attachment_changes[name]
       end
+
+      def reset_changes
+        record.attachment_changes.delete(name)
+      end
   end
 end
 

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -61,6 +61,7 @@ module ActiveStorage
       if attached?
         attachment.purge
         write_attachment nil
+        reset_changes
       end
     end
 
@@ -69,6 +70,7 @@ module ActiveStorage
       if attached?
         attachment.purge_later
         write_attachment nil
+        reset_changes
       end
     end
 

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -245,6 +245,13 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "purge doesn't raise when blob is not persisted" do
+    build_blob_after_unfurling.tap do |blob|
+      assert_nothing_raised { blob.purge }
+      assert blob.destroyed?
+    end
+  end
+
   test "uses service from blob when provided" do
     with_service("mirror") do
       blob = create_blob(filename: "funky.jpg", service_name: :local)


### PR DESCRIPTION
### Summary

- Purging a not persisted blob no longer raise a `FrozenError`.
- Purging a not persisted record no longer raise an `ActiveRecord::ActiveRecordError`.

Fixes #37069


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
