### PR TITLE
Fix markdown link from #42640

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -94,8 +94,9 @@
     `errors.messages` and `errors.details` hashes directly will have no effect. Moving forward,
     please convert those direct manipulations to use provided API methods instead.
     Please note that `errors#add` now accepts `options` as keyword arguments instead of `Hash` which
-    introduced a change in Ruby 3 to [keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).
-    arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).
+    introduced a change in Ruby 3 to [keyword arguments][kwargs-ann].
+
+    [kwargs-ann]: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
 
     The list of deprecated methods and their planned future behavioral changes at the next major release are:
 


### PR DESCRIPTION
It looks like we merged some broken markdown in #42640.

<img width="1001" alt="Screen Shot 2021-06-30 at 8 28 51" src="https://user-images.githubusercontent.com/277819/123880278-43689980-d97d-11eb-9529-d823931a6d29.png">
