### PR TITLE
Add note to the guides about action names versus ActionController reserved methods

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -65,7 +65,12 @@ The [Layouts and Rendering Guide](layouts_and_rendering.html) explains this in m
 
 Only public methods are callable as actions. It is a best practice to lower the visibility of methods (with `private` or `protected`) which are not intended to be actions, like auxiliary methods or filters.
 
+WARNING: Some method names are reserved by Action Controller. Accidentally redefining them as actions, or even as auxiliary methods, could result in `SystemStackError`. If you limit your controllers to only RESTful [Resource Routing][] actions you should not need to worry about this.
+
+NOTE: If you must use a reserved method as an action name, one workaround is to use a custom route to map the reserved method name to your non-reserved action method.
+
 [`ActionController::Base`]: https://api.rubyonrails.org/classes/ActionController/Base.html
+[Resource Routing]: https://guides.rubyonrails.org/routing.html#resource-routing-the-rails-default
 
 Parameters
 ----------


### PR DESCRIPTION
### Summary

This commit updates the ActionController Overview section of the Guide to add a note about the potential for method naming conflicts, as detailed below, but stops short of a full list of reserved methods since it's a.) lengthy, and b.) likely to change as internal APIs are updated.

Closes https://github.com/rails/rails/issues/41323

### Other Information

In both Rails 5.2 and Rails 6.1, [defining a controller action method named `config` will result in a `SystemStackError: stack level too deep` exception](https://github.com/rails/rails/issues/41323) for all requests routed to that controller. This is because `ActiveSupport` defines `ActiveSupport::Configurable#config` which is included into `ActionController::Base` by default, and the new config action overrides it. Any actions in the controller will call `render` which eventually will call `logger` which is a configurable attribute which calls `config` which then calls the new `config` action which calls `render` and so on. `config` is [not the only method](https://github.com/rails/rails/issues/41323#issuecomment-860344220) that will trigger this behavior if redefined in a controller: In Rails 6.1, there are 17 methods that would result in `SystemStackError`, 9 that would result in `ArgumentError`, and 3 that would result in a `AbstractController::DoubleRenderError`. Most of these methods are obvious that they should be avoided, like `render`, but some, including `config` since it's never something the user would typically call themselves and its buried deep down in some dependencies, are surprising when encountered and the `SystemStackError` that simply points back to the action method isn't very helpful when trying to debug what has happened.
