### PR TITLE
Skip logging backtrace when exception is in `rescue_responses`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Configuration setting to skip logging an uncaught exception backtrace when the exception is
+    present in `rescued_responses`.
+
+    It may be too noisy to get all backtraces logged for applications that manage uncaught
+    exceptions via `rescued_responses` and `exceptions_app`.
+    `config.action_dispatch.log_rescued_responses` (defaults to `true`) can be set to `false` in
+    this case, so that only exceptions not found in `rescued_responses` will be logged.
+
+    *Alexander Azarov*, *Mike Dalessio*
+
 *   Ignore file fixtures on `db:fixtures:load`
 
     *Kevin Sjöberg*

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -10,6 +10,7 @@ module ActionDispatch
   # This middleware is responsible for logging exceptions and
   # showing a debugging page in case the request is local.
   class DebugExceptions
+    cattr_accessor :log_rescued_responses, instance_accessor: false, default: true
     cattr_reader :interceptors, instance_accessor: false, default: []
 
     def self.register_interceptor(object = nil, &block)
@@ -135,6 +136,7 @@ module ActionDispatch
         logger = logger(request)
 
         return unless logger
+        return if !log_rescued_responses?(request) && wrapper.rescue_response?
 
         exception = wrapper.exception
         trace = wrapper.exception_trace
@@ -175,6 +177,11 @@ module ActionDispatch
 
       def api_request?(content_type)
         @response_format == :api && !content_type.html?
+      end
+
+      def log_rescued_responses?(request)
+        per_request = request.get_header("action_dispatch.log_rescued_responses")
+        per_request.nil? ? @@log_rescued_responses : per_request
       end
   end
 end

--- a/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
+++ b/actionpack/lib/action_dispatch/middleware/exception_wrapper.rb
@@ -118,6 +118,10 @@ module ActionDispatch
       Rack::Utils.status_code(@@rescue_responses[class_name])
     end
 
+    def rescue_response?
+      @@rescue_responses.key?(exception.class.name)
+    end
+
     def source_extracts
       backtrace.map do |trace|
         file, line_number = extract_file_and_line_number(trace)

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -25,6 +25,7 @@ module ActionDispatch
     config.action_dispatch.perform_deep_munge = true
     config.action_dispatch.request_id_header = "X-Request-Id"
     config.action_dispatch.return_only_request_media_type_on_content_type = true
