### PR TITLE
Add tests for argument error messages in ActiveRecord methods

### DIFF
--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -296,12 +296,25 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal("New Topic", topic_reloaded.title)
   end
 
-  def test_save!
+  def test_save_valid_record
     topic = Topic.new(title: "New Topic")
     assert topic.save!
+  end
 
-    reply = WrongReply.new
-    assert_raise(ActiveRecord::RecordInvalid) { reply.save! }
+  def test_save_invalid_record
+    reply = WrongReply.new(title: "New reply")
+    error = assert_raise(ActiveRecord::RecordInvalid) { reply.save! }
+
+    assert_equal "Validation failed: Content Empty", error.message
+  end
+
+  def test_save_destroyed_object
+    topic = Topic.create!(title: "New Topic")
+    topic.destroy!
+
+    error = assert_raise(ActiveRecord::RecordNotSaved) { topic.save! }
+
+    assert_equal "Failed to save the record", error.message
   end
 
   def test_save_null_string_attributes

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -39,7 +39,9 @@ class UpdateAllTest < ActiveRecord::TestCase
   end
 
   def test_update_all_with_blank_argument
-    assert_raises(ArgumentError) { Comment.update_all({}) }
+    error = assert_raises(ArgumentError) { Comment.update_all({}) }
+
+    assert_equal "Empty list of attributes to change", error.message
   end
 
   def test_update_all_with_joins

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -425,9 +425,12 @@ class RelationScopingTest < ActiveRecord::TestCase
       select_sql = capture_sql { Author.first }.first
       assert_match(/organization_id/, select_sql)
 
-      assert_raises ArgumentError do
+      error = assert_raises ArgumentError do
         Author.where(organization_id: 1).scoping(all_queries: false) { }
       end
+
+      assert_equal "Scoping is set to apply to all queries and cannot be " \
+       "unset in a nested block.", error.message
     end
   end
 end


### PR DESCRIPTION
### Summary

 - Added test for the error message of `#save!`
 - Added test for the error message of `#update_all`
 - Added test for the error message of `#scoping`