### PR TITLE
Fix ArgumentError message for without method

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1162,7 +1162,7 @@ module ActiveRecord
       records.compact!
 
       unless records.all?(klass)
-        raise ArgumentError, "You must only pass a single or collection of #{klass.name} objects to #excluding."
+        raise ArgumentError, "You must only pass a single or collection of #{klass.name} objects to ##{__callee__}."
       end
 
       spawn.excluding!(records)

--- a/activerecord/test/cases/excluding_test.rb
+++ b/activerecord/test/cases/excluding_test.rb
@@ -48,6 +48,9 @@ class ExcludingTest < ActiveRecord::TestCase
   def test_raises_on_record_from_different_class
     error = assert_raises(ArgumentError) { Post.excluding(@post, comments(:greetings)) }
     assert_equal "You must only pass a single or collection of Post objects to #excluding.", error.message
+
+    error = assert_raises(ArgumentError) { Post.without(@post, comments(:greetings)) }
+    assert_equal "You must only pass a single or collection of Post objects to #without.", error.message
   end
 
   private


### PR DESCRIPTION
### Summary

Closes #42273 

There is an alias for the `#excluding` method called `#without`. When using without instead of excluding, if we don't pass a single or collection of the class objects, the error raised is:

```
You must only pass a single or collection of #{klass.name} objects to #excluding
```

when it should be

```
You must only pass a single or collection of #{klass.name} objects to #without
```
