### PR TITLE
Default editor setting for rails credentials:edit

### DIFF
--- a/railties/lib/rails/command/helpers/editor.rb
+++ b/railties/lib/rails/command/helpers/editor.rb
@@ -7,12 +7,15 @@ module Rails
     module Helpers
       module Editor
         private
+
           def ensure_editor_available(command:)
-            if ENV["EDITOR"].to_s.empty?
+            if default_editor.to_s.empty?
               say "No $EDITOR to open file in. Assign one like this:"
               say ""
               say %(EDITOR="mate --wait" #{command})
               say ""
+              say "You can also assign a default editor in an environment file like development.rb:"
+              say "config.credentials.default_editor = 'vim'"
               say "For editors that fork and exit immediately, it's important to pass a wait flag,"
               say "otherwise the credentials will be saved immediately with no chance to edit."
 
@@ -20,6 +23,10 @@ module Rails
             else
               true
             end
+          end
+
+          def default_editor
+            ENV["EDITOR"] || Rails.application.config.credentials&.default_editor
           end
 
           def catch_editing_exceptions

--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -26,7 +26,7 @@ module Rails
 
       def edit
         extract_environment_option_from_argument(default_environment: nil)
-        require_application!
+        require_application_and_environment!
 
         ensure_editor_available(command: "bin/rails credentials:edit") || (return)
 
@@ -91,7 +91,7 @@ module Rails
 
         def change_credentials_in_system_editor
           credentials.change do |tmp_path|
-            system("#{ENV["EDITOR"]} #{tmp_path}")
+            system("#{default_editor} #{tmp_path}")
           end
         end
 

--- a/railties/lib/rails/commands/encrypted/encrypted_command.rb
+++ b/railties/lib/rails/commands/encrypted/encrypted_command.rb
@@ -21,7 +21,7 @@ module Rails
       end
 
       def edit(file_path)
-        require_application!
+        require_application_and_environment!
         encrypted = Rails.application.encrypted(file_path, key_path: options[:key])
 
         ensure_editor_available(command: "bin/rails encrypted:edit") || (return)


### PR DESCRIPTION
Make it possible to set a default editor for rails credentials:edit so that you don't have to set one every time you call the command. 

### Summary

This makes it possible to set up a default editor, but even if set you can still override it with the `EDITOR` env variable. 

Add an option to set the default editor to use for `rails credentials:edit`.
I think that most people will probably only use one editor, so being able to set the default would be nice. 
Also had to teach about this to a new developer in our team, and not having to teach about the `EDITOR=` command would have made it simpler. Plus for some reason I always forget the editor command. :exploding_head: 

### Other Information

I'm using `config.credentials.default_editor` to set the default editor. 
This is using the Configuration::Custom class to set it.
Not sure if this is the best way to go here. 

`security.md`  doesn't have any mention of the environment variable needed for the command so I haven't added anything about this setting to it. (Since it's about security it might not be the best place?)

First pull request against Rails so I beg your forgiveness if I have missed something or done something wrong. 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
