### PR TITLE
Add tests for ArgumentError errors in finder methods

### DIFF
--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -145,9 +145,12 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_find_passing_active_record_object_is_not_permitted
-    assert_raises(ArgumentError) do
+    error = assert_raises(ArgumentError) do
       Topic.find(Topic.last)
     end
+
+    assert_equal "You are passing an instance of ActiveRecord::Base to `find`. " \
+    "Please pass the id of the object by calling `.id`.", error.message
   end
 
   def test_symbols_table_ref
@@ -245,9 +248,12 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   def test_exists_passing_active_record_object_is_not_permitted
-    assert_raises(ArgumentError) do
+    error = assert_raises(ArgumentError) do
       Topic.exists?(Topic.new)
     end
+
+    assert_equal "You are passing an instance of ActiveRecord::Base to `exists?`. " \
+    "Please pass the id of the object by calling `.id`.", error.message
   end
 
   def test_exists_does_not_select_columns_without_alias

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -53,6 +53,17 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_equal "2 updated", Topic.find(2).content
   end
 
+  def test_update_many_with_active_record_base_object
+    error = assert_raises(ArgumentError) do
+      Topic.update(Topic.first, "content" => "1 updated")
+    end
+
+    assert_equal "You are passing an instance of ActiveRecord::Base to `update`. " \
+    "Please pass the id of the object by calling `.id`.", error.message
+
+    assert_not_equal "1 updated", Topic.first.content
+  end
+
   def test_class_level_update_without_ids
     topics = Topic.all
     assert_equal 5, topics.length


### PR DESCRIPTION
### Summary

This PR includes enhancements to the tests of the `ArgumentError` error message for some finder methods:
 - **Enhanced** test for calling  `#find` with an instance of `ActiveRecord::Base` (now checks the error message).
 - **Enhanced** test for calling  `#exists?` with an instance of `ActiveRecord::Base` (now checks the error message).
 - **Added** test for calling `#update` with an instance of `ActiveRecord::Base`
