### PR TITLE
add connection_identifier to ConnectionStub

### DIFF
--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -62,6 +62,25 @@ module ActionCable
       def transmit(cable_message)
         transmissions << cable_message.with_indifferent_access
       end
+
+      def connection_identifier
+        unless defined? @connection_identifier
+          @connection_identifier = connection_gid identifiers.filter_map { |id| instance_variable_get("@#{id}") }
+        end
+
+        @connection_identifier
+      end
+
+      private
+        def connection_gid(ids)
+          ids.map do |o|
+            if o.respond_to? :to_gid_param
+              o.to_gid_param
+            else
+              o.to_s
+            end
+          end.sort.join(":")
+        end
     end
 
     # Superclass for Action Cable channel functional tests.

--- a/actioncable/lib/action_cable/channel/test_case.rb
+++ b/actioncable/lib/action_cable/channel/test_case.rb
@@ -65,7 +65,7 @@ module ActionCable
 
       def connection_identifier
         unless defined? @connection_identifier
-          @connection_identifier = connection_gid identifiers.filter_map { |id| instance_variable_get("@#{id}") }
+          @connection_identifier = connection_gid identifiers.filter_map { |id| send(id.to_sym) if id }
         end
 
         @connection_identifier

--- a/actioncable/test/channel/test_case_test.rb
+++ b/actioncable/test/channel/test_case_test.rb
@@ -62,6 +62,7 @@ class StubConnectionTest < ActionCable::Channel::TestCase
 
     assert_equal "John", subscription.username
     assert subscription.admin
+    assert_equal "John:true", connection.connection_identifier
   end
 end
 


### PR DESCRIPTION
Our test suite makes extensive use of `ActionCable::Channel::TestCase#stub_connection`. In our `ActionCable::Channel` class, we recently switched from operating on `connection.identifiers` to `connection.connection_identifier`.

This caused our tests to fail, even though the application works fine.

We solved this problem by monkey-patching `ConnectionStub` to include `connection_identifier`, but this method should be available for everyone.