### PR TITLE
Strict loading cascade down to middle records

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -239,11 +239,11 @@ module ActiveRecord
               scope.merge!(preload_scope)
             end
 
-            if preload_scope && preload_scope.strict_loading_value
-              scope.strict_loading
-            else
-              scope
-            end
+            cascade_strict_loading(scope)
+          end
+
+          def cascade_strict_loading(scope)
+            preload_scope&.strict_loading_value ? scope.strict_loading : scope
           end
       end
     end

--- a/activerecord/lib/active_record/associations/preloader/through_association.rb
+++ b/activerecord/lib/active_record/associations/preloader/through_association.rb
@@ -134,7 +134,7 @@ module ActiveRecord
               end
             end
 
-            scope
+            cascade_strict_loading(scope)
           end
       end
     end


### PR DESCRIPTION
### Summary

`strict_loading` now cascade to middle records of through associations.

Fixes #42421

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
