### PR TITLE
Inclusion validation - support `Float::NAN` and `BigDecimal(Float::NAN)`

### DIFF
--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -27,12 +27,16 @@ module ActiveModel
         if value.is_a?(Array)
           value.all? { |v| members.public_send(inclusion_method(members), v) }
         else
-          members.public_send(inclusion_method(members), value)
+          members.public_send(inclusion_method(members), value) || nan_included?(members, value)
         end
       end
 
       def delimiter
         @delimiter ||= options[:in] || options[:within]
+      end
+
+      def nan_included?(members, value)
+        value.respond_to?(:nan?) && value.nan? && members.any?(&:nan?)
       end
 
       # After Ruby 2.2, <tt>Range#include?</tt> on non-number-or-time-ish ranges checks all

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 
+require "bigdecimal"
 require "models/topic"
 require "models/person"
 
@@ -170,6 +171,32 @@ class InclusionValidationTest < ActiveModel::TestCase
     p = Person.new
     p.karma = %w(abe monkey)
 
+    assert p.valid?
+  ensure
+    Person.clear_validators!
+  end
+
+  def test_validates_inclusion_of_float_nan
+    Person.validates_inclusion_of :salary, in: [Float::NAN, 0, 1]
+
+    p = Person.new
+    p.salary = 1
+    assert p.valid?
+
+    p = Person.new
+    p.salary = 2
+    assert_not p.valid?
+
+    p = Person.new
+    p.salary = 0
+    assert p.valid?
+
+    p = Person.new
+    p.salary = Float::NAN
+    assert p.valid?
+
+    p = Person.new
+    p.salary = BigDecimal(Float::NAN)
     assert p.valid?
   ensure
     Person.clear_validators!


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/41660

Currently the `includes` validator works fine if you want to check for `Float::NAN`. But sometimes Rails converts floats to BigDecimals internally, and in that case it stops working. This adds support for that.

I'm not sure if this warrants a changelog entry?