### PR TITLE
Reset `@association_scope` when resetting an association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,17 +1,10 @@
-*   Association#reset also resets the cached `association_scope`
+*   `Association#reset` also resets the association scope.
 
-    After loading a `has_one` association on an object then resetting the
-    association, calling save on the object has the effect of loading the
-    association again (as part of
-    `AutosaveAssocation#save_has_one_association`). When the association is
-    loaded in this way, the query to find the associated record was based on
-    the `association_scope` as evaluated originally. The conditions were
-    not _re_-evaluated, meaning they could be stale. If the scope includes
-    `Time.current`, for example, the cached `association_scope` would include
-    an old timestamp.
+    After loading a `has_one` association on an object and calling `reset`,
+    calling `save` would reload the association using a cached scope, which
+    could result in incorrect associated objects.
 
-    Now, when resetting an association, the `association_scope` is also reset.
-    hen the association is later reloaded, the scope is evaluated afresh.
+    Now when resetting an association, the association's scope is also reset.
 
     Fixes #42637
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Association#reset also resets the cached `association_scope`
+
+    After loading a `has_one` association on an object then resetting the
+    association, calling save on the object has the effect of loading the
+    association again (as part of
+    `AutosaveAssocation#save_has_one_association`). When the association is
+    loaded in this way, the query to find the associated record was based on
+    the `association_scope` as evaluated originally. The conditions were
+    not _re_-evaluated, meaning they could be stale. If the scope includes
+    `Time.current`, for example, the cached `association_scope` would include
+    an old timestamp.
+
+    Now, when resetting an association, the `association_scope` is also reset.
+    hen the association is later reloaded, the scope is evaluated afresh.
+
+    Fixes #42637
+
+    *Ollie Haydon-Mulligan*
+
 *   Accept optional transaction args to `ActiveRecord::Locking::Pessimistic#with_lock`
 
     `#with_lock` now accepts transaction options like `requires_new:`,

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -44,7 +44,6 @@ module ActiveRecord
         @disable_joins = @reflection.options[:disable_joins] || false
 
         reset
-        reset_scope
       end
 
       # Resets the \loaded flag to +false+ and sets the \target to +nil+.
@@ -65,7 +64,6 @@ module ActiveRecord
       def reload(force = false)
         klass.connection.clear_query_cache if force && klass
         reset
-        reset_scope
         load_target
         self unless target.nil?
       end

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -53,6 +53,7 @@ module ActiveRecord
         @target = nil
         @stale_state = nil
         @inversed = false
+        reset_scope
       end
 
       def reset_negative_cache # :nodoc:

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -18,6 +18,7 @@ require "models/department"
 require "models/club"
 require "models/membership"
 require "models/parrot"
+require "models/service_contract"
 
 class HasOneAssociationsTest < ActiveRecord::TestCase
   self.use_transactional_tests = false unless supports_savepoints?
@@ -886,5 +887,16 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
       car.build_special_bulb
       car.build_special_bulb
     end
+  end
+
+  def test_reset_then_save_loads_association_with_correct_scope
+    car = Car.create
+    car.create_active_service_contract
+    car.active_service_contract.update(expires_at: Time.current)
+    car.association(:active_service_contract).reset
+
+    car.save
+
+    assert_nil car.active_service_contract
   end
 end

--- a/activerecord/test/models/car.rb
+++ b/activerecord/test/models/car.rb
@@ -12,6 +12,7 @@ class Car < ActiveRecord::Base
   has_many :awesome_bulbs, -> { awesome }, class_name: "Bulb"
 
   has_one :bulb
+  has_one :active_service_contract, -> { active }, class_name: "ServiceContract"
 
   has_many :tyres
   has_many :engines, dependent: :destroy, inverse_of: :my_car

--- a/activerecord/test/models/service_contract.rb
+++ b/activerecord/test/models/service_contract.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ServiceContract < ActiveRecord::Base
+  def self.active
+    where(expires_at: nil).or(expiring)
+  end
+
+  def self.expiring
+    where("expires_at > ?", Time.current)
+  end
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -669,11 +669,6 @@ ActiveRecord::Schema.define do
     t.string   :name
   end
 
-  create_table :service_contracts, force: true do |t|
-    t.integer :car_id
-    t.datetime :expires_at
-  end
-
   create_table :movies, force: true, id: false do |t|
     t.primary_key :movieid
     t.string      :name
@@ -946,6 +941,11 @@ ActiveRecord::Schema.define do
       t.belongs_to :session, foreign_key: true
       t.belongs_to :seminar, foreign_key: true
     end
+  end
+
+  create_table :service_contracts, force: true do |t|
+    t.integer :car_id
+    t.datetime :expires_at
   end
 
   create_table :shape_expressions, force: true do |t|

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -669,6 +669,11 @@ ActiveRecord::Schema.define do
     t.string   :name
   end
 
+  create_table :service_contracts, force: true do |t|
+    t.integer :car_id
+    t.datetime :expires_at
+  end
+
   create_table :movies, force: true, id: false do |t|
     t.primary_key :movieid
     t.string      :name


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Fixes https://github.com/rails/rails/issues/42637

When we load an association (`active_service_contract`) on an object (`car`), then reset that association (`car.association(:active_service_contract).reset`), the next time the association is loaded should trigger a fresh query to find any associated record. 

This PR aims to ensure that's the case.

After loading an association on an object then resetting the association, calling `save` on the object has the effect of loading the association again (as part of `AutosaveAssocation#save_has_one_association`). Currently, when the association is loaded in this way, the query to find the associated record is based on the `association_scope` as it was evaluated _originally_. The conditions are not re-evaluated, meaning they can be stale. (In the test case in this PR, an expired `service_contract` is returned as if its expiry is still in the future, because the timestamp in the scope has become out-of-date.)

With this PR, the stale `association_scope` is `reset` when we call `Association#reset`, so when the association is next loaded (including as part of `AutosaveAssocation#save_has_one_association`), the `association_scope` gets _re_-evaluated and the values included in it are current.