### PR TITLE
Passing extra parameters in `ActiveStorage::Blob#url` to S3 Client

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Passing extra parameters in `ActiveStorage::Blob#url` to S3 Client
+
+    This allows calls of `ActiveStorage::Blob#url` to have more interaction with
+    the S3 Presigner, enabling, amongst other options, custom S3 domain URL
+    Generation.
+
+    ```ruby
+    blob = ActiveStorage::Blob.last
+
+    blob.url # => https://<bucket-name>.s3.<region>.amazonaws.com/<key>
+    blob.url(virtual_host: true) # => # => https://<bucket-name>/<key>
+    ```
+
+    *josegomezr*
+
 *   Allow setting a `Cache-Control` on files uploaded to GCS.
     
     ```yaml

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -96,14 +96,14 @@ module ActiveStorage
     end
 
     private
-      def private_url(key, expires_in:, filename:, disposition:, content_type:, **)
+      def private_url(key, expires_in:, filename:, disposition:, content_type:, **client_opts)
         object_for(key).presigned_url :get, expires_in: expires_in.to_i,
           response_content_disposition: content_disposition_with(type: disposition, filename: filename),
-          response_content_type: content_type
+          response_content_type: content_type, **client_opts
       end
 
-      def public_url(key, **)
-        object_for(key).public_url
+      def public_url(key, **client_opts)
+        object_for(key).public_url(**client_opts)
       end
 
 

--- a/activestorage/test/service/s3_public_service_test.rb
+++ b/activestorage/test/service/s3_public_service_test.rb
@@ -23,6 +23,15 @@ if SERVICE_CONFIGURATIONS[:s3_public]
       assert_equal "200", response.code
     end
 
+    test "public URL generation (virtual host enabled)" do
+      url = @service.url(@key, filename: ActiveStorage::Filename.new("avatar.png"), virtual_host: true)
+
+      assert_match(/#{@service.bucket.name}\/#{@key}/, url)
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "200", response.code
+    end
+
     test "direct upload" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"


### PR DESCRIPTION
### Summary


This allows calls of `ActiveStorage::Blob#url` to have more interaction with the S3 Presigner, enabling, amongst other options,
custom S3 domain URL Generation.

Closes #42488
