### PR TITLE
Allow set a Array of Path on Preview Mailers Path

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,6 +1,16 @@
+*   Allow passing an array of strings to preview_path
+
+    This is now possible:
+    ```ruby
+    config.action_mailer.preview_path = [
+      "#{Foo::Engine.root}/test/mailers/previews",
+      "#{Bar::Engine.root}/test/mailers/previews"
+    ]
+    ```
+    *Victor Lima Campos*
+
 *   Configures a default of 5 for both `open_timeout` and `read_timeout` for SMTP Settings.
 
     *André Luis Leal Cardoso Junior*
-
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/actionmailer/CHANGELOG.md) for previous changes.

--- a/actionmailer/lib/action_mailer/preview.rb
+++ b/actionmailer/lib/action_mailer/preview.rb
@@ -119,9 +119,7 @@ module ActionMailer
 
       private
         def load_previews
-          if preview_path
-            Dir["#{preview_path}/**/*_preview.rb"].sort.each { |file| require_dependency file }
-          end
+          Array.wrap(preview_path).each { |pp| Dir["#{pp}/**/*_preview.rb"].sort.each { |file| require_dependency file } }
         end
 
         def preview_path

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -66,8 +66,8 @@ module ActionMailer
     initializer "action_mailer.set_autoload_paths" do |app|
       options = app.config.action_mailer
 
-      if options.show_previews && options.preview_path
-        ActiveSupport::Dependencies.autoload_paths << options.preview_path
+      if options.show_previews
+        Array.wrap(options.preview_path).each { |preview_path| ActiveSupport::Dependencies.autoload_paths << preview_path }
       end
     end
 

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -118,6 +118,63 @@ module ApplicationTests
       assert_match '<li><a href="/rails/mailers/notifier/foo">foo</a></li>', last_response.body
     end
 
+    test "mailer previews are loaded from a custom array of preview_path" do
+      app_dir "lib/mailer_previews"
+      add_to_config "config.action_mailer.preview_path = ['#{app_path}/lib/mailer_previews', '#{app_path}/lib/mailer_previews_2']"
+
+      mailer "notifier", <<-RUBY
+        class Notifier < ActionMailer::Base
+          default from: "from@example.com"
+
+          def foo
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier/foo", <<-RUBY
+        Hello, World!
+      RUBY
+
+      app_file "lib/mailer_previews/notifier_preview.rb", <<-RUBY
+        class NotifierPreview < ActionMailer::Preview
+          def foo
+            Notifier.foo
+          end
+        end
+      RUBY
+
+      mailer "notifier2", <<-RUBY
+        class Notifier2 < ActionMailer::Base
+          default from: "from@example.com"
+
+          def bar
+            mail to: "to@example.org"
+          end
+        end
+      RUBY
+
+      text_template "notifier2/bar", <<-RUBY
+        Hello, World!
+      RUBY
+
+      app_file "lib/mailer_previews_2/notifier2_preview.rb", <<-RUBY
+        class Notifier2Preview < ActionMailer::Preview
+          def bar
+            Notifier2.bar
+          end
+        end
+      RUBY
+
+      app("development")
+
+      get "/rails/mailers"
+      assert_match '<h3><a href="/rails/mailers/notifier">Notifier</a></h3>', last_response.body
+      assert_match '<li><a href="/rails/mailers/notifier/foo">foo</a></li>', last_response.body
+      assert_match '<h3><a href="/rails/mailers/notifier2">Notifier2</a></h3>', last_response.body
+      assert_match '<li><a href="/rails/mailers/notifier2/bar">bar</a></li>', last_response.body
+    end
+
     test "mailer previews are reloaded across requests" do
       app("development")
 


### PR DESCRIPTION
### Summary

Allow pass a array for preview mailer path, allowing project preview mailers from different engines.

### Other Information

Case of Use:

Where I work, the project are break in many engines and we use patches to customize it to each customer.
But there is no easy way to preview emails in this case, because, before this PR, it's only possible to load one path on application.rb.

This code allow us to do this:

```rb
    config.action_mailer.preview_path = [
      "#{Vportal::Engine.root}/test/mailers/previews",
      "#{Vprocessmanager::Engine.root}/test/mailers/previews",
      "#{Vdashboard::Engine.root}/test/mailers/previews",
      "#{VcommercialPartnerRegistration::Engine.root}/test/mailers/previews",
      "#{VbulkUpload::Engine.root}/test/mailers/previews",
      "#{Vinvoice::Engine.root}/test/mailers/previews",
      "#{Vpurchase::Engine.root}/test/mailers/previews",
      "#{Vdelivery::Engine.root}/test/mailers/previews",
      "#{Vreports::Engine.root}/test/mailers/previews",
      "#{Vmasterdata::Engine.root}/test/mailers/previews",
      "#{Vannouncement::Engine.root}/test/mailers/previews",
      "#{Vfactoring::Engine.root}/test/mailers/previews"
    ]
```

closes #42701