### PR TITLE
Allow image_tag to resize active storage images based on width/height attributes

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Adds `resize_active_storage_images` option to allow `image_tag` to automatically
+    resize active storage images based on specified `width`, `height` or `size` and a
+    default resolution of 2x.
+
+    Before:
+    ```erb
+    <%= image_tag user.avatar.variant(resize_to_limit: [400x400]), size: 200 %>
+    ```
+
+    After:
+    ```erb
+    <%= image_tag user.avatar, size: 200 %>
+    ```
+
+    *Breno Gazzola*
+
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
 *   No changes.

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -13,6 +13,7 @@ module ActionView
     config.action_view.image_loading = nil
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
+    config.action_view.resize_active_storage_images = false
 
     config.eager_load_namespaces << ActionView
 
@@ -52,6 +53,7 @@ module ActionView
       ActionView::Helpers::AssetTagHelper.image_decoding = app.config.action_view.delete(:image_decoding)
       ActionView::Helpers::AssetTagHelper.preload_links_header = app.config.action_view.delete(:preload_links_header)
       ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default = app.config.action_view.delete(:apply_stylesheet_media_default)
+      ActionView::Helpers::AssetTagHelper.resize_active_storage_images = app.config.action_view.delete(:resize_active_storage_images)
     end
 
     config.after_initialize do |app|

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -877,6 +877,27 @@ specific:
 <%= image_tag user.avatar.variant(resize_to_limit: [100, 100], format: :jpeg, saver: { subsample_mode: "on", strip: true, interlace: true, quality: 80 }) %>
 ```
 
+A common pattern for image transformations is downsizing an image to the dimensions 
+it will be displayed at in an `img` tag (or twice that for HiDPI displays). For Active Storage
+images, the `image_tag` helper can handle this automatically by adding the following to
+`config/application.rb`
+
+```ruby
+config.action_view.resize_active_storage_images = true
+```
+
+This will allow `image_tag` to shrink (but not enlarge) images to twice value of the specified
+`width`, `height` or `size` attributes:
+
+```erb
+<!-- Without auto resizing -->
+<%= image_tag user.avatar.variant(resize_to_limit: [200, 200], size: 100 %>
+
+<!-- With auto resizing -->
+<%= image_tag user.avatar, size: 100 %>
+```
+
+
 [`variant`]: https://api.rubyonrails.org/classes/ActiveStorage/Blob/Representable.html#method-i-variant
 [Vips]: https://www.rubydoc.info/gems/ruby-vips/Vips/Image
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1159,6 +1159,8 @@ Determines whether `button_to` will render `<button>` element, regardless of whe
 
 Determines whether `stylesheet_link_tag` will render `screen` as the default value for the attribute `media` when it's not provided.
 
+* `config.action_view.resize_active_storage_images` determines whether `image_tag` will automatically resize image blobs if a `width` or `height` is specified, using a 2x resolution. This defaults to `false`. 
+
 ### Configuring Action Mailbox
 
 `config.action_mailbox` provides the following configuration options:

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2549,6 +2549,23 @@ module ApplicationTests
       assert_equal false, ActionView::Helpers::AssetTagHelper.apply_stylesheet_media_default
     end
 
+    test "ActionView::Helpers::AssetTagHelper.resize_active_storage_images is false by default" do
+      app "development"
+      assert_not ActionView::Helpers::AssetTagHelper.resize_active_storage_images
+    end
+
+    test "ActionView::Helpers::AssetTagHelper.resize_active_storage_images can be configured via config.action_view.resize_active_storage_images" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.action_view.resize_active_storage_images = true
+        end
+      RUBY
+
+      app "development"
+
+      assert ActionView::Helpers::AssetTagHelper.resize_active_storage_images
+    end
+
     test "stylesheet_link_tag sets the Link header by default" do
       app_file "app/controllers/pages_controller.rb", <<-RUBY
       class PagesController < ApplicationController


### PR DESCRIPTION
### Summary
Developers are becoming more aware of the importance of fast loading pages and tools like PageSpeed Insights have made it considerably easier to understand what can be improved and how. One of the lowest hanging fruits is image optimization, which usually involves:

1. Async loading/decoding;
2. Downsizing;
3. Compressing;
4. Ensuring the tag has both `width` and `height`.
5. Using a modern file format

Item 1 has been handled by PRs #38452 and #40839. This PR should handle item 2. Basically, if `image_tag` is given a `blob` or an `attachment` along with a `width`, `height` or `size`, it will use `resize_to_limit` to produce a variant that has a 2x resolution.

Now:
```erb
<%= image_tag user.avatar.variant(resize_to_limit: [400x400]), size: 200 %>
```

With this PR
```erb
<%= image_tag user.avatar, size: 200 %>
```

### Other Information
I've chosen 2x as default because that's what Twitter does too: [Capping image fidelity on ultra-high resolution devices](https://blog.twitter.com/engineering/en_us/topics/infrastructure/2019/capping-image-fidelity-on-ultra-high-resolution-devices.html)

If there is interest in this PR, I will submit other PRs to handle items 3, 4 and 5 of the list. My goal is to make Rails reach a point where users can flip a few configuration options and then, just by passing `image_tag` a `width` or `height`, they will get back an image that passes all PageSpeed Insight audits, without having to learn how to do that or creating their own helper tag.