### PR TITLE
Use rails guides instead of edge guides [ci skip]

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -5,7 +5,7 @@
 # WARNING: All Active Storage controllers are publicly accessible by default. The
 # generated URLs are hard to guess, but permanent by design. If your files
 # require a higher level of protection consider implementing
-# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+# {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 

--- a/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
@@ -5,7 +5,7 @@
 # WARNING: All Active Storage controllers are publicly accessible by default. The
 # generated URLs are hard to guess, but permanent by design. If your files
 # require a higher level of protection consider implementing
-# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+# {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::RedirectController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
 

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -5,7 +5,7 @@
 # WARNING: All Active Storage controllers are publicly accessible by default. The
 # generated URLs are hard to guess, but permanent by design. If your files
 # require a higher level of protection consider implementing
-# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+# {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::ProxyController < ActiveStorage::Representations::BaseController
   def show
     http_cache_forever public: true do

--- a/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
@@ -5,7 +5,7 @@
 # WARNING: All Active Storage controllers are publicly accessible by default. The
 # generated URLs are hard to guess, but permanent by design. If your files
 # require a higher level of protection consider implementing
-# {Authenticated Controllers}[https://edgeguides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
+# {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::RedirectController < ActiveStorage::Representations::BaseController
   def show
     expires_in ActiveStorage.service_urls_expire_in


### PR DESCRIPTION
This PR is a follow-up of https://github.com/rails/rails/pull/41503 and should only be merged once the following link: https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers shows the new section `Authenticated Controllers`

Notice that the only change of this PR respect to https://github.com/rails/rails/pull/41503 is changing links from the edgeguides to the normal guides. 