### PR TITLE
Output UJs test failures in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,6 @@ gem "aws-sdk-sns", require: false
 gem "webmock"
 
 group :ujs do
-  gem "qunit-selenium"
   gem "webdrivers"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,9 +345,6 @@ GEM
     puma (5.3.2)
       nio4r (~> 2.0)
     que (0.14.3)
-    qunit-selenium (0.0.4)
-      selenium-webdriver
-      thor
     raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -563,7 +560,6 @@ DEPENDENCIES
   puma
   que
   queue_classic!
-  qunit-selenium
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
   rails!

--- a/ci/qunit-selenium-runner.rb
+++ b/ci/qunit-selenium-runner.rb
@@ -1,22 +1,81 @@
 # frozen_string_literal: true
 
-require "qunit/selenium/test_runner"
+require "webdrivers"
 
-if ARGV[1]
-  driver = ::Selenium::WebDriver.for(:remote, url: ARGV[1], desired_capabilities: :chrome)
+# This class based on https://github.com/smontanari/qunit-selenium, with a few tweaks to make it easier to read output.
+# Copyright (c) 2014 Silvio Montanari
+# License: MIT
+class TestRun
+  TestResult = Struct.new(:tests, :assertions, :duration, :raw_output)
+
+  ID_TESTRESULT = "qunit-testresult"
+  ID_TESTS = "qunit-tests"
+
+  def initialize(driver)
+    @qunit_testresult = driver[ID_TESTRESULT]
+    @qunit_tests = driver[ID_TESTS]
+  end
+
+  def completed?
+    @qunit_testresult.text =~ /Tests completed/
+  end
+
+  def result
+    assertions = { total: total_assertions, passed: passed_assertions, failed: failed_assertions }
+    tests = { total: total_tests, passed: pass_tests, failed: fail_tests }
+    TestResult.new(tests, assertions, duration, raw_output)
+  end
+
+  private
+    def raw_output
+      @qunit_tests.text
+    end
+
+    def duration
+      match = /Tests completed in (?<milliseconds>\d+) milliseconds/.match @qunit_testresult.text
+      match[:milliseconds].to_i / 1000
+    end
+
+    %w(total passed failed).each do |result|
+      define_method("#{result}_assertions".to_sym) do
+        @qunit_testresult.find_elements(:class, result).first.text.to_i
+      end
+    end
+
+    def total_tests
+      @qunit_tests.find_elements(:css, "##{ID_TESTS} > *").count
+    end
+
+    %w(pass fail).each do |result|
+      define_method("#{result}_tests".to_sym) do
+        @qunit_tests.find_elements(:css, "##{ID_TESTS} > .#{result}").count
+      end
+    end
+end
+
+driver = if ARGV[1]
+  ::Selenium::WebDriver.for(:remote, url: ARGV[1], desired_capabilities: :chrome)
 else
-  require "webdrivers"
-
   driver_options = Selenium::WebDriver::Chrome::Options.new
   driver_options.add_argument("--headless")
   driver_options.add_argument("--disable-gpu")
   driver_options.add_argument("--no-sandbox")
 
-  driver = ::Selenium::WebDriver.for(:chrome, options: driver_options)
+  ::Selenium::WebDriver.for(:chrome, options: driver_options)
 end
 
-result = QUnit::Selenium::TestRunner.new(driver).open(ARGV[0], timeout: 60)
+driver.get(ARGV[0])
+
+result = TestRun.new(driver).tap do |run|
+  ::Selenium::WebDriver::Wait.new(timeout: 60).until do
+    run.completed?
+  end
+end.result
+
 driver.quit
 
 puts "Time: #{result.duration} seconds, Total: #{result.assertions[:total]}, Passed: #{result.assertions[:passed]}, Failed: #{result.assertions[:failed]}"
+if result.tests[:failed] > 0
+  puts "Qunit output follows. Look for lines that have failures, eg (1, n, n) - those are your failing lines\r\n\r\n#{result.raw_output}"
+end
 exit(result.tests[:failed] > 0 ? 1 : 0)

--- a/ci/qunit-selenium-runner.rb
+++ b/ci/qunit-selenium-runner.rb
@@ -3,8 +3,30 @@
 require "webdrivers"
 
 # This class based on https://github.com/smontanari/qunit-selenium, with a few tweaks to make it easier to read output.
+# The license from https://github.com/smontanari/qunit-selenium is enclosed:
+#
+# The MIT License (MIT)
+#
 # Copyright (c) 2014 Silvio Montanari
-# License: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 class TestRun
   TestResult = Struct.new(:tests, :assertions, :duration, :raw_output)
 


### PR DESCRIPTION
Found out in https://github.com/rails/rails/pull/42512 that the test failures from UJs tests don't print out [in CI](https://buildkite.com/rails/rails/builds/78356#700f184a-ffdb-4795-a122-42dddcbbf5d7/1137), or when you run the tests locally. The number of assertions shows, but not which individual ones broke.

![image](https://user-images.githubusercontent.com/509837/122275689-9c2e3180-cea9-11eb-8ee1-09d8517510c1.png)

Currently we use https://github.com/smontanari/qunit-selenium which is a thin wrapper over `::Selenium::WebDriver` that parses the results. I have taken the relevant code from that gem and brought it in house, then added some extra methods to read the raw output from the test results, and print it out when tests fail. I've also offered the changes upstream (https://github.com/smontanari/qunit-selenium/pull/3), but as the gem hasn't been updated in 7 years I thought it would be better to include them directly in here.

Here's an example of the output you'll now get when tests fail: https://gist.github.com/ghiculescu/3cdaf74b051b8ce022f79f39285ac4f8

Here's an example in CI: https://buildkite.com/rails/rails/builds/78360#87935aa0-3d6c-44cb-b7f4-384bc59117db

![image](https://user-images.githubusercontent.com/509837/122278534-9c7bfc00-ceac-11eb-87f5-f2a2fcd1056c.png)

It's not pretty, but it's a big improvement over not seeing the results at all.