### PR TITLE
Fix ActiveStorage duplicating blobs when replace_on_assign_to_many flag disabled

### DIFF
--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -27,7 +27,7 @@ module ActiveStorage
 
     # Returns all attached blobs.
     def blobs
-      change.present? ? change.blobs : record.public_send("#{name}_blobs")
+      change.present? ? change.attachables : record.public_send("#{name}_blobs")
     end
 
     # Attaches one or more +attachables+ to the record.

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -147,7 +147,7 @@ module ActiveStorage
             else
               if Array(attachables).any?
                 attachment_changes["#{name}"] =
-                  ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs + attachables)
+                  ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs | attachables)
               end
             end
           end

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -759,6 +759,39 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "should attach two files when replace_on_assign_to_many is disabled with association setter and attach helper method" do
+    append_on_assign do
+      user = User.new(name: "Tina", highlights: [fixture_file_upload("image.gif")])
+      user.highlights.attach fixture_file_upload("racecar.jpg")
+      user.save
+
+      user.reload
+      assert_equal 2, user.highlights.count
+      assert_equal "image.gif", user.highlights.first.filename.to_s
+      assert_equal "racecar.jpg", user.highlights.second.filename.to_s
+      assert ActiveStorage::Blob.service.exist?(user.highlights.first.key)
+      assert ActiveStorage::Blob.service.exist?(user.highlights.second.key)
+    end
+  end
+
+  test "should attach three files when replace_on_assign_to_many is disabled with association setter method" do
+    append_on_assign do
+      user = User.new(name: "Tina", highlights: [fixture_file_upload("image.gif")])
+      user.highlights = [fixture_file_upload("racecar.jpg")]
+      user.highlights = [fixture_file_upload("report.pdf")]
+      user.save
+
+      user.reload
+      assert_equal 3, user.highlights.count
+      assert_equal "image.gif", user.highlights.first.filename.to_s
+      assert_equal "racecar.jpg", user.highlights.second.filename.to_s
+      assert_equal "report.pdf", user.highlights.third.filename.to_s
+      assert ActiveStorage::Blob.service.exist?(user.highlights.first.key)
+      assert ActiveStorage::Blob.service.exist?(user.highlights.second.key)
+      assert ActiveStorage::Blob.service.exist?(user.highlights.third.key)
+    end
+  end
+
   private
     def append_on_assign
       ActiveStorage.replace_on_assign_to_many, previous = false, ActiveStorage.replace_on_assign_to_many


### PR DESCRIPTION
Fixes #40827

In this scenario, Active Storage assigned blobs in two different
ways. First, using the association setter method and next using
Active Storage `attach`. When `replace_on_assign_to_many` was
disabled, the un-persisted blobs was attached alongs with
attachable array consisting old and new blob.

This PR attempts to fix the issue by excluding the un-persisted
blobs while trying above mentioned scenario.

cc/ @santib @zzak