### PR TITLE
Add docs for CDN in front of ActiveStorage

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -124,17 +124,17 @@ When the application is configured to proxy files by default, use the `rails_sto
 
 Optionally, files can be proxied instead. This means that your application servers will download file data from the storage service in response to requests. This can be useful for serving files from a CDN.
 
-Explicitly proxy attachments using the `rails_storage_proxy_path` and `_url` route helpers:
-
-```erb
-<%= image_tag rails_storage_proxy_path(@user.avatar) %>
-```
-
-Or configure Active Storage to use proxying by default:
+You can configure Active Storage to use proxying by default:
 
 ```ruby
 # config/initializers/active_storage.rb
 Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy
+```
+
+Or if you want to explicitly proxy specific attachments there are URL helpers you can use in the form of `rails_storage_proxy_path` and `rails_storage_proxy_url`.
+
+```erb
+<%= image_tag rails_storage_proxy_path(@user.avatar) %>
 ```
 
 ## Direct uploads


### PR DESCRIPTION
### Summary

For context, we started trying to add a configuration to make this simpler here https://github.com/rails/rails/pull/42305 but we were suggested to add docs instead because it was already simple enough to add a new configuration on ActiveStorage.

When writing these docs, we started by copying over some docs that were in the [ActiveStorage README](https://github.com/rails/rails/blob/main/activestorage/README.md#proxying) and then extending it with the configuration suggested by @fleck (who introduced the ability to have a CDN in front of ActiveStorage) here https://github.com/rails/rails/pull/34477#issuecomment-651467261

cc @pixeltrix @zzak