### PR TITLE
Fix typo in ActionableError [skip ci]

### DIFF
--- a/activesupport/lib/active_support/actionable_error.rb
+++ b/activesupport/lib/active_support/actionable_error.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  # Actionable errors let's you define actions to resolve an error.
+  # Actionable errors lets you define actions to resolve an error.
   #
   # To make an error actionable, include the <tt>ActiveSupport::ActionableError</tt>
   # module and invoke the +action+ class macro to define the action. An action


### PR DESCRIPTION
"let's you" is short for "let us you".
It should be "lets you" instead.