### PR TITLE
Fix "wrong number of arguments" error

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -45,7 +45,7 @@ module ActionDispatch
         end
 
         def register_selenium(app)
-          Capybara::Selenium::Driver.new(app, **{ browser: @browser.type }.merge(browser_options)).tap do |driver|
+          Capybara::Selenium::Driver.new(app, browser: @browser.type, **browser_options).tap do |driver|
             driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
           end
         end
@@ -61,7 +61,7 @@ module ActionDispatch
         end
 
         def register_rack_test(app)
-          Capybara::RackTest::Driver.new(app, { respect_data_method: true }.merge(@options))
+          Capybara::RackTest::Driver.new(app, respect_data_method: true, **@options)
         end
 
         def setup


### PR DESCRIPTION
Follow-up to #41467.

[`Capybara::RackTest::Driver#initialize`](https://github.com/teamcapybara/capybara/blob/3.35.3/lib/capybara/rack_test/driver.rb#L17) uses keyword arguments, just like [`Capybara::Selenium::Driver#initialize`](https://github.com/teamcapybara/capybara/blob/3.35.3/lib/capybara/selenium/driver.rb#L92).