### PR TITLE
Exit with error when rails is called with invalid arguments from wrong directory

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Exit with non-zero status when `rails` is called with invalid parameters outside of project directory.
+
+    *endenis*
+
 *   `package.json` now uses a strict version constraint for Rails JavaScript packages on new Rails apps.
 
     *Zachary Scott*, *Alex Ghiculescu*

--- a/railties/lib/rails/cli.rb
+++ b/railties/lib/rails/cli.rb
@@ -11,9 +11,4 @@ Signal.trap("INT") { puts; exit(1) }
 
 require "rails/command"
 
-if ARGV.first == "plugin"
-  ARGV.shift
-  Rails::Command.invoke :plugin, ARGV
-else
-  Rails::Command.invoke :application, ARGV
-end
+Rails::Command.exec_outside_of_project_directory(ARGV)

--- a/railties/lib/rails/command.rb
+++ b/railties/lib/rails/command.rb
@@ -16,6 +16,7 @@ module Rails
     include Behavior
 
     HELP_MAPPINGS = %w(-h -? --help)
+    VERSION_MAPPINGS = %w(-v --version)
 
     class << self
       def hidden_commands # :nodoc:
@@ -38,7 +39,7 @@ module Rails
 
         command_name, namespace = "help", "help" if command_name.blank? || HELP_MAPPINGS.include?(command_name)
         command_name, namespace, args = "application", "application", ["--help"] if rails_new_with_no_path?(args)
-        command_name, namespace = "version", "version" if %w( -v --version ).include?(command_name)
+        command_name, namespace = "version", "version" if VERSION_MAPPINGS.include?(command_name)
 
         original_argv = ARGV.dup
         ARGV.replace(args)
@@ -86,6 +87,21 @@ module Rails
 
       def print_commands # :nodoc:
         commands.each { |command| puts("  #{command}") }
+      end
+
+      def exec_outside_of_project_directory(argv)
+        case argv.first
+        when "plugin"
+          argv.shift
+          invoke :plugin, argv
+        when *VERSION_MAPPINGS
+          invoke :version
+        when nil, "new", *HELP_MAPPINGS
+          invoke :application, argv
+        else
+          invoke :application, ["--help"]
+          exit(1)
+        end
       end
 
       private

--- a/railties/lib/rails/commands/application/application_command.rb
+++ b/railties/lib/rails/commands/application/application_command.rb
@@ -25,13 +25,7 @@ module Rails
       def perform(*args)
         Rails::Generators::AppGenerator.start \
           Rails::Generators::ARGVScrubber.new(args).prepare!
-        exit(1) if invalid_command?(args.first)
       end
-
-      private
-        def invalid_command?(argument)
-          argument.present? && !Rails::Generators::ARGVScrubber.valid_argument?(argument)
-        end
     end
   end
 end

--- a/railties/lib/rails/commands/application/application_command.rb
+++ b/railties/lib/rails/commands/application/application_command.rb
@@ -25,7 +25,13 @@ module Rails
       def perform(*args)
         Rails::Generators::AppGenerator.start \
           Rails::Generators::ARGVScrubber.new(args).prepare!
+        exit(1) if invalid_command?(args.first)
       end
+
+      private
+        def invalid_command?(argument)
+          argument.present? && !Rails::Generators::ARGVScrubber.valid_argument?(argument)
+        end
     end
   end
 end

--- a/railties/lib/rails/commands/version/version_command.rb
+++ b/railties/lib/rails/commands/version/version_command.rb
@@ -4,7 +4,8 @@ module Rails
   module Command
     class VersionCommand < Base # :nodoc:
       def perform
-        Rails::Command.invoke :application, [ "--version" ]
+        require "rails/version"
+        puts "Rails #{Rails::VERSION::STRING}"
       end
     end
   end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -628,6 +628,10 @@ module Rails
         end
       end
 
+      def self.valid_argument?(argument)
+        argument == "new"
+      end
+
       private
         def handle_version_request!(argument)
           if ["--version", "-v"].include?(argument)
@@ -638,7 +642,7 @@ module Rails
         end
 
         def handle_invalid_command!(argument, argv)
-          if argument == "new"
+          if self.class.valid_argument?(argument)
             yield
           else
             ["--help"] + argv.drop(1)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -600,8 +600,8 @@ module Rails
     end
 
     # This class handles preparation of the arguments before the AppGenerator is
-    # called. The class provides version or help information if they were
-    # requested, and also constructs the railsrc file (used for extra configuration
+    # called. The class provides help information if it was requested,
+    # and also constructs the railsrc file (used for extra configuration
     # options).
     #
     # This class should be called before the AppGenerator is required and started
@@ -612,7 +612,6 @@ module Rails
       end
 
       def prepare!
-        handle_version_request!(@argv.first)
         handle_invalid_command!(@argv.first, @argv) do
           handle_rails_rc!(@argv.drop(1))
         end
