### PR TITLE
Bump rack to remove ssl? override

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ PATH
     actionpack (7.0.0.alpha)
       actionview (= 7.0.0.alpha)
       activesupport (= 7.0.0.alpha)
-      rack (~> 2.0, >= 2.0.9)
+      rack (~> 2.0, >= 2.2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)

--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", version
 
-  s.add_dependency "rack",      "~> 2.0", ">= 2.0.9"
+  s.add_dependency "rack",      "~> 2.0", ">= 2.2.0"
   s.add_dependency "rack-test", ">= 0.6.3"
   s.add_dependency "rails-html-sanitizer", "~> 1.0", ">= 1.2.0"
   s.add_dependency "rails-dom-testing", "~> 2.0"

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -428,10 +428,6 @@ module ActionDispatch
     def commit_flash
     end
 
-    def ssl?
-      super || scheme == "wss"
-    end
-
     def inspect # :nodoc:
       "#<#{self.class.name} #{method} #{original_url.dump} for #{remote_ip}>"
     end


### PR DESCRIPTION
[Rack 2.2+ understands "wss" as being "ssl"](https://github.com/rack/rack/commit/5b7e48e1e13d5df458d83855af60cb0498d836b3), so bumping the requirement lets us remove this override.
