### PR TITLE
Avoid `merge` deprecation warning on default scopes

### DIFF
--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -92,8 +92,6 @@ module Arel # :nodoc: all
     class NotEqual < Binary
       include FetchAttribute
 
-      def equality?; true; end
-
       def invert
         Arel::Nodes::Equality.new(left, right)
       end

--- a/activerecord/lib/arel/nodes/binary.rb
+++ b/activerecord/lib/arel/nodes/binary.rb
@@ -92,6 +92,8 @@ module Arel # :nodoc: all
     class NotEqual < Binary
       include FetchAttribute
 
+      def equality?; true; end
+
       def invert
         Arel::Nodes::Equality.new(left, right)
       end

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -157,6 +157,23 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal authors, david_and_mary.or(david_and_bob)
   end
 
+  def test_merge_not_clause
+    david, mary, bob = authors(:david, :mary, :bob)
+
+    not_mary = Author.where.not(id: mary.id)
+    assert_equal [david, bob], not_mary
+
+    assert_deprecated do
+      assert_equal [david], Author.where(id: david).merge(not_mary)
+    end
+    assert_equal [david, bob], Author.where(id: david).merge(not_mary, rewhere: true)
+
+    assert_deprecated do
+      assert_equal [], Author.where(id: mary).merge(not_mary)
+    end
+    assert_equal [david, bob], Author.where(id: mary).merge(not_mary, rewhere: true)
+  end
+
   def test_merge_not_in_clause
     david, mary, bob = authors(:david, :mary, :bob)
 

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -574,6 +574,14 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal comment, post.comment_with_default_scope_references_associations.to_a.first
   end
 
+  def test_default_scope_with_where_not
+    post = PostWithCommentWithDefaultScopeWhereNot.create!(title: "Hello World", body: "Here we go.")
+    comment = post.comment_with_default_scope_where_not.create!(body: "Great post.")
+    assert_not_deprecated do
+      assert_equal comment, post.comment_with_default_scope_where_not.to_a.first
+    end
+  end
+
   def test_default_scope_with_references_works_through_association
     post = PostWithCommentWithDefaultScopeReferencesAssociation.create!(title: "Hello World", body: "Here we go.")
     comment = post.comment_with_default_scope_references_associations.create!(body: "Great post.", developer_id: Developer.first.id)

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -99,3 +99,7 @@ class CommentWithAfterCreateUpdate < Comment
     update(body: "bar")
   end
 end
+
+class CommentWithDefaultScopeWhereNot < Comment
+  default_scope -> { where.not(post_id: nil) }
+end

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -310,6 +310,12 @@ class PostWithCommentWithDefaultScopeReferencesAssociation < ActiveRecord::Base
   has_one :first_comment, class_name: "CommentWithDefaultScopeReferencesAssociation", foreign_key: :post_id
 end
 
+class PostWithCommentWithDefaultScopeWhereNot < ActiveRecord::Base
+  self.inheritance_column = :disabled
+  self.table_name = "posts"
+  has_many :comment_with_default_scope_where_not, foreign_key: :post_id
+end
+
 class SerializedPost < ActiveRecord::Base
   serialize :title
 end


### PR DESCRIPTION
Adds a failing test for https://github.com/rails/rails/pull/39328#issuecomment-860917061

I don't know how to fix it, but wanted to confirm the issue. @kamipo would love any pointers (or if you want to take it over, please do!)