### PR TITLE
Use IAM for URL signing with GCS when no credentials are provided

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow using [IAM](https://cloud.google.com/storage/docs/access-control/signed-urls) when signing URLs with GCS.
+
+    ```yaml
+    gcs:
+      service: GCS
+      ...
+      iam: true
+    ```
+    *RRethy*
+
 *   OpenSSL constants are now used for Digest computations.
 
     *Dirkjan Bussink*

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 gem "google-cloud-storage", "~> 1.11"
+require "google/apis/iamcredentials_v1"
 require "google/cloud/storage"
 
 module ActiveStorage
@@ -95,13 +96,20 @@ module ActiveStorage
           version = :v4
         end
 
-        generated_url = bucket.signed_url(key,
+        args = {
           content_md5: checksum,
           expires: expires_in,
           headers: headers,
           method: "PUT",
-          version: version
-        )
+          version: version,
+        }
+
+        if @config[:iam]
+          args[:issuer] = issuer
+          args[:signer] = signer
+        end
+
+        generated_url = bucket.signed_url(key, **args)
 
         payload[:url] = generated_url
 
@@ -123,10 +131,20 @@ module ActiveStorage
 
     private
       def private_url(key, expires_in:, filename:, content_type:, disposition:, **)
-        file_for(key).signed_url expires: expires_in, query: {
-          "response-content-disposition" => content_disposition_with(type: disposition, filename: filename),
-          "response-content-type" => content_type
+        args = {
+          expires: expires_in,
+          query: {
+            "response-content-disposition" => content_disposition_with(type: disposition, filename: filename),
+            "response-content-type" => content_type
+          }
         }
+
+        if @config[:iam]
+          args[:issuer] = issuer
+          args[:signer] = signer
+        end
+
+        file_for(key).signed_url(**args)
       end
 
       def public_url(key, **)
@@ -160,7 +178,37 @@ module ActiveStorage
       end
 
       def client
-        @client ||= Google::Cloud::Storage.new(**config.except(:bucket, :cache_control))
+        @client ||= Google::Cloud::Storage.new(**config.except(:bucket, :cache_control, :iam, :gsa_email))
+      end
+
+      def issuer
+        @issuer ||= if @config[:gsa_email]
+          @config[:gsa_email]
+        else
+          uri = URI.parse("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email")
+          http = Net::HTTP.new(uri.host, uri.port)
+          request = Net::HTTP::Get.new(uri.request_uri)
+          request["Metadata-Flavor"] = "Google"
+
+          http.request(request).body
+        end
+      end
+
+      def signer
+        # https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/Project.html#signed_url-instance_method
+        lambda do |string_to_sign|
+          iam_client = Google::Apis::IamcredentialsV1::IAMCredentialsService.new
+
+          scopes = ["https://www.googleapis.com/auth/iam"]
+          iam_client.authorization = Google::Auth.get_application_default(scopes)
+
+          request = Google::Apis::IamcredentialsV1::SignBlobRequest.new(
+            payload: string_to_sign
+          )
+          resource = "projects/-/serviceAccounts/#{issuer}"
+          response = iam_client.sign_service_account_blob(resource, request)
+          response.signed_blob
+        end
       end
   end
 end

--- a/activestorage/test/service/configurations.example.yml
+++ b/activestorage/test/service/configurations.example.yml
@@ -21,6 +21,8 @@
 #   }
 #   project:
 #   bucket:
+#   iam: false
+#   gsa_email: "foobar@baz.iam.gserviceaccount.com"
 #
 # azure:
 #   service: AzureStorage

--- a/activestorage/test/service/gcs_service_test.rb
+++ b/activestorage/test/service/gcs_service_test.rb
@@ -151,6 +151,40 @@ if SERVICE_CONFIGURATIONS[:gcs]
       assert_match(/storage\.googleapis\.com\/.*response-content-disposition=inline.*test\.txt.*response-content-type=text%2Fplain/,
         @service.url(@key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
     end
+
+    if SERVICE_CONFIGURATIONS[:gcs].key?(:gsa_email)
+      test "direct upload with IAM signing" do
+        config_with_iam = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ iam: true }) }
+        service = ActiveStorage::Service.configure(:gcs, config_with_iam)
+
+        key      = SecureRandom.base58(24)
+        data     = "Some text"
+        checksum = Digest::MD5.base64digest(data)
+        url      = service.url_for_direct_upload(key, expires_in: 5.minutes, content_type: "text/plain", content_length: data.size, checksum: checksum)
+
+        uri = URI.parse(url)
+        request = Net::HTTP::Put.new(uri.request_uri)
+        request.body = data
+        request.add_field("Content-Type", "")
+        request.add_field("Content-MD5", checksum)
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+          http.request request
+        end
+
+        assert_equal data, service.download(key)
+      ensure
+        service.delete key
+      end
+
+      test "url with IAM signing" do
+        config_with_iam = { gcs: SERVICE_CONFIGURATIONS[:gcs].merge({ iam: true }) }
+        service = ActiveStorage::Service.configure(:gcs, config_with_iam)
+
+        key = SecureRandom.base58(24)
+        assert_match(/storage\.googleapis\.com\/.*response-content-disposition=inline.*test\.txt.*response-content-type=text%2Fplain/,
+          service.url(key, expires_in: 2.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("test.txt"), content_type: "text/plain"))
+      end
+    end
   end
 else
   puts "Skipping GCS Service tests because no GCS configuration was supplied"

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -246,6 +246,25 @@ google:
   cache_control: "public, max-age=3600"
 ```
 
+Optionally use [IAM](https://cloud.google.com/storage/docs/access-control/signed-urls#signing-iam) instead of the `credentials` when signing URLs. This is useful if you are authenticating your GKE applications with Workload Identity, see [this Google Cloud blog post](https://cloud.google.com/blog/products/containers-kubernetes/introducing-workload-identity-better-authentication-for-your-gke-applications) for more information.
+
+```yaml
+google:
+  service: GCS
+  ...
+  iam: true
+```
+
+Optionally use a specific GSA when signing URLs. When using IAM, the [metadata server](https://cloud.google.com/compute/docs/storing-retrieving-metadata) will be contacted to get the GSA email, but this metadata server is not always present (e.g. local tests) and you may wish to use a non-default GSA.
+
+```yaml
+google:
+  service: GCS
+  ...
+  iam: true
+  gsa_email: "foobar@baz.iam.gserviceaccount.com"
+```
+
 Add the [`google-cloud-storage`](https://github.com/GoogleCloudPlatform/google-cloud-ruby/tree/master/google-cloud-storage) gem to your `Gemfile`:
 
 ```ruby


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/42725.

When signing a URL with GCS, they can specify `:iam` in the `storage.yml` to use Workload Identity to sign URLs instead of the credentials. This is done for `url_for_direct_upload` and `private_url`.

The `signer` code comes from https://googleapis.dev/ruby/google-cloud-storage/latest/Google/Cloud/Storage/Project.html#signed_url-instance_method.

The `issuer` code just contacts the metadata server to get the email associated with the current GSA. The `issuer` method also checks for a `:gsa_email` which it will use instead of contacting the metadata server which would not be present for tests and local development.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)
-->

