### PR TITLE
Remove LocalCache in FileStore

### DIFF
--- a/activesupport/lib/active_support/cache/file_store.rb
+++ b/activesupport/lib/active_support/cache/file_store.rb
@@ -11,7 +11,6 @@ module ActiveSupport
     # FileStore implements the Strategy::LocalCache strategy which implements
     # an in-memory cache inside of a block.
     class FileStore < Store
-      prepend Strategy::LocalCache
       attr_reader :cache_path
 
       DIR_FORMATTER = "%03X"

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -32,7 +32,6 @@ class FileStoreTest < ActiveSupport::TestCase
   include CacheStoreBehavior
   include CacheStoreVersionBehavior
   include CacheStoreCoderBehavior
-  include LocalCacheBehavior
   include CacheDeleteMatchedBehavior
   include CacheIncrementDecrementBehavior
   include CacheInstrumentationBehavior

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -204,6 +204,7 @@ module TestHelpers
         config.hosts << proc { true }
         config.eager_load = false
         config.session_store :cookie_store, key: "_myapp_session"
+        config.cache_store = :mem_cache_store
         config.active_support.deprecation = :log
         config.action_controller.allow_forgery_protection = false
       RUBY


### PR DESCRIPTION
Ref: https://github.com/rails/rails/issues/42611

### Context

`LocalCache` used to keep the deserialized value in memory, however this opened the door for the cached value to be mutated (see #36656 and https://github.com/rails/rails/pull/37587). So it used to both save the backend rountrip, and the deserialization cost.

But now that we almost always need to deserialize local cache entries, `LocalCache` now at best only save the backend rountrip. And in the case of the `FileStore` it's pretty much nothing.

### Benchmark

I used a slightly modified version of @hoangtuyb96's benchmark: https://gist.github.com/casperisfine/80620e26aaf786a9d3016d5823ade15b

```
$ DISABLE_LOCAL_CACHE=1 SIZE=10 ruby bench-as-cache.rb 
fetch in rails 7.0.0.alpha
                        258.287  (± 1.5%) i/s -      1.300k in   5.034323s
write in rails 7.0.0.alpha
                          1.776k (± 3.3%) i/s -      8.960k in   5.050029s
$ SIZE=10 ruby bench-as-cache.rb 
fetch in rails 7.0.0.alpha
                        233.276  (± 6.9%) i/s -      1.175k in   5.065071s
write in rails 7.0.0.alpha
                          1.476k (±10.3%) i/s -      7.238k in   5.030478s

$ DISABLE_LOCAL_CACHE=1 SIZE=1000 ruby bench-as-cache.rb 
fetch in rails 7.0.0.alpha
                        228.549  (± 6.6%) i/s -      1.144k in   5.026979s
write in rails 7.0.0.alpha
                        129.034  (± 2.3%) i/s -    648.000  in   5.024184s

$ SIZE=1000 ruby bench-as-cache.rb
fetch in rails 7.0.0.alpha
                        234.919  (± 7.2%) i/s -      1.170k in   5.011433s
write in rails 7.0.0.alpha
                         67.769  (± 1.5%) i/s -    342.000  in   5.048530s
```

So `LocalCache` is pretty much useless for `FileStore`.