### PR TITLE
Deleting an item from the Middleware stack should raise if the item is not found

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deleting an item from the Middleware stack will raise if the item is not found
+
+    Previously, calling `config.middleware.delete(ItemNotInMiddleware)` would fail silently.
+    Now it will raise, same as `config.middleware.move(0, ItemNotInMiddleware)` does.
+
+    *Alex Ghiculescu*
+
 *   OpenSSL constants are now used for Digest computations.
 
     *Dirkjan Bussink*

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -130,7 +130,7 @@ module ActionDispatch
     ruby2_keywords(:swap)
 
     def delete(target)
-      middlewares.delete_if { |m| m.name == target.name }
+      middlewares.reject! { |m| m.name == target.name } || (raise "No such middleware to delete: #{target.inspect}")
     end
 
     def move(target, source)

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -105,6 +105,12 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     end
   end
 
+  test "delete requires the middleware to be in the stack" do
+    assert_raises RuntimeError do
+      @stack.delete(BazMiddleware)
+    end
+  end
+
   test "move preserves the arguments of the moved middleware" do
     @stack.use BazMiddleware, true, foo: "bar"
     @stack.move_before(FooMiddleware, BazMiddleware)


### PR DESCRIPTION
Currently if you call any `move` operation on the middleware stack with a middleware item that doesn't exist, [it will raise](https://github.com/rails/rails/blob/53d54694e9a423642ba9c984207097e9522db26f/actionpack/test/dispatch/middleware_stack_test.rb#L102). But the same doesn't happen if you call `delete` with a non-existant item. This makes it hard to debug issues like https://github.com/rails/rails/pull/42652 as the `delete` call fails silently.

I think `delete` should raise same as `move` does, and this PR implements that.

This would be a breaking change if someone has code calling `delete` on a non-existant middleware item, the fix would be to just remove that code since it's not doing anything.
