### PR TITLE
Allow the construction of a CTE from a string (#42561)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow construction of CTEs using strings, fixing #42561.
+
+    *J Smith*
+
 *   Adds support for `if_not_exists` to `add_foreign_key` and `if_exists` to `remove_foreign_key`.
 
     Applications can set their migrations to ignore exceptions raised when adding a foreign key

--- a/activerecord/lib/arel/select_manager.rb
+++ b/activerecord/lib/arel/select_manager.rb
@@ -226,7 +226,13 @@ module Arel # :nodoc: all
       else
         node_class = Nodes::With
       end
-      @ast.with = node_class.new(subqueries.flatten)
+      @ast.with = node_class.new(subqueries.flatten.map do |subquery|
+        if String === subquery
+          Arel.sql(subquery)
+        else
+          subquery
+        end
+      end)
 
       self
     end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -926,11 +926,17 @@ module Arel # :nodoc: all
             when Arel::Nodes::TableAlias
               name = child.name
               relation = child.relation
+            when String
+              collector << child
             end
 
-            collector << quote_table_name(name)
-            collector << " AS "
-            visit relation, collector
+            case child
+            when Arel::Nodes::As, Arel::Nodes::TableAlias
+              collector << quote_table_name(name)
+              collector << " AS "
+
+              visit relation, collector
+            end
           end
 
           collector

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -926,7 +926,7 @@ module Arel # :nodoc: all
             when Arel::Nodes::TableAlias
               name = child.name
               relation = child.relation
-            when String
+            when Arel::Nodes::SqlLiteral
               collector << child
             end
 

--- a/activerecord/test/cases/arel/select_manager_test.rb
+++ b/activerecord/test/cases/arel/select_manager_test.rb
@@ -361,6 +361,18 @@ module Arel
           SELECT * FROM "replies"
         }
       end
+
+      it "should support Strings" do
+        users_top      = Table.new(:users_top)
+        comments       = Table.new(:comments)
+
+        select_manager = comments.project(Arel.star).with('"users_top" AS (SELECT "users"."id" FROM "users" WHERE "users"."karma" > 100)')
+                          .where(comments[:author_id].in(users_top.project(users_top[:id])))
+
+        _(select_manager.to_sql).must_be_like %{
+          WITH "users_top" AS (SELECT "users"."id" FROM "users" WHERE "users"."karma" > 100) SELECT * FROM "comments" WHERE "comments"."author_id" IN (SELECT "users_top"."id" FROM "users_top")
+        }
+      end
     end
 
     describe "ast" do

--- a/activerecord/test/cases/arel/visitors/to_sql_test.rb
+++ b/activerecord/test/cases/arel/visitors/to_sql_test.rb
@@ -755,6 +755,15 @@ module Arel
             WITH expr1 AS (SELECT * FROM "bar"), expr2 AS (SELECT * FROM "baz") SELECT * FROM expr2
           }
         end
+
+        it "handles table strings" do
+          manager = Table.new(:foo).project(Arel.star).from(Arel.sql("expr2"))
+          manager.with('expr1 AS (SELECT * FROM "bar")', 'expr2 AS (SELECT * FROM "baz")')
+
+          _(compile(manager.ast)).must_be_like %{
+            WITH expr1 AS (SELECT * FROM "bar"), expr2 AS (SELECT * FROM "baz") SELECT * FROM expr2
+          }
+        end
       end
 
       describe "Nodes::WithRecursive" do


### PR DESCRIPTION
### Summary

Constructing CTE `WITH` statements from strings broke some time between Rails 6.0 and 6.1.

See #42561 for details.

It might be a good idea to merge this in as a bug fix to 6-1-stable, since this behaviour was working in 6.0.