### PR TITLE
Add `net/smtp` gem for bug report templates to support Ruby 3.1

### DIFF
--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -10,6 +10,11 @@ gemfile(true) do
   # Activate the gem you are reporting the issue against.
   gem "rails", "6.1.0"
   gem "sqlite3"
+  if RUBY_VERSION >= "3.1"
+    # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+    # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
+    gem "net-smtp", require: false
+  end
 end
 
 require "active_record/railtie"

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -9,6 +9,11 @@ gemfile(true) do
 
   gem "rails", github: "rails/rails", branch: "main"
   gem "sqlite3"
+  if RUBY_VERSION >= "3.1"
+    # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
+    # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
+    gem "net-smtp", require: false
+  end
 end
 
 require "active_record/railtie"


### PR DESCRIPTION
### Summary

Ruby 3.1 extracts some gems to bundled one, which requires adding these gems to Gemfile explicitly.
`net/smtp` is one of them, which affected Action Mailbox bug report templates.

* Steps to reproduce

Install `ruby 3.1.0dev`

```ruby
git clone https://github.com/rails/rails.git
cd rails/guides
ruby bug_report_templates/action_mailbox_gem.rb
ruby bug_report_templates/action_mailbox_main.rb
```

* This commit addresses the following error `cannot load such file -- net/smtp (LoadError)`

```ruby
$ ruby bug_report_templates/action_mailbox_gem.rb
... snip ...
Using rails 6.1.0
/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require': cannot load such file -- net/smtp (LoadError)
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/mail-2.7.1/lib/mail.rb:9:in `<module:Mail>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/mail-2.7.1/lib/mail.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/actionmailbox-6.1.0/lib/action_mailbox/mail_ext.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/actionmailbox-6.1.0/lib/action_mailbox.rb:3:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/actionmailbox-6.1.0/lib/action_mailbox/engine.rb:9:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/activesupport-6.1.0/lib/active_support/dependencies.rb:332:in `require'
	from bug_report_templates/action_mailbox_gem.rb:17:in `<main>'
```

Refer
https://bugs.ruby-lang.org/issues/17873
https://github.com/ruby/ruby/pull/4530

