### PR TITLE
Fix migrations with the same timestamps in multiple databases

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -94,9 +94,11 @@ db_namespace = namespace :db do
       original_db_config = ActiveRecord::Base.connection_db_config
       mapped_versions = ActiveRecord::Tasks::DatabaseTasks.db_configs_with_versions(db_configs)
 
-      mapped_versions.sort.each do |version, db_config|
-        ActiveRecord::Base.establish_connection(db_config)
-        ActiveRecord::Tasks::DatabaseTasks.migrate(version)
+      mapped_versions.sort.each do |version, db_configs|
+        db_configs.each do |db_config|
+          ActiveRecord::Base.establish_connection(db_config)
+          ActiveRecord::Tasks::DatabaseTasks.migrate(version)
+        end
       end
     end
 

--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -286,7 +286,7 @@ module ActiveRecord
       end
 
       def db_configs_with_versions(db_configs) # :nodoc:
-        db_configs_with_versions = {}
+        db_configs_with_versions = Hash.new { |h, k| h[k] = [] }
 
         db_configs.each do |db_config|
           ActiveRecord::Base.establish_connection(db_config)
@@ -295,7 +295,7 @@ module ActiveRecord
 
           versions_to_run.each do |version|
             next if target_version && target_version != version
-            db_configs_with_versions[version] = db_config
+            db_configs_with_versions[version] << db_config
           end
         end
 


### PR DESCRIPTION
In #42604 we added functionality that would sort the migrations by
timestamp so that if there were 2 migrations in 2 databases that were
dependent on one another they would be run in timestamp order rather
than in cluster order.

While debugging another issue I realized that if the timestamps are the
same that only one of the migrations will get run. This fixes the issue
by collecting all the db configs for a version so that we get the entire
list.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>