### PR TITLE
Read `has_one` through association target from memory for new records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Read `has_one` through association target from memory for new records.
+
+    When reading an `has_one` through association for a new record and loading from DB
+    is not possible retrieves the association target from the in memory through association:
+
+    ```ruby
+    class Book < ActiveRecord::Base
+      belongs_to :author
+    end
+
+    class Author < ActiveRecord::Base
+    end
+
+    class Reader < ActiveRecord::Base
+      has_one :book
+      has_one :author, through: :book
+    end
+
+    author = Author.new
+    book = Book.new(author: author)
+    reader = Reader.new(book: book)
+    reader.author
+    # => correctly returns `author`, previously returns `nil`.
+    ```
+
+    *Jacopo Beschi*
+
 *   Allow preloading of associations with instance dependent scopes
 
     *John Hawthorn*, *John Crepezzi*, *Adam Hess*, *Eileen M. Uchitelle*, *Dinah Shi*

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -176,7 +176,7 @@ module ActiveRecord
       # ActiveRecord::RecordNotFound is rescued within the method, and it is
       # not reraised. The proxy is \reset and +nil+ is the return value.
       def load_target
-        @target = find_target if (@stale_state && stale_target?) || find_target?
+        @target = find_target if load_target?
 
         loaded! unless loaded?
         target
@@ -275,6 +275,10 @@ module ActiveRecord
 
         def scope_for_create
           scope.scope_for_create
+        end
+
+        def load_target?
+          (@stale_state && stale_target?) || find_target?
         end
 
         def find_target?

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -445,4 +445,14 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   ensure
     CustomerCarrier.current_customer = nil
   end
+
+  def test_has_one_through_loads_target_from_memory
+    category = Category.new
+    club = Club.new(name: "LRUG", category: category)
+    current_membership = CurrentMembership.new(club: club)
+    new_member = Member.new(name: "Chris", current_membership: current_membership)
+
+    assert_equal club, new_member.club
+    assert_equal category, new_member.club_category
+  end
 end


### PR DESCRIPTION
### Summary

When reading an `has_one` through association for a new record and loading from DB is not possible retrieves the association target from the in memory through association.

Fixes #42387

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
