### PR TITLE
Get rid of `mattr_accessor` in `ActiveRecord::Core`

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -185,6 +185,43 @@ module ActiveRecord
   singleton_class.attr_accessor :reading_role
   self.reading_role = :reading
 
+  # Sets the async_query_executor for an application. By default the thread pool executor
+  # set to +nil+ which will not run queries in the background. Applications must configure
+  # a thread pool executor to use this feature. Options are:
+  #
+  #   * nil - Does not initialize a thread pool executor. Any async calls will be
+  #   run in the foreground.
+  #   * :global_thread_pool - Initializes a single +Concurrent::ThreadPoolExecutor+
+  #   that uses the +async_query_concurrency+ for the +max_threads+ value.
+  #   * :multi_thread_pool - Initializes a +Concurrent::ThreadPoolExecutor+ for each
+  #   database connection. The initializer values are defined in the configuration hash.
+  singleton_class.attr_accessor :async_query_executor
+  self.async_query_executor = nil
+
+  def self.global_thread_pool_async_query_executor # :nodoc:
+    concurrency = global_executor_concurrency || 4
+    @global_thread_pool_async_query_executor ||= Concurrent::ThreadPoolExecutor.new(
+      min_threads: 0,
+      max_threads: concurrency,
+      max_queue: concurrency * 4,
+      fallback_policy: :caller_runs
+    )
+  end
+
+  # Set the +global_executor_concurrency+. This configuration value can only be used
+  # with the global thread pool async query executor.
+  def self.global_executor_concurrency=(global_executor_concurrency)
+    if self.async_query_executor.nil? || self.async_query_executor == :multi_thread_pool
+      raise ArgumentError, "`global_executor_concurrency` cannot be set when using the executor is nil or set to multi_thead_pool. For multiple thread pools, please set the concurrency in your database configuration."
+    end
+
+    @global_executor_concurrency = global_executor_concurrency
+  end
+
+  def self.global_executor_concurrency # :nodoc:
+    @global_executor_concurrency ||= nil
+  end
+
   ##
   # :singleton-method:
   #

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -197,6 +197,13 @@ module ActiveRecord
   singleton_class.attr_accessor :application_record_class
   self.application_record_class = nil
 
+  ##
+  # :singleton-method:
+  # Set the application to log or raise when an association violates strict loading.
+  # Defaults to :raise.
+  singleton_class.attr_accessor :action_on_strict_loading_violation
+  self.action_on_strict_loading_violation = :raise
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -185,6 +185,15 @@ module ActiveRecord
   singleton_class.attr_accessor :reading_role
   self.reading_role = :reading
 
+  ##
+  # :singleton-method:
+  # Specify a threshold for the size of query result sets. If the number of
+  # records in the set exceeds the threshold, a warning is logged. This can
+  # be used to identify queries which load thousands of records and
+  # potentially cause memory bloat.
+  singleton_class.attr_accessor :warn_on_records_fetched_greater_than
+  self.warn_on_records_fetched_greater_than = false
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -194,6 +194,9 @@ module ActiveRecord
   singleton_class.attr_accessor :warn_on_records_fetched_greater_than
   self.warn_on_records_fetched_greater_than = false
 
+  singleton_class.attr_accessor :application_record_class
+  self.application_record_class = nil
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -172,6 +172,13 @@ module ActiveRecord
   singleton_class.attr_accessor :legacy_connection_handling
   self.legacy_connection_handling = true
 
+  ##
+  # :singleton-method:
+  # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling
+  # dates and times from the database. This is set to :utc by default.
+  singleton_class.attr_accessor :default_timezone
+  self.default_timezone = :utc
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -200,6 +200,9 @@ module ActiveRecord
   singleton_class.attr_accessor :queues
   self.queues = {}
 
+  singleton_class.attr_accessor :maintain_test_schema
+  self.maintain_test_schema = nil
+
   ##
   # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -204,6 +204,57 @@ module ActiveRecord
   singleton_class.attr_accessor :action_on_strict_loading_violation
   self.action_on_strict_loading_violation = :raise
 
+  ##
+  # :singleton-method:
+  # Specifies the format to use when dumping the database schema with Rails'
+  # Rakefile. If :sql, the schema is dumped as (potentially database-
+  # specific) SQL statements. If :ruby, the schema is dumped as an
+  # ActiveRecord::Schema file which can be loaded into any database that
+  # supports migrations. Use :ruby if you want to have different database
+  # adapters for, e.g., your development and test environments.
+  singleton_class.attr_accessor :schema_format
+  self.schema_format = :ruby
+
+  ##
+  # :singleton-method:
+  # Specifies if an error should be raised if the query has an order being
+  # ignored when doing batch queries. Useful in applications where the
+  # scope being ignored is error-worthy, rather than a warning.
+  singleton_class.attr_accessor :error_on_ignored_order
+  self.error_on_ignored_order = false
+
+  ##
+  # :singleton-method:
+  # Specify whether or not to use timestamps for migration versions
+  singleton_class.attr_accessor :timestamped_migrations
+  self.timestamped_migrations = true
+
+  ##
+  # :singleton-method:
+  # Specify whether schema dump should happen at the end of the
+  # bin/rails db:migrate command. This is true by default, which is useful for the
+  # development environment. This should ideally be false in the production
+  # environment where dumping schema is rarely needed.
+  singleton_class.attr_accessor :dump_schema_after_migration
+  self.dump_schema_after_migration = true
+
+  ##
+  # :singleton-method:
+  # Specifies which database schemas to dump when calling db:schema:dump.
+  # If the value is :schema_search_path (the default), any schemas listed in
+  # schema_search_path are dumped. Use :all to dump all schemas regardless
+  # of schema_search_path, or a string of comma separated schemas for a
+  # custom list.
+  singleton_class.attr_accessor :dump_schemas
+  self.dump_schemas = :schema_search_path
+
+  ##
+  # :singleton-method:
+  # Show a warning when Rails couldn't parse your database.yml
+  # for multiple databases.
+  singleton_class.attr_accessor :suppress_multiple_database_warning
+  self.suppress_multiple_database_warning = false
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -187,6 +187,14 @@ module ActiveRecord
 
   ##
   # :singleton-method:
+  #
+  # Specifies if the methods calling database queries should be logged below
+  # their relevant queries. Defaults to false.
+  singleton_class.attr_accessor :verbose_query_logs
+  self.verbose_query_logs = false
+
+  ##
+  # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of
   # records in the set exceeds the threshold, a warning is logged. This can
   # be used to identify queries which load thousands of records and

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -179,6 +179,12 @@ module ActiveRecord
   singleton_class.attr_accessor :default_timezone
   self.default_timezone = :utc
 
+  singleton_class.attr_accessor :writing_role
+  self.writing_role = :writing
+
+  singleton_class.attr_accessor :reading_role
+  self.reading_role = :reading
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -195,6 +195,13 @@ module ActiveRecord
 
   ##
   # :singleton-method:
+  #
+  # Specifies the names of the queues used by background jobs.
+  singleton_class.attr_accessor :queues
+  self.queues = {}
+
+  ##
+  # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of
   # records in the set exceeds the threshold, a warning is logged. This can
   # be used to identify queries which load thousands of records and

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -460,7 +460,7 @@ module ActiveRecord
 
       private
         def build_async_executor
-          case Base.async_query_executor
+          case ActiveRecord.async_query_executor
           when :multi_thread_pool
             if @db_config.max_threads > 0
               Concurrent::ThreadPoolExecutor.new(
@@ -471,7 +471,7 @@ module ActiveRecord
               )
             end
           when :global_thread_pool
-            Base.global_thread_pool_async_query_executor
+            ActiveRecord.global_thread_pool_async_query_executor
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -113,7 +113,7 @@ module ActiveRecord
       # if the value is a Time responding to usec.
       def quoted_date(value)
         if value.acts_like?(:time)
-          if ActiveRecord::Base.default_timezone == :utc
+          if ActiveRecord.default_timezone == :utc
             value = value.getutc if !value.utc?
           else
             value = value.getlocal

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -443,7 +443,7 @@ module ActiveRecord
 
       def async_enabled? # :nodoc:
         supports_concurrent_connections? &&
-          !Base.async_query_executor.nil? && !pool.async_executor.nil?
+          !ActiveRecord.async_query_executor.nil? && !pool.async_executor.nil?
       end
 
       # This is meant to be implemented by the adapters that support extensions

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -41,9 +41,9 @@ module ActiveRecord
         def execute(sql, name = nil, async: false)
           check_if_write_query(sql)
 
-          # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+          # make sure we carry over any changes to ActiveRecord.default_timezone that have been
           # made since we established the connection
-          @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
+          @connection.query_options[:database_timezone] = ActiveRecord.default_timezone
 
           super
         end
@@ -152,9 +152,9 @@ module ActiveRecord
             materialize_transactions
             mark_transaction_written_if_write(sql)
 
-            # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+            # make sure we carry over any changes to ActiveRecord.default_timezone that have been
             # made since we established the connection
-            @connection.query_options[:database_timezone] = ActiveRecord::Base.default_timezone
+            @connection.query_options[:database_timezone] = ActiveRecord.default_timezone
 
             type_casted_binds = type_casted_binds(binds)
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -79,7 +79,7 @@ module ActiveRecord
               # We need to check explicitly for ActiveSupport::TimeWithZone because
               # we need to transform it to Time objects but we don't want to
               # transform Time objects to themselves.
