### PR TITLE
Strip final newline from Action View renders

### DIFF
--- a/actionview/lib/action_view/template/handlers/erb.rb
+++ b/actionview/lib/action_view/template/handlers/erb.rb
@@ -16,6 +16,9 @@ module ActionView
         # Do not escape templates of these mime types.
         class_attribute :escape_ignore_list, default: ["text/plain"]
 
+        # Strip trailing newlines from rendered output
+        class_attribute :strip_trailing_newlines, default: false
+
         ENCODING_TAG = Regexp.new("\\A(<%#{ENCODING_FLAG}-?%>)[ \\t]*")
 
         def self.call(template, source)
@@ -44,6 +47,9 @@ module ActionView
 
           # Always make sure we return a String in the default_internal
           erb.encode!
+
+          # Strip trailing newlines from the template if enabled
+          erb.chomp! if strip_trailing_newlines
 
           options = {
             escape: (self.class.escape_ignore_list.include? template.type),

--- a/actionview/test/actionpack/abstract/abstract_controller_test.rb
+++ b/actionview/test/actionpack/abstract/abstract_controller_test.rb
@@ -52,6 +52,10 @@ module AbstractController
         render "index.erb"
       end
 
+      def with_final_newline
+        render "with_final_newline.erb"
+      end
+
       def index_to_string
         self.response_body = render_to_string "index"
       end
@@ -82,6 +86,14 @@ module AbstractController
       test "rendering templates works" do
         @controller.process(:index)
         assert_equal "Hello from index.erb", @controller.response_body
+      end
+
+      test "stripping final newline works" do
+        ActionView::Template::Handlers::ERB.strip_trailing_newlines = true
+        @controller.process(:with_final_newline)
+        assert_equal "Hello from with_final_newline.erb", @controller.response_body
+      ensure
+        ActionView::Template::Handlers::ERB.strip_trailing_newlines = false
       end
 
       test "render_to_string works with a String as an argument" do

--- a/actionview/test/actionpack/abstract/views/with_final_newline.erb
+++ b/actionview/test/actionpack/abstract/views/with_final_newline.erb
@@ -1,0 +1,1 @@
+Hello from with_final_newline.erb


### PR DESCRIPTION
### Summary

Closes #42201

Introduces the `strip_trailing_newlines` option to `ActionView::Template::Handlers::ERB`, which removes trailing newlines from rendered output. This means that partials can be rendered inline without introducing additional whitespace to the output, which affects how the browser may render it.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

To save you recapping those issues, ending files with a newline is something of a standard, as explained by [this StackOverflow thread's answers](https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file). We lint for this @raisedevs. Ordinarily, it doesn't introduce problems, but Rails renders trailing newlines, which are interpreted by the browser as whitespace. So when a partial is rendered inline with other text, the newlines cause a space between the rendered partial and the next character.

I think it should be the default that trailing newlines are stripped, and I'm not sure it'd be harmful to introduce that. But I've kept `false` as the default because that's how things are now.

<details>
<summary>Some questions I had while writing this</summary>

:wave: This is my first contribution to Rails, so I've tried to be meticulous about it. But there are a few questions I have around this:

- ~~I imagine the config option might have a place in the documentation, so I'll look to update this if that's correct.~~ Added to the Guides.
- I'm not 100% confident that this is the best implementation. It achieves what I want it to, but I don't know if it's better placed in `ActionView::Template::Handlers`.
- I'm also not sure if my test is in the right part of the suite.
- As mentioned back over on the issue, this doesn't also reso<!-- -->lve github/view_component#913. Assuming that library still uses `render_in`, it might be possible to fix that, but whether that's even Action View's responsibility is another story entirely.
</details

Thanks in advance for checking this out, folks.