### PR TITLE
Fix `render layout:` to be able to render layout blocks with collections

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fix `render layout: @collection` with provided block
+
+    According to the documentation `render layout:` should
+    be able to render the provided collection. Previously, 
+    render failed with 'Missing partial'.
+
+    *Theo Delaune*, *Marcelo Lauxen*
+
 *   The `translate` helper now passes `default` values that aren't
     translation keys through `I18n.translate` for interpolation.
 

--- a/actionview/lib/action_view/renderer/collection_renderer.rb
+++ b/actionview/lib/action_view/renderer/collection_renderer.rb
@@ -159,10 +159,10 @@ module ActionView
 
           collection_body = if template
             cache_collection_render(payload, view, template, collection) do |filtered_collection|
-              collection_with_template(view, template, layout, filtered_collection)
+              collection_with_template(view, template, layout, filtered_collection, block)
             end
           else
-            collection_with_template(view, nil, layout, collection)
+            collection_with_template(view, nil, layout, collection, block)
           end
 
           return RenderedCollection.empty(@lookup_context.formats.first) if collection_body.empty?
@@ -171,7 +171,7 @@ module ActionView
         end
       end
 
-      def collection_with_template(view, template, layout, collection)
+      def collection_with_template(view, template, layout, collection, block)
         locals = @locals
         cache = {}
 
@@ -186,7 +186,9 @@ module ActionView
 
           _template = (cache[path] ||= (template || find_template(path, @locals.keys + [as, counter, iteration])))
 
-          content = _template.render(view, locals)
+          content = _template.render(view, locals) do |*name|
+            view._layout_for(*name, &block)
+          end
           content = layout.render(view, locals) { content } if layout
           partial_iteration.iterate!
           build_rendered_template(content, _template)

--- a/actionview/test/fixtures/posts/_post.html.erb
+++ b/actionview/test/fixtures/posts/_post.html.erb
@@ -1,0 +1,1 @@
+<%= post.title %><%= yield post %>

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -474,6 +474,16 @@ module RenderTestCases
     assert_equal "Before\npartial html\nYield!\nAfter\n", render
   end
 
+  def test_render_layout_with_block_and_collection_inside
+    render = @controller_view.render(layout: [ Post.new("Amazon"), Post.new("Yahoo") ]) { " is title !" }
+    assert_equal "Amazon is title !Yahoo is title !", render
+  end
+
+  def test_render_layout_with_block_and_collection_inside_with_locals
+    render = @controller_view.render(layout: [ Post.new("Amazon"), Post.new("Yahoo") ]) { |post| " #{post.title} !" }
+    assert_equal "Amazon Amazon !Yahoo Yahoo !", render
+  end
+
   def test_render_inline
     assert_equal "Hello, World!", @view.render(inline: "Hello, World!")
   end


### PR DESCRIPTION
### Summary

As the documentation suggests [here](https://github.com/rails/rails/blob/main/actionview/lib/action_view/renderer/partial_renderer.rb#L246-L253) we should be able to provide a block when rendering a collection, but this currently doesn't works and raises an error.

This feature was introduced in this [commit](https://github.com/rails/rails/commit/38c7d73e73d569211c4dfadf96fc295a925b7c9c) and then in [this commit](https://github.com/rails/rails/commit/d0301e13f4d6e2ddf956ecf80e85384c1ea5346c) was made some refactoring which created the method [render_template](https://github.com/rails/rails/commit/d0301e13f4d6e2ddf956ecf80e85384c1ea5346c#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfR208) and [render_collection](https://github.com/rails/rails/commit/d0301e13f4d6e2ddf956ecf80e85384c1ea5346c#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfR223) which at the time passed the block to the [render_template](https://github.com/rails/rails/commit/d0301e13f4d6e2ddf956ecf80e85384c1ea5346c#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfR241), after creating the `render_template` and `render_collection` methods in [this commit](https://github.com/rails/rails/commit/d7415f792cefeaa11453d7ac1d0c3813b2883599) there was made a change to access the block through a instance variable, before it was passed [here](https://github.com/rails/rails/commit/d7415f792cefeaa11453d7ac1d0c3813b2883599#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfL208) as a parameter and then it changed to using the instance variable [here](https://github.com/rails/rails/commit/d7415f792cefeaa11453d7ac1d0c3813b2883599#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfR234) and then in [this commit](https://github.com/rails/rails/commit/4945d8223964d4ccb3c0a0f4107f15ae1c6c4a09) the `render_collection` implementation has changed, where it before was calling [render_template(template)](https://github.com/rails/rails/commit/4945d8223964d4ccb3c0a0f4107f15ae1c6c4a09#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfL225) it started calling [template.render(@view, locals)](https://github.com/rails/rails/commit/4945d8223964d4ccb3c0a0f4107f15ae1c6c4a09#diff-43fdb513723309ae22c15a97745420167203e74e7d8e4268d8bbce92510c9acfR237) and at this point when rendering collections the block wasn't evaluated anymore. And then after removing that behavior there was made a last cleanup in this [commit](https://github.com/rails/rails/commit/9f5cd0156ab907d8097fc9c588823a9b09038b93) removing the [specs](https://github.com/rails/rails/commit/9f5cd0156ab907d8097fc9c588823a9b09038b93#diff-6c4629231ddafdf373d236bb81cf08685d48b0b6154d86779c377814e5a62016L489-L1168) and pointing in the commit message that `<% render :partial do |args| %>` was removed but the docs related to this weren't.

### Other Information

After digging into this the last [commit](https://github.com/rails/rails/commit/9f5cd0156ab907d8097fc9c588823a9b09038b93) that I mention makes it explicit that this behavior was removed from rails, so I'm not sure if we should bring the behavior back or remove the docs that mention it.

Based on work done in this PR https://github.com/rails/rails/pull/17249

Closes #17224