### PR TITLE
Make ActiveStorage default variant transformations explicit and customizable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Adds `optimizers` to active storage, which allow transformations to be applied to all
+    representations of active storage blobs automatically, according to their format
+    
+    *Breno Gazzola*
+
 *   Attachments can be deleted after their association is no longer defined.
 
     Fixes #42514

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -100,15 +100,7 @@ module ActiveStorage::Blob::Representable
 
   private
     def default_variant_transformations
-      { format: default_variant_format }
-    end
-
-    def default_variant_format
-      if web_image?
-        format || :png
-      else
-        :png
-      end
+      optimizer_class.new(self).transformations
     end
 
     def format
@@ -121,5 +113,9 @@ module ActiveStorage::Blob::Representable
 
     def variant_class
       ActiveStorage.track_variants ? ActiveStorage::VariantWithRecord : ActiveStorage::Variant
+    end
+
+    def optimizer_class
+      ActiveStorage.optimizers.detect { |klass| klass.accept?(format) }
     end
 end

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -41,6 +41,7 @@ module ActiveStorage
   autoload :Service
   autoload :Previewer
   autoload :Analyzer
+  autoload :Optimizer
 
   mattr_accessor :logger
   mattr_accessor :verifier
@@ -50,6 +51,7 @@ module ActiveStorage
 
   mattr_accessor :previewers, default: []
   mattr_accessor :analyzers,  default: []
+  mattr_accessor :optimizers, default: []
 
   mattr_accessor :paths, default: {}
 

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -17,6 +17,10 @@ require "active_storage/analyzer/image_analyzer/vips"
 require "active_storage/analyzer/video_analyzer"
 require "active_storage/analyzer/audio_analyzer"
 
+require "active_storage/optimizer/jpeg_optimizer"
+require "active_storage/optimizer/png_optimizer"
+require "active_storage/optimizer/web_image_optimizer"
+
 require "active_storage/service/registry"
 
 require "active_storage/reflection"
@@ -28,6 +32,7 @@ module ActiveStorage
     config.active_storage = ActiveSupport::OrderedOptions.new
     config.active_storage.previewers = [ ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer ]
     config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
+    config.active_storage.optimizers = [ ActiveStorage::Optimizer::JpegOptimizer, ActiveStorage::Optimizer::PngOptimizer, ActiveStorage::Optimizer::WebImageOptimizer ]
     config.active_storage.paths = ActiveSupport::OrderedOptions.new
     config.active_storage.queues = ActiveSupport::InheritableOptions.new
 
@@ -84,6 +89,7 @@ module ActiveStorage
         ActiveStorage.variant_processor = app.config.active_storage.variant_processor || :mini_magick
         ActiveStorage.previewers        = app.config.active_storage.previewers || []
         ActiveStorage.analyzers         = app.config.active_storage.analyzers || []
+        ActiveStorage.optimizers        = app.config.active_storage.optimizers || []
         ActiveStorage.paths             = app.config.active_storage.paths || {}
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false

--- a/activestorage/lib/active_storage/optimizer.rb
+++ b/activestorage/lib/active_storage/optimizer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  # This is an abstract base class for optimizers, which apply transformations to blob representations.
+  # See ActiveStorage::Optimizer::WebImageOptimizer for an example of a concrete subclass.
+  class Optimizer
+    attr_reader :blob
+
+    # Implement this method in a concrete subclass. Have it return true when given a format from which
+    # the optimizer knows the transformations that should be applied.
+    def self.accept?(format)
+      false
+    end
+
+    def initialize(blob)
+      @blob = blob
+    end
+
+    # Override this method in a concrete subclass. Have it return a Hash of transformations.
+    def transformations
+      raise NotImplementedError
+    end
+
+    private
+      def vips?
+        ActiveStorage.variant_processor == :vips
+      end
+  end
+end

