### PR TITLE
Fix ActiveStorage guide links [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -549,9 +549,9 @@ require a higher level of protection consider implementing
 To generate a permanent URL for a blob, you can pass the blob to the
 [`url_for`][ActionView::RoutingUrlFor#url_for] view helper. This generates a
 URL with the blob's [`signed_id`][ActiveStorage::Blob#signed_id]
-that is routed to the blob's
-[`RedirectController`](ActiveStorage::Blobs::RedirectController).
+that is routed to the blob's [`RedirectController`][ActiveStorage::Blobs::RedirectController]
 
+[ActiveStorage::Blobs::RedirectController]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
 ```ruby
 url_for(user.avatar)
 # => /rails/active_storage/blobs/:signed_id/my-avatar.png
@@ -646,10 +646,10 @@ guess but permanent. Anyone that knows the blob URL will be able to access it,
 even if a `before_action` in your `ApplicationController` would otherwise
 require a login. If your files require a higher level of protection, you can
 implement your own authenticated controllers, based on the
-[`ActiveStorage::Blobs::RedirectController`](ActiveStorage::Blobs::RedirectController),
-[`ActiveStorage::Blobs::ProxyController`](ActiveStorage::Blobs::ProxyController),
-[`ActiveStorage::Representations::RedirectController`](ActiveStorage::Representations::RedirectController) and
-[`ActiveStorage::Representations::ProxyController`](ActiveStorage::Representations::ProxyController)
+[`ActiveStorage::Blobs::RedirectController`][],
+[`ActiveStorage::Blobs::ProxyController`][],
+[`ActiveStorage::Representations::RedirectController`][] and
+[`ActiveStorage::Representations::ProxyController`][]
 
 To only allow an account to access their own logo you could do the following:
 
@@ -684,10 +684,10 @@ config.active_storage.draw_routes = false
 
 to prevent files being accessed with the publicly accessible URLs.
 
-[ActiveStorage::Blobs::RedirectController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb)
-[ActiveStorage::Blobs::ProxyController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb)
-[ActiveStorage::Representations::RedirectController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/redirect_controller.rb)
-[ActiveStorage::Representations::ProxyController]: (https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/proxy_controller.rb)
+[`ActiveStorage::Blobs::RedirectController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
+[`ActiveStorage::Blobs::ProxyController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+[`ActiveStorage::Representations::RedirectController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
+[`ActiveStorage::Representations::ProxyController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
 
 Downloading Files
 -----------------


### PR DESCRIPTION
### Summary

I found that some links on ActiveStorage edge guide are not working as you can see on my attachment:

<img width="965" alt="Screenshot 2021-07-05 at 20 49 27" src="https://user-images.githubusercontent.com/16633/124509637-9c4b8e00-ddd2-11eb-9669-d7c9d2362f8c.png">

I also noticed that some links point to `github.com` instead of `api.rubyonrails.org`. What is the consensus here? Would you change them to `rubyonrails.org`?