-              if ActiveRecord::Base.default_timezone == :utc
+              if ActiveRecord.default_timezone == :utc
                 value.getutc
               else
                 value.getlocal

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -696,7 +696,7 @@ module ActiveRecord
           materialize_transactions
           mark_transaction_written_if_write(sql)
 
-          # make sure we carry over any changes to ActiveRecord::Base.default_timezone that have been
+          # make sure we carry over any changes to ActiveRecord.default_timezone that have been
           # made since we established the connection
           update_typemap_for_default_timezone
 
@@ -810,7 +810,7 @@ module ActiveRecord
           # If using Active Record's time zone support configure the connection to return
           # TIMESTAMP WITH ZONE types in UTC.
           unless variables["timezone"]
-            if ActiveRecord::Base.default_timezone == :utc
+            if ActiveRecord.default_timezone == :utc
               variables["timezone"] = "UTC"
             elsif @local_tz
               variables["timezone"] = @local_tz

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -184,7 +184,7 @@ module ActiveRecord
         raise NotImplementedError, "connected_to_many can only be called on ActiveRecord::Base."
       end
 
-      prevent_writes = true if role == reading_role
+      prevent_writes = true if role == ActiveRecord.reading_role
 
       connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes }
       yield
@@ -204,7 +204,7 @@ module ActiveRecord
         raise NotImplementedError, "`connecting_to` is not available with `legacy_connection_handling`."
       end
 
-      prevent_writes = true if role == reading_role
+      prevent_writes = true if role == ActiveRecord.reading_role
 
       self.connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self] }
     end
@@ -240,7 +240,7 @@ module ActiveRecord
 
     def lookup_connection_handler(handler_key) # :nodoc:
       if ActiveRecord.legacy_connection_handling
-        handler_key ||= ActiveRecord::Base.writing_role
+        handler_key ||= ActiveRecord.writing_role
         connection_handlers[handler_key] ||= ActiveRecord::ConnectionAdapters::ConnectionHandler.new
       else
         ActiveRecord::Base.connection_handler
@@ -356,7 +356,7 @@ module ActiveRecord
       end
 
       def with_role_and_shard(role, shard, prevent_writes)
-        prevent_writes = true if role == reading_role
+        prevent_writes = true if role == ActiveRecord.reading_role
 
         if ActiveRecord.legacy_connection_handling
           with_handler(role.to_sym) do

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -127,12 +127,6 @@ module ActiveRecord
 
       class_attribute :belongs_to_required_by_default, instance_accessor: false
 
-      ##
-      # :singleton-method:
-      # Set the application to log or raise when an association violates strict loading.
-      # Defaults to :raise.
-      mattr_accessor :action_on_strict_loading_violation, instance_accessor: false, default: :raise
-
       class_attribute :strict_loading_by_default, instance_accessor: false, default: false
       class_attribute :strict_loading_mode, instance_accessor: true, default: :all
 
@@ -345,7 +339,7 @@ module ActiveRecord
       self.default_shard = :default
 
       def self.strict_loading_violation!(owner:, reflection:) # :nodoc:
-        case action_on_strict_loading_violation
+        case ActiveRecord.action_on_strict_loading_violation
         when :raise
           message = "`#{owner}` is marked for strict_loading. The `#{reflection.klass}` association named `:#{reflection.name}` cannot be lazily loaded."
           raise ActiveRecord::StrictLoadingViolationError.new(message)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -78,42 +78,6 @@ module ActiveRecord
 
       class_attribute :default_shard, instance_writer: false
 
-      # Sets the async_query_executor for an application. By default the thread pool executor
-      # set to +nil+ which will not run queries in the background. Applications must configure
-      # a thread pool executor to use this feature. Options are:
-      #
-      #   * nil - Does not initialize a thread pool executor. Any async calls will be
-      #   run in the foreground.
-      #   * :global_thread_pool - Initializes a single +Concurrent::ThreadPoolExecutor+
-      #   that uses the +async_query_concurrency+ for the +max_threads+ value.
-      #   * :multi_thread_pool - Initializes a +Concurrent::ThreadPoolExecutor+ for each
-      #   database connection. The initializer values are defined in the configuration hash.
-      mattr_accessor :async_query_executor, instance_accessor: false, default: nil
-
-      def self.global_thread_pool_async_query_executor # :nodoc:
-        concurrency = global_executor_concurrency || 4
-        @@global_thread_pool_async_query_executor ||= Concurrent::ThreadPoolExecutor.new(
-          min_threads: 0,
-          max_threads: concurrency,
-          max_queue: concurrency * 4,
-          fallback_policy: :caller_runs
-        )
-      end
-
-      # Set the +global_executor_concurrency+. This configuration value can only be used
-      # with the global thread pool async query executor.
-      def self.global_executor_concurrency=(global_executor_concurrency)
-        if async_query_executor.nil? || async_query_executor == :multi_thread_pool
-          raise ArgumentError, "`global_executor_concurrency` cannot be set when using the executor is nil or set to multi_thead_pool. For multiple thread pools, please set the concurrency in your database configuration."
-        end
-
-        @@global_executor_concurrency = global_executor_concurrency
-      end
-
-      def self.global_executor_concurrency # :nodoc:
-        @@global_executor_concurrency ||= nil
-      end
-
       def self.application_record_class? # :nodoc:
         if ActiveRecord.application_record_class
           self == ActiveRecord.application_record_class

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -146,8 +146,6 @@ module ActiveRecord
 
       class_attribute :default_shard, instance_writer: false
 
-      mattr_accessor :application_record_class, instance_accessor: false, default: nil
-
       # Sets the async_query_executor for an application. By default the thread pool executor
       # set to +nil+ which will not run queries in the background. Applications must configure
       # a thread pool executor to use this feature. Options are:
@@ -185,8 +183,8 @@ module ActiveRecord
       end
 
       def self.application_record_class? # :nodoc:
-        if Base.application_record_class
-          self == Base.application_record_class
+        if ActiveRecord.application_record_class
+          self == ActiveRecord.application_record_class
         else
           if defined?(ApplicationRecord) && self == ApplicationRecord
             true

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -144,10 +144,6 @@ module ActiveRecord
       class_attribute :strict_loading_by_default, instance_accessor: false, default: false
       class_attribute :strict_loading_mode, instance_accessor: true, default: :all
 
-      mattr_accessor :writing_role, instance_accessor: false, default: :writing
-
-      mattr_accessor :reading_role, instance_accessor: false, default: :reading
-
       class_attribute :has_many_inversing, instance_accessor: false, default: false
 
       mattr_accessor :sqlite3_production_warning, instance_accessor: false, default: true
@@ -357,7 +353,7 @@ module ActiveRecord
       end
 
       self.default_connection_handler = ConnectionAdapters::ConnectionHandler.new
-      self.default_role = writing_role
+      self.default_role = ActiveRecord.writing_role
       self.default_shard = :default
 
       def self.strict_loading_violation!(owner:, reflection:) # :nodoc:
@@ -457,6 +453,22 @@ module ActiveRecord
 
       def default_timezone # :nodoc:
         ActiveRecord.default_timezone
+      end
+
+      def reading_role # :nodoc:
+        ActiveSupport::Deprecation.warn(<<~MSG)
+          ActiveRecord::Base.reading_role is deprecated and will be removed in Rails 7.0.
+          Use `ActiveRecord.reading_role` instead.
+        MSG
+        ActiveRecord.reading_role
+      end
+
+      def writing_role # :nodoc:
+        ActiveSupport::Deprecation.warn(<<~MSG)
+          ActiveRecord::Base.writing_role is deprecated and will be removed in Rails 7.0.
+          Use `ActiveRecord.writing_role` instead.
+        MSG
+        ActiveRecord.writing_role
       end
 
       def initialize_generated_modules # :nodoc:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -138,8 +138,6 @@ module ActiveRecord
 
       class_attribute :has_many_inversing, instance_accessor: false, default: false
 
-      mattr_accessor :sqlite3_production_warning, instance_accessor: false, default: true
-
       class_attribute :default_connection_handler, instance_writer: false
 
       class_attribute :default_role, instance_writer: false

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -22,13 +22,6 @@ module ActiveRecord
       ##
       # :singleton-method:
       #
-      # Specifies if the methods calling database queries should be logged below
-      # their relevant queries. Defaults to false.
-      mattr_accessor :verbose_query_logs, instance_writer: false, default: false
-
-      ##
-      # :singleton-method:
-      #
       # Specifies the names of the queues used by background jobs.
       mattr_accessor :queues, instance_accessor: false, default: {}
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -341,6 +341,10 @@ module ActiveRecord
         ActiveRecord.default_timezone
       end
 
+      def maintain_test_schema # :nodoc:
+        ActiveRecord.maintain_test_schema
+      end
+
       def reading_role # :nodoc:
         ActiveSupport::Deprecation.warn(<<~MSG)
           ActiveRecord::Base.reading_role is deprecated and will be removed in Rails 7.0.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -72,12 +72,6 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling
-      # dates and times from the database. This is set to :utc by default.
-      mattr_accessor :default_timezone, instance_writer: false, default: :utc
-
-      ##
-      # :singleton-method:
       # Specifies the format to use when dumping the database schema with Rails'
       # Rakefile. If :sql, the schema is dumped as (potentially database-
       # specific) SQL statements. If :ruby, the schema is dumped as an
