### PR TITLE
Fix #41661 attaching multiple times within transaction

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -138,13 +138,14 @@ module ActiveStorage
 
           def #{name}=(attachables)
             attachables = Array(attachables).compact_blank
+            pending_uploads = attachment_changes["#{name}"].try(:pending_uploads)
 
             if ActiveStorage.replace_on_assign_to_many
               attachment_changes["#{name}"] =
                 if attachables.none?
                   ActiveStorage::Attached::Changes::DeleteMany.new("#{name}", self)
                 else
-                  ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, attachables)
+                  ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, attachables, pending_uploads: pending_uploads)
                 end
             else
               ActiveSupport::Deprecation.warn \
@@ -155,7 +156,7 @@ module ActiveStorage
 
               if attachables.any?
                 attachment_changes["#{name}"] =
-                  ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs + attachables)
+                  ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs + attachables, pending_uploads: pending_uploads)
               end
             end
           end


### PR DESCRIPTION
### Summary

Fix #41661 . Similar to https://github.com/rails/rails/commit/836eb915b14f01eca8a5ea655e4f30b6a8a7ce38 when attaching multiple times within a transaction we need to check for `change&.attachables` instead of just `blobs`.

In the test I created a blob outside the transaction on purpose to make sure it won't get deleted because of the code change