### PR TITLE
Fix hot-path raising in ActionDispatch::Static

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -137,11 +137,8 @@ module ActionDispatch
       end
 
       def file_readable?(path)
-        file_stat = File.stat(File.join(@root, path.b))
-      rescue SystemCallError
-        false
-      else
-        file_stat.file? && file_stat.readable?
+        file_path = File.join(@root, path.b)
+        File.file?(file_path) && File.readable?(file_path)
       end
 
       def compressible?(content_type)


### PR DESCRIPTION
Using File.stat where a file does not exist raises an exception.

Since ActionDispatch::Static does this:

```ruby
def call(env)
  @file_handler.attempt(env) || @app.call(env)
end
```

... this means that around 8 exceptions are raised and rescued on each
request which is passed to the application.

This change improves latency by ~.14 milliseconds on all applications.

This is a partial revert of #37265.

Before (rack-mini-profiler's trace-exceptions output show first, then benchmark):

```
Exceptions: (8 total)
  Errno::ENOENT (8)

Backtraces
#1: Errno::ENOENT - "No such file or directory @ rb_file_s_stat - /Users/nateberkopec/Code/upstream/testapp/public/.br"
 etc etc

❯ wrk -c 1 -t 1 http://localhost:3000
Running 10s test @ http://localhost:3000
  1 threads and 1 connections
connection 0: 4227 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.40ms  835.49us  18.77ms   96.07%
    Req/Sec   423.76     44.41   470.00     89.00%
  4227 requests in 10.02s, 2.97MB read
```

After:

```
Exceptions raised during request

No exceptions raised

❯ wrk -c 1 -t 1 http://localhost:3000
Running 10s test @ http://localhost:3000
  1 threads and 1 connections
connection 0: 4565 requests completed
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.26ms    1.16ms  25.38ms   96.78%
    Req/Sec   458.00     57.43   555.00     64.00%
  4565 requests in 10.01s, 3.21MB read

```

Thanks to my client Gusto for sponsoring work on this PR 🎉 

