### PR TITLE
Correct example config method

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -46,7 +46,7 @@ config.active_record.schema_format = :ruby
 
 Rails will use that particular setting to configure Active Record.
 
-WARNING: Use the public configuration methods over calling directly to the associated class. e.g. `config.application.action_mailer.options` instead of `ActionMailer::Base.options`.
+WARNING: Use the public configuration methods over calling directly to the associated class. e.g. `Rails.application.config.action_mailer.options` instead of `ActionMailer::Base.options`.
 
 NOTE: If you need to apply configuration directly to a class, use a [lazy load hook](https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html) in an initializer to avoid auto-loading the class before initialization has completed. This will break because autoloading during initialization cannot be safely repeated when the app reloads.
 


### PR DESCRIPTION
There is no config.application config

Follow up to https://github.com/rails/rails/pull/42322

[ci skip]

/cc @zzak @HParker 