### PR TITLE
Add missing DOM ids to rails/mailers/email.html template

### DIFF
--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -56,35 +56,35 @@
   <dl>
     <% if @email.respond_to?(:smtp_envelope_from) && Array(@email.from) != Array(@email.smtp_envelope_from) %>
       <dt>SMTP-From:</dt>
-      <dd><%= @email.smtp_envelope_from %></dd>
+      <dd id="smtp-from"><%= @email.smtp_envelope_from %></dd>
     <% end %>
 
     <% if @email.respond_to?(:smtp_envelope_to) && @email.to != @email.smtp_envelope_to %>
       <dt>SMTP-To:</dt>
-      <dd><%= @email.smtp_envelope_to %></dd>
+      <dd id="smtp-to"><%= @email.smtp_envelope_to %></dd>
     <% end %>
 
     <dt>From:</dt>
-    <dd><%= @email.header['from'] %></dd>
+    <dd id="from"><%= @email.header['from'] %></dd>
 
     <% if @email.reply_to %>
       <dt>Reply-To:</dt>
-      <dd><%= @email.header['reply-to'] %></dd>
+      <dd id="reply_to"><%= @email.header['reply-to'] %></dd>
     <% end %>
 
     <dt>To:</dt>
-    <dd><%= @email.header['to'] %></dd>
+    <dd id="to"><%= @email.header['to'] %></dd>
 
     <% if @email.cc %>
       <dt>CC:</dt>
-      <dd><%= @email.header['cc'] %></dd>
+      <dd id="cc"><%= @email.header['cc'] %></dd>
     <% end %>
 
     <dt>Date:</dt>
-    <dd><%= Time.current.rfc2822 %></dd>
+    <dd id="date"><%= Time.current.rfc2822 %></dd>
 
     <dt>Subject:</dt>
-    <dd><strong><%= @email.subject %></strong></dd>
+    <dd><strong id="subject"><%= @email.subject %></strong></dd>
 
     <% unless @email.attachments.nil? || @email.attachments.empty? %>
       <dt>Attachments:</dt>

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -56,12 +56,12 @@
   <dl>
     <% if @email.respond_to?(:smtp_envelope_from) && Array(@email.from) != Array(@email.smtp_envelope_from) %>
       <dt>SMTP-From:</dt>
-      <dd id="smtp-from"><%= @email.smtp_envelope_from %></dd>
+      <dd id="smtp_from"><%= @email.smtp_envelope_from %></dd>
     <% end %>
 
     <% if @email.respond_to?(:smtp_envelope_to) && @email.to != @email.smtp_envelope_to %>
       <dt>SMTP-To:</dt>
-      <dd id="smtp-to"><%= @email.smtp_envelope_to %></dd>
+      <dd id="smtp_to"><%= @email.smtp_envelope_to %></dd>
     <% end %>
 
     <dt>From:</dt>


### PR DESCRIPTION
### Summary

Instead of using Capybara/Selenium my team uses [Cypress](https://www.cypress.io/) for all end to end tests. We have a test that checks that all Mailer Preview actions of all mailers could be opened and rendered without an error. This helped us to catch bugs earlier because there are lots of mailer and mailer actions.

The issue that we faced was that important most of the `dd` elements like(to, from, subject etc) were really hard to get to in DOM because they didn't have a unique selector. This PR fixes it.

Below is what our Cypress test look like: 

```javascript
context('Mailer Preview', () => {
  it('works for all mailer actions', () => {
    cy.visit('/rails/mailers')

    cy.get('li a').each($a => {
      const href = $a.attr('href');
      cy.log(href)
      cy.visit(href)

      cy.get('#from').then($dd => {
        cy.log('FROM :' + $dd.get(0).innerText)
        //expect($dd.get(0).innerText).to.eq('from@example.com')
      })

      cy.get('#to').then($dd => {
        cy.log('TO: ' + $dd.get(0).innerText)
        //expect($dd.get(0).innerText).to.eq('foo@bar.com')
      })

      cy.get('#subject').then($dd => {
        cy.log('SUBJECT: ' + $dd.get(0).innerText)
        //expect($dd.get(0).innerText).to.eq('Test subject')
      })

      cy.get('#mime_type').then($dd => {
        cy.log('MIME TYPE: ' + $dd.get(0).innerText)
        //expect($dd.get(0).innerText).to.eq('HTML email')
      })

      cy.get('[download="icon.png"]').should('exist')
    })
  })
})
```


### Other Information

Attachment elements weren't updated because they already have `download` attribute with a file name.
I've used markup validator from https://validator.w3.org/ and it didn't find any errors or warnings related to this update.

Below is a screenshot of a very simplified test run in Cypress:

![cypress-run-results](https://user-images.githubusercontent.com/61983/121823693-97059280-ccaf-11eb-8781-07617e9ae0bd.png)
