### PR TITLE
Credentials: support hash style access in more cases

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -35,7 +35,13 @@ module ActiveSupport
 
     private
       def deep_transform(hash)
-        hash.transform_values { |value| value.is_a?(Hash) ? ActiveSupport::InheritableOptions.new(deep_transform(value)) : value }
+        return hash unless hash.is_a?(Hash)
+
+        h = ActiveSupport::InheritableOptions.new
+        hash.each do |k, v|
+          h[k] = deep_transform(v)
+        end
+        h
       end
 
       def options

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -45,6 +45,8 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_not @credentials.something.bad
     assert_equal "bar", @credentials.dig(:something, :nested, :foo)
     assert_equal "bar", @credentials.something.nested.foo
+    assert_equal [:good, :bad, :nested], @credentials.something.keys
+    assert_equal ({ good: true, bad: false, nested: { foo: "bar" } }), @credentials.something
   end
 
   test "reading comment-only configuration" do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/42351

https://github.com/rails/rails/pull/42106 broke if you wanted to treat a set of nested credentials as a hash. This PR fixes it.
