### PR TITLE
Make `autosave` option work with `has_and_belongs_to_many`

### DIFF
--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -105,6 +105,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
           rhs_options[:foreign_key] = options[:association_foreign_key]
         end
 
+         if options.key? :autosave
+           rhs_options[:autosave] = options[:autosave]
+         end
+
         rhs_options
       end
   end

--- a/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
+++ b/activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb
@@ -105,9 +105,9 @@ module ActiveRecord::Associations::Builder # :nodoc:
           rhs_options[:foreign_key] = options[:association_foreign_key]
         end
 
-         if options.key? :autosave
-           rhs_options[:autosave] = options[:autosave]
-         end
+        if options.key? :autosave
+          rhs_options[:autosave] = options[:autosave]
+        end
 
         rhs_options
       end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -13,6 +13,7 @@ require "models/customer"
 require "models/developer"
 require "models/computer"
 require "models/invoice"
+require "models/like"
 require "models/line_item"
 require "models/mouse"
 require "models/order"
@@ -151,6 +152,24 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
 
   def test_should_not_add_the_same_callbacks_multiple_times_for_has_and_belongs_to_many
     assert_no_difference_when_adding_callbacks_twice_for Pirate, :parrots
+  end
+
+  def test_should_save_associated_records_when_has_and_belongs_to_many_with_autosave
+    book = PublishedBook.new(name: 'Good title', isbn: "010101101")
+    author = Author.create!(name: 'Jhon')
+    book.authors_autosave  << author
+    book.save!
+
+    like = Like.new(reason: 'Good content.')
+    book = PublishedBook.find(book.id)
+    like.published_books << book
+    author = book.authors_autosave[0]
+    author.name = 'Paul'
+    assert_equal true, author.changed?
+    assert_equal false, book.changed?
+    like.save!
+
+    assert_equal author.reload.name, 'Paul'
   end
 
   def test_cyclic_autosaves_do_not_add_multiple_validations

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -155,21 +155,21 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   end
 
   def test_should_save_associated_records_when_has_and_belongs_to_many_with_autosave
-    book = PublishedBook.new(name: 'Good title', isbn: "010101101")
-    author = Author.create!(name: 'Jhon')
-    book.authors_autosave  << author
+    book = PublishedBook.new(name: "Good title", isbn: "010101101")
+    author = Author.create!(name: "Jhon")
+    book.authors_autosave << author
     book.save!
 
-    like = Like.new(reason: 'Good content.')
+    like = Like.new(reason: "Good content.")
     book = PublishedBook.find(book.id)
     like.published_books << book
     author = book.authors_autosave[0]
-    author.name = 'Paul'
+    author.name = "Paul"
     assert_equal true, author.changed?
     assert_equal false, book.changed?
     like.save!
 
-    assert_equal author.reload.name, 'Paul'
+    assert_equal author.reload.name, "Paul"
   end
 
   def test_cyclic_autosaves_do_not_add_multiple_validations

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -165,7 +165,7 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
     like.published_books << book
     author = book.authors_autosave[0]
     author.name = "Paul"
-    assert_equal true, author.changed?
+    assert_predicate author, :changed?
     assert_equal false, book.changed?
     like.save!
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -166,7 +166,7 @@ class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
     author = book.authors_autosave[0]
     author.name = "Paul"
     assert_predicate author, :changed?
-    assert_equal false, book.changed?
+    assert_not_predicate book, :changed?
     like.save!
 
     assert_equal author.reload.name, "Paul"

--- a/activerecord/test/cases/json_serialization_test.rb
+++ b/activerecord/test/cases/json_serialization_test.rb
@@ -268,7 +268,7 @@ class DatabaseConnectedJsonEncodingTest < ActiveRecord::TestCase
       authors = [@david, @mary]
       encoded = ActiveSupport::JSON.encode(authors, except: [
         :name, :author_address_id, :author_address_extra_id,
-        :organization_id, :owned_essay_id
+        :organization_id, :owned_essay_id, :published_book_id
       ])
       assert_equal %([{"id":1},{"id":2}]), encoded
     end

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -32,4 +32,7 @@ class PublishedBook < ActiveRecord::Base
   enum :cover, { hard: "0", soft: "1" }, default: :hard
 
   validates_uniqueness_of :isbn
+
+  has_and_belongs_to_many :likes
+  has_many :authors_autosave, class_name: "Author", autosave: true
 end

--- a/activerecord/test/models/like.rb
+++ b/activerecord/test/models/like.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Like < ActiveRecord::Base
+  has_and_belongs_to_many :published_books, :autosave => true
+end

--- a/activerecord/test/models/like.rb
+++ b/activerecord/test/models/like.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Like < ActiveRecord::Base
-  has_and_belongs_to_many :published_books, :autosave => true
+  has_and_belongs_to_many :published_books, autosave: true
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define do
     t.references :author_address_extra
     t.string :organization_id
     t.string :owned_essay_id
+    t.integer :published_book_id
   end
 
   create_table :author_addresses, force: true do |t|
@@ -557,6 +558,15 @@ ActiveRecord::Schema.define do
   end
 
   add_foreign_key :lessons_students, :students, on_delete: :cascade
+
+  create_table :likes, force: true do |t|
+    t.string :reason, :length => 250
+  end
+
+  create_table :books_likes, force: true do |t|
+    t.integer :published_book_id
+    t.integer :like_id
+  end
 
   create_table :lint_models, force: true
 

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -560,7 +560,7 @@ ActiveRecord::Schema.define do
   add_foreign_key :lessons_students, :students, on_delete: :cascade
 
   create_table :likes, force: true do |t|
-    t.string :reason, :length => 250
+    t.string :reason, length: 250
   end
 
   create_table :books_likes, force: true do |t|


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/32476 scenarios when we have a `has_and_belongs_to_many` with a `autosave: true` option. In such case, the associated records need to saved as well, even if the associated post didn't not changed. 

