### PR TITLE
Ignore LocalStore expired entries

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `ActiveSupport::Cache` local cache strategy read of expired entries.
+
+    Previously if the local cache contained an expired entry, attempting to read it would
+    result in a cache miss regardless of the central cache content.
+
+    Now the expired entry is pruned from the local cache, and the central cache is read instead.
+
+    *Jean Boussier*
+
 *   `TimeZone.iso8601` now accepts valid ordinal values similar to Ruby's `Date._iso8601` method.
     A valid ordinal value will be converted to an instance of `TimeWithZone` using the `:year`
     and `:yday` fragments returned from `Date._iso8601`.

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -146,7 +146,17 @@ module ActiveSupport
           end
 
           def fetch_entry(key, options = nil) # :nodoc:
-            @data.fetch(key) { @data[key] = Entry.build(yield) }
+            hit = true
+            entry = @data.fetch(key) do
+              hit = false
+              @data[key] = Entry.build(yield)
+            end
+
+            if hit && entry&.expired?
+              @data.delete(key)
+              entry = @data[key] = Entry.build(yield)
+            end
+            entry
           end
         end
 


### PR DESCRIPTION
If the local store returned an expired entry, we should fallback to hitting the real backend rather than treat it as a cache miss.

I found this one while investigating a performance refactoring (ref: https://github.com/rails/rails/issues/42611).

It's hard to tell wether it was by design or not. On one hand we do cache misses forever (https://github.com/rails/rails/pull/22194), so maybe it make sense to forever treat an expired entry as a miss.

But on the other hand, not respecting the expiry might lead to consistency issues.
