### PR TITLE
Use the lookup_context to find the correct template path

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_template_digest.rb
@@ -44,7 +44,7 @@ module ActionController
       # template digest from the ETag.
       def pick_template_for_etag(options)
         unless options[:template] == false
-          options[:template] || "#{controller_path}/#{action_name}"
+          options[:template] || lookup_context.find_all(action_name, _prefixes).first&.virtual_path
         end
       end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -65,6 +65,12 @@ module Namespaced
   end
 end
 
+class InheritedRenderTestController < ImplicitRenderTestController
+  def hello_world
+    fresh_when(etag: "abc")
+  end
+end
+
 class TestController < ActionController::Base
   protect_from_forgery
 
@@ -716,6 +722,28 @@ class NamespacedEtagRenderTest < ActionController::TestCase
     assert_response :not_modified
 
     modify_template("namespaced/implicit_render_test/hello_world") do
+      request.if_none_match = etag
+      get :hello_world
+      assert_response :ok
+      assert_not_equal etag, @response.etag
+    end
+  end
+end
+
+class InheritedEtagRenderTest < ActionController::TestCase
+  tests InheritedRenderTestController
+  include TemplateModificationHelper
+
+  def test_etag_reflects_template_digest
+    get :hello_world
+    assert_response :ok
+    assert_not_nil etag = @response.etag
+
+    request.if_none_match = etag
+    get :hello_world
+    assert_response :not_modified
+
+    modify_template("implicit_render_test/hello_world") do
       request.if_none_match = etag
       get :hello_world
       assert_response :ok


### PR DESCRIPTION
This replaces the controller/action method of finding a path with the lookup_context which should always find the same thing as the render method finds.

Closes: https://github.com/rails/rails/issues/42417