### PR TITLE
Orphaned attachment relationship safe navigation (42514)

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Attachments can be deleted after their association is no longer defined.
+
+    Fixes #42514
+
+    *Don Sisco*
+
 *   Allow to detach an attachment when record is not persisted
 
     *Jacopo Beschi*

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -74,7 +74,7 @@ class ActiveStorage::Attachment < ActiveStorage::Record
     end
 
     def dependent
-      record.attachment_reflections[name]&.options[:dependent]
+      record.attachment_reflections[name]&.options&.fetch(:dependent, nil)
     end
 
     def variants

--- a/activestorage/test/models/attachment_test.rb
+++ b/activestorage/test/models/attachment_test.rb
@@ -134,6 +134,14 @@ class ActiveStorage::AttachmentTest < ActiveSupport::TestCase
     assert_equal blob, ActiveStorage::Blob.find_signed(signed_id)
   end
 
+  test "can destroy attachment without existing relation" do
+    blob = create_blob
+    @user.highlights.attach(blob)
+    attachment = @user.highlights.find_by(blob_id: blob.id)
+    attachment.update_attribute(:name, "old_highlights")
+    assert_nothing_raised { attachment.destroy }
+  end
+
   private
     def assert_blob_identified_before_owner_validated(owner, blob, content_type)
       validated_content_type = nil


### PR DESCRIPTION
### Summary
closes #42514

Utilizes safe navigation in looking up dependent relationship.

As described in the issue, this may happen when removing an attachment relationship and some attachment records are orphaned. Deleting them through active record causes an unsafe hash lookup call.