### PR TITLE
Remove linebreak from hash_digest_class framework defaults for consistency

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -25,7 +25,6 @@
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
-#
 # Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the format of the cache entry.


### PR DESCRIPTION
### Summary

All new 7.0 framework defaults don't have an extra linebreak between the
explanation and the actual config.
For consistency we should remove it for `hash_digest_class` as well.