--- a/activestorage/lib/active_storage/optimizer/jpeg_optimizer.rb
+++ b/activestorage/lib/active_storage/optimizer/jpeg_optimizer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  #
+  # Performs lossy compression on jpg/jpeg images.
+  #
+  # Options below are available to all jpeg encoders
+  # - strip               : Removes all metadata;
+  # - quality             : 85 is the recommended value by the PageSpeed apache module;
+  # - interlace           : Writes an interlaced JPEG, which gives the impression of faster loading in slow connections;
+  # - sampling_factor     : Reduced color detail, smaller file sizes;
+  # - colorspace          : Ensure compatibility when performing transformations;
+  #
+  # Options below are available only if vips/image magick where compiled against {mozjpeg}[https://github.com/mozilla/mozjpeg].
+  # - optimize_coding     : Slightly slower processing, slightly smaller file sizes;
+  # - optimize_scans      : Slower processing, slightly smaller files sizes;
+  # - trellis_quant       : Slower processing, smaller file sizes;
+  # - quant_table         : 3 produces good results in the default quality setting, but causes banding at high compression.
+  # - overshoot_deringing : Reduces ringing artifacts, specially in areas where black text appears on white background.
+  #
+  # Vips will ignore them if mozjpeg is not available. ImageMagick will apply them automatically if it is.
+  #
+  # For a more complete explanation of each option check the {vips}[https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-jpegsave] and {ImageMagick}[https://imagemagick.org/script/command-line-options.php] documentation.
+  class Optimizer::JpegOptimizer < Optimizer
+    def self.accept?(format)
+      %w[ jpg jpeg ].include?(format.to_s)
+    end
+
+    def transformations
+      if vips?
+        { format: "jpg", saver: { strip: true, quality: 85, interlace: true, optimize_coding: true, trellis_quant: true, quant_table: 3, optimize_scans: true, overshoot_deringing: true } }
+      else
+        { format: "jpg", saver: { strip: true, quality: 85, interlace: "JPEG", sampling_factor: "4:2:0", colorspace: "sRGB" } }
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/optimizer/png_optimizer.rb
+++ b/activestorage/lib/active_storage/optimizer/png_optimizer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  #
+  # Performs lossless compression on png images.
+  #
+  # Vips uses "compression" to indicate how much effort it should spend to compress the image.
+  # Higher values increaase processing time and reduce file sizes. Ranges from 0 to 9.
+  #
+  # ImageMagick uses "quality", but it works differently from JPEG quality. 75 is the default
+  # and means compression level of 7 with adaptive PNG filtering.
+  #
+  # For a more complete explanation of each option check the {vips}[https://libvips.github.io/libvips/API/current/VipsForeignSave.html#vips-pngsave] and {ImageMagick}[https://imagemagick.org/script/command-line-options.php#quality] documentation.
+  class Optimizer::PngOptimizer < Optimizer
+    def self.accept?(format)
+      format.to_s == "png"
+    end
+
+    def transformations
+      if vips?
+        { format: "png", saver: { strip: true, compression: 9 } }
+      else
+        { format: "png", saver: { strip: true, quality: 75 } }
+      end
+    end
+  end
+end

--- a/activestorage/lib/active_storage/optimizer/web_image_optimizer.rb
+++ b/activestorage/lib/active_storage/optimizer/web_image_optimizer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ActiveStorage
+  #
+  # Does not apply any transformations to blobs that are web images.
+  # Converts blobs that aren't web images into PNGs.
+  #
+  class Optimizer::WebImageOptimizer < Optimizer
+    def self.accept?(format)
+      true
+    end
+
+    def transformations
+      { format: default_variant_format }
+    end
+
+    private
+      def default_variant_format
+        if blob.send(:web_image?)
+          blob.send(:format) || :png
+        else
+          :png
+        end
+      end
+  end
+end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -208,7 +208,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
 
     assert_nil blob.send(:format)
-    assert_equal :png, blob.send(:default_variant_format)
+    assert_equal :png, blob.send(:default_variant_transformations)[:format]
   end
 
   private

--- a/activestorage/test/optimizer/jpeg_optimizer_test.rb
+++ b/activestorage/test/optimizer/jpeg_optimizer_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+require "active_storage/optimizer/web_image_optimizer"
+
+class ActiveStorage::Optimizer::JpegOptimizerTest < ActiveSupport::TestCase
+  test "transforming with vips" do
+    optimize_variants_with(:vips) do
+      optimizer = ActiveStorage::Optimizer::JpegOptimizer.new(nil)
+
+      assert_equal "jpg", optimizer.transformations[:format]
+      assert_equal 85, optimizer.transformations[:saver][:quality]
+    end
+  end
+
+  test "transforming with image magick" do
+    optimize_variants_with(:mini_magick) do
+      optimizer = ActiveStorage::Optimizer::JpegOptimizer.new(nil)
+
+      assert_equal "jpg", optimizer.transformations[:format]
+      assert_equal 85, optimizer.transformations[:saver][:quality]
+    end
+  end
+
+  private
+    def optimize_variants_with(processor)
+      previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, processor
+      yield
+    rescue LoadError
+      ENV["CI"] ? raise : skip("Variant processor #{processor.inspect} is not installed")
+    ensure
+      ActiveStorage.variant_processor = previous_processor
+    end
+end

