### PR TITLE
`eager_loading?` works when ordering tables with a schema prefix.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   `eager_loading?` works when ordering tables with a schema prefix.
+
+    Some DBMS (e.g. PostgreSQL) allows to define multiple schemas per database.
+    `eager_loading?` now works when ordering using a table name which contains a schema prefix.
+
+    *Jacopo Beschi*
+
 *   Avoid validating a unique field if it has not changed and is backed by a unique index.
 
     Previously, when saving a record, ActiveRecord will perform an extra query to check for the uniqueness of

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -482,6 +482,10 @@ module ActiveRecord
         true
       end
 
+      def supports_database_schema?
+        false
+      end
+
       def async_enabled? # :nodoc:
         supports_concurrent_connections? &&
           !ActiveRecord.async_query_executor.nil? && !pool.async_executor.nil?

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -253,6 +253,10 @@ module ActiveRecord
         database_version >= 12_00_00 # >= 12.0
       end
 
+      def supports_database_schema?
+        true
+      end
+
       def index_algorithms
         { concurrently: "CONCURRENTLY" }
       end

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1647,7 +1647,13 @@ module ActiveRecord
             end
           end
         end
-        references.map! { |arg| arg =~ /^\W?(\w+)\W?\./ && $1 }.compact!
+        references_matcher = /
+          ^\W?
+          # schema.table | table
+          ((?:\w+\.\w+) | (?:\w+))
+          \W?\.
+        /x
+        references.map! { |arg| arg =~ references_matcher && $1 }.compact!
         references
       end
 

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -84,6 +84,7 @@ end
   supports_insert_conflict_target?
   supports_optimizer_hints?
   supports_datetime_with_precision?
+  supports_database_schema?
 ].each do |method_name|
   define_method method_name do
     ActiveRecord::Base.connection.public_send(method_name)


### PR DESCRIPTION
### Summary

Some DBMS (e.g. PostgreSQL) allows to define multiple schemas per database.
`eager_loading?` now works when ordering using a table name which contains a schema prefix.

Fixes #42331

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
