### PR TITLE
Disable automatic write protection on replicas

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Disable automatic write protection on replicas.
+
+    Write protection is no longer automatically enabled for replicas. Write protection should be enabled by the database user settings.
+
+    *Adam Hess*
+
 *   The MySQL adapter now cast numbers and booleans bind parameters to to string for safety reasons.
 
     When comparing a string and a number in a query, MySQL convert the string to a number. So for
@@ -6,7 +12,7 @@
 
     Active Record already protect against that vulnerability when it knows the type of the column
     being compared, however until now it was still vulnerable when using bind parameters:
-    
+
     ```ruby
     User.where("login_token = ?", 0).first
     ```

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -131,15 +131,12 @@ module ActiveRecord
 
       # Determines whether writes are currently being prevented.
       #
-      # Returns true if the connection is a replica.
-      #
       # If the application is using legacy handling, returns
       # true if +connection_handler.prevent_writes+ is set.
       #
       # If the application is using the new connection handling
       # will return true based on +current_preventing_writes+.
       def preventing_writes?
-        return true if replica?
         return ActiveRecord::Base.connection_handler.prevent_writes if ActiveRecord.legacy_connection_handling
         return false if connection_klass.nil?
 

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -184,8 +184,6 @@ module ActiveRecord
         raise NotImplementedError, "connected_to_many can only be called on ActiveRecord::Base."
       end
 
-      prevent_writes = true if role == ActiveRecord.reading_role
-
       connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes }
       yield
     ensure
@@ -203,8 +201,6 @@ module ActiveRecord
       if ActiveRecord.legacy_connection_handling
         raise NotImplementedError, "`connecting_to` is not available with `legacy_connection_handling`."
       end
-
-      prevent_writes = true if role == ActiveRecord.reading_role
 
       self.connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self] }
     end
@@ -356,8 +352,6 @@ module ActiveRecord
       end
 
       def with_role_and_shard(role, shard, prevent_writes)
-        prevent_writes = true if role == ActiveRecord.reading_role
-
         if ActiveRecord.legacy_connection_handling
           with_handler(role.to_sym) do
             connection_handler.while_preventing_writes(prevent_writes) do

--- a/activerecord/lib/active_record/middleware/database_selector/resolver.rb
+++ b/activerecord/lib/active_record/middleware/database_selector/resolver.rb
@@ -58,7 +58,7 @@ module ActiveRecord
           end
 
           def read_from_replica(&blk)
-            ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role, prevent_writes: true) do
+            ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role) do
               instrumenter.instrument("database_selector.active_record.read_from_replica") do
                 yield
               end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1721,7 +1721,7 @@ class BasicsTest < ActiveRecord::TestCase
     SecondAbstractClass.connecting_to(role: :reading)
 
     assert SecondAbstractClass.connected_to?(role: :reading)
-    assert SecondAbstractClass.current_preventing_writes
+    assert_not SecondAbstractClass.current_preventing_writes
   ensure
     ActiveRecord::Base.connected_to_stack.pop
   end
@@ -1777,24 +1777,24 @@ class BasicsTest < ActiveRecord::TestCase
     end
   end
 
-  test "#connected_to_many sets prevent_writes if role is reading" do
+  test "#connected_to_many does not sets prevent_writes if role is reading" do
     ActiveRecord::Base.connected_to_many([SecondAbstractClass], role: :reading) do
-      assert SecondAbstractClass.current_preventing_writes
+      assert_not SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
 
-  test "#connected_to_many with a single argument for classes" do
+  test "#connected_to_many with a single argument for classes does not set prevent_writes" do
     ActiveRecord::Base.connected_to_many(SecondAbstractClass, role: :reading) do
-      assert SecondAbstractClass.current_preventing_writes
+      assert_not SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end
 
-  test "#connected_to_many with a multiple classes without brackets works" do
+  test "#connected_to_many with a multiple classes without brackets does not prevent_writes" do
     ActiveRecord::Base.connected_to_many(FirstAbstractClass, SecondAbstractClass, role: :reading) do
-      assert FirstAbstractClass.current_preventing_writes
-      assert SecondAbstractClass.current_preventing_writes
+      assert_not FirstAbstractClass.current_preventing_writes
+      assert_not SecondAbstractClass.current_preventing_writes
       assert_not ActiveRecord::Base.current_preventing_writes
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_multi_db_test.rb
@@ -130,7 +130,7 @@ module ActiveRecord
             assert_equal :reading, ActiveRecord::Base.current_role
             assert ActiveRecord::Base.connected_to?(role: :reading)
             assert_not ActiveRecord::Base.connected_to?(role: :writing)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing) do

