### PR TITLE
Create full_message & full_message_format validation option [Feature Request]

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -518,8 +518,8 @@ module ActiveModel
     # Returns a full message for a given attribute.
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
-    def full_message(attribute, message)
-      Error.full_message(attribute, message, @base)
+    def full_message(attribute, message, message_format: false)
+      Error.full_message(attribute, message, @base, message_format)
     end
 
     # Translates an error message in its default scope

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -518,8 +518,8 @@ module ActiveModel
     # Returns a full message for a given attribute.
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
-    def full_message(attribute, message, message_format: false)
-      Error.full_message(attribute, message, @base, message_format)
+    def full_message(attribute, message, full_message_format: false)
+      Error.full_message(attribute, message, @base, full_message_format)
     end
 
     # Translates an error message in its default scope

--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -21,6 +21,8 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "must be blank").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -95,6 +95,8 @@ module ActiveModel
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "must be
       #   accepted").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       # * <tt>:accept</tt> - Specifies a value that is considered accepted.
       #   Also accepts an array of possible values. The default value is
       #   an array ["1", true], which makes it easy to relate to an HTML

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -66,6 +66,8 @@ module ActiveModel
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "doesn't match
       #   <tt>%{translated_attribute_name}</tt>").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       # * <tt>:case_sensitive</tt> - Looks for an exact match. Ignored by
       #   non-text columns (+true+ by default).
       #

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -37,6 +37,8 @@ module ActiveModel
       #   <tt>Range#cover?</tt>, otherwise with <tt>include?</tt>.
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   reserved").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -91,6 +91,8 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "is invalid").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       # * <tt>:with</tt> - Regular expression that if the attribute matches will
       #   result in a successful validation. This can be provided as a proc or
       #   lambda returning regular expression which will be called at runtime.

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -35,6 +35,8 @@ module ActiveModel
       # * <tt>:within</tt> - A synonym(or alias) for <tt>:in</tt>
       # * <tt>:message</tt> - Specifies a custom error message (default is: "is
       #   not included in the list").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -115,6 +115,8 @@ module ActiveModel
       # * <tt>:message</tt> - The error message to use for a <tt>:minimum</tt>,
       #   <tt>:maximum</tt>, or <tt>:is</tt> violation. An alias of the appropriate
       #   <tt>too_long</tt>/<tt>too_short</tt>/<tt>wrong_length</tt> message.
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+ and +:strict+.

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -160,6 +160,8 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "is not a number").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       # * <tt>:only_integer</tt> - Specifies whether the value has to be an
       #   integer (default is +false+).
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+ (default is

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -27,6 +27,8 @@ module ActiveModel
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
+      # * <tt>:full_message_format</tt> - Format of full_message (default is: "%{attribute} %{message}").
+      # * <tt>:full_message</tt> - A custom error message with "%{message}" as a full_message_format
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -99,8 +99,8 @@ module ActiveModel
       #   validates :token, length: 24, strict: TokenLengthException
       #
       #
-      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+
-      # and +:message+ can be given to one specific validator, as a hash:
+      # Finally, the options +:if+, +:unless+, +:on+, +:allow_blank+, +:allow_nil+, +:strict+,
+      # +:message+, +:full_message_format+ and +:full_message+ can be given to one specific validator, as a hash:
       #
       #   validates :password, presence: { if: :password_required?, message: 'is forgotten.' }, confirmation: true
       def validates(*attributes)

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -181,21 +181,28 @@ class ErrorTest < ActiveModel::TestCase
     assert_equal "press the button", error.full_message
   end
 
-  test "full_message returns the given message when passed message_format option" do
-    error = ActiveModel::Error.new(Person.new, :name, message: "press the button", message_format: "%{message}")
+  test "full_message returns the given message when passed full_message_format option" do
+    error = ActiveModel::Error.new(Person.new, :name, message: "press the button", full_message_format: "%{message}")
     assert_equal "press the button", error.full_message
 
-    error = ActiveModel::Error.new(Person.new, :name, message: "should be valid", message_format: "%{attribute} %{message}")
+    error = ActiveModel::Error.new(Person.new, :name, message: "should be valid", full_message_format: "%{attribute} %{message}")
     assert_equal "name should be valid", error.full_message
 
-    error = ActiveModel::Error.new(Person.new, :name, :blank, message_format: "%{attribute} %{message}")
+    error = ActiveModel::Error.new(Person.new, :name, :blank, full_message_format: "%{attribute} %{message}")
     assert_equal "name can't be blank", error.full_message
 
-    error = ActiveModel::Error.new(Person.new, :name, :blank, message_format: "%{message}")
+    error = ActiveModel::Error.new(Person.new, :name, :blank, full_message_format: "%{message}")
     assert_equal "can't be blank", error.full_message
 
-    error = ActiveModel::Error.new(Person.new, :name, :blank, message_format: "something hardcoded")
+    error = ActiveModel::Error.new(Person.new, :name, :blank, full_message_format: "something hardcoded")
     assert_equal "something hardcoded", error.full_message
+
+    # Use a locale without errors.format
+    error = ActiveModel::Error.new(Person.new, :name, full_message: "can't be blank")
+    I18n.with_locale(:unknown) { assert_equal "can't be blank", error.full_message }
+
+    error = ActiveModel::Error.new(Person.new, :name, message: "can't be blank", full_message_format: "%{message}")
+    I18n.with_locale(:unknown) { assert_equal "can't be blank", error.full_message }
   end
 
   test "full_message returns the given message with the attribute name included" do
@@ -255,7 +262,7 @@ class ErrorTest < ActiveModel::TestCase
       allow_blank: false,
       strict: true,
       message: "message",
-      message_format: "%{message}",
+      full_message_format: "%{message}",
       full_message: "message",
     )
 

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -176,6 +176,28 @@ class ErrorTest < ActiveModel::TestCase
     assert_equal "press the button", error.full_message
   end
 
