### PR TITLE
Always draw `disk_service` routes

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Allows rendering url helpers and routes for the disk service even when
+    `config.active_storage.draw_routes` is set to false.
+
+    *Stefanni Brasil and Thiago Araujo*
+
 *   Attachments can be deleted after their association is no longer defined.
 
     Fixes #42514

--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -1,82 +1,90 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  scope ActiveStorage.routes_prefix do
-    get "/blobs/redirect/:signed_id/*filename" => "active_storage/blobs/redirect#show", as: :rails_service_blob
-    get "/blobs/proxy/:signed_id/*filename" => "active_storage/blobs/proxy#show", as: :rails_service_blob_proxy
-    get "/blobs/:signed_id/*filename" => "active_storage/blobs/redirect#show"
+  if ActiveStorage.draw_routes
+    scope ActiveStorage.routes_prefix do
+      get "/blobs/redirect/:signed_id/*filename" => "active_storage/blobs/redirect#show", as: :rails_service_blob
+      get "/blobs/proxy/:signed_id/*filename" => "active_storage/blobs/proxy#show", as: :rails_service_blob_proxy
+      get "/blobs/:signed_id/*filename" => "active_storage/blobs/redirect#show"
 
-    get "/representations/redirect/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show", as: :rails_blob_representation
-    get "/representations/proxy/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/proxy#show", as: :rails_blob_representation_proxy
-    get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show"
+      get "/representations/redirect/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show", as: :rails_blob_representation
+      get "/representations/proxy/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/proxy#show", as: :rails_blob_representation_proxy
+      get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show"
 
-    get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
-    put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
-    post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
-  end
+      get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
+      put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
+      post "/direct_uploads" => "active_storage/direct_uploads#create", as: :rails_direct_uploads
+    end
 
-  direct :rails_representation do |representation, options|
-    route_for(ActiveStorage.resolve_model_to_route, representation, options)
-  end
+    direct :rails_representation do |representation, options|
+      route_for(ActiveStorage.resolve_model_to_route, representation, options)
+    end
 
-  resolve("ActiveStorage::Variant") { |variant, options| route_for(ActiveStorage.resolve_model_to_route, variant, options) }
-  resolve("ActiveStorage::VariantWithRecord") { |variant, options| route_for(ActiveStorage.resolve_model_to_route, variant, options) }
-  resolve("ActiveStorage::Preview") { |preview, options| route_for(ActiveStorage.resolve_model_to_route, preview, options) }
+    resolve("ActiveStorage::Variant") { |variant, options| route_for(ActiveStorage.resolve_model_to_route, variant, options) }
+    resolve("ActiveStorage::VariantWithRecord") { |variant, options| route_for(ActiveStorage.resolve_model_to_route, variant, options) }
+    resolve("ActiveStorage::Preview") { |preview, options| route_for(ActiveStorage.resolve_model_to_route, preview, options) }
 
-  direct :rails_blob do |blob, options|
-    route_for(ActiveStorage.resolve_model_to_route, blob, options)
-  end
+    direct :rails_blob do |blob, options|
+      route_for(ActiveStorage.resolve_model_to_route, blob, options)
+    end
 
-  resolve("ActiveStorage::Blob")       { |blob, options| route_for(ActiveStorage.resolve_model_to_route, blob, options) }
-  resolve("ActiveStorage::Attachment") { |attachment, options| route_for(ActiveStorage.resolve_model_to_route, attachment.blob, options) }
+    resolve("ActiveStorage::Blob")       { |blob, options| route_for(ActiveStorage.resolve_model_to_route, blob, options) }
+    resolve("ActiveStorage::Attachment") { |attachment, options| route_for(ActiveStorage.resolve_model_to_route, attachment.blob, options) }
 
-  direct :rails_storage_proxy do |model, options|
-    expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
+    direct :rails_storage_proxy do |model, options|
+      expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
 
-    if model.respond_to?(:signed_id)
-      route_for(
-        :rails_service_blob_proxy,
-        model.signed_id(expires_in: expires_in),
-        model.filename,
-        options
-      )
-    else
-      signed_blob_id = model.blob.signed_id(expires_in: expires_in)
-      variation_key  = model.variation.key
-      filename       = model.blob.filename
+      if model.respond_to?(:signed_id)
+        route_for(
+          :rails_service_blob_proxy,
+          model.signed_id(expires_in: expires_in),
+          model.filename,
+          options
+        )
+      else
+        signed_blob_id = model.blob.signed_id(expires_in: expires_in)
+        variation_key  = model.variation.key
+        filename       = model.blob.filename
 
