### PR TITLE
Fix migration compatibility for default precision value on datetime columns (Round 2)

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -99,6 +99,11 @@ module ActiveRecord
             end
           end
           alias :belongs_to :references
+
+          def column(name, type, index: nil, **options)
+            options[:precision] ||= nil
+            super
+          end
         end
 
         def create_table(table_name, **options)
@@ -143,6 +148,11 @@ module ActiveRecord
       class V5_2 < V6_0
         module TableDefinition
           def timestamps(**options)
+            options[:precision] ||= nil
+            super
+          end
+
+          def column(name, type, index: nil, **options)
             options[:precision] ||= nil
             super
           end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -351,7 +351,127 @@ module ActiveRecord
         connection.drop_table :more_testings rescue nil
       end
 
-      def test_datetime_doesnt_set_precision_on_change_table
+      def test_datetime_doesnt_set_precision_on_change_table_4_2
+        create_migration = Class.new(ActiveRecord::Migration[4.2]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.datetime :published_at
+            end
+          end
+        }.new
+
+        change_migration = Class.new(ActiveRecord::Migration[4.2]) {
+          def migrate(x)
+            change_table :more_testings do |t|
+              t.datetime :published_at, default: Time.now
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
+      def test_datetime_doesnt_set_precision_on_change_table_5_0
+        create_migration = Class.new(ActiveRecord::Migration[5.0]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.datetime :published_at
+            end
+          end
+        }.new
+
+        change_migration = Class.new(ActiveRecord::Migration[5.0]) {
+          def migrate(x)
+            change_table :more_testings do |t|
+              t.datetime :published_at, default: Time.now
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
+      def test_datetime_doesnt_set_precision_on_change_table_5_1
+        create_migration = Class.new(ActiveRecord::Migration[5.1]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.datetime :published_at
+            end
+          end
+        }.new
+
+        change_migration = Class.new(ActiveRecord::Migration[5.1]) {
+          def migrate(x)
+            change_table :more_testings do |t|
+              t.datetime :published_at, default: Time.now
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
+      def test_datetime_doesnt_set_precision_on_change_table_5_2
+        create_migration = Class.new(ActiveRecord::Migration[5.2]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.datetime :published_at
+            end
+          end
+        }.new
+
+        change_migration = Class.new(ActiveRecord::Migration[5.2]) {
+          def migrate(x)
+            change_table :more_testings do |t|
+              t.datetime :published_at, default: Time.now
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
+      def test_datetime_doesnt_set_precision_on_change_table_6_0
+        create_migration = Class.new(ActiveRecord::Migration[6.0]) {
+          def migrate(x)
+            create_table :more_testings do |t|
+              t.datetime :published_at
+            end
+          end
+        }.new
+
+        change_migration = Class.new(ActiveRecord::Migration[6.0]) {
+          def migrate(x)
+            change_table :more_testings do |t|
+              t.datetime :published_at, default: Time.now
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [create_migration, change_migration], @schema_migration).migrate
+
+        assert connection.column_exists?(:more_testings, :published_at, **precision_implicit_default)
+      ensure
+        connection.drop_table :more_testings rescue nil
+      end
+
+      def test_datetime_doesnt_set_precision_on_change_table_6_1
         create_migration = Class.new(ActiveRecord::Migration[6.1]) {
           def migrate(x)
             create_table :more_testings do |t|


### PR DESCRIPTION
### What

Fix migration compatibility for default precision value on datetime columns

### Why

Microseconds precision is the new default and was introduced on https://github.com/rails/rails/pull/42297, but in https://github.com/rails/rails/pull/42606 I found a compatibility issue. Another compatibility issue has been raised in https://github.com/rails/rails/pull/42606#issuecomment-869779286. ActiveRecord::Migration::Compatibility should prevent the introduction of this new behaviour on previous versions to 7.0.

### How

1. I've added test cases from rails 4.2 to 6.1 f365588, showing that `t.datime` compatibility is broken from 4.2 to 6.0, 
2. I've redefined the `column` method for Rails on `V6_0` class cddfc07 to fix the compatibility on Rails 6.0
3. Following the same approach on cddfc07, 7d5c443e00 redefines the `column` method behaviour on the class `V5_2` Fixing compatibility on rails version from 4.2 to 5.2

cc @guilleiguaran @zzak @ghiculescu @Tonkpils 