### PR TITLE
Formatting markup in an rdoc comment [ci skip]

### DIFF
--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -118,7 +118,7 @@ module ActiveModel
       #     end
       #   end
       #
-      # Or with a block where self points to the current record to be validated:
+      # Or with a block where +self+ points to the current record to be validated:
       #
       #   class Comment
       #     include ActiveModel::Validations


### PR DESCRIPTION
### Summary

Adds monospace markup to identifier in `activemodel/lib/active_model/validations.rb`.