### PR TITLE
Improve logging of schema cache at startup.

### DIFF
--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -150,11 +150,12 @@ To keep using the current cache store, you can turn off cache versioning entirel
               next if current_version.nil?
 
               if cache.version != current_version
-                warn "Ignoring #{filename} because it has expired. The current schema version is #{current_version}, but the one in the cache is #{cache.version}."
+                warn "Ignoring #{filename} because it has expired. The current schema version is #{current_version}, but the one in the schema cache file is #{cache.version}."
                 next
               end
             end
 
+            Rails.logger.info("Using schema cache file #{filename}")
             connection_pool.set_schema_cache(cache)
           end
         end


### PR DESCRIPTION
This change allows verification if the schema cache was used at startup.

Fixes #42664. 

### Steps to reproduce
Create a schema cache file:

```
rake db:schema:cache:dump
```

then run

```
rails s
```

### Expected behavior
There should be some logging to determine if the schema_cache is used.

### Actual behavior
No logging.

### System configuration
**Rails version**:6.1.3.2
**Ruby version**:2.7.3