+    config.action_dispatch.log_rescued_responses = true
 
     config.action_dispatch.default_headers = {
       "X-Frame-Options" => "SAMEORIGIN",
@@ -47,6 +48,7 @@ module ActionDispatch
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_request_media_type_on_content_type
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
+        ActionDispatch::DebugExceptions.log_rescued_responses = app.config.action_dispatch.log_rescued_responses
       end
 
       ActiveSupport.on_load(:action_dispatch_response) do

--- a/actionpack/test/dispatch/debug_exceptions_test.rb
+++ b/actionpack/test/dispatch/debug_exceptions_test.rb
@@ -515,9 +515,9 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     backtrace_cleaner = ActiveSupport::BacktraceCleaner.new
     backtrace_cleaner.add_silencer { true }
 
-    env = { "action_dispatch.show_exceptions" => true,
-           "action_dispatch.logger" => Logger.new(output),
-           "action_dispatch.backtrace_cleaner" => backtrace_cleaner }
+    env = { "action_dispatch.show_exceptions"   => true,
+            "action_dispatch.logger"            => Logger.new(output),
+            "action_dispatch.backtrace_cleaner" => backtrace_cleaner }
 
     get "/", headers: env
     assert_operator((output.rewind && output.read).lines.count, :>, 10)
@@ -544,7 +544,7 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
     assert_equal 3, log.lines.count
   end
 
-  test "doesn't log the framework backtrace when error type is a invalid mine type" do
+  test "doesn't log the framework backtrace when error type is a invalid mime type" do
     @app = ProductionApp
 
     output = StringIO.new
@@ -564,6 +564,20 @@ class DebugExceptionsTest < ActionDispatch::IntegrationTest
 
     assert_includes log, "ActionDispatch::Http::MimeNegotiation::InvalidType (ActionDispatch::Http::MimeNegotiation::InvalidType)"
     assert_equal 3, log.lines.count
+  end
+
+  test "skips logging when rescued" do
+    @app = DevelopmentApp
+
+    output = StringIO.new
+
+    env = { "action_dispatch.show_exceptions"       => true,
+            "action_dispatch.logger"                => Logger.new(output),
+            "action_dispatch.log_rescued_responses" => false }
+
+    get "/parameter_missing", headers: env
+    assert_response 400
+    assert_empty (output.rewind && output.read).lines
   end
 
   test "display backtrace when error type is SyntaxError" do

--- a/actionpack/test/dispatch/exception_wrapper_test.rb
+++ b/actionpack/test/dispatch/exception_wrapper_test.rb
@@ -66,6 +66,18 @@ module ActionDispatch
       assert_equal 400, wrapper.status_code
     end
 
+    test "#rescue_response? returns false for an exception that's not in rescue_responses" do
+      exception = RuntimeError.new
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal false, wrapper.rescue_response?
+    end
+
+    test "#rescue_response? returns true for an exception that is in rescue_responses" do
+      exception = ActionController::RoutingError.new("")
+      wrapper = ExceptionWrapper.new(@cleaner, exception)
+      assert_equal true, wrapper.rescue_response?
+    end
+
     test "#application_trace cannot be nil" do
       nil_backtrace_wrapper = ExceptionWrapper.new(@cleaner, BadlyDefinedError.new)
       nil_cleaner_wrapper = ExceptionWrapper.new(nil, BadlyDefinedError.new)

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -689,6 +689,9 @@ Defaults to `'signed cookie'`.
   in the `ActionDispatch::SSL` middleware. Defaults to `308` as defined in
   https://tools.ietf.org/html/rfc7538.
 
+* `config.action_dispatch.log_rescued_responses` enables logging those unhandled
+  exceptions configured in `rescue_responses`. It defaults to `true`.
+
 * `ActionDispatch::Callbacks.before` takes a block of code to run before the request.
 
 * `ActionDispatch::Callbacks.after` takes a block of code to run after the request.

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3159,6 +3159,22 @@ module ApplicationTests
       assert_equal false, ActionDispatch::Request.return_only_media_type_on_content_type
     end
 
+    test "ActionDispatch::DebugExceptions.log_rescued_responses is true by default" do
+      app "development"
+
+      assert_equal true, ActionDispatch::DebugExceptions.log_rescued_responses
+    end
+
+    test "ActionDispatch::DebugExceptions.log_rescued_responses can be configured" do
+      add_to_config <<-RUBY
+        config.action_dispatch.log_rescued_responses = false
+      RUBY
+
+      app "development"
+
+      assert_equal false, ActionDispatch::DebugExceptions.log_rescued_responses
+    end
+
     test "logs a warning when running SQLite3 in production" do
       restore_sqlite3_warning
       app_file "config/initializers/active_record.rb", <<~RUBY


### PR DESCRIPTION
### Summary

This is a rebase of #33976 by @alaz which was stale-closed. I've maintained @alaz's authorship in the commits.

Problem description is at #9343

`DebugExceptions` always logs backtrace for uncaught exceptions. This behavior may be undesirable for applications that manage exceptions_app and maintain own list of rescue_responses.

This PR:
- make it possible for `DebugExceptions` to skip logging backtraces for "known" uncaught exceptions, i.e. those in `rescue_responses`
- provide a configuration setting to control this behaviour


An example of the behavior difference introduced would be when hitting an invalid route:

__before__:

```
I, [2021-06-24T15:27:05.851618 #83145]  INFO -- : [c790a85c-0bb0-4c08-b12c-815217d60520] Started GET "/no_route" for 127.0.0.1 at 2021-06-24 15:27:05 -0400
F, [2021-06-24T15:27:05.852046 #83145] FATAL -- : [c790a85c-0bb0-4c08-b12c-815217d60520]
[c790a85c-0bb0-4c08-b12c-815217d60520] ActionController::RoutingError (No route matches [GET] "/no_route"):
[c790a85c-0bb0-4c08-b12c-815217d60520]
```

__after__:

```
I, [2021-06-24T15:27:46.000655 #83415]  INFO -- : [aec0717f-0352-4d23-a4b5-ad327b9cfbee] Started GET "/no_route" for 127.0.0.1 at 2021-06-24 15:27:46 -0400
```