### PR TITLE
Document Active Storage attachment and attachments field generators [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -320,7 +320,13 @@ The [`has_one_attached`][] macro sets up a one-to-one mapping between records an
 files. Each record can have one file attached to it.
 
 For example, suppose your application has a `User` model. If you want each user to
-have an avatar, define the `User` model like this:
+have an avatar, run a model generator command as follows:
+
+```ruby
+bin/rails generate model User avatar:attachment
+```
+
+or define the `User` model like this
 
 ```ruby
 class User < ApplicationRecord
@@ -396,7 +402,13 @@ The [`has_many_attached`][] macro sets up a one-to-many relationship between rec
 and files. Each record can have many files attached to it.
 
 For example, suppose your application has a `Message` model. If you want each
-message to have many images, define the `Message` model like this:
+message to have many images, run a model generator command as follows:
+
+```ruby
+bin/rails generate model Message images:attachments
+```
+
+or define the `Message` model like this:
 
 ```ruby
 class Message < ApplicationRecord


### PR DESCRIPTION
Found while debugging issue: #42380

I was under an assumption that we have to manually add
`has_one_attached :<name>` and `has_many_attached :<name>`
in the model. The scaffold generator does more even more work 
with attachment and attachments field generators. Hoping to 
document it next if this seems okay.

In issue #42296, user was trying to do something similar.

This PR documents the attachment and attachments field
generator to make it more visible to all people.