### PR TITLE
Fix CI failure caused by error_highlight gem

### DIFF
--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -918,7 +918,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     }
     assert_instance_of Topic, error.record
     assert_equal "hello", error.attribute
-    assert_equal "unknown attribute 'hello' for Topic.", error.message
+    assert_match "unknown attribute 'hello' for Topic.", error.message
   end
 
   test "method overrides in multi-level subclasses" do

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -62,7 +62,7 @@ class InheritanceTest < ActiveRecord::TestCase
     e = assert_raises NameError do
       Company.send :compute_type, "NonexistentModel"
     end
-    assert_equal "uninitialized constant Company::NonexistentModel", e.message
+    assert_match "uninitialized constant Company::NonexistentModel", e.message
     assert_equal "Company::NonexistentModel", e.name
   end
 

--- a/activerecord/test/cases/nested_attributes_test.rb
+++ b/activerecord/test/cases/nested_attributes_test.rb
@@ -67,7 +67,7 @@ class TestNestedAttributesInGeneral < ActiveRecord::TestCase
     exception = assert_raise ActiveModel::UnknownAttributeError do
       Pirate.new(ship_attributes: { sail: true })
     end
-    assert_equal "unknown attribute 'sail' for Ship.", exception.message
+    assert_match "unknown attribute 'sail' for Ship.", exception.message
   end
 
   def test_should_disable_allow_destroy_by_default
@@ -606,7 +606,7 @@ module NestedAttributesOnACollectionAssociationTests
     exception = assert_raise ActiveModel::UnknownAttributeError do
       @pirate.parrots_attributes = [{ peg_leg: true }]
     end
-    assert_equal "unknown attribute 'peg_leg' for Parrot.", exception.message
+    assert_match "unknown attribute 'peg_leg' for Parrot.", exception.message
   end
 
   def test_should_save_only_one_association_on_create

--- a/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_per_thread_test.rb
@@ -100,28 +100,28 @@ class ModuleAttributeAccessorPerThreadTest < ActiveSupport::TestCase
         thread_cattr_reader "1nvalid"
       end
     end
-    assert_equal "invalid attribute name: 1nvalid", exception.message
+    assert_match "invalid attribute name: 1nvalid", exception.message
 
     exception = assert_raises NameError do
       Class.new do
         thread_cattr_writer "1nvalid"
       end
     end
-    assert_equal "invalid attribute name: 1nvalid", exception.message
+    assert_match "invalid attribute name: 1nvalid", exception.message
 
     exception = assert_raises NameError do
       Class.new do
         thread_mattr_reader "1valid_part"
       end
     end
-    assert_equal "invalid attribute name: 1valid_part", exception.message
+    assert_match "invalid attribute name: 1valid_part", exception.message
 
     exception = assert_raises NameError do
       Class.new do
         thread_mattr_writer "2valid_part"
       end
     end
-    assert_equal "invalid attribute name: 2valid_part", exception.message
+    assert_match "invalid attribute name: 2valid_part", exception.message
   end
 
   def test_should_return_same_value_by_class_or_instance_accessor

--- a/activesupport/test/core_ext/module/attribute_accessor_test.rb
+++ b/activesupport/test/core_ext/module/attribute_accessor_test.rb
@@ -85,28 +85,28 @@ class ModuleAttributeAccessorTest < ActiveSupport::TestCase
         cattr_reader "1nvalid"
       end
     end
-    assert_equal "invalid attribute name: 1nvalid", exception.message
+    assert_match "invalid attribute name: 1nvalid", exception.message
 
     exception = assert_raises NameError do
       Class.new do
         cattr_writer "1nvalid"
       end
     end
-    assert_equal "invalid attribute name: 1nvalid", exception.message
+    assert_match "invalid attribute name: 1nvalid", exception.message
 
     exception = assert_raises NameError do
       Class.new do
         mattr_reader "valid_part\ninvalid_part"
       end
     end
-    assert_equal "invalid attribute name: valid_part\ninvalid_part", exception.message
+    assert_match "invalid attribute name: valid_part\ninvalid_part", exception.message
 
     exception = assert_raises NameError do
       Class.new do
         mattr_writer "valid_part\ninvalid_part"
       end
     end
-    assert_equal "invalid attribute name: valid_part\ninvalid_part", exception.message
+    assert_match "invalid attribute name: valid_part\ninvalid_part", exception.message
   end
 
   def test_should_use_default_value_if_block_passed

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1078,7 +1078,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     e = assert_raises(NoMethodError) {
       @twz.this_method_does_not_exist
     }
-    assert_equal "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00:ActiveSupport::TimeWithZone", e.message
+    assert_match "undefined method `this_method_does_not_exist' for Fri, 31 Dec 1999 19:00:00.000000000 EST -05:00:ActiveSupport::TimeWithZone", e.message
     assert_no_match "rescue", e.backtrace.first
   end
 end

--- a/railties/test/application/loading_test.rb
+++ b/railties/test/application/loading_test.rb
@@ -44,10 +44,10 @@ class LoadingTest < ActiveSupport::TestCase
     boot_app
 
     e = assert_raise(NameError) { User }
-    assert_equal "uninitialized constant #{self.class}::User", e.message
+    assert_match "uninitialized constant #{self.class}::User", e.message
 
     e = assert_raise(NameError) { Post }
-    assert_equal "uninitialized constant Post::NON_EXISTING_CONSTANT", e.message
+    assert_match "uninitialized constant Post::NON_EXISTING_CONSTANT", e.message
   end
 
   test "concerns in app are autoloaded" do


### PR DESCRIPTION
Since https://github.com/ruby/ruby/pull/4586, error.message includes the line of code that raised.

https://bugs.ruby-lang.org/issues/17930
