### PR TITLE
Raise an error if `pool_config` is `nil` in `set_pool_config`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/pool_manager.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_manager.rb
@@ -36,7 +36,11 @@ module ActiveRecord
       end
 
       def set_pool_config(role, shard, pool_config)
-        @name_to_role_mapping[role][shard] = pool_config
+        if pool_config
+          @name_to_role_mapping[role][shard] = pool_config
+        else
+          raise ArgumentError, "The `pool_config` for the :#{role} role and :#{shard} shard was `nil`. Please check your configuration. If you want your writing role to be something other than `:writing` set `config.active_record.writing_role` in your application configuration. The same setting should be applied for the `reading_role` if applicable."
+        end
       end
     end
   end

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -434,6 +434,38 @@ module ActiveRecord
           self.abstract_class = true
         end
 
+        def test_using_a_role_other_than_writing_raises
+          connection_handler = ActiveRecord::Base.connection_handler
+          ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+          Object.const_set(:ApplicationRecord, ApplicationRecord)
+
+          ApplicationRecord.connects_to(shards: { default: { all: :arunit }, one: { all: :arunit } })
+
+          assert_raises(ArgumentError) { setup_shared_connection_pool }
+        ensure
+          ActiveRecord.application_record_class = nil
+          Object.send(:remove_const, :ApplicationRecord)
+          ActiveRecord::Base.connection_handler = connection_handler
+          ActiveRecord::Base.establish_connection :arunit
+        end
+
+        def test_setting_writing_role_is_used_over_writing
+          connection_handler = ActiveRecord::Base.connection_handler
+          ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+          old_role, ActiveRecord.writing_role = ActiveRecord.writing_role, :all
+          Object.const_set(:ApplicationRecord, ApplicationRecord)
+
+          ApplicationRecord.connects_to(shards: { default: { all: :arunit }, one: { all: :arunit } })
+
+          assert_nothing_raised { setup_shared_connection_pool }
+        ensure
+          ActiveRecord.writing_role = old_role
+          ActiveRecord.application_record_class = nil
+          Object.send(:remove_const, :ApplicationRecord)
+          ActiveRecord::Base.connection_handler = connection_handler
+          ActiveRecord::Base.establish_connection :arunit
+        end
+
         def test_application_record_prevent_writes_can_be_changed
           Object.const_set(:ApplicationRecord, ApplicationRecord)
 


### PR DESCRIPTION
In #41549 a user was getting an error that the `pool_config` was `nil`
so the `all_connection_pools` method would raise an error. After getting
a reproduction application I saw that if the application is
misconfigured this can happen. For example, if an application uses
`:all` for the writing role but does not set
`config.active_record.writing_role = :all` then the
`setup_shared_connection_pool` pool method will get a `nil` value for
the `writing_pool_config` and set that in `set_pool_config`. I
considered fixing this in `setup_shared_connection_pool` directly and
raising an error there, but there's a possibility this _can_ happen in
an external gem or application code if they're using these private APIs
and realistically we never want any code, Rails or otherwise, to be able
to set a `nil` pool config in the pools.

Note: In the test I made a new connection handler so that we have
isolated pools to test against. Otherwise we'll be testing against the
existing pools but we don't want to mess those up.

Closes #41549