### PR TITLE
Use an empty query instead of SELECT 1

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use an empty query to check if the PostgreSQL connection is still active
+
+    An empty query is faster than `SELECT 1`.
+
+    *Heinrich Lee Yu*
+
 *   Add `ActiveRecord::Base#previously_persisted?`
 
     Returns `true` if the object has been previously persisted but now it has been deleted.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -292,7 +292,7 @@ module ActiveRecord
       # Is this connection alive and ready for queries?
       def active?
         @lock.synchronize do
-          @connection.query "SELECT 1"
+          @connection.query ";"
         end
         true
       rescue PG::Error


### PR DESCRIPTION
### Summary

This changes the query used by the PostgresQL Adapter to check if the connection is alive.

It now uses an empty query instead of `SELECT 1`. This is slightly faster as it skips Postgres' query planner.

### Other Information

Benchmarking both queries was done in https://gitlab.com/gitlab-org/gitlab/-/issues/220055#note_463405732 and it showed that using an empty query resulted in a higher throughput.

GitLab.com has been running this patch for around 6 months now.
