### PR TITLE
[ci skip] clarify rails 6 required for AS :attachment in generator

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -321,18 +321,18 @@ The [`has_one_attached`][] macro sets up a one-to-one mapping between records an
 files. Each record can have one file attached to it.
 
 For example, suppose your application has a `User` model. If you want each user to
-have an avatar, run a model generator command as follows:
-
-```ruby
-bin/rails generate model User avatar:attachment
-```
-
-or define the `User` model like this
+have an avatar, define the `User` model as follows:
 
 ```ruby
 class User < ApplicationRecord
   has_one_attached :avatar
 end
+```
+
+or if you are using Rails 6.0+, you can run a model generator command like this:
+
+```ruby
+bin/rails generate model User avatar:attachment
 ```
 
 You can create a user with an avatar:
@@ -403,18 +403,18 @@ The [`has_many_attached`][] macro sets up a one-to-many relationship between rec
 and files. Each record can have many files attached to it.
 
 For example, suppose your application has a `Message` model. If you want each
-message to have many images, run a model generator command as follows:
-
-```ruby
-bin/rails generate model Message images:attachments
-```
-
-or define the `Message` model like this:
+message to have many images, define the `Message` model as follows:
 
 ```ruby
 class Message < ApplicationRecord
   has_many_attached :images
 end
+```
+
+or if you are using Rails 6.0+, you can run a model generator command like this:
+
+```ruby
+bin/rails generate model Message images:attachments
 ```
 
 You can create a message with images:


### PR DESCRIPTION
### Summary

The current guides appear to indicate that the :attachment and
:attachments field generators can be used with any version of Active
Storage, however they were added in ecdcf06, which was first included in
Rails 6.0.

This updates the docs to indicate that Rails 6 is necessary to use those
fields in model generators.

### Other Information

Ref #42434 
