### PR TITLE
Added a warning message while accessing credentials through rails command

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1206,6 +1206,16 @@ TIP: Learn more about credentials with `bin/rails credentials:help`.
 
 WARNING: Keep your master key safe. Do not commit your master key.
 
+#### Accessing environment specific credentials
+
+In order to access the credentials file for a specific environment, use the `--environment=` option.
+
+For example, to edit a production credential file, you need to run:
+
+```sh
+bin/rails credentials:edit --environment=production
+```
+
 Dependency Management and CVEs
 ------------------------------
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -89,6 +89,12 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_match(/secret_key_base/, output)
   end
 
+  test "edit command from a non-development environment trying to access another environment credentials" do
+    switch_env("RAILS_ENV", "staging") do
+      output = run_edit_command(environment: :production)
+      assert_match(/You are accessing production credentials from the staging environment\.\nDid you mean to run `bin\/rails credentials:edit --environment staging`\?\nFor more information try `bin\/rails credentials:help`/, output)
+    end
+  end
 
   test "show credentials" do
     assert_match(/access_key_id: 123/, run_show_command)
@@ -122,6 +128,12 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
     assert_no_match(/secret_key_base/, output)
   end
 
+  test "show command from a non-development environment trying to access another environment credentials" do
+    switch_env("RAILS_ENV", "staging") do
+      output = run_show_command(environment: :production)
+      assert_match(/You are accessing production credentials from the staging environment\.\nDid you mean to run `bin\/rails credentials:show --environment staging`\?\nFor more information try `bin\/rails credentials:help`/, output)
+    end
+  end
 
   test "diff enroll diffing" do
     assert_match(/\benrolled project/i, run_diff_command(enroll: true))


### PR DESCRIPTION
### Summary

Fixes #41830 

The current implementation shows an non-blocking warning message to the user when running `bin/rails credentials:show` or `bin/rails credentials:edit` from an non-development environment and used `--environment` different from the current environment of the system. 

That is, when the `credentials` commands are ran from a production environment but with `--environment=staging` flag, the user will be shown a warning message. 

### Other Information

From the discussion at #41830, I also thought if we could add to show_command also, it would be beneficial. This is my first time contribution to the Rails code (One earlier contribution was rejected, so not counting that in 😅), so kindly help me out if the code I introduced isn't as per the Rails convention or I should be thinking from different perspective or maybe add more thoughts with certain implementation areas.
