### PR TITLE
Configure browser only when using Selenium

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -5,13 +5,13 @@ module ActionDispatch
     class Driver # :nodoc:
       def initialize(name, **options, &capabilities)
         @name = name
-        @browser = Browser.new(options[:using])
         @screen_size = options[:screen_size]
         @options = options[:options] || {}
         @capabilities = capabilities
 
         if name == :selenium
           require "selenium/webdriver"
+          @browser = Browser.new(options[:using])
           @browser.preload
         end
       end
@@ -28,7 +28,7 @@ module ActionDispatch
         end
 
         def register
-          @browser.configure(&@capabilities)
+          @browser&.configure(&@capabilities)
 
           Capybara.register_driver @name do |app|
             case @name

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -148,13 +148,11 @@ class DriverTest < ActiveSupport::TestCase
     ::Selenium::WebDriver::Chrome::Service.driver_path = original_driver_path
   end
 
-  test "does not preload if used driver is not :selenium" do
-    assert_not_called_on_instance_of(ActionDispatch::SystemTesting::Browser, :preload) do
-      ActionDispatch::SystemTesting::Driver.new(:rack_test, using: :chrome)
-    end
+  test "does not configure browser if driver is not :selenium" do
+    # sanity check
+    assert ActionDispatch::SystemTesting::Driver.new(:selenium).instance_variable_get(:@browser)
 
-    assert_not_called_on_instance_of(ActionDispatch::SystemTesting::Browser, :preload) do
-      ActionDispatch::SystemTesting::Driver.new(:poltergeist)
-    end
+    assert_nil ActionDispatch::SystemTesting::Driver.new(:rack_test).instance_variable_get(:@browser)
+    assert_nil ActionDispatch::SystemTesting::Driver.new(:poltergeist).instance_variable_get(:@browser)
   end
 end


### PR DESCRIPTION
Since #39179, `selenium/webdriver` is required only when using the `:selenium` driver.  However, `ActionDispatch::SystemTesting::Browser` references `::Selenium` [as soon as it is instantiated](https://github.com/rails/rails/blob/f263530bf709f611920b5f663882e5113b4f984b/actionpack/lib/action_dispatch/system_testing/browser.rb#L53-L61), and thus raises an error when using a non-`:selenium` driver.

This commit ensures that `ActionDispatch::SystemTesting::Browser` is instantiated only when using the `:selenium` driver.

---

I chose this approach because `ActionDispatch::SystemTesting::Browser` seems to be intended for use with Selenium only.  But if that's not the case, there are a few alternatives I can explore.
