### PR TITLE
remove scaffold.scss file after run rails d scaffold modelName

### DIFF
--- a/railties/lib/rails/commands/destroy/destroy_assistance.rb
+++ b/railties/lib/rails/commands/destroy/destroy_assistance.rb
@@ -1,0 +1,8 @@
+
+module DestroyAssistance
+    def self.delete_css_file_generate_with_scaffold
+        path = Rails.root.join('app', 'assets', 'stylesheets', 'scaffolds.scss')
+        FileUtils.remove_file(path,force=true)
+        puts " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
+      end
+end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -17,7 +17,7 @@ module Rails
       def delete_css_file_generate_with_scaffold
         path = Rails.root.join('app', 'assets', 'stylesheets', 'scaffolds.scss')
         FileUtils.remove_file(path,force=true)
-        path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
+        puts " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
       end
 
       def perform(*)
@@ -28,7 +28,7 @@ module Rails
         load_generators
 
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root
-        puts " "*6+"\e[31mremove\e[0m"+" "*4  +delete_css_file_generate_with_scaffold if generator == "scaffold"
+        return delete_css_file_generate_with_scaffold if generator == "scaffold"
       end
     end
   end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators"
+
 module Rails
   module Command
     class DestroyCommand < Base # :nodoc:
@@ -16,7 +17,7 @@ module Rails
       def delete_css_file_generate_with_scaffold
         path = Rails.root.join('app', 'assets', 'stylesheets', 'scaffolds.scss')
         FileUtils.remove_file(path,force=true)
-        puts " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
+        " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
       end
 
       def perform(*)
@@ -27,7 +28,7 @@ module Rails
         load_generators
 
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root
-        return delete_css_file_generate_with_scaffold if generator == "scaffold"
+        puts delete_css_file_generate_with_scaffold if generator == "scaffold"
       end
     end
   end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -17,7 +17,7 @@ module Rails
       def delete_css_file_generate_with_scaffold
         path = Rails.root.join('app', 'assets', 'stylesheets', 'scaffolds.scss')
         FileUtils.remove_file(path,force=true)
-        " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
+        path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
       end
 
       def perform(*)
@@ -28,7 +28,7 @@ module Rails
         load_generators
 
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root
-        puts delete_css_file_generate_with_scaffold if generator == "scaffold"
+        puts " "*6+"\e[31mremove\e[0m"+" "*4  +delete_css_file_generate_with_scaffold if generator == "scaffold"
       end
     end
   end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/generators"
+require_relative "destroy_assistance"
 
 module Rails
   module Command
@@ -14,12 +15,6 @@ module Rails
         end
       end
 
-      def delete_css_file_generate_with_scaffold
-        path = Rails.root.join('app', 'assets', 'stylesheets', 'scaffolds.scss')
-        FileUtils.remove_file(path,force=true)
-        puts " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
-      end
-
       def perform(*)
         generator = args.shift
         return help unless generator
@@ -28,7 +23,7 @@ module Rails
         load_generators
 
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root
-        return delete_css_file_generate_with_scaffold if generator == "scaffold"
+        return DestroyAssistance.delete_css_file_generate_with_scaffold if generator == "scaffold"
       end
     end
   end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails/generators"
-
 module Rails
   module Command
     class DestroyCommand < Base # :nodoc:
@@ -14,6 +13,12 @@ module Rails
         end
       end
 
+      def delete_css_file_generate_with_scaffold
+        path = Rails.root.join('app', 'assets', 'stylesheets', 'scaffolds.scss')
+        FileUtils.remove_file(path,force=true)
+        puts " "*6+"\e[31mremove\e[0m"+" "*4  + path.to_s.split("/").reverse.slice(0,4).reverse.join("/")
+      end
+
       def perform(*)
         generator = args.shift
         return help unless generator
@@ -22,6 +27,7 @@ module Rails
         load_generators
 
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root
+        return delete_css_file_generate_with_scaffold if generator == "scaffold"
       end
     end
   end

