### PR TITLE
Improve `AS::TimeWithZone` error message on `NoMethodError`

### DIFF
--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -542,7 +542,7 @@ module ActiveSupport
     def method_missing(sym, *args, &block)
       wrap_with_time_zone time.__send__(sym, *args, &block)
     rescue NoMethodError => e
-      raise e, e.message.sub(time.inspect, inspect), e.backtrace
+      raise e, e.message.sub(time.inspect, inspect).sub("Time", "ActiveSupport::TimeWithZone"), e.backtrace
     end
 
     private

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1078,7 +1078,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }
-    assert_equal "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00:Time", e.message
+    assert_equal "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00:ActiveSupport::TimeWithZone", e.message
     assert_no_match "rescue", e.backtrace.first
   end
 end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/41835
Followup: https://github.com/rails/rails/pull/41938

Because we re-use the message generated by the `Time` instance it causes `TimeWithZone` to still pretend being a `Time` instance even with `remove_deprecated_time_with_zone_name = true` which is confusing.

I could try to only change this if the new behavior was opted it, but since it's an error message I think we can consider this a non-breaking change. Happy to change it if I'm wrong though.

cc @shioyama 

cc @pixeltrix @rafaelfranca 