### PR TITLE
Removed unused function param

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -261,7 +261,7 @@ module ActiveRecord
       #   ], unique_by: :isbn)
       #
       #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
-      def upsert_all(attributes, on_duplicate: :update, returning: nil, unique_by: nil, update_sql: nil)
+      def upsert_all(attributes, on_duplicate: :update, returning: nil, unique_by: nil)
         InsertAll.new(self, attributes, on_duplicate: on_duplicate, returning: returning, unique_by: unique_by).execute
       end
 


### PR DESCRIPTION
`update_sql` param got introduced in https://github.com/rails/rails/pull/41933#issue-613712361. But seems like we are not using / passing it within the function.