### PR TITLE
Replace uglifier with terser in dummy applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "bcrypt", "~> 3.1.11", require: false
 
 # This needs to be with require false to avoid it being automatically loaded by
 # sprockets.
-gem "uglifier", ">= 1.3.0", require: false
+gem "terser", ">= 1.1.4", require: false
 
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,6 +479,8 @@ GEM
     stackprof (0.2.17)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
+    terser (1.1.4)
+      execjs (>= 0.3.0, < 3)
     thin (1.8.1)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -492,8 +494,6 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.0.0)
     useragent (0.16.10)
     vegas (0.1.11)
@@ -590,9 +590,9 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   stackprof
   sucker_punch
+  terser (>= 1.1.4)
   turbolinks (~> 5)
   tzinfo-data
-  uglifier (>= 1.3.0)
   w3c_validators (~> 1.3.6)
   wdm (>= 0.1.0)
   webdrivers

--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
### Summary

Terser is more up to date with modern javascript features, and the
uglifier gem repository recommends using it for minifying ES6+.

Followup for 955041b/#42621 