### PR TITLE
Fix disable joins with sti type

### DIFF
--- a/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
+++ b/activerecord/lib/active_record/associations/disable_joins_association_scope.rb
@@ -32,6 +32,12 @@ module ActiveRecord
 
         def add_constraints(reflection, key, join_ids, owner, ordered)
           scope = reflection.build_scope(reflection.aliased_table).where(key => join_ids)
+
+          relation = reflection.klass.scope_for_association
+          scope.merge!(
+            relation.except(:select, :create_with, :includes, :preload, :eager_load, :joins, :left_outer_joins)
+          )
+
           scope = reflection.constraints.inject(scope) do |memo, scope_chain_item|
             item = eval_scope(reflection, scope_chain_item, owner)
             scope.unscope!(*item.unscope_values)

--- a/activerecord/lib/active_record/associations/has_one_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_through_association.rb
@@ -6,12 +6,6 @@ module ActiveRecord
     class HasOneThroughAssociation < HasOneAssociation #:nodoc:
       include ThroughAssociation
 
-      def find_target
-        return scope.first if disable_joins
-
-        super
-      end
-
       private
         def replace(record, save = true)
           create_through_record(record, save)

--- a/activerecord/lib/active_record/associations/singular_association.rb
+++ b/activerecord/lib/active_record/associations/singular_association.rb
@@ -38,7 +38,11 @@ module ActiveRecord
         end
 
         def find_target
-          super.first
+          if disable_joins
+            scope.first
+          else
+            super.first
+          end
         end
 
         def replace(record)

--- a/activerecord/test/models/member.rb
+++ b/activerecord/test/models/member.rb
@@ -5,6 +5,7 @@ class Member < ActiveRecord::Base
   has_one :selected_membership
   has_one :membership
   has_one :club, through: :current_membership
+  has_one :club_without_joins, through: :current_membership, source: :club, disable_joins: true
   has_one :selected_club, through: :selected_membership, source: :club
   has_one :favorite_club, -> { where "memberships.favorite = ?", true }, through: :membership, source: :club
   has_one :hairy_club, -> { where clubs: { name: "Moustache and Eyebrow Fancier Club" } }, through: :membership, source: :club


### PR DESCRIPTION
This PR includes 2 changes.

**Move find_target to more correct place for disable joins**
Instead of redefining this in has_one_association we can define this in
singular association and reuse the existing `find_target` method.

**Fix disable_joins when using an enum STI type**
When a model has an STI enum type, the type wasn't properly applied when
disable joins was set to true. In this case we need to apply the scope
from the association in `add_constraints` so that `type` is included in
the query. Otherwise in a `has_one :through` with `type` all records
will be returned because we're not filtering on type.

Long term I think this might be in the wrong place and that we want to
do this in a new definition of `target_scope` but that's a future
refactoring that needs to be done.
