### PR TITLE
[ci skip] Fixed wrong reference link in active storage guide.

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -561,7 +561,7 @@ even if a `before_action` in your `ApplicationController` would otherwise
 require a login. If your files require a higher level of protection consider
 implementing your own authenticated
 [`ActiveStorage::Blobs::RedirectController`](ActiveStorage::Blobs::RedirectController) and
-[`ActiveStorage::Representations::RedirectController`](ActiveStorage::Blobs::RedirectController)
+[`ActiveStorage::Representations::RedirectController`](ActiveStorage::Representations::RedirectController)
 
 To create a download link, use the `rails_blob_{path|url}` helper. Using this
 helper allows you to set the disposition.


### PR DESCRIPTION
### Summary

The active storage guide has updated via this PR #42483 with wrong reference for `ActiveStorage::Representations::RedirectController`. This PR fixes the same.

cc: @p8 @zzak 