### PR TITLE
Added test for or query error message

### DIFF
--- a/activerecord/test/cases/relation/and_test.rb
+++ b/activerecord/test/cases/relation/and_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/author"
+
+module ActiveRecord
+  class AndTest < ActiveRecord::TestCase
+    fixtures :authors
+
+    def test_and
+      david, mary, bob = authors(:david, :mary, :bob)
+
+      david_and_mary = Author.where(id: [david, mary]).order(:id)
+      mary_and_bob   = Author.where(id: [mary, bob]).order(:id)
+
+      assert_equal [mary], david_and_mary.and(mary_and_bob)
+    end
+
+    def test_and_with_non_relation_attribute
+      hash = { "id" => 123 }
+      error = assert_raises(ArgumentError) do
+        Author.and(hash)
+      end
+
+      assert_equal(
+        "You have passed Hash object to #and. Pass an ActiveRecord::Relation object instead.",
+        error.message
+      )
+    end
+
+    def test_and_with_structurally_incompatible_scope
+      posts_scope = Author.unscope(:order).limit(10).offset(10).select(:id).order(:id)
+      error = assert_raises(ArgumentError) do
+        Author.limit(10).select(:id).order(:name).and(posts_scope)
+      end
+
+      assert_equal(
+        "Relation passed to #and must be structurally compatible. Incompatible values: [:order, :offset]",
+        error.message
+      )
+    end
+  end
+end

--- a/activerecord/test/cases/relation/or_test.rb
+++ b/activerecord/test/cases/relation/or_test.rb
@@ -133,9 +133,11 @@ module ActiveRecord
     end
 
     def test_or_with_non_relation_object_raises_error
-      assert_raises ArgumentError do
+      error = assert_raises ArgumentError do
         Post.where(id: [1, 2, 3]).or(title: "Rails")
       end
+
+      assert_equal "You have passed Hash object to #or. Pass an ActiveRecord::Relation object instead.", error.message
     end
 
     def test_or_with_references_inequality


### PR DESCRIPTION
### Summary
 - Added small test to check error message when an object which is not an instance of ActiveRecord::Relation is passed to `#or`
 
 
### Notes
 - Also found that `"#and"` method behaves the same way, and doesn't have it's error message tested, but I wasn't able to determine where should I add the tests for the `#and` method. If I can get some insight on this I can include that to the PR as well (or open a separate one). 
 
 
 (edited)
 Thanks to @p8 I found where `and` tests were, seems we are just testing `and` [methods in merging tests](https://github.com/rails/rails/pull/39558/files) so I added a separate file for specific `and` methods