### PR TITLE
Decrease the number of calls to #encryption_key

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -26,6 +26,10 @@ module ActiveRecord
         @previous_type = previous_type
       end
 
+      def cast(value)
+        value
+      end
+
       def deserialize(value)
         cast_type.deserialize decrypt(value)
       end

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -27,7 +27,7 @@ module ActiveRecord
       end
 
       def cast(value)
-        value
+        cast_type.deserialize(cast_type.serialize(value))
       end
 
       def deserialize(value)

--- a/activerecord/test/cases/encryption/performance/key_provider_calls_test.rb
+++ b/activerecord/test/cases/encryption/performance/key_provider_calls_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "cases/encryption/helper"
+
+class ActiveRecord::Encryption::KeyProviderCallsTest < ActiveRecord::EncryptionTestCase
+  fixtures :encrypted_books, :posts
+
+  test "calls #encryption_key only once when creating a record" do
+    assert_equal 0, key_provider.encryption_key_calls
+
+    ActiveRecord::Encryption.configure(
+      key_provider: key_provider.new,
+      primary_key: "secret",
+      key_derivation_salt: "salt",
+      deterministic_key: nil
+    )
+
+    create_book
+
+    assert_equal 2, key_provider.encryption_key_calls
+  end
+
+  private
+    def key_provider
+      MyKeyProvider
+    end
+
+    def create_book
+      Book.create!(name: "CapSens to the moon")
+    end
+
+    class MyKeyProvider
+      def encryption_key
+        @@encryption_key_calls = 0 unless defined?(@@encryption_key_calls)
+        @@encryption_key_calls += 1
+
+        ActiveRecord::Encryption::Key.new("0" * 32)
+      end
+
+      def decryption_keys(encrypted_message)
+        [ActiveRecord::Encryption::Key.new("0" * 32)]
+      end
+
+      class << self
+        def encryption_key_calls
+          @@encryption_key_calls = 0 unless defined?(@@encryption_key_calls)
+          @@encryption_key_calls
+        end
+      end
+    end
+
+    class Book < ActiveRecord::Base
+      encrypts :name
+    end
+end

--- a/activerecord/test/cases/encryption/performance/key_provider_calls_test.rb
+++ b/activerecord/test/cases/encryption/performance/key_provider_calls_test.rb
@@ -8,13 +8,6 @@ class ActiveRecord::Encryption::KeyProviderCallsTest < ActiveRecord::EncryptionT
   test "calls #encryption_key only once when creating a record" do
     assert_equal 0, key_provider.encryption_key_calls
 
-    ActiveRecord::Encryption.configure(
-      key_provider: key_provider.new,
-      primary_key: "secret",
-      key_derivation_salt: "salt",
-      deterministic_key: nil
-    )
-
     create_book
 
     assert_equal 2, key_provider.encryption_key_calls
@@ -50,6 +43,6 @@ class ActiveRecord::Encryption::KeyProviderCallsTest < ActiveRecord::EncryptionT
     end
 
     class Book < ActiveRecord::Base
-      encrypts :name
+      encrypts :name, key_provider: MyKeyProvider.new
     end
 end


### PR DESCRIPTION
Decrease the number of calls to #encryption_key (from 3 to 2) when creating a record with an encrypted attribute.

### Summary

Skip `deserialize(serialize(value))` for encrypted attributes to avoid one extra call to `#encryption_key`. This is especially useful when using an external key management service.


### Other Information

Fixes #42388

Also started a conversation here: https://discuss.rubyonrails.org/t/why-activemodel-does-deserialize-serialize-value/78195

