### PR TITLE
Adds support for `one?` and `many?` to handle grouped relations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Adds support for `one?` and `many?` to handle grouped relations.
+
+    Both `one?` and `many?` defined on `ActiveRecord::Relation` use `count(:all)` which does not return an
+    Integer but a Hash when there is a `group` clause present. `one?` would compare the returned hash with `1`
+    and always return false, `many?` would raise a `TypeError`.
+
+    Now, `one?` and `many?` will return true if the relation contains one, c.q. more than one *group*.
+
+    Fixes #41870
+
+    *Michiel de Mare*
+
 *   Relation#destroy_all perform its work in batches
 
     Since destroy_all actually loads the entire relation and then iteratively destroys the records one by one,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -296,14 +296,14 @@ module ActiveRecord
     def one?
       return super if block_given?
       return records.one? if limit_value || loaded?
-      limited_count == 1
+      (limited_count.is_a?(Hash) ? limited_count.size : limited_count) == 1
     end
 
     # Returns true if there is more than one record.
     def many?
       return super if block_given?
       return records.many? if limit_value || loaded?
-      limited_count > 1
+      (limited_count.is_a?(Hash) ? limited_count.size : limited_count) > 1
     end
 
     # Returns a stable cache key that can be used to identify this query.

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1179,6 +1179,39 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_predicate posts.limit(1), :many?
   end
 
+  def test_none_one_and_many_with_groups
+    no_posts = Post.where(tags_count: 999).group(:tags_count)
+    assert_equal 0, no_posts.count.size
+    one_post = Post.where(tags_count: 3).group(:tags_count)
+    assert_equal 1, one_post.count.size
+    many_posts = Post.group(:tags_count)
+    assert_equal 3, many_posts.count.size
+
+    assert_predicate no_posts, :none?
+    assert_not_predicate one_post, :none?
+    assert_not_predicate many_posts, :none?
+
+    assert_not_predicate no_posts, :one?
+    assert_predicate one_post, :one?
+    assert_not_predicate many_posts, :one?
+
+    assert_not_predicate no_posts, :many?
+    assert_not_predicate one_post, :many?
+    assert_predicate many_posts, :many?
+  end
+
+  def test_one_with_groups
+    posts = Post.group(:tags_count)
+    assert_predicate posts, :many?
+    assert_not_predicate posts, :one?
+  end
+
+  def test_none_with_groups
+    posts = Post.group(:tags_count)
+    assert_predicate posts, :many?
+    assert_not_predicate posts, :one?
+  end
+
   def test_none?
     posts = Post.all
     assert_queries(1) do


### PR DESCRIPTION
Both `one?` and `many?` defined on `ActiveRecord::Relation` use `count(:all)`
which does not return an Integer but a Hash when there is a `group` clause
present. `one?` would compare the returned hash with `1` and always return
false, `many?` would raise a `TypeError`.

Now, `one?` and `many?` will return true if the relation contains one,
c.q. more than one *group*.

Fixes #41870

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
