### PR TITLE
Support using replicas when using `rails dbconsole`

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -102,7 +102,7 @@ module Rails
       # first time around to show a consistent error message to people
       # relying on 2-level database configuration.
 
-      @db_config = configurations.configs_for(env_name: environment, name: database)
+      @db_config = configurations.configs_for(env_name: environment, name: database, include_replicas: true)
 
       unless @db_config
         raise ActiveRecord::AdapterNotSpecified,

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -226,6 +226,25 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     end
   end
 
+  def test_specifying_a_replica_database
+    options = {
+      database: "primary_replica",
+    }
+
+    sample_config = {
+      "test" => {
+        "primary" => {},
+        "primary_replica" => {
+          "replica" => true
+        }
+      }
+    }
+
+    app_db_config(sample_config) do
+      assert_equal "primary_replica", Rails::DBConsole.new(options).db_config.name
+    end
+  end
+
   def test_specifying_a_missing_database
     app_db_config({}) do
       e = assert_raises(ActiveRecord::AdapterNotSpecified) do


### PR DESCRIPTION
### Summary

When using `rails dbconsole`, any replicas are ignored. However, this is often a really useful feature -- for example, in production if you're trying to query data against a non-active database for analytics purposes.

### Other Information

If for some reason this is a breaking change, I can add an `--include-replicas` flag as a `dbconsole` argument 