### PR TITLE
Add 'self' to Rails::ApplicationController Content-Security-Policy

### DIFF
--- a/railties/lib/rails/application_controller.rb
+++ b/railties/lib/rails/application_controller.rb
@@ -7,8 +7,8 @@ class Rails::ApplicationController < ActionController::Base # :nodoc:
   before_action :disable_content_security_policy_nonce!
 
   content_security_policy do |policy|
-    policy.script_src :unsafe_inline
-    policy.style_src :unsafe_inline
+    policy.script_src :self, :unsafe_inline
+    policy.style_src :self, :unsafe_inline
   end
 
   private


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
When creating a brand new project, the welcome page had an error in the console relating to the rack-mini-profiler script being blocked due to CSP. This adds `'self'` to the script and style CSP so that the profiler loads successfully

<img width="1226" alt="image" src="https://user-images.githubusercontent.com/2488460/120874623-721e6a80-c59f-11eb-8f1f-5fde7e2fb0d0.png">
