### PR TITLE
Use BigDecimal compatible operation in NumberToRoundedConverter

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_rounded_converter.rb
@@ -20,14 +20,19 @@ module ActiveSupport
           end
 
           formatted_string =
-            if rounded_number.nan? || rounded_number.infinite? || rounded_number == rounded_number.to_i
-              "%00.#{precision}f" % rounded_number
+            if rounded_number.nan?
+              "NaN"
+            elsif rounded_number.infinite?
+              "Inf"
             else
               s = rounded_number.to_s("F")
-              s << "0" * precision
               a, b = s.split(".", 2)
-              a << "."
-              a << b[0, precision]
+              if precision != 0
+                b << "0" * precision
+                a << "."
+                a << b[0, precision]
+              end
+              a
             end
         else
           formatted_string = rounded_number

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -207,6 +207,7 @@ module ActiveSupport
           assert_equal "9775.0000000000000000", number_helper.number_to_rounded("9775", precision: 20, significant: true)
           assert_equal "9775." + "0" * 96, number_helper.number_to_rounded("9775", precision: 100, significant: true)
           assert_equal("97.7", number_helper.number_to_rounded(Rational(9772, 100), precision: 3, significant: true))
+          assert_equal "28729870200000000000000", number_helper.number_to_rounded(0.287298702e23.to_d, precision: 0, significant: true)
         end
       end
 


### PR DESCRIPTION
### Summary
`NumberToRoundedConverter` uses operations with `BigDecimal` that will show inaccurate results due to the fact that the number is converted to `Float` to use that operation. Inaccuracies will arise when `Float` cannot accurately store the number.
*Example*
```ruby
"%00.3f" % 0.287298702e23.to_d
=> "28729870199999998984192.000"
```

```ruby
require 'bigdecimal'
require 'bigdecimal/util'

# when convertion is accurate from BigDecimal to Float
BigDecimal('2872987020000001.0') == BigDecimal('2872987020000001.0').to_f
=> true
"%00.1f" % BigDecimal('2872987020000001.0')
=> "2872987020000001.0"
"%00.1f" % BigDecimal('2872987020000001.0') == BigDecimal('2872987020000001.0').to_s('F')
=> true

# when convertion is not accurate from BigDecimal to Float
BigDecimal('28729870200000001.0') == BigDecimal('28729870200000001.0').to_f
=> false
"%00.1f" % BigDecimal('28729870200000001.0')
=> "28729870200000000.0"
"%00.1f" % BigDecimal('28729870200000001.0') == BigDecimal('28729870200000001.0').to_s('F')
=> false
```


So any BigDecimal number that cannot be expressed as a float accurately will make this operation inaccurately.

This is an attempt to fix https://github.com/rails/rails/issues/42302

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
Now that `rounded_number == rounded_number.to_i` condition is not needed I changed the if...else to return `'Nan'` when `rounded_number.nan?` and `'Inf'` when `rounded_number.infinite?` instead of `"%00.#{precision}f" % rounded_number` that returns the same string for those cases

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
