### PR TITLE
Generate less initializers in new/upgraded Rails apps

### DIFF
--- a/actionmailbox/test/dummy/config/initializers/application_controller_renderer.rb
+++ b/actionmailbox/test/dummy/config/initializers/application_controller_renderer.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# ActiveSupport::Reloader.to_prepare do
-#   ApplicationController.renderer.defaults.merge!(
-#     http_host: 'example.org',
-#     https: false
-#   )
-# end

--- a/actionmailbox/test/dummy/config/initializers/cookies_serializer.rb
+++ b/actionmailbox/test/dummy/config/initializers/cookies_serializer.rb
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/actiontext/test/dummy/config/initializers/application_controller_renderer.rb
+++ b/actiontext/test/dummy/config/initializers/application_controller_renderer.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# ActiveSupport::Reloader.to_prepare do
-#   ApplicationController.renderer.defaults.merge!(
-#     http_host: 'example.org',
-#     https: false
-#   )
-# end

--- a/actiontext/test/dummy/config/initializers/cookies_serializer.rb
+++ b/actiontext/test/dummy/config/initializers/cookies_serializer.rb
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/activestorage/test/dummy/config/initializers/application_controller_renderer.rb
+++ b/activestorage/test/dummy/config/initializers/application_controller_renderer.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-# Be sure to restart your server when you modify this file.
-
-# ApplicationController.renderer.defaults.merge!(
-#   http_host: 'example.org',
-#   https: false
-# )

--- a/activestorage/test/dummy/config/initializers/cookies_serializer.rb
+++ b/activestorage/test/dummy/config/initializers/cookies_serializer.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   New and upgraded Rails apps no longer generate `config/initializers/application_controller_renderer.rb`
+    or `config/initializers/cookies_serializer.rb`
+
+    The default value for `cookies_serializer` (`:json`) has been moved to `config.load_defaults("7.0")`.
+    The new framework defaults file sets the serializer to `:marshal`.
+
+    *Alex Ghiculescu*
+
 *   `package.json` now uses a strict version constraint for Rails JavaScript packages on new Rails apps.
 
     *Zachary Scott*, *Alex Ghiculescu*

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -199,6 +199,7 @@ module Rails
 
           if respond_to?(:action_dispatch)
             action_dispatch.return_only_request_media_type_on_content_type = false
+            action_dispatch.cookies_serializer = :json
           end
 
           if respond_to?(:action_controller)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -133,7 +133,6 @@ module Rails
     end
 
     def config_when_updating
-      cookie_serializer_config_exist  = File.exist?("config/initializers/cookies_serializer.rb")
       action_cable_config_exist       = File.exist?("config/cable.yml")
       active_storage_config_exist     = File.exist?("config/storage.yml")
       rack_cors_config_exist          = File.exist?("config/initializers/cors.rb")
@@ -146,10 +145,6 @@ module Rails
       @config_target_version = Rails.application.config.loaded_config_version || "5.0"
 
       config
-
-      unless cookie_serializer_config_exist
-        gsub_file "config/initializers/cookies_serializer.rb", /json(?!,)/, "marshal"
-      end
 
       if !options[:skip_action_cable] && !action_cable_config_exist
         template "config/cable.yml"
@@ -176,10 +171,6 @@ module Rails
       end
 
       if options[:api]
-        unless cookie_serializer_config_exist
-          remove_file "config/initializers/cookies_serializer.rb"
-        end
-
         unless csp_config_exist
           remove_file "config/initializers/content_security_policy.rb"
         end
@@ -542,7 +533,6 @@ module Rails
 
       def delete_non_api_initializers_if_api_option
         if options[:api]
-          remove_file "config/initializers/cookies_serializer.rb"
           remove_file "config/initializers/content_security_policy.rb"
           remove_file "config/initializers/permissions_policy.rb"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/application_controller_renderer.rb.tt
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# ActiveSupport::Reloader.to_prepare do
-#   ApplicationController.renderer.defaults.merge!(
-#     http_host: "example.org",
-#     https: false
-#   )
-# end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/cookies_serializer.rb.tt
@@ -1,5 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -5,6 +5,7 @@
 # Once upgraded flip defaults one by one to migrate to the new default.
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.
@@ -43,3 +44,13 @@
 # of the video).
 # Rails.application.config.active_storage.video_preview_arguments =
 #   "-vf select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015),loop=loop=-1:size=2,trim=start_frame=1 -frames:v 1 -f image2"
