### PR TITLE
Adjust guides to explain the need to disable the ActiveStorage default  routes when implementing authenticated routes [ci skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -674,6 +674,14 @@ end
 <%= image_tag account_logo_path %>
 ```
 
+And then you might want to disable the Active Storage default routes with:
+
+```ruby
+config.active_storage.draw_routes = false
+```
+
+to prevent files being accessed with the publicly accessible URLs.
+
 [ActiveStorage::Blobs::RedirectController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb)
 [ActiveStorage::Representations::RedirectController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/redirect_controller.rb)
 


### PR DESCRIPTION
### Summary

Follow up of https://github.com/rails/rails/pull/42551

If you don't stop drawing ActiveStorage routes, the files will still be accessible through publicly accessible URLs even when implementing the now suggested approach.

Other option would be overriding the ActiveStorage controllers or routes, but seems like that was not recommended by George.

cc @p8 @zzak 