### PR TITLE
Add clear message when rails new finishes

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -572,6 +572,10 @@ module Rails
         @after_bundle_callbacks.each(&:call)
       end
 
+      def finish_message
+        say "Successfully created a new Rails app! Take a look at https://guides.rubyonrails.org/getting_started.html for more info on next steps."
+      end
+
       def self.banner
         "rails new #{arguments.map(&:usage).join(' ')} [options]"
       end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1286,6 +1286,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "web-console", app_root
   end
 
+  def test_finish_message_printed_at_end
+    output = run_generator.split("\n").last
+    assert_match(/Successfully created a new Rails app/, output)
+  end
+
   private
     def stub_rails_application(root)
       Rails.application.config.root = root


### PR DESCRIPTION
### Summary

Running `rails new` for the first time on a computer can easily generate
hundreds of lines of output. Before this change, the end of the output
would read:

    Webpacker successfully installed 🎉 🍰

While that line makes sense when all of the output is read from top to
bottom, it is kinda confusing for a new user who just created a new
Rails app and glossed over all of the intermediate output from the
command.

This change adds an explicit message to the end of `rails new` that
says 1) the command finished successfully and 2) here's some more info
if you don't know what to do next.