### PR TITLE
Fix delegation in ActiveModel::Type::Registry

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix delegation in ActiveModel::Type::Registry#lookup
+
+    Passing a last positional argument `{}` would be incorrectly considered as keyword argument.
+
+    *Benoit Daloze*
+
 *   Cache and re-use generated attribute methods.
 
     Generated methods with identical implementations will now share their instruction sequences

--- a/activemodel/lib/active_model/type/registry.rb
+++ b/activemodel/lib/active_model/type/registry.rb
@@ -20,15 +20,16 @@ module ActiveModel
         registrations[type_name] = block
       end
 
-      def lookup(symbol, *args, **kwargs)
+      def lookup(symbol, *args)
         registration = registrations[symbol]
 
         if registration
-          registration.call(symbol, *args, **kwargs)
+          registration.call(symbol, *args)
         else
           raise ArgumentError, "Unknown type #{symbol.inspect}"
         end
       end
+      ruby2_keywords(:lookup)
 
       private
         attr_reader :registrations

--- a/activemodel/test/cases/type/registry_test.rb
+++ b/activemodel/test/cases/type/registry_test.rb
@@ -12,6 +12,8 @@ module ActiveModel
 
         assert_equal "", registry.lookup(:foo)
         assert_equal [], registry.lookup(:bar)
+        assert_equal [:a, :a], registry.lookup(:bar, 2, :a) # Array.new(2, :a)
+        assert_equal [{}, {}], registry.lookup(:bar, 2, {}) # Array.new(2, {})
       end
 
       test "a block can be registered" do


### PR DESCRIPTION
### Summary

* Without the change the new test fails like this:
```
  Failure:
  ActiveModel::Type::RegistryTest#test_a_class_can_be_registered_for_a_symbol [test/cases/type/registry_test.rb:16]:
  Expected: [{}, {}]
    Actual: [nil, nil]
```
* (*args, **kwargs)-delegation is not correct on Ruby 2.7 unless the
  target always accepts keyword arguments (not the case for `Array.new`).
  See https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html

Looking at the history, the bug was introduced in 1a40a4811312900a9dfb7f92d089186347fa6034.