+
+# If you're upgrading and haven't set `cookies_serializer` previously, your cookie serializer
+# was `:marshal`. Continue to use that for backward-compatibility with old cookies.
+# If you have configured the serializer elsewhere, you can remove this.
+#
+# To convert all cookies to JSON, use the `:hybrid` formatter.
+# If you're confident all your cookies are JSON formatted, you can switch to the `:json` formatter.
+#
+# See https://guides.rubyonrails.org/action_controller_overview.html#cookies for more information.
+# Rails.application.config.action_dispatch.cookies_serializer = :marshal

--- a/railties/test/application/middleware/cookies_test.rb
+++ b/railties/test/application/middleware/cookies_test.rb
@@ -94,6 +94,7 @@ module ApplicationTests
 
         config.action_dispatch.signed_cookie_digest = "SHA512"
         config.action_dispatch.signed_cookie_salt = "sha512 salt"
+        config.action_dispatch.cookies_serializer = :marshal
 
         config.action_dispatch.cookies_rotations.tap do |cookies|
           cookies.rotate :signed, sha1_secret,   digest: "SHA1"
@@ -164,6 +165,7 @@ module ApplicationTests
         config.action_dispatch.use_authenticated_cookie_encryption = true
         config.action_dispatch.encrypted_cookie_cipher = "aes-256-gcm"
         config.action_dispatch.authenticated_encrypted_cookie_salt = "salt"
+        config.action_dispatch.cookies_serializer = :marshal
 
         config.action_dispatch.cookies_rotations.tap do |cookies|
           cookies.rotate :encrypted, first_secret

--- a/railties/test/application/middleware/session_test.rb
+++ b/railties/test/application/middleware/session_test.rb
@@ -167,6 +167,8 @@ module ApplicationTests
       add_to_config <<-RUBY
         # Enable AEAD cookies
         config.action_dispatch.use_authenticated_cookie_encryption = true
+
+        config.action_dispatch.cookies_serializer = :marshal
       RUBY
 
       require "#{app_path}/config/environment"
@@ -217,6 +219,7 @@ module ApplicationTests
       add_to_config <<-RUBY
         # Enable AEAD cookies
         config.action_dispatch.use_authenticated_cookie_encryption = true
+        config.action_dispatch.cookies_serializer = :marshal
       RUBY
 
       require "#{app_path}/config/environment"
@@ -280,6 +283,8 @@ module ApplicationTests
 
         # Use SHA1 key derivation
         config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
+
+        config.action_dispatch.cookies_serializer = :marshal
       RUBY
 
       begin

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -93,7 +93,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       { api: true, update: true }, { destination_root: destination_root, shell: @shell }
     quietly { generator.update_config_files }
 
-    assert_no_file "config/initializers/cookies_serializer.rb"
     assert_no_file "config/initializers/assets.rb"
     assert_no_file "config/initializers/content_security_policy.rb"
     assert_no_file "config/initializers/permissions_policy.rb"
@@ -136,7 +135,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
         config/environments/production.rb
         config/environments/test.rb
         config/initializers
-        config/initializers/application_controller_renderer.rb
         config/initializers/backtrace_silencers.rb
         config/initializers/cors.rb
         config/initializers/filter_parameter_logging.rb
@@ -170,7 +168,6 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
          app/views/layouts/application.html.erb
          bin/yarn
          config/initializers/assets.rb
