### PR TITLE
activerecord: Implement different table names for different operations

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -425,8 +425,17 @@ module ActiveRecord
       end
 
       # Returns an instance of <tt>Arel::Table</tt> loaded with the current table name.
-      def arel_table # :nodoc:
-        @arel_table ||= Arel::Table.new(table_name, klass: self)
+      def arel_table(operation = nil) # :nodoc:
+        case operation
+        when :update then
+          @arel_table_update ||= Arel::Table.new(update_table_name, klass: self)
+        when :delete then
+          @arel_table_delete ||= Arel::Table.new(delete_table_name, klass: self)
+        when :insert then
+          @arel_table_insert ||= Arel::Table.new(insert_table_name, klass: self)
+        else
+          @arel_table ||= Arel::Table.new(table_name, klass: self)
+        end
       end
 
       def arel_attribute(name, table = arel_table) # :nodoc:
@@ -459,7 +468,7 @@ module ActiveRecord
         end
 
         def table_metadata
-          TableMetadata.new(self, arel_table)
+          TableMetadata.new(self, arel_table(:metadata))
         end
     end
 

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -237,6 +237,21 @@ module ActiveRecord
         @table_name
       end
 
+      def insert_table_name
+        reset_table_name unless defined?(@table_name)
+        @insert_table_name || @table_name
+      end
+
+      def update_table_name
+        reset_table_name unless defined?(@table_name)
+        @update_table_name || @table_name
+      end
+
+      def delete_table_name
+        reset_table_name unless defined?(@table_name)
+        @delete_table_name || @table_name
+      end
+
       # Sets the table name explicitly. Example:
       #
       #   class Project < ActiveRecord::Base
@@ -255,6 +270,21 @@ module ActiveRecord
         @arel_table        = nil
         @sequence_name     = nil unless defined?(@explicit_sequence_name) && @explicit_sequence_name
         @predicate_builder = nil
+      end
+
+      def insert_table_name=(value)
+        @insert_table_name = value && value.to_s
+        @arel_table_insert = nil
+      end
+
+      def update_table_name=(value)
+        @update_table_name = value && value.to_s
+        @arel_table_insert = nil
+      end
+
+      def delete_table_name=(value)
+        @delete_table_name = value && value.to_s
+        @arel_table_insert = nil
       end
 
       # Returns a quoted version of the table name, used to construct SQL statements.

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -239,16 +239,19 @@ module ActiveRecord
 
       def insert_table_name
         reset_table_name unless defined?(@table_name)
+        @insert_table_name = nil unless defined?(@insert_table_name)
         @insert_table_name || @table_name
       end
 
       def update_table_name
         reset_table_name unless defined?(@table_name)
+        @update_table_name = nil unless defined?(@update_table_name)
         @update_table_name || @table_name
       end
 
       def delete_table_name
         reset_table_name unless defined?(@table_name)
+        @delete_table_name = nil unless defined?(@delete_table_name)
         @delete_table_name || @table_name
       end
 
@@ -279,12 +282,12 @@ module ActiveRecord
 
       def update_table_name=(value)
         @update_table_name = value && value.to_s
-        @arel_table_insert = nil
+        @arel_table_update = nil
       end
 
       def delete_table_name=(value)
         @delete_table_name = value && value.to_s
-        @arel_table_insert = nil
+        @arel_table_delete = nil
       end
 
       # Returns a quoted version of the table name, used to construct SQL statements.

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -417,12 +417,13 @@ module ActiveRecord
           end
         end
 
-        im = Arel::InsertManager.new(arel_table)
+        table = arel_table(:insert)
+        im = Arel::InsertManager.new(table)
 
         if values.empty?
           im.insert(connection.empty_insert_statement_value(primary_key))
         else
-          im.insert(values.transform_keys { |name| arel_table[name] })
+          im.insert(values.transform_keys { |name| table[name] })
         end
 
         connection.insert(im, "#{self} Create", primary_key || false, primary_key_value)
@@ -439,8 +440,9 @@ module ActiveRecord
           constraints << current_scope.where_clause.ast
         end
 
-        um = Arel::UpdateManager.new(arel_table)
-        um.set(values.transform_keys { |name| arel_table[name] })
+        table = arel_table(:update)
+        um = Arel::UpdateManager.new(table)
+        um.set(values.transform_keys { |name| table[name] })
         um.wheres = constraints
 
         connection.update(um, "#{self} Update")
@@ -457,7 +459,7 @@ module ActiveRecord
           constraints << current_scope.where_clause.ast
         end
 
-        dm = Arel::DeleteManager.new(arel_table)
+        dm = Arel::DeleteManager.new(arel_table(:delete))
         dm.wheres = constraints
 
         connection.delete(dm, "#{self} Destroy")

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1259,4 +1259,24 @@ class PersistenceTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.remove_column(:topics, :foo)
     Topic.reset_column_information
   end
+
+  def test_update_table_with_other_table_name
+    item = ViewItem.create1(name: 'view item')
+    assert item.persisted?
+
+    item2 = ViewItem.find_by(id: item.id)
+    assert_equal item.name, item2.name
+
+    item3 = Item.find_by(id: item.id)
+    assert_equal item.name, item3.name
+
+    item.update!(name: 'view item changed')
+    assert_equal 'view item changed', item2.reload.name
+    assert_equal 'view item changed', item3.reload.name
+
+    item.destroy
+
+    item4 = ViewItem.find_by(id: item.id)
+    assert_equal nil, item4
+  end
 end

--- a/activerecord/test/models/view_item.rb
+++ b/activerecord/test/models/view_item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ViewItem < ActiveRecord::Base
+  self.table_name = :items
+  self.insert_table_name = :view_items
+  self.update_table_name = :view_items
+  self.delete_table_name = :view_items
+end

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -62,6 +62,9 @@ ActiveRecord::Schema.define do
     t.binary :binary_column,    limit: 1
   end
 
+  # Add a UNION to ensure read-only view
+  execute "CREATE OR REPLACE VIEW view_items AS SELECT * FROM items UNION SELECT LIMIT 0"
+
   execute "DROP PROCEDURE IF EXISTS ten"
 
   execute <<~SQL

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -41,6 +41,9 @@ ActiveRecord::Schema.define do
     t.oid :obj_id
   end
 
+  # Add a UNION to ensure read-only view
+  execute "CREATE OR REPLACE VIEW view_items AS SELECT * FROM items UNION SELECT LIMIT 0"
+
   drop_table "postgresql_timestamp_with_zones", if_exists: true
   drop_table "postgresql_partitioned_table", if_exists: true
   drop_table "postgresql_partitioned_table_parent", if_exists: true

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
+  execute "CREATE VIEW IF NOT EXISTS view_items AS SELECT * FROM items"
+
   create_table :defaults, force: true do |t|
     t.date :fixed_date, default: "2004-01-01"
     t.datetime :fixed_time, default: "2004-01-01 00:00:00"


### PR DESCRIPTION
### Summary

Fixes #42711

Allow to customize ActiveRecord table name depending on the circumstances. Permit to have a different table name for UPDATE, INSERT, DELETE queries.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
