### PR TITLE
Add CDN host option to ActiveStorage

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -137,6 +137,13 @@ Or configure Active Storage to use proxying by default:
 Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
 ```
 
+In order to configure a CDN for Active Storage set the corresponding host in `config/environments/production.rb` like:
+```ruby
+  config.active_storage.cdn_host = "https://cdn.example.com"
+```
+
+The CDN host will only affect routes generated with proxy mode.
+
 ## Direct uploads
 
 Active Storage, with its included JavaScript library, supports uploading directly from the client to the cloud.

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -67,6 +67,7 @@ module ActiveStorage
 
   mattr_accessor :replace_on_assign_to_many, default: false
   mattr_accessor :track_variants, default: false
+  mattr_accessor :cdn_host
 
   module Transformers
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -95,6 +95,7 @@ module ActiveStorage
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false
+        ActiveStorage.cdn_host = app.config.active_storage.cdn_host
       end
     end
 

--- a/activestorage/test/urls/rails_storage_proxy_url_test.rb
+++ b/activestorage/test/urls/rails_storage_proxy_url_test.rb
@@ -36,4 +36,50 @@ class RailsStorageProxyUrlTest < ActiveSupport::TestCase
     variant = @blob.variant(resize: "100x100")
     assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
   end
+
+  test "rails_storage_proxy_url with cdn_host adds the host to the url" do
+    with_cdn "https://cdn.example.com" do
+      assert_includes rails_storage_proxy_url(@blob), "https://cdn.example.com/rails/active_storage/blobs/proxy/"
+    end
+  end
+
+  test "rails_storage_proxy_url with cdn_host overrides the default application host" do
+    original_url_options = Rails.application.routes.default_url_options.dup
+    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+    with_cdn "https://cdn.example.com" do
+      assert_includes rails_storage_proxy_url(@blob), "https://cdn.example.com/rails/active_storage/blobs/proxy/"
+    end
+  ensure
+    Rails.application.routes.default_url_options = original_url_options
+  end
+
+  test "rails_storage_proxy_url with cdn_host and port adds the host to the url" do
+    with_cdn "https://cdn.example.com:7777" do
+      assert_includes rails_storage_proxy_url(@blob), "https://cdn.example.com:7777/rails/active_storage/blobs/proxy/"
+    end
+  end
+
+  test "rails_storage_proxy_url with cdn_host without protocol adds the host to the url" do
+    with_cdn "cdn.example.com" do
+      assert_includes rails_storage_proxy_url(@blob), "http://cdn.example.com/rails/active_storage/blobs/proxy/"
+    end
+  end
+
+  test "rails_storage_proxy_url without cdn_host uses the default application host" do
+    original_url_options = Rails.application.routes.default_url_options.dup
+    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+    with_cdn nil do
+      assert_includes rails_storage_proxy_url(@blob), "http://test.example.com:3001/rails/active_storage/blobs/proxy/"
+    end
+  ensure
+    Rails.application.routes.default_url_options = original_url_options
+  end
+
+  private
+    def with_cdn(cdn_host)
+      ActiveStorage.cdn_host, previous = cdn_host, ActiveStorage.cdn_host
+      yield
+    ensure
+      ActiveStorage.cdn_host = previous
+    end
 end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -529,6 +529,30 @@ jobs, Cronjobs, etc.), you can access the `rails_blob_path` like this:
 Rails.application.routes.url_helpers.rails_blob_path(user.avatar, only_path: true)
 ```
 
+### Proxy mode
+
+Optionally, files can be proxied instead. This means that your application servers will download file data from the storage service in response to requests. This can be useful for serving files from a CDN.
+
+Explicitly proxy attachments using the `rails_storage_proxy_path` and `_url` route helpers:
+
+```erb
+<%= image_tag rails_storage_proxy_path(@user.avatar) %>
+```
+
+Or configure Active Storage to use proxying by default:
+
+```ruby
+# config/initializers/active_storage.rb
+Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
+```
+
+In order to configure a CDN for Active Storage set the corresponding host in `config/environments/production.rb` like:
+```ruby
+  config.active_storage.cdn_host = "https://cdn.example.com"
+```
+
+The CDN host will only affect routes generated with proxy mode.
+
 Downloading Files
 -----------------
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1058,6 +1058,8 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
     The default is `:rails_storage_redirect`.
 
+* `config.active_storage.cdn_host` can be used to set a CDN for ActiveStorage when generating links with proxy mode.
+
 ### Configuring Action Text
 
 * `config.action_text.attachment_tag_name` accepts a string for the HTML tag used to wrap attachments. Defaults to `"action-text-attachment"`.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -45,6 +45,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # Enable serving of attachments from a CDN.
+  # config.active_storage.cdn_host = "http://cdn.example.com"
+
   <%- end -%>
   <%- unless options[:skip_action_cable] -%>
   # Mount Action Cable outside main process or domain.


### PR DESCRIPTION
### Summary

Some time ago https://github.com/rails/rails/pull/34477 was implemented to allow apps to configure a CDN in front of ActiveStorage images. But somehow there is still not a clear way to configure a CDN for ActiveStorage.

This PR attempts to make it easier (and document it better) to configure a CDN for Active Storage. It only affects routes generated with proxy mode because it wouldn't make sense to put a CDN in front of URLs that redirect to the storage service. What's more proxy mode doesn't really make sense if not using a CDN, it would just mean increasing the load of your servers without benefit. For that reason we think this PR would be very valuable to the community.