### PR TITLE
Fix delegation in ActiveModel::Type.lookup

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Fix delegation in ActiveModel::Type::Registry#lookup
+*   Fix delegation in ActiveModel::Type::Registry#lookup and ActiveModel::Type.lookup
 
     Passing a last positional argument `{}` would be incorrectly considered as keyword argument.
 

--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -30,9 +30,10 @@ module ActiveModel
         registry.register(type_name, klass, &block)
       end
 
-      def lookup(*args, **kwargs) # :nodoc:
-        registry.lookup(*args, **kwargs)
+      def lookup(*args) # :nodoc:
+        registry.lookup(*args)
       end
+      ruby2_keywords(:lookup)
 
       def default_value # :nodoc:
         @default_value ||= Value.new

--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -30,10 +30,9 @@ module ActiveModel
         registry.register(type_name, klass, &block)
       end
 
-      def lookup(*args) # :nodoc:
-        registry.lookup(*args)
+      def lookup(...) # :nodoc:
+        registry.lookup(...)
       end
-      ruby2_keywords(:lookup)
 
       def default_value # :nodoc:
         @default_value ||= Value.new

--- a/activemodel/test/cases/type_test.rb
+++ b/activemodel/test/cases/type_test.rb
@@ -18,6 +18,7 @@ module ActiveModel
       ActiveModel::Type.register(:foo, type)
 
       assert_equal type.new(:arg), ActiveModel::Type.lookup(:foo, :arg)
+      assert_equal type.new({}), ActiveModel::Type.lookup(:foo, {})
     end
   end
 end


### PR DESCRIPTION
### Summary


* Without the change the new test fails like this:
```
  Failure:
  ActiveModel::TypeTest#test_registering_a_new_type [test/cases/type_test.rb:21]:
  Expected: #<struct args={}>
    Actual: #<struct args=nil>
```
* (*args, **kwargs)-delegation is not correct on Ruby 2.7 unless the
  target always accepts keyword arguments (not the case for `Struct.new(:args).new`).
  See https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html

### Other Information

Similar to https://github.com/rails/rails/pull/42266, similar issue, similar fix.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
