### PR TITLE
Fix new framework defaults for `destroy_all_in_batches`

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -43,6 +43,6 @@
 # of the video).
 # Rails.application.config.active_storage.video_preview_arguments =
 #   "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
-#
+
 # Enforce destroy in batches when calling ActiveRecord::Relation#destroy_all
-Rails.application.config.active_record.destroy_all_in_batches = true
+# Rails.application.config.active_record.destroy_all_in_batches = true


### PR DESCRIPTION
Small issue from https://github.com/rails/rails/pull/40445, the configuration should be commented out by default.

cc @robertomiranda 