### PR TITLE
Remove docs for `render layout:` with a block and args

### DIFF
--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -217,40 +217,6 @@ module ActionView
   #   </div>
   #
   # As you can see, the <tt>:locals</tt> hash is shared between both the partial and its layout.
-  #
-  # If you pass arguments to "yield" then this will be passed to the block. One way to use this is to pass
-  # an array to layout and treat it as an enumerable.
-  #
-  #   <%# app/views/users/_user.html.erb %>
-  #   <div class="user">
-  #     Budget: $<%= user.budget %>
-  #     <%= yield user %>
-  #   </div>
-  #
-  #   <%# app/views/users/index.html.erb %>
-  #   <%= render layout: @users do |user| %>
-  #     Title: <%= user.title %>
-  #   <% end %>
-  #
-  # This will render the layout for each user and yield to the block, passing the user, each time.
-  #
-  # You can also yield multiple times in one layout and use block arguments to differentiate the sections.
-  #
-  #   <%# app/views/users/_user.html.erb %>
-  #   <div class="user">
-  #     <%= yield user, :header %>
-  #     Budget: $<%= user.budget %>
-  #     <%= yield user, :footer %>
-  #   </div>
-  #
-  #   <%# app/views/users/index.html.erb %>
-  #   <%= render layout: @users do |user, section| %>
-  #     <%- case section when :header -%>
-  #       Title: <%= user.title %>
-  #     <%- when :footer -%>
-  #       Deadline: <%= user.deadline %>
-  #     <%- end -%>
-  #   <% end %>
   class PartialRenderer < AbstractRenderer
     include CollectionCaching
 


### PR DESCRIPTION
This behavior was removed in 9f5cd0156ab907d8097fc9c588823a9b09038b93 but these docs were missed.

Fixes #42540

I also double checked the tests and the only related one I found was [here](https://github.com/rails/rails/blob/main/actionview/test/fixtures/actionpack/test/using_layout_around_block.html.erb) but this does not cover the block w/ args.