### PR TITLE
Adjust docs of create_or_find_by

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -182,7 +182,7 @@ module ActiveRecord
       find_by(attributes) || create!(attributes, &block)
     end
 
-    # Attempts to create a record with the given attributes in a table that has a unique constraint
+    # Attempts to create a record with the given attributes in a table that has a unique database constraint
     # on one or several of its columns. If a row already exists with one or several of these
     # unique constraints, the exception such an insertion would normally raise is caught,
     # and the existing record with those attributes is found using #find_by!.
@@ -193,7 +193,7 @@ module ActiveRecord
     #
     # There are several drawbacks to #create_or_find_by, though:
     #
-    # * The underlying table must have the relevant columns defined with unique constraints.
+    # * The underlying table must have the relevant columns defined with unique database constraints.
     # * A unique constraint violation may be triggered by only one, or at least less than all,
     #   of the given attributes. This means that the subsequent #find_by! may fail to find a
     #   matching record, which will then raise an <tt>ActiveRecord::RecordNotFound</tt> exception,


### PR DESCRIPTION
### Summary

- Mention explicitly in the docs that `create_of_find_by` requires a DB constraint.

Closes #36027

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
