### PR TITLE
Correct documentation around ActiveRecord::Associations::Preloader#initialize [skip ci]

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -80,8 +80,8 @@ module ActiveRecord
       #   example, specifying <tt>{ author: :avatar }</tt> will preload a
       #   book's author, as well as that author's avatar.
       #
-      # +:associations+ has the same format as the +:include+ option for
-      # <tt>ActiveRecord::Base.find</tt>. So +associations+ could look like this:
+      # +:associations+ has the same format as the +:include+ method in
+      # <tt>ActiveRecord::QueryMethods</tt>. So +associations+ could look like this:
       #
       #   :books
       #   [ :books, :author ]


### PR DESCRIPTION
### Summary
Closes #41879. This seemed interesting to correct. Even if it's not part of the API, people may refer to it (I've personally used it to fix tricky N+1 queries and to integrate efficiently with GraphQL) so it seemed like a good idea to keep it up to date.