### PR TITLE
Normalize virtual attributes on ActiveRecord::Persistence#becomes

### DIFF
--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -99,6 +99,10 @@ module ActiveModel
       AttributeSet.new(new_attributes)
     end
 
+    def reverse_merge!(target_attributes)
+      attributes.reverse_merge!(target_attributes.attributes) && self
+    end
+
     def ==(other)
       attributes == other.attributes
     end

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,30 @@
+*   Adapts virtual attributes on `ActiveRecord::Persistence#becomes`.
+
+    When source and target classes have a different set of attributes adapts
+    attributes such that the extra attributes from target are added.
+
+    ```ruby
+    class Person < ApplicationRecord
+    end
+
+    class WebUser < Person
+      attribute :is_admin, :boolean
+      after_initialize :set_admin
+
+      def set_admin
+        write_attribute(:is_admin, email =~ /@ourcompany\.com$/)
+      end
+    end
+
+    person = Person.find_by(email: "email@ourcompany.com")
+    person.respond_to? :is_admin
+    # => false
+    person.becomes(User).is_admin?
+    # => true
+    ```
+
+    *Jacopo Beschi*, *Sampson Crowley*
+
 *   Fix `ActiveRecord::QueryMethods#in_order_of` to include `nil`s, to match the
     behavior of `Enumerable#in_order_of`.
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -707,11 +707,14 @@ module ActiveRecord
     # Note: The new instance will share a link to the same attributes as the original class.
     # Therefore the STI column value will still be the same.
     # Any change to the attributes on either instance will affect both instances.
+    # This includes any attribute initialization done by the new instance.
+    #
     # If you want to change the STI column as well, use #becomes! instead.
     def becomes(klass)
       became = klass.allocate
 
       became.send(:initialize) do |becoming|
+        @attributes.reverse_merge!(becoming.instance_variable_get(:@attributes))
         becoming.instance_variable_set(:@attributes, @attributes)
         becoming.instance_variable_set(:@mutations_from_database, @mutations_from_database ||= nil)
         becoming.instance_variable_set(:@new_record, new_record?)

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -350,6 +350,23 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal %w{name}, client.changed
   end
 
+  def test_becomes_initializes_missing_attributes
+    company = Company.new(name: "GrowingCompany")
+
+    client = company.becomes(LargeClient)
+
+    assert_equal 50, client.extra_size
+  end
+
+  def test_becomes_keeps_extra_attributes
+    client = LargeClient.new(name: "ShrinkingCompany")
+
+    company = client.becomes(Company)
+
+    assert_equal 50, company.extra_size
+    assert_equal 50, client.extra_size
+  end
+
   def test_delete_many
     original_count = Topic.count
     Topic.delete(deleting = [1, 2])

--- a/activerecord/test/models/company.rb
+++ b/activerecord/test/models/company.rb
@@ -209,6 +209,16 @@ class ExclusivelyDependentFirm < Company
   has_many :dependent_conditional_clients_of_firm, -> { order("id").where("name = ?", "BigShot Inc.") }, foreign_key: "client_of", class_name: "Client", dependent: :delete_all
 end
 
+class LargeClient < Client
+  attribute :extra_size, :integer
+
+  after_initialize :set_extra_size
+
+  def set_extra_size
+    self[:extra_size] = 50
+  end
+end
+
 class SpecialClient < Client
 end
 


### PR DESCRIPTION
### Summary

When source and target classes have a different set of attributes adapts
attributes such that the extra attributes from target are added.

Fixes #41195

Co-authored-by: SampsonCrowley <sampsonsprojects@gmail.com>
Co-authored-by: Jonathan Hefner <jonathan@hefner.pro>

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
