### PR TITLE
Transform hash keys by a hash argument

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -724,35 +724,39 @@ module ActionController
 
     # Returns a new <tt>ActionController::Parameters</tt> instance with the
     # results of running +block+ once for every key. The values are unchanged.
-    def transform_keys(&block)
-      return to_enum(:transform_keys) unless block_given?
+    # An optional hash argument can be provided to map keys to new keys.
+    def transform_keys(*args, &block)
+      return to_enum(:transform_keys) if args.empty? && !block_given?
       new_instance_with_inherited_permitted_status(
-        @parameters.transform_keys(&block)
+        @parameters.transform_keys(*args, &block)
       )
     end
 
     # Performs keys transformation and returns the altered
     # <tt>ActionController::Parameters</tt> instance.
-    def transform_keys!(&block)
-      return to_enum(:transform_keys!) unless block_given?
-      @parameters.transform_keys!(&block)
+    def transform_keys!(*args, &block)
+      return to_enum(:transform_keys!) if args.empty? && !block_given?
+      @parameters.transform_keys!(*args, &block)
       self
     end
 
     # Returns a new <tt>ActionController::Parameters</tt> instance with the
     # results of running +block+ once for every key. This includes the keys
     # from the root hash and from all nested hashes and arrays. The values are unchanged.
-    def deep_transform_keys(&block)
+    # An optional hash argument can be provided to map keys to new keys.
+    def deep_transform_keys(*args, &block)
+      return to_enum(:deep_transform_keys) if args.empty? && !block_given?
       new_instance_with_inherited_permitted_status(
-        @parameters.deep_transform_keys(&block)
+        @parameters.deep_transform_keys(*args, &block)
       )
     end
 
     # Returns the <tt>ActionController::Parameters</tt> instance changing its keys.
     # This includes the keys from the root hash and from all nested hashes and arrays.
     # The values are unchanged.
-    def deep_transform_keys!(&block)
-      @parameters.deep_transform_keys!(&block)
+    def deep_transform_keys!(*args, &block)
+      return to_enum(:deep_transform_keys!) if args.empty? && !block_given?
+      @parameters.deep_transform_keys!(*args, &block)
       self
     end
 

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -234,6 +234,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.slice(:person), :permitted?
   end
 
+  test "transform_keys returns transformed parameters" do
+    assert_equal ActionController::Parameters.new(
+      user: { age: "32",
+              name: { first: "David", last: "Heinemeier Hansson" },
+              addresses: [{ city: "Chicago", state: "Illinois" }] }
+    ), @params.transform_keys(person: :user)
+  end
+
   test "transform_keys retains permitted status" do
     @params.permit!
     assert_predicate @params.transform_keys { |k| k }, :permitted?
@@ -251,6 +259,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   test "transform_keys! without a block returns an enumerator" do
     assert_kind_of Enumerator, @params.transform_keys!
     assert_kind_of ActionController::Parameters, @params.transform_keys!.each { |k| k }
+  end
+
+  test "deep_transform_keys returns transformed parameters" do
+    assert_equal ActionController::Parameters.new(
+      user: { AGE:       "32",
+              NAME:      { FIRST: "David", LAST: "Heinemeier Hansson" },
+              locations: [{ CITY: "Chicago", STATE: "Illinois" }] }
+    ), @params.deep_transform_keys(person: :user, addresses: :locations) { |k| k.upcase }
   end
 
   test "deep_transform_keys retains permitted status" do

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -101,6 +101,14 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
     assert_not_predicate @params.slice!(:person), :permitted?
   end
 
+  test "transform_keys! returns transformed parameters" do
+    assert_equal ActionController::Parameters.new(
+      user: { age:       "32",
+              name:      { first: "David", last: "Heinemeier Hansson" },
+              addresses: [{ city: "Chicago", state: "Illinois" }] }
+    ), @params.transform_keys!(person: :user)
+  end
+
   test "transform_keys! retains permitted status" do
     @params.permit!
     assert_predicate @params.transform_keys! { |k| k }, :permitted?
@@ -117,6 +125,14 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
 
   test "transform_values! retains unpermitted status" do
     assert_not_predicate @params.transform_values! { |v| v }, :permitted?
+  end
+
+  test "deep_transform_keys! returns transformed parameters" do
+    assert_equal ActionController::Parameters.new(
+      user: { AGE:       "32",
+              NAME:      { FIRST: "David", LAST: "Heinemeier Hansson" },
+              locations: [{ CITY: "Chicago", STATE: "Illinois" }] }
+    ), @params.deep_transform_keys!(person: :user, addresses: :locations) { |k| k.upcase }
   end
 
   test "deep_transform_keys! retains permitted status" do

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -429,6 +429,10 @@ module ActiveSupport
           end
         end
       end
