### PR TITLE
make Model.find_by! error consistent

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -334,7 +334,7 @@ module ActiveRecord
       end
 
       def find_by!(*args) # :nodoc:
-        find_by(*args) || raise(RecordNotFound.new("Couldn't find #{name}", name))
+        find_by(*args) || where(*args).raise_record_not_found_exception!
       end
 
       def default_timezone # :nodoc:

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1648,9 +1648,11 @@ class FinderTest < ActiveRecord::TestCase
   end
 
   test "find_by! raises RecordNotFound if the record is missing" do
-    assert_raises(ActiveRecord::RecordNotFound) do
+    error = assert_raises(ActiveRecord::RecordNotFound) do
       Post.find_by!("1 = 0")
     end
+
+    assert_equal "Couldn't find Post with [WHERE (1 = 0)]", error.message
   end
 
   test "find on a scope does not perform statement caching" do


### PR DESCRIPTION
### Summary

Previously, Model.find_by! provided less information in its error
message than similar queries:

```ruby
User.find_by!(id: 'bad') rescue puts $!.message
# => Couldn't find User
Project.last.users.find_by!(id: 'bad') rescue puts $!.message
# => Couldn't find User with [WHERE "users"."project_id" = $1 AND "users"."id" = $2]
User.where(id: 'bad').take! rescue puts $!.message
# => Couldn't find User with [WHERE "users"."id" = $1]
```

This changes the error message for Model.find_by! to add the additional info
the other errors have, making it more consistent:

```ruby
User.find_by!(id: 'bad') rescue puts $!.message
# => Couldn't find User with [WHERE "users"."id" = $1]
```

### Other Information

Fixes #42439 
