### PR TITLE
Improve "Serving Files" headings [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -523,15 +523,18 @@ user.avatar.purge_later
 [Attached::One#purge]: https://api.rubyonrails.org/classes/ActiveStorage/Attached/One.html#method-i-purge
 [Attached::One#purge_later]: https://api.rubyonrails.org/classes/ActiveStorage/Attached/One.html#method-i-purge_later
 
-Linking to Files
-----------------
+Serving Files
+-------------
+
+Active Storage supports two ways to serve files: redirecting and proxying.
+
+### Redirect mode
 
 To generate a permanent URL for a blob, you can pass the blob to the
 [`url_for`][ActionView::RoutingUrlFor#url_for] view helper. This generates a
 URL with the blob's [`signed_id`][ActiveStorage::Blob#signed_id]
 that is routed to the blob's
 [`RedirectController`](ActiveStorage::Blobs::RedirectController).
-
 
 ```ruby
 url_for(user.avatar)


### PR DESCRIPTION
### Summary

The Active Storage README, uses 'serving' instead of 'linking' files.
Serving better describes the section as we don't mention HTML links in
the texts.
https://github.com/rails/rails/blob/main/activestorage/README.md

This also adds a 'Redirect Mode' heading to supplement the 'Proxy Mode'
heading.