### PR TITLE
Fix deprecation in railties maintain_test_schema

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -651,7 +651,7 @@ module ActiveRecord
       end
 
       def maintain_test_schema! #:nodoc:
-        if ActiveRecord::Base.maintain_test_schema
+        if ActiveRecord.maintain_test_schema
           suppress_messages { load_schema_if_pending! }
         end
       end


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/42489 introduced deprecation warnings which got triggered by tests requiring `railties/test_help` and calling `maintain_test_schema!`