### PR TITLE
Clear initializers once they are ran

### DIFF
--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -391,6 +391,16 @@ module Rails
       self
     end
 
+    def clear_initializers # :nodoc:
+      Bootstrap.clear_initializers
+      ordered_railties.flatten.each do |initializable|
+        next if initializable == self
+        initializable.clear_initializers
+      end
+      Finisher.clear_initializers
+      super
+    end
+
     def initializers #:nodoc:
       Bootstrap.initializers_for(self) +
       railties_initializers(super) +

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -60,11 +60,17 @@ module Rails
       initializers.tsort_each do |initializer|
         initializer.run(*args) if initializer.belongs_to?(group)
       end
+      clear_initializers
       @ran = true
     end
 
     def initializers
       @initializers ||= self.class.initializers_for(self)
+    end
+
+    def clear_initializers # :nodoc:
+      @initializers = nil
+      self.class.clear_initializers
     end
 
     module ClassMethods
@@ -79,6 +85,13 @@ module Rails
           initializers = initializers + klass.initializers
         end
         initializers
+      end
+
+      def clear_initializers # :nodoc:
+        @initializers = nil
+        if is_a?(Class) && superclass.respond_to?(:clear_initializers)
+          superclass.clear_initializers
+        end
       end
 
       def initializers_for(binding)


### PR DESCRIPTION
As they can only be ran once, there is no reason to keep them in memory. Unless I'm missing something?

