### PR TITLE
Set Active Record configurations on after_initialize

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -240,6 +240,9 @@ module ActiveRecord
   singleton_class.attr_accessor :queues
   self.queues = {}
 
+  singleton_class.attr_accessor :maintain_test_schema
+  self.maintain_test_schema = nil
+
   ##
   # :singleton-method:
   # Specify a threshold for the size of query result sets. If the number of

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -78,8 +78,6 @@ module ActiveRecord
 
       class_attribute :default_shard, instance_writer: false
 
-      mattr_accessor :maintain_test_schema, instance_accessor: false
-
       def self.application_record_class? # :nodoc:
         if ActiveRecord.application_record_class
           self == ActiveRecord.application_record_class
@@ -341,7 +339,7 @@ module ActiveRecord
 
       %w(
         reading_role writing_role legacy_connection_handling default_timezone index_nested_attribute_errors
-        verbose_query_logs queues warn_on_records_fetched_greater_than
+        verbose_query_logs queues warn_on_records_fetched_greater_than maintain_test_schema
         application_record_class action_on_strict_loading_violation schema_format error_on_ignored_order
         timestamped_migrations dump_schema_after_migration dump_schemas suppress_multiple_database_warning
       ).each do |attr|

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -651,7 +651,7 @@ module ActiveRecord
       end
 
       def maintain_test_schema! #:nodoc:
-        if ActiveRecord::Base.maintain_test_schema
+        if ActiveRecord.maintain_test_schema
           suppress_messages { load_schema_if_pending! }
         end
       end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -211,11 +211,13 @@ To keep using the current cache store, you can turn off cache versioning entirel
     initializer "active_record.set_configs" do |app|
       configs = app.config.active_record
 
-      configs.each do |k, v|
-        next if k == :encryption
-        setter = "#{k}="
-        if ActiveRecord.respond_to?(setter)
-          ActiveRecord.send(setter, v)
+      config.after_initialize do
+        configs.each do |k, v|
+          next if k == :encryption
+          setter = "#{k}="
+          if ActiveRecord.respond_to?(setter)
+            ActiveRecord.send(setter, v)
+          end
         end
       end
 


### PR DESCRIPTION
Otherwise you can't change `config.active_record.*` from `config/initializers`.

Until now it somewhat worked because the config would be assigned when `ActiveRecord::Base` would be first referenced. But it was quite brittle anyway.

I might merge this one quickly once I get a green CI as to fix the `main` branch. But I'd love to have second opinions on it.