### PR TITLE
Fix disable_joins when join foreign key is not ID

### DIFF
--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -16,7 +16,8 @@ module ActiveRecord
 
       private
         def last_scope_chain(reverse_chain, owner)
-          first_scope = [reverse_chain.shift, false, [owner.id]]
+          first_item = reverse_chain.shift
+          first_scope = [first_item, false, [owner._read_attribute(first_item.join_foreign_key)]]
 
           reverse_chain.inject(first_scope) do |(reflection, ordered, join_ids), next_reflection|
             key = reflection.join_primary_key

--- a/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
@@ -4,9 +4,13 @@ require "cases/helper"
 require "models/member"
 require "models/member_detail"
 require "models/organization"
+require "models/project"
+require "models/developer"
+require "models/company"
+require "models/computer"
 
 class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
-  fixtures :members, :organizations
+  fixtures :members, :organizations, :projects, :developers, :companies
 
   def setup
     @member = members(:groucho)
@@ -39,5 +43,22 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
     members = Member.preload(:organization, :organization_without_joins).to_a
     assert_no_queries { members[0].organization }
     assert_no_queries { members[0].organization_without_joins }
+  end
+
+  def test_has_one_through_with_belongs_to_on_disable_joins
+    firm = Firm.create!(name: "Adequate Holdings")
+    project = Project.create!(name: "Project 1", firm: firm)
+    Developer.create!(name: "Gorbypuff", firm: firm)
+
+    joins = capture_sql { project.lead_developer }
+    no_joins = capture_sql { project.lead_developer_disable_joins }
+
+    assert_equal project.lead_developer, project.lead_developer_disable_joins
+    assert_equal 2, no_joins.count
+    assert_equal 1, joins.count
+    assert_match(/INNER JOIN/, joins.first)
+    no_joins.each do |nj|
+      assert_no_match(/INNER JOIN/, nj)
+    end
   end
 end

--- a/activerecord/test/models/project.rb
+++ b/activerecord/test/models/project.rb
@@ -16,6 +16,7 @@ class Project < ActiveRecord::Base
   has_and_belongs_to_many :well_paid_salary_groups, -> { group("developers.salary").having("SUM(salary) > 10000").select("SUM(salary) as salary") }, class_name: "Developer"
   belongs_to :firm
   has_one :lead_developer, through: :firm, inverse_of: :contracted_projects
+  has_one :lead_developer_disable_joins, through: :firm, inverse_of: :contracted_projects, source: :lead_developer, disable_joins: true
 
   begin
     previous_value, ActiveRecord::Base.belongs_to_required_by_default =


### PR DESCRIPTION
If you have a `has_one through` association where the `through` has a
`belongs_to` the foreign key won't be `id` for the joins. This change
ensures we use the correct foreign key when querying with disable joins
turned off. Prior to this change the call to `project.lead_developer`
would return `nil` if `disable_joins` was set.

Project has one lead developer through firm. Project also belongs to
firm. So when we call `project.lead_developer` it needs to find the
lead developer through the firm. In these cases we don't want to read
the owners id, we want to read the attribute that will give us the
value of the first chain item's `join_foreign_key`.
