### PR TITLE
fix missing require of active_support/notifications in cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -10,6 +10,7 @@ require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"
+require "active_support/notifications"
 
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.


### PR DESCRIPTION
### Summary

The cache.rb now depends on notifications, but it's not listed as an
explicit import so this causes breakages when using activesupport
outside of rails.

### Other Information

The line that uses notifications symbol https://github.com/rails/rails/blob/3b728f62d9563a410a57ad4c7b07c6f22bf42b5f/activesupport/lib/active_support/cache.rb#L776

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
