### PR TITLE
destroy_all_in_batches is off by default for newly generated Rails apps.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -27,9 +27,6 @@
     config.active_record.destroy_all_in_batches = true
     ```
 
-    The option is on by default for newly generated Rails apps. Can be set in
-    an initializer to prevent differences across environments.
-
     *Genadi Samokovarov*, *Roberto Miranda*
 
 *   Adds support for `if_not_exists` to `add_foreign_key` and `if_exists` to `remove_foreign_key`.


### PR DESCRIPTION
### Summary

Rails.application.config.active_record.destroy_all_in_batches = true  is off by default for newly generated Rails apps.


Following up https://github.com/rails/rails/pull/42673#issuecomment-874744582