### PR TITLE
Deprecate usage of `purge` and `purge_later` from the association extension.

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,5 +1,9 @@
+*   Deprecate usage of `purge` and `purge_later` from the association extension.
+
+    *Jacopo Beschi*
+
 *   Allow setting a `Cache-Control` on files uploaded to GCS.
-    
+
     ```yaml
     gcs:
       service: GCS

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -155,13 +155,25 @@ module ActiveStorage
 
         has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading do
           def purge
+            deprecate(:purge)
             each(&:purge)
             reset
           end
 
           def purge_later
+            deprecate(:purge_later)
             each(&:purge_later)
             reset
+          end
+
+          private
+          def deprecate(action)
+            reflection_name = proxy_association.reflection.name
+            attached_name = reflection_name.to_s.partition("_").first
+            ActiveSupport::Deprecation.warn(<<-MSG.squish)
+              Calling `#{action}` from `#{reflection_name}` is deprecated and will be removed in Rails 7.1.
+              To migrate to Rails 7.1's behavior call `#{action}` from `#{attached_name}` instead: `#{attached_name}.#{action}`.
+            MSG
           end
         end
         has_many :"#{name}_blobs", through: :"#{name}_attachments", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading


### PR DESCRIPTION
### Summary

Follow up of https://github.com/rails/rails/pull/42383#issuecomment-860512832.

Calling `purge` and `purge_later` from the association extension raise a deprecation warning.
These methods will be removed in the `7.1` release.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
