### PR TITLE
AR: run encryption tests in CI

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -189,7 +189,7 @@ end
   end
 
   # Make sure the adapter test evaluates the env setting task
-  task "test_#{adapter}" => ["#{adapter}:env", "test:#{adapter}", "test:integration:active_job:#{adapter}"]
+  task "test_#{adapter}" => ["#{adapter}:env", "test:#{adapter}", "test:integration:active_job:#{adapter}", "test:encryption:performance:#{adapter}"]
   task "isolated_test_#{adapter}" => ["#{adapter}:env", "test:isolated:#{adapter}"]
 end
 


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/42492#issuecomment-861599097

Turns out the Active Job integration tests were already running, I just missed them the first time around :(

The encryption performance tests weren't though, so this PR fixes that.