### PR TITLE
Support default `cache_control` in GCS Active Storage

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Allow setting a `Cache-Control` on files uploaded to GCS.
+    
+    ```yaml
+    gcs:
+      service: GCS
+      ...
+      cache_control: "public, max-age=3600"
+    ``` 
+    *maleblond*
 
 *   The parameters sent to `ffmpeg` for generating a video preview image are now
     configurable under `config.active_storage.video_preview_arguments`.

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -95,8 +95,14 @@ module ActiveStorage
           version = :v4
         end
 
-        generated_url = bucket.signed_url(key, method: "PUT", expires: expires_in, content_md5: checksum,
-headers: headers, version: version)
+        generated_url = bucket.signed_url(key,
+          content_md5: checksum,
+          expires: expires_in,
+          headers: headers,
+          method: "PUT",
+          version: version
+        )
+
         payload[:url] = generated_url
 
         generated_url

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -19,7 +19,7 @@ module ActiveStorage
         # binary and attachment when the file's content type requires it. The only way to force them is to
         # store them as object's metadata.
         content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
-        bucket.create_file(io, key, md5: checksum, content_type: content_type, content_disposition: content_disposition)
+        bucket.create_file(io, key, md5: checksum, cache_control: @config[:cache_control], content_type: content_type, content_disposition: content_disposition)
       rescue Google::Cloud::InvalidArgumentError
         raise ActiveStorage::IntegrityError
       end
@@ -84,8 +84,19 @@ module ActiveStorage
 
     def url_for_direct_upload(key, expires_in:, checksum:, **)
       instrument :url, key: key do |payload|
-        generated_url = bucket.signed_url key, method: "PUT", expires: expires_in, content_md5: checksum
+        headers = {}
+        version = :v2
 
+        if @config[:cache_control].present?
+          headers["Cache-Control"] = @config[:cache_control]
+          # v2 signing doesn't support non `x-goog-` headers. Only switch to v4 signing
+          # if necessary for back-compat; v4 limits the expiration of the URL to 7 days
+          # whereas v2 has no limit
+          version = :v4
+        end
+
+        generated_url = bucket.signed_url(key, method: "PUT", expires: expires_in, content_md5: checksum,
+headers: headers, version: version)
         payload[:url] = generated_url
 
         generated_url
@@ -95,7 +106,13 @@ module ActiveStorage
     def headers_for_direct_upload(key, checksum:, filename: nil, disposition: nil, **)
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
-      { "Content-MD5" => checksum, "Content-Disposition" => content_disposition }
+      headers = { "Content-MD5" => checksum, "Content-Disposition" => content_disposition }
+
+      if @config[:cache_control].present?
+        headers["Cache-Control"] = @config[:cache_control]
+      end
+
+      headers
     end
 
     private
@@ -137,7 +154,7 @@ module ActiveStorage
       end
 
       def client
-        @client ||= Google::Cloud::Storage.new(**config.except(:bucket))
+        @client ||= Google::Cloud::Storage.new(**config.except(:bucket, :cache_control))
       end
   end
 end

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -57,6 +57,36 @@ if SERVICE_CONFIGURATIONS[:gcs]
       @service.delete key
     end
 
+    test "direct upload with cache control" do
+      config_with_cache_control = { gcs: service_config[:gcs].merge({ cache_control: "public, max-age=1800" }) }
+      service = ActiveStorage::Service.configure(:gcs, config_with_cache_control)
+
+      key      = SecureRandom.base58(24)
+      data     = "Some text"
+      checksum = Digest::MD5.base64digest(data)
+      url      = service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+      uri = URI.parse url
+      request = Net::HTTP::Put.new uri.request_uri
+      request.body = data
+      headers = service.headers_for_direct_upload(key, checksum: checksum, filename: ActiveStorage::Filename.new("test.txt"), disposition: :attachment)
+      assert_equal(headers["Cache-Control"], "public, max-age=1800")
+
+      headers.each do |k, v|
+        request.add_field k, v
+      end
+      request.add_field "Content-Type", ""
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request request
+      end
+
+      url = service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal("public, max-age=1800", response["Cache-Control"])
+    ensure
+      service.delete(key)
+    end
+
     test "upload with content_type and content_disposition" do
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
@@ -83,6 +113,23 @@ if SERVICE_CONFIGURATIONS[:gcs]
       assert_match(/inline;.*test.html/, response["Content-Disposition"])
     ensure
       @service.delete key
+    end
+
+    test "upload with cache_control" do
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+
+      config_with_cache_control = { gcs: service_config[:gcs].merge({ cache_control: "public, max-age=1800" }) }
+      service = ActiveStorage::Service.configure(:gcs, config_with_cache_control)
+
+      service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain")
+
+      url = service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal "public, max-age=1800", response["Cache-Control"]
+    ensure
+      service.delete key
     end
 
     test "update metadata" do

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -235,6 +235,15 @@ google:
   bucket: ""
 ```
 
+Optionally provide a Cache-Control metadata to set on uploaded assets:
+
+```yaml
+google:
+  service: GCS
+  ...
+  cache_control: "public, max-age=3600"
+```
+
 Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) gem to your `Gemfile`:
 
 ```ruby
@@ -822,6 +831,7 @@ Take care to allow:
   * `Content-Disposition` (except for Azure Storage)
   * `x-ms-blob-content-disposition` (for Azure Storage only)
   * `x-ms-blob-type` (for Azure Storage only)
+  * `Cache-Control` (for GCS, only if `cache_control` is set)
 
 No CORS configuration is required for the Disk service since it shares your app’s origin.
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Relates to #32325  + #39188. This PR adds support for a `cache_control` configuration on an Active Storage GCS service to set a default Cache-Control metadata on all assets uploaded to GCS:

```yaml
gcs:
  service: GCS
  ...
  cache_control: "public, max-age=3600"
``` 

### Other Information

This PR is fully backward compatible, as it doesn't change any behavior when not providing the `cache_control` setting.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
