### PR TITLE
Skip sending preload links headers when streaming

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -544,6 +544,7 @@ module ActionView
         MAX_HEADER_SIZE = 8_000 # Some HTTP client and proxies have a 8kiB header limit
         def send_preload_links_header(preload_links, max_header_size: MAX_HEADER_SIZE)
           return if preload_links.empty?
+          return if response.sending?
 
           if respond_to?(:request) && request
             request.send_early_hints("Link" => preload_links.join("\n"))

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -24,6 +24,7 @@ class AssetTagHelperTest < ActionView::TestCase
     def headers
       @headers ||= {}
     end
+    def sending?; false; end
   end
 
   def setup


### PR DESCRIPTION
@seejohnrun and I were investigating [ActionController::Streaming](https://api.rubyonrails.org/classes/ActionController/Streaming.html) on our Twitch stream last week and bumped into a failure because of `stylesheet_link_tag` calling `send_preload_links_header` and failing with `ActionDispatch::IllegalStateError: header already sent`.

Disabling `config.action_view.preload_links_header` made this work, but that isn't motioned in the documentation (https://api.rubyonrails.org/classes/ActionController/Streaming.html) and I think it would be better to Just Work than require configuration changes.

The rest of `send_preload_links_header` seems to prefer to fail silently (which makes sense, since it's just hints) so this PR makes it do the same if the response is already `sending?`.