@@ -459,6 +453,10 @@ module ActiveRecord
 
       def find_by!(*args) # :nodoc:
         find_by(*args) || raise(RecordNotFound.new("Couldn't find #{name}", name))
+      end
+
+      def default_timezone # :nodoc:
+        ActiveRecord.default_timezone
       end
 
       def initialize_generated_modules # :nodoc:

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -22,12 +22,6 @@ module ActiveRecord
       ##
       # :singleton-method:
       #
-      # Specifies the names of the queues used by background jobs.
-      mattr_accessor :queues, instance_accessor: false, default: {}
-
-      ##
-      # :singleton-method:
-      #
       # Specifies the job used to destroy associations in the background
       class_attribute :destroy_association_async_job, instance_writer: false, instance_predicate: false, default: false
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -65,8 +65,6 @@ module ActiveRecord
       # to the database while the app is running.
       class_attribute :enumerate_columns_in_select_statements, instance_accessor: false, default: false
 
-      mattr_accessor :maintain_test_schema, instance_accessor: false
-
       class_attribute :belongs_to_required_by_default, instance_accessor: false
 
       class_attribute :strict_loading_by_default, instance_accessor: false, default: false

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -111,14 +111,6 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Specify a threshold for the size of query result sets. If the number of
-      # records in the set exceeds the threshold, a warning is logged. This can
-      # be used to identify queries which load thousands of records and
-      # potentially cause memory bloat.
-      mattr_accessor :warn_on_records_fetched_greater_than, instance_writer: false
-
-      ##
-      # :singleton-method:
       # Show a warning when Rails couldn't parse your database.yml
       # for multiple databases.
       mattr_accessor :suppress_multiple_database_warning, instance_writer: false, default: false

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -72,51 +72,6 @@ module ActiveRecord
 
       ##
       # :singleton-method:
-      # Specifies the format to use when dumping the database schema with Rails'
-      # Rakefile. If :sql, the schema is dumped as (potentially database-
-      # specific) SQL statements. If :ruby, the schema is dumped as an
-      # ActiveRecord::Schema file which can be loaded into any database that
-      # supports migrations. Use :ruby if you want to have different database
-      # adapters for, e.g., your development and test environments.
-      mattr_accessor :schema_format, instance_writer: false, default: :ruby
-
-      ##
-      # :singleton-method:
-      # Specifies if an error should be raised if the query has an order being
-      # ignored when doing batch queries. Useful in applications where the
-      # scope being ignored is error-worthy, rather than a warning.
-      mattr_accessor :error_on_ignored_order, instance_writer: false, default: false
-
-      ##
-      # :singleton-method:
-      # Specify whether or not to use timestamps for migration versions
-      mattr_accessor :timestamped_migrations, instance_writer: false, default: true
-
-      ##
-      # :singleton-method:
-      # Specify whether schema dump should happen at the end of the
-      # bin/rails db:migrate command. This is true by default, which is useful for the
-      # development environment. This should ideally be false in the production
-      # environment where dumping schema is rarely needed.
-      mattr_accessor :dump_schema_after_migration, instance_writer: false, default: true
-
-      ##
-      # :singleton-method:
-      # Specifies which database schemas to dump when calling db:schema:dump.
-      # If the value is :schema_search_path (the default), any schemas listed in
-      # schema_search_path are dumped. Use :all to dump all schemas regardless
-      # of schema_search_path, or a string of comma separated schemas for a
-      # custom list.
-      mattr_accessor :dump_schemas, instance_writer: false, default: :schema_search_path
-
-      ##
-      # :singleton-method:
-      # Show a warning when Rails couldn't parse your database.yml
-      # for multiple databases.
-      mattr_accessor :suppress_multiple_database_warning, instance_writer: false, default: false
-
-      ##
-      # :singleton-method:
       # Force enumeration of all columns in SELECT statements.
       # e.g. `SELECT first_name, last_name FROM ...` instead of `SELECT * FROM ...`
       # This avoids +PreparedStatementCacheExpired+ errors when a column is added

--- a/activerecord/lib/active_record/destroy_association_async_job.rb
+++ b/activerecord/lib/active_record/destroy_association_async_job.rb
@@ -6,7 +6,7 @@ module ActiveRecord
 
   # Job to destroy the records associated with a destroyed record in background.
   class DestroyAssociationAsyncJob < ActiveJob::Base
-    queue_as { ActiveRecord::Base.queues[:destroy] }
+    queue_as { ActiveRecord.queues[:destroy] }
 
     discard_on ActiveJob::DeserializationError
 

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -163,12 +163,12 @@ module ActiveRecord
       # will share a database connection with Active Record. It is the class
       # that connects to your primary database.
       def primary_abstract_class
-        if Base.application_record_class && Base.application_record_class.name != name
-          raise ArgumentError, "The `primary_abstract_class` is already set to #{Base.application_record_class.inspect}. There can only be one `primary_abstract_class` in an application."
+        if ActiveRecord.application_record_class && ActiveRecord.application_record_class.name != name
+          raise ArgumentError, "The `primary_abstract_class` is already set to #{ActiveRecord.application_record_class.inspect}. There can only be one `primary_abstract_class` in an application."
         end
 
         self.abstract_class = true
-        Base.application_record_class = self
+        ActiveRecord.application_record_class = self
       end
 
       # Returns the value to be stored in the inheritance column for STI.

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -177,7 +177,7 @@ module ActiveRecord
       def can_use_fast_cache_version?(timestamp)
         timestamp.is_a?(String) &&
           cache_timestamp_format == :usec &&
-          default_timezone == :utc &&
+          ActiveRecord.default_timezone == :utc &&
           !updated_at_came_from_user?
       end
 

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -116,7 +116,7 @@ module ActiveRecord
       def debug(progname = nil, &block)
         return unless super
 
-        if ActiveRecord::Base.verbose_query_logs
+        if ActiveRecord.verbose_query_logs
           log_query_source
         end
       end

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -50,7 +50,7 @@ module ActiveRecord
 
         private
           def read_from_primary(&blk)
-            ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role, prevent_writes: true) do
+            ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role, prevent_writes: true) do
               instrumenter.instrument("database_selector.active_record.read_from_primary") do
                 yield
               end
@@ -58,7 +58,7 @@ module ActiveRecord
           end
 
           def read_from_replica(&blk)
-            ActiveRecord::Base.connected_to(role: ActiveRecord::Base.reading_role, prevent_writes: true) do
+            ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role, prevent_writes: true) do
               instrumenter.instrument("database_selector.active_record.read_from_replica") do
                 yield
               end
@@ -66,7 +66,7 @@ module ActiveRecord
           end
 
           def write_to_primary(&blk)
-            ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role, prevent_writes: false) do
+            ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role, prevent_writes: false) do
               instrumenter.instrument("database_selector.active_record.wrote_to_primary") do
                 yield
               ensure

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -136,7 +136,7 @@ module ActiveRecord
     action "Run pending migrations" do
       ActiveRecord::Tasks::DatabaseTasks.migrate
 
-      if ActiveRecord::Base.dump_schema_after_migration
+      if ActiveRecord.dump_schema_after_migration
         ActiveRecord::Tasks::DatabaseTasks.dump_schema(
           ActiveRecord::Base.connection_db_config
         )
@@ -632,7 +632,7 @@ module ActiveRecord
         all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
 
         needs_update = !all_configs.all? do |db_config|
-          Tasks::DatabaseTasks.schema_up_to_date?(db_config, ActiveRecord::Base.schema_format)
+          Tasks::DatabaseTasks.schema_up_to_date?(db_config, ActiveRecord.schema_format)
         end
 
         if needs_update
@@ -994,7 +994,7 @@ module ActiveRecord
 
     # Determines the version number of the next migration.
     def next_migration_number(number)
-      if ActiveRecord::Base.timestamped_migrations
+      if ActiveRecord.timestamped_migrations
         [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % number].max
       else
         SchemaMigration.normalize_migration_number(number)

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -651,7 +651,7 @@ module ActiveRecord
       end
 
       def maintain_test_schema! #:nodoc:
-        if ActiveRecord::Base.maintain_test_schema
+        if ActiveRecord.maintain_test_schema
           suppress_messages { load_schema_if_pending! }
         end
       end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -651,7 +651,7 @@ module ActiveRecord
       end
 
       def maintain_test_schema! #:nodoc:
-        if ActiveRecord.maintain_test_schema
+        if ActiveRecord::Base.maintain_test_schema
           suppress_messages { load_schema_if_pending! }
         end
       end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -224,7 +224,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
     initializer "active_record.initialize_database" do
       ActiveSupport.on_load(:active_record) do
         if ActiveRecord.legacy_connection_handling
-          self.connection_handlers = { writing_role => ActiveRecord::Base.default_connection_handler }
+          self.connection_handlers = { ActiveRecord.writing_role => ActiveRecord::Base.default_connection_handler }
         end
         self.configurations = Rails.application.config.database_configuration
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -72,7 +72,6 @@ module ActiveRecord
     initializer "active_record.initialize_timezone" do
       ActiveSupport.on_load(:active_record) do
         self.time_zone_aware_attributes = true
-        self.default_timezone = :utc
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -198,6 +198,17 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
     end
 