--- a/activestorage/test/optimizer/png_optimizer_test.rb
+++ b/activestorage/test/optimizer/png_optimizer_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+require "active_storage/optimizer/web_image_optimizer"
+
+class ActiveStorage::Optimizer::PngOptimizerTest < ActiveSupport::TestCase
+  test "transforming with vips" do
+    optimize_variants_with(:vips) do
+      optimizer = ActiveStorage::Optimizer::PngOptimizer.new(nil)
+
+      assert_equal "png", optimizer.transformations[:format]
+      assert_equal 9, optimizer.transformations[:saver][:compression]
+    end
+  end
+
+  test "transforming with image magick" do
+    optimize_variants_with(:mini_magick) do
+      optimizer = ActiveStorage::Optimizer::PngOptimizer.new(nil)
+
+      assert_equal "png", optimizer.transformations[:format]
+      assert_equal 75, optimizer.transformations[:saver][:quality]
+    end
+  end
+
+  private
+    def optimize_variants_with(processor)
+      previous_processor, ActiveStorage.variant_processor = ActiveStorage.variant_processor, processor
+      yield
+    rescue LoadError
+      ENV["CI"] ? raise : skip("Variant processor #{processor.inspect} is not installed")
+    ensure
+      ActiveStorage.variant_processor = previous_processor
+    end
+end

--- a/activestorage/test/optimizer/web_image_optimizer_test.rb
+++ b/activestorage/test/optimizer/web_image_optimizer_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+require "active_storage/optimizer/web_image_optimizer"
+
+class ActiveStorage::Optimizer::WebImageOptimizerTest < ActiveSupport::TestCase
+  test "transforming a web image" do
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    optimizer = ActiveStorage::Optimizer::WebImageOptimizer.new(blob)
+
+    assert_equal "jpg", optimizer.transformations[:format]
+  end
+
+  test "transforming a variable image" do
+    blob = create_file_blob(filename: "racecar.tif", content_type: "image/tiff")
+    optimizer = ActiveStorage::Optimizer::WebImageOptimizer.new(blob)
+
+    assert_equal :png, optimizer.transformations[:format]
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1027,6 +1027,8 @@ You can find more detailed configuration options in the
 
 * `config.active_storage.previewers` accepts an array of classes indicating the image previewers available in Active Storage blobs. The default is `[ActiveStorage::Previewer::PopplerPDFPreviewer, ActiveStorage::Previewer::MuPDFPreviewer, ActiveStorage::Previewer::VideoPreviewer]`. `PopplerPDFPreviewer` and `MuPDFPreviewer` can generate a thumbnail from the first page of a PDF blob; `VideoPreviewer` from the relevant frame of a video blob.
 
+* `config.active_storage.optimizers` accepts an array of classes indicating the image optimizers available for Active Storage blobs. The default is `[ActiveStorage::Optimizer::WebImageOptimizer]`. The web image optimizer will not apply any optimizations to web images, but will convert variable image blobs that are not web images into PNGs.  
+
 * `config.active_storage.paths` accepts a hash of options indicating the locations of previewer/analyzer commands. The default is `{}`, meaning the commands will be looked for in the default path. Can include any of these options:
     * `:ffprobe` - The location of the ffprobe executable.
     * `:mutool` - The location of the mutool executable.


### PR DESCRIPTION
### Summary
While not immediately obvious, ActiveStorage automatically applies certain transformations to all requested variants:

1. Any image file that is not a web image will be converted to PNG;
2. If no quality setting is given, ImageMagick and libvips will automatically apply their quality defaults, which vary depending on the image format;

This PR adds to active storage a feature called `optimizers`, which makes this behavior explicit, fine tunes it for the web, and allows developers to define their own defaults. 

It does that by changing the `default_variant_transformations` in the `representable` concern to have it call upon the optimizers instead of simply returning a hash with the fallback format that should be used for image blobs that are not web images.

Before:
```
def default_variant_transformations
  { format: default_variant_format }
end
```

Now:
```
def default_variant_transformations
  optimizer_class.new(self).transformations
end

def optimizer_class
  ActiveStorage.optimizers.detect { |klass| klass.accept?(format) }
end
```

### Other Information
Should the developer want to display the original image, they can still do that by using `image_tag` without any extra parameters. And if they want to have different defaults, they can prepend their own optimizers to the array, just like they would to with analyzers.

### Further improvements
If we allow the representations controller to detect the accept header and pass it forward to the representation we can potentially add an optimizer for webp (or JPEG XL) and automatically serve modern file formats to browsers that can handle it. 