-         config/initializers/cookies_serializer.rb
          config/initializers/content_security_policy.rb
          config/initializers/permissions_policy.rb
          lib/assets

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -52,10 +52,8 @@ DEFAULT_APP_FILES = %w(
   config/environments/production.rb
   config/environments/test.rb
   config/initializers
-  config/initializers/application_controller_renderer.rb
   config/initializers/assets.rb
   config/initializers/backtrace_silencers.rb
-  config/initializers/cookies_serializer.rb
   config/initializers/content_security_policy.rb
   config/initializers/filter_parameter_logging.rb
   config/initializers/inflections.rb
@@ -198,12 +196,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_new_application_use_json_serializer
-    run_generator
-
-    assert_file("config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :json/)
-  end
-
   def test_new_application_not_include_api_initializers
     run_generator
 
@@ -226,33 +218,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_file "config/initializers/content_security_policy.rb" do |content|
       assert_match(/#   policy\.connect_src/, content)
-    end
-  end
-
-  def test_app_update_keep_the_cookie_serializer_if_it_is_already_configured
-    app_root = File.join(destination_root, "myapp")
-    run_generator [app_root]
-
-    stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
-      generator.send(:app_const)
-      quietly { generator.update_config_files }
-      assert_file("#{app_root}/config/initializers/cookies_serializer.rb", /Rails\.application\.config\.action_dispatch\.cookies_serializer = :json/)
-    end
-  end
-
-  def test_app_update_set_the_cookie_serializer_to_marshal_if_it_is_not_already_configured
-    app_root = File.join(destination_root, "myapp")
-    run_generator [app_root]
-
-    FileUtils.rm("#{app_root}/config/initializers/cookies_serializer.rb")
-
-    stub_rails_application(app_root) do
-      generator = Rails::Generators::AppGenerator.new ["rails"], [], destination_root: app_root, shell: @shell
-      generator.send(:app_const)
-      quietly { generator.update_config_files }
-      assert_file("#{app_root}/config/initializers/cookies_serializer.rb",
-                  /Valid options are :json, :marshal, and :hybrid\.\nRails\.application\.config\.action_dispatch\.cookies_serializer = :marshal/)
     end
   end
 


### PR DESCRIPTION
Currently when you make a new Rails app, we generate a lot of initializers. For new users, I think we should try and include as few as possible - the less files, the less daunting a new app is. And for upgrades I'd like to [continue to simplify the update process](https://github.com/rails/rails/pull/41083), in this case by not bringing back initializers you have probably already dismissed or modified.

In this PR I'm proposing we remove two initializers: `application_controller_renderer.rb` and `cookies_serializer.rb`:

---------------

**`application_controller_renderer.rb`**: This configures [`ActionController::Renderer`](https://api.rubyonrails.org/classes/ActionController/Renderer.html), for rendering views outside of controller actions. I don't think this is something most Rails apps will need (certainly not on day 1); users can configure this feature when they need it.

**`cookies_serializer.rb`**: This was added for [Rails 4.1](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#cookies-serializer). The behaviour is:

- For new apps, the initializer says `:json`.
- For upgraded apps that don't have the initializer, it is added with value `:marshal`.
- If there's no initializer, the [default value](https://github.com/rails/rails/blob/c9a89a4067834a095a41084030b8c9ccdbce77d5/actionpack/lib/action_dispatch/middleware/cookies.rb#L589) is `:marshal`.

Since nobody should be upgrading direct from Rails 4.0 to Rails 7.0, we can simplify this by using new framework defaults, that way we don't need to create an extra file for every new app. The behavior will now be:

- For new apps, `config.load_defaults("7.0")` sets the value to `:json`.
- The `new_framework_defaults_7_0.rb` file explains this, and suggests using `:marshal` to keep the behavior you had before Rails 7, or `:hybrid` to upgrade to JSON cookies.
- No changes to [the code](https://github.com/rails/rails/blob/c9a89a4067834a095a41084030b8c9ccdbce77d5/actionpack/lib/action_dispatch/middleware/cookies.rb#L589); the default value is `:marshal` if you don't set one.

So if you were not setting a `cookies_serializer` previously and you want to keep using `:marshal`, you'll need to explicitly set this before using `config.load_defaults("7.0")`, otherwise it will switch to `:json`. The upside of this is you won't get the `cookies_serializer.rb` file created for you every time you upgrade.

---------------

You can see all the initializers in a new app here: https://github.com/rails/rails/tree/main/railties/lib/rails/generators/rails/app/templates/config/initializers

I think there's probably a few other files that don't need to be there, but these two seemed like the most clear cut changes to me. But I'm okay with expanding the scope of this!