### PR TITLE
Return "test" as the controller_name in ActionView tests

### DIFF
--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -9,7 +9,6 @@ class TestControllerWithExtraEtags < ActionController::Base
     "test/hello_world.erb" => "Hello world!"
   )]
 
-  def self.controller_name; "test"; end
   def self.controller_path; "test"; end
 
   etag { nil  }

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -24,6 +24,10 @@ module ActionView
         self.class.controller_path = path
       end
 
+      def self.controller_name
+        "test"
+      end
+
       def initialize
         super
         self.class.controller_path = ""

--- a/actionview/test/actionpack/controller/capture_test.rb
+++ b/actionview/test/actionpack/controller/capture_test.rb
@@ -6,7 +6,6 @@ require "active_support/logger"
 class CaptureController < ActionController::Base
   self.view_paths = [ File.expand_path("../../fixtures/actionpack", __dir__) ]
 
-  def self.controller_name; "test"; end
   def self.controller_path; "test"; end
 
   def content_for

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -56,6 +56,10 @@ module ActionView
       assert_same _view, view
     end
 
+    test "returns controller_name" do
+      assert_equal "test", controller_name
+    end
+
     test "retrieve non existing config values" do
       assert_nil ActionView::Base.empty.config.something_odd
     end


### PR DESCRIPTION
before https://github.com/rails/rails/pull/40125 test names would be
set to "test" after this change controller_name was nil when using
ActionView::TestCase.

This returns ActionView::TestCase to previous behavior returning "test"

The previous change seemed open to maintaining this behavior. The discussion in https://github.com/rails/rails/issues/42384 seems to suggest the same.

closes: https://github.com/rails/rails/issues/42384