### PR TITLE
Update test dummy application defaults to remove warnings

### DIFF
--- a/actionmailbox/test/dummy/config/application.rb
+++ b/actionmailbox/test/dummy/config/application.rb
@@ -7,7 +7,7 @@ Bundler.require(*Rails.groups)
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/actiontext/test/dummy/config/application.rb
+++ b/actiontext/test/dummy/config/application.rb
@@ -8,7 +8,7 @@ require "action_text"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -33,7 +33,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="content" id="trix_input_1" />' \
         '<trix-editor input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -47,7 +47,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -61,7 +61,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="custom-class" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -75,7 +75,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[not_an_attribute]" id="message_not_an_attribute_trix_input_message" />' \
         '<trix-editor id="message_not_an_attribute" input="message_not_an_attribute_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -89,7 +89,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[content]" id="trix_input_2" />' \
         '<trix-editor id="message_content" input="trix_input_2" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -103,7 +103,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
         '<trix-editor placeholder="Content" id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -119,7 +119,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[title]" id="message_title_trix_input_message" />' \
         '<trix-editor placeholder="Story title" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -133,7 +133,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[title]" id="message_title_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;" />' \
         '<trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
@@ -147,7 +147,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal \
-      '<form action="/messages" accept-charset="UTF-8" data-remote="true" method="post">' \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
         '<input type="hidden" name="message[title]" id="message_title_trix_input_message" form="other_form" />' \
         '<trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -4,6 +4,7 @@
 # ActiveStorage::VariantRecord. This is only used if `ActiveStorage.track_variants` is enabled.
 class ActiveStorage::VariantWithRecord
   attr_reader :blob, :variation
+  delegate :service, to: :blob
 
   def initialize(blob, variation)
     @blob, @variation = blob, ActiveStorage::Variation.wrap(variation)

--- a/activestorage/test/database/setup.rb
+++ b/activestorage/test/database/setup.rb
@@ -3,7 +3,8 @@
 require_relative "create_users_migration"
 require_relative "create_groups_migration"
 
-ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+# Writing and reading roles are required for the "previewing on the writer DB" test
+ActiveRecord::Base.connects_to(database: { writing: :primary, reading: :replica })
 ActiveRecord::Base.connection.migration_context.migrate
 ActiveStorageCreateUsers.migrate(:up)
 ActiveStorageCreateGroups.migrate(:up)

--- a/activestorage/test/dummy/config/application.rb
+++ b/activestorage/test/dummy/config/application.rb
@@ -15,7 +15,7 @@ Bundler.require(*Rails.groups)
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     config.active_storage.service = :local
   end

--- a/activestorage/test/dummy/config/database.yml
+++ b/activestorage/test/dummy/config/database.yml
@@ -1,25 +1,8 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
-default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
-
-development:
-  <<: *default
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3
+  primary: &primary
+    adapter: sqlite3
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+    timeout: 5000
+    database: ':memory:'
+  replica:
+    <<: *primary

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -54,8 +54,8 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
   test "previewing on the writer DB" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
 
-    # Simulate a selector middleware switching to a read-only replica.
-    ActiveRecord::Base.connection_handler.while_preventing_writes do
+    # prevent_writes option is required because there is no automatic write protection anymore
+    ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role, prevent_writes: true) do
       blob.preview(resize: "640x280").processed
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1068,7 +1068,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
 * `config.active_storage.video_preview_arguments` can be used to alter the way ffmpeg generates video preview images.
 
-    The default is `"-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"`
+    The default is `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 
     1. `select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015)`: Select the first video frame, plus keyframes, plus frames that meet the scene change threshold.
     2. `loop=loop=-1:size=2,trim=start_frame=1`: To use the first video frame as a fallback when no other frames meet the criteria, loop the first (one or) two selected frames, then drop the first looped frame.
@@ -1090,7 +1090,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_support.cache_format_version`: `7.0`
 - `config.action_dispatch.return_only_request_media_type_on_content_type`: `false`
 - `config.action_mailer.smtp_timeout`: `5`
-- `config.active_storage.video_preview_arguments`: `"-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"`
+- `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 
 #### For '6.1', defaults from previous versions below and:
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -223,7 +223,8 @@ module Rails
 
           if respond_to?(:active_storage)
             active_storage.video_preview_arguments =
-              "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"
+              "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1'" \
+              " -frames:v 1 -f image2"
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -42,4 +42,4 @@
 # better preview images (rather than the previous default of using the first frame
 # of the video).
 # Rails.application.config.active_storage.video_preview_arguments =
-#   "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"
+#   "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3032,7 +3032,8 @@ module ApplicationTests
       app "development"
 
       assert_equal ActiveStorage.video_preview_arguments,
-        "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"
+        "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1'" \
+        " -frames:v 1 -f image2"
     end
 
     test "hosts include .localhost in development" do


### PR DESCRIPTION
Affected gems:

* actionmailbox
* activestorage
* actiontext

This fixes the following warning:

```
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
`legacy_connection_handling` to `false` in your application.

The new connection handling does not support `connection_handlers`
getter and setter.

Read more about how to migrate at: https://guides.rubyonrails.org/active_record_multiple_databases.html#migrate-to-the-new-connection-handling
 (called from require at ~/.gem/ruby/3.1.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34)
 ```