### PR TITLE
Allow travel/travel_to blocks after standalone travel/travel_to

### DIFF
--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -162,6 +162,7 @@ module ActiveSupport
           now = date_or_time.to_time.change(usec: 0)
         end
 
+        stubbed_time = Time.now if simple_stubs.stubbing(Time, :now)
         simple_stubs.stub_object(Time, :now) { at(now.to_i) }
         simple_stubs.stub_object(Date, :today) { jd(now.to_date.jd) }
         simple_stubs.stub_object(DateTime, :now) { jd(now.to_date.jd, now.hour, now.min, now.sec, Rational(now.utc_offset, 86400)) }
@@ -171,7 +172,11 @@ module ActiveSupport
             self.in_block = true
             yield
           ensure
-            travel_back
+            if stubbed_time
+              travel_to stubbed_time
+            else
+              travel_back
+            end
             self.in_block = false
           end
         end

--- a/activesupport/lib/active_support/testing/time_helpers.rb
+++ b/activesupport/lib/active_support/testing/time_helpers.rb
@@ -126,7 +126,7 @@ module ActiveSupport
       #   end
       #   Time.current # => Sat, 09 Nov 2013 15:34:49 EST -05:00
       def travel_to(date_or_time)
-        if block_given? && simple_stubs.stubbing(Time, :now)
+        if block_given? && in_block
           travel_to_nested_block_call = <<~MSG
 
       Calling `travel_to` with a block, when we have previously already made a call to `travel_to`, can lead to confusing time stubbing.
@@ -168,9 +168,11 @@ module ActiveSupport
 
         if block_given?
           begin
+            self.in_block = true
             yield
           ensure
             travel_back
+            self.in_block = false
           end
         end
       end
@@ -232,6 +234,8 @@ module ActiveSupport
         def simple_stubs
           @simple_stubs ||= SimpleStubs.new
         end
+
+        attr_accessor :in_block
     end
   end
 end

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -192,11 +192,17 @@ class TimeTravelTest < ActiveSupport::TestCase
       inner_expected_time = Time.new(2004, 10, 24, 1, 4, 44)
       travel_to outer_expected_time
 
+      assert_equal outer_expected_time, Time.now
+
       assert_nothing_raised do
         travel_to(inner_expected_time) do
           assert_equal inner_expected_time, Time.now
         end
       end
+
+      assert_equal outer_expected_time, Time.now
+    ensure
+      travel_back
     end
   end
 

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -186,6 +186,20 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_helper_travel_with_subsequent_block
+    Time.stub(:now, Time.now) do
+      outer_expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+      inner_expected_time = Time.new(2004, 10, 24, 1, 4, 44)
+      travel_to outer_expected_time
+
+      assert_nothing_raised do
+        travel_to(inner_expected_time) do
+          assert_equal inner_expected_time, Time.now
+        end
+      end
+    end
+  end
+
   def test_travel_to_will_reset_the_usec_to_avoid_mysql_rounding
     Time.stub(:now, Time.now) do
       travel_to Time.utc(2014, 10, 10, 10, 10, 50, 999999) do


### PR DESCRIPTION
As of #24890, nested `travel`/`travel_to` raise an error.

But a `travel`/`travel_to` block following a stand-alone `travel`/`travel_to` block also raises.

I don't think this was the intention #24890. If it was, I think this is a bit too opinionated, so I suggest we relax this restriction.

In particular I would like to call `freeze_time` in `setup` to make tests robust against time passing during the test and possible even freeze time on a hardcoded date, so the test results are robust against running the test suite on different times (weekends, near midnight etc.). However, this prevents me from using `travel`/`travel_to` blocks in my test.