### PR TITLE
Enable destroy_all_in_batches on new defaults framework

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -27,6 +27,9 @@
     config.active_record.destroy_all_in_batches = true
     ```
 
+    The option is on by default for newly generated Rails apps. Can be set in
+    an initializer to prevent differences across environments.
+
     *Genadi Samokovarov*, *Roberto Miranda*
 
 *   Adds support for `if_not_exists` to `add_foreign_key` and `if_exists` to `remove_foreign_key`.

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -42,6 +42,6 @@
 # of the video).
 # Rails.application.config.active_storage.video_preview_arguments =
 #   "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
-
+#
 # Enforce destroy in batches when calling ActiveRecord::Relation#destroy_all
-# Rails.application.config.active_record.destroy_all_in_batches = true
+Rails.application.config.active_record.destroy_all_in_batches = true


### PR DESCRIPTION
### Summary

Reverts https://github.com/rails/rails/pull/42673 originally introduced by @ghiculescu, merged by @eileencodes. I'm continuing the discussion open in https://github.com/rails/rails/pull/42714#issuecomment-875108378 by @rafaelfranca and @guilleiguaran about whether this should be enabled/disable by default 