### PR TITLE
Extract methods `assert_queries` and `assert_no_queries`

### DIFF
--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "active_record_unit"
+require "active_record/testing/query_assertions"
 
 class RelationCacheTest < ActionView::TestCase
+  include ActiveRecord::Testing::QueryAssertions
+
   tests ActionView::Helpers::CacheHelper
 
   def setup
@@ -24,17 +27,4 @@ class RelationCacheTest < ActionView::TestCase
   end
 
   def view_cache_dependencies; []; end
-
-  def assert_queries(num)
-    ActiveRecord::Base.connection.materialize_transactions
-    count = 0
-
-    ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
-      count += 1 unless ["SCHEMA", "TRANSACTION"].include? payload[:name]
-    end
-
-    result = yield
-    assert_equal num, count, "#{count} instead of #{num} queries were executed."
-    result
-  end
 end

--- a/activerecord/lib/active_record/testing/query_assertions.rb
+++ b/activerecord/lib/active_record/testing/query_assertions.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Testing
+    module QueryAssertions # :nodoc:
+      def assert_queries(expected_count = 1, options = {})
+        ignore_none = options.fetch(:ignore_none) { expected_count == :any }
+        ActiveRecord::Base.connection.materialize_transactions
+        SQLCounter.clear_log
+        result = yield
+        the_log = ignore_none ? SQLCounter.log_all : SQLCounter.log
+
+        if expected_count == :any
+          assert_operator the_log.size, :>=, 1, "1 or more queries expected, but none were executed."
+        else
+          message = "#{the_log.size} instead of #{expected_count} queries were executed.#{the_log.size == 0 ? '' : "\nQueries:\n#{the_log.join("\n")}"}"
+          assert_equal expected_count, the_log.size, message
+        end
+
+        result
+      end
+
+      def assert_no_queries(&block)
+        assert_queries(0, &block)
+      end
+
+      class SQLCounter # :nodoc:
+        class << self
+          attr_accessor :ignored_sql, :log, :log_all
+          def clear_log; self.log = []; self.log_all = []; end
+        end
+
+        clear_log
+
+        def call(*, values)
+          return if values[:cached]
+
+          sql = values[:sql]
+          self.class.log_all << sql
+          self.class.log << sql unless ["SCHEMA", "TRANSACTION"].include? values[:name]
+        end
+      end
+
+      ActiveSupport::Notifications.subscribe("sql.active_record", SQLCounter.new)
+    end
+  end
+end

--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -649,7 +649,7 @@ class DirtyTest < ActiveRecord::TestCase
         jon = Person.create! first_name: "Jon"
       end
 
-      assert ActiveRecord::SQLCounter.log_all.none? { |sql| sql.include?("followers_count") }
+      assert SQLCounter.log_all.none? { |sql| sql.include?("followers_count") }
 
       jon.reload
       assert_equal "Jon", jon.first_name

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -9,6 +9,7 @@ require "active_support/test_case"
 require "active_support/core_ext/object/try"
 require "active_support/testing/autorun"
 require "active_support/configuration_file"
+require "active_record/testing/query_assertions"
 require "active_storage/service/mirror_service"
 require "image_processing/mini_magick"
 
@@ -46,6 +47,8 @@ ActiveStorage.verifier = ActiveSupport::MessageVerifier.new("Testing")
 ActiveStorage::FixtureSet.file_fixture_path = File.expand_path("fixtures/files", __dir__)
 
 class ActiveSupport::TestCase
+  include ActiveRecord::Testing::QueryAssertions
+
   self.file_fixture_path = ActiveStorage::FixtureSet.file_fixture_path
 
   include ActiveRecord::TestFixtures
@@ -58,23 +61,6 @@ class ActiveSupport::TestCase
 
   teardown do
     ActiveStorage::Current.reset
-  end
-
-  def assert_queries(expected_count)
-    ActiveRecord::Base.connection.materialize_transactions
-
-    queries = []
-    ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
-      queries << payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(payload[:name])
-    end
-
-    yield.tap do
-      assert_equal expected_count, queries.size, "#{queries.size} instead of #{expected_count} queries were executed. #{queries.inspect}"
-    end
-  end
-
-  def assert_no_queries(&block)
-    assert_queries(0, &block)
   end
 
   private


### PR DESCRIPTION
### Summary

Inspired by https://github.com/rails/rails/pull/40842/files#r650377037

Both methods are defined in multiple parts of the framework. It would
be useful to put them in a proper place, so that repetition is
avoided.

I chose the implementation from `ActiveRecord` because it's a bit more
complete with the `SQLCounter` class, and also because other parts
depend on it.