### PR TITLE
Report async queries lock wait duration

### DIFF
--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -37,9 +37,12 @@ module ActiveRecord
 
       return if IGNORE_PAYLOAD_NAMES.include?(payload[:name])
 
-      name  = "#{payload[:name]} (#{event.duration.round(1)}ms)"
+      name = if payload[:async]
+        "ASYNC #{payload[:name]} (#{payload[:lock_wait].round(1)}ms) (db time #{event.duration.round(1)}ms)"
+      else
+        "#{payload[:name]} (#{event.duration.round(1)}ms)"
+      end
       name  = "CACHE #{name}" if payload[:cached]
-      name  = "ASYNC #{name}" if payload[:async]
       sql   = payload[:sql]
       binds = nil
 

--- a/activerecord/test/cases/log_subscriber_test.rb
+++ b/activerecord/test/cases/log_subscriber_test.rb
@@ -133,6 +133,12 @@ class LogSubscriberTest < ActiveRecord::TestCase
     end
   end
 
+  def test_async_query
+    logger = TestDebugLogSubscriber.new
+    logger.sql(Event.new(0.9, sql: "SELECT * from models", name: "Model Load", async: true, lock_wait: 0.01))
+    assert_match(/ASYNC Model Load \(0\.0ms\) \(db time 0\.9ms\)  SELECT/i, logger.debugs.last)
+  end
+
   def test_query_logging_coloration_with_nested_select
     logger = TestDebugLogSubscriber.new
     logger.colorize_logging = true

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -62,6 +62,7 @@ module ActiveRecord
           status[:executed] = true
           status[:async] = event.payload[:async]
           status[:thread_id] = Thread.current.object_id
+          status[:lock_wait] = event.payload[:lock_wait]
         end
       end
 
@@ -70,6 +71,11 @@ module ActiveRecord
       assert_equal expected_records, deferred_posts.to_a
       assert_equal Post.connection.supports_concurrent_connections?, status[:async]
       assert_equal Thread.current.object_id, status[:thread_id]
+      if Post.connection.supports_concurrent_connections?
+        assert_instance_of Float, status[:lock_wait]
+      else
+        assert_nil status[:lock_wait]
+      end
     ensure
       ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
     end

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -6,26 +6,6 @@ module ActiveSupport
   module Notifications
     # Instrumenters are stored in a thread local.
     class Instrumenter
-      class Buffer # :nodoc:
-        def initialize(instrumenter)
-          @instrumenter = instrumenter
-          @events = []
-        end
-
-        def instrument(name, payload = {}, &block)
-          event = @instrumenter.new_event(name, payload)
-          @events << event
-          event.record(&block)
-        end
-
-        def flush
-          events, @events = @events, []
-          events.each do |event|
-            ActiveSupport::Notifications.publish_event(event)
-          end
-        end
-      end
-
       attr_reader :id
 
       def initialize(notifier)
@@ -53,10 +33,6 @@ module ActiveSupport
 
       def new_event(name, payload = {}) # :nodoc:
         Event.new(name, nil, nil, @id, payload)
-      end
-
-      def buffer # :nodoc:
-        Buffer.new(self)
       end
 
       # Send a start notification with +name+ and +payload+.

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -107,17 +107,6 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     end
   end
 
-  def test_does_not_send_buffered_events_if_logger_is_nil
-    ActiveSupport::LogSubscriber.logger = nil
-    assert_not_called(@log_subscriber, :some_event) do
-      ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-      buffer = ActiveSupport::Notifications.instrumenter.buffer
-      buffer.instrument "some_event.my_log_subscriber"
-      buffer.flush
-      wait
-    end
-  end
-
   def test_does_not_fail_with_non_namespaced_events
     ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
     instrument "whatever"


### PR DESCRIPTION
### Context
This duration is very important to figure wether the `load_async` actually improved something. For async queries to be efficient, you need to schedule them long enough before you block on the result, otherwise you won't have gained anything (or even made things slower as there's some overhead).

So I think the Active Record logs should display that timing, otherwise it is hard to have a good picture of the async queries effectiveness.

### Examples

Here's two parallel queries of similar time, we wait about 1ms to get the result of the async one:

```
DEBUG -- :   Category Load (117.2ms)  SELECT *, sleep(0.001) FROM `categories` LIMIT 100
DEBUG -- :   ASYNC (1ms) Post Load (117.5ms)  SELECT *, sleep(0.001) FROM `posts` LIMIT 100
```

Or a less balanced case, where we waited for about half of the full duration for the query to complete:

```
DEBUG -- :   Category Load (62.1ms)  SELECT *, sleep(0.001) FROM `categories` LIMIT 50
DEBUG -- :   ASYNC (64ms) Post Load (126.1ms)  SELECT *, sleep(0.001) FROM `posts` LIMIT 100
```

### Implementation

I'm not really happy with the implementation (hence the draft), but I can't think of something really better.

I'd also love feedback on the log format, I don't think `ASYNC (64ms) Post Load (126.1ms)` is quite clear enough about what each timing mean.

