### PR TITLE
Remove IE6-7-8 file download related hack/fix

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove IE6-7-8 file download related hack/fix from ActionController::DataStreaming module
+
+    Not hugely relevant due to age of those IE versions and it creates somewhat unexpected Cache-Control headers.
+
+    *Tadas Sasnauskas*
+
 *   Configuration setting to skip logging an uncaught exception backtrace when the exception is
     present in `rescued_responses`.
 

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -138,14 +138,6 @@ module ActionController #:nodoc:
         end
 
         headers["Content-Transfer-Encoding"] = "binary"
-
-        # Fix a problem with IE 6.0 on opening downloaded files:
-        # If Cache-Control: no-cache is set (which Rails does by default),
-        # IE removes the file it just downloaded from its cache immediately
-        # after it displays the "open/save" dialog, which means that if you
-        # hit "open" the file isn't there anymore when the application that
-        # is called for handling the download is run, so let's workaround that
-        response.cache_control[:public] ||= false
       end
   end
 end

--- a/actionpack/test/controller/send_file_test.rb
+++ b/actionpack/test/controller/send_file_test.rb
@@ -146,7 +146,6 @@ class SendFileTest < ActionController::TestCase
       assert_equal "image/png", response.content_type
       assert_equal %(disposition; filename="filename"; filename*=UTF-8''filename), response.get_header("Content-Disposition")
       assert_equal "binary", response.get_header("Content-Transfer-Encoding")
-      assert_equal "private", response.get_header("Cache-Control")
     end
   end
 


### PR DESCRIPTION
IE 6-7-8 has bug when 'Cache-Control: no-cache' head would break file download.
It's been fixed in IE9 (which is also ancient and barely used version).

Some extra details [here][1] and [here][2].

The way this fix is implemented clashes with what's been done in PR #40324. By
adding ':public' key to cache control header set it wipes default headers.

Since IE 6-7-8 are ancient browsers - let's just get rid of this hack.

[1]: https://stackoverflow.com/q/9766639/843067
[2]: https://stackoverflow.com/q/3415370/843067