### PR TITLE
Add index sidebar to guides index page

### DIFF
--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -5,7 +5,7 @@ require "yaml"
 module RailsGuides
   module Helpers
     def guide(name, url, options = {}, &block)
-      link = content_tag(:a, href: url) { name }
+      link = content_tag(:a, id: name.parameterize, href: url) { name }
       result = content_tag(:dt, link)
 
       if options[:work_in_progress]

--- a/guides/source/index.html.erb
+++ b/guides/source/index.html.erb
@@ -14,11 +14,24 @@
     <% end -%>
     <dd class="work-in-progress">Guides marked with this icon are currently being worked on and will not be available in the Guides Index menu. While still useful, they may contain incomplete information and even errors. You can help by reviewing them and posting your comments and corrections.</dd>
   </dl>
+  <h3 class="chapter"><img src="images/chapters_icon.gif" alt="" />Guides</h3>
+  <ol class="chapters">
+    <% documents_by_section.each do |section| %>
+      <li><a href="#<%= section['name'].parameterize %>"><%= section['name'] %></a></li>
+      <ul>
+      <% section['documents'].each do |document| %>
+        <% unless document['work_in_progress'] %>
+          <li><a href="#<%= document['name'].parameterize %>"><%= document['name'] %></a></li>
+        <% end %>
+      <% end %>
+      </ul>
+    <% end %>
+  </ol>
 </div>
 <% end %>
 
 <% documents_by_section.each do |section| %>
-  <h3><%= section['name'] %></h3>
+  <h3 id="<%= section['name'].parameterize %>"><%= section['name'] %></h3>
   <dl>
     <% section['documents'].each do |document| %>
       <%= guide(document['name'], document['url'], work_in_progress: document['work_in_progress']) do %>


### PR DESCRIPTION
### Summary

Unlike all the other guides, the index page doesn't have an index sidebar.

To improve navigation and add an overview of all guides an index is
added. Guides that are `work_in_progress` aren't shown, because they
are excluded from the Guides Index menu as well.

<img width="896" alt="image" src="https://user-images.githubusercontent.com/28561/124010837-a559eb00-d9df-11eb-858f-453b0cbcb3b0.png">