### PR TITLE
Fix inconsistent counter cache behaviour when optimistic locking enabled

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix inconsistent counter cache behaviour when optimistic locking enabled
+
+    Previously if optimistic locking was enabled on a model which `belongs_to`
+    some associate model, with `counter_cache: true`, the counter cache column
+    on the associate record would not be updated when destroying the belonging
+    record.
+
+    Now the counter caching will be updated, as expected, whether using
+    optimistic locking or not on the belonging model.
+
+    Fixes #41655
+
+    *Unathi Chonco*
+
 *   Add config option for ignoring tables when dumping the schema cache.
 
     Applications can now be configured to ignore certain tables when dumping the schema cache.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -959,7 +959,7 @@ module ActiveRecord
     end
 
     def destroy_row
-      _delete_row
+      @_destroy_row_affected_rows ||= _delete_row
     end
 
     def _delete_row


### PR DESCRIPTION
### Summary
If optimistic locking is enabled on a model which `belongs_to`
some associate model, with `counter_cache: true`, the counter cache column
on the associate record is not updated when destroying the belonging
model.
This behaviour was caused by inconsistent behaviour between the private
`#destroy_row` methods in `Locking::Optimistic` and `CounterCache`.

Now both modules always rely on `Persistence#destroy_row` to calculate
the affected rows necessary to complete their specific logic.
`Locking::Optimistic` no longer duplicates the call to
`self.class._delete_record` after building a custom set of constraints,
but instead implements `_constraints_hash` (renamed from
`_primary_key_constraints_hash`) which will add the locking column and
value for use `Persistence#_delete_row`.

Fixes: #41655 
