### PR TITLE
Expose BatchEnumerator attributes

### DIFF
--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -12,6 +12,20 @@ module ActiveRecord
         @finish = finish
       end
 
+      # The primary key value from which the BatchEnumerator starts, inclusive of the value.
+      attr_reader :start
+
+      # The primary key value at which the BatchEnumerator ends, inclusive of the value.
+      attr_reader :finish
+
+      # The relation from which the BatchEnumerator yields batches.
+      attr_reader :relation
+
+      # The size of the batches yielded by the BatchEnumerator.
+      def batch_size
+        @of
+      end
+
       # Looping through a collection of records from the database (using the
       # +all+ method, for example) is very inefficient since it will try to
       # instantiate all the objects at once.

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -306,6 +306,14 @@ class EachTest < ActiveRecord::TestCase
     end
   end
 
+  def test_in_batches_has_attribute_readers
+    enumerator = Post.no_comments.in_batches(of: 2, start: 42, finish: 84)
+    assert_equal Post.no_comments, enumerator.relation
+    assert_equal 2, enumerator.batch_size
+    assert_equal 42, enumerator.start
+    assert_equal 84, enumerator.finish
+  end
+
   def test_in_batches_should_yield_relation_if_block_given
     assert_queries(6) do
       Post.in_batches(of: 2) do |relation|


### PR DESCRIPTION
`BatchEnumerator` is a simple object storing a few parameters coming from `ActiveRecord::Batches#in_batches` when it's called without a block.

Sometimes, it's useful to access those values, in our case, a library receiving a `BatchEnumerator` from application code.

Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com> @adrianna-chang-shopify 

### Summary

Adds the attribute readers, and a method to return `batch_size` from the `@of` instance variable.

cc @byroot @rafaelfranca
 