+
+    SQLITE3_PRODUCTION_WARN = "You are running SQLite in production, this is generally not recommended."\
+      " You can disable this warning by setting \"config.active_record.sqlite3_production_warning=false\"."
+    initializer "active_record.sqlite3_production_warning" do
+      if config.active_record.delete(:sqlite3_production_warning) && Rails.env.production?
+        ActiveSupport.on_load(:active_record_sqlite3adapter) do
+          Rails.logger.warn(SQLITE3_PRODUCTION_WARN)
+        end
+      end
+    end
+
     initializer "active_record.set_configs" do |app|
       configs = app.config.active_record
 
@@ -229,16 +240,6 @@ To keep using the current cache store, you can turn off cache versioning entirel
         self.configurations = Rails.application.config.database_configuration
 
         establish_connection
-      end
-    end
-
-    SQLITE3_PRODUCTION_WARN = "You are running SQLite in production, this is generally not recommended."\
-      " You can disable this warning by setting \"config.active_record.sqlite3_production_warning=false\"."
-    initializer "active_record.sqlite3_production_warning" do
-      if config.active_record.sqlite3_production_warning && Rails.env.production?
-        ActiveSupport.on_load(:active_record_sqlite3adapter) do
-          Rails.logger.warn(SQLITE3_PRODUCTION_WARN)
-        end
       end
     end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -224,8 +224,15 @@ To keep using the current cache store, you can turn off cache versioning entirel
         configs.each do |k, v|
           next if k == :encryption
           setter = "#{k}="
-          next if ActiveRecord.respond_to?(setter)
-          send(setter, v)
+          # Some existing initializers might rely on Active Record configuration
+          # being copied from the config object to their actual destination when
+          # `ActiveRecord::Base` is loaded.
+          # So to preserve backward compatibility we copy the config a second time.
+          if ActiveRecord.respond_to?(setter)
+            ActiveRecord.send(setter, v)
+          else
+            send(setter, v)
+          end
         end
       end
     end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -62,7 +62,7 @@ module ActiveRecord
         console.level = Rails.logger.level
         Rails.logger.extend ActiveSupport::Logger.broadcast console
       end
-      ActiveRecord::Base.verbose_query_logs = false
+      ActiveRecord.verbose_query_logs = false
     end
 
     runner do

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -96,9 +96,9 @@ db_namespace = namespace :db do
     ActiveRecord::Base.establish_connection(original_db_config)
   end
 
-  # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false
+  # IMPORTANT: This task won't dump the schema if ActiveRecord.dump_schema_after_migration is set to false
   task :_dump do
-    if ActiveRecord::Base.dump_schema_after_migration
+    if ActiveRecord.dump_schema_after_migration
       db_namespace["schema:dump"].invoke
     end
     # Allow this task to be called as many times as required. An example is the
@@ -108,9 +108,9 @@ db_namespace = namespace :db do
 
   namespace :_dump do
     ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
-      # IMPORTANT: This task won't dump the schema if ActiveRecord::Base.dump_schema_after_migration is set to false
+      # IMPORTANT: This task won't dump the schema if ActiveRecord.dump_schema_after_migration is set to false
       task name do
-        if ActiveRecord::Base.dump_schema_after_migration
+        if ActiveRecord.dump_schema_after_migration
           db_namespace["schema:dump:#{name}"].invoke
         end
         # Allow this task to be called as many times as required. An example is the
@@ -430,7 +430,7 @@ db_namespace = namespace :db do
 
     desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `config.active_record.schema_format`) into the database"
     task load: [:load_config, :check_protected_environments] do
-      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(ActiveRecord::Base.schema_format, ENV["SCHEMA"])
+      ActiveRecord::Tasks::DatabaseTasks.load_schema_current(ActiveRecord.schema_format, ENV["SCHEMA"])
     end
 
     task load_if_ruby: ["db:create", :environment] do
