### PR TITLE
Make `FlashHash#delete` behave like `Hash#delete`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Deleting a key from `ActionDispatch::Flash::FlashHash` returns the deleted
+    value, the same way that `Hash#delete` would.
+
+    *Sean Doyle*
+
 *   Allow Capybara driver name overrides in `SystemTestCase::driven_by`
 
     Allow users to prevent conflicts among drivers that use the same driver

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,9 @@
 *   Deleting a key from `ActionDispatch::Flash::FlashHash` returns the deleted
     value, the same way that `Hash#delete` would.
 
+    This will be the behavior in Rails 7.0 but it can be controlled now with
+    `config.action_dispatch.flash_hash_delete_returns_value`.
+
     *Sean Doyle*
 
 *   Allow Capybara driver name overrides in `SystemTestCase::driven_by`

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -174,11 +174,16 @@ module ActionDispatch
         @flashes.key? name.to_s
       end
 
+      # Deletes the entry for the given key and returns its associated value.
+      #
+      #   flash[:alert] = "Something went wrong."
+      #   flash.delete :alert # => "Something went wrong."
+      #   flash[:alert] # => nil
+      #
       def delete(key)
         key = key.to_s
         @discard.delete key
         @flashes.delete key
-        self
       end
 
       def to_hash

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -61,6 +61,8 @@ module ActionDispatch
       config.action_dispatch.always_write_cookie = Rails.env.development? if config.action_dispatch.always_write_cookie.nil?
       ActionDispatch::Cookies::CookieJar.always_write_cookie = config.action_dispatch.always_write_cookie
 
+      ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value = config.action_dispatch.flash_hash_delete_returns_value
+
       ActionDispatch.test_app = app
     end
   end

--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -42,8 +42,9 @@ module ActionDispatch
 
     def test_delete
       @hash["foo"] = "bar"
-      @hash.delete "foo"
+      value = @hash.delete "foo"
 
+      assert_equal "bar", value
       assert_not @hash.key?("foo")
       assert_nil @hash["foo"]
     end

--- a/actionpack/test/controller/flash_hash_test.rb
+++ b/actionpack/test/controller/flash_hash_test.rb
@@ -44,9 +44,22 @@ module ActionDispatch
       @hash["foo"] = "bar"
       value = @hash.delete "foo"
 
+      assert_deprecated { assert_equal @hash.to_h, value.to_h }
+      assert_not @hash.key?("foo")
+      assert_nil @hash["foo"]
+    end
+
+    def test_delete_configured_to_return_value
+      ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value = true
+
+      @hash["foo"] = "bar"
+      value = @hash.delete "foo"
+
       assert_equal "bar", value
       assert_not @hash.key?("foo")
       assert_nil @hash["foo"]
+    ensure
+      ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value = false
     end
 
     def test_to_hash

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1073,6 +1073,10 @@ Takes a block of code to run before the request.
 
 Takes a block of code to run after the request.
 
+* `config.action_dispatch.flash_hash_delete_returns_value` when deleting a value
+  from the `FlashHash`, return the deleted value instead of the `FlashHash`
+  instance. Defaults to `false`.
+
 ### Configuring Action View
 
 `config.action_view` includes a small number of configuration settings:

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -201,6 +201,7 @@ module Rails
           if respond_to?(:action_dispatch)
             action_dispatch.return_only_request_media_type_on_content_type = false
             action_dispatch.cookies_serializer = :json
+            action_dispatch.flash_hash_delete_returns_value = true
           end
 
           if respond_to?(:action_view)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -73,7 +73,10 @@
 #
 # Protect from open redirect attacks in `redirect_back_or_to` and `redirect_to`.
 # Rails.application.config.action_controller.raise_on_open_redirects = true
-
+#
+# Return the deleted value when calling `FlashHash#delete`
+# Rails.application.config.action_pack.flash_hash_delete_returns_value = true
+#
 # Change the variant processor for Active Storage.
 # Changing this default means updating all places in your code that
 # generate variants to use image processing macros and ruby-vips

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1345,6 +1345,32 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_open_redirects
     end
 
+    test "ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value is true by default for new apps" do
+      app "development"
+
+      assert_equal true, ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value
+    end
+
+    test "ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value is false by default for upgraded apps" do
+      remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config 'config.load_defaults "6.1"'
+      app "development"
+
+      assert_equal false, ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value
+    end
+
+    test "ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value can be configured in the new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_0.rb", <<-RUBY
+        Rails.application.config.action_dispatch.flash_hash_delete_returns_value = true
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActionDispatch::Flash::FlashHash.flash_hash_delete_returns_value
+    end
+
     test "config.action_dispatch.show_exceptions is sent in env" do
       make_basic_app do |application|
         application.config.action_dispatch.show_exceptions = true


### PR DESCRIPTION
### Summary

Prior to this commit, the `FlashHash#delete` return value was the
instance itself.

[The last time this code was changed][76c2ea7] (10 years ago at the time
of submission), `FlashHash` defined its own delegating versions of
`Hash` methods, as an alternative to inheriting from `Hash` directly.

This behavior isn't mentioned in the method's documentation (this commit
also introduces a documentation comment for the method), and isn't
covered by the test suite.

This behavior diverges from [Hash#delete][], since that method returns
the delete value(s).

[Hash#delete]: https://ruby-doc.org/core-3.0.1/Hash.html#method-i-delete
[FlashHash#delete]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/Flash/FlashHash.html#method-i-delete
[76c2ea7]: https://github.com/rails/rails/commit/76c2ea7882a83159408bdf1f7c363f442a65c4f1

### Other Information

To met, this seems like a breaking change despite the lack of documentation affirming the chain-able behavior.