### PR TITLE
Consider AC::Parameters as Hash in url_for

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -822,10 +822,12 @@ module ActionDispatch
         path = route_with_params.path(method_name)
         params = route_with_params.params
 
-        if options[:params].is_a?(Hash)
-          params.merge! options[:params]
-        elsif options.key? :params
-          params[:params] = options[:params]
+        if options.key? :params
+          if options[:params]&.respond_to?(:to_hash)
+            params.merge! options[:params]
+          else
+            params[:params] = options[:params]
+          end
         end
 
         options[:path]        = path

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -362,6 +362,15 @@ module AbstractController
         assert_equal({ id: "1" }.to_query, params[1])
       end
 
+      def test_params_option_strong_parameters
+        request_params = ActionController::Parameters.new({ domain: "foo", id: "1", other: "BAD" })
+        url = W.new.url_for(only_path: true, controller: "c", action: "a", params: request_params.permit(:domain, :id))
+        params = extract_params(url)
+        assert_equal("/c/a?domain=foo&id=1", url)
+        assert_equal({ domain: "foo" }.to_query, params[0])
+        assert_equal({ id: "1" }.to_query, params[1])
+      end
+
       def test_non_hash_params_option
         url = W.new.url_for(only_path: true, controller: "c", action: "a", params: "p")
         params = extract_params(url)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/42020

It's not uncommon to want to forward request parameters, as such the `:params` parameter of `url_for` often receive an AC::Parameters instance.

That previous PR did break our app quite extensively, and while I'm not 100% certain that behavior was intended, I can say with certainty that it's common.
