### PR TITLE
Minor: Typo in ActiveSupport::SecureCompareRotator doc

### DIFF
--- a/activesupport/lib/active_support/secure_compare_rotator.rb
+++ b/activesupport/lib/active_support/secure_compare_rotator.rb
@@ -17,7 +17,7 @@ module ActiveSupport
   #
   #   class MyController < ApplicationController
   #     def authenticate_request
-  #       rotator = ActiveSupport::SecureComparerotator.new('new_password')
+  #       rotator = ActiveSupport::SecureCompareRotator.new('new_password')
   #       rotator.rotate('old_password')
   #
   #       authenticate_or_request_with_http_basic do |username, password|


### PR DESCRIPTION
### Summary

Fix a minor typo in `ActiveSupport::SecureCompareRotator` doc

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
