### PR TITLE
[ci skip] Rails Guides dark mode fix

### DIFF
--- a/guides/assets/stylesheets/dark.css
+++ b/guides/assets/stylesheets/dark.css
@@ -127,7 +127,7 @@
     background-position: 10px 10px;
   }
 
-  .info {
+  .info, #mainCol dd.kindle, #subCol dd.kindle {
     border: 1px solid #d5e9f6;
     background-color: #243440;
     color: #d5e9f6;
@@ -135,8 +135,6 @@
     background-size: 28px 28px;
     background-position: 10px 10px;
   }
-
-
 
   .clipboard-button {
     color: #ddd;


### PR DESCRIPTION
### Summary

Testing #41987 change to include dark mode on Rails Guides. The Kindle part of `index.html.erb` used on official releases was not included a small part that was not covered yet.

It is a simple change thanks to @mgodwin awesome work.

### Other Information

#### before

![image](https://user-images.githubusercontent.com/9326123/121072560-c136ec00-c7a7-11eb-972c-0980a53c30ec.png)


#### after

![image](https://user-images.githubusercontent.com/9326123/121072543-bbd9a180-c7a7-11eb-8e64-1269e9f8f106.png)