@@ -438,7 +438,7 @@ db_namespace = namespace :db do
         Using `bin/rails db:schema:load_if_ruby` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :ruby` to use `schema.rb` and run `bin/rails db:schema:load` instead.
       MSG
-      db_namespace["schema:load"].invoke if ActiveRecord::Base.schema_format == :ruby
+      db_namespace["schema:load"].invoke if ActiveRecord.schema_format == :ruby
     end
 
     namespace :dump do
@@ -458,7 +458,7 @@ db_namespace = namespace :db do
         desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `config.active_record.schema_format`) into the #{name} database"
         task name => :load_config do
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
-          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ActiveRecord::Base.schema_format, ENV["SCHEMA"])
+          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ActiveRecord.schema_format, ENV["SCHEMA"])
         end
       end
     end
@@ -520,7 +520,7 @@ db_namespace = namespace :db do
         Using `bin/rails db:structure:load_if_sql` is deprecated and will be removed in Rails 7.0.
         Configure the format using `config.active_record.schema_format = :sql` to use `structure.sql` and run `bin/rails db:schema:load` instead.
       MSG
-      db_namespace["schema:load"].invoke if ActiveRecord::Base.schema_format == :sql
+      db_namespace["schema:load"].invoke if ActiveRecord.schema_format == :sql
     end
 
     namespace :dump do
@@ -577,7 +577,7 @@ db_namespace = namespace :db do
       ActiveRecord::Schema.verbose = false
       ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |db_config|
         filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(db_config.name)
-        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ActiveRecord::Base.schema_format, filename)
+        ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ActiveRecord.schema_format, filename)
       end
     ensure
       if should_reconnect
@@ -623,7 +623,7 @@ db_namespace = namespace :db do
           ActiveRecord::Schema.verbose = false
           filename = ActiveRecord::Tasks::DatabaseTasks.dump_filename(name)
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: "test", name: name)
-          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ActiveRecord::Base.schema_format, filename)
+          ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config, ActiveRecord.schema_format, filename)
         ensure
           if should_reconnect
             ActiveRecord::Base.establish_connection(ActiveRecord::Tasks::DatabaseTasks.env.to_sym)

--- a/activerecord/lib/active_record/relation/batches.rb
+++ b/activerecord/lib/active_record/relation/batches.rb
@@ -284,7 +284,7 @@ module ActiveRecord
       end
 
       def act_on_ignored_order(error_on_ignore)
-        raise_error = (error_on_ignore.nil? ? klass.error_on_ignored_order : error_on_ignore)
+        raise_error = (error_on_ignore.nil? ? ActiveRecord.error_on_ignored_order : error_on_ignore)
 
         if raise_error
           raise ArgumentError.new(ORDER_IGNORE_MESSAGE)

--- a/activerecord/lib/active_record/relation/record_fetch_warning.rb
+++ b/activerecord/lib/active_record/relation/record_fetch_warning.rb
@@ -17,8 +17,8 @@ module ActiveRecord
         QueryRegistry.reset
 
         super.tap do |records|
-          if logger && warn_on_records_fetched_greater_than
-            if records.length > warn_on_records_fetched_greater_than
+          if logger && ActiveRecord.warn_on_records_fetched_greater_than
+            if records.length > ActiveRecord.warn_on_records_fetched_greater_than
               logger.warn "Query fetched #{records.size} #{@klass} records: #{QueryRegistry.queries.join(";")}"
             end
           end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -13,8 +13,8 @@ module ActiveRecord
     ##
     # :singleton-method:
     # A list of tables which should not be dumped to the schema.
-    # Acceptable values are strings as well as regexp if ActiveRecord::Base.schema_format == :ruby.
-    # Only strings are accepted if ActiveRecord::Base.schema_format == :sql.
+    # Acceptable values are strings as well as regexp if ActiveRecord.schema_format == :ruby.
+    # Only strings are accepted if ActiveRecord.schema_format == :sql.
     cattr_accessor :ignore_tables, default: []
 
     ##

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -161,7 +161,7 @@ module ActiveRecord
         begin
           Rails.application.config.load_database_yaml
         rescue
-          unless ActiveRecord::Base.suppress_multiple_database_warning
+          unless ActiveRecord.suppress_multiple_database_warning
             $stderr.puts "Rails couldn't infer whether you are using multiple databases from your database.yml and can't generate the tasks for the non-primary databases. If you'd like to use this feature, please simplify your ERB."
           end
 
@@ -210,8 +210,8 @@ module ActiveRecord
           # Skipped when no database
           migrate
 
-          if ActiveRecord::Base.dump_schema_after_migration
-            dump_schema(db_config, ActiveRecord::Base.schema_format)
+          if ActiveRecord.dump_schema_after_migration
+            dump_schema(db_config, ActiveRecord.schema_format)
           end
         rescue ActiveRecord::NoDatabaseError
           config_name = db_config.name
@@ -220,7 +220,7 @@ module ActiveRecord
           if File.exist?(dump_filename(config_name))
             load_schema(
               db_config,
-              ActiveRecord::Base.schema_format,
+              ActiveRecord.schema_format,
               nil
             )
           else
@@ -358,7 +358,7 @@ module ActiveRecord
         database_adapter_for(db_config, *arguments).structure_load(filename, flags)
       end
 
-      def load_schema(db_config, format = ActiveRecord::Base.schema_format, file = nil) # :nodoc:
+      def load_schema(db_config, format = ActiveRecord.schema_format, file = nil) # :nodoc:
         file ||= dump_filename(db_config.name, format)
 
         verbose_was, Migration.verbose = Migration.verbose, verbose? && ENV["VERBOSE"]
@@ -380,7 +380,7 @@ module ActiveRecord
         Migration.verbose = verbose_was
       end
 
-      def schema_up_to_date?(configuration, format = ActiveRecord::Base.schema_format, file = nil, environment = nil, name = nil)
+      def schema_up_to_date?(configuration, format = ActiveRecord.schema_format, file = nil, environment = nil, name = nil)
         db_config = resolve_configuration(configuration)
 
         if environment || name
@@ -401,7 +401,7 @@ module ActiveRecord
         ActiveRecord::InternalMetadata[:schema_sha1] == schema_sha1(file)
       end
 
-      def reconstruct_from_schema(db_config, format = ActiveRecord::Base.schema_format, file = nil) # :nodoc:
+      def reconstruct_from_schema(db_config, format = ActiveRecord.schema_format, file = nil) # :nodoc:
         file ||= dump_filename(db_config.name, format)
 
         check_schema_file(file)
@@ -419,7 +419,7 @@ module ActiveRecord
         load_schema(db_config, format, file)
       end
 
-      def dump_schema(db_config, format = ActiveRecord::Base.schema_format) # :nodoc:
+      def dump_schema(db_config, format = ActiveRecord.schema_format) # :nodoc:
         require "active_record/schema_dumper"
         filename = dump_filename(db_config.name, format)
         connection = ActiveRecord::Base.connection
@@ -441,12 +441,12 @@ module ActiveRecord
         end
       end
 
-      def schema_file(format = ActiveRecord::Base.schema_format)
+      def schema_file(format = ActiveRecord.schema_format)
         File.join(db_dir, schema_file_type(format))
       end
       deprecate :schema_file
 
-      def schema_file_type(format = ActiveRecord::Base.schema_format)
+      def schema_file_type(format = ActiveRecord.schema_format)
         case format
         when :ruby
           "schema.rb"
@@ -455,7 +455,7 @@ module ActiveRecord
         end
       end
 
-      def dump_filename(db_config_name, format = ActiveRecord::Base.schema_format)
+      def dump_filename(db_config_name, format = ActiveRecord.schema_format)
         filename = if ActiveRecord::Base.configurations.primary?(db_config_name)
           schema_file_type(format)
         else
@@ -475,7 +475,7 @@ module ActiveRecord
         schema_cache_path || ENV["SCHEMA_CACHE"] || File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, filename)
       end
 
-      def load_schema_current(format = ActiveRecord::Base.schema_format, file = nil, environment = env)
+      def load_schema_current(format = ActiveRecord.schema_format, file = nil, environment = env)
         each_current_configuration(environment) do |db_config|
           load_schema(db_config, format, file)
         end

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -50,13 +50,13 @@ module ActiveRecord
         set_psql_env
 
         search_path = \
-          case ActiveRecord::Base.dump_schemas
+          case ActiveRecord.dump_schemas
           when :schema_search_path
             configuration_hash[:schema_search_path]
           when :all
             nil
           when String
-            ActiveRecord::Base.dump_schemas
+            ActiveRecord.dump_schemas
           end
 
         args = ["--schema-only", "--no-privileges", "--no-owner", "--file", filename]

--- a/activerecord/lib/active_record/test_databases.rb
+++ b/activerecord/lib/active_record/test_databases.rb
@@ -14,7 +14,7 @@ module ActiveRecord
       ActiveRecord::Base.configurations.configs_for(env_name: env_name).each do |db_config|
         db_config._database = "#{db_config.database}-#{i}"
 
-        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, ActiveRecord::Base.schema_format, nil)
+        ActiveRecord::Tasks::DatabaseTasks.reconstruct_from_schema(db_config, ActiveRecord.schema_format, nil)
       end
     ensure
       ActiveRecord::Base.establish_connection

--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -194,7 +194,7 @@ module ActiveRecord
       # can see data in the open transaction on the writing connection.
       def setup_shared_connection_pool
         if ActiveRecord.legacy_connection_handling
-          writing_handler = ActiveRecord::Base.connection_handlers[ActiveRecord::Base.writing_role]
+          writing_handler = ActiveRecord::Base.connection_handlers[ActiveRecord.writing_role]
 
           ActiveRecord::Base.connection_handlers.values.each do |handler|
             if handler != writing_handler
@@ -221,7 +221,7 @@ module ActiveRecord
           handler.connection_pool_names.each do |name|
             pool_manager = handler.send(:owner_to_pool_manager)[name]
             pool_manager.shard_names.each do |shard_name|
-              writing_pool_config = pool_manager.get_pool_config(ActiveRecord::Base.writing_role, shard_name)
+              writing_pool_config = pool_manager.get_pool_config(ActiveRecord.writing_role, shard_name)
               @saved_pool_configs[name][shard_name] ||= {}
               pool_manager.role_names.each do |role|
                 next unless pool_config = pool_manager.get_pool_config(role, shard_name)

--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -75,7 +75,7 @@ module ActiveRecord
       end
 
       def current_time_from_proper_timezone
-        default_timezone == :utc ? Time.now.utc : Time.now
+        ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
       end
 
       private

--- a/activerecord/lib/active_record/type/internal/timezone.rb
+++ b/activerecord/lib/active_record/type/internal/timezone.rb
@@ -5,11 +5,11 @@ module ActiveRecord
     module Internal
       module Timezone
         def is_utc?
-          ActiveRecord::Base.default_timezone == :utc
+          ActiveRecord.default_timezone == :utc
         end
 
         def default_timezone
-          ActiveRecord::Base.default_timezone
+          ActiveRecord.default_timezone
         end
       end
     end

--- a/activerecord/lib/rails/generators/active_record/model/templates/abstract_base_class.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/model/templates/abstract_base_class.rb.tt
@@ -2,6 +2,6 @@
 class <%= abstract_class_name %> < ApplicationRecord
   self.abstract_class = true
 
-  connects_to database: { <%= ActiveRecord::Base.writing_role %>: :<%= database -%> }
+  connects_to database: { <%= ActiveRecord.writing_role %>: :<%= database -%> }
 end
 <% end -%>

--- a/activerecord/test/cases/adapters/postgresql/range_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/range_test.rb
@@ -143,7 +143,7 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_tsrange_values
-    tz = ::ActiveRecord::Base.default_timezone
+    tz = ::ActiveRecord.default_timezone
     assert_equal Time.public_send(tz, 2010, 1, 1, 14, 30, 0)..Time.public_send(tz, 2011, 1, 1, 14, 30, 0), @first_range.ts_range
     assert_equal Time.public_send(tz, 2010, 1, 1, 14, 30, 0)...Time.public_send(tz, 2011, 1, 1, 14, 30, 0), @second_range.ts_range
     assert_equal(-Float::INFINITY...Float::INFINITY, @fourth_range.ts_range)
@@ -205,13 +205,13 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_create_tsrange
-    tz = ::ActiveRecord::Base.default_timezone
+    tz = ::ActiveRecord.default_timezone
     assert_equal_round_trip(@new_range, :ts_range,
                             Time.public_send(tz, 2010, 1, 1, 14, 30, 0)...Time.public_send(tz, 2011, 2, 2, 14, 30, 0))
   end
 
   def test_update_tsrange
-    tz = ::ActiveRecord::Base.default_timezone
+    tz = ::ActiveRecord.default_timezone
     assert_equal_round_trip(@first_range, :ts_range,
                             Time.public_send(tz, 2010, 1, 1, 14, 30, 0)...Time.public_send(tz, 2011, 2, 2, 14, 30, 0))
     assert_nil_round_trip(@first_range, :ts_range,
@@ -219,7 +219,7 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_escaped_tsrange
-    tz = ::ActiveRecord::Base.default_timezone
+    tz = ::ActiveRecord.default_timezone
     assert_equal_round_trip(@first_range, :ts_range,
                             Time.public_send(tz, -1000, 1, 1, 14, 30, 0)...Time.public_send(tz, 2020, 2, 2, 14, 30, 0))
   end
@@ -259,13 +259,13 @@ class PostgresqlRangeTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_create_tsrange_preserve_usec
-    tz = ::ActiveRecord::Base.default_timezone
+    tz = ::ActiveRecord.default_timezone
     assert_equal_round_trip(@new_range, :ts_range,
                             Time.public_send(tz, 2010, 1, 1, 14, 30, 0, 125435)...Time.public_send(tz, 2011, 2, 2, 14, 30, 0, 225435))
   end
 
   def test_update_tsrange_preserve_usec
-    tz = ::ActiveRecord::Base.default_timezone
+    tz = ::ActiveRecord.default_timezone
     assert_equal_round_trip(@first_range, :ts_range,
                             Time.public_send(tz, 2010, 1, 1, 14, 30, 0, 142432)...Time.public_send(tz, 2011, 2, 2, 14, 30, 0, 224242))
     assert_nil_round_trip(@first_range, :ts_range,

--- a/activerecord/test/cases/asynchronous_queries_test.rb
+++ b/activerecord/test/cases/asynchronous_queries_test.rb
@@ -143,8 +143,8 @@ end
 
 class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
   def test_null_configuration_uses_a_single_null_executor_by_default
-    old_value = ActiveRecord::Base.async_query_executor
-    ActiveRecord::Base.async_query_executor = nil
+    old_value = ActiveRecord.async_query_executor
+    ActiveRecord.async_query_executor = nil
 
     handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
@@ -161,12 +161,12 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal 2, handler.all_connection_pools.count
   ensure
     clean_up_connection_handler
-    ActiveRecord::Base.async_query_executor = old_value
+    ActiveRecord.async_query_executor = old_value
   end
 
   def test_one_global_thread_pool_is_used_when_set_with_default_concurrency
-    old_value = ActiveRecord::Base.async_query_executor
-    ActiveRecord::Base.async_query_executor = :global_thread_pool
+    old_value = ActiveRecord.async_query_executor
+    ActiveRecord.async_query_executor = :global_thread_pool
 
     handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
@@ -194,16 +194,16 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
-    ActiveRecord::Base.async_query_executor = old_value
+    ActiveRecord.async_query_executor = old_value
   end
 
   def test_concurrency_can_be_set_on_global_thread_pool
-    old_value = ActiveRecord::Base.async_query_executor
-    ActiveRecord::Base.async_query_executor = :global_thread_pool
-    old_concurrency = ActiveRecord::Base.global_executor_concurrency
-    old_global_thread_pool_async_query_executor = ActiveRecord::Core.class_variable_get(:@@global_thread_pool_async_query_executor)
-    ActiveRecord::Core.class_variable_set(:@@global_thread_pool_async_query_executor, nil)
-    ActiveRecord::Base.global_executor_concurrency = 8
+    old_value = ActiveRecord.async_query_executor
+    ActiveRecord.async_query_executor = :global_thread_pool
+    old_concurrency = ActiveRecord.global_executor_concurrency
+    old_global_thread_pool_async_query_executor = ActiveRecord.instance_variable_get(:@global_thread_pool_async_query_executor)
+    ActiveRecord.instance_variable_set(:@global_thread_pool_async_query_executor, nil)
+    ActiveRecord.global_executor_concurrency = 8
 
     handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
@@ -231,31 +231,31 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
-    ActiveRecord::Base.global_executor_concurrency = old_concurrency
-    ActiveRecord::Base.async_query_executor = old_value
-    ActiveRecord::Core.class_variable_set(:@@global_thread_pool_async_query_executor, old_global_thread_pool_async_query_executor)
+    ActiveRecord.global_executor_concurrency = old_concurrency
+    ActiveRecord.async_query_executor = old_value
+    ActiveRecord.instance_variable_set(:@global_thread_pool_async_query_executor, old_global_thread_pool_async_query_executor)
   end
 
   def test_concurrency_cannot_be_set_with_null_executor_or_multi_thread_pool
-    old_value = ActiveRecord::Base.async_query_executor
-    ActiveRecord::Base.async_query_executor = nil
+    old_value = ActiveRecord.async_query_executor
+    ActiveRecord.async_query_executor = nil
 
     assert_raises ArgumentError do
-      ActiveRecord::Base.global_executor_concurrency = 8
+      ActiveRecord.global_executor_concurrency = 8
     end
 
-    ActiveRecord::Base.async_query_executor = :multi_thread_pool
+    ActiveRecord.async_query_executor = :multi_thread_pool
 
     assert_raises ArgumentError do
-      ActiveRecord::Base.global_executor_concurrency = 8
+      ActiveRecord.global_executor_concurrency = 8
     end
   ensure
-    ActiveRecord::Base.async_query_executor = old_value
+    ActiveRecord.async_query_executor = old_value
   end
 
   def test_multi_thread_pool_executor_configuration
-    old_value = ActiveRecord::Base.async_query_executor
-    ActiveRecord::Base.async_query_executor = :multi_thread_pool
+    old_value = ActiveRecord.async_query_executor
+    ActiveRecord.async_query_executor = :multi_thread_pool
 
     handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
     config_hash = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash
@@ -285,12 +285,12 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_not_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
-    ActiveRecord::Base.async_query_executor = old_value
+    ActiveRecord.async_query_executor = old_value
   end
 
   def test_multi_thread_pool_is_used_only_by_configurations_that_enable_it
-    old_value = ActiveRecord::Base.async_query_executor
-    ActiveRecord::Base.async_query_executor = :multi_thread_pool
+    old_value = ActiveRecord.async_query_executor
+    ActiveRecord.async_query_executor = :multi_thread_pool
 
     handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
 
@@ -320,6 +320,6 @@ class AsynchronousExecutorTypeTest < ActiveRecord::TestCase
     assert_not_equal async_pool1, async_pool2
   ensure
     clean_up_connection_handler
-    ActiveRecord::Base.async_query_executor = old_value
+    ActiveRecord.async_query_executor = old_value
   end
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -207,26 +207,26 @@ class EachTest < ActiveRecord::TestCase
 
   def test_find_in_batches_should_not_error_if_config_overridden
     # Set the config option which will be overridden
-    prev = ActiveRecord::Base.error_on_ignored_order
-    ActiveRecord::Base.error_on_ignored_order = true
+    prev = ActiveRecord.error_on_ignored_order
+    ActiveRecord.error_on_ignored_order = true
     assert_nothing_raised do
       PostWithDefaultScope.find_in_batches(error_on_ignore: false) { }
     end
   ensure
     # Set back to default
-    ActiveRecord::Base.error_on_ignored_order = prev
+    ActiveRecord.error_on_ignored_order = prev
   end
 
   def test_find_in_batches_should_error_on_config_specified_to_error
     # Set the config option
-    prev = ActiveRecord::Base.error_on_ignored_order
-    ActiveRecord::Base.error_on_ignored_order = true
+    prev = ActiveRecord.error_on_ignored_order
+    ActiveRecord.error_on_ignored_order = true
     assert_raise(ArgumentError) do
       PostWithDefaultScope.find_in_batches() { }
     end
   ensure
     # Set back to default
-    ActiveRecord::Base.error_on_ignored_order = prev
+    ActiveRecord.error_on_ignored_order = prev
   end
 
   def test_find_in_batches_should_not_error_by_default

--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -285,8 +285,8 @@ module ActiveRecord
       end
 
       def test_default_handlers_are_writing_and_reading
-        assert_equal :writing, ActiveRecord::Base.writing_role
-        assert_equal :reading, ActiveRecord::Base.reading_role
+        assert_equal :writing, ActiveRecord.writing_role
+        assert_equal :reading, ActiveRecord.reading_role
       end
 
       if Process.respond_to?(:fork)

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -362,21 +362,21 @@ module ActiveRecord
       end
 
       def test_default_handlers_are_writing_and_reading
-        assert_equal :writing, ActiveRecord::Base.writing_role
-        assert_equal :reading, ActiveRecord::Base.reading_role
+        assert_equal :writing, ActiveRecord.writing_role
+        assert_equal :reading, ActiveRecord.reading_role
       end
 
       def test_an_application_can_change_the_default_handlers
-        old_writing = ActiveRecord::Base.writing_role
-        old_reading = ActiveRecord::Base.reading_role
-        ActiveRecord::Base.writing_role = :default
-        ActiveRecord::Base.reading_role = :readonly
+        old_writing = ActiveRecord.writing_role
+        old_reading = ActiveRecord.reading_role
+        ActiveRecord.writing_role = :default
+        ActiveRecord.reading_role = :readonly
 
-        assert_equal :default, ActiveRecord::Base.writing_role
-        assert_equal :readonly, ActiveRecord::Base.reading_role
+        assert_equal :default, ActiveRecord.writing_role
+        assert_equal :readonly, ActiveRecord.reading_role
       ensure
-        ActiveRecord::Base.writing_role = old_writing
-        ActiveRecord::Base.reading_role = old_reading
+        ActiveRecord.writing_role = old_writing
+        ActiveRecord.reading_role = old_reading
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -448,7 +448,7 @@ module ActiveRecord
             end
           end
         ensure
-          ActiveRecord::Base.application_record_class = nil
+          ActiveRecord.application_record_class = nil
           Object.send(:remove_const, :ApplicationRecord)
           ActiveRecord::Base.establish_connection :arunit
         end

--- a/activerecord/test/cases/connection_adapters/legacy_connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/legacy_connection_handlers_multi_db_test.rb
@@ -424,21 +424,21 @@ module ActiveRecord
       end
 
       def test_default_handlers_are_writing_and_reading
-        assert_equal :writing, ActiveRecord::Base.writing_role
-        assert_equal :reading, ActiveRecord::Base.reading_role
+        assert_equal :writing, ActiveRecord.writing_role
+        assert_equal :reading, ActiveRecord.reading_role
       end
 
       def test_an_application_can_change_the_default_handlers
-        old_writing = ActiveRecord::Base.writing_role
-        old_reading = ActiveRecord::Base.reading_role
-        ActiveRecord::Base.writing_role = :default
-        ActiveRecord::Base.reading_role = :readonly
+        old_writing = ActiveRecord.writing_role
+        old_reading = ActiveRecord.reading_role
+        ActiveRecord.writing_role = :default
+        ActiveRecord.reading_role = :readonly
 
-        assert_equal :default, ActiveRecord::Base.writing_role
-        assert_equal :readonly, ActiveRecord::Base.reading_role
+        assert_equal :default, ActiveRecord.writing_role
+        assert_equal :readonly, ActiveRecord.reading_role
       ensure
-        ActiveRecord::Base.writing_role = old_writing
-        ActiveRecord::Base.reading_role = old_reading
+        ActiveRecord.writing_role = old_writing
+        ActiveRecord.reading_role = old_reading
       end
     end
   end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -90,12 +90,12 @@ end
 def with_timezone_config(cfg)
   verify_default_timezone_config
 
-  old_default_zone = ActiveRecord::Base.default_timezone
+  old_default_zone = ActiveRecord.default_timezone
   old_awareness = ActiveRecord::Base.time_zone_aware_attributes
   old_zone = Time.zone
 
   if cfg.has_key?(:default)
-    ActiveRecord::Base.default_timezone = cfg[:default]
+    ActiveRecord.default_timezone = cfg[:default]
   end
   if cfg.has_key?(:aware_attributes)
     ActiveRecord::Base.time_zone_aware_attributes = cfg[:aware_attributes]
@@ -105,7 +105,7 @@ def with_timezone_config(cfg)
   end
   yield
 ensure
-  ActiveRecord::Base.default_timezone = old_default_zone
+  ActiveRecord.default_timezone = old_default_zone
   ActiveRecord::Base.time_zone_aware_attributes = old_awareness
   Time.zone = old_zone
 end
@@ -123,12 +123,12 @@ def verify_default_timezone_config
       Got: #{Time.zone}
     MSG
   end
-  if ActiveRecord::Base.default_timezone != EXPECTED_DEFAULT_TIMEZONE
+  if ActiveRecord.default_timezone != EXPECTED_DEFAULT_TIMEZONE
     $stderr.puts <<-MSG
 \n#{self}
-    Global state `ActiveRecord::Base.default_timezone` was leaked.
+    Global state `ActiveRecord.default_timezone` was leaked.
       Expected: #{EXPECTED_DEFAULT_TIMEZONE}
-      Got: #{ActiveRecord::Base.default_timezone}
+      Got: #{ActiveRecord.default_timezone}
     MSG
   end
   if ActiveRecord::Base.time_zone_aware_attributes != EXPECTED_TIME_ZONE_AWARE_ATTRIBUTES

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -184,18 +184,18 @@ class LogSubscriberTest < ActiveRecord::TestCase
   end
 
   def test_verbose_query_logs
-    ActiveRecord::Base.verbose_query_logs = true
+    ActiveRecord.verbose_query_logs = true
 
     logger = TestDebugLogSubscriber.new
     logger.sql(Event.new(0, sql: "hi mom!"))
     assert_equal 2, @logger.logged(:debug).size
     assert_match(/↳/, @logger.logged(:debug).last)
   ensure
-    ActiveRecord::Base.verbose_query_logs = false
+    ActiveRecord.verbose_query_logs = false
   end
 
   def test_verbose_query_with_ignored_callstack
-    ActiveRecord::Base.verbose_query_logs = true
+    ActiveRecord.verbose_query_logs = true
 
     logger = TestDebugLogSubscriber.new
     def logger.extract_query_source_location(*); nil; end
@@ -204,7 +204,7 @@ class LogSubscriberTest < ActiveRecord::TestCase
     assert_equal 1, @logger.logged(:debug).size
     assert_no_match(/↳/, @logger.logged(:debug).last)
   ensure
-    ActiveRecord::Base.verbose_query_logs = false
+    ActiveRecord.verbose_query_logs = false
   end
 
   def test_verbose_query_logs_disabled_by_default

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1396,13 +1396,13 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   end
 
   def clear
-    ActiveRecord::Base.timestamped_migrations = true
+    ActiveRecord.timestamped_migrations = true
     to_delete = Dir[@migrations_path + "/*.rb"] - @existing_migrations
     File.delete(*to_delete)
   end
 
   def test_copying_migrations_without_timestamps
-    ActiveRecord::Base.timestamped_migrations = false
+    ActiveRecord.timestamped_migrations = false
     @migrations_path = MIGRATIONS_ROOT + "/valid"
     @existing_migrations = Dir[@migrations_path + "/*.rb"]
 
@@ -1423,7 +1423,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   end
 
   def test_copying_migrations_without_timestamps_from_2_sources
-    ActiveRecord::Base.timestamped_migrations = false
+    ActiveRecord.timestamped_migrations = false
     @migrations_path = MIGRATIONS_ROOT + "/valid"
     @existing_migrations = Dir[@migrations_path + "/*.rb"]
 
@@ -1507,7 +1507,7 @@ class CopyMigrationsTest < ActiveRecord::TestCase
   end
 
   def test_copying_migrations_preserving_magic_comments
-    ActiveRecord::Base.timestamped_migrations = false
+    ActiveRecord.timestamped_migrations = false
     @migrations_path = MIGRATIONS_ROOT + "/valid"
     @existing_migrations = Dir[@migrations_path + "/*.rb"]
 

--- a/activerecord/test/cases/primary_class_test.rb
+++ b/activerecord/test/cases/primary_class_test.rb
@@ -27,7 +27,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
     assert_predicate ApplicationRecord, :application_record_class?
     assert_predicate ApplicationRecord, :abstract_class?
   ensure
-    ActiveRecord::Base.application_record_class = nil
+    ActiveRecord.application_record_class = nil
     Object.send(:remove_const, :ApplicationRecord)
   end
 
@@ -46,7 +46,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
     assert_not_predicate ActiveRecord::Base, :application_record_class?
     assert_not_predicate ActiveRecord::Base, :abstract_class?
   ensure
-    ActiveRecord::Base.application_record_class = nil
+    ActiveRecord.application_record_class = nil
   end
 
   def test_primary_abstract_class_cannot_be_reset
@@ -56,7 +56,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
       PrimaryClassTest::AnotherAppRecord.primary_abstract_class
     end
   ensure
-    ActiveRecord::Base.application_record_class = nil
+    ActiveRecord.application_record_class = nil
   end
 
   def test_primary_abstract_class_is_used_over_application_record_if_set
@@ -75,7 +75,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
     assert_not_predicate ActiveRecord::Base, :application_record_class?
     assert_not_predicate ActiveRecord::Base, :abstract_class?
   ensure
-    ActiveRecord::Base.application_record_class = nil
+    ActiveRecord.application_record_class = nil
     Object.send(:remove_const, :ApplicationRecord)
   end
 
@@ -96,7 +96,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
     assert_not_predicate ApplicationRecord, :application_record_class?
     assert_predicate ApplicationRecord, :abstract_class?
   ensure
-    ActiveRecord::Base.application_record_class = nil
+    ActiveRecord.application_record_class = nil
     Object.send(:remove_const, :ApplicationRecord)
   end
 
@@ -110,7 +110,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
       assert_predicate ApplicationRecord, :application_record_class?
       assert_equal ActiveRecord::Base.connection, ApplicationRecord.connection
     ensure
-      ActiveRecord::Base.application_record_class = nil
+      ActiveRecord.application_record_class = nil
       Object.send(:remove_const, :ApplicationRecord)
       ActiveRecord::Base.establish_connection :arunit
     end
@@ -125,7 +125,7 @@ class PrimaryClassTest < ActiveRecord::TestCase
       assert_predicate PrimaryClassTest::PrimaryAppRecord, :abstract_class?
       assert_equal ActiveRecord::Base.connection, PrimaryClassTest::PrimaryAppRecord.connection
     ensure
-      ActiveRecord::Base.application_record_class = nil
+      ActiveRecord.application_record_class = nil
       ActiveRecord::Base.establish_connection :arunit
     end
   end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -760,7 +760,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   private
     def with_temporary_connection_pool
-      pool_config = ActiveRecord::Base.connection_handler.send(:owner_to_pool_manager).fetch("ActiveRecord::Base").get_pool_config(ActiveRecord::Base.writing_role, :default)
+      pool_config = ActiveRecord::Base.connection_handler.send(:owner_to_pool_manager).fetch("ActiveRecord::Base").get_pool_config(ActiveRecord.writing_role, :default)
       new_pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(pool_config)
 
       pool_config.stub(:pool, new_pool) do

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -178,13 +178,13 @@ module ActiveRecord
       fixtures :posts, :comments
 
       def setup
-        @old_config = ActiveRecord::Base.async_query_executor
-        ActiveRecord::Base.async_query_executor = nil
+        @old_config = ActiveRecord.async_query_executor
+        ActiveRecord.async_query_executor = nil
         ActiveRecord::Base.establish_connection :arunit
       end
 
       def teardown
-        ActiveRecord::Base.async_query_executor = @old_config
+        ActiveRecord.async_query_executor = @old_config
         ActiveRecord::Base.establish_connection :arunit
       end
 
@@ -302,8 +302,8 @@ module ActiveRecord
       fixtures :posts, :comments
 
       def setup
-        @old_config = ActiveRecord::Base.async_query_executor
-        ActiveRecord::Base.async_query_executor = :multi_thread_pool
+        @old_config = ActiveRecord.async_query_executor
+        ActiveRecord.async_query_executor = :multi_thread_pool
 
         handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
         config_hash1 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash
@@ -319,7 +319,7 @@ module ActiveRecord
       end
 
       def teardown
-        ActiveRecord::Base.async_query_executor = @old_config
+        ActiveRecord.async_query_executor = @old_config
         clean_up_connection_handler
       end
 
@@ -434,8 +434,8 @@ module ActiveRecord
 
       def setup
         @previous_env, ENV["RAILS_ENV"] = ENV["RAILS_ENV"], "default_env"
-        @old_config = ActiveRecord::Base.async_query_executor
-        ActiveRecord::Base.async_query_executor = :multi_thread_pool
+        @old_config = ActiveRecord.async_query_executor
+        ActiveRecord.async_query_executor = :multi_thread_pool
         config_hash1 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary").configuration_hash
         config_hash2 = ActiveRecord::Base.configurations.configs_for(env_name: "arunit2", name: "primary").configuration_hash
         config = {
@@ -453,7 +453,7 @@ module ActiveRecord
       def teardown
         ENV["RAILS_ENV"] = @previous_env
         ActiveRecord::Base.configurations = @prev_configs
-        ActiveRecord::Base.async_query_executor = @old_config
+        ActiveRecord.async_query_executor = @old_config
         clean_up_connection_handler
       end
 

--- a/activerecord/test/cases/relation/record_fetch_warning_test.rb
+++ b/activerecord/test/cases/relation/record_fetch_warning_test.rb
@@ -10,19 +10,19 @@ module ActiveRecord
 
     def setup
       @original_logger = ActiveRecord::Base.logger
-      @original_warn_on_records_fetched_greater_than = ActiveRecord::Base.warn_on_records_fetched_greater_than
+      @original_warn_on_records_fetched_greater_than = ActiveRecord.warn_on_records_fetched_greater_than
       @log = StringIO.new
     end
 
     def teardown
       ActiveRecord::Base.logger = @original_logger
-      ActiveRecord::Base.warn_on_records_fetched_greater_than = @original_warn_on_records_fetched_greater_than
+      ActiveRecord.warn_on_records_fetched_greater_than = @original_warn_on_records_fetched_greater_than
     end
 
     def test_warn_on_records_fetched_greater_than_allowed_limit
       ActiveRecord::Base.logger = ActiveSupport::Logger.new(@log)
       ActiveRecord::Base.logger.level = Logger::WARN
-      ActiveRecord::Base.warn_on_records_fetched_greater_than = 1
+      ActiveRecord.warn_on_records_fetched_greater_than = 1
 
       Post.all.to_a
 
@@ -32,7 +32,7 @@ module ActiveRecord
     def test_does_not_warn_on_records_fetched_less_than_allowed_limit
       ActiveRecord::Base.logger = ActiveSupport::Logger.new(@log)
       ActiveRecord::Base.logger.level = Logger::WARN
-      ActiveRecord::Base.warn_on_records_fetched_greater_than = 100
+      ActiveRecord.warn_on_records_fetched_greater_than = 100
 
       Post.all.to_a
 

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -548,7 +548,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
   end
 
   def test_strict_loading_violation_raises_by_default
-    assert_equal :raise, ActiveRecord::Base.action_on_strict_loading_violation
+    assert_equal :raise, ActiveRecord.action_on_strict_loading_violation
 
     developer = Developer.first
     assert_not_predicate developer, :strict_loading?
@@ -562,9 +562,9 @@ class StrictLoadingTest < ActiveRecord::TestCase
   end
 
   def test_strict_loading_violation_can_log_instead_of_raise
-    old_value = ActiveRecord::Base.action_on_strict_loading_violation
-    ActiveRecord::Base.action_on_strict_loading_violation = :log
-    assert_equal :log, ActiveRecord::Base.action_on_strict_loading_violation
+    old_value = ActiveRecord.action_on_strict_loading_violation
+    ActiveRecord.action_on_strict_loading_violation = :log
+    assert_equal :log, ActiveRecord.action_on_strict_loading_violation
 
     developer = Developer.first
     assert_not_predicate developer, :strict_loading?
@@ -576,7 +576,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
       developer.audit_logs.to_a
     end
   ensure
-    ActiveRecord::Base.action_on_strict_loading_violation = old_value
+    ActiveRecord.action_on_strict_loading_violation = old_value
   end
 
   private

--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -482,11 +482,11 @@ if current_adapter?(:PostgreSQLAdapter)
 
       private
         def with_dump_schemas(value, &block)
-          old_dump_schemas = ActiveRecord::Base.dump_schemas
-          ActiveRecord::Base.dump_schemas = value
+          old_dump_schemas = ActiveRecord.dump_schemas
+          ActiveRecord.dump_schemas = value
           yield
         ensure
-          ActiveRecord::Base.dump_schemas = old_dump_schemas
+          ActiveRecord.dump_schemas = old_dump_schemas
         end
 
         def with_structure_dump_flags(flags)

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -20,7 +20,7 @@ module ARTest
 
   def self.connect
     ActiveRecord.legacy_connection_handling = false
-    ActiveRecord::Base.async_query_executor = :global_thread_pool
+    ActiveRecord.async_query_executor = :global_thread_pool
     puts "Using #{connection_name}"
     ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
     ActiveRecord::Base.configurations = test_configuration_hashes

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -93,7 +93,7 @@ class ActiveStorage::Preview
 
     def process
       previewer.preview(service_name: blob.service_name) do |attachable|
-        ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+        ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role) do
           image.attach(attachable)
         end
       end

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -41,7 +41,7 @@ class ActiveStorage::VariantWithRecord
 
     def create_or_find_record(image:)
       @record =
-        ActiveRecord::Base.connected_to(role: ActiveRecord::Base.writing_role) do
+        ActiveRecord::Base.connected_to(role: ActiveRecord.writing_role) do
           blob.variant_records.create_or_find_by!(variation_digest: variation.digest) do |record|
             record.image.attach(image)
           end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2384,7 +2384,7 @@ module ApplicationTests
     test "active record job queue is set" do
       app "development"
 
-      assert_equal ActiveSupport::InheritableOptions.new(destroy: :active_record_destroy), ActiveRecord::Base.queues
+      assert_equal ActiveSupport::InheritableOptions.new(destroy: :active_record_destroy), ActiveRecord.queues
     end
 
     test "destroy association async job should be loaded in configs" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1660,13 +1660,13 @@ module ApplicationTests
 
       app "production"
 
-      assert_not ActiveRecord::Base.dump_schema_after_migration
+      assert_not ActiveRecord.dump_schema_after_migration
     end
 
     test "config.active_record.dump_schema_after_migration is true by default in development" do
       app "development"
 
-      assert ActiveRecord::Base.dump_schema_after_migration
+      assert ActiveRecord.dump_schema_after_migration
     end
 
     test "config.active_record.verbose_query_logs is false by default in development" do
@@ -1677,7 +1677,7 @@ module ApplicationTests
 
     test "config.active_record.suppress_multiple_database_warning is false by default in development" do
       app "development"
-      assert_not ActiveRecord::Base.suppress_multiple_database_warning
+      assert_not ActiveRecord.suppress_multiple_database_warning
     end
 
     test "config.annotations wrapping SourceAnnotationExtractor::Annotation class" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1672,7 +1672,7 @@ module ApplicationTests
     test "config.active_record.verbose_query_logs is false by default in development" do
       app "development"
 
-      assert_not ActiveRecord::Base.verbose_query_logs
+      assert_not ActiveRecord.verbose_query_logs
     end
 
     test "config.active_record.suppress_multiple_database_warning is false by default in development" do

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3142,14 +3142,6 @@ module ApplicationTests
       assert_equal false, ActionDispatch::Request.return_only_media_type_on_content_type
     end
 
-    test "config.active_record.sqlite3_production_warning is on by default for new apps" do
-      restore_sqlite3_warning
-
-      app "development"
-
-      assert_equal true, ActiveRecord::Base.sqlite3_production_warning
-    end
-
     test "logs a warning when running SQLite3 in production" do
       restore_sqlite3_warning
       app_file "config/initializers/active_record.rb", <<~RUBY

--- a/railties/test/application/initializers/notifications_test.rb
+++ b/railties/test/application/initializers/notifications_test.rb
@@ -32,7 +32,7 @@ module ApplicationTests
 
       logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
       ActiveRecord::Base.logger = logger
-      ActiveRecord::Base.verbose_query_logs = false
+      ActiveRecord.verbose_query_logs = false
 
       # Mimic Active Record notifications
       instrument "sql.active_record", name: "SQL", sql: "SHOW tables"

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -274,14 +274,14 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_migration_without_timestamps
-    ActiveRecord::Base.timestamped_migrations = false
+    ActiveRecord.timestamped_migrations = false
     run_generator ["account"]
     assert_file "db/migrate/001_create_accounts.rb", /class CreateAccounts < ActiveRecord::Migration\[[0-9.]+\]/
 
     run_generator ["project"]
     assert_file "db/migrate/002_create_projects.rb", /class CreateProjects < ActiveRecord::Migration\[[0-9.]+\]/
   ensure
-    ActiveRecord::Base.timestamped_migrations = true
+    ActiveRecord.timestamped_migrations = true
   end
 
   def test_migration_with_configured_path

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -203,7 +203,7 @@ module RailtiesTest
         load "rails/tasks/engine.rake"
       RUBY
 
-      add_to_config "ActiveRecord::Base.timestamped_migrations = false"
+      add_to_config "ActiveRecord.timestamped_migrations = false"
 
       boot_rails
 


### PR DESCRIPTION
See https://github.com/rails/rails/pull/42442 for full context.

In short class variables are slow, particularly in classes with many ancestors, and `ActiveRecord::Base` has over 60 ancestors. 

Only a small handful of these really matter performance wise, however the idea is to migrate them all regardless for consistency and to ensure future contributors will follow the new pattern rather than add new `mattr`.

There are a few more in various Active Record concerns, I'll clean them up in a followup.

I'm opening mostly to get a green CI as the general principle was agreed by others.