### PR TITLE
Minor docs style fix [ci skip]

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -39,7 +39,7 @@
 *   Added a faster and more compact `ActiveSupport::Cache` serialization format.
 
     It can be enabled with `config.active_support.cache_format_version = 7.0` or
-    `config.load_defaults(7.0)`. Regardless of the configuration Active Support
+    `config.load_defaults 7.0`. Regardless of the configuration Active Support
     7.0 can read cache entries serialized by Active Support 6.1 which allows to
     upgrade without invalidating the cache. However Rails 6.1 can't read the
     new format, so all readers must be upgraded before the new format is enabled.

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -131,7 +131,7 @@ To enable it you must set `config.active_support.cache_format_version = 7.0`:
 ```ruby
 # config/application.rb
 
-config.load_defaults(6.1)
+config.load_defaults 6.1
 config.active_support.cache_format_version = 7.0
 ```
 
@@ -140,7 +140,7 @@ Or simply:
 ```ruby
 # config/application.rb
 
-config.load_defaults(7.0)
+config.load_defaults 7.0
 ```
 
 However Rails 6.1 applications are not able to read this new serialization format,


### PR DESCRIPTION
This is a really minor PR but it called my attention so I'm opening it just in case.. 

The occurrences that I'm changing in this PR are the only places where we use `load_defaults(...)` with parenthesis, in every other place we call it without parenthesis (including in `railties/lib/rails/generators/rails/app/templates/config/application.rb.tt`) So I thought it would be a good idea to keep the docs consistent with the rest.

Feel free to close it if you don't mind about such small details 😄 