### PR TITLE
Support clearing acronyms from inflector

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Inflector::Inflections#clear(:acronyms)` is now supported,
+    and `inflector.clear` / `inflector.clear(:all)` also clears acronyms.
+
+    *Alex Ghiculescu*, *Oliver Peate*
+
 *   Raise `ActiveSupport::EncryptedFile::MissingKeyError` when the
     `RAILS_MASTER_KEY` environment variable is blank (e.g. `""`).
 

--- a/activesupport/lib/active_support/inflector/inflections.rb
+++ b/activesupport/lib/active_support/inflector/inflections.rb
@@ -222,15 +222,24 @@ module ActiveSupport
       # Clears the loaded inflections within a given scope (default is
       # <tt>:all</tt>). Give the scope as a symbol of the inflection type, the
       # options are: <tt>:plurals</tt>, <tt>:singulars</tt>, <tt>:uncountables</tt>,
-      # <tt>:humans</tt>.
+      # <tt>:humans</tt>, <tt>:acronyms</tt>.
       #
       #   clear :all
       #   clear :plurals
       def clear(scope = :all)
         case scope
         when :all
-          @plurals, @singulars, @uncountables, @humans = [], [], Uncountables.new, []
-        else
+          clear(:acronyms)
+          clear(:plurals)
+          clear(:singulars)
+          clear(:uncountables)
+          clear(:humans)
+        when :acronyms
+          @acronyms = {}
+          define_acronym_regex_patterns
+        when :uncountables
+          @uncountables = Uncountables.new
+        when :plurals, :singulars, :humans
           instance_variable_set "@#{scope}", []
         end
       end

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -469,6 +469,18 @@ class InflectorTest < ActiveSupport::TestCase
     RUBY
   end
 
+  def test_clear_acronyms_resets_to_reusable_state
+    ActiveSupport::Inflector.inflections.clear(:acronyms)
+
+    assert_empty ActiveSupport::Inflector.inflections.acronyms
+
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.acronym "HTML"
+    end
+
+    assert_equal "HTML", "html".titleize
+  end
+
   def test_inflector_locality
     ActiveSupport::Inflector.inflections(:es) do |inflect|
       inflect.plural(/$/, "s")
@@ -512,6 +524,7 @@ class InflectorTest < ActiveSupport::TestCase
       inflect.singular(/(database)s$/i, '\1')
       inflect.uncountable("series")
       inflect.human("col_rpted_bugs", "Reported bugs")
+      inflect.acronym("HTML")
 
       inflect.clear :all
 
@@ -519,6 +532,7 @@ class InflectorTest < ActiveSupport::TestCase
       assert_empty inflect.singulars
       assert_empty inflect.uncountables
       assert_empty inflect.humans
+      assert_empty inflect.acronyms
     end
   end
 
@@ -529,6 +543,7 @@ class InflectorTest < ActiveSupport::TestCase
       inflect.singular(/(database)s$/i, '\1')
       inflect.uncountable("series")
       inflect.human("col_rpted_bugs", "Reported bugs")
+      inflect.acronym("HTML")
 
       inflect.clear
 
@@ -536,6 +551,22 @@ class InflectorTest < ActiveSupport::TestCase
       assert_empty inflect.singulars
       assert_empty inflect.uncountables
       assert_empty inflect.humans
+      assert_empty inflect.acronyms
+    end
+  end
+
+  def test_clear_all_resets_camelize_and_underscore_regexes
+    ActiveSupport::Inflector.inflections do |inflect|
+      # ensure any data is present
+      inflect.acronym("HTTP")
+      assert_equal "http_s", "HTTPS".underscore
+      assert_equal "Https", "https".camelize
+
+      inflect.clear :all
+
+      assert_empty inflect.acronyms
+      assert_equal "https", "HTTPS".underscore
+      assert_equal "Https", "https".camelize
     end
   end
 
@@ -592,13 +623,20 @@ class InflectorTest < ActiveSupport::TestCase
     end
   end
 
-  %w(plurals singulars uncountables humans acronyms).each do |scope|
+  %i(plurals singulars uncountables humans).each do |scope|
     define_method("test_clear_inflections_with_#{scope}") do
       # clear the inflections
       ActiveSupport::Inflector.inflections do |inflect|
         inflect.clear(scope)
         assert_equal [], inflect.public_send(scope)
       end
+    end
+  end
+
+  def test_clear_inflections_with_acronyms
+    ActiveSupport::Inflector.inflections do |inflect|
+      inflect.clear(:acronyms)
+      assert_equal({}, inflect.acronyms)
     end
   end
 end


### PR DESCRIPTION
### Summary

Attempting to clear acronyms in the Inflector breaks the implementation. This results in a `TypeError` when attempting to set another acronym:

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "activesupport", require: "active_support/all"
end

ActiveSupport::Inflector.inflections do |inflect|
  inflect.clear :acronyms
  inflect.acronym "HTML" # => '[]=': no implicit conversion of String into Integer (TypeError)
end
```

This is because `#clear` sets a new Array for `@acronyms`:

https://github.com/rails/rails/blob/051b0fcd29e927ec8adf7ac11d3a469645e1d8d6/activesupport/lib/active_support/inflector/inflections.rb#L233-L234

Rather than a Hash (the default initialized value):

https://github.com/rails/rails/blob/051b0fcd29e927ec8adf7ac11d3a469645e1d8d6/activesupport/lib/active_support/inflector/inflections.rb#L78-L79

This PR also extends `ActiveSupport::Inflector::Inflections#clear` / `#clear(:all)` to clear acronyms, since this wasn't covered.

### Other Information

I discovered this issue whilst writing a test for https://github.com/rails/activeresource/pull/361