### PR TITLE
Optimized Cache::Entry should support old dalli_store values

### DIFF
--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -228,4 +228,11 @@ module LocalCacheBehavior
       end
     end
   end
+
+  def test_local_cache_should_read_and_write_false
+    @cache.with_local_cache do
+      assert @cache.write("foo", false)
+      assert_equal false, @cache.read("foo")
+    end
+  end
 end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -232,6 +232,42 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     assert_compressed(LARGE_OBJECT)
   end
 
+  def test_can_load_raw_values_from_dalli_store
+    key = "test-with-value-the-way-the-dalli-store-did"
+
+    @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), "value", 0, compress: false) }
+    assert_nil @cache.read(key)
+    assert_equal "value", @cache.fetch(key) { "value" }
+  end
+
+  def test_can_load_raw_falsey_values_from_dalli_store
+    key = "test-with-false-value-the-way-the-dalli-store-did"
+
+    @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), false, 0, compress: false) }
+    assert_nil @cache.read(key)
+    assert_equal false, @cache.fetch(key) { false }
+  end
+
+  def test_can_load_raw_values_from_dalli_store_with_local_cache
+    key = "test-with-value-the-way-the-dalli-store-did-with-local-cache"
+
+    @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), "value", 0, compress: false) }
+    @cache.with_local_cache do
+      assert_nil @cache.read(key)
+      assert_equal "value", @cache.fetch(key) { "value" }
+    end
+  end
+
+  def test_can_load_raw_falsey_values_from_dalli_store_with_local_cache
+    key = "test-with-false-value-the-way-the-dalli-store-did-with-local-cache"
+
+    @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), false, 0, compress: false) }
+    @cache.with_local_cache do
+      assert_nil @cache.read(key)
+      assert_equal false, @cache.fetch(key) { false }
+    end
+  end
+
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join


### PR DESCRIPTION
Same bug as https://github.com/rails/rails/pull/42559, but a very different fix due to https://github.com/rails/rails/pull/42025. To recap, the issue:

- While using the `dalli_store`, you set any value in the Rails cache with no expiry.
- You change to the `mem_cache_store`.
- You upgrade to Rails 7.
- You try to read the same cache key you set in step 1, and it crashes on read.

https://github.com/rails/rails/pull/42025 was backward compatible with entries written using the `mem_cache_store`, but *not* the `dalli_store` which did not use `ActiveSupport::Cache::Entry`. So this is actually worse than https://github.com/rails/rails/pull/42559 in that it would impact any key that was written by the `dalli_store` and then was read by Rails 7.

This PR fixes that by rescuing when a value can't be handled by the new coder system and falling back to just returning an `Entry`.
