### PR TITLE
ActiveStorage: Allow the parameters sent to ffmpeg to be configurable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   The parameters sent to `ffmpeg` for generating a video preview image are now
+    configurable under `config.active_storage.video_preview_arguments`.
+
+    *Brendon Muir*
+
 *   Don't raise an error if the mime type is not recognized.
 
     Fixes #41777.

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -67,6 +67,8 @@ module ActiveStorage
   mattr_accessor :replace_on_assign_to_many, default: false
   mattr_accessor :track_variants, default: false
 
+  mattr_accessor :video_preview_arguments, default: "-y -vframes 1 -f image2"
+
   module Transformers
     extend ActiveSupport::Autoload
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -92,6 +92,7 @@ module ActiveStorage
         ActiveStorage.service_urls_expire_in = app.config.active_storage.service_urls_expire_in || 5.minutes
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
+        ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"
 
         ActiveStorage.replace_on_assign_to_many = app.config.active_storage.replace_on_assign_to_many || false
         ActiveStorage.track_variants = app.config.active_storage.track_variants || false

--- a/activestorage/lib/active_storage/previewer/video_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/video_previewer.rb
@@ -28,7 +28,7 @@ module ActiveStorage
 
     private
       def draw_relevant_frame_from(file, &block)
-        draw self.class.ffmpeg_path, "-i", file.path, "-y", "-vframes", "1", "-f", "image2", "-", &block
+        draw self.class.ffmpeg_path, "-i", file.path, *Shellwords.split(ActiveStorage.video_preview_arguments), "-", &block
       end
   end
 end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1031,6 +1031,10 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 
     The default is `:rails_storage_redirect`.
 
+* `config.active_storage.video_preview_arguments` can be used to alter the way ffmpeg generates video preview images.
+
+    The default is `"-y -vframes 1 -f image2"`
+
 ### Results of `config.load_defaults`
 
 `config.load_defaults` sets new defaults up to and including the version passed. Such that passing, say, `6.0` also gets the new defaults from every version before it.
@@ -1107,6 +1111,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_support.use_authenticated_message_encryption`: `false`
 - `config.active_support.hash_digest_class`: `::Digest::MD5`
 - `ActiveSupport.utc_to_local_returns_utc_offset_times`: `false`
+- `config.active_storage.video_preview_arguments`: `"-y -vframes 1 -f image2"`
 
 ### Configuring a Database
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2905,6 +2905,22 @@ module ApplicationTests
       assert_not_includes(output, "rails_direct_uploads")
     end
 
+    test "ActiveStorage.video_preview_arguments has a default" do
+      app "development"
+
+      assert_equal ActiveStorage.video_preview_arguments, "-y -vframes 1 -f image2"
+    end
+
+    test "ActiveStorage.video_preview_arguments can be configured" do
+      add_to_config <<-RUBY
+        config.active_storage.video_preview_arguments = "-y -vframes 1 -ss 00:00:05 -f image2"
+      RUBY
+
+      app "development"
+
+      assert_equal ActiveStorage.video_preview_arguments, "-y -vframes 1 -ss 00:00:05 -f image2"
+    end
+
     test "hosts include .localhost in development" do
       app "development"
       assert_includes Rails.application.config.hosts, ".localhost"


### PR DESCRIPTION
### Summary

The parameters sent to `ffmpeg` for generating a video preview image are now configurable under `config.active_storage.video_preview_arguments`.

This is a back-port of https://github.com/rails/rails/pull/42471

### Other Information

Concerns: https://github.com/rails/rails/pull/39096