### PR TITLE
Drop support for the `SERVER_ADDR` header

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Drop support for the `SERVER_ADDR` header
+
+    Following up https://github.com/rack/rack/pull/1573 and https://github.com/rails/rails/pull/42349
+
+    *Ricardo Díaz*
+
 *   Set session options when initializing a basic session.
 
     *Gannon McGibbon*

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -42,11 +42,8 @@ module ActionDispatch
         HTTP_NEGOTIATE HTTP_PRAGMA HTTP_CLIENT_IP
         HTTP_X_FORWARDED_FOR HTTP_ORIGIN HTTP_VERSION
         HTTP_X_CSRF_TOKEN HTTP_X_REQUEST_ID HTTP_X_FORWARDED_HOST
-        SERVER_ADDR
         ].freeze
 
-    # TODO: Remove SERVER_ADDR when we remove support to Rack 2.1.
-    # See https://github.com/rack/rack/commit/c173b188d81ee437b588c1e046a1c9f031dea550
     ENV_METHODS.each do |env|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1
         # frozen_string_literal: true

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -222,7 +222,7 @@ module ActionDispatch
         if forwarded = x_forwarded_host.presence
           forwarded.split(/,\s?/).last
         else
-          get_header("HTTP_HOST") || "#{server_name || server_addr}:#{get_header('SERVER_PORT')}"
+          get_header("HTTP_HOST") || "#{server_name}:#{get_header('SERVER_PORT')}"
         end
       end
 


### PR DESCRIPTION
### Summary

Following up https://github.com/rails/rails/pull/42349 and https://github.com/rack/rack/pull/1573 the `SERVER_ADDR` header
can be dropped, considering that it's not required by the CGI spec.