### PR TITLE
Pass useCapture to @rails/ujs event listener

### DIFF
--- a/actionview/app/assets/javascripts/rails-ujs/utils/event.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/utils/event.coffee
@@ -66,3 +66,4 @@ Rails.delegate = (element, selector, eventType, handler) ->
     if target instanceof Element and handler.call(target, e) == false
       e.preventDefault()
       e.stopPropagation()
+  , true


### PR DESCRIPTION
### Summary

React 17 changed how it attaches events. This change broke @rails/ujs when used within React components. https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues suggests using useCapture to resolve this. I've confirmed that this does indeed resolve the issue in my codebase.
