### PR TITLE
Allow collection cache invalidation on new collection entries

### DIFF
--- a/actionpack/test/controller/caching_test.rb
+++ b/actionpack/test/controller/caching_test.rb
@@ -408,7 +408,7 @@ class CollectionCacheController < ActionController::Base
   def index_ordered_with_cache_invalidation_on_new_entry
     @customers = [Customer.new("david", 1), Customer.new("david", 2), Customer.new("david", 3)]
     @customers.push(Customer.new("david", 4)) if params[:invalidate]
-    render partial: "customers/customer_no_cache", collection: @customers, cached: true, invalidate_cache_on_new_entry: params[:invalidate]
+    render partial: "customers/customer_no_cache", collection: @customers, cached: { invalidate_on_new_entry: params[:invalidate] }
   end
 
   def index_explicit_render_in_controller

--- a/actionpack/test/fixtures/customers/_customer_no_cache.html.erb
+++ b/actionpack/test/fixtures/customers/_customer_no_cache.html.erb
@@ -1,0 +1,2 @@
+<% controller.partial_rendered_times += 1 %>
+<%= customer_no_cache.name %>, <%= customer_no_cache.id %>

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Adds cache option `invalidate_on_new_entry` to collection rendering to
+    allow cache invalidation of the entire collection when a new entry is available.
+
+    ```html+erb
+    <%= render partial: "pictures/picture", collection: @pictures, cached: { invalidate_on_new_entry: true }  %>
+    ```
+
+    *Vincent Rolea*
+
 *   The `translate` helper now passes `default` values that aren't
     translation keys through `I18n.translate` for interpolation.
 

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -37,6 +37,14 @@ module ActionView
         # Extract the items for the keys that are not found
         collection = keyed_collection.reject { |key, _| cached_partials.key?(key) }.values
 
+        # If new entries are available to the collection and cache invalidation on
+        # new entry is required, we clear the cache and set the collection as the
+        # initial one
+        if !collection.empty? && @options[:invalidate_cache_on_new_entry]
+          collection = keyed_collection.values
+          cached_partials = {}
+        end
+
         rendered_partials = collection.empty? ? [] : yield(collection_iterator.from_collection(collection))
 
         index = 0

--- a/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb
@@ -40,7 +40,7 @@ module ActionView
         # If new entries are available to the collection and cache invalidation on
         # new entry is required, we clear the cache and set the collection as the
         # initial one
-        if !collection.empty? && @options[:invalidate_cache_on_new_entry]
+        if !collection.empty? && @options[:cached].is_a?(Hash) && @options[:cached][:invalidate_on_new_entry]
           collection = keyed_collection.values
           cached_partials = {}
         end

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -120,6 +120,15 @@ All cached templates from previous renders will be fetched at once with much
 greater speed. Additionally, the templates that haven't yet been cached will be
 written to cache and multi fetched on the next render.
 
+Cache entries of a collection will not be invalidated when a new entry is added. You
+can pass the `invalidate_on_new_entry` option to `cached` to add it:
+
+```html+erb
+<%= render partial: 'products/product', collection: @products, cached: { invalidate_on_new_entry: true } %>
+```
+
+If one of the item present in `@products` is not present in the cache, all items of the collection will be re-rendered.
+
 ### Russian Doll Caching
 
 You may want to nest cached fragments inside other cached fragments. This is


### PR DESCRIPTION
### Summary
[Discussion available here](https://discuss.rubyonrails.org/t/allow-collection-cache-invalidation-on-new-collection-entries/78133)

Adds a new `invalidate_cache_on_new_entry` option for rendering collection, to allow cache invalidation of the entire collection when new items are available. 

This is specifically useful when a template depends on the collection iterator variables to display data :

```erb
# app/views/pictures/_picture.html.erb 
<% index = picture_iteration.index %>
<% size = picture_iteration.size %>

<li class="carousel-slide"> 
  <img src="..." /> 
  <span class="legend"><%= picture.name %> (<%= index + 1 %>/<%= size %>)</span>
</li> 
```

Adding new items to the collection would yield incoherent results, as iterators are set on the non-cached collection size, and not the entire collection. Plus, cached templates are out of sync with the new collection size. 

By adding `invalidate_cache_on_new_entry` on the render call, I can now re-render the whole collection to keep values coherent:

```erb
# app/views/pictures/index.html.erb 

<%= render partial: "public/venues/picture", collection: @venue.pictures, cached: true, invalidate_cache_on_new_entry: true  %>
```

