### PR TITLE
Fix AR::TypeSerialized to work with AM::Type::ImmutableString

### DIFF
--- a/activerecord/lib/active_record/type/serialized.rb
+++ b/activerecord/lib/active_record/type/serialized.rb
@@ -37,8 +37,7 @@ module ActiveRecord
       def changed_in_place?(raw_old_value, value)
         return false if value.nil?
         raw_new_value = encoded(value)
-        raw_old_value.nil? != raw_new_value.nil? ||
-          subtype.changed_in_place?(raw_old_value, raw_new_value)
+        raw_old_value != raw_new_value
       end
 
       def accessor

--- a/activerecord/test/cases/serialized_attribute_test.rb
+++ b/activerecord/test/cases/serialized_attribute_test.rb
@@ -469,6 +469,30 @@ class SerializedAttributeTest < ActiveRecord::TestCase
     assert_equal({ "trial" => true }, topic.content)
   end
 
+  def test_mutation_detection
+    mutable_model = Class.new(Topic) do
+      # self.immutable_strings_by_default = true
+      attribute :content, ActiveModel::Type::String.new
+      serialize :content, Hash
+    end
+    topic = mutable_model.create!(content: { "foo" => "bar" })
+    assert_not_predicate topic, :changed?
+    topic.content["foo"] = "plop"
+    assert_predicate topic, :changed?
+  end
+
+  def test_mutation_detection_with_immutable_string
+    mutable_model = Class.new(Topic) do
+      # self.immutable_strings_by_default = true
+      attribute :content, ActiveModel::Type::ImmutableString.new
+      serialize :content, Hash
+    end
+    topic = mutable_model.create!(content: { "foo" => "bar" })
+    assert_not_predicate topic, :changed?
+    topic.content["foo"] = "plop"
+    assert_predicate topic, :changed?
+  end
+
   def test_mutation_detection_does_not_double_serialize
     coder = Object.new
     def coder.dump(value)


### PR DESCRIPTION
### Context

I tried to enable `immutable_strings_by_default` in our app, but it caused lots of bugs with all our `serialized` columns. From what I could tell the change detection is broken.

### Problem

The problem is that it delegates to the "subtype", and in the case of ImmutableString, it simply returns a static `false`.

I think it's incorrect to ask the subtype for mutation.

cc @kamipo since you might have context over this feature.

However my patch breaks https://github.com/rails/rails/blob/a8461b721793ca267acf28470de50ab4ac8e684b/activerecord/test/cases/serialized_attribute_test.rb#L472, but I'm having trouble understanding what this test is about.

