### PR TITLE
Add missing new defaults to new_framework_defaults_7_0.rb.tt

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1098,7 +1098,9 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.active_support.key_generator_hash_digest_class`: `OpenSSL::Digest::SHA256`
 - `config.active_support.hash_digest_class`: `OpenSSL::Digest::SHA256`
 - `config.active_support.cache_format_version`: `7.0`
+- `config.active_support.remove_deprecated_time_with_zone_name` : `true`
 - `config.action_dispatch.return_only_request_media_type_on_content_type`: `false`
+- `config.action_controller.silence_disabled_session_errors` : `false`
 - `config.action_mailer.smtp_timeout`: `5`
 - `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -6,6 +6,10 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
+# Raise an error when trying to use forgery protection without a working
+# session.
+# Rails.application.config.action_controller.silence_disabled_session_errors = false
+
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.
 # Rails.application.config.action_view.button_to_generates_button_tag = true
@@ -26,6 +30,10 @@
 # Changing this default means that for example Etags change and
 # various cache keys leading to cache invalidation.
 # Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA256
+
+# Don't override ActiveSupport::TimeWithZone.name and use the default Ruby
+# implementation.
+# Rails.application.config.active_support.remove_deprecated_time_with_zone_name = true
 
 # Change the format of the cache entry.
 # Changing this default means that all new cache entries added to the cache


### PR DESCRIPTION
### Summary
`railties/lib/rails/application/configuration.rb` contains defaults that
haven't been added to the `new_framework_defaults_7_0.rb.tt`.
This commit adds these defaults to ease migration for the following defaults:

`config.action_controller.silence_disabled_session_errors`
https://github.com/rails/rails/commit/c1c96a014049b2660ce3a89b3c1b7aef072ae922

`config.active_support.remove_deprecated_time_with_zone_name`
https://github.com/rails/rails/commit/3457a4676d91836ac3dfd6765f069eee752c598c