### PR TITLE
config_for accepts root shared as an array

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `config_for` error when there's only a shared root array
+
+    *Loïc Delmaire*
+
 *   Raise an error in generators if an index type is invalid.
 
     *Petrik de Heus*

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -247,9 +247,11 @@ module Rails
         config, shared = all_configs[env.to_sym], all_configs[:shared]
 
         if shared
-          config = {} if config.nil?
-          if config.is_a?(Hash)
+          config = {} if config.nil? && shared.is_a?(Hash)
+          if config.is_a?(Hash) && shared.is_a?(Hash)
             config = shared.deep_merge(config)
+          elsif config.nil?
+            config = shared
           end
         end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2057,6 +2057,32 @@ module ApplicationTests
       assert_equal %w( foo bar ), Rails.application.config.my_custom_config
     end
 
+    test "config_for works with only a shared root array" do
+      set_custom_config <<~RUBY
+        shared:
+          - foo
+          - bar
+      RUBY
+
+      app "development"
+
+      assert_equal %w( foo bar ), Rails.application.config.my_custom_config
+    end
+
+    test "config_for returns only the env array when shared is an array" do
+      set_custom_config <<~RUBY
+        development:
+          - baz
+        shared:
+          - foo
+          - bar
+      RUBY
+
+      app "development"
+
+      assert_equal %w( baz ), Rails.application.config.my_custom_config
+    end
+
     test "config_for uses the Pathname object if it is provided" do
       set_custom_config <<~RUBY, "Pathname.new(Rails.root.join('config/custom.yml'))"
         development:


### PR DESCRIPTION
### Summary

Fix a bug when a configuration has only a shared root array key for `config_for`.

Closes #42698 