### PR TITLE
Fix migration compatibility for default precision value on datetime columns

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -48,6 +48,10 @@ module ActiveRecord
         end
 
         def add_column(table_name, column_name, type, **options)
+          if type == :datetime
+            options[:precision] ||= nil
+          end
+
           type = PostgreSQLCompat.compatible_timestamp_type(type, connection)
           super
         end
@@ -63,6 +67,11 @@ module ActiveRecord
         module TableDefinition
           def new_column_definition(name, type, **options)
             type = PostgreSQLCompat.compatible_timestamp_type(type, @conn)
+            super
+          end
+
+          def column(name, type, index: nil, **options)
+            options[:precision] ||= nil
             super
           end
         end
@@ -265,6 +274,8 @@ module ActiveRecord
           if type == :primary_key
             type = :integer
             options[:primary_key] = true
+          elsif type == :datetime
+            options[:precision] ||= nil
           end
           super
         end
@@ -295,11 +306,6 @@ module ActiveRecord
             options[:null] = true if options[:null].nil?
             super
           end
-
-          def column(name, type, index: nil, **options)
-            options[:precision] ||= nil
-            super
-          end
         end
 
         def add_reference(table_name, ref_name, **options)
@@ -326,14 +332,6 @@ module ActiveRecord
 
         def remove_index(table_name, column_name = nil, **options)
           options[:name] = index_name_for_remove(table_name, column_name, options)
-          super
-        end
-
-        def add_column(table_name, column_name, type, **options)
-          if type == :datetime
-            options[:precision] ||= nil
-          end
-
           super
         end
 

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -375,7 +375,19 @@ module ActiveRecord
         connection.drop_table :more_testings rescue nil
       end
 
-      def test_datetime_doesnt_set_precision_on_add_column
+      def test_datetime_doesnt_set_precision_on_add_column_5_0
+        migration = Class.new(ActiveRecord::Migration[5.0]) {
+          def migrate(x)
+            add_column :testings, :published_at, :datetime, default: Time.now
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+        assert connection.column_exists?(:testings, :published_at, **precision_implicit_default)
+      end
+
+      def test_datetime_doesnt_set_precision_on_add_column_6_1
         migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
             add_column :testings, :published_at, :datetime, default: Time.now

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -336,7 +336,7 @@ module ActiveRecord
       end
 
       def test_datetime_doesnt_set_precision_on_create_table
-        migration = Class.new(ActiveRecord::Migration[4.2]) {
+        migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
             create_table :more_testings do |t|
               t.datetime :published_at
@@ -352,7 +352,7 @@ module ActiveRecord
       end
 
       def test_datetime_doesnt_set_precision_on_change_table
-        create_migration = Class.new(ActiveRecord::Migration[4.2]) {
+        create_migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
             create_table :more_testings do |t|
               t.datetime :published_at
@@ -360,7 +360,7 @@ module ActiveRecord
           end
         }.new
 
-        change_migration = Class.new(ActiveRecord::Migration[4.2]) {
+        change_migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
             change_table :more_testings do |t|
               t.datetime :published_at, default: Time.now
@@ -376,7 +376,7 @@ module ActiveRecord
       end
 
       def test_datetime_doesnt_set_precision_on_add_column
-        migration = Class.new(ActiveRecord::Migration[4.2]) {
+        migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
             add_column :testings, :published_at, :datetime, default: Time.now
           end


### PR DESCRIPTION
## Background

I have made a mistake on https://github.com/rails/rails/pull/42297, the definitions for add_column and column were put under the wrong class 
https://github.com/rails/rails/blob/246bac42a090524e5386912a4b955c327c6a4ba9/activerecord/lib/active_record/migration/compatibility.rb#L286-L335

As you can notice above they are in the V4_2 class when they should be in V6_1, in https://github.com/rails/rails/pull/42606/commits/9b9d9c7bf9437f498ac4e925de0594920cf4baa9 I could verify this by changing the versions of the migrations from 4.2 to 6.1, please the errors here  https://buildkite.com/rails/rails/builds/78711#d5c2b003-4552-4173-afc9-61e46d8b4fde

## Solution

Move the definitions to v6_1 and tweak V5_0 to add support older than 5.0 365acb6


cc @guilleiguaran @zzak @ghiculescu 