### PR TITLE
Upgrade sdoc to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.1.0"
+  gem "sdoc", ">= 2.2.0"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.3.0)
+    rdoc (6.3.1)
     redcarpet (3.2.3)
     redis (4.2.5)
     redis-namespace (1.8.1)
@@ -458,7 +458,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sdoc (2.1.0)
+    sdoc (2.2.0)
       rdoc (>= 5.0)
     selenium-webdriver (4.0.0.beta3)
       childprocess (>= 0.5, < 5.0)
@@ -613,7 +613,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sass-rails
-  sdoc (>= 2.1.0)
+  sdoc (>= 2.2.0)
   selenium-webdriver (>= 4.0.0.alpha7)
   sequel
   sidekiq


### PR DESCRIPTION
Sdoc 2.2.0 has improved accessibility and bug fixes.

Changelog:

* Add 'skip to content' link and improve shortcut keys
* Fix link hovers in headings
* Fix clearing search results
* Update Merge script to work with sdoc v2
* Remove outline from reset stylesheet
* Remove TAB override in panel
* Move to GitHub action for tests
* Fix Ctrl+C copying

Preview: https://master--nervous-roentgen-6c1877.netlify.app/

@MikeRogers0 even made a screencast showing the 'skip to content' functionality:
https://www.youtube.com/watch?v=RbXg8BLSDpY