### PR TITLE
Fix update & destroy queries when default_scope is nillable with all_…

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -94,6 +94,12 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, create_sql)
   end
 
+  def test_nilable_default_scope_with_all_queries_runs_on_create
+    create_sql = capture_sql { DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita") }.first
+
+    assert_no_match(/AND$/, create_sql)
+  end
+
   def test_default_scope_runs_on_select
     Mentor.create!
     DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
@@ -108,6 +114,13 @@ class DefaultScopingTest < ActiveRecord::TestCase
     select_sql = capture_sql { DeveloperWithDefaultMentorScopeAllQueries.find_by(name: "Eileen") }.first
 
     assert_match(/mentor_id/, select_sql)
+  end
+
+  def test_nilable_default_scope_with_all_queries_runs_on_select
+    DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    select_sql = capture_sql { DeveloperWithDefaultNilableMentorScopeAllQueries.find_by(name: "Nikita") }.first
+
+    assert_no_match(/AND$/, select_sql)
   end
 
   def test_default_scope_doesnt_run_on_update
@@ -126,6 +139,13 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, update_sql)
   end
 
+  def test_nilable_default_scope_with_all_queries_runs_on_update
+    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    update_sql = capture_sql { dev.update!(name: "Not Nikita") }.first
+
+    assert_no_match(/AND$/, update_sql)
+  end
+
   def test_default_scope_doesnt_run_on_update_columns
     Mentor.create!
     dev = DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
@@ -140,6 +160,13 @@ class DefaultScopingTest < ActiveRecord::TestCase
     update_sql = capture_sql { dev.update_columns(name: "Not Eileen") }.first
 
     assert_match(/mentor_id/, update_sql)
+  end
+
+  def test_nilable_default_scope_with_all_queries_runs_on_update_columns
+    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    update_sql = capture_sql { dev.update_columns(name: "Not Nikita") }.first
+
+    assert_no_match(/AND$/, update_sql)
   end
 
   def test_default_scope_doesnt_run_on_destroy
@@ -158,6 +185,13 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, destroy_sql)
   end
 
+  def test_nilable_default_scope_with_all_queries_runs_on_destroy
+    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    destroy_sql = capture_sql { dev.destroy }.first
+
+    assert_no_match(/AND$/, destroy_sql)
+  end
+
   def test_default_scope_doesnt_run_on_reload
     Mentor.create!
     dev = DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen")
@@ -172,6 +206,13 @@ class DefaultScopingTest < ActiveRecord::TestCase
     reload_sql = capture_sql { dev.reload }.first
 
     assert_match(/mentor_id/, reload_sql)
+  end
+
+  def test_nilable_default_scope_with_all_queries_runs_on_destroy
+    dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
+    reload_sql = capture_sql { dev.reload }.first
+
+    assert_no_match(/AND$/, reload_sql)
   end
 
   def test_default_scope_with_all_queries_doesnt_run_on_destroy_when_unscoped

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -162,6 +162,12 @@ class DeveloperWithDefaultMentorScopeAllQueries < ActiveRecord::Base
   default_scope -> { where(mentor_id: 1) }, all_queries: true
 end
 
+class DeveloperWithDefaultNilableMentorScopeAllQueries < ActiveRecord::Base
+  self.table_name = "developers"
+  firm_id = nil # Could be something like Current.mentor_id
+  default_scope -> { where(firm_id: firm_id) if firm_id }, all_queries: true
+end
+
 class DeveloperWithIncludes < ActiveRecord::Base
   self.table_name = "developers"
   has_many :audit_logs, foreign_key: :developer_id


### PR DESCRIPTION
### Rails design question ❓ 

This PR won't make sense if Rails should not support nilable blocks passed in the `default_scope` method. Like: 
`default_scope { nil }` or `default_scope -> { nil }`  where `nil` represents a nillable expression.
Currently it works but I'm not sure if that's intentional. Please let me know if we don't want `default_scope` block to support nillable values. Thanks!

### Summary

There is a neat example of possible `all_queries` capability usage:
https://github.com/rails/rails/blob/951deecc52f191ca85bd5c0416b382f4852c6f72/activerecord/CHANGELOG.md#L755-L757
But it our project we want to use it like `default_scope -> { where(blog_id: Current.blog.id) if Current.blog.present? }, all_queries: true ` to avoid queries like `WHERE blog_id IS NULL`

However currently it's not working properly with destroy & update queries because it builds incorrect SQL statement when default scope block is `nil`. 
Here is an example of `update` query for a code like `Article.last.touch`:
```SQL
 UPDATE `articles` SET `articles`.`updated_at` = '2021-06-16 23:09:05.294765'  WHERE `articles`.`id` = 34 AND
```
As you can see this empty `AND` statement at the end is what was generated for the empty default scope

Raised exception for mysql:
```
ActiveRecord::StatementInvalid: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
```

As a workaround I've considered something like:
```ruby
default_scope(all_queries: true) { Current.blog.present? ? where(blog_id: Current.blog.id) : where('1=1') }
```
