### PR TITLE
Deprecate replace_on_assign_to_many

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deprecate `config.active_storage.replace_on_assign_to_many`. Future versions of Rails
+    will behave the same way as when the config is set to `true`.
+
+    *Santiago Bartesaghi*
+
 *   Remove deprecated methods: `build_after_upload`, `create_after_upload!` in favor of `create_and_upload!`,
     and `service_url` in favor of `url`.
 

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -145,6 +145,12 @@ module ActiveStorage
                   ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, attachables)
                 end
             else
+              ActiveSupport::Deprecation.warn \
+                "config.active_storage.replace_on_assign_to_many is deprecated and will be removed in Rails 7.1. " \
+                "Make sure that your code works well with config.active_storage.replace_on_assign_to_many set to true before upgrading. " \
+                "To append new attachables to the Active Storage association, prefer using `attach`. " \
+                "Using association setter would result in purging the existing attached attachments and replacing them with new ones."
+
               if Array(attachables).any?
                 attachment_changes["#{name}"] =
                   ActiveStorage::Attached::Changes::CreateMany.new("#{name}", self, #{name}.blobs + attachables)

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -777,6 +777,21 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "deprecation warning when replace_on_assign_to_many is false" do
+    append_on_assign do
+      message = <<-MSG.squish
+        DEPRECATION WARNING: config.active_storage.replace_on_assign_to_many is deprecated and will be removed in Rails 7.1.
+        Make sure that your code works well with config.active_storage.replace_on_assign_to_many set to true before upgrading.
+        To append new attachables to the Active Storage association, prefer using `attach`.
+        Using association setter would result in purging the existing attached attachments and replacing them with new ones.
+      MSG
+
+      assert_deprecated(message) do
+        @user.update! highlights: [create_blob(filename: "whenever.jpg")]
+      end
+    end
+  end
+
   private
     def append_on_assign
       ActiveStorage.replace_on_assign_to_many, previous = false, ActiveStorage.replace_on_assign_to_many

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -697,7 +697,7 @@ user.highlights.first.filename # => "funky.jpg"
 user.highlights.second.filename # => "town.jpg"
 ```
 
-Existing applications can opt in to this new behavior by setting `config.active_storage.replace_on_assign_to_many` to `true`. The old behavior will be deprecated in Rails 6.1 and removed in a subsequent release.
+Existing applications can opt in to this new behavior by setting `config.active_storage.replace_on_assign_to_many` to `true`. The old behavior will be deprecated in Rails 7.0 and removed in Rails 7.1.
 
 Upgrading from Rails 5.1 to Rails 5.2
 -------------------------------------


### PR DESCRIPTION
### Summary

Deprecate `replace_on_assign_to_many`

In the first commit I thought on displaying the deprecation on initialization, but then I thought it would be better for users to get the deprecation warning on usage so I added a second commit changing the approach.