### PR TITLE
Faster check for any default scope with all_queries

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -57,7 +57,7 @@ module ActiveRecord
         # default_scopes for the model  where +all_queries+ is true.
         def default_scopes?(all_queries: false)
           if all_queries
-            self.default_scopes.map(&:all_queries).include?(true)
+            self.default_scopes.any?(&:all_queries)
           else
             self.default_scopes.any?
           end


### PR DESCRIPTION
### Summary

Faster & presumably cleaner way of checking for default scopes with `true` `all_queries` attribute

It might look like a cosmetic change but on the other hand might be worth implementing for a better readability and performance at scale. Thanks!

### Other Information

I'm not sure what is the size of the `default_scopes` array on average but it seems to be a bit faster even with an empty array, here is some benchmarks: 

#### Benchmark code:
```ruby
DEFAULT_SCOPES_NUM = 1

Obj = Struct.new(:all_queries)
data = Array.new(DEFAULT_SCOPES_NUM) { Obj.new(rand < 0.5) }
puts data.inspect
Benchmark.ips do |x|
  x.report('map.include') { data.map(&:all_queries).include?(true) }
  x.report('any?') { data.any?(&:all_queries) }
  x.compare!
end
```


#### DEFAULT_SCOPES_NUM = 0
```
Calculating -------------------------------------
         map.include      5.803M (± 4.8%) i/s -     29.436M in   5.084265s
                any?     10.324M (± 3.6%) i/s -     52.006M in   5.045096s

Comparison:
                any?: 10324011.1 i/s
         map.include:  5802745.5 i/s - 1.78x  (± 0.00) slower
```

#### DEFAULT_SCOPES_NUM = 1

```
=> [#<struct Obj all_queries=true>]
Calculating -------------------------------------
         map.include      4.349M (± 8.0%) i/s -     21.841M in   5.056497s
                any?      7.178M (± 4.8%) i/s -     36.253M in   5.064650s

Comparison:
                any?:  7178478.4 i/s
         map.include:  4349401.5 i/s - 1.65x  (± 0.00) slower
```

#### DEFAULT_SCOPES_NUM = 5
```
=> [#<struct Obj all_queries=true>, #<struct Obj all_queries=false>, #<struct Obj all_queries=true>, #<struct Obj all_queries=false>, #<struct Obj all_queries=true>]
Calculating -------------------------------------
         map.include      1.958M (±11.8%) i/s -      9.781M in   5.066797s
                any?      7.133M (± 1.4%) i/s -     35.796M in   5.019214s

Comparison:
                any?:  7133324.7 i/s
         map.include:  1957590.5 i/s - 3.64x  (± 0.00) slower

```