--- a/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handlers_sharding_db_test.rb
@@ -135,7 +135,7 @@ module ActiveRecord
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
             assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
@@ -153,7 +153,7 @@ module ActiveRecord
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
             assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :default)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing, shard: :shard_one) do

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -391,23 +391,23 @@ module ActiveRecord
 
             # Switch only primary to reading
             PrimaryBase.connected_to(role: :reading) do
-              assert_predicate PrimaryBase.connection, :preventing_writes?
+              assert_not_predicate PrimaryBase.connection, :preventing_writes?
               assert_not_predicate SecondaryBase.connection, :preventing_writes?
 
               # Switch global to reading
               ActiveRecord::Base.connected_to(role: :reading) do
-                assert_predicate PrimaryBase.connection, :preventing_writes?
-                assert_predicate SecondaryBase.connection, :preventing_writes?
+                assert_not_predicate PrimaryBase.connection, :preventing_writes?
+                assert_not_predicate SecondaryBase.connection, :preventing_writes?
 
                 # Switch only secondary to writing
                 SecondaryBase.connected_to(role: :writing) do
-                  assert_predicate PrimaryBase.connection, :preventing_writes?
+                  assert_not_predicate PrimaryBase.connection, :preventing_writes?
                   assert_not_predicate SecondaryBase.connection, :preventing_writes?
                 end
 
                 # Ensure restored to global reading
-                assert_predicate PrimaryBase.connection, :preventing_writes?
-                assert_predicate SecondaryBase.connection, :preventing_writes?
+                assert_not_predicate PrimaryBase.connection, :preventing_writes?
+                assert_not_predicate SecondaryBase.connection, :preventing_writes?
               end
 
               # Switch everything to writing
@@ -416,7 +416,7 @@ module ActiveRecord
                 assert_not_predicate SecondaryBase.connection, :preventing_writes?
               end
 
-              assert_predicate PrimaryBase.connection, :preventing_writes?
+              assert_not_predicate PrimaryBase.connection, :preventing_writes?
               assert_not_predicate SecondaryBase.connection, :preventing_writes?
             end
 
@@ -444,7 +444,7 @@ module ActiveRecord
             assert_not_predicate ApplicationRecord.connection, :preventing_writes?
 
             ApplicationRecord.connected_to(role: :reading) do
-              assert_predicate ApplicationRecord.connection, :preventing_writes?
+              assert_not_predicate ApplicationRecord.connection, :preventing_writes?
             end
           end
         ensure

--- a/activerecord/test/cases/connection_adapters/legacy_connection_handlers_multi_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/legacy_connection_handlers_multi_db_test.rb
@@ -146,7 +146,7 @@ module ActiveRecord
             assert_equal :reading, ActiveRecord::Base.current_role
             assert ActiveRecord::Base.connected_to?(role: :reading)
             assert_not ActiveRecord::Base.connected_to?(role: :writing)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing) do

--- a/activerecord/test/cases/connection_adapters/legacy_connection_handlers_sharding_db_test.rb
+++ b/activerecord/test/cases/connection_adapters/legacy_connection_handlers_sharding_db_test.rb
@@ -150,7 +150,7 @@ module ActiveRecord
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
             assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :shard_one)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing, shard: :default) do
@@ -172,7 +172,7 @@ module ActiveRecord
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :shard_one)
             assert_not ActiveRecord::Base.connected_to?(role: :writing, shard: :default)
             assert_not ActiveRecord::Base.connected_to?(role: :reading, shard: :default)
-            assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+            assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
           end
 
           ActiveRecord::Base.connected_to(role: :writing, shard: :shard_one) do

--- a/activerecord/test/cases/database_selector_test.rb
+++ b/activerecord/test/cases/database_selector_test.rb
@@ -62,7 +62,7 @@ module ActiveRecord
           called = true
 
           assert ActiveRecord::Base.connected_to?(role: :reading)
-          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
 
           ActiveRecord::Base.connected_to(role: :writing, prevent_writes: false) do
             assert ActiveRecord::Base.connected_to?(role: :writing)
@@ -70,7 +70,7 @@ module ActiveRecord
           end
 
           assert ActiveRecord::Base.connected_to?(role: :reading)
-          assert_predicate ActiveRecord::Base.connection, :preventing_writes?
+          assert_not_predicate ActiveRecord::Base.connection, :preventing_writes?
         end
         assert called
       end


### PR DESCRIPTION
This allows users to use write protection if they want, but no longer treats it as a catch all. Write protection is not accurate enough to classify all cases correctly. Instead users should configure their replicas to not allow writes and rely on the database erroring if the query is not allowed.


Alternative solution for: https://github.com/rails/rails/issues/42432
Fixes: https://github.com/rails/rails/issues/42432