### PR TITLE
make acts_like behavior more intuitive

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Previously, `acts_like?` would return true no matter what `acts_like_*` returned,
+    however this behavior is now deprecated for non-boolean return values.
+
+    ```ruby
+    class RubberDuck
+      # Deprecated
+      def acts_like_duck; end
+
+      # Should be updated to
+      def acts_like_duck
+        true
+      end
+    end
+    ```
+
+    The return value of `acts_like_*` will always be used by enabling the configuration:
+
+    ```ruby
+    config.active_support.use_acts_like_return_value = true
+    ```
+
+    *Hartley McGuire*
+
 *   Add `ActiveSupport::TestCase#stub_const` to stub a constant for the duration of a yield.
 
     *DHH*

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -93,6 +93,7 @@ module ActiveSupport
 
   cattr_accessor :test_order # :nodoc:
   cattr_accessor :test_parallelization_threshold, default: 50 # :nodoc:
+  cattr_accessor :use_acts_like_return_value, default: false
 
   singleton_class.attr_accessor :error_reporter # :nodoc:
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -148,5 +148,13 @@ module ActiveSupport
         end
       end
     end
+
+    initializer "active_support.set_use_acts_like_return_value" do |app|
+      config.after_initialize do
+        if app.config.active_support.use_acts_like_return_value
+          ActiveSupport.use_acts_like_return_value = true
+        end
+      end
+    end
   end
 end

--- a/activesupport/test/core_ext/object/acts_like_test.rb
+++ b/activesupport/test/core_ext/object/acts_like_test.rb
@@ -13,6 +13,40 @@ class ObjectTests < ActiveSupport::TestCase
     end
   end
 
+  class TimeSubclass < Time
+    def acts_like_time?
+      false
+    end
+  end
+
+  class DateSubclass < Date
+    def acts_like_date?
+      false
+    end
+  end
+
+  class StringSubclass < String
+    def acts_like_string?
+      false
+    end
+  end
+
+  class Duck
+    def acts_like_duck?
+      true
+    end
+  end
+
+  class RubberDuck < Duck
+    def acts_like_duck?
+      false
+    end
+  end
+
+  class DeprecatedDuck
+    def acts_like_duck?; end
+  end
+
   def test_duck_typing
     object = Object.new
     time   = Time.now
@@ -35,4 +69,52 @@ class ObjectTests < ActiveSupport::TestCase
     assert duck.acts_like?(:time)
     assert_not duck.acts_like?(:date)
   end
+
+  def test_subclasses_can_override
+    time_sub = TimeSubclass.now
+    date_sub = DateSubclass.today
+    string_sub = StringSubclass.new
+    duck = Duck.new
+    rubber_duck = RubberDuck.new
+
+    assert_not time_sub.acts_like?(:time)
+    assert_not date_sub.acts_like?(:date)
+    assert_not string_sub.acts_like?(:string)
+
+    assert duck.acts_like?(:duck)
+    assert_not rubber_duck.acts_like?(:duck)
+  end
+
+  def test_ignore_return_value_deprecated
+    with_use_acts_like_return_value(false) do
+      deprecated_duck = DeprecatedDuck.new
+
+      deprecated_acts_like = assert_deprecated do
+        deprecated_duck.acts_like?(:duck)
+      end
+
+      assert deprecated_acts_like
+    end
+  end
+
+  def test_use_acts_like_return_value
+    with_use_acts_like_return_value(true) do
+      deprecated_duck = DeprecatedDuck.new
+
+      acts_like = assert_not_deprecated do
+        deprecated_duck.acts_like?(:duck)
+      end
+
+      assert_not acts_like
+    end
+  end
+
+  private
+    def with_use_acts_like_return_value(value)
+      old_acts_like_return_value = ActiveSupport.use_acts_like_return_value
+      ActiveSupport.use_acts_like_return_value = value
+      yield
+    ensure
+      ActiveSupport.use_acts_like_return_value = old_acts_like_return_value
+    end
 end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -292,10 +292,11 @@ The method [`acts_like?`][Object#acts_like?] provides a way to check whether som
 
 ```ruby
 def acts_like_string?
+  true
 end
 ```
 
-which is only a marker, its body or return value are irrelevant. Then, client code can query for duck-type-safeness this way:
+Then, client code can query for duck-type-safeness this way:
 
 ```ruby
 some_klass.acts_like?(:string)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -62,6 +62,7 @@ Below are the default values associated with each target version. In cases of co
 
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-XSS-Protection" => "0", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
+- [`config.active_support.use_acts_like_return_value`](#config-active-support-use-acts-like-return-value): `true`
 
 #### Default Values for Target Version 7.0
 
@@ -1836,6 +1837,17 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.0                   | `true`               |
+
+#### `config.active_support.use_acts_like_return_value`
+
+Changes whether the return value of `acts_like_duck` will be used when `acts_like?(:duck)` is called on an object
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 7.1                   | `true`               |
 
 #### `ActiveSupport::Logger.silencer`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -267,6 +267,10 @@ module Rails
               "Referrer-Policy" => "strict-origin-when-cross-origin"
             }
           end
+
+          if respond_to?(:active_support)
+            active_support.use_acts_like_return_value = true
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -24,3 +24,6 @@
 #   "X-Permitted-Cross-Domain-Policies" => "none",
 #   "Referrer-Policy" => "strict-origin-when-cross-origin"
 # }
+
+# Use the return value of `acts_like_*` methods when calling `acts_like?`.
+# Rails.application.config.active_support.use_acts_like_return_value = true

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3537,6 +3537,32 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_missing_callback_actions
     end
 
+    test "ActiveSupport.use_acts_like_return_value is true by default for new apps" do
+      app "development"
+
+      assert_equal true, ActiveSupport.use_acts_like_return_value
+    end
+
+    test "ActiveSupport.use_acts_like_return_value is false by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "6.1"'
+      app "development"
+
+      assert_equal false, ActiveSupport.use_acts_like_return_value
+    end
+
+    test "ActiveSupport.use_acts_like_return_value can be configured in the new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_0.rb", <<-RUBY
+        Rails.application.config.active_support.use_acts_like_return_value = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveSupport.use_acts_like_return_value
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
### Summary

Previously, defining an `acts_like-*?` method would result in `acts_like?`
returning true for that type no matter what the underlying method
returned. This change makes the result of `acts_like?` more intuitive:
the return value of `acts_like_*?` is respected.

### Other Information

Fixes #42292 
