### PR TITLE
Move test to more correct file

### DIFF
--- a/activerecord/test/cases/connection_adapters/connection_handler_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_handler_test.rb
@@ -62,6 +62,32 @@ module ActiveRecord
       end
 
       unless in_memory_db?
+        def test_not_setting_writing_role_while_using_another_named_role_raises
+          connection_handler = ActiveRecord::Base.connection_handler
+          ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+
+          ActiveRecord::Base.connects_to(shards: { default: { all: :arunit }, one: { all: :arunit } })
+
+          assert_raises(ArgumentError) { setup_shared_connection_pool }
+        ensure
+          ActiveRecord::Base.connection_handler = connection_handler
+          ActiveRecord::Base.establish_connection :arunit
+        end
+
+        def test_setting_writing_role_while_using_another_named_role_does_not_raise
+          connection_handler = ActiveRecord::Base.connection_handler
+          ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
+          old_role, ActiveRecord.writing_role = ActiveRecord.writing_role, :all
+
+          ActiveRecord::Base.connects_to(shards: { default: { all: :arunit }, one: { all: :arunit } })
+
+          assert_nothing_raised { setup_shared_connection_pool }
+        ensure
+          ActiveRecord.writing_role = old_role
+          ActiveRecord::Base.connection_handler = connection_handler
+          ActiveRecord::Base.establish_connection :arunit
+        end
+
         def test_establish_connection_with_primary_works_without_deprecation
           old_config = ActiveRecord::Base.configurations
           config = { "primary" => { "adapter" => "sqlite3", "database" => "test/db/primary.sqlite3" } }

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -434,38 +434,6 @@ module ActiveRecord
           self.abstract_class = true
         end
 
-        def test_using_a_role_other_than_writing_raises
-          connection_handler = ActiveRecord::Base.connection_handler
-          ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
-          Object.const_set(:ApplicationRecord, ApplicationRecord)
-
-          ApplicationRecord.connects_to(shards: { default: { all: :arunit }, one: { all: :arunit } })
-
-          assert_raises(ArgumentError) { setup_shared_connection_pool }
-        ensure
-          ActiveRecord.application_record_class = nil
-          Object.send(:remove_const, :ApplicationRecord)
-          ActiveRecord::Base.connection_handler = connection_handler
-          ActiveRecord::Base.establish_connection :arunit
-        end
-
-        def test_setting_writing_role_is_used_over_writing
-          connection_handler = ActiveRecord::Base.connection_handler
-          ActiveRecord::Base.connection_handler = ActiveRecord::ConnectionAdapters::ConnectionHandler.new
-          old_role, ActiveRecord.writing_role = ActiveRecord.writing_role, :all
-          Object.const_set(:ApplicationRecord, ApplicationRecord)
-
-          ApplicationRecord.connects_to(shards: { default: { all: :arunit }, one: { all: :arunit } })
-
-          assert_nothing_raised { setup_shared_connection_pool }
-        ensure
-          ActiveRecord.writing_role = old_role
-          ActiveRecord.application_record_class = nil
-          Object.send(:remove_const, :ApplicationRecord)
-          ActiveRecord::Base.connection_handler = connection_handler
-          ActiveRecord::Base.establish_connection :arunit
-        end
-
         def test_application_record_prevent_writes_can_be_changed
           Object.const_set(:ApplicationRecord, ApplicationRecord)
 


### PR DESCRIPTION
This test is about connection swapping but not nested connections so it
fits better in the connection handler test. Additionally I renamed the
tests to make more sense and removed unnecessary parts like using
ApplicationRecord, the bug is reproducible on ActiveRecord::Base alone.