### PR TITLE
Clarify new_framework_defaults instructions

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -1,8 +1,10 @@
 # Be sure to restart your server when you modify this file.
 #
-# This file contains migration options to ease your Rails 7.0 upgrade.
+# This file eases your Rails 7.0 framework defaults upgrade.
 #
-# Once upgraded flip defaults one by one to migrate to the new default.
+# Uncomment each configuration one by one to switch to the new default.
+# Once your application is ready to run with all new defaults, you can remove
+# this file and set the `config.load_defaults` to `7.0`.
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 


### PR DESCRIPTION
### Summary

Framework defaults cause confusion for contributors when adding new entries.
Should the new defaults be defined in either
`railties/lib/rails/application/configuration.rb` and/or
`config/initializers/new_framework_defaults_7_0.rb.tt`?
And should these define the new or old defaults?

See the following issues for examples of the confusion:
https://github.com/rails/rails/pull/42718 https://github.com/rails/rails/pull/42673 https://github.com/rails/rails/pull/41055

Hopefully this clarifies things by making it clear the new framework defaults
are commented out in `new_framework_defaults_7_0.rb.tt`.

By mentioning `config.load_defaults` it hopefully clarifies that these
defaults should be similar to the ones defined by `load_defaults`.
    
Also reword "flip" to "uncomment" to make it clear you should uncomment
the config instead of setting `true` to `false`.

The wording somewhat matches the guides as well:
https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#configure-framework-defaults