### PR TITLE
Allow for insert all without having a primary key

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -28,7 +28,7 @@ module ActiveRecord
       @returning = (connection.supports_insert_returning? ? primary_keys : false) if @returning.nil?
       @returning = false if @returning == []
 
-      @unique_by = find_unique_index_for(unique_by)
+      @unique_by = find_unique_index_for(unique_by) if unique_by || @on_duplicate == :update
       @on_duplicate = :skip if @on_duplicate == :update && updatable_columns.empty?
 
       ensure_valid_options_for_connection!

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -226,11 +226,18 @@ class InsertAllTest < ActiveRecord::TestCase
 
       Cart.upsert_all [{ id: 3, shop_id: 2, title: "My other cart" }], unique_by: [:shop_id, :id]
     end
+  end
 
-    error = assert_raises ArgumentError do
-      Cart.insert_all! [{ id: 2, shop_id: 1, title: "My cart" }]
+  def test_insert_all_without_unique_by_can_work_without_a_matching_index
+    skip unless supports_insert_conflict_target?
+
+    assert_difference "Cart.count", 1 do
+      Cart.insert_all [{ id: 2, shop_id: 1, title: "My cart" }]
     end
-    assert_match "No unique index found for id", error.message
+
+    assert_difference "Cart.count", 1 do
+      Cart.insert_all! [{ id: 2, shop_id: 2, title: "My cart" }]
+    end
   end
 
   def test_insert_all_and_upsert_all_works_with_composite_primary_keys_when_unique_by_is_not_provided


### PR DESCRIPTION
### Summary

Allow insert_all to work when there is no index on the primary key.

Currently, when we insert_all lookup to make sure that there is a valid unique constraint on the primary key - but this should only be required for upserts.

Fixes #41848
