### PR TITLE
Prefer (...) new argument forwarding syntax

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -84,10 +84,9 @@ module AbstractController
 
         methods.each do |method|
           _helpers_for_modification.class_eval <<~ruby_eval, file, line
-            def #{method}(*args, &block)                    # def current_user(*args, &block)
-              controller.send(:'#{method}', *args, &block)  #   controller.send(:'current_user', *args, &block)
+            def #{method}(...)                    # def current_user(...)
+              controller.send(:'#{method}', ...)  #   controller.send(:'current_user', ...)
             end                                             # end
-            ruby2_keywords(:'#{method}')
           ruby_eval
         end
       end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -151,10 +151,9 @@ module ActionDispatch
       middlewares.insert(target_index + 1, source_middleware)
     end
 
-    def use(klass, *args, &block)
-      middlewares.push(build_middleware(klass, args, block))
+    def use(...)
+      middlewares.push(build_middleware(...))
     end
-    ruby2_keywords(:use)
 
     def build(app = nil, &block)
       instrumenting = ActiveSupport::Notifications.notifier.listening?(InstrumentationProxy::EVENT_NAME)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -656,10 +656,9 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *args, &block) #:nodoc:
-        nearest_delegate.send(name, *args, &block)
+      def method_missing(...) #:nodoc:
+        nearest_delegate.send(...)
       end
-      ruby2_keywords(:method_missing)
 
       def migrate(direction)
         new.migrate direction

--- a/activerecord/lib/active_record/migration/command_recorder.rb
+++ b/activerecord/lib/active_record/migration/command_recorder.rb
@@ -108,9 +108,9 @@ module ActiveRecord
 
       ReversibleAndIrreversibleMethods.each do |method|
         class_eval <<-EOV, __FILE__, __LINE__ + 1
-          def #{method}(*args, &block)          # def create_table(*args, &block)
-            record(:"#{method}", args, &block)  #   record(:create_table, args, &block)
-          end                                   # end
+          def #{method}(...)                # def create_table(...)
+            record(:"#{method}", ...)       #   record(:create_table, ...)
+          end                               # end
         EOV
         ruby2_keywords(method)
       end

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -156,15 +156,14 @@ module ActiveSupport
           @current_instances_key ||= name.to_sym
         end
 
-        def method_missing(name, *args, &block)
+        def method_missing(...)
           # Caches the method definition as a singleton method of the receiver.
           #
           # By letting #delegate handle it, we avoid an enclosure that'll capture args.
           singleton_class.delegate name, to: :instance
 
-          send(name, *args, &block)
+          send(...)
         end
-        ruby2_keywords(:method_missing)
 
         def respond_to_missing?(name, _)
           super || instance.respond_to?(name)


### PR DESCRIPTION
Prefer (...) over ruby2_keywords
(...) is already used in several places in Rails and looks nicer.

Reference :- [https://github.com/eregon/rails/commit/191ee5eec93074e2c109fea5770c54e973901a1b#comments](https://github.com/eregon/rails/commit/191ee5eec93074e2c109fea5770c54e973901a1b#comments)