### PR TITLE
Add `available_records` argument to Associations::Preloader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -87,6 +87,12 @@ module ActiveRecord
       #   [ :books, :author ]
       #   { author: :avatar }
       #   [ :books, { author: :avatar } ]
+      #
+      # +available_records+ is an array of ActiveRecord::Base. The Preloader
+      # will try to use the objects in this array to preload the requested
+      # associations before querying the database. This can save database
+      # queries by reusing in-memory objects. The optimization is only applied
+      # to single associations (i.e. :belongs_to, :has_one) with no scopes.
       def initialize(associate_by_default: true, **kwargs)
         if kwargs.empty?
           ActiveSupport::Deprecation.warn("Calling `Preloader#initialize` without arguments is deprecated and will be removed in Rails 7.0.")
@@ -94,6 +100,7 @@ module ActiveRecord
           @records = kwargs[:records]
           @associations = kwargs[:associations]
           @scope = kwargs[:scope]
+          @available_records = kwargs[:available_records] || []
           @associate_by_default = associate_by_default
 
           @tree = Branch.new(
@@ -112,7 +119,7 @@ module ActiveRecord
       end
 
       def call
-        Batch.new([self]).call
+        Batch.new([self], available_records: @available_records).call
 
         loaders
       end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -163,6 +163,25 @@ module ActiveRecord
           end
         end
 
+        def associate_records_from_unscoped(unscoped_records)
+          return if unscoped_records.nil? || unscoped_records.empty?
+          return if !reflection_scope.empty_scope?
+          return if preload_scope && !preload_scope.empty_scope?
+          return if reflection.collection?
+
+          unscoped_records.each do |record|
+            owners = owners_by_key[convert_key(record[association_key_name])]
+            owners&.each_with_index do |owner, i|
+              association = owner.association(reflection.name)
+              association.target = record
+
+              if i == 0 # Set inverse on first owner
+                association.set_inverse_instance(record)
+              end
+            end
+          end
+        end
+
         private
           attr_reader :owners, :reflection, :preload_scope, :model
 

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Essay < ActiveRecord::Base
-  belongs_to :author
+  belongs_to :author, primary_key: :name
   belongs_to :writer, primary_key: :name, polymorphic: true
   belongs_to :category, primary_key: :name
   has_one :owner, primary_key: :name


### PR DESCRIPTION
Sometimes when we are preloading associations on records, we already have
the association objects loaded in-memory. But the Preloader will go to the
database to fetch them anyways because there is no way to tell it about
these loaded objects. This PR adds a new `available_records` argument to
supply the Preloader with a set of in-memory records that it can use to
fill associations without making a database query.

`available_records` is an array of ActiveRecord::Base objects. Mixed
models are supported. Preloader will use these records to try to fill the
requested associations before querying the database. This can save database
queries by reusing in-memory objects.

The optimization is only applied to single associations (i.e. :belongs_to,
:has_one) as we must query the database to do an exhaustive lookup for
collections (i.e. :has_many). It also requires the query to have no scopes
as scopes can filter associations even if they are already in memory.

```ruby
# Assume we have post and all_authors loaded elsewhere
comment = Comment.last
post = Post.find_by(id: comment.post_id)
all_authors = Author.all.to_a

# Previously this would have executed two queries to fetch post and author.
Preloader.new([comment], [:post, :author]).call

# Using the available_records parameter, this executes zero queries since
# the associated records are already in memory.
Preloader.new([comment], [:post, :author], available_records: [post, all_authors]).call
```

cc/ co-author @jhawthorn 🍐