### PR TITLE
Problem: ActionMailbox uses default ActiveStorage service

### DIFF
--- a/actionmailbox/CHANGELOG.md
+++ b/actionmailbox/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Add ability to configure ActiveStorage service
+    for storing email raw source.
+
+    ```yml
+    # config/storage.yml
+    incoming_emails:
+      service: Disk
+      root: /secure/dir/for/emails/only
+    ```
+
+    ```ruby
+    config.action_mailbox.storage_service = :incoming_emails
+    ```
+
+    *Yurii Rashkovskii*
+
 *   Add ability to incinerate an inbound message through the conductor interface.
 
     *Santiago Bartesaghi*

--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -29,7 +29,7 @@ module ActionMailbox
 
     include Incineratable, MessageId, Routable
 
-    has_one_attached :raw_email
+    has_one_attached :raw_email, service: ActionMailbox.storage_service
     enum status: %i[ pending processing delivered failed bounced ]
 
     def mail

--- a/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email/message_id.rb
@@ -35,7 +35,8 @@ module ActionMailbox::InboundEmail::MessageId
       end
 
       def create_and_upload_raw_email!(source)
-        ActiveStorage::Blob.create_and_upload! io: StringIO.new(source), filename: "message.eml", content_type: "message/rfc822"
+        ActiveStorage::Blob.create_and_upload! io: StringIO.new(source), filename: "message.eml", content_type: "message/rfc822",
+                                               service_name: ActionMailbox.storage_service
       end
   end
 end

--- a/actionmailbox/lib/action_mailbox.rb
+++ b/actionmailbox/lib/action_mailbox.rb
@@ -14,4 +14,5 @@ module ActionMailbox
   mattr_accessor :incinerate, default: true
   mattr_accessor :incinerate_after, default: 30.days
   mattr_accessor :queues, default: {}
+  mattr_accessor :storage_service
 end

--- a/actionmailbox/lib/action_mailbox/engine.rb
+++ b/actionmailbox/lib/action_mailbox/engine.rb
@@ -20,6 +20,8 @@ module ActionMailbox
     config.action_mailbox.queues = ActiveSupport::InheritableOptions.new \
       incineration: :action_mailbox_incineration, routing: :action_mailbox_routing
 
+    config.action_mailbox.storage_service = nil
+
     initializer "action_mailbox.config" do
       config.after_initialize do |app|
         ActionMailbox.logger = app.config.action_mailbox.logger || Rails.logger
@@ -27,6 +29,7 @@ module ActionMailbox
         ActionMailbox.incinerate_after = app.config.action_mailbox.incinerate_after || 30.days
         ActionMailbox.queues = app.config.action_mailbox.queues || {}
         ActionMailbox.ingress = app.config.action_mailbox.ingress
+        ActionMailbox.storage_service = app.config.action_mailbox.storage_service
       end
     end
   end

--- a/actionmailbox/test/dummy/config/storage.yml
+++ b/actionmailbox/test/dummy/config/storage.yml
@@ -6,6 +6,10 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+test_email:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage_email") %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -785,6 +785,8 @@ Defaults to `'signed cookie'`.
 
 * `config.action_mailbox.queues.routing` accepts a symbol indicating the Active Job queue to use for routing jobs. When this option is `nil`, routing jobs are sent to the default Active Job queue (see `config.active_job.default_queue_name`).
 
+* `config.action_mailbox.storage_service` accepts a symbol indicating the Active Storage service to use for uploading emails. When this option is `nil`, emails are uploaded to the default Active Storage service (see `config.active_storage.service`).
+
 ### Configuring Action Mailer
 
 There are a number of settings available on `config.action_mailer`:

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2946,6 +2946,25 @@ module ApplicationTests
       assert_equal :another_queue, ActionMailbox.queues[:routing]
     end
 
+    test "ActionMailbox.storage_service is nil by default (default service)" do
+      app "development"
+      assert_nil(ActionMailbox.storage_service)
+    end
+
+    test "ActionMailbox.storage_service can be configured" do
+      add_to_config <<-RUBY
+        config.active_storage.service_configurations = {
+          email: {
+            root: "#{Dir.tmpdir}/email",
+            service: "Disk"
+          }
+        }
+        config.action_mailbox.storage_service = :email
+      RUBY
+      app "development"
+      assert_equal(:email, ActionMailbox.storage_service)
+    end
+
     test "ActionMailer::Base.delivery_job is ActionMailer::MailDeliveryJob by default" do
       app "development"
 


### PR DESCRIPTION
This is imperfect in situations when a separation
between regular files (such as uploads) and emails
is necessary (for the purposes of regulatory compliance,
proper compartmentalization, etc.)

Solution: allow configuring ActionMailbox's storage service

### Summary

Extends ActionMailbox functionality by allowing to configure ActiveStorage
service.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

Discussion: https://discuss.rubyonrails.org/t/feature-proposal-actionmailbox-storage-service-configuration/78307