### PR TITLE
Deprecate `partial_writes` in favor of `partial_inserts` and `partial_updates`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Deprecate `partial_writes` in favor of `partial_inserts` and `partial_updates`.
+
+    This allows to have a different behavior on update and create.
+
+    *Jean Boussier*
+
 *   Fix compatibility with `psych >= 4`.
 
     Starting in Psych 4.0.0 `YAML.load` behaves like `YAML.safe_load`. To preserve compatibility

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -14,7 +14,8 @@ module ActiveRecord
           raise "You cannot include Dirty after Timestamp"
         end
 
-        class_attribute :partial_writes, instance_writer: false, default: true
+        class_attribute :partial_updates, instance_writer: false, default: true
+        class_attribute :partial_inserts, instance_writer: false, default: true
 
         # Attribute methods for "changed in last call to save?"
         attribute_method_affix(prefix: "saved_change_to_", suffix: "?", parameters: "**options")
@@ -24,6 +25,32 @@ module ActiveRecord
         # Attribute methods for "will change if I call save?"
         attribute_method_affix(prefix: "will_save_change_to_", suffix: "?", parameters: "**options")
         attribute_method_suffix("_change_to_be_saved", "_in_database", parameters: false)
+      end
+
+      module ClassMethods
+        def partial_writes
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            ActiveRecord::Base.partial_writes is deprecated and will be removed in Rails 7.1.
+            Use `partial_updates` and `partial_inserts` instead.
+          MSG
+          partial_updates && partial_inserts
+        end
+
+        def partial_writes?
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `ActiveRecord::Base.partial_writes?` is deprecated and will be removed in Rails 7.1.
+            Use `partial_updates?` and `partial_inserts?` instead.
+          MSG
+          partial_updates? && partial_inserts?
+        end
+
+        def partial_writes=(value)
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            `ActiveRecord::Base.partial_writes=` is deprecated and will be removed in Rails 7.1.
+            Use `partial_updates=` and `partial_inserts=` instead.
+          MSG
+          self.partial_updates = self.partial_inserts = value
+        end
       end
 
       # <tt>reload</tt> the record and clears changed attributes.
@@ -185,20 +212,24 @@ module ActiveRecord
           @_touch_attr_names, @_skip_dirty_tracking = nil, nil
         end
 
-        def _update_record(attribute_names = attribute_names_for_partial_writes)
+        def _update_record(attribute_names = attribute_names_for_partial_updates)
           affected_rows = super
           changes_applied
           affected_rows
         end
 
-        def _create_record(attribute_names = attribute_names_for_partial_writes)
+        def _create_record(attribute_names = attribute_names_for_partial_inserts)
           id = super
           changes_applied
           id
         end
 
-        def attribute_names_for_partial_writes
-          partial_writes? ? changed_attribute_names_to_save : attribute_names
+        def attribute_names_for_partial_updates
+          partial_updates? ? changed_attribute_names_to_save : attribute_names
+        end
+
+        def attribute_names_for_partial_inserts
+          partial_inserts? ? changed_attribute_names_to_save : attribute_names
         end
     end
   end

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -127,7 +127,7 @@ module ActiveRecord
     end
 
     def should_record_timestamps?
-      record_timestamps && (!partial_writes? || has_changes_to_save?)
+      record_timestamps && (!partial_updates? || has_changes_to_save?)
     end
 
     def timestamp_attributes_for_create_in_model

--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -1007,15 +1007,15 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
     assert_nothing_raised { user.jobs_pool.clear }
   end
 
-  def test_has_and_belongs_to_many_while_partial_writes_false
-    original_partial_writes = ActiveRecord::Base.partial_writes
-    ActiveRecord::Base.partial_writes = false
+  def test_has_and_belongs_to_many_while_partial_inserts_false
+    original_partial_inserts = ActiveRecord::Base.partial_inserts
+    ActiveRecord::Base.partial_inserts = false
     developer = Developer.new(name: "Mehmet Emin İNAÇ")
     developer.projects << Project.new(name: "Bounty")
 
     assert developer.save
   ensure
-    ActiveRecord::Base.partial_writes = original_partial_writes
+    ActiveRecord::Base.partial_inserts = original_partial_inserts
   end
 
   def test_has_and_belongs_to_many_with_belongs_to

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -267,7 +267,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
 
     firm = Firm.first
     firm.account = Account.first
-    assert_queries(Firm.partial_writes? ? 0 : 1) { firm.save! }
+    assert_queries(Firm.partial_updates? ? 0 : 1) { firm.save! }
 
     firm = Firm.first.dup
     firm.account = Account.first

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -943,11 +943,14 @@ class DirtyTest < ActiveRecord::TestCase
 
   private
     def with_partial_writes(klass, on = true)
-      old = klass.partial_writes?
-      klass.partial_writes = on
+      old_inserts = klass.partial_inserts?
+      old_updates = klass.partial_updates?
+      klass.partial_inserts = on
+      klass.partial_updates = on
       yield
     ensure
-      klass.partial_writes = old
+      klass.partial_inserts = old_inserts
+      klass.partial_updates = old_updates
     end
 
     def check_pirate_after_save_failure(pirate)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -416,7 +416,9 @@ in controllers and views. This defaults to `false`.
 
 * `config.active_record.record_timestamps` is a boolean value which controls whether or not timestamping of `create` and `update` operations on a model occur. The default value is `true`.
 
-* `config.active_record.partial_writes` is a boolean value and controls whether or not partial writes are used (i.e. whether updates only set attributes that are dirty). Note that when using partial writes, you should also use optimistic locking `config.active_record.lock_optimistically` since concurrent updates may write attributes based on a possibly stale read state. The default value is `true`.
+* `config.active_record.partial_inserts` is a boolean value and controls whether or not partial writes are used when creating new records (i.e. whether inserts only set attributes that are different from the default). The default value is `true`.
+
+* `config.active_record.partial_updates` is a boolean value and controls whether or not partial writes are used when updating existing records (i.e. whether updates only set attributes that are dirty). Note that when using partial updates, you should also use optimistic locking `config.active_record.lock_optimistically` since concurrent updates may write attributes based on a possibly stale read state. The default value is `true`.
 
 * `config.active_record.maintain_test_schema` is a boolean value which controls whether Active Record should try to keep your test database schema up-to-date with `db/schema.rb` (or `db/structure.sql`) when you run your tests. The default is `true`.
 


### PR DESCRIPTION
This allows to have a different behavior on update and create.

For instance it might be desirable to disable partial inserts to protect against a concurrent migration removing the default value of a column, which would cause processes with an outdated schema cache to fail on insert.

We've been running a similar patch since 2015 because we experienced this very problem.

I'd be even tempted to disable `partial_inserts` by default, but maybe it has advantages I don't see?

cc @rafaelfranca @etiennebarrie @adrianna-chang-shopify 