@@ -628,21 +627,9 @@ module Rails
         end
       end
 
-      def self.valid_argument?(argument)
-        argument == "new"
-      end
-
       private
-        def handle_version_request!(argument)
-          if ["--version", "-v"].include?(argument)
-            require "rails/version"
-            puts "Rails #{Rails::VERSION::STRING}"
-            exit(0)
-          end
-        end
-
         def handle_invalid_command!(argument, argv)
-          if self.class.valid_argument?(argument)
+          if argument == "new"
             yield
           else
             ["--help"] + argv.drop(1)

--- a/railties/test/application/outside_cli_test.rb
+++ b/railties/test/application/outside_cli_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RAILS_ISOLATED_ENGINE = true
+require "isolation/abstract_unit"
+
+require "rails/gem_version"
+require "open3"
+
+# These tests check rails CLI launched outside of the project directory
+class OutsideCliTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::Isolation
+
+  test "help command works" do
+    output = rails_cli_output("--help")
+    assert_match "The 'rails new' command creates a new Rails application", output
+  end
+
+  test "help short-cut alias works" do
+    output = rails_cli_output("-h")
+    assert_match "The 'rails new' command creates a new Rails application", output
+  end
+
+  test "invalid command displays help and exits with non-zero status" do
+    output, exit_status = rails_cli("some-invalid-command")
+    assert_not_equal 0, exit_status
+    assert_match "The 'rails new' command creates a new Rails application", output
+  end
+
+  test "version command works" do
+    output = rails_cli_output("--version")
+    assert_equal "Rails #{Rails.gem_version}\n", output
+  end
+
+  test "version short-cut alias works" do
+    output = rails_cli_output("-v")
+    assert_equal "Rails #{Rails.gem_version}\n", output
+  end
+
+  def rails_cli(cmd)
+    output, status = Open3.capture2("#{rails_executable} #{cmd}")
+    [output, status.exitstatus]
+  end
+
+  def rails_cli_output(cmd)
+    rails_cli(cmd).first
+  end
+end

--- a/railties/test/generators/argv_scrubber_test.rb
+++ b/railties/test/generators/argv_scrubber_test.rb
@@ -16,21 +16,6 @@ module Rails
 
       include EnvHelpers
 
-      def test_version
-        ["-v", "--version"].each do |str|
-          scrubber = ARGVScrubber.new [str]
-          output    = nil
-          exit_code = nil
-          scrubber.extend(Module.new {
-            define_method(:puts) { |string| output = string }
-            define_method(:exit) { |code| exit_code = code }
-          })
-          scrubber.prepare!
-          assert_equal "Rails #{Rails::VERSION::STRING}", output
-          assert_equal 0, exit_code
-        end
-      end
-
       def test_default_help
         argv = ["zomg", "how", "are", "you"]
         scrubber = ARGVScrubber.new argv

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -95,6 +95,12 @@ module TestHelpers
     end
   end
 
+  module Cli
+    def rails_executable
+      "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails"
+    end
+  end
+
   module Generation
     # Build an application by invoking the generator and going through the whole stack.
     def build_app(options = {})
@@ -490,6 +496,7 @@ end
 
 class ActiveSupport::TestCase
   include TestHelpers::Paths
+  include TestHelpers::Cli
   include TestHelpers::Rack
   include TestHelpers::Generation
   include TestHelpers::Reload
@@ -500,6 +507,7 @@ end
 # Create a scope and build a fixture rails app
 Module.new do
   extend TestHelpers::Paths
+  extend TestHelpers::Cli
 
   def self.sh(cmd)
     output = `#{cmd}`
@@ -510,7 +518,7 @@ Module.new do
   FileUtils.rm_rf(app_template_path)
   FileUtils.mkdir_p(app_template_path)
 
-  sh "#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails new #{app_template_path} --skip-bundle --skip-spring --skip-listen --no-rc --skip-webpack-install --quiet"
+  sh "#{rails_executable} new #{app_template_path} --skip-bundle --skip-spring --skip-listen --no-rc --skip-webpack-install --quiet"
   File.open("#{app_template_path}/config/boot.rb", "w") do |f|
     f.puts 'require "rails/all"'
   end

--- a/railties/test/railties/generators_test.rb
+++ b/railties/test/railties/generators_test.rb
@@ -28,7 +28,7 @@ module RailtiesTests
     end
 
     def rails(cmd)
-      `#{Gem.ruby} #{RAILS_FRAMEWORK_ROOT}/railties/exe/rails #{cmd}`
+      `#{rails_executable} #{cmd}`
     end
 
     def build_engine(is_mountable = false)


### PR DESCRIPTION
### Summary

This PR fixes the problem I had with rails command-line tool: rails exits with zero code if launched with invalid parameters in command-line outside of project directory https://github.com/rails/rails/issues/42607

I simply added `exit(1)` for situations when there is an argument that is replaced by `--help`.

