### PR TITLE
Fix ActiveStorage has_many_attached when record is not persisted

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow to purge an attachment when record is not persisted for `has_many_attached`
+
+    *Jacopo Beschi*
+
 *   Add `with_all_variant_records` method to eager load all variant records on an attachment at once.
     `with_attached_image` scope now eager loads variant records if using variant tracking.
 

--- a/activestorage/lib/active_storage/attached.rb
+++ b/activestorage/lib/active_storage/attached.rb
@@ -16,10 +16,6 @@ module ActiveStorage
       def change
         record.attachment_changes[name]
       end
-
-      def reset_changes
-        record.attachment_changes.delete(name)
-      end
   end
 end
 

--- a/activestorage/lib/active_storage/attached/changes.rb
+++ b/activestorage/lib/active_storage/attached/changes.rb
@@ -11,6 +11,9 @@ module ActiveStorage
 
       autoload :DeleteOne
       autoload :DeleteMany
+
+      autoload :PurgeOne
+      autoload :PurgeMany
     end
   end
 end

--- a/activestorage/lib/active_storage/attached/changes/purge_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/purge_many.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  class Attached::Changes::PurgeMany #:nodoc:
+    attr_reader :name, :record, :attachments
+
+    def initialize(name, record, attachments)
+      @name, @record, @attachments = name, record, attachments
+    end
+
+    def purge
+      attachments.each(&:purge)
+      reset
+    end
+
+    def purge_later
+      attachments.each(&:purge_later)
+      reset
+    end
+
+    private
+      def reset
+        record.attachment_changes.delete(name)
+        record.public_send("#{name}_attachments").reset
+      end
+  end
+end

--- a/activestorage/lib/active_storage/attached/changes/purge_one.rb
+++ b/activestorage/lib/active_storage/attached/changes/purge_one.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  class Attached::Changes::PurgeOne #:nodoc:
+    attr_reader :name, :record, :attachment
+
+    def initialize(name, record, attachment)
+      @name, @record, @attachment = name, record, attachment
+    end
+
+    def purge
+      attachment&.purge
+      reset
+    end
+
+    def purge_later
+      attachment&.purge_later
+      reset
+    end
+
+    private
+      def reset
+        record.attachment_changes.delete(name)
+        record.public_send("#{name}_attachment=", nil)
+      end
+  end
+end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -3,6 +3,19 @@
 module ActiveStorage
   # Decorated proxy object representing of multiple attachments to a model.
   class Attached::Many < Attached
+    ##
+    # :method: purge
+    #
+    # Directly purges each associated attachment (i.e. destroys the blobs and
+    # attachments and deletes the files on the service).
+    delegate :purge, to: :purge_many
+
+    ##
+    # :method: purge_later
+    #
+    # Purges each associated attachment through the queuing system.
+    delegate :purge_later, to: :purge_many
+
     delegate_missing_to :attachments
 
     # Returns all the associated attachment records.
@@ -52,15 +65,9 @@ module ActiveStorage
       attachments.delete_all if attached?
     end
 
-    ##
-    # :method: purge
-    #
-    # Directly purges each associated attachment (i.e. destroys the blobs and
-    # attachments and deletes the files on the service).
-
-    ##
-    # :method: purge_later
-    #
-    # Purges each associated attachment through the queuing system.
+    private
+      def purge_many
+        Attached::Changes::PurgeMany.new(name, record, attachments)
+      end
   end
 end

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -497,6 +497,15 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "purging delete changes when record is not persisted" do
+    user = User.new
+    user.avatar = nil
+
+    user.avatar.purge
+
+    assert_nil user.attachment_changes["avatar"]
+  end
+
   test "purging later" do
     create_blob(filename: "funky.jpg").tap do |blob|
       @user.avatar.attach blob


### PR DESCRIPTION
### Summary

This is a follow up of #42256.

Purging a not persisted record no longer raise an error for`has_many_attached`.

Moves the `purge` and `purge_later` logic of `ActiveStorage::Attached` to `Attached::Changes` API.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
