### PR TITLE
Allow removing LocalCache middleware in application.rb

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -130,7 +130,7 @@ module ActionDispatch
     ruby2_keywords(:swap)
 
     def delete(target)
-      middlewares.delete_if { |m| m.klass == target }
+      middlewares.delete_if { |m| m.name == target.name }
     end
 
     def move(target, source)
@@ -180,10 +180,10 @@ module ActionDispatch
         Middleware.new(klass, args, block)
       end
 
-      def index_of(index)
-        raise "ActionDispatch::MiddlewareStack::FakeRuntime can not be referenced in middleware operations" if index == FakeRuntime
+      def index_of(klass)
+        raise "ActionDispatch::MiddlewareStack::FakeRuntime can not be referenced in middleware operations" if klass == FakeRuntime
 
-        if index == Rack::Runtime && @rack_runtime_deprecated
+        if klass == Rack::Runtime && @rack_runtime_deprecated
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Rack::Runtime is removed from the default middleware stack in Rails
             and referencing it in middleware operations without adding it back
@@ -192,7 +192,7 @@ module ActionDispatch
         end
 
         middlewares.index do |m|
-          m.klass == index || (@rack_runtime_deprecated && m.klass == FakeRuntime && index == Rack::Runtime)
+          m.name == klass.name || (@rack_runtime_deprecated && m.klass == FakeRuntime && klass == Rack::Runtime)
         end
       end
   end


### PR DESCRIPTION
All other middlewares can be removed from the stack in `config/application.rb`. `ActiveSupport::Cache::Strategy::LocalCache::Middleware` cannot, because it is added to the stack as an instance rather than a class, here: https://github.com/rails/rails/blob/main/railties/lib/rails/application/bootstrap.rb#L62. As a result, [this check](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/middleware/stack.rb#L133) fails unless you also pass the same instance. The instance is not available in `config/appliaction.rb` because `Rails.cache` has not been initialized yet (it's initialized when the middleware is set).

This means that if you want to remove the local cache middleware you have to make an initiailzer just for that. Unlike all other middlewares which can be dealt with as classes in `config/application.rb`.

The fix is to check the middleware's `name`, not `klass`, for delete operations. The name is [provided explicitly](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/cache/strategy/local_cache.rb#L162) presumably for this reason.
