### PR TITLE
feat: Add a check for dash / hls video and audio

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -193,12 +193,12 @@ class ActiveStorage::Blob < ActiveStorage::Record
   
   # Returns true if the content_type is an HLS track.
   def hls?
-    content_type.match?(%r{application/x-mpegurl|vnd.apple.mpegurl}i)
+    content_type.match?(%r{application/x-mpegurl|vnd\.apple\.mpegurl}i)
   end
     
   # Returns true if the content_type is an Dash track.
   def dash?
-    content_type.match?(%r{application/dash+xml}i)
+    content_type.match?(%r{application/dash\+xml}i)
   end
 
   # Returns the URL of the blob on the service. This returns a permanent URL for public files, and returns a

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -180,7 +180,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
   def audio?
     content_type.start_with?("audio") || hls? || dash?
   end
-  
+
   # Returns true if the content_type of this blob is in the video range, like video/mp4 or if its a Dash / HLS track.
   def video?
     content_type.start_with?("video") || hls? || dash?

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -176,19 +176,29 @@ class ActiveStorage::Blob < ActiveStorage::Record
     content_type.start_with?("image")
   end
 
-  # Returns true if the content_type of this blob is in the audio range, like audio/mpeg.
+  # Returns true if the content_type of this blob is in the audio range, like audio/mpeg or if its a Dash / HLS track.
   def audio?
-    content_type.start_with?("audio")
+    content_type.start_with?("audio") || hls? || dash?
   end
-
-  # Returns true if the content_type of this blob is in the video range, like video/mp4.
+  
+  # Returns true if the content_type of this blob is in the video range, like video/mp4 or if its a Dash / HLS track.
   def video?
-    content_type.start_with?("video")
+    content_type.start_with?("video") || hls? || dash?
   end
 
   # Returns true if the content_type of this blob is in the text range, like text/plain.
   def text?
     content_type.start_with?("text")
+  end
+  
+  # Returns true if the content_type is an HLS track.
+  def hls?
+    content_type.match?(%r{application/x-mpegurl|vnd.apple.mpegurl}i)
+  end
+    
+  # Returns true if the content_type is an Dash track.
+  def dash?
+    content_type.match?(%r{application/dash+xml}i)
   end
 
   # Returns the URL of the blob on the service. This returns a permanent URL for public files, and returns a

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -196,7 +196,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
     content_type.match?(%r{application/x-mpegurl|vnd\.apple\.mpegurl}i)
   end
     
-  # Returns true if the content_type is an Dash track.
+  # Returns true if the content_type is a Dash track.
   def dash?
     content_type.match?(%r{application/dash\+xml}i)
   end


### PR DESCRIPTION
### Summary

Adds booleans for dash / HLS videos as well as adding the checks for hls / dash in the `#video?` and `#audio?` methods.

### Other Information

I've recently been using HLS for video / audio files and noticed that ActiveStorage blobs dont account for HLS / Dash videos as video or audio.

HLS and Dash can be used with `<video>` or `<audio>` tags by using various polyfills on unsupported browsers in various forms including the following 2 packages:

https://github.com/video-dev/hls.js/

https://github.com/Dash-Industry-Forum/dash.js/wiki

This is a preliminary PR and I'd love to hear other's thoughts on if this belongs here or not. I'd be happy to add tests if we think this is worthwhile.