### PR TITLE
[ci skip] Fix inaccurate callback documentation

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -494,7 +494,7 @@ WARNING. When a transaction completes, the `after_commit` or `after_rollback` ca
 
 WARNING. The code executed within `after_commit` or `after_rollback` callbacks is itself not enclosed within a transaction.
 
-WARNING. Using both `after_create_commit` and `after_update_commit` in the same model will only allow the last callback defined to take effect, and will override all others.
+WARNING. Using both `after_create_commit` and `after_update_commit` with the same method name will only allow the last callback defined to take effect, as they both internally alias to `after_commit` which overrides previously defined callbacks with the same method name.
 
 ```ruby
 class User < ApplicationRecord


### PR DESCRIPTION
### Summary

Fixes #42457 

### Other Information

The callback de-deduplication logic currently happens at the time callbacks are set on a model. A fix that would implicitly solve a few issues around de-duping would be to apply the following for all callbacks accepting symbolized method names:

- Rather than front-load de-duplication, have a Set created during the application of each callback (ex: `on_update`) and dynamically de-duplicate invocations of a specific method here. This would implicitly stop duplicate predicate methods from running in the cases of overlapping `if` and `unless` conditions while also allowing for distinct `if` and `unless` conditions to pass in the same symbolized method name for the same callback method.