### PR TITLE
Raise missing key error when master key env variable is blank

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raise `ActiveSupport::EncryptedFile::MissingKeyError` when the
+    `RAILS_MASTER_KEY` environment variable is blank (e.g. `""`).
+
+    *Sunny Ripert*
+
 *   The `from:` option is added to `ActiveSupport::TestCase#assert_no_changes`.
 
     It permits asserting on the initial value that is expected not to change.
@@ -7,7 +12,7 @@
       post :create, params: { status: { ok: true } }
     end
     ```
-  
+
     *George Claghorn*
 
 *   Deprecate `ActiveSupport::SafeBuffer`'s incorrect implicit conversion of objects into string.

--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -98,7 +98,7 @@ module ActiveSupport
 
 
       def read_env_key
-        ENV[env_key]
+        ENV[env_key].presence
       end
 
       def read_key_file

--- a/activesupport/test/encrypted_file_test.rb
+++ b/activesupport/test/encrypted_file_test.rb
@@ -55,6 +55,22 @@ class EncryptedFileTest < ActiveSupport::TestCase
     end
   end
 
+  test "raise MissingKeyError when env key is blank" do
+    FileUtils.rm_rf @key_path
+
+    begin
+      ENV["CONTENT_KEY"] = ""
+      raised = assert_raise ActiveSupport::EncryptedFile::MissingKeyError do
+        @encrypted_file.write @content
+        @encrypted_file.read
+      end
+
+      assert_match(/Missing encryption key to decrypt file/, raised.message)
+    ensure
+      ENV["CONTENT_KEY"] = nil
+    end
+  end
+
   test "raise InvalidKeyLengthError when key is too short" do
     File.write(@key_path, ActiveSupport::EncryptedFile.generate_key[0..-2])
 


### PR DESCRIPTION
### Summary

When the `RAILS_MASTER_KEY` is blank (e.g. `""`) and the `master.key` is missing, the current error that is returned is:

> ActiveSupport::EncryptedFile::InvalidKeyLengthError: Encryption key must be exactly 32 characters.

To make this clearer, we can ignore the environment variable when it is blank. It would then raise:

> ActiveSupport::EncryptedFile::MissingKeyError: Missing encryption key to decrypt file with. Ask your team for your master key and write it to /your/app/config/master.key or put it in the ENV['RAILS_MASTER_KEY'].

### Other Information

This may help people faced with #33528.