### PR TITLE
Prefer (...) new argument forwarding syntax

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -656,10 +656,9 @@ module ActiveRecord
         end
       end
 
-      def method_missing(name, *args, &block) #:nodoc:
-        nearest_delegate.send(name, *args, &block)
+      def method_missing(...) #:nodoc:
+        nearest_delegate.send(...)
       end
-      ruby2_keywords(:method_missing)
 
       def migrate(direction)
         new.migrate direction

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -156,15 +156,14 @@ module ActiveSupport
           @current_instances_key ||= name.to_sym
         end
 
-        def method_missing(name, *args, &block)
+        def method_missing(...)
           # Caches the method definition as a singleton method of the receiver.
           #
           # By letting #delegate handle it, we avoid an enclosure that'll capture args.
           singleton_class.delegate name, to: :instance
 
-          send(name, *args, &block)
+          send(...)
         end
-        ruby2_keywords(:method_missing)
 
         def respond_to_missing?(name, _)
           super || instance.respond_to?(name)


### PR DESCRIPTION
Prefer (...) over ruby2_keywords
(...) is already used in several places in Rails and looks nicer.

Reference :- [https://github.com/eregon/rails/commit/191ee5eec93074e2c109fea5770c54e973901a1b#comments](https://github.com/eregon/rails/commit/191ee5eec93074e2c109fea5770c54e973901a1b#comments)