### PR TITLE
HTML helpers accept style option with hash values

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -113,6 +113,9 @@ module ActionView
                 output << sep
                 output << boolean_tag_option(key)
               end
+            elsif key.to_sym == :style
+              output << sep
+              output << style_tag_option(key, value, escape)
             elsif !value.nil?
               output << sep
               output << tag_option(key, value, escape)
@@ -123,6 +126,16 @@ module ActionView
 
         def boolean_tag_option(key)
           %(#{key}="#{key}")
+        end
+
+        def style_tag_option(key, value, escape)
+          case value
+          when Hash
+            value = value.map { |k, v| "#{k}: #{v}\;" }.join(' ')
+            tag_option(key, value, escape)
+          else
+            tag_option(key, value, escape)
+          end
         end
 
         def tag_option(key, value, escape)

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -131,7 +131,7 @@ module ActionView
         def style_tag_option(key, value, escape)
           case value
           when Hash
-            value = value.map { |k, v| "#{k}: #{v}\;" }.join(' ')
+            value = value.map { |k, v| "#{k}: #{v}\;" }.join(" ")
             tag_option(key, value, escape)
           else
             tag_option(key, value, escape)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -462,6 +462,16 @@ class TagHelperTest < ActionView::TestCase
     assert_equal '<a href="&amp;">content</a>', tag.a(href: "&amp;", escape_attributes: false) { "content" }
   end
 
+  def test_style_option_with_string_value
+    assert_dom_equal '<div style="color: #ff0000; border-bottom: 1px solid #ff0000;">content</div>',
+      content_tag('div', 'content', style: "color: #ff0000; border-bottom: 1px solid #ff0000;")
+  end
+
+  def test_style_option_with_hash_value
+    assert_dom_equal '<div style="color: #ff0000; border-bottom: 1px solid #ff0000;">content</div>',
+      content_tag('div', 'content', style: { color: '#ff0000', 'border-bottom': '1px solid #ff0000' })
+  end
+
   def test_data_attributes
     ["data", :data].each { |data|
       assert_dom_equal '<a data-a-float="3.14" data-a-big-decimal="-123.456" data-a-number="1" data-array="[1,2,3]" data-hash="{&quot;key&quot;:&quot;value&quot;}" data-string-with-quotes="double&quot;quote&quot;party&quot;" data-string="hello" data-symbol="foo" />',

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -464,12 +464,12 @@ class TagHelperTest < ActionView::TestCase
 
   def test_style_option_with_string_value
     assert_dom_equal '<div style="color: #ff0000; border-bottom: 1px solid #ff0000;">content</div>',
-      content_tag('div', 'content', style: "color: #ff0000; border-bottom: 1px solid #ff0000;")
+      content_tag("div", "content", style: "color: #ff0000; border-bottom: 1px solid #ff0000;")
   end
 
   def test_style_option_with_hash_value
     assert_dom_equal '<div style="color: #ff0000; border-bottom: 1px solid #ff0000;">content</div>',
-      content_tag('div', 'content', style: { color: '#ff0000', 'border-bottom': '1px solid #ff0000' })
+      content_tag("div", "content", style: { color: "#ff0000", "border-bottom": "1px solid #ff0000" })
   end
 
   def test_data_attributes


### PR DESCRIPTION
### Summary
Make it possible to use hash values to define style options for HTML helpers.

For example:
```ruby
content_tag('div', 'content', style: { color: '#ff0000', 'border-bottom': '1px solid #ff0000' })
```

will result in:
```html
<div style="color: #ff0000; border-bottom: 1px solid #ff0000;">content</div>
```

A similar method call with a string style value will result in the same output:
```ruby
content_tag('div', 'content', style: "color: #ff0000; border-bottom: 1px solid #ff0000;")
```