### PR TITLE
[ci skip] add activestorage config section

### DIFF
--- a/activestorage/README.md
+++ b/activestorage/README.md
@@ -175,6 +175,12 @@ Active Storage, with its included JavaScript library, supports uploading directl
 | `direct-upload:end` | `<input>` | `{id, file}` | A direct upload has ended. |
 | `direct-uploads:end` | `<form>` | None | All direct uploads have ended. |
 
+
+### Important Configurations
+
+By default your `has_many_attached` edits will erase and replace, this is usually not the expected behaviour when you want to add content as you go in an admin (or any other place).
+To change this just add `config.active_storage.replace_on_assign_to_many = false` to your config and now you can really edit your many contents on resources.
+
 ## License
 
 Active Storage is released under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
### Summary

After dealing with lot of problems I decided to propose a config section for ActiveStorage and add a useful config option that may help others hours of search.
The specific config is to disable `has_many_attachment` replace by default behavior, this goes against most admin edits in my opinion. And as opinions are just that I prefer to expose the configuration and let people choose what they want.
