### PR TITLE
Postgres: allow blank queries while preventing writes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/blank"
+
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
@@ -27,7 +29,9 @@ module ActiveRecord
         private_constant :READ_QUERY
 
         def write_query?(sql) # :nodoc:
-          !READ_QUERY.match?(sql)
+          cleaned_query = sql.gsub(%r{/\*(.*)\*/}, "").strip # remove comments
+
+          cleaned_query.present? && cleaned_query != ";" && !READ_QUERY.match?(cleaned_query)
         end
 
         # Executes an SQL statement, returning a PG::Result object on success

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_prevent_writes_test.rb
@@ -94,6 +94,15 @@ module ActiveRecord
         end
       end
 
+      def test_doesnt_error_when_a_healthcheck_query_is_called_while_preventing_writes
+        ActiveRecord::Base.while_preventing_writes do
+          assert_queries(1) { @connection.execute("") }
+          assert_queries(1) { @connection.execute("/*application:ruby_explorer,deployed_to:development,server:Adams-Computer.Home*/") }
+          assert_queries(1) { @connection.execute(";") }
+          assert_queries(1) { @connection.execute("; /* application:ruby_explorer,deployed_to:development,server:Adams-Computer.Home */") }
+        end
+      end
+
       private
         def with_example_table(definition = "id serial primary key, number integer, data character varying(255)", &block)
           super(@connection, "ex", definition, &block)
@@ -193,6 +202,15 @@ module ActiveRecord
               assert_equal [], @connection.execute("CLOSE cur_ex").entries
             end
           end
+        end
+      end
+
+      def test_doesnt_error_when_a_healthcheck_query_is_called_while_preventing_writes
+        ActiveRecord::Base.while_preventing_writes do
+          assert_queries(1) { @connection.execute("") }
+          assert_queries(1) { @connection.execute("/*application:ruby_explorer,deployed_to:development,server:Adams-Computer.Home*/") }
+          assert_queries(1) { @connection.execute(";") }
+          assert_queries(1) { @connection.execute("; /* application:ruby_explorer,deployed_to:development,server:Adams-Computer.Home */") }
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/42432

Only Postgres seems to allow empty queries, so the fix is only included for it.