### PR TITLE
Fix outdated explanation of take_failed_screenshot usage

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -40,10 +40,7 @@ module ActionDispatch
         # Takes a screenshot of the current page in the browser if the test
         # failed.
         #
-        # +take_failed_screenshot+ is included in <tt>application_system_test_case.rb</tt>
-        # that is generated with the application. To take screenshots when a test
-        # fails add +take_failed_screenshot+ to the teardown block before clearing
-        # sessions.
+        # +take_failed_screenshot+ is called during system test teardown.
         def take_failed_screenshot
           take_screenshot if failed? && supports_screenshot?
         end


### PR DESCRIPTION
### Summary

Correct outdated explanation of how `take_failed_screenshot` is used. 

This method was removed from the generated file and included via module in `ActionDispatch::SystemTestCase` in 161cf89e134267f9b579f493ca19b12c30d5fd36.

### Other Information

The current status of this method might even warrant a `nodoc`