### PR TITLE
unsafe_load secrets.yml with psych 4

### DIFF
--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -25,7 +25,10 @@ module Rails
         paths.each_with_object(Hash.new) do |path, all_secrets|
           require "erb"
 
-          secrets = YAML.load(ERB.new(preprocess(path)).result) || {}
+          source = ERB.new(preprocess(path)).result
+          secrets = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(source) : YAML.load(source)
+          secrets ||= {}
+
           all_secrets.merge!(secrets["shared"].deep_symbolize_keys) if secrets["shared"]
           all_secrets.merge!(secrets[env].deep_symbolize_keys) if secrets[env]
         end


### PR DESCRIPTION
### Summary

Pysch 4 now defaults `YAML.load` to `YAML.safe_load`, which does not allow aliases unless an aliases flag is given:
https://github.com/ruby/psych/pull/487
https://github.com/ruby/psych/blob/216f94fb9aacb0754f1dd2257b8d6a61b278a8b2/lib/psych.rb#L322
 
This PR switches secret loading to use `unsafe_load`. This should be fine because `secrets.yml` is in-repo, and therefore trusted. I have copied the implementation from https://github.com/rails/rails/pull/42257, which did the same thing for `database.yml`

This maintains backwards compatibility to allow developers to have a `secrets.yml` like 
```yaml
development: &default_settings
  thing_client_id: 'abcd'
  thing_client_secret: 'xyz'
test:
  <<: *default_settings
  
  #... etc.
```


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
