### PR TITLE
Revise documentation example wording - ActiveRecord::Relation#find_or_create_by [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -155,7 +155,7 @@ module ActiveRecord
     # above can be alternatively written this way:
     #
     #   # Find the first user named "Scarlett" or create a new one with a
-    #   # different last name.
+    #   # particular last name.
     #   User.find_or_create_by(first_name: 'Scarlett') do |user|
     #     user.last_name = 'Johansson'
     #   end


### PR DESCRIPTION
### Summary

Updating the wording of the example to clarify the meaning and to match the wording of the previous paragraph.

### Other Information

I know this is only one word, but I feel that this wording change is important as this confused me when I was reading the documentation for `find_or_create_by` for the first time. The word `different` used to describe this example implies either that there will be some sort of comparison to other users, or that the last name of the created record's `last_name` is different from the former version of the example, or that the last name used in this alternative example is different from the one used in its former counterpart, none of which are true.

In reality, the following is possible:

```
User.find_or_create_by({first_name: "Penélope", last_name: "Johansson"})
# => #<User id: 1, first_name: "Penélope", last_name: "Johansson">

User.find_or_create_by(first_name: 'Scarlett') do |user|
  user.last_name = 'Johansson'
end
# => #<User id: 2, first_name: "Scarlett", last_name: "Johansson">

User.all
# => #<ActiveRecord::Relation [<User id: 1, first_name: "Penélope", last_name: "Johansson">, <User id: 2, first_name: "Scarlett", last_name: "Johansson">]
```

I believe that this wording change more accurately and clearly reflects the actual functionality of `find_or_create_by` and would better aid others such as myself in reading the documentation going forward. I feel that using the wording from the previous example again here will improve the documentation for `find_or_create_by`.


