### PR TITLE
Truncate more ActionCable broadcast messages to 300 chars

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Truncate broadcast logging messages.
+
+    *J Smith*
+
 *   OpenSSL constants are now used for Digest computations.
 
     *Dirkjan Bussink*

--- a/actioncable/lib/action_cable/server/broadcasting.rb
+++ b/actioncable/lib/action_cable/server/broadcasting.rb
@@ -40,7 +40,7 @@ module ActionCable
           end
 
           def broadcast(message)
-            server.logger.debug { "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect}" }
+            server.logger.debug { "[ActionCable] Broadcasting to #{broadcasting}: #{message.inspect.truncate(300)}" }
 
             payload = { broadcasting: broadcasting, message: message, coder: coder }
             ActiveSupport::Notifications.instrument("broadcast.action_cable", payload) do


### PR DESCRIPTION
### Summary

Truncation to ActionCable logging was added way back in 2016, but here's another location where the logging messages can get out of hand. The previous PR can be found at #23709. 
