### PR TITLE
Update docs active record encryption (in Rotating keys section)

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -291,7 +291,7 @@ As with other built-in key providers, you can provide a list of primary keys in 
 
 ### Custom key providers
 
-For more advanced key-management schemes, you can configure a custom key provider in a initializer:
+For more advanced key-management schemes, you can configure a custom key provider in an initializer:
 
 ```ruby
 ActiveRecord::Encryption.key_provider = MyKeyProvider.new
@@ -340,17 +340,17 @@ The key will be used internally to derive the key used to encrypt and decrypt th
 
 ### Rotating keys
 
-`active_record.encryption` can work with lists of keys, to support implementing key-rotation schemes:
+`active_record.encryption` can work with lists of keys to support implementing key-rotation schemes:
 
-- The **first key** will be used for encrypting new content.
-- All the keys will be tried when decrypting content, until one works.
+- The **last key** will be used for encrypting new content.
+- All the keys will be tried when decrypting content until one works.
 
 ```yml
 active_record
   encryption:
     primary_key:
-        - bc17e7b413fd4720716a7633027f8cc4 # Active, encrypts new content
         - a1cc4d7b9f420e40a337b9e68c5ecec6 # Previous keys can still decrypt existing content
+        - bc17e7b413fd4720716a7633027f8cc4 # Active, encrypts new content
     key_derivation_salt: a3226b97b3b2f8372d1fc6d497a0c0d3
 ```
 


### PR DESCRIPTION
### Summary

Honestly, I am not sure this is was expected or bug, but.

When I tried to implement the rotating keys of the Active record encryption using the edge Rails (Github main branch), I found that Rails using the last primary keys rather first one when encrypts the new content.

I try to reproduce this step-by-step in this bellow:

First, I am generating the active record encryption keys:

```
active_record_encryption:
  primary_key: 121bd2026c924a6e0407b21a79c5a8a8
  deterministic_key: gReNA2ZZgi8z5OKLBqqMYPpTVYalhQMp
  key_derivation_salt: q6xHC9V0L1lKd1OPng5Y6MFKoIbEEWYM
```

Then, creating the article model:

```rb
# app/models/article.rb
class Article < ApplicationRecord
  encrypts :title
end
```

Then, add the config to see the related references key in the database:
 
```rb
# config/application.rb
config.active_record.encryption.store_key_references = true
```

Then, I try to add some records:
```rb
irb(main):003:0> Article.create title: "Hello, World"
  TRANSACTION (0.2ms)  BEGIN
  Article Create (1.3ms)  INSERT INTO `articles` (`title`, `created_at`, `updated_at`) VALUES ('{\"p\":\"9BxcuDFHBbmgnNpl\",\"h\":{\"iv\":\"4qLQAznJeJZY+QAq\",\"at\":\"t8CIpL1TEulLGE+JMpIaoQ==\",\"i\":\"YmM2Mg==\"}}', '2021-06-20 08:04:18.815405', '2021-06-20 08:04:18.815405')
  TRANSACTION (4.2ms)  COMMIT
=> #<Article:0x00007fa5726296b0 id: 38, title: "Hello, World", created_at: Sun, 20 Jun 2021 08:04:18.815405000 UTC +00:00, updated_at: Sun, 20 Jun 2021 08:04:18.815405000 UTC +00:00>
irb(main):004:0> Article.create title: "Hello, World 2"
  TRANSACTION (0.2ms)  BEGIN
  Article Create (0.7ms)  INSERT INTO `articles` (`title`, `created_at`, `updated_at`) VALUES ('{\"p\":\"zpaRidjI61Qx/tZsHpE=\",\"h\":{\"iv\":\"ZyYZCRpWqfaVXTkx\",\"at\":\"RigwgKRd3/edsudItrwI3g==\",\"i\":\"YmM2Mg==\"}}', '2021-06-20 08:04:20.693878', '2021-06-20 08:04:20.693878')
  TRANSACTION (0.8ms)  COMMIT
=> #<Article:0x00007fa571a9c630 id: 39, title: "Hello, World 2", created_at: Sun, 20 Jun 2021 08:04:20.693878000 UTC +00:00, updated_at: Sun, 20 Jun 2021 08:04:20.693878000 UTC +00:00>
```

Seems like, the key was for the records was`YmM2Mg==`. 

And then, I tried to rotate the key, followed the [docs](https://edgeguides.rubyonrails.org/active_record_encryption.html#rotating-keys) I add the new key in the first place, like this:

```
active_record_encryption:
  primary_key:
    - 9f8e08d77d121e282d5e6813937fc430
    - 121bd2026c924a6e0407b21a79c5a8a8
  deterministic_key: gReNA2ZZgi8z5OKLBqqMYPpTVYalhQMp
  key_derivation_salt: q6xHC9V0L1lKd1OPng5Y6MFKoIbEEWYM
``` 

And try to create the new article:

```rb
irb(main):001:0> Article.create title: "Hello, World 3"
  TRANSACTION (0.2ms)  BEGIN
  Article Create (4.5ms)  INSERT INTO `articles` (`title`, `created_at`, `updated_at`) VALUES ('{\"p\":\"balZazMyKG53SUcScuk=\",\"h\":{\"iv\":\"oMhV5BSuIr3Lz0YY\",\"at\":\"Qfe5unmJgLTj79bsTcyHdw==\",\"i\":\"YmM2Mg==\"}}', '2021-06-20 08:08:36.469669', '2021-06-20 08:08:36.469669')
  TRANSACTION (4.9ms)  COMMIT
=> #<Article:0x00007f9af81ef998 id: 40, title: "Hello, World 3", created_at: Sun, 20 Jun 2021 08:08:36.469669000 UTC +00:00, updated_at: Sun, 20 Jun 2021 08:08:36.469669000 UTC +00:00>
```

And the references key still the same, that is "YmM2Mg==", so I try to switch the position to this:

```
active_record_encryption:
  primary_key:
    - 121bd2026c924a6e0407b21a79c5a8a8
    - 9f8e08d77d121e282d5e6813937fc430
  deterministic_key: gReNA2ZZgi8z5OKLBqqMYPpTVYalhQMp
  key_derivation_salt: q6xHC9V0L1lKd1OPng5Y6MFKoIbEEWYM
```

And, then try to create new record:

```rb
irb(main):002:0> Article.create title: "Hello, World 4"
  TRANSACTION (0.2ms)  BEGIN
  Article Create (0.3ms)  INSERT INTO `articles` (`title`, `created_at`, `updated_at`) VALUES ('{\"p\":\"M4wyXNTPOsKcbYp/0tE=\",\"h\":{\"iv\":\"OpLIJm8XUxtc6X4c\",\"at\":\"cpJhUdQLNfCZA4pcYEmu2w==\",\"i\":\"Mjc2OA==\"}}', '2021-06-20 08:13:07.971267', '2021-06-20 08:13:07.971267')
  TRANSACTION (0.9ms)  COMMIT
=> #<Article:0x00007fa632bb5a50 id: 42, title: "Hello, World 4", created_at: Sun, 20 Jun 2021 08:13:07.971267000 UTC +00:00, updated_at: Sun, 20 Jun 2021 08:13:07.971267000 UTC +00:00>
```

It works as expected, the reference key was changed to `Mjc2OA==` from the old one (`YmM2Mg==`). 

So, because of that I assumed active record encryption using the last key for encrypts the new content instead of the first one.

But, again I am not sure this is just for a typo in docs or this is a bugs, so feel free to decline the PR ya :)

Thank you.

### Other Information

None.
