### PR TITLE
Fix race condition when attaching multiple files

### DIFF
--- a/activestorage/lib/active_storage/attached/changes/create_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_many.rb
@@ -33,7 +33,13 @@ module ActiveStorage
       end
 
       def build_subchange_from(attachable)
-        ActiveStorage::Attached::Changes::CreateOneOfMany.new(name, record, attachable)
+        ActiveStorage::Attached::Changes::CreateOneOfMany.new(name, record, attachable, previous_attachments)
+      end
+
+      # Using a direct query instead of `record.public_send("#{name}_attachments")` because of a race condition
+      # where some attachments were missing due to them being memoized in a previous stage
+      def previous_attachments
+        @previous_attachments ||= ActiveStorage::Attachment.where(record: record, name: name)
       end
 
       def assign_associated_attachments

--- a/activestorage/lib/active_storage/attached/changes/create_one_of_many.rb
+++ b/activestorage/lib/active_storage/attached/changes/create_one_of_many.rb
@@ -2,9 +2,16 @@
 
 module ActiveStorage
   class Attached::Changes::CreateOneOfMany < Attached::Changes::CreateOne #:nodoc:
+    attr_reader :attachments
+
+    def initialize(name, record, attachable, attachments)
+      super(name, record, attachable)
+      @attachments = attachments
+    end
+
     private
       def find_attachment
-        record.public_send("#{name}_attachments").detect { |attachment| attachment.blob_id == blob.id }
+        attachments.detect { |attachment| attachment.blob_id == blob.id }
       end
   end
 end


### PR DESCRIPTION
### Summary
Fixes #36578. There was a race condition where when uploading multiple files to a `has_many_attached` through direct upload in different parallel requests there would be a unique constraint violation. This was caused because the attachments were preloaded in a previous stage, and the code failed to find the newly added attachments after another transaction was committed.

The solution was to use a fresh collection of the record, but since this was on `CreateOneOfMany`, the query would cause an N+1. We decided to inject this collection and traverse it inside as usual.

Not sure if it's worth (or even possible) implementing automated tests for race conditions.