### PR TITLE
ActiveStorage: Allow the parameters sent to `ffmpeg` to be configurable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+*   The parameters sent to `ffmpeg` for generating a video preview image are now
+    configurable under `config.active_storage.video_preview_arguments`.
+
+    *Brendon Muir*
+
+*   The ActiveStorage video previewer will now use scene change detection to generate
+    better preview images (rather than the previous default of using the first frame
+    of the video). This change requires FFmpeg v3.4+.
+
+    *Jonathan Hefner*
+
 *   Add support for ActiveStorage expiring URLs.
 
     ```ruby

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -69,6 +69,8 @@ module ActiveStorage
   mattr_accessor :replace_on_assign_to_many, default: false
   mattr_accessor :track_variants, default: false
 
+  mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -94,6 +94,7 @@ module ActiveStorage
         ActiveStorage.urls_expire_in = app.config.active_storage.urls_expire_in
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
+        ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false

--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -28,21 +28,7 @@ module ActiveStorage
 
     private
       def draw_relevant_frame_from(file, &block)
-        ffmpeg_args = [
-          "-i", file.path,
-          "-vf",
-            # Select the first video frame, plus keyframes and frames
-            # that meet the scene change threshold.
-            'select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),' +
-            # Loop the first 1-2 selected frames in case we were only
-            # able to select 1 frame, then drop the first looped frame.
-            # This lets us use the first video frame as a fallback.
-            "loop=loop=-1:size=2,trim=start_frame=1",
-          "-frames:v", "1",
-          "-f", "image2", "-",
-        ]
-
-        draw self.class.ffmpeg_path, *ffmpeg_args, &block
+        draw self.class.ffmpeg_path, "-i", file.path, *Shellwords.split(ActiveStorage.video_preview_arguments), "-", &block
       end
   end
 end

--- a/guides/CHANGELOG.md
+++ b/guides/CHANGELOG.md
@@ -1,4 +1,3 @@
 
 
-
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/guides/CHANGELOG.md) for previous changes.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1066,6 +1066,13 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
     The default is `:rails_storage_redirect`.
 
+* `config.active_storage.video_preview_arguments` can be used to alter the way ffmpeg generates video preview images.
+
+    The default is `"-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"`
+
+    1. `select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015)`: Select the first video frame, plus keyframes, plus frames that meet the scene change threshold.
+    2. `loop=loop=-1:size=2,trim=start_frame=1`: To use the first video frame as a fallback when no other frames meet the criteria, loop the first (one or) two selected frames, then drop the first looped frame.
+
 ### Configuring Action Text
 
 * `config.action_text.attachment_tag_name` accepts a string for the HTML tag used to wrap attachments. Defaults to `"action-text-attachment"`.
@@ -1083,6 +1090,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_support.cache_format_version`: `7.0`
 - `config.action_dispatch.return_only_request_media_type_on_content_type`: `false`
 - `config.action_mailer.smtp_timeout`: `5`
+- `config.active_storage.video_preview_arguments`: `"-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"`
 
 #### For '6.1', defaults from previous versions below and:
 
@@ -1162,6 +1170,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.action_dispatch.return_only_request_media_type_on_content_type`: `true`
 - `ActiveSupport.utc_to_local_returns_utc_offset_times`: `false`
 - `config.action_mailer.smtp_timeout`: `nil`
+- `config.active_storage.video_preview_arguments`: `"-y -vframes 1 -f image2"`
 
 ### Configuring a Database
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -162,6 +162,13 @@ processes have been updated you can set `config.active_support.cache_format_vers
 Rails 7.0 is able to read both formats so the cache won't be invalidated during the
 upgrade.
 
+### ActiveStorage video preview image generation
+
+Video preview image generation now uses FFmpeg's scene change detection to generate
+more meaningful preview images. Previously the first frame of the video would be used
+and that caused problems if the video faded in from black. This change requires
+FFmpeg v3.4+.
+
 Upgrading from Rails 6.0 to Rails 6.1
 -------------------------------------
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -220,6 +220,11 @@ module Rails
           if respond_to?(:action_mailer)
             action_mailer.smtp_timeout = 5
           end
+
+          if respond_to?(:active_storage)
+            active_storage.video_preview_arguments =
+              "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -37,3 +37,9 @@
 
 # Set both the `:open_timeout` and `:read_timeout` values for `:smtp` delivery method.
 # Rails.application.config.action_mailer.smtp_timeout = 5
+
+# The ActiveStorage video previewer will now use scene change detection to generate
+# better preview images (rather than the previous default of using the first frame
+# of the video).
+# Rails.application.config.active_storage.video_preview_arguments =
+#   "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3019,6 +3019,22 @@ module ApplicationTests
       assert_not_includes(output, "rails_direct_uploads")
     end
 
+    test "ActiveStorage.video_preview_arguments uses the old arguments without Rails 7 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal ActiveStorage.video_preview_arguments,
+        "-y -vframes 1 -f image2"
+    end
+
+    test "ActiveStorage.video_preview_arguments uses the new arguments by default" do
+      app "development"
+
+      assert_equal ActiveStorage.video_preview_arguments,
+        "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"
+    end
+
     test "hosts include .localhost in development" do
       app "development"
       assert_includes Rails.application.config.hosts, ".localhost"


### PR DESCRIPTION
### Summary

The parameters sent to `ffmpeg` for generating a video preview image are now configurable under `config.active_storage.video_preview_arguments`.

This PR also better documents a previous commit from Jonathan Hefner (@jonathanhefner) that changes the default video image preview to use scene detection to generate a better preview.

### Other Information

I don't think any additional tests are required since preview generation should be tested under both configurations in the CI suite.

Concerns: https://github.com/rails/rails/pull/39096