I added to the guides for active storage and adjusted the changelog.

### Tests

~For testing, I mocked GCSService and replaced `signer` and `issuer` with basic implementations that don't do any network calls.~

~There must be some mocking done since the tests are not run in GKE and thus the metadata server for `issuer` can't be contacted and many of the `signer` api calls that are done under the hood will fail. I had initially tried to just mock the requests but it would mean mocking all the following endpoints:~

~- http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email~
~- https://oauth2.googleapis.com/token~
~- https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/**{context_dependant_GSA_email}**:signBlob~

~The last call of the 3 needs the GSA email which afaik we can't get access to. As well, each call required a body to be returned with a lot of specific information which I wasn't able to get them all working (especially the 3rd URL). Lastly, the 3rd url above was having issues when I returned a string in the body, I couldn't figure out why by the google gem wasn't parsing it into a hash which means that the [reponse.signed_blob method call](https://github.com/rails/rails/pull/42723/files#diff-3436515ce2c78b7021a73a628255e70bd27fa22db4f54ac34be4e9a81ca6c2b4R206) would fail (method call on a string). However, even if I could mock all the web requests, these would be super flaky tests since the gem could change under our feet and the tests would break. This is why I opted to just write a mock class and stub the two methods that didn't have a great way of handling.~

With the addition of `:gsa_email`, the tests can now be integration tests since we are not dependant on the metadata server anymore. However, `activestorage/test/service/configurations.yml.enc` still needs to be updated with this key so CI runs those tests. I don't have the ability to do this so I need help with that.