### PR TITLE
Get rid of `cattr_accessor` in `ActiveRecord::Base`

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -222,6 +222,9 @@ module ActiveRecord
     @global_executor_concurrency ||= nil
   end
 
+  singleton_class.attr_accessor :index_nested_attribute_errors
+  self.index_nested_attribute_errors = false
+
   ##
   # :singleton-method:
   #

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -63,8 +63,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       included do
-        mattr_accessor :time_zone_aware_attributes, instance_writer: false, default: false
-
+        class_attribute :time_zone_aware_attributes, instance_writer: false, default: false
         class_attribute :skip_time_zone_conversion_for_attributes, instance_writer: false, default: []
         class_attribute :time_zone_aware_types, instance_writer: false, default: [ :datetime, :time ]
       end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -150,7 +150,6 @@ module ActiveRecord
 
     included do
       Associations::Builder::Association.extensions << AssociationBuilderExtension
-      mattr_accessor :index_nested_attribute_errors, instance_writer: false, default: false
     end
 
     module ClassMethods # :nodoc:
@@ -335,7 +334,7 @@ module ActiveRecord
 
         unless valid = record.valid?(context)
           if reflection.options[:autosave]
-            indexed_attribute = !index.nil? && (reflection.options[:index_errors] || ActiveRecord::Base.index_nested_attribute_errors)
+            indexed_attribute = !index.nil? && (reflection.options[:index_errors] || ActiveRecord.index_nested_attribute_errors)
 
             record.errors.group_by_attribute.each { |attribute, errors|
               attribute = normalize_reflection_attribute(indexed_attribute, reflection, index, attribute)

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -127,8 +127,7 @@ module ActiveRecord
     # <tt>attribute :foo, :string</tt>. Defaults to false.
 
     included do
-      mattr_accessor :primary_key_prefix_type, instance_writer: false
-
+      class_attribute :primary_key_prefix_type, instance_writer: false
       class_attribute :table_name_prefix, instance_writer: false, default: ""
       class_attribute :table_name_suffix, instance_writer: false, default: ""
       class_attribute :schema_migrations_table_name, instance_accessor: false, default: "schema_migrations"

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -10,7 +10,7 @@ module ActiveRecord
       # :singleton-method:
       # Set the secret used for the signed id verifier instance when using Active Record outside of Rails.
       # Within Rails, this is automatically set using the Rails application key generator.
-      mattr_accessor :signed_id_verifier_secret, instance_writer: false
+      class_attribute :signed_id_verifier_secret, instance_writer: false
     end
 
     module ClassMethods

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -512,8 +512,8 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
   end
 
   def test_errors_should_be_indexed_when_global_flag_is_set
-    old_attribute_config = ActiveRecord::Base.index_nested_attribute_errors
-    ActiveRecord::Base.index_nested_attribute_errors = true
+    old_attribute_config = ActiveRecord.index_nested_attribute_errors
+    ActiveRecord.index_nested_attribute_errors = true
 
     molecule = Molecule.new
     valid_electron = Electron.new(name: "electron")
@@ -527,7 +527,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal ["can't be blank"], molecule.errors["electrons[1].name"]
     assert_not_equal ["can't be blank"], molecule.errors["electrons.name"]
   ensure
-    ActiveRecord::Base.index_nested_attribute_errors = old_attribute_config
+    ActiveRecord.index_nested_attribute_errors = old_attribute_config
   end
 
   def test_errors_details_should_be_set
@@ -559,8 +559,8 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
   end
 
   def test_errors_details_should_be_indexed_when_global_flag_is_set
-    old_attribute_config = ActiveRecord::Base.index_nested_attribute_errors
-    ActiveRecord::Base.index_nested_attribute_errors = true
+    old_attribute_config = ActiveRecord.index_nested_attribute_errors
+    ActiveRecord.index_nested_attribute_errors = true
 
     molecule = Molecule.new
     valid_electron = Electron.new(name: "electron")
@@ -574,7 +574,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttrib
     assert_equal [{ error: :blank }], molecule.errors.details[:"electrons[1].name"]
     assert_equal [], molecule.errors.details[:"electrons.name"]
   ensure
-    ActiveRecord::Base.index_nested_attribute_errors = old_attribute_config
+    ActiveRecord.index_nested_attribute_errors = old_attribute_config
   end
 
   def test_valid_adding_with_nested_attributes


### PR DESCRIPTION
See https://github.com/rails/rails/pull/42442 for full context.

In short class variables are slow, particularly in classes with many ancestors, and `ActiveRecord::Base` has over 60 ancestors. 

Only a small handful of these really matter performance wise, however the idea is to migrate them all regardless for consistency and to ensure future contributors will follow the new pattern rather than add new `mattr/cattr`.

This should be the last ones in `ActiveRecord::Base`. There are others in other Active Record classes, but since they don't have large ancestor chains, it doesn't matter much.

I'll look at other classes with large ancestors chains instead (`ActionController::Base` ?)