### PR TITLE
Fix number_to_currency to avoid negative format when displaying zero.

### DIFF
--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -11,9 +11,16 @@ module ActiveSupport
         number = self.number.to_s.strip
         format = options[:format]
 
-        if number.sub!(/^-/, "") &&
-           (options[:precision] != 0 || number.to_f > 0.5)
-          format = options[:negative_format]
+        if number.sub!(/^-/, "")
+          number_f = number.to_f.abs
+          if number_f == 0.0
+            # likely an alternate input format that failed to parse.
+            # see https://github.com/rails/rails/pull/39350
+            format = options[:negative_format]
+          else
+            number_f *= 10**options[:precision]
+            format = options[:negative_format] if number_f > 0.5
+          end
         end
 
         rounded_number = NumberToRoundedConverter.convert(number, options)

--- a/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb
@@ -19,7 +19,7 @@ module ActiveSupport
             format = options[:negative_format]
           else
             number_f *= 10**options[:precision]
-            format = options[:negative_format] if number_f > 0.5
+            format = options[:negative_format] if number_f >= 0.5
           end
         end
 

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -81,6 +81,7 @@ module ActiveSupport
           assert_equal("$0", number_helper.number_to_currency(-0.456789, precision: 0))
           assert_equal("$0.0", number_helper.number_to_currency(-0.0456789, precision: 1))
           assert_equal("$0.00", number_helper.number_to_currency(-0.00456789, precision: 2))
+          assert_equal("-$1", number_helper.number_to_currency(-0.5, precision: 0))
           assert_equal("$1,11", number_helper.number_to_currency("1,11"))
           assert_equal("$0,11", number_helper.number_to_currency("0,11"))
           assert_equal("$,11", number_helper.number_to_currency(",11"))

--- a/activesupport/test/number_helper_test.rb
+++ b/activesupport/test/number_helper_test.rb
@@ -79,6 +79,8 @@ module ActiveSupport
           assert_equal("1,234,567,890.50 - K&#269;", number_helper.number_to_currency("-1234567890.50", unit: "K&#269;", format: "%n %u", negative_format: "%n - %u"))
           assert_equal("0.00", number_helper.number_to_currency(+0.0, unit: "", negative_format: "(%n)"))
           assert_equal("$0", number_helper.number_to_currency(-0.456789, precision: 0))
+          assert_equal("$0.0", number_helper.number_to_currency(-0.0456789, precision: 1))
+          assert_equal("$0.00", number_helper.number_to_currency(-0.00456789, precision: 2))
           assert_equal("$1,11", number_helper.number_to_currency("1,11"))
           assert_equal("$0,11", number_helper.number_to_currency("0,11"))
           assert_equal("$,11", number_helper.number_to_currency(",11"))


### PR DESCRIPTION
### Summary

Fix number_to_currency to avoid negative format when displaying zero.

For example, make this test pass (which without this patch returns "-$0.00"):

```ruby
assert_equal("$0.00", number_helper.number_to_currency(-0.00456789, precision: 2))
```

This PR also fixes a bug where `-0.5` displayed with `precision` 0 would incorrectly use the positive format.

Closes #42577


### Other Information

This is a more-complete version of the fix in #37865 which originally
addressed #37846.

Also see context at #39350 with respect to alternate input formats.
