### PR TITLE
Ensure Action Text migration use config set primary_key_type

### DIFF
--- a/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
+++ b/actiontext/db/migrate/20180528164100_create_action_text_tables.rb
@@ -1,13 +1,25 @@
 class CreateActionTextTables < ActiveRecord::Migration[6.0]
   def change
-    create_table :action_text_rich_texts do |t|
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
       t.string     :name, null: false
       t.text       :body, size: :long
-      t.references :record, null: false, polymorphic: true, index: false
+      t.references :record, null: false, polymorphic: true, index: false, type: foreign_key_type
 
       t.timestamps
 
       t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
     end
   end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
 end


### PR DESCRIPTION
Similar to: #42378

PR copy pastes similar changes for the migration 
from #42378. I have recently made a mistake of not 
updating the primary_key_type to uuid in Action Text
migration. 

Tried adding test cases for the changes but
migration file would always use id as primary_key_type
and reference type as foreign_key_type. Did not find
any good way to assert the changes.

Tested locally and following is the schema
generated for Action Text migration if
`primary_key_type: :uuid`

```
create_table "action_text_rich_texts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
    t.string "name", null: false
    t.text "body"
    t.string "record_type", null: false
    t.uuid "record_id", null: false
    t.datetime "created_at", precision: 6, null: false
    t.datetime "updated_at", precision: 6, null: false
    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
  end
```