### PR TITLE
Remove DidYouMean fallback for Rails::Command::Spellchecker

### DIFF
--- a/railties/lib/rails/command/spellchecker.rb
+++ b/railties/lib/rails/command/spellchecker.rb
@@ -7,50 +7,8 @@ module Rails
         def suggest(word, from:)
           if defined?(DidYouMean::SpellChecker)
             DidYouMean::SpellChecker.new(dictionary: from.map(&:to_s)).correct(word).first
-          else
-            from.sort_by { |w| levenshtein_distance(word, w) }.first
           end
         end
-
-        private
-          # This code is based directly on the Text gem implementation.
-          # Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher.
-          #
-          # Returns a value representing the "cost" of transforming str1 into str2.
-          def levenshtein_distance(str1, str2) # :doc:
-            s = str1
-            t = str2
-            n = s.length
-            m = t.length
-
-            return m if 0 == n
-            return n if 0 == m
-
-            d = (0..m).to_a
-            x = nil
-
-            # avoid duplicating an enumerable object in the loop
-            str2_codepoint_enumerable = str2.each_codepoint
-
-            str1.each_codepoint.with_index do |char1, i|
-              e = i + 1
-
-              str2_codepoint_enumerable.with_index do |char2, j|
-                cost = (char1 == char2) ? 0 : 1
-                x = [
-                  d[j + 1] + 1, # insertion
-                  e + 1,        # deletion
-                  d[j] + cost   # substitution
-                ].min
-                d[j] = e
-                e = x
-              end
-
-              d[m] = x
-            end
-
-            x
-          end
       end
     end
   end


### PR DESCRIPTION
In Ruby 2.7 DidYouMean is included as a default gem.
The included version of DidYouMean (1.4.0) includes DidYouMean::Spellchecker:
https://github.com/ruby/did_you_mean/blob/v1.4.0/lib/did_you_mean/spell_checker.rb

As the SpellChecker is included by default, we no longer need to add a levenshtein fallback.
Someone might still run Rails with DidYouMean disabled by using the
--disable-did_you_mean flag. In that case we return an empty string as
they probably don't expect suggestions.