### PR TITLE
Add rubymine's folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pkg/
 /tmp/
 /yarn-error.log
 /test-reports/
+/.idea/


### PR DESCRIPTION
Can I request that we add Rubymine's `.idea` folder to the `.gitignore` file? I keep having to reset and sometimes force push my commits because I forgot about it and did a `git add .`