### PR TITLE
Add a commented root path declaration to routes.rb

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  # Even single page applications require a root ("/") path:
-  # root "controller#action"
+  # Set the application's home page:
+  # root "articles#index"
 end

--- a/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/routes.rb.tt
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  # Even single page applications require a root ("/") path:
+  # root "controller#action"
 end


### PR DESCRIPTION
### Summary

After starting more than a hundred Rails projects, I still have to look up the syntax for `root`... **every time**. A straw poll of my friends suggests that I'm not the only one with this damage. I fully acknowledge that it is silly, but objectively less silly than `forty_two`.

Adding a simple comment to the `routes.rb` template with the `root` suggested is one less thing a newcomer to Rails has to Google to get started on their first project.