+
+      def _deep_transform_keys_convert_argument(keys_hash)
+        super&.with_indifferent_access
+      end
   end
 end
 

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -57,11 +57,17 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @upcase_array_of_hashes, @string_array_of_hashes.deep_transform_keys { |key| key.to_s.upcase }
     assert_equal @upcase_array_of_hashes, @symbol_array_of_hashes.deep_transform_keys { |key| key.to_s.upcase }
     assert_equal @upcase_array_of_hashes, @mixed_array_of_hashes.deep_transform_keys { |key| key.to_s.upcase }
+
+    assert_equal @nested_strings, @nested_symbols.deep_transform_keys(a: "a", b: "b", c: "c")
+    assert_equal @nested_mixed, @nested_symbols.deep_transform_keys(a: "a", c: "c")
+    assert_equal @nested_symbols, @nested_strings.deep_transform_keys("a" => :a, "b" => :b, "c" => :c)
+    assert_equal @nested_symbols, @nested_symbols.deep_transform_keys(non_existing: "foo", "a" => "bar")
+    assert_equal({ z: { "B" => { "C" => 3 } } }, @nested_symbols.deep_transform_keys(a: :z) { |key| key.to_s.upcase })
   end
 
   def test_deep_transform_keys_not_mutates
     transformed_hash = @nested_mixed.deep_dup
-    transformed_hash.deep_transform_keys { |key| key.to_s.upcase }
+    transformed_hash.deep_transform_keys("a" => :z) { |key| key.to_s.upcase }
     assert_equal @nested_mixed, transformed_hash
   end
 
@@ -72,12 +78,19 @@ class HashExtTest < ActiveSupport::TestCase
     assert_equal @upcase_array_of_hashes, @string_array_of_hashes.deep_dup.deep_transform_keys! { |key| key.to_s.upcase }
     assert_equal @upcase_array_of_hashes, @symbol_array_of_hashes.deep_dup.deep_transform_keys! { |key| key.to_s.upcase }
     assert_equal @upcase_array_of_hashes, @mixed_array_of_hashes.deep_dup.deep_transform_keys! { |key| key.to_s.upcase }
+
+    assert_equal @nested_strings, @nested_symbols.deep_dup.deep_transform_keys!(a: "a", b: "b", c: "c")
+    assert_equal @nested_mixed, @nested_symbols.deep_dup.deep_transform_keys!(a: "a", c: "c")
+    assert_equal @nested_symbols, @nested_strings.deep_dup.deep_transform_keys!("a" => :a, "b" => :b, "c" => :c)
+    assert_equal @nested_symbols, @nested_symbols.deep_dup.deep_transform_keys!(non_existing: "foo")
+    assert_equal({ "z" => { "B" => { "C" => 3 } } },
+                 @nested_symbols.deep_dup.deep_transform_keys!(a: "z") { |key| key.to_s.upcase })
   end
 
   def test_deep_transform_keys_with_bang_mutates
     transformed_hash = @nested_mixed.deep_dup
-    transformed_hash.deep_transform_keys! { |key| key.to_s.upcase }
-    assert_equal @nested_upcase_strings, transformed_hash
+    transformed_hash.deep_transform_keys!("a" => :z) { |key| key.to_s.upcase }
+    assert_equal({ z: { "B" => { "C" => 3 } } }, transformed_hash)
     assert_equal({ "a" => { b: { "c" => 3 } } }, @nested_mixed)
   end
 

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -457,7 +457,20 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of Enumerator, enum
   end
 
-  def test_indifferent_deep_transform_keys
+  def test_indifferent_deep_transform_keys_with_hash
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings).deep_transform_keys("a" => "aa", :b => "bb", "c" => "cc")
+
+    assert_equal({ "aa" => { "bb" => { "cc" => 3 } } }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings).deep_transform_keys("a" => :a, "b" => :b, "c" => :c)
+
+    assert_equal(3, hash[:a][:b][:c])
+    assert_equal(3, hash["a"]["b"]["c"])
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_deep_transform_keys_with_block
     hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings).deep_transform_keys { |k| k * 2 }
 
     assert_equal({ "aa" => { "bb" => { "cc" => 3 } } }, hash)
@@ -467,6 +480,13 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
 
     assert_equal(3, hash[:a][:b][:c])
     assert_equal(3, hash["a"]["b"]["c"])
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_deep_transform_keys_with_hash_and_block
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings).deep_transform_keys("a" => "z") { |k| k * 2 }
+
+    assert_equal({ "z" => { "bb" => { "cc" => 3 } } }, hash)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
@@ -512,7 +532,22 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of Enumerator, enum
   end
 
-  def test_indifferent_deep_transform_keys_bang
+  def test_indifferent_deep_transform_keys_bang_with_hash
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings)
+    hash.deep_transform_keys!("a" => "aa", :b => "bb", "c" => "cc")
+
+    assert_equal({ "aa" => { "bb" => { "cc" => 3 } } }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings)
+    hash.deep_transform_keys!("a" => :a, "b" => :b, "c" => :c)
+
+    assert_equal(3, hash[:a][:b][:c])
+    assert_equal(3, hash["a"]["b"]["c"])
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_deep_transform_keys_bang_with_block
     hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings)
     hash.deep_transform_keys! { |k| k * 2 }
 
