### PR TITLE
Formatter ISO8601 to avoid scientific notation in more cases

### DIFF
--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -27,7 +27,7 @@ module ActiveSupport
         time << "#{parts[:hours]}H"     if parts.key?(:hours)
         time << "#{parts[:minutes]}M"   if parts.key?(:minutes)
         if parts.key?(:seconds)
-          time << "#{sprintf(@precision ? "%0.0#{@precision}f" : '%g', parts[:seconds])}S"
+          time << "#{format_seconds(parts[:seconds])}S"
         end
         output << "T#{time}" unless time.empty?
         output
@@ -53,6 +53,14 @@ module ActiveSupport
 
         def week_mixed_with_date?(parts)
           parts.key?(:weeks) && (parts.keys & DATE_COMPONENTS).any?
+        end
+
+        def format_seconds(seconds)
+          if @precision
+            sprintf("%0.0#{@precision}f", seconds)
+          else
+            seconds.to_s
+          end
         end
     end
   end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -625,6 +625,7 @@ class DurationTest < ActiveSupport::TestCase
       ["P1Y1M1DT1H",    1.year + 1.month + 1.day + 1.hour],
       ["PT0S",          0.minutes                        ],
       ["PT-0.2S",       (-0.2).seconds                   ],
+      ["PT1000000S",    1_000_000.seconds                ],
     ]
     expectations.each do |expected_output, duration|
       assert_equal expected_output, duration.iso8601, expected_output.inspect


### PR DESCRIPTION
### Summary

I was unaware until today, but %f and %g return different values for large second durations

```ruby
sprintf("%g", 1_000_000) # => "1e+06"
```


```ruby
sprintf("%0.2f", 1_000_000) # => "1000000.00"
```

for ISO8601 we never want scientific notation

closes: https://github.com/rails/rails/issues/42344