+  test "full_message returns the given message when passed full_message option" do
+    error = ActiveModel::Error.new(Person.new, :name, full_message: "press the button")
+    assert_equal "press the button", error.full_message
+  end
+
+  test "full_message returns the given message when passed message_format option" do
+    error = ActiveModel::Error.new(Person.new, :name, message: "press the button", message_format: "%{message}")
+    assert_equal "press the button", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, message: "should be valid", message_format: "%{attribute} %{message}")
+    assert_equal "name should be valid", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, :blank, message_format: "%{attribute} %{message}")
+    assert_equal "name can't be blank", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, :blank, message_format: "%{message}")
+    assert_equal "can't be blank", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, :blank, message_format: "something hardcoded")
+    assert_equal "something hardcoded", error.full_message
+  end
+
   test "full_message returns the given message with the attribute name included" do
     error = ActiveModel::Error.new(Person.new, :name, :blank)
     assert_equal "name can't be blank", error.full_message
@@ -232,7 +254,9 @@ class ErrorTest < ActiveModel::TestCase
       allow_nil: false,
       allow_blank: false,
       strict: true,
-      message: "message"
+      message: "message",
+      message_format: "%{message}",
+      full_message: "message",
     )
 
     assert_equal(

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -596,10 +596,10 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal "press the button", person.errors.full_message(:base, "press the button")
   end
 
-  test "full_message returns the given message when message_format is passed in" do
+  test "full_message returns the given message when full_message_format is passed in" do
     person = Person.new
-    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank", message_format: "%{message}")
-    assert_equal "cannot be blank", person.errors.full_message(:name_test, "cannot be blank", message_format: "%{message}")
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank", full_message_format: "%{message}")
+    assert_equal "cannot be blank", person.errors.full_message(:name_test, "cannot be blank", full_message_format: "%{message}")
   end
 
   test "full_message returns the given message with the attribute name included" do

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -596,6 +596,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal "press the button", person.errors.full_message(:base, "press the button")
   end
 
+  test "full_message returns the given message when message_format is passed in" do
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank", message_format: "%{message}")
+    assert_equal "cannot be blank", person.errors.full_message(:name_test, "cannot be blank", message_format: "%{message}")
+  end
+
   test "full_message returns the given message with the attribute name included" do
     person = Person.new
     assert_equal "name cannot be blank", person.errors.full_message(:name, "cannot be blank")


### PR DESCRIPTION
### Summary

Currently, the default format for a full error message is `'%{attribute} %{message}'` this can only be changed with the help of locales and i18n for both ActiveModels & ActiveRecords. 

This new feature adds the ability to format a full error message of an attribute without locales files. It can now be used on any classes that include `ActiveModel::Validations` and fully formatted error messages can be displayed consistently on web views as:

* a group with `errors.full_messages` (on top of a form like the scaffold generator for example)
* next to their appropriate form field with `errors.where(:attribute_name)`. 

Additionally, It seems that the format required from people is either `'%{attribute} %{message}'` or `'%{message}'` this patch  adds a `full_message` option which is a shortcut that uses the `full_message_format: '%{message}'` option introduced.

**What do people think?**

**_I'm happy to update documentation and changelog if this is accepted. I will need guidance about where would be the appropriate place for documentation updates as I'm not sure._** 

### Usage

For apps using locales and i18n nothing has changed. For apps that don't rely much on i18n, devs can format full error messages in the model definition.

Here is a description of the new behaviour, existing behaviour still applies.

```ruby
class Person
  include ActiveModel::Model
  attr_accessor :age, :name

  validates :name, presence: { full_message: 'A person name cannot be blank' }
  validates :age, numericality: {
    greater_than_or_equal_to: 18,
    message: 'A person must be over 18',
    full_message_format: '%{message}'
  }
end

person = Person.new(age: 17).tap(&:valid?)

person.errors.full_messages
["A person must be over 18", "A person name cannot be blank"]

person.errors.where(:name).map(&:message)
["A person name cannot be blank"]

# works with Errors#add
person = Person.new
person.errors.add(:name, full_message: 'A person name cannot be blank')
person.errors.add(:age, 'A person must be over 18', full_message_format: '%{message}')

person.errors.full_messages
["A person must be over 18", "A person name cannot be blank"]

person.errors.where(:name).map(&:message)
["A person name cannot be blank"]
```

### Why?

I work with clients that want validation steps or custom error messages that don't necessarily start with the attribute name. Sometimes I wish I had the flexibility of `:base` errors for an attribute without having to write down custom validation methods and keep a consistent way to display error messages on the view.

### Other

Haven't benchmarked it.

As I'm writing the description, I realise people have tried to do this for a while now:

* https://github.com/rails/rails/pull/12457#issuecomment-70334857
* https://github.com/rails/rails/pull/32919

And we can override the format with I18n:
* https://github.com/rails/rails/pull/32956


### Test

You can copy-paste this gist to test it locally.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "alexb52/rails", branch: "full_message_updates"
  gem "byebug"
end

require "active_model"
require "minitest/autorun"
require "logger"
require "byebug"

class Person
  include ActiveModel::Validations

  attr_accessor :name, :favourite_colour, :legacy_code

  validates :name, presence: true # default
  validates :favourite_colour, inclusion: { in: ["blue", "red"], message: "A person favourite colour must be blue or red", full_message_format: '%{message}' }
  validates :legacy_code, format: { with: /\A[a-zA-Z]+\z/, full_message: "PDLP must only include letters" }
end

class PersonTest < Minitest::Test
  def setup
    @errors = Person.new.tap(&:valid?).errors
  end

  def test_full_messages
    assert_equal @errors.full_messages, [
      "Name can't be blank",
      "A person favourite colour must be blue or red",
      "PDLP must only include letters"
    ]
  end

  def test_full_messages_for
    assert_equal @errors.full_messages_for(:name),             ["Name can't be blank"]
    assert_equal @errors.full_messages_for(:favourite_colour), ["A person favourite colour must be blue or red"]
    assert_equal @errors.full_messages_for(:legacy_code),      ["PDLP must only include letters"]
  end

  def test_message
    assert_equal @errors.where(:name).map(&:message),             ["can't be blank"]
    assert_equal @errors.where(:favourite_colour).map(&:message), ["A person favourite colour must be blue or red"]
    assert_equal @errors.where(:legacy_code).map(&:message),      ["PDLP must only include letters"]
  end

  def test_errors_add
    person = Person.new
    person.errors.add(:favourite_colour, full_message: "A person favourite colour must be blue or red")
    assert_equal person.errors.full_messages, ["A person favourite colour must be blue or red"]
  end
end
```
