### PR TITLE
Add load hook for ActiveStorage::VariantRecord

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add a load hook called `active_storage_variant_record` (providing `ActiveStorage::VariantRecord`)
+    to allow for overriding aspects of the `ActiveStorage::VariantRecord` class. This makes
+    `ActiveStorage::VariantRecord` consistent with `ActiveStorage::Blob` and `ActiveStorage::Attachment`
+    that already have load hooks.
+
+    *Brendon Muir*
+
 *   `ActiveStorage::PreviewError` is raised when a previewer is unable to generate a preview image.
 
     *Alex Robbin*

--- a/activestorage/app/models/active_storage/variant_record.rb
+++ b/activestorage/app/models/active_storage/variant_record.rb
@@ -6,3 +6,5 @@ class ActiveStorage::VariantRecord < ActiveStorage::Record
   belongs_to :blob
   has_one_attached :image
 end
+
+ActiveSupport.run_load_hooks :active_storage_variant_record, ActiveStorage::VariantRecord

--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1525,6 +1525,7 @@ These are the load hooks you can use in your own code. To hook into the initiali
 | `ActiveJob::TestCase`                | `active_job_test_case`               |
 | `ActiveRecord::Base`                 | `active_record`                      |
 | `ActiveStorage::Attachment`          | `active_storage_attachment`          |
+| `ActiveStorage::VariantRecord`       | `active_storage_variant_record`      |
 | `ActiveStorage::Blob`                | `active_storage_blob`                |
 | `ActiveStorage::Record`              | `active_storage_record`              |
 | `ActiveSupport::TestCase`            | `active_support_test_case`           |


### PR DESCRIPTION
### Summary

Add a load hook called `active_storage_variant_record` (providing `ActiveStorage::VariantRecord`) to allow for overriding aspects of the `ActiveStorage::VariantRecord` class. This makes `ActiveStorage::VariantRecord` consistent with `ActiveStorage::Blob` and `ActiveStorage::Attachment` that already have load hooks.

### Other Information

This hook is required if one wants to override aspects of this model (e.g. the table name).

I've not added any new tests given https://github.com/rails/rails/commit/da2c92377c7f36469e56dc25a4ac0604157ac778 didn't add any tests when the hooks were added to the other ActiveStorage models.