### PR TITLE
Permit attachments in inbound email conductor mail params

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `attachments` to the list of permitted parameters for inbound emails conductor.
+
+    When using the conductor to test inbound emails with attachments, this prevents an
+    unpermitted parameter warning in default configurations, and prevents errors for
+    applications that set:
+
+    ```ruby
+    config.action_controller.action_on_unpermitted_parameters = :raise
+    ```
+
+    *David Jones*, *Dana Henke*
+
 *   Add ability to configure ActiveStorage service
     for storing email raw source.
 

--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -20,12 +20,16 @@ module Rails
 
     private
       def new_mail
-        Mail.new(params.require(:mail).permit(:from, :to, :cc, :bcc, :x_original_to, :in_reply_to, :subject, :body).to_h).tap do |mail|
+        Mail.new(mail_params.except(:attachments).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
-          params[:mail][:attachments].to_a.each do |attachment|
+          mail_params[:attachments].to_a.each do |attachment|
             mail.add_file(filename: attachment.original_filename, content: attachment.read)
           end
         end
+      end
+
+      def mail_params
+        params.require(:mail).permit(:from, :to, :cc, :bcc, :x_original_to, :in_reply_to, :subject, :body, attachments: [])
       end
 
       def create_inbound_email(mail)

--- a/actionmailbox/test/dummy/config/environments/test.rb
+++ b/actionmailbox/test/dummy/config/environments/test.rb
@@ -46,4 +46,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Raise error if unpermitted parameters are sent
+  config.action_controller.action_on_unpermitted_parameters = :raise
 end


### PR DESCRIPTION
### Summary

When uploading email attachments using the inbound emails conductor in development mode, it throws a warning about the unpermitted parameter `:attachments`.

With the app configured with `config.action_controller.action_on_unpermitted_parameters = :raise`, this also raises an error.

Additionally, the "unpermitted" attachments parameter is then used to create attachments, bypassing the strong parameter safeguard.

This PR permits the `:attachments` param, but strips it from being passed to `Mail.new`, then uses the permitted param to build the mail attachments inside the mail block.

### Steps to reproduce

- `git clone rails`
- `cd rails`
- `bundle exec rails new ~/my-test-app --dev`
- `cd ~/my-test-app`
- `bin/rails action_mailbox:install`
- `bin/rails db:migrate`
- Setup mailbox route:
  - `echo "class ApplicationMailbox < ActionMailbox::Base\n  routing all: :catchall\nend" > 'app/mailboxes/application_mailbox.rb'`
  - `echo "class CatchallMailbox < ApplicationMailbox\n  def process; end\nend" > 'app/mailboxes/catchall_mailbox.rb`
- `bin/rails server`
- Add file attachment to a test inbound email:
  - Visit `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails/new`
  - Click "Choose Files"
  - Choose any test file to include as an attachment
  - Click the "Deliver inbound email" button

#### Expected result:

Email is processed with ActionMailbox without warning.

#### Actual result:

The console shows this in red text:

> Unpermitted parameter: :attachments. Context: {  }

#### With the app configured to raise on unpermitted parameters:

- Add `config.action_controller.action_on_unpermitted_parameters = :raise` to `config/development.rb`
- `bin/rails server`
- Visit `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails/new`
- Click "Choose Files"
- Choose any test file to include as an attachment
- Click the "Deliver inbound email" button

#### Expected result:

Attachment is processed by ActionMailer without raising an error.

#### Actual result:

Rails throws error, displays the exception page, and message is not processed:

> ActionController::UnpermittedParameters in Rails::Conductor::ActionMailbox::InboundEmailsController#create
> found unpermitted parameter: :attachments

