### PR TITLE
Set default application language to I18n.locale

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -9,6 +9,10 @@
     Fixes #40744.
 
     *Michael Duchemin*
+    
+*   Set default language for `application.html.erb` to `I18n.locale`.
+
+    *Monica Mateiu*
 
 *   Raise an error in generators if a field type is invalid.
 

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%%= I18n.locale %>">
   <head>
     <title><%= camelized %></title>
     <%%= csrf_meta_tags %>

--- a/railties/test/application/initializers/i18n_test.rb
+++ b/railties/test/application/initializers/i18n_test.rb
@@ -45,6 +45,34 @@ module ApplicationTests
       assert_equal :de, I18n.default_locale
     end
 
+    test "views are generated with default language" do
+      require "rails/generators"
+      rails("generate", "controller", "home", "index")
+
+      require "rack/test"
+      extend Rack::Test::Methods
+      load_app
+
+      get "/home/index"
+      assert_includes last_response.body, "<html lang=\"en\">"
+    end
+
+    test "views are updated with default locale" do
+      require "rails/generators"
+      rails("generate", "controller", "home", "index")
+
+      add_to_config <<-RUBY
+        config.i18n.default_locale = :de
+      RUBY
+
+      require "rack/test"
+      extend Rack::Test::Methods
+      load_app
+
+      get "/home/index"
+      assert_includes last_response.body, "<html lang=\"de\">"
+    end
+
     # Load paths
     test "no config locales directory present should return empty load path" do
       FileUtils.rm_rf "#{app_path}/config/locales"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1286,6 +1286,15 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "web-console", app_root
   end
 
+  def test_application_template_has_locale
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    assert_file "#{app_root}/app/views/layouts/application.html.erb" do |content|
+      assert_match(/I18n.locale/, content)
+    end
+  end
+
   private
     def stub_rails_application(root)
       Rails.application.config.root = root


### PR DESCRIPTION
### Summary
This PR aims to improve the accessibility of Rails apps by adding a `lang` attribute to HTML templates generated by the framework. I started with `application.html.erb` and set its `lang` to `I18n.locale`, so the language gets automatically updated when the locale is updated. There's a lot more work to be done, as _all_ html templates need to be updated. So this would be the pilot, I suppose 🙂

Benefits include:
- making it easier for translation services to detect the page language
- helping screen reader software read things out properly
- improving the experience for people who use text-to-speech software

It's also a step towards meeting [Success Criterion 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page) of the Web Content Accessibility Guidelines.

### What these changes do
Modifying the template for `application.html.erb` will have the following effect: in any new Rails app, all new pages generated via `rails g controller ControllerName action` will be created with a `lang` in their HTML. The language will then evaluate to whatever `I18n.locale` is.

To test this:
- pull down the branch
- run `bundle exec rails new ~/my-test-app --dev` to generate an app that uses the branch
- `cd ~/my-test-app` then run `bundle install`, `rails webpacker:install` to install dependencies
- generate a new controller with `rails g controller Home index`
- start the server with `rails s`
- go to `http://localhost:3000/home/index`, inspect the page and verify that the HTML tag has `lang="en"`
- in `config.application.rb`, change your default locale to German with `config.i18n.default_locale = :de`
- restart the server and navigate to `http://localhost:3000/home/index` - you should be prompted to translate the page (in Google Chrome) and when inspecting the page you should now see `html lang="de"`

### Other Information
- I would have liked to have examples that check that the rendered html includes `<html lang="en">` by default, and `<html lang="de">` when I set `I18n.locale = :de`. However, I'm not sure _where_ to include these tests. If you can think of any better tests I could write, please help point me in the right direction
- wasn't sure whether I had to update the CHANGELOG for this. Happy to remove this if needed
- read full [forum discussion](https://discuss.rubyonrails.org/t/accessibility-proposal-add-lang-attribute-to-generated-views/77634/4) here