### PR TITLE
Add net-smtp and matrix to the Gemfile to fix the ruby-head build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -169,3 +169,15 @@ end
 
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "wdm", ">= 0.1.0", platforms: [:mingw, :mswin, :x64_mingw, :mswin64]
+
+if RUBY_VERSION >= "3.1"
+  # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+  # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
+  gem "net-smtp", require: false
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+
+  # matrix was removed from default gems in Ruby 3.1, but is used by the `capybara` gem.
+  # So we need to add it as a dependency until `capybara` is fixed: https://github.com/teamcapybara/capybara/pull/2468
+  gem "matrix", require: false
+end


### PR DESCRIPTION
Both were recently removed from Ruby's default gems.

Ref: https://bugs.ruby-lang.org/issues/17873
Ref: https://github.com/mikel/mail/pull/1439
Ref: https://github.com/teamcapybara/capybara/pull/2468

This should fix Rails' ruby-head builds until `mail` and `capybara` merge and publish the fixes. 