### PR TITLE
Implement ActionMailbox incinerate in conductor

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,4 +1,6 @@
+*   Add ability to incinerate an inbound message through the conductor interface.
 
+    *Santiago Bartesaghi*
 
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/actionmailbox/CHANGELOG.md) for previous changes.

--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/incinerates_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/incinerates_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Rails
+  # Incinerating will destroy an email that is due and has already been processed.
+  class Conductor::ActionMailbox::IncineratesController < Rails::Conductor::BaseController
+    def create
+      ActionMailbox::InboundEmail.find(params[:inbound_email_id]).incinerate
+
+      redirect_to main_app.rails_conductor_inbound_emails_url
+    end
+  end
+end

--- a/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/show.html.erb
+++ b/actionmailbox/app/views/rails/conductor/action_mailbox/inbound_emails/show.html.erb
@@ -4,7 +4,7 @@
 
 <ul>
   <li><%= button_to "Route again", main_app.rails_conductor_inbound_email_reroute_path(@inbound_email), method: :post %></li>
-  <li>Incinerate</li>
+  <li><%= button_to "Incinerate", main_app.rails_conductor_inbound_email_incinerate_path(@inbound_email), method: :post %></li>
 </ul>
 
 <details>

--- a/actionmailbox/config/routes.rb
+++ b/actionmailbox/config/routes.rb
@@ -21,5 +21,6 @@ Rails.application.routes.draw do
     post "inbound_emails/sources", to: "inbound_emails/sources#create", as: :rails_conductor_inbound_email_sources
 
     post ":inbound_email_id/reroute" => "reroutes#create", as: :rails_conductor_inbound_email_reroute
+    post ":inbound_email_id/incinerate" => "incinerates#create", as: :rails_conductor_inbound_email_incinerate
   end
 end

--- a/railties/test/commands/routes_test.rb
+++ b/railties/test/commands/routes_test.rb
@@ -64,17 +64,18 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
     MESSAGE
 
     assert_equal <<~MESSAGE, run_routes_command([ "-g", "POST" ])
-                                     Prefix Verb URI Pattern                                                         Controller#Action
-                                            POST /cart(.:format)                                                     cart#create
-              rails_postmark_inbound_emails POST /rails/action_mailbox/postmark/inbound_emails(.:format)             action_mailbox/ingresses/postmark/inbound_emails#create
-                 rails_relay_inbound_emails POST /rails/action_mailbox/relay/inbound_emails(.:format)                action_mailbox/ingresses/relay/inbound_emails#create
-              rails_sendgrid_inbound_emails POST /rails/action_mailbox/sendgrid/inbound_emails(.:format)             action_mailbox/ingresses/sendgrid/inbound_emails#create
-              rails_mandrill_inbound_emails POST /rails/action_mailbox/mandrill/inbound_emails(.:format)             action_mailbox/ingresses/mandrill/inbound_emails#create
-               rails_mailgun_inbound_emails POST /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)         action_mailbox/ingresses/mailgun/inbound_emails#create
-                                            POST /rails/conductor/action_mailbox/inbound_emails(.:format)            rails/conductor/action_mailbox/inbound_emails#create
-      rails_conductor_inbound_email_sources POST /rails/conductor/action_mailbox/inbound_emails/sources(.:format)    rails/conductor/action_mailbox/inbound_emails/sources#create
-      rails_conductor_inbound_email_reroute POST /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format) rails/conductor/action_mailbox/reroutes#create
-                       rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                      active_storage/direct_uploads#create
+                                     Prefix Verb URI Pattern                                                            Controller#Action
+                                            POST /cart(.:format)                                                        cart#create
+              rails_postmark_inbound_emails POST /rails/action_mailbox/postmark/inbound_emails(.:format)                action_mailbox/ingresses/postmark/inbound_emails#create
+                 rails_relay_inbound_emails POST /rails/action_mailbox/relay/inbound_emails(.:format)                   action_mailbox/ingresses/relay/inbound_emails#create
+              rails_sendgrid_inbound_emails POST /rails/action_mailbox/sendgrid/inbound_emails(.:format)                action_mailbox/ingresses/sendgrid/inbound_emails#create
+              rails_mandrill_inbound_emails POST /rails/action_mailbox/mandrill/inbound_emails(.:format)                action_mailbox/ingresses/mandrill/inbound_emails#create
+               rails_mailgun_inbound_emails POST /rails/action_mailbox/mailgun/inbound_emails/mime(.:format)            action_mailbox/ingresses/mailgun/inbound_emails#create
+                                            POST /rails/conductor/action_mailbox/inbound_emails(.:format)               rails/conductor/action_mailbox/inbound_emails#create
+      rails_conductor_inbound_email_sources POST /rails/conductor/action_mailbox/inbound_emails/sources(.:format)       rails/conductor/action_mailbox/inbound_emails/sources#create
+      rails_conductor_inbound_email_reroute POST /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)    rails/conductor/action_mailbox/reroutes#create
+   rails_conductor_inbound_email_incinerate POST /rails/conductor/action_mailbox/:inbound_email_id/incinerate(.:format) rails/conductor/action_mailbox/incinerates#create
+                       rails_direct_uploads POST /rails/active_storage/direct_uploads(.:format)                         active_storage/direct_uploads#create
     MESSAGE
 
     assert_equal <<~MESSAGE, run_routes_command([ "-g", "basketballs" ])
