### PR TITLE
Add `ActiveRecord::Base#previously_persisted?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord::Base#previously_persisted?`
+
+    Returns `true` if the object has been previously persisted but now it has been deleted.
+
 *   Deprecate `partial_writes` in favor of `partial_inserts` and `partial_updates`.
 
     This allows to have a different behavior on update and create.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -467,6 +467,11 @@ module ActiveRecord
       @previously_new_record
     end
 
+    # Returns true if this object was previously persisted but now it has been deleted.
+    def previously_persisted?
+      !new_record? && destroyed?
+    end
+
     # Returns true if this object has been destroyed, otherwise returns false.
     def destroyed?
       @destroyed

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -800,6 +800,14 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal false, Topic.find(1).previously_new_record?
   end
 
+  def test_previously_persisted_returns_boolean
+    assert_equal false, Topic.new.previously_persisted?
+    assert_equal false, Topic.new.destroy.previously_persisted?
+    assert_equal false, Topic.first.previously_persisted?
+    assert_equal true, Topic.first.destroy.previously_persisted?
+    assert_equal true, Topic.first.delete.previously_persisted?
+  end
+
   def test_dup
     topic = Topic.find(1)
     duped_topic = nil

--- a/activerecord/test/cases/clone_test.rb
+++ b/activerecord/test/cases/clone_test.rb
@@ -14,6 +14,7 @@ module ActiveRecord
       assert cloned.persisted?, "topic persisted"
       assert_not cloned.new_record?, "topic is not new"
       assert_not cloned.previously_new_record?, "topic was not previously new"
+      assert_not cloned.previously_persisted?, "topic was not previously persisted"
     end
 
     def test_stays_frozen

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -293,9 +293,8 @@ class ActiveStorage::Blob < ActiveStorage::Record
   # blobs. Note, though, that deleting the file off the service will initiate an HTTP connection to the service, which may
   # be slow or prevented, so you should not use this method inside a transaction or in callbacks. Use #purge_later instead.
   def purge
-    previously_persisted = persisted?
     destroy
-    delete if previously_persisted
+    delete if previously_persisted?
   rescue ActiveRecord::InvalidForeignKey
   end
 


### PR DESCRIPTION
### Summary

Returns `true` if the object has been previously persisted but now it has been deleted.

This is a follow up of https://github.com/rails/rails/pull/42256/files#r641914920

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
