### PR TITLE
Rename GeneratedAttribute#default to #example_value

### DIFF
--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -111,20 +111,27 @@ module Rails
       end
 
       def default
-        @default ||= case type
-                     when :integer                     then 1
-                     when :float                       then 1.5
-                     when :decimal                     then "9.99"
-                     when :datetime, :timestamp, :time then Time.now.to_s(:db)
-                     when :date                        then Date.today.to_s(:db)
-                     when :string                      then name == "type" ? "" : "MyString"
-                     when :text                        then "MyText"
-                     when :boolean                     then false
-                     when :references, :belongs_to,
-                          :attachment, :attachments,
-                          :rich_text                   then nil
-                     else
-                       ""
+        ActiveSupport::Deprecation.warn <<~MSG.squish
+          Rails::Generators::GeneratedAttribute#default is deprecated and will be removed in 7.1.
+          Use #example_value instead."
+        MSG
+      end
+
+      def example_value
+        @example_value ||= case type
+                           when :integer                     then 1
+                           when :float                       then 1.5
+                           when :decimal                     then "9.99"
+                           when :datetime, :timestamp, :time then Time.now.to_s(:db)
+                           when :date                        then Date.today.to_s(:db)
+                           when :string                      then name == "type" ? "" : "MyString"
+                           when :text                        then "MyText"
+                           when :boolean                     then false
+                           when :references, :belongs_to,
+                                :attachment, :attachments,
+                                :rich_text                   then nil
+                           else
+                             ""
         end
       end
 

--- a/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
+++ b/railties/lib/rails/generators/test_unit/model/templates/fixtures.yml.tt
@@ -6,9 +6,9 @@
   <%- if attribute.password_digest? -%>
   password_digest: <%%= BCrypt::Password.create("secret") %>
   <%- elsif attribute.reference? -%>
-  <%= yaml_key_value(attribute.column_name.delete_suffix("_id"), attribute.default || name) %>
+  <%= yaml_key_value(attribute.column_name.delete_suffix("_id"), attribute.example_value || name) %>
   <%- elsif !attribute.virtual? -%>
-  <%= yaml_key_value(attribute.column_name, attribute.default) %>
+  <%= yaml_key_value(attribute.column_name, attribute.example_value) %>
   <%- end -%>
   <%- if attribute.polymorphic? -%>
   <%= yaml_key_value("#{attribute.name}_type", attribute.human_name) %>

--- a/railties/lib/rails/generators/testing/assertions.rb
+++ b/railties/lib/rails/generators/testing/assertions.rb
@@ -111,15 +111,23 @@ module Rails
           assert_equal(field_type, create_generated_attribute(attribute_type).field_type)
         end
 
-        # Asserts the given attribute type gets a proper default value:
+        # Asserts the given attribute type gets a proper example value:
         #
-        #   assert_field_default_value :string, "MyString"
-        def assert_field_default_value(attribute_type, value)
+        #   assert_field_example_value :string, "MyString"
+        def assert_field_example_value(attribute_type, value)
           if value.nil?
-            assert_nil(create_generated_attribute(attribute_type).default)
+            assert_nil(create_generated_attribute(attribute_type).example_value)
           else
-            assert_equal(value, create_generated_attribute(attribute_type).default)
+            assert_equal(value, create_generated_attribute(attribute_type).example_value)
           end
+        end
+
+        def assert_field_default_value(attribute_type, value) #:nodoc:
+          ActiveSupport::Deprecation.warn <<~MSG.squish
+            #assert_field_default_value is deprecated and will be removed in 7.1.
+            Use #assert_field_example_value instead.
+          MSG
+          assert_field_example_value(attribute_type, value)
         end
       end
     end

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -68,54 +68,66 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_match message, e.message
   end
 
-  def test_default_value_is_integer
-    assert_field_default_value :integer, 1
+  def test_assert_field_default_value_is_deprecated
+    assert_deprecated do
+      assert_field_default_value :integer, 1
+    end
   end
 
-  def test_default_value_is_float
-    assert_field_default_value :float, 1.5
+  def test_default_is_deprecated
+    assert_deprecated do
+      create_generated_attribute(:integer).default
+    end
   end
 
-  def test_default_value_is_decimal
-    assert_field_default_value :decimal, "9.99"
+  def test_example_value_is_integer
+    assert_field_example_value :integer, 1
   end
 
-  def test_default_value_is_datetime
+  def test_example_value_is_float
+    assert_field_example_value :float, 1.5
+  end
+
+  def test_example_value_is_decimal
+    assert_field_example_value :decimal, "9.99"
+  end
+
+  def test_example_value_is_datetime
     %w(datetime timestamp time).each do |attribute_type|
-      assert_field_default_value attribute_type, Time.now.to_s(:db)
+      assert_field_example_value attribute_type, Time.now.to_s(:db)
     end
   end
 
-  def test_default_value_is_date
-    assert_field_default_value :date, Date.today.to_s(:db)
+  def test_example_value_is_date
+    assert_field_example_value :date, Date.today.to_s(:db)
   end
 
-  def test_default_value_is_string
-    assert_field_default_value :string, "MyString"
+  def test_example_value_is_string
+    assert_field_example_value :string, "MyString"
   end
 
-  def test_default_value_for_type
+  def test_example_value_for_type
     att = Rails::Generators::GeneratedAttribute.parse("type:string")
-    assert_equal("", att.default)
+    assert_equal("", att.example_value)
   end
 
-  def test_default_value_is_text
-    assert_field_default_value :text, "MyText"
+  def test_example_value_is_text
+    assert_field_example_value :text, "MyText"
   end
 
-  def test_default_value_is_boolean
-    assert_field_default_value :boolean, false
+  def test_example_value_is_boolean
+    assert_field_example_value :boolean, false
   end
 
-  def test_default_value_is_nil
+  def test_example_value_is_nil
     %w(references belongs_to rich_text attachment attachments).each do |attribute_type|
-      assert_field_default_value attribute_type, nil
+      assert_field_example_value attribute_type, nil
     end
   end
 
-  def test_default_value_is_empty_string
+  def test_example_value_is_empty_string
     %w(digest token).each do |attribute_type|
-      assert_field_default_value attribute_type, ""
+      assert_field_example_value attribute_type, ""
     end
   end
 


### PR DESCRIPTION
### Summary

GeneratedAttribute has a `default` method that is used for adding
example data to generated fixtures:
     
      one:
        name: MyString
        age: 1

The method name `default` does not explain that it's used for fixture
data. It also prevents us from using a method named `default` for
generating default database column values from the CLI.
For example setting the default for an integer column:

    rails g model User age:integer:0