@@ -187,6 +188,7 @@ rails_blob_representation_proxy GET  /rails/active_storage/representations/proxy
 new_rails_conductor_inbound_email_source GET    /rails/conductor/action_mailbox/inbound_emails/sources/new(.:format)                              rails/conductor/action_mailbox/inbound_emails/sources#new
    rails_conductor_inbound_email_sources POST   /rails/conductor/action_mailbox/inbound_emails/sources(.:format)                                  rails/conductor/action_mailbox/inbound_emails/sources#create
    rails_conductor_inbound_email_reroute POST   /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)                               rails/conductor/action_mailbox/reroutes#create
+rails_conductor_inbound_email_incinerate POST   /rails/conductor/action_mailbox/:inbound_email_id/incinerate(.:format)                            rails/conductor/action_mailbox/incinerates#create
                       rails_service_blob GET    /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)                               active_storage/blobs/redirect#show
                 rails_service_blob_proxy GET    /rails/active_storage/blobs/proxy/:signed_id/*filename(.:format)                                  active_storage/blobs/proxy#show
                                          GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                                        active_storage/blobs/redirect#show
@@ -303,46 +305,51 @@ new_rails_conductor_inbound_email_source GET    /rails/conductor/action_mailbox/
       URI               | /rails/conductor/action_mailbox/:inbound_email_id/reroute(.:format)
       Controller#Action | rails/conductor/action_mailbox/reroutes#create
       --[ Route 19 ]-------------
+      Prefix            | rails_conductor_inbound_email_incinerate
+      Verb              | POST
+      URI               | /rails/conductor/action_mailbox/:inbound_email_id/incinerate(.:format)
+      Controller#Action | rails/conductor/action_mailbox/incinerates#create
+      --[ Route 20 ]-------------
       Prefix            | rails_service_blob
       Verb              | GET
       URI               | /rails/active_storage/blobs/redirect/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
-      --[ Route 20 ]-------------
+      --[ Route 21 ]-------------
       Prefix            | rails_service_blob_proxy
       Verb              | GET
       URI               | /rails/active_storage/blobs/proxy/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/proxy#show
-      --[ Route 21 ]-------------
+      --[ Route 22 ]-------------
       Prefix            | 
       Verb              | GET
       URI               | /rails/active_storage/blobs/:signed_id/*filename(.:format)
       Controller#Action | active_storage/blobs/redirect#show
-      --[ Route 22 ]-------------
+      --[ Route 23 ]-------------
       Prefix            | rails_blob_representation
       Verb              | GET
       URI               | /rails/active_storage/representations/redirect/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
-      --[ Route 23 ]-------------
+      --[ Route 24 ]-------------
       Prefix            | rails_blob_representation_proxy
       Verb              | GET
       URI               | /rails/active_storage/representations/proxy/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/proxy#show
-      --[ Route 24 ]-------------
+      --[ Route 25 ]-------------
       Prefix            | 
       Verb              | GET
       URI               | /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format)
       Controller#Action | active_storage/representations/redirect#show
-      --[ Route 25 ]-------------
+      --[ Route 26 ]-------------
       Prefix            | rails_disk_service
       Verb              | GET
       URI               | /rails/active_storage/disk/:encoded_key/*filename(.:format)
       Controller#Action | active_storage/disk#show
-      --[ Route 26 ]-------------
+      --[ Route 27 ]-------------
       Prefix            | update_rails_disk_service
       Verb              | PUT
       URI               | /rails/active_storage/disk/:encoded_token(.:format)
       Controller#Action | active_storage/disk#update
-      --[ Route 27 ]-------------
+      --[ Route 28 ]-------------
       Prefix            | rails_direct_uploads
       Verb              | POST
       URI               | /rails/active_storage/direct_uploads(.:format)


### PR DESCRIPTION
### Summary

The Rails Conductor for ActionMailbox inbound messages has a non implemented action "Incinerate". I think there are 3 possible approaches here:
1. Implement a controller that calls `incinerate` on the inbound message
2. Make the `incinerate` button call to the `destroy` action of inbound messages since it might not make sense to check for `due?` and `processed?` before destroying an inbound message within the conductor
3. Remove the `incinerate` button from the view if it doesn't add much value having it be implemented.

I have been thinking about it, and finally decided to go with 1. but it's up to discussion. Furthermore, this PR is not handling the case where the inbound message can't be incinerated either because the inbound message is not due or not processed yet. But I think that could be handled in a follow up PR.