### PR TITLE
fix ArgumentError when missing translation

### DIFF
--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -169,7 +169,7 @@ module ActionView
           end
         end
 
-        def missing_translation(key, options)
+        def missing_translation(key, **options)
           keys = I18n.normalize_keys(options[:locale] || I18n.locale, key, options[:scope])
 
           title = +"translation missing: #{keys.join(".")}"


### PR DESCRIPTION
fix "wrong number of arguments (given 1, expected 2)" error when missing translation
