### PR TITLE
Fix test failing in Active Storage's GCS service

### DIFF
--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -58,7 +58,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
     end
 
     test "direct upload with cache control" do
-      config_with_cache_control = { gcs: service_config[:gcs].merge({ cache_control: "public, max-age=1800" }) }
+      config_with_cache_control = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ cache_control: "public, max-age=1800" }) }
       service = ActiveStorage::Service.configure(:gcs, config_with_cache_control)
 
       key      = SecureRandom.base58(24)
@@ -119,7 +119,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
       key      = SecureRandom.base58(24)
       data     = "Something else entirely!"
 
-      config_with_cache_control = { gcs: service_config[:gcs].merge({ cache_control: "public, max-age=1800" }) }
+      config_with_cache_control = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ cache_control: "public, max-age=1800" }) }
       service = ActiveStorage::Service.configure(:gcs, config_with_cache_control)
 
       service.upload(key, StringIO.new(data), checksum: Digest::MD5.base64digest(data), content_type: "text/plain")


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


Ref. https://github.com/rails/rails/pull/42509#issuecomment-864053693

This PR should fix two tests in `main` that are failing since https://github.com/rails/rails/pull/42509: https://buildkite.com/rails/rails/builds/78375#6fb6fd5c-1d74-4491-b9c8-97ee7ad52c67

```
Error:
--
ActiveStorage::Service::GCSServiceTest#test_upload_with_cache_control:
NoMethodError: undefined method `delete' for nil:NilClass
/rails/activestorage/test/service/gcs_service_test.rb:132:in `ensure in block in &lt;class:GCSServiceTest&gt;'
/rails/activestorage/test/service/gcs_service_test.rb:132:in `block in &lt;class:GCSServiceTest&gt;'
```

We were trying to use a variable that doesn't exist (`service_config` instead of `SERVICE_CONFIGURATIONS`). Those tests only run in the `main` branch, which is why this failure wasn't caught before the PR was merged