### PR TITLE
Adds Active Storage association_name? method to has_{many/one}_attached

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Add Active Storage association_name? method to has_{many/one}_attached.
+    Returns `true` if attachable are attached.
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_one_attached :avatar
+      has_many_attached :documents
+    end
+
+    user = User.create!
+    user.documents.attach(...)
+    ```
+
+    Before:
+    ```ruby
+    user.avatar.attached?    # => false
+    user.documents.attached? # => true
+    ```
+
+    After:
+    ```ruby
+    user.avatar?    # => false
+    user.documents? # => true
+    ```
+
+    *Abhay Nikam*
+
 *   Allow to purge an attachment when record is not persisted for `has_one_attached`
 
     *Jacopo Beschi*

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -65,6 +65,10 @@ module ActiveStorage
                 ActiveStorage::Attached::Changes::CreateOne.new("#{name}", self, attachable)
               end
           end
+
+          def #{name}?
+            ActiveStorage::Attached::One.new("#{name}", self).attached?
+          end
         CODE
 
         has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
@@ -150,6 +154,10 @@ module ActiveStorage
                   ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs + attachables)
               end
             end
+          end
+
+          def #{name}?
+            ActiveStorage::Attached::Many.new("#{name}", self).attached?
           end
         CODE
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -667,6 +667,18 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "attachables attached with ?" do
+    assert_not @user.highlights.attached?
+    assert_not @user.highlights?
+
+    @user.highlights.attach(
+      { io: StringIO.new("STUFF"), filename: "funky.jpg", content_type: "image/jpeg" },
+      { io: StringIO.new("THINGS"), filename: "town.jpg", content_type: "image/jpeg" }
+    )
+    assert @user.highlights.attached?
+    assert @user.highlights?
+  end
+
   private
     def append_on_assign
       ActiveStorage.replace_on_assign_to_many, previous = false, ActiveStorage.replace_on_assign_to_many

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -663,4 +663,13 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
 
     assert_match(/Cannot find variant :unknown for User#avatar_with_variants/, error.message)
   end
+
+  test "attachable attached with ?" do
+    assert_not @user.avatar.attached?
+    assert_not @user.avatar?
+
+    @user.avatar.attach create_blob(filename: "funky.jpg")
+    assert @user.avatar.attached?
+    assert @user.avatar?
+  end
 end


### PR DESCRIPTION
Similar to: #37951

Example:
```
class User < ActiveRecord::Base
  has_one_attached :avatar
  has_many_attached :documents
end
```

Before:
```
user = User.create!
user.avatar.attached?    # => false
user.documents.attached? # => true
```

After:
```
user.avatar?    # => false
user.documents? # => true
```