### PR TITLE
Enhancement: add error message test for where

### DIFF
--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -423,7 +423,9 @@ module ActiveRecord
     end
 
     def test_where_with_unsupported_arguments
-      assert_raises(ArgumentError) { Author.where(42) }
+      error = assert_raises(ArgumentError) { Author.where(42) }
+
+      assert_equal "Unsupported argument type: 42 (Integer)", error.message
     end
 
     def test_invert_where


### PR DESCRIPTION
### Summary

Added test for the message error when calling `where` with invalid arguments.
