### PR TITLE
Deduplicate similar regexps in the router to reduce memory retention

### DIFF
--- a/actionpack/lib/action_dispatch/journey.rb
+++ b/actionpack/lib/action_dispatch/journey.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "action_dispatch/journey/regexp_cache"
 require "action_dispatch/journey/router"
 require "action_dispatch/journey/gtg/builder"
 require "action_dispatch/journey/gtg/simulator"

--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -11,7 +11,7 @@ module ActionDispatch
         attr_reader :memos
 
         DEFAULT_EXP = /[^.\/?]+/
-        DEFAULT_EXP_ANCHORED = Regexp.new(/\A#{DEFAULT_EXP}\Z/)
+        DEFAULT_EXP_ANCHORED = RegexpCache.anchored(DEFAULT_EXP)
 
         def initialize
           @stdparam_states = {}
@@ -165,7 +165,7 @@ module ActionDispatch
           case sym
           when Regexp
             # we must match the whole string to a token boundary
-            sym = Regexp.new(/\A#{sym}\Z/)
+            sym = RegexpCache.anchored(sym)
           when Symbol
             # account for symbols in the constraints the same as strings
             sym = sym.to_s

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -83,7 +83,7 @@ module ActionDispatch
           end
 
           def accept(node)
-            %r{\A#{visit node}\Z}
+            RegexpCache.anchored(visit(node))
           end
 
           def visit_CAT(node)
@@ -185,7 +185,7 @@ module ActionDispatch
 
         def requirements_for_missing_keys_check
           @requirements_for_missing_keys_check ||= requirements.transform_values do |regex|
-            /\A#{regex}\Z/
+            RegexpCache.anchored(regex)
           end
         end
 

--- a/actionpack/lib/action_dispatch/journey/regexp_cache.rb
+++ b/actionpack/lib/action_dispatch/journey/regexp_cache.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  # :stopdoc:
+  module Journey
+    module RegexpCache
+      extend self
+
+      ANCHORED = {}
+
+      def anchored(source)
+        ANCHORED[source] ||= /\A#{source}\Z/
+      end
+    end
+  end
+end

--- a/actionpack/lib/action_dispatch/journey/regexp_cache.rb
+++ b/actionpack/lib/action_dispatch/journey/regexp_cache.rb
@@ -6,9 +6,10 @@ module ActionDispatch
     module RegexpCache
       extend self
 
-      ANCHORED = {}
+      ANCHORED = ObjectSpace::WeakMap.new
 
       def anchored(source)
+        source = -source.to_s
         ANCHORED[source] ||= /\A#{source}\Z/
       end
     end


### PR DESCRIPTION
While profiling our app boot, I noticed that journey was rebuilding the same small set of regexps a lot of times:

```
Allocated String Report
-----------------------------------
 663.88 kB   16597  "\\A(?-mix:[^.\\/?]+)\\Z"
             16592  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb:168
                 5  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb:14

...

 331.92 kB    8298  "(?-mix:[^.\\/?]+)"
              8296  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb:168
                 2  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb:14

...

 445.63 kB    5064  "(?-mix:\\b(\\d{4}-\\d{2}|unstable|unversioned)\\b)"
              3372  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/path/pattern.rb:206
              1686  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/path/pattern.rb:99
                 6  rails-c8f0c6450c75/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb:168
```

The profiler can only display strings, but they are then used to build the corresponding regexps. Even worse in one case the pattern is `Regexp.new(/\A#{source}\Z/)`, which means we build two regexps for no reason.

Regexps are costly in tow ways: they use quite a lot of memory, and they also take quite a bit of CPU to compile when they are instantiated.

So I believe we can save a bit of resident memory by deduplicating these regexps. Of course the saved amount depends on the number of routes. 

In our case the saving is about `2.85MiB`.

Before:
```
retained memory by class
-----------------------------------
  10.87 MB  Regexp
```

After:
```
retained memory by class
-----------------------------------
   7.50 MB  Regexp
```

### Implementations

I left two commits because I have two possible implementations and I'm unsure which I should favor.

The first one use a regular hash, so we can use equality to deduplicate the regexp. The problem is that it might cause us to hold onto objects that would normally be GCed (`~140KiB` more in our app).

The second one uses `ObjectSpace::WeakMap`, so the strings have to be interned before they can be used as keys, because `WeakMap` use identity comparison.

Ideally we could use the simpler implementation, and clear the hash when we know we won't need it anymore, but I couldn't find a proper hook for that. If someone has an idea about that.

cc @rafaelfranca thoughts?