### PR TITLE
Fix documentation for ActiveRecord#create_with [ci skip]

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -933,7 +933,7 @@ module ActiveRecord
     # You can pass +nil+ to #create_with to reset attributes:
     #
     #   users = users.create_with(nil)
-    #   users.new.name # => 'Oscar'
+    #   users.new.name # => nil
     def create_with(value)
       spawn.create_with!(value)
     end


### PR DESCRIPTION
### Summary

As per documentation `users.create_with(nil)` will reset attributes to be used when creating new records from a relation object. However, the example `users.new.name` was wrongly stating that `'Oscar'` will be returned when in fact it’s `nil`.

