### PR TITLE
Add `attributes_for_database` method to return attributes as they would be in the database

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveModel::AttributeSet#values_for_database`
+
+    Returns attributes with values for assignment to the database.
+
+    *Chris Salzberg*
+
 *   Fix delegation in ActiveModel::Type::Registry#lookup and ActiveModel::Type.lookup
 
     Passing a last positional argument `{}` would be incorrectly considered as keyword argument.

--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -25,6 +25,10 @@ module ActiveModel
       attributes.transform_values(&:value_before_type_cast)
     end
 
+    def values_for_database
+      attributes.transform_values(&:value_for_database)
+    end
+
     def to_hash
       keys.index_with { |name| self[name].value }
     end

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -209,6 +209,21 @@ module ActiveModel
       assert_equal "value from user", attributes.fetch_value(:foo)
     end
 
+    class MySerializedType < ::ActiveModel::Type::Value
+      def serialize(value)
+        value + " serialized"
+      end
+    end
+
+    test "values_for_database" do
+      builder = AttributeSet::Builder.new(foo: MySerializedType.new)
+      attributes = builder.build_from_database
+
+      attributes.write_from_user(:foo, "value")
+
+      assert_equal({ foo: "value serialized" }, attributes.values_for_database)
+    end
+
     test "freezing doesn't prevent the set from materializing" do
       builder = AttributeSet::Builder.new(foo: Type::String.new)
       attributes = builder.build_from_database(foo: "1")

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `ActiveRecord::Base#attributes_for_database`
+
+    Returns attributes with values for assignment to the database.
+
+    *Chris Salzberg*
+
 *   Use an empty query to check if the PostgreSQL connection is still active
 
     An empty query is faster than `SELECT 1`.

--- a/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
+++ b/activerecord/lib/active_record/attribute_methods/before_type_cast.rb
@@ -66,6 +66,11 @@ module ActiveRecord
         @attributes.values_before_type_cast
       end
 
+      # Returns a hash of attributes for assignment to the database.
+      def attributes_for_database
+        @attributes.values_for_database
+      end
+
       private
         # Dispatch target for <tt>*_before_type_cast</tt> attribute methods.
         def attribute_before_type_cast(attr_name)

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -216,6 +216,17 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     end
   end
 
+  test "read attributes_for_database" do
+    topic = Topic.new
+    topic.content = { one: 1, two: 2 }
+
+    db_attributes = Topic.instantiate(topic.attributes_for_database).attributes
+    before_type_cast_attributes = Topic.instantiate(topic.attributes_before_type_cast).attributes
+
+    assert_equal topic.attributes, db_attributes
+    assert_not_equal topic.attributes, before_type_cast_attributes
+  end
+
   test "read attributes_after_type_cast on a date" do
     tz = "Pacific Time (US & Canada)"
 

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -378,6 +378,14 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal "published", @book.status
   end
 
+  test "attributes_for_database" do
+    assert_equal 2, @book.attributes_for_database["status"]
+
+    @book.status = "published"
+
+    assert_equal 2, @book.attributes_for_database["status"]
+  end
+
   test "invalid definition values raise an ArgumentError" do
     e = assert_raises(ArgumentError) do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
### Summary

_TL;DR: I wanted a method that returns a record's attributes such that they can be used to regenerate the record with `instantiate`. There is no such method AFAICT, so I added one._

I am working on serialization which takes a record's attributes and serializes them in such a way that they can be used to recreate the record. The criteria is that the serializer should behave externally exactly like `Marshal`.

I started using `foo.attributes_before_type_cast` to serialize, and `Foo.instantiate(attributes_before_type_cast)` to deserialize, but found that this broke on json attributes if the assigned key values are symbols, since in this case `foo.attributes_before_type_cast` will return the attributes with symbol keys, whereas `Marshal.load(Marshal.dump(...))` would return the instance with string-valued keys on the json column.

The problem is that `attributes_before_type_cast`, as its name implies, returns the attributes before any type casting, but what we want to pass to `instantiate` is the attributes _as they would be in the database_.

In this PR I have added a method, `attributes_for_database`, which does this. It has this unique "round-trip" property:

```ruby
Foo.instantiate(foo.attributes_for_database).attributes == foo.attributes
```

In other words, you can use this version of attributes to re-create the original record. This makes it ideal for use in serialization.

I also added `ActiveModel::AttributeSet#values_for_database` which seemed like the right place to actually do the "work" of transforming values.

### Other Information

Not sure about placement of methods and tests, happy to move just let me know 🙏 

Note: there is a precedent for this method in #40456, which added a private `attribute_for_database` method for individual attributes.

cc @rafaelfranca @byroot 