### PR TITLE
Don't attach UJS form submission handlers to Turbo forms

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs.coffee
@@ -21,13 +21,10 @@
   formSubmitSelector: 'form:not([data-turbo=true])',
 
   # Form input elements bound by rails-ujs
-  formInputClickSelector: 'form input[type=submit], form input[type=image], form button[type=submit], form button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])'
-
-  # Form input elements disabled during form submission
   formInputClickSelector: 'form:not([data-turbo=true]) input[type=submit], form:not([data-turbo=true]) input[type=image], form:not([data-turbo=true]) button[type=submit], form:not([data-turbo=true]) button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
 
   # Form input elements re-enabled after form submission
-  formEnableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled'
+  formDisableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled'
 
   # Form file input elements
   fileInputSelector: 'input[name][type=file]:not([disabled])'

--- a/actionview/app/assets/javascripts/rails-ujs.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs.coffee
@@ -18,13 +18,13 @@
   inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]'
 
   # Form elements bound by rails-ujs
-  formSubmitSelector: 'form'
+  formSubmitSelector: 'form:not([data-turbo=true])',
 
   # Form input elements bound by rails-ujs
   formInputClickSelector: 'form input[type=submit], form input[type=image], form button[type=submit], form button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])'
 
   # Form input elements disabled during form submission
-  formDisableSelector: 'input[data-disable-with]:enabled, button[data-disable-with]:enabled, textarea[data-disable-with]:enabled, input[data-disable]:enabled, button[data-disable]:enabled, textarea[data-disable]:enabled'
+  formInputClickSelector: 'form:not([data-turbo=true]) input[type=submit], form:not([data-turbo=true]) input[type=image], form:not([data-turbo=true]) button[type=submit], form:not([data-turbo=true]) button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
 
   # Form input elements re-enabled after form submission
   formEnableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled'

--- a/actionview/app/assets/javascripts/rails-ujs.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs.coffee
@@ -23,8 +23,11 @@
   # Form input elements bound by rails-ujs
   formInputClickSelector: 'form:not([data-turbo=true]) input[type=submit], form:not([data-turbo=true]) input[type=image], form:not([data-turbo=true]) button[type=submit], form:not([data-turbo=true]) button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
 
+  # Form input elements disabled during form submission
+  formDisableSelector: 'input[data-disable-with]:enabled, button[data-disable-with]:enabled, textarea[data-disable-with]:enabled, input[data-disable]:enabled, button[data-disable]:enabled, textarea[data-disable]:enabled'
+
   # Form input elements re-enabled after form submission
-  formDisableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled'
+  formEnableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled'
 
   # Form file input elements
   fileInputSelector: 'input[name][type=file]:not([disabled])'


### PR DESCRIPTION
If you're migrating an application written for Rails UJS to the new Turbo framework in Hotwire, you might well want to have Turbo and UJS coexisting during the migration (or forever!). To do this, you need a way to distinguish how handles form submissions. With these updated selectors, Rails UJS will leave forms marked with `data-turbo=true` alone, leaving them to be processed by Turbo.

(Mirror PR of https://github.com/rails/jquery-ujs/pull/521).