### PR TITLE
Adding docs link to ujs readme

### DIFF
--- a/actionview/app/assets/javascripts/README.md
+++ b/actionview/app/assets/javascripts/README.md
@@ -7,7 +7,7 @@ This unobtrusive scripting support file is developed for the Ruby on Rails frame
 - make forms or hyperlinks submit data asynchronously with Ajax;
 - have submit buttons become automatically disabled on form submit to prevent double-clicking.
 
-These features are achieved by adding certain [`data` attributes][data] to your HTML markup. In Rails, they are added by the framework's template helpers.
+These features are achieved by adding certain [`data` attributes][data] to your HTML markup. Documentation about the various supported `data` attributes is [available here][ujsdocs]. In Rails, they are added by the framework's template helpers.
 
 ## Optional prerequisites
 
@@ -55,3 +55,4 @@ rails-ujs is released under the [MIT License](MIT-LICENSE).
 [data]: https://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-attributes "Embedding custom non-visible data with the data-* attributes"
 [validator]: https://validator.w3.org/
 [csrf]: https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html
+[ujsdocs]: https://github.com/rails/jquery-ujs/wiki


### PR DESCRIPTION
[As mentioned in this ticket](https://github.com/rails/rails/issues/30924) the UJS readme does not link to the documentation. Ideally, we'd migrate all of the docs over to ujs readme, but I figured simply linking to the current wiki-based documentation is a better UX.
