### PR TITLE
Define deprecated delegators for the cattr that were moved out of AR::Base

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -909,15 +909,15 @@ module ActiveRecord
         end
 
         def update_typemap_for_default_timezone
-          if @default_timezone != ActiveRecord::Base.default_timezone && @timestamp_decoder
-            decoder_class = ActiveRecord::Base.default_timezone == :utc ?
+          if @default_timezone != ActiveRecord.default_timezone && @timestamp_decoder
+            decoder_class = ActiveRecord.default_timezone == :utc ?
               PG::TextDecoder::TimestampUtc :
               PG::TextDecoder::TimestampWithoutTimeZone
 
             @timestamp_decoder = decoder_class.new(@timestamp_decoder.to_h)
             @connection.type_map_for_results.add_coder(@timestamp_decoder)
 
-            @default_timezone = ActiveRecord::Base.default_timezone
+            @default_timezone = ActiveRecord.default_timezone
 
             # if default timezone has changed, we need to reconfigure the connection
             # (specifically, the session time zone)

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -337,28 +337,33 @@ module ActiveRecord
         find_by(*args) || raise(RecordNotFound.new("Couldn't find #{name}", name))
       end
 
-      def default_timezone # :nodoc:
-        ActiveRecord.default_timezone
-      end
-
       def maintain_test_schema # :nodoc:
         ActiveRecord.maintain_test_schema
       end
 
-      def reading_role # :nodoc:
-        ActiveSupport::Deprecation.warn(<<~MSG)
-          ActiveRecord::Base.reading_role is deprecated and will be removed in Rails 7.1.
-          Use `ActiveRecord.reading_role` instead.
-        MSG
-        ActiveRecord.reading_role
-      end
+      %w(
+        reading_role writing_role legacy_connection_handling default_timezone index_nested_attribute_errors
+        verbose_query_logs queues maintain_test_schema warn_on_records_fetched_greater_than
+        application_record_class action_on_strict_loading_violation schema_format error_on_ignored_order
+        timestamped_migrations dump_schema_after_migration dump_schemas suppress_multiple_database_warning
+      ).each do |attr|
+        module_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          def #{attr}
+            ActiveSupport::Deprecation.warn(<<~MSG)
+              ActiveRecord::Base.#{attr} is deprecated and will be removed in Rails 7.1.
+              Use `ActiveRecord.#{attr}` instead.
+            MSG
+            ActiveRecord.#{attr}
+          end
 
-      def writing_role # :nodoc:
-        ActiveSupport::Deprecation.warn(<<~MSG)
-          ActiveRecord::Base.writing_role is deprecated and will be removed in Rails 7.1.
-          Use `ActiveRecord.writing_role` instead.
-        MSG
-        ActiveRecord.writing_role
+          def #{attr}=(value)
+            ActiveSupport::Deprecation.warn(<<~MSG)
+              ActiveRecord::Base.#{attr}= is deprecated and will be removed in Rails 7.1.
+              Use `ActiveRecord.#{attr}=` instead.
+            MSG
+            ActiveRecord.#{attr} = value
+          end
+        RUBY
       end
 
       def initialize_generated_modules # :nodoc:


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/42445#issuecomment-860935889

Most of them are considered public API, so we first need to deprecate
before we can entirely remove them.

@rafaelfranca 