### PR TITLE
Improve mysql2 mismatched foreign keys reporting

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -852,9 +852,12 @@ module ActiveRecord
         end
 
         def mismatched_foreign_key(message, sql:, binds:)
+          foreign_key_pat =
+            /Referencing column '(\w+)' and referenced/i =~ message ? $1 : '\w+'
+
           match = %r/
             (?:CREATE|ALTER)\s+TABLE\s*(?:`?\w+`?\.)?`?(?<table>\w+)`?.+?
-            FOREIGN\s+KEY\s*\(`?(?<foreign_key>\w+)`?\)\s*
+            FOREIGN\s+KEY\s*\(`?(?<foreign_key>#{foreign_key_pat})`?\)\s*
             REFERENCES\s*(`?(?<target_table>\w+)`?)\s*\(`?(?<primary_key>\w+)`?\)
           /xmi.match(sql)
 


### PR DESCRIPTION
When we add multiple foreign keys at the same time via `ALTER/CREATE TABLE` and one of them has mismatched type, mysql adapter always parses and reports the first `FOREIGN KEY ... REFERENCES` statement from the error message.

We do not always know the exact failed foreign key reference.

MariaDB does not report the failing column name in its error: 
Error Code | Error | Description
--- | --- | ---
1215 | ER_CANNOT_ADD_FOREIGN | Cannot add foreign key constraint

But MySQL does in one case:
Error Code | Error | Description
--- | --- | ---
1215 | ER_CANNOT_ADD_FOREIGN | Cannot add foreign key constraint
3780 | ER_FK_INCOMPATIBLE_COLUMNS | Referencing column '%s' and referenced column '%s' in foreign key constraint '%s' are incompatible.

This case seems the most popular for me.

We can handle another case, but that would require brittle parsing of errored sql to determine all columns used in foreign keys, their types and comparing these types with types of the primary keys from the referenced tables.

Closes #42661
