### PR TITLE
Make `ActiveRecord::Base.has_many_inversing` a `class_attribute`

### DIFF
--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -125,7 +125,7 @@ module ActiveRecord
 
         def invertible_for?(record)
           inverse = inverse_reflection_for(record)
-          inverse && (inverse.has_one? || ActiveRecord::Base.has_many_inversing)
+          inverse && (inverse.has_one? || inverse.klass.has_many_inversing)
         end
 
         def stale_state

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -275,7 +275,7 @@ module ActiveRecord
       end
 
       def target=(record)
-        return super unless ActiveRecord::Base.has_many_inversing
+        return super unless reflection.klass.has_many_inversing
 
         case record
         when Array

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -154,7 +154,7 @@ module ActiveRecord
 
       mattr_accessor :reading_role, instance_accessor: false, default: :reading
 
-      mattr_accessor :has_many_inversing, instance_accessor: false, default: false
+      class_attribute :has_many_inversing, instance_accessor: false, default: false
 
       mattr_accessor :sqlite3_production_warning, instance_accessor: false, default: true
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -687,7 +687,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_with_has_many_inversing_should_try_to_set_inverse_instances_when_the_inverse_is_a_has_many
-    with_has_many_inversing do
+    with_has_many_inversing(Interest) do
       interest = interests(:trainspotting)
       human = interest.human
       assert_not_nil human.interests
@@ -702,7 +702,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_with_has_many_inversing_should_have_single_record_when_setting_record_through_attribute_in_build_method
-    with_has_many_inversing do
+    with_has_many_inversing(Interest) do
       human = Human.create!
       human.interests.build(
         human: human
@@ -714,7 +714,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_with_has_many_inversing_does_not_trigger_association_callbacks_on_set_when_the_inverse_is_a_has_many
-    with_has_many_inversing do
+    with_has_many_inversing(Interest) do
       human = interests(:trainspotting).human_with_callbacks
       assert_not_predicate human, :add_callback_called?
     end
@@ -766,7 +766,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_building_has_many_parent_association_inverses_one_record
-    with_has_many_inversing do
+    with_has_many_inversing(Interest) do
       interest = Interest.new
       interest.build_human
       assert_equal 1, interest.human.interests.size
@@ -868,7 +868,7 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_with_has_many_inversing_should_try_to_set_inverse_instances_when_the_inverse_is_a_has_many
-    with_has_many_inversing do
+    with_has_many_inversing(Interest) do
       interest = interests(:llama_wrangling)
       human = interest.polymorphic_human
       assert_not_nil human.polymorphic_interests
@@ -883,7 +883,7 @@ class InversePolymorphicBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_with_has_many_inversing_does_not_trigger_association_callbacks_on_set_when_the_inverse_is_a_has_many
-    with_has_many_inversing do
+    with_has_many_inversing(Interest) do
       human = interests(:llama_wrangling).polymorphic_human_with_callbacks
       assert_not_predicate human, :add_callback_called?
     end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -80,12 +80,15 @@ module ActiveRecord
       model.column_names.include?(column_name.to_s)
     end
 
-    def with_has_many_inversing
-      old = ActiveRecord::Base.has_many_inversing
-      ActiveRecord::Base.has_many_inversing = true
+    def with_has_many_inversing(model = ActiveRecord::Base)
+      old = model.has_many_inversing
+      model.has_many_inversing = true
       yield
     ensure
-      ActiveRecord::Base.has_many_inversing = old
+      model.has_many_inversing = old
+      if model != ActiveRecord::Base && !old
+        model.singleton_class.remove_method(:has_many_inversing) # reset the class_attribute
+      end
     end
 
     def reset_callbacks(klass, kind)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/37429

This allows to enable or disable thew new behavior on a per mode basis, which is helpful for large applications where fixing all the problems at once is too much.

cc @rafaelfranca since we discussed this.