### PR TITLE
Introduce docker-compose.yml file to activerecord directory

### DIFF
--- a/activerecord/docker-compose.yml
+++ b/activerecord/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  mysql:
+    image: mysql:5.6
+    networks:
+      - rails
+    environment:
+      MYSQL_USER: rails
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    ports:
+      - 3306:3306
+
+networks:
+  rails:
+    name: rails

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -418,12 +418,14 @@ For MySQL and PostgreSQL, it is sufficient to run:
 
 ```bash
 $ cd activerecord
+$ docker compose up -d mysql
 $ bundle exec rake db:mysql:build
 ```
 Or:
 
 ```bash
 $ cd activerecord
+$ docker compose up -d postgresql
 $ bundle exec rake db:postgresql:build
 ```
 
@@ -446,6 +448,7 @@ $ bundle exec rake test:postgresql
 Finally,
 
 ```bash
+$ docker compose up -d
 $ bundle exec rake test
 ```
 


### PR DESCRIPTION
### Summary

Recently I've worked on a couple of changes on ActiveRecord and I've found it useful to have this kind of definition inside of the ActiveRecord directory. The idea is to help contributors to set up their test databases by using docker containers and have their environment ready to run their tests and switch between the RDMS versions.

Ideally, the docker-compose.yml will match with definitions on [activerecord/test/config.example.yml](https://github.com/rails/rails/blob/main/activerecord/test/config.example.yml).


For running your tests on MySQL and PostgreSQL, it is sufficient to run:

 ```bash
 $ cd activerecord
$ docker compose up -d mysql
$ bundle exec rake db:mysql:build
$ ARCON=mysql2 bundle exec rake db:mysql:build
 ```
 Or:
 
 ```bash
 $ cd activerecord
$ docker compose up -d postgresql
$ bundle exec rake db:postgresql:build
$ ARCON=postgresql bundle exec rake db:mysql:build
 ```

Finally, in case of wanting to run the test suite against all RDMS available you could run:

```
$ docker compose up -d
$ bundle exec rake test
```