### PR TITLE
Respect the `dependent: :destroy_async` when replacing the association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Respect the `dependent: :destroy_async` when replacing the association.
+
+    *Maciej Małecki*
+
 *   Move the forcing of clear text encoding to the `ActiveRecord::Encryption::Encryptor`.
 
     Fixes #42699.


### PR DESCRIPTION
See https://github.com/rails/rails/issues/42430

There are two ways for deleting an associated record:

  1. by deleting it explicitly (i.e. `parent.has_many.first.destroy!`),
  2. by replacing the association (i.e. `parent.has_many = []`).

Previously, Active Record respected the asynchronous deletion only with
the first approach. When replacing the association, it just detached the
record(s) from the parent without removing them from the database (via
enqueuing relevant background job).

Make the dependent option consistent and cleanup records from the
database even when removing them via replacing the association.

Fixes #42430