### PR TITLE
Make assigning a readonly attribute a no-op

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,24 @@
+*   Assigning a readonly attribute is now a no-op. Previously it would assign but not persist.
+
+    For example:
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      attr_readonly :content
+    end
+    Post.create!(content: "cannot be updated")
+    post.content # "cannot be updated" (1)
+    post.content = "something else"
+    post.content # "cannot be updated" (2)
+    post.save!
+    post.reload
+    post.content # "cannot be updated" (3)
+    ```
+
+    Previously call 2 would have returned "something else" which was inconsistent with save behavior.
+
+    *Alex Ghiculescu*
+
 *   Add config option for ignoring tables when dumping the schema cache.
 
     Applications can now be configured to ignore certain tables when dumping the schema cache.

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -23,7 +23,15 @@ module ActiveRecord
       #   post = Post.create!(title: "Introducing Ruby on Rails!")
       #   post.update(title: "a different title") # change to title will be ignored
       def attr_readonly(*attributes)
-        self._attr_readonly = Set.new(attributes.map(&:to_s)) + (_attr_readonly || [])
+        new_attributes = attributes.map(&:to_s).reject { |a| _attr_readonly.include?(a) }
+
+        new_attributes.each do |attribute|
+          define_method("#{attribute}=") do |value|
+            super(value) if new_record?
+          end
+        end
+
+        self._attr_readonly = Set.new(new_attributes) + _attr_readonly
       end
 
       # Returns an array of all the attributes that have been specified as readonly.

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -702,13 +702,53 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal Set.new([ "title", "comments_count" ]), ReadonlyTitlePost.readonly_attributes
 
     post = ReadonlyTitlePost.create(title: "cannot change this", body: "changeable")
-    post.reload
     assert_equal "cannot change this", post.title
+    assert_equal "changeable", post.body
+    post = Post.find(post.id)
+    assert_equal "cannot change this", post.title
+    assert_equal "changeable", post.body
 
-    post.update(title: "try to change", body: "changed")
-    post.reload
+    post.title = "changed via write_attribute"
+    post.body = "changed via write_attribute"
     assert_equal "cannot change this", post.title
-    assert_equal "changed", post.body
+    assert_equal "changed via write_attribute", post.body
+
+    post.assign_attributes(body: "changed via assign_attributes", title: "changed via assign_attributes")
+    assert_equal "cannot change this", post.title
+    assert_equal "changed via assign_attributes", post.body
+
+    post.update(title: "changed via update", body: "changed via update")
+    assert_equal "cannot change this", post.title
+    assert_equal "changed via update", post.body
+    post = Post.find(post.id)
+    assert_equal "cannot change this", post.title
+    assert_equal "changed via update", post.body
+  end
+
+  def test_readonly_attributes_on_a_new_record
+    assert_equal Set.new([ "title", "comments_count" ]), ReadonlyTitlePost.readonly_attributes
+
+    post = ReadonlyTitlePost.new(title: "can change this until you save", body: "changeable")
+    assert_equal "can change this until you save", post.title
+    assert_equal "changeable", post.body
+
+    post.title = "changed via write_attribute"
+    post.body = "changed via write_attribute"
+    assert_equal "changed via write_attribute", post.title
+    assert_equal "changed via write_attribute", post.body
+
+    post.assign_attributes(body: "changed via assign_attributes", title: "changed via assign_attributes")
+    assert_equal "changed via assign_attributes", post.title
+    assert_equal "changed via assign_attributes", post.body
+
+    post.save!
+
+    post.update(title: "changed via update", body: "changed via update")
+    assert_equal "changed via assign_attributes", post.title
+    assert_equal "changed via update", post.body
+    post = Post.find(post.id)
+    assert_equal "changed via assign_attributes", post.title
+    assert_equal "changed via update", post.body
   end
 
   def test_unicode_column_name


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/41520

After thinking about this a bit, I think this is a bug and the behaviour should match saving, for non-new records.
