### PR TITLE
Document ActiveStorage::Attached::One#blank? [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -13,6 +13,13 @@ module ActiveStorage
       change.present? ? change.attachment : record.public_send("#{name}_attachment")
     end
 
+    # Returns +true+ if an attachment is not attached.
+    #
+    #   class User < ApplicationRecord
+    #     has_one_attached :avatar
+    #   end
+    #
+    #   User.new.avatar.blank? # => true
     def blank?
       !attached?
     end


### PR DESCRIPTION
I was looking for a better way to say attachment is not attached. 
Found `blank?` could be used but it wasn't documented well. 

This PR just adds the documentation for same. 

On side-note, could we add an alias saying `not_attached?`?
It reads better in the code `user.avatar.not_attached?` then `avatar.blank?` 
or `!user.attached?`. I can raise a patch for same if it sounds okay? 😊 
