### PR TITLE
Add developer docs on how `ActiveRecord::Migration::Compatibility` works

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -12,7 +12,24 @@ module ActiveRecord
         end
         const_get(name)
       end
-
+      
+      # This file exists to ensure that old migrations run the same way they did before a Rails upgrade.
+      # eg. if you write a migration on Rails 6.1, then upgrade to Rails 7, the migration should do the same thing to your
+      # database as it did when you were running Rails 6.1
+      #
+      # "Current" is an alias for `ActiveRecord::Migration`, it represents the current Rails version.
+      # New migration functionality that will never be backward compatible should be added directly to `ActiveRecord::Migration`.
+      #
+      # There are classes for each prior Rails version. Each class descends from the *next* Rails version, so:
+      # 6.1 < 7.0
+      # 5.2 < 6.0 < 6.1 < 7.0
+      #
+      # If you are introducing new migration functionality that should only apply from Rails 7 onward, then you should
+      # find the class that immediately precedes it (6.1), and override the relevant migration methods to undo your changes.
+      #
+      # For example, Rails 6 added a default value for the `precision` option on datetime columns. So in this file, the `V5_2`
+      # class sets the value of `precision` to `nil` if it's not explicitly provided. This way, the default value will not apply
+      # for migrations written for 5.2, but will for migrations written for 6.0.
       V7_0 = Current
 
       class V6_1 < V7_0

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -12,7 +12,7 @@ module ActiveRecord
         end
         const_get(name)
       end
-      
+
       # This file exists to ensure that old migrations run the same way they did before a Rails upgrade.
       # eg. if you write a migration on Rails 6.1, then upgrade to Rails 7, the migration should do the same thing to your
       # database as it did when you were running Rails 6.1


### PR DESCRIPTION
In https://github.com/rails/rails/pull/41084#discussion_r626739953, @pixeltrix helped me work through adding a new feature to the migration compatibility system. We both founded it a bit head scratching understanding the inheritance chain. In this PR I'm adding comments for future developers working on this to hopefully save some head scratching.

These comments aren't intended to be public - I think the `# :nodoc: all` on line 5 should prevent that.
