### PR TITLE
[ci skip] Improve sentence around setting xhr:true

### DIFF
--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -199,7 +199,7 @@ module ActionDispatch
       #   merged into the Rack env hash.
       # - +env+: Additional env to pass, as a Hash. The headers will be
       #   merged into the Rack env hash.
-      # - +xhr+: Set to +true+ if you want to make and Ajax request.
+      # - +xhr+: Set to +true+ if you want to make an Ajax request.
       #   Adds request headers characteristic of XMLHttpRequest e.g. HTTP_X_REQUESTED_WITH.
       #   The headers will be merged into the Rack env hash.
       # - +as+: Used for encoding the request with different content type.


### PR DESCRIPTION
### Summary

Improve sentence around setting `xhr: true`.

Also if we look at the previous lines (https://github.com/rails/rails/pull/42267/files#diff-7c57a19207aafe25adcf81324c922c9bda0205db771c91f5365de6eb10197b53R200)
```
# +headers+: Additional headers to pass, as a Hash. The headers will be
#   merged into the Rack env hash.
# - +env+: Additional env to pass, as a Hash. The headers will be
#   merged into the Rack env hash.
```
The second part (env): `The headers will be merged into the Rack env hash.` seems like a dup of the line above, wondering if that should be updated too?

```
# - +env+: Additional env to pass, as a Hash. The env hash will be
#   merged into the Rack env hash.
```
