### PR TITLE
Fix spelling of associations in guides

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -523,7 +523,7 @@ add_belongs_to :taggings, :taggable, polymorphic: true
 ```
 
 The polymorphic option will create two columns on the taggings table which can
-be used for polymorphic assocations: `taggable_type` and `taggable_id`.
+be used for polymorphic associations: `taggable_type` and `taggable_id`.
 
 A foreign key can be created with the the `foreign_key` option.
 


### PR DESCRIPTION
### Summary

I had a failing build in a unrelated PR warning about the misspelling:
```
./guides/source/active_record_migrations.md:526: assocations ==> associations
```
https://github.com/rails/rails/pull/42570/checks