### PR TITLE
Fix error message on top level update when sending an array of records

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -308,6 +308,11 @@ module ActiveRecord
       # for updating all records in a single query.
       def update(id = :all, attributes)
         if id.is_a?(Array)
+          if id.any?(ActiveRecord::Base)
+            raise ArgumentError,
+              "You are passing an array of ActiveRecord::Base instances to `update`. " \
+              "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`."
+          end
           id.map { |one_id| find(one_id) }.each_with_index { |object, idx|
             object.update(attributes[idx])
           }

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -64,6 +64,18 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_not_equal "1 updated", Topic.first.content
   end
 
+  def test_update_many_with_array_of_active_record_base_objects
+    error = assert_raise(ArgumentError) do
+      Topic.update(Topic.first(2), content: "updated")
+    end
+
+    assert_equal "You are passing an array of ActiveRecord::Base instances to `update`. " \
+    "Please pass the ids of the objects by calling `pluck(:id)` or `map(&:id)`.", error.message
+
+    assert_not_equal "updated", Topic.first.content
+    assert_not_equal "updated", Topic.second
+  end
+
   def test_class_level_update_without_ids
     topics = Topic.all
     assert_equal 5, topics.length


### PR DESCRIPTION
### Summary
When sending an array of records the error message would reference the `#find` method, which is confusing. This PR fixes that issue making it consistent to sending just one record

```ruby
# before
Topic.update(Topic.last, content: "updated")
# => #<ArgumentError: You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.>
Topic.update(Topic.last(3), content: "updated")
# => #<ArgumentError: You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.>

# after
Topic.update(Topic.last, content: "updated")
# => #<ArgumentError: You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.>
Topic.update(Topic.last(3), content: "updated")
# => #<ArgumentError: You are passing an instance of ActiveRecord::Base to `update`. Please pass the id of the object by calling `.id`.>
```
