### PR TITLE
CREATE TEMPORARY TABLE is a readonly query

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         end
       end
 
-      DEFAULT_READ_QUERY = [:begin, :commit, :explain, :release, :rollback, :savepoint, :select, :with] # :nodoc:
+      DEFAULT_READ_QUERY = [:begin, :commit, :explain, :release, :rollback, :savepoint, :select, :with, /CREATE\s+TEMPORARY\s+TABLE/] # :nodoc:
       private_constant :DEFAULT_READ_QUERY
 
       def self.build_read_query_regexp(*parts) # :nodoc:

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -60,6 +60,20 @@ module ActiveRecord
       end
     end
 
+    def test_errors_when_a_create_table_query_is_called_while_preventing_writes
+      ActiveRecord::Base.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @connection.execute("CREATE TABLE subscribers2 (nick VARCHAR(255))")
+        end
+      end
+    end
+
+    def test_doesnt_error_when_a_create_temporary_table_query_is_called_while_preventing_writes
+      ActiveRecord::Base.while_preventing_writes do
+        @connection.execute("CREATE TEMPORARY TABLE subscribers2 (nick VARCHAR(255))")
+      end
+    end
+
     if ActiveRecord::Base.connection.supports_common_table_expressions?
       def test_doesnt_error_when_a_read_query_with_a_cte_is_called_while_preventing_writes
         @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')")
@@ -183,6 +197,20 @@ module ActiveRecord
       @connection_handler.while_preventing_writes do
         result = @connection.select_all("SELECT subscribers.* FROM subscribers WHERE nick = '138853948594'")
         assert_equal 1, result.length
+      end
+    end
+
+    def test_errors_when_a_create_table_query_is_called_while_preventing_writes
+      @connection_handler.while_preventing_writes do
+        assert_raises(ActiveRecord::ReadOnlyError) do
+          @connection.execute("CREATE TABLE subscribers2 (nick VARCHAR(255))")
+        end
+      end
+    end
+
+    def test_doesnt_error_when_a_create_temporary_table_query_is_called_while_preventing_writes
+      @connection_handler.while_preventing_writes do
+        @connection.execute("CREATE TEMPORARY TABLE subscribers2 (nick VARCHAR(255))")
       end
     end
 


### PR DESCRIPTION
### Summary
Trying to create a temporary table in a [while_preventing_writes](https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activerecord/lib/active_record/connection_handling.rb#L212-L229) raises an `ActiveRecord::ReadOnlyError`.

Creating a temporary table is not a write operation, so it should be allowed on read-only connections.