### PR TITLE
Fix migrations compatibility for polymorphic references default index name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -220,6 +220,10 @@ module ActiveRecord
 
         def index_options(table_name)
           index_options = as_options(index).merge(conditional_options)
+
+          # legacy reference index names are used on versions 6.0 and earlier
+          return index_options if options[:_uses_legacy_reference_index_name]
+
           index_options[:name] ||= polymorphic_index_name(table_name) if polymorphic
           index_options
         end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -269,72 +269,6 @@ module ActiveRecord
         end
       end
 
-      def test_create_table_with_polymorphic_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            create_table :more_testings do |t|
-              t.references :widget, polymorphic: true, index: true
-              t.belongs_to :gizmo, polymorphic: true, index: true
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
-      ensure
-        connection.drop_table :more_testings rescue nil
-      end
-
-      def test_change_table_with_polymorphic_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            change_table :testings do |t|
-              t.references :widget, polymorphic: true, index: true
-              t.belongs_to :gizmo, polymorphic: true, index: true
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
-      end
-
-      def test_create_join_table_with_polymorphic_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            create_join_table :more, :testings do |t|
-              t.references :widget, polymorphic: true, index: true
-              t.belongs_to :gizmo, polymorphic: true, index: true
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
-      ensure
-        connection.drop_table :more_testings rescue nil
-      end
-
-      def test_polymorphic_add_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            add_reference :testings, :widget, polymorphic: true, index: true
-            add_belongs_to :testings, :gizmo, polymorphic: true, index: true
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
-      end
-
       def test_datetime_doesnt_set_precision_on_create_table
         migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
@@ -598,6 +532,132 @@ module ActiveRecord
           end
         end
     end
+  end
+end
+
+module LegacyPolymorphicReferenceIndexTestCases
+  attr_reader :connection
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @schema_migration = @connection.schema_migration
+    @verbose_was = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    connection.create_table :testings, if_not_exists: true
+  end
+
+  def teardown
+    ActiveRecord::Migration.verbose = @verbose_was
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    connection.drop_table :testings rescue nil
+  end
+
+  def test_create_table_with_polymorphic_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        create_table :more_testings do |t|
+          t.references :widget, polymorphic: true, index: true
+          t.belongs_to :gizmo, polymorphic: true, index: true
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_change_table_with_polymorphic_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        change_table :testings do |t|
+          t.references :widget, polymorphic: true, index: true
+          t.belongs_to :gizmo, polymorphic: true, index: true
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
+  end
+
+  def test_create_join_table_with_polymorphic_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        create_join_table :more, :testings do |t|
+          t.references :widget, polymorphic: true, index: true
+          t.belongs_to :gizmo, polymorphic: true, index: true
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_polymorphic_add_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        add_reference :testings, :widget, polymorphic: true, index: true
+        add_belongs_to :testings, :gizmo, polymorphic: true, index: true
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
+  end
+end
+
+module LegacyPolymorphicReferenceIndexTest
+  class V6_0 < ActiveRecord::TestCase
+    include LegacyPolymorphicReferenceIndexTestCases
+
+    self.use_transactional_tests = false
+
+    private
+      def migration_class
+        ActiveRecord::Migration[6.0]
+      end
+  end
+
+  class V5_2 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[5.2]
+      end
+  end
+
+  class V5_1 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[5.1]
+      end
+  end
+
+  class V5_0 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[5.0]
+      end
+  end
+
+  class V4_2 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[4.2]
+      end
   end
 end
 


### PR DESCRIPTION
Most changes are extracting existing test cases into a separate module to easily test agains all affected rails versions.

Closes #41693
Closes #41547
Closes #44268

Some `super`s in `def compatible_table_definition(t)` bodies were missing and this caused some compatibility classes to not took its place properly. 

I also haven't found a good way to override `ConnectionAdapters::ReferenceDefinition#index_options` (like mentioned in https://github.com/rails/rails/pull/38717#issuecomment-624204682), so used an original implementation (hash private option) from that PR.  