### PR TITLE
Fix the `turbolinks` npm -> github reference

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -326,7 +326,7 @@ module Rails
         # since Turbolinks is deprecated, let's just always point to main.
         # expect this to be replaced with Hotwire at some point soon.
         if options.main? || options.edge?
-          "git://github.com/turbolinks/turbolinks.git#main"
+          "turbolinks/turbolinks#master"
         else
           "^5.2.0"
         end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -551,7 +551,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/"@rails\/ujs": "latest"/, content)
       assert_match(/"@rails\/activestorage": "latest"/, content)
       assert_match(/"@rails\/actioncable": "latest"/, content)
-      assert_match(/"turbolinks": "git:\/\/github.com\/turbolinks\/turbolinks.git#main"/, content)
+      assert_match(/"turbolinks": "turbolinks\/turbolinks#master"/, content)
     end
   end
 


### PR DESCRIPTION
Bug in https://github.com/rails/rails/pull/42263

You can replicate this by doing `rails new --main` with that PR. This is the output you'd get: https://gist.github.com/ghiculescu/7bc14b428cec4caa32f795b922d5a90b

This now uses the correct github reference, per the [npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#github-urls). Now it works: https://gist.github.com/ghiculescu/cb56cdba53b00b877b21893ecf2fb3cf