### PR TITLE
[ci skip] Mention executable test cases in issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -2,6 +2,11 @@
 <!-- (Guidelines for creating a bug report are [available
 here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#creating-a-bug-report)) -->
 
+<!-- Paste your executable test case created from one of the scripts found [here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#create-an-executable-test-case) below: -->
+```ruby
+# Your reproduction script goes here
+```
+
 ### Expected behavior
 <!-- Tell us what should happen -->
 


### PR DESCRIPTION
### Summary

A lot of bug reports have useful reproduction steps that could be a reproduction script, but they seem to have either not found the reproduction script template or didn't read the 'contributing to rails' page at all. This links to the same page at the section that includes the reproduction scripts with a stronger call to action making it clear that they need a reproduction script.
