### PR TITLE
Fix bug report templates failing to run

### DIFF
--- a/guides/bug_report_templates/action_controller_gem.rb
+++ b/guides/bug_report_templates/action_controller_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.1.0"
+  gem "rails", "~>6.1.0"
 end
 
 require "rack/test"

--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.1.0"
+  gem "rails", "~>6.1.0"
   gem "sqlite3"
   if RUBY_VERSION >= "3.1"
     # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.

--- a/guides/bug_report_templates/active_storage_gem.rb
+++ b/guides/bug_report_templates/active_storage_gem.rb
@@ -8,7 +8,7 @@ gemfile(true) do
   git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
   # Activate the gem you are reporting the issue against.
-  gem "rails", "6.1.0"
+  gem "rails", "~>6.1.0"
   gem "sqlite3"
 end
 


### PR DESCRIPTION
### Summary

Fix the bug report templates that are no longer running because of the mime magic dependency. To repro, run any of the 3 scripts I have updated, e.g.

`> ruby guides/bug_report_templates/action_controller_gem.rb`
`> ruby guides/bug_report_templates/action_mailbox_gem.rb`
`> ruby guides/bug_report_templates/active_storage_gem.rb`

Output:

```
Fetching gem metadata from https://rubygems.org/.............
Resolving dependencies....
Using rake 13.0.3
Using concurrent-ruby 1.1.9
Using minitest 5.14.4
Using thread_safe 0.3.6
Using zeitwerk 2.4.2
Using builder 3.2.4
Using erubi 1.10.0
Using crass 1.0.6
Using rack 2.2.3
Using mini_mime 1.1.0
Using bundler 2.2.17
Using thor 1.1.0
Using racc 1.5.2
Using nio4r 2.5.7
Using tzinfo 1.2.9
Using rack-test 1.1.0
Using mail 2.7.1
Using sprockets 4.0.2
Using websocket-extensions 0.1.5
Using method_source 1.0.0
Using i18n 1.8.10
Using nokogiri 1.11.7 (x86_64-darwin)
Using websocket-driver 0.7.5
Using loofah 2.10.0
Fetching mimemagic 0.3.10
Using rails-html-sanitizer 1.3.0
Fetching activesupport 6.0.0
Installing mimemagic 0.3.10 with native extensions
Installing activesupport 6.0.0
Using rails-dom-testing 2.0.3
Using globalid 0.4.2
Fetching activemodel 6.0.0
Fetching activejob 6.0.0
Fetching actionview 6.0.0
Installing activejob 6.0.0
Installing activemodel 6.0.0
Installing actionview 6.0.0
Fetching activerecord 6.0.0
Fetching actionpack 6.0.0
Installing activerecord 6.0.0
Installing actionpack 6.0.0
Using sprockets-rails 3.2.2
Fetching actionmailer 6.0.0
Fetching railties 6.0.0
Fetching actioncable 6.0.0
Installing actionmailer 6.0.0
Installing actioncable 6.0.0
Installing railties 6.0.0
Traceback (most recent call last):
	16: from action_controller_gem.rb:5:in `<main>'
	15: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/inline.rb:55:in `gemfile'
	14: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/settings.rb:134:in `temporary'
	13: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/inline.rb:62:in `block in gemfile'
	12: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/settings.rb:134:in `temporary'
	11: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/inline.rb:63:in `block (2 levels) in gemfile'
	10: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer.rb:24:in `install'
	 9: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer.rb:72:in `run'
	 8: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/process_lock.rb:9:in `lock'
	 7: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/process_lock.rb:9:in `open'
	 6: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/process_lock.rb:12:in `block in lock'
	 5: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer.rb:90:in `block in run'
	 4: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer.rb:210:in `install'
	 3: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer.rb:270:in `install_in_parallel'
	 2: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer/parallel_installer.rb:71:in `call'
	 1: from /Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer/parallel_installer.rb:102:in `call'
/Users/haroon/.gem/ruby/2.7.2/gems/bundler-2.2.17/lib/bundler/installer/parallel_installer.rb:220:in `handle_error': Gem::Ext::BuildError: ERROR: Failed to build gem native extension. (Bundler::InstallError)
\e[0m
    current directory: /Users/haroon/.gem/ruby/2.7.2/gems/mimemagic-0.3.10/ext/mimemagic
/Users/haroon/.rubies/ruby-2.7.2/bin/ruby -I/Users/haroon/.rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems -rrubygems /Users/haroon/.gem/ruby/2.7.2/gems/rake-13.0.3/exe/rake RUBYARCHDIR\\=/Users/haroon/.gem/ruby/2.7.2/extensions/x86_64-darwin-20/2.7.0-static/mimemagic-0.3.10 RUBYLIBDIR\\=/Users/haroon/.gem/ruby/2.7.2/extensions/x86_64-darwin-20/2.7.0-static/mimemagic-0.3.10
Ignoring bcrypt-3.1.13 because its extensions are not built. Try: gem pristine bcrypt --version 3.1.13
Ignoring bootsnap-1.4.5 because its extensions are not built. Try: gem pristine bootsnap --version 1.4.5
Ignoring byebug-11.0.1 because its extensions are not built. Try: gem pristine byebug --version 11.0.1
Ignoring curses-1.0.2 because its extensions are not built. Try: gem pristine curses --version 1.0.2
Ignoring ffi-1.11.3 because its extensions are not built. Try: gem pristine ffi --version 1.11.3
Ignoring json-2.3.1 because its extensions are not built. Try: gem pristine json --version 2.3.1
Ignoring libxml-ruby-3.1.0 because its extensions are not built. Try: gem pristine libxml-ruby --version 3.1.0
Ignoring msgpack-1.3.1 because its extensions are not built. Try: gem pristine msgpack --version 1.3.1
Ignoring nio4r-2.5.2 because its extensions are not built. Try: gem pristine nio4r --version 2.5.2
Ignoring pg-1.1.4 because its extensions are not built. Try: gem pristine pg --version 1.1.4
Ignoring puma-4.3.6 because its extensions are not built. Try: gem pristine puma --version 4.3.6
Ignoring puma-4.3.1 because its extensions are not built. Try: gem pristine puma --version 4.3.1
rake aborted!
Could not find MIME type database in the following locations: ["/usr/local/share/mime/packages/freedesktop.org.xml", "/opt/homebrew/share/mime/packages/freedesktop.org.xml", "/opt/local/share/mime/packages/freedesktop.org.xml", "/usr/share/mime/packages/freedesktop.org.xml"]

Ensure you have either installed the shared-mime-info package for your distribution, or
obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
of that file.

This gem might be installed as a dependency of some bigger package, such as rails, activestorage,
axlsx or cucumber. While most of these packages use the functionality of this gem, some gems have
included this gem by accident. Set USE_FREEDESKTOP_PLACEHOLDER=true if you are certain that you
do not need this gem, and wish to skip the inclusion of freedesktop.org.xml.

The FREEDESKTOP_PLACEHOLDER option is meant as a transitional feature, and will be deprecated in
the next release.
/Users/haroon/.gem/ruby/2.7.2/gems/mimemagic-0.3.10/ext/mimemagic/Rakefile:15:in `locate_mime_database'
/Users/haroon/.gem/ruby/2.7.2/gems/mimemagic-0.3.10/ext/mimemagic/Rakefile:39:in `block in <top (required)>'
/Users/haroon/.gem/ruby/2.7.2/gems/rake-13.0.3/exe/rake:27:in `<main>'
Tasks: TOP => default
(See full trace by running task with --trace)

rake failed, exit code 1

Gem files will remain installed in /Users/haroon/.gem/ruby/2.7.2/gems/mimemagic-0.3.10 for inspection.
Results logged to /Users/haroon/.gem/ruby/2.7.2/extensions/x86_64-darwin-20/2.7.0-static/mimemagic-0.3.10/gem_make.out

\e[0m\e[31mAn error occurred while installing mimemagic (0.3.10), and Bundler cannot continue.
Make sure that `gem install mimemagic -v '0.3.10' --source 'https://rubygems.org/'` succeeds before bundling.\e[0m

In Gemfile:
  rails was resolved to 6.0.0, which depends on
    actionmailbox was resolved to 6.0.0, which depends on
      activestorage was resolved to 6.0.0, which depends on
        marcel was resolved to 0.3.3, which depends on
          mimemagic
```