### PR TITLE
Update the alias for the generator that target the main branch

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -97,7 +97,7 @@ module Rails
         class_option :edge,                type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository"
 
-        class_option :main,                type: :boolean, default: false, aliases: "--master",
+        class_option :main,                type: :boolean, default: false, aliases: "--main",
                                            desc: "Set up the #{name} with Gemfile pointing to Rails repository main branch"
 
         class_option :rc,                  type: :string, default: nil,

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -875,8 +875,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
   end
 
-  def test_master_option
-    run_generator [destination_root, "--master"]
+  def test_main_option_using_alias
+    run_generator [destination_root, "--main"]
     assert_file "Gemfile", %r{^gem\s+["']rails["'],\s+github:\s+["']#{Regexp.escape("rails/rails")}["'],\s+branch:\s+["']main["']$}
   end
 


### PR DESCRIPTION
### Summary

Rails no longer has the master branch, updating the alias to be `--main`, inline with the naming of the rails repo. This class is nodoc so this change should be good IMO -- even if it causes a user frustration when they type in the master flag and it does not work, hopefully they will try the --main flag instead.

Current command usage: 
- `rails new app_name --master` (drop this)
- `rails new app_name --main` (preferred)