### PR TITLE
Remove already deprecated methods in ActiveStorage

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Remove deprecated methods: `build_after_upload`, `create_after_upload!` in favor of `create_and_upload!`,
+    and `service_url` in favor of `url`.
+
+    *Santiago Bartesaghi*
+
 *   Add support of `strict_loading_by_default` to `ActiveStorage::Representations` controllers
 
     *Anton Topchii*, *Andrew White*

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -86,14 +86,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
       super(id, purpose: purpose)
     end
 
-    def build_after_upload(io:, filename:, content_type: nil, metadata: nil, service_name: nil, identify: true, record: nil) #:nodoc:
-      new(filename: filename, content_type: content_type, metadata: metadata, service_name: service_name).tap do |blob|
-        blob.upload(io, identify: identify)
-      end
-    end
-
-    deprecate :build_after_upload
-
     def build_after_unfurling(key: nil, io:, filename:, content_type: nil, metadata: nil, service_name: nil, identify: true, record: nil) #:nodoc:
       new(key: key, filename: filename, content_type: content_type, metadata: metadata, service_name: service_name).tap do |blob|
         blob.unfurl(io, identify: identify)
@@ -114,9 +106,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
         blob.upload_without_unfurling(io)
       end
     end
-
-    alias_method :create_after_upload!, :create_and_upload!
-    deprecate create_after_upload!: :create_and_upload!
 
     # Returns a saved blob _without_ uploading a file to the service. This blob will point to a key where there is
     # no file yet. It's intended to be used together with a client-side upload, which will first create the blob
@@ -207,9 +196,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.url key, expires_in: expires_in, filename: ActiveStorage::Filename.wrap(filename || self.filename),
       content_type: content_type_for_serving, disposition: forced_disposition_for_serving || disposition, **options
   end
-
-  alias_method :service_url, :url
-  deprecate service_url: :url
 
   # Returns a URL that can be used to directly upload a file for this blob on the service. This URL is intended to be
   # short-lived for security and only generated on-demand by the client-side JavaScript responsible for doing the uploading.

--- a/activestorage/app/models/active_storage/preview.rb
+++ b/activestorage/app/models/active_storage/preview.rb
@@ -66,9 +66,6 @@ class ActiveStorage::Preview
     end
   end
 
-  alias_method :service_url, :url
-  deprecate service_url: :url
-
   # Returns a combination key of the blob and the variation that together identifies a specific variant.
   def key
     if processed?

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -79,9 +79,6 @@ class ActiveStorage::Variant
     service.url key, expires_in: expires_in, disposition: disposition, filename: filename, content_type: content_type
   end
 
-  alias_method :service_url, :url
-  deprecate service_url: :url
-
   # Downloads the file associated with this variant. If no block is given, the entire file is read into memory and returned.
   # That'll use a lot of RAM for very large files. If a block is given, then the download is streamed and yielded in chunks.
   def download(&block)

--- a/activestorage/app/models/active_storage/variant_with_record.rb
+++ b/activestorage/app/models/active_storage/variant_with_record.rb
@@ -29,9 +29,6 @@ class ActiveStorage::VariantWithRecord
 
   delegate :key, :url, :download, to: :image, allow_nil: true
 
-  alias_method :service_url, :url
-  deprecate service_url: :url
-
   private
     def transform_blob
       blob.open do |input|

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -32,26 +32,6 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_equal data, blob.download
   end
 
-  test "create_after_upload! has the same effect as create_and_upload!" do
-    data = "Some other, even more funky file"
-    blob = assert_deprecated do
-      ActiveStorage::Blob.create_after_upload!(io: StringIO.new(data), filename: "funky.bin")
-    end
-
-    assert blob.persisted?
-    assert_equal data, blob.download
-  end
-
-  test "build_after_upload uploads to service but does not save the Blob" do
-    data = "A potentially overwriting file"
-    blob = assert_deprecated do
-      ActiveStorage::Blob.build_after_upload(io: StringIO.new(data), filename: "funky.bin")
-    end
-
-    assert_not blob.persisted?
-    assert_equal data, blob.download
-  end
-
   test "create_and_upload sets byte size and checksum" do
     data = "Hello world!"
     blob = create_blob data: data


### PR DESCRIPTION
### Summary

These methods were already deprecated on Rails 6.1, so I think it'd be appropriate to remove them for Rails 7.0

For reference, the deprecations where added here:
https://github.com/rails/rails/pull/34827
https://github.com/rails/rails/pull/37856