@@ -524,6 +559,14 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
 
     assert_equal(3, hash[:a][:b][:c])
     assert_equal(3, hash["a"]["b"]["c"])
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_deep_transform_keys_bang_with_hash_and_block
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@nested_strings)
+    hash.deep_transform_keys!("a" => "z") { |k| k * 2 }
+
+    assert_equal({ "z" => { "bb" => { "cc" => 3 } } }, hash)
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 

--- a/activesupport/test/hash_with_indifferent_access_test.rb
+++ b/activesupport/test/hash_with_indifferent_access_test.rb
@@ -420,7 +420,19 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
   end
 
-  def test_indifferent_transform_keys
+  def test_indifferent_transform_keys_with_hash
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys("a" => "aa", :b => :bb)
+
+    assert_equal({ "aa" => 1, "bb" => 2 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys("non_existing" => "cc")
+
+    assert_equal(@strings, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_transform_keys_with_block
     hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys { |k| k * 2 }
 
     assert_equal({ "aa" => 1, "bb" => 2 }, hash)
@@ -431,6 +443,18 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(1, hash[:a])
     assert_equal(1, hash["a"])
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_transform_keys_with_hash_and_block
+    hash = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys("a" => "z") { |k| k * 2 }
+
+    assert_equal({ "z" => 1, "bb" => 2 }, hash)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
+  end
+
+  def test_indifferent_transform_keys_returns_enumerator
+    enum = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys
+    assert_instance_of Enumerator, enum
   end
 
   def test_indifferent_deep_transform_keys
@@ -446,7 +470,21 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, hash
   end
 
-  def test_indifferent_transform_keys_bang
+  def test_indifferent_transform_keys_bang_with_hash
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.transform_keys!("a" => "aa", :b => :bb)
+
+    assert_equal({ "aa" => 1, "bb" => 2 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.transform_keys!("c" => "cc", :d => :dd)
+
+    assert_equal({ "a" => 1, "b" => 2 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
+  def test_indifferent_transform_keys_bang_with_block
     indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
     indifferent_strings.transform_keys! { |k| k * 2 }
 
@@ -459,6 +497,19 @@ class HashWithIndifferentAccessTest < ActiveSupport::TestCase
     assert_equal(1, indifferent_strings[:a])
     assert_equal(1, indifferent_strings["a"])
     assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
+  def test_indifferent_transform_keys_bang_with_hash_and_block
+    indifferent_strings = ActiveSupport::HashWithIndifferentAccess.new(@strings)
+    indifferent_strings.transform_keys!("a" => "z") { |k| k * 2 }
+
+    assert_equal({ "z" => 1, "bb" => 2 }, indifferent_strings)
+    assert_instance_of ActiveSupport::HashWithIndifferentAccess, indifferent_strings
+  end
+
+  def test_indifferent_transform_keys_bang_returns_enumerator
+    enum = ActiveSupport::HashWithIndifferentAccess.new(@strings).transform_keys!
+    assert_instance_of Enumerator, enum
   end
 
   def test_indifferent_deep_transform_keys_bang


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
Ruby 3.0 has added to the methods `Hash#transform_keys` and `Hash#transform_keys!` the ability to accept an optional hash argument for mapping old keys to new keys:
https://bugs.ruby-lang.org/issues/16274
https://github.com/ruby/ruby/commit/b25e27277dc39f25cfca4db8452d254f6cc8046e
Documentation for the latest version of `Hash#transform_keys`:
https://ruby-doc.org/core-3.0.1/Hash.html#method-i-transform_keys

This PR adds this ability for consistency with native ruby `Hash#transform_keys` to the following methods:

- ActiveSupport::HashWithIndifferentAccess#transform_keys
- ActiveSupport::HashWithIndifferentAccess#transform_keys!
- ActiveSupport::HashWithIndifferentAccess#deep_transform_keys
- ActiveSupport::HashWithIndifferentAccess#deep_transform_keys!
- Hash#deep_transform_keys
- Hash#deep_transform_keys!
- ActionController::Parameters#transform_keys
- ActionController::Parameters#transform_keys!
- ActionController::Parameters#deep_transform_keys
- ActionController::Parameters#deep_transform_keys!

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
In addition, the behavior of `deep_transform_keys` has changed slightly in the case that no argument or block are passed, and the new implementation returns an `Enumerator`. I do not think that this could lead to any breaking changes, because in the current implementation an exception is simply raised when trying to call a non-existent block in the method body.
But this may be slightly irrelevant to the main purpose of this PR. My implementation checks if the block exists before calling it in the method body. If it would not return an enumerator, then it will be necessary to explicitly raise an ArgumentError if no argument or block are passed.