-      route_for(
-        :rails_blob_representation_proxy,
-        signed_blob_id,
-        variation_key,
-        filename,
-        options
-      )
+        route_for(
+          :rails_blob_representation_proxy,
+          signed_blob_id,
+          variation_key,
+          filename,
+          options
+        )
+      end
+    end
+
+    direct :rails_storage_redirect do |model, options|
+      expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
+
+      if model.respond_to?(:signed_id)
+        route_for(
+          :rails_service_blob,
+          model.signed_id(expires_in: expires_in),
+          model.filename,
+          options
+        )
+      else
+        signed_blob_id = model.blob.signed_id(expires_in: expires_in)
+        variation_key  = model.variation.key
+        filename       = model.blob.filename
+
+        route_for(
+          :rails_blob_representation,
+          signed_blob_id,
+          variation_key,
+          filename,
+          options
+        )
+      end
+    end
+  # Always draw ActiveStorage when draw_routes is true or current storage adapter is a disk_service
+  elsif ActiveStorage.disk_service_enabled?
+    scope ActiveStorage.routes_prefix do
+      get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
+      put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service
     end
   end
-
-  direct :rails_storage_redirect do |model, options|
-    expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
-
-    if model.respond_to?(:signed_id)
-      route_for(
-        :rails_service_blob,
-        model.signed_id(expires_in: expires_in),
-        model.filename,
-        options
-      )
-    else
-      signed_blob_id = model.blob.signed_id(expires_in: expires_in)
-      variation_key  = model.variation.key
-      filename       = model.blob.filename
-
-      route_for(
-        :rails_blob_representation,
-        signed_blob_id,
-        variation_key,
-        filename,
-        options
-      )
-    end
-  end
-end if ActiveStorage.draw_routes
+end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -71,6 +71,10 @@ module ActiveStorage
 
   mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
 
+  def self.disk_service_enabled?
+    Blob.service.try(:disk?) || false
+  end
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -72,6 +72,10 @@ module ActiveStorage
       end
     end
 
+    def disk?
+      true
+    end
+
     def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
       instrument :url, key: key do |payload|
         verified_token_with_expiration = ActiveStorage.verifier.generate(

--- a/activestorage/lib/active_storage/service/mirror_service.rb
+++ b/activestorage/lib/active_storage/service/mirror_service.rb
@@ -49,6 +49,11 @@ module ActiveStorage
       perform_across_services :delete_prefixed, prefix
     end
 
+    def disk?
+      [ primary, *mirrors ].any? do |service|
+        service.try(:disk?)
+      end
+    end
 
     # Copy the file at the +key+ from the primary service to each of the mirrors where it doesn't already exist.
     def mirror(key, checksum:)

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -28,6 +28,10 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "disk?" do
+    assert_equal true, @service.disk?
+  end
+
   test "URL generation" do
     original_url_options = Rails.application.routes.default_url_options.dup
     Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)

--- a/activestorage/test/service/mirror_service_test.rb
+++ b/activestorage/test/service/mirror_service_test.rb
@@ -57,6 +57,10 @@ class ActiveStorage::Service::MirrorServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "disk?" do
+    assert_equal true, @service.disk?
+  end
+
   test "mirroring a file from the primary service to secondary services where it doesn't exist" do
     key      = SecureRandom.base58(24)
     data     = "Something else entirely!"

--- a/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/storage.yml.tt
@@ -6,6 +6,12 @@ local:
   service: Disk
   root: <%%= Rails.root.join("storage") %>
 
+mirror:
+  service: Mirror
+  primary: test
+  mirrors:
+    - local
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3118,6 +3118,7 @@ module ApplicationTests
     test "ActiveStorage.draw_routes can be configured via config.active_storage.draw_routes" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do
+          config.active_storage.service = :local
           config.active_storage.draw_routes = false
         end
       RUBY
@@ -3125,9 +3126,25 @@ module ApplicationTests
       output = rails("routes")
       assert_not_includes(output, "rails_service_blob")
       assert_not_includes(output, "rails_blob_representation")
-      assert_not_includes(output, "rails_disk_service")
-      assert_not_includes(output, "update_rails_disk_service")
       assert_not_includes(output, "rails_direct_uploads")
+      assert_includes(output, "rails_disk_service")
+      assert_includes(output, "update_rails_disk_service")
+    end
+
+    test "MirrorService with draw routes = false" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_storage.service = :mirror
+          config.active_storage.draw_routes = false
+        end
+      RUBY
+
+      output = rails("routes")
+      assert_not_includes(output, "rails_service_blob")
+      assert_not_includes(output, "rails_blob_representation")
+      assert_not_includes(output, "rails_direct_uploads")
+      assert_includes(output, "rails_disk_service")
+      assert_includes(output, "update_rails_disk_service")
     end
 
     test "ActiveStorage.video_preview_arguments uses the old arguments without Rails 7 defaults" do


### PR DESCRIPTION
### Summary

Fixes #42043 

When `config.active_storage.draw_routes = false` while the current storage adapter is using the `disk_service`, and one attempts to call the url method on an attachment (`model.attachment.url`), it raises this error:
```
Active Storage Disk Service NoMethodError: undefined method `rails_disk_service_url' 
``` 

This PR fixes this issue by doing the following:
- Always draw ActiveStorage routes when the current storage adapter is using `disk_service`.

### Bug fix reproducing steps

A gist with the reproducing steps appointing to our branch can be found [here](https://gist.github.com/stefannibrasil/e8050ad97ab32e14f07dca651e186703).