### PR TITLE
Verify raised error message in test case.

### DIFF
--- a/actionmailbox/test/unit/router_test.rb
+++ b/actionmailbox/test/unit/router_test.rb
@@ -140,9 +140,10 @@ module ActionMailbox
     end
 
     test "invalid address" do
-      assert_raises(ArgumentError) do
+      error = assert_raises(ArgumentError) do
         @router.add_route Array.new, to: :first
       end
+      assert_equal "Expected a Symbol, String, Regexp, Proc, or matchable, got []", error.message
     end
 
     test "single string mailbox_for" do


### PR DESCRIPTION
We are raising an explicit error message in `ActionMailbox::Router::Route` class when validating address. I think we need to verify the error message raised in test.

Hope this change is relevant.