--- a/railties/lib/rails/commands/destroy/destroy_command.rb
+++ b/railties/lib/rails/commands/destroy/destroy_command.rb
@@ -21,9 +21,9 @@ module Rails
 
         require_application_and_environment!
         load_generators
-
+        
         Rails::Generators.invoke generator, args, behavior: :revoke, destination_root: Rails::Command.root
-        return DestroyAssistance.delete_css_file_generate_with_scaffold if generator == "scaffold"
+        return DestroyAssistance.delete_css_file_generate_with_scaffold if generator == "scaffold"  &&  args.first !="--help"
       end
     end
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -2,7 +2,7 @@
 
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
-require_relative "rails/command/destroy/destroy_assistance"
+require_relative "../../lib/rails/commands/destroy/destroy_assistance"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -2,6 +2,7 @@
 
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
+require_relative "rails/commands/destroy/destroy_command"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
@@ -223,6 +224,12 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     # Assets
     assert_file "app/assets/stylesheets/scaffold.css", /.scaffold_record/
     assert_no_file "app/assets/stylesheets/product_lines.css"
+  end
+
+  def test_delete_css_file_generate_with_scaffold
+    #Assets
+    output = Rails::Command::DestroyCommand.new.delete_css_file_generate_with_scaffold
+    assert_equal "app/assets/stylesheets/scaffolds.scss",output.split(' ')[1,output.split(' ').size][0]
   end
 
   def test_scaffold_with_namespace_on_invoke

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -2,6 +2,7 @@
 
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
+require_relative "rails/command/destroy/destroy_assistance"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
@@ -227,7 +228,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
   def test_delete_css_file_generate_with_scaffold
     #Assets
-    assert_no_file "app/assets/stylesheets/scaffolds.scss"
+    assert_equal DestroyAssistance.delete_css_file_generate_with_scaffold,nil
   end
 
   def test_scaffold_with_namespace_on_invoke

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -229,7 +229,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   def test_delete_css_file_generate_with_scaffold
     #Assets
     output = Rails::Command::DestroyCommand.new.delete_css_file_generate_with_scaffold
-    assert_equal "app/assets/stylesheets/scaffolds.scss",output.split(' ')[1,output.split(' ').size][0]
+    assert_equal "app/assets/stylesheets/scaffolds.scss",output
   end
 
   def test_scaffold_with_namespace_on_invoke

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -2,7 +2,6 @@
 
 require "generators/generators_test_helper"
 require "rails/generators/rails/scaffold/scaffold_generator"
-require_relative "rails/commands/destroy/destroy_command"
 
 class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
@@ -228,8 +227,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
 
   def test_delete_css_file_generate_with_scaffold
     #Assets
-    output = Rails::Command::DestroyCommand.new.delete_css_file_generate_with_scaffold
-    assert_equal "app/assets/stylesheets/scaffolds.scss",output
+    assert_no_file "app/assets/stylesheets/scaffolds.scss"
   end
 
   def test_scaffold_with_namespace_on_invoke


### PR DESCRIPTION

**I'm really sorry, because I couldn't manage the other branch well and I created this branch. I hope that will do the trick now**
**Here is after launching the scaffold command. Take a good look at the scaffolds.scss file on the last line.**


![before](https://user-images.githubusercontent.com/37194177/116833570-f00ee080-abb1-11eb-8a28-b27c7e406a88.png)


**Here after destroying the scaffold command without my modifications. The destroy command does not delete the generated scaffolds.scss file, it just skip and I have checked in my directory hierarchy and put it there.**


![with](https://user-images.githubusercontent.com/37194177/116833660-60b5fd00-abb2-11eb-8190-24382930f74e.png)


**here after with my modifications. So I delete the scaffolds.scss file generated by the scaffold command**

![after](https://user-images.githubusercontent.com/37194177/116833701-99ee6d00-abb2-11eb-8f36-7d833589e0d7.png)


