### PR TITLE
Test cleanup for cache store tests

### DIFF
--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -152,7 +152,7 @@ class OptimizedFileStoreTest < FileStoreTest
     super
   end
 
-  def forward_compatibility
+  def test_forward_compatibility
     previous_format = ActiveSupport::Cache.format_version
     ActiveSupport::Cache.format_version = 6.1
     @old_store = lookup_store
@@ -162,7 +162,7 @@ class OptimizedFileStoreTest < FileStoreTest
     assert_equal "bar", @cache.read("foo")
   end
 
-  def forward_compatibility
+  def test_backward_compatibility
     previous_format = ActiveSupport::Cache.format_version
     ActiveSupport::Cache.format_version = 6.1
     @old_store = lookup_store

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -289,7 +289,7 @@ class OptimizedMemCacheStoreTest < MemCacheStoreTest
     super
   end
 
-  def forward_compatibility
+  def test_forward_compatibility
     previous_format = ActiveSupport::Cache.format_version
     ActiveSupport::Cache.format_version = 6.1
     @old_store = lookup_store
@@ -299,7 +299,7 @@ class OptimizedMemCacheStoreTest < MemCacheStoreTest
     assert_equal "bar", @cache.read("foo")
   end
 
-  def forward_compatibility
+  def test_backward_compatibility
     previous_format = ActiveSupport::Cache.format_version
     ActiveSupport::Cache.format_version = 6.1
     @old_store = lookup_store

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -216,7 +216,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       super
     end
 
-    def forward_compatibility
+    def test_forward_compatibility
       previous_format = ActiveSupport::Cache.format_version
       ActiveSupport::Cache.format_version = 6.1
       @old_store = lookup_store
@@ -226,7 +226,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_equal "bar", @cache.read("foo")
     end
 
-    def forward_compatibility
+    def test_backward_compatibility
       previous_format = ActiveSupport::Cache.format_version
       ActiveSupport::Cache.format_version = 6.1
       @old_store = lookup_store


### PR DESCRIPTION
Cleans up some tests added in https://github.com/rails/rails/pull/42025

- Fixes duplicate method names
- Adds `test_` to the method names so the tests run (I confirmed they weren't running by adding a `raise` inside one then running `bin/test test/cache/stores/mem_cache_store_test.rb`)