### PR TITLE
Allow to overwrite Cache-Control header in `fresh_when` and `stale?`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `cache_control: {}` option to `fresh_when` and `stale?`
+
+    Works as a shortcut to set `response.cache_control` with the above methods.
+
+    *Jacopo Beschi*
+
 *   Writing into a disabled session will now raise an error.
 
     Previously when no session store was set, writing into the session would silently fail.

--- a/actionpack/lib/action_controller/metal/conditional_get.rb
+++ b/actionpack/lib/action_controller/metal/conditional_get.rb
@@ -57,6 +57,8 @@ module ActionController
     #   304 Not Modified response if last_modified <= If-Modified-Since.
     # * <tt>:public</tt> By default the Cache-Control header is private, set this to
     #   +true+ if you want your application to be cacheable by other devices (proxy caches).
+    # * <tt>:cache_control</tt> When given will overwrite an existing Cache-Control header.
+    #   See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
     # * <tt>:template</tt> By default, the template digest for the current
     #   controller/action is included in ETags. If the action renders a
     #   different template, you can include its digest instead. If the action
@@ -98,12 +100,21 @@ module ActionController
     #     fresh_when(@article, public: true)
     #   end
     #
+    # When overwriting Cache-Control header:
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #     fresh_when(@article, public: true, cache_control: { no_cache: true })
+    #   end
+    #
+    # This will set in the response Cache-Control = public, no-cache.
+    #
     # When rendering a different template than the default controller/action
     # style, you can indicate which digest to include in the ETag:
     #
     #   before_action { fresh_when @article, template: 'widgets/show' }
     #
-    def fresh_when(object = nil, etag: nil, weak_etag: nil, strong_etag: nil, last_modified: nil, public: false, template: nil)
+    def fresh_when(object = nil, etag: nil, weak_etag: nil, strong_etag: nil, last_modified: nil, public: false, cache_control: {}, template: nil)
       weak_etag ||= etag || object unless strong_etag
       last_modified ||= object.try(:updated_at) || object.try(:maximum, :updated_at)
 
@@ -117,6 +128,7 @@ module ActionController
 
       response.last_modified = last_modified if last_modified
       response.cache_control[:public] = true if public
+      response.cache_control.merge!(cache_control)
 
       head :not_modified if request.fresh?(response)
     end
@@ -147,6 +159,8 @@ module ActionController
     #   304 Not Modified response if last_modified <= If-Modified-Since.
     # * <tt>:public</tt> By default the Cache-Control header is private, set this to
     #   +true+ if you want your application to be cacheable by other devices (proxy caches).
+    # * <tt>:cache_control</tt> When given will overwrite an existing Cache-Control header.
+    #   See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html for more possibilities.
     # * <tt>:template</tt> By default, the template digest for the current
     #   controller/action is included in ETags. If the action renders a
     #   different template, you can include its digest instead. If the action
@@ -208,6 +222,21 @@ module ActionController
     #       end
     #     end
     #   end
+    #
+    # When overwriting Cache-Control header:
+    #
+    #   def show
+    #     @article = Article.find(params[:id])
+    #
+    #     if stale?(@article, public: true, cache_control: { no_cache: true })
+    #       @statistics = @articles.really_expensive_call
+    #       respond_to do |format|
+    #         # all the supported formats
+    #       end
+    #     end
+    #   end
+    #
+    # This will set in the response Cache-Control = public, no-cache.
     #
     # When rendering a different template than the default controller/action
     # style, you can indicate which digest to include in the ETag:

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -87,7 +87,7 @@ class TestController < ActionController::Base
   end
 
   def conditional_hello
-    if stale?(last_modified: Time.now.utc.beginning_of_day, etag: [:foo, 123])
+    if stale?(last_modified: Time.now.utc.beginning_of_day, etag: [:foo, 123], cache_control: { no_cache: true })
       render action: "hello_world"
     end
   end
@@ -217,7 +217,7 @@ class TestController < ActionController::Base
   before_action :handle_last_modified_and_etags, only: :conditional_hello_with_bangs
 
   def handle_last_modified_and_etags
-    fresh_when(last_modified: Time.now.utc.beginning_of_day, etag: [ :foo, 123 ])
+    fresh_when(last_modified: Time.now.utc.beginning_of_day, etag: [ :foo, 123 ], public: false, cache_control: { no_cache: true, public: true })
   end
 
   def head_created
@@ -502,6 +502,11 @@ class LastModifiedRenderTest < ActionController::TestCase
     assert_equal @last_modified, @response.headers["Last-Modified"]
   end
 
+  def test_responds_with_custom_cache_control_headers
+    get :conditional_hello
+    assert_equal "no-cache", @response.headers["Cache-Control"]
+  end
+
   def test_responds_with_last_modified_with_record
     get :conditional_hello_with_record
     assert_equal @last_modified, @response.headers["Last-Modified"]
@@ -602,6 +607,12 @@ class LastModifiedRenderTest < ActionController::TestCase
   def test_last_modified_works_with_less_than_too
     @request.if_modified_since = 5.years.ago.httpdate
     get :conditional_hello_with_bangs
+    assert_response :success
+  end
+
+  def test_last_modified_with_custom_cache_control_headers
+    get :conditional_hello_with_bangs
+    assert_equal "public, no-cache", @response.headers["Cache-Control"]
     assert_response :success
   end
 end


### PR DESCRIPTION
### Summary

Add a `cache_control: {}` option to `fresh_when` and `stale?`,
when given works as a shortcut to set `response.cache_control` manually.

Closes #41644
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
