### PR TITLE
Update Active Storage guide about num migration added in setup

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -35,8 +35,9 @@ files.
 
 ## Setup
 
-Active Storage uses two tables in your application’s database named
-`active_storage_blobs` and `active_storage_attachments`. After creating a new
+Active Storage uses three tables in your application’s database named
+`active_storage_blobs`, `active_storage_variant_records`
+and `active_storage_attachments`. After creating a new
 application (or upgrading your application to Rails 5.2), run
 `bin/rails active_storage:install` to generate a migration that creates these
 tables. Use `bin/rails db:migrate` to run the migration.


### PR DESCRIPTION
Active Storage now tracks variants in the database by defaults
and adds a table `active_storage_variant_records`. This was added
in PR: #37901

This PR updates the documentation to make it clear.

