### PR TITLE
Make vips the default variant processor for new apps

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Make `vips` the default variant processor for new apps.
+
+    See the upgrade guide for instructions on converting from `mini_magick` to `vips`. `mini_magick` is
+    not deprecated, existing apps can keep using it.
+
+    *Breno Gazzola*
+
 *   Allow using [IAM](https://cloud.google.com/storage/docs/access-control/signed-urls) when signing URLs with GCS.
 
     ```yaml

--- a/activestorage/app/models/active_storage/variant.rb
+++ b/activestorage/app/models/active_storage/variant.rb
@@ -42,7 +42,7 @@
 # You can combine any number of ImageMagick/libvips operations into a variant, as well as any macros provided by the
 # ImageProcessing gem (such as +resize_to_limit+):
 #
-#   avatar.variant(resize_to_limit: [800, 800], monochrome: true, rotate: "-90")
+#   avatar.variant(resize_to_limit: [800, 800], colourspace: "b-w", rotate: "-90")
 #
 # Visit the following links for a list of available ImageProcessing commands and ImageMagick/libvips operations:
 #

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -8,7 +8,7 @@ require "mini_mime"
 # In case you do need to use this directly, it's instantiated using a hash of transformations where
 # the key is the command and the value is the arguments. Example:
 #
-#   ActiveStorage::Variation.new(resize_to_limit: [100, 100], monochrome: true, trim: true, rotate: "-90")
+#   ActiveStorage::Variation.new(resize_to_limit: [100, 100], colourspace: "b-w", rotate: "-90", saver: { trim: true })
 #
 # The options map directly to {ImageProcessing}[https://github.com/janko-m/image_processing] commands.
 class ActiveStorage::Variation

--- a/activestorage/test/controllers/representations/proxy_controller_test.rb
+++ b/activestorage/test/controllers/representations/proxy_controller_test.rb
@@ -12,12 +12,12 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,
       signed_blob_id: @blob.signed_id,
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
-    image = read_image(@blob.variant(resize: "100x100"))
+    image = read_image(@blob.variant(resize_to_limit: [100, 100]))
     assert_equal 100, image.width
     assert_equal 67, image.height
   end
@@ -26,7 +26,7 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,
       signed_blob_id: "invalid",
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_response :not_found
   end
@@ -44,7 +44,7 @@ end
 class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadingTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "racecar.jpg"
-    @blob.variant(resize: "100x100").processed
+    @blob.variant(resize_to_limit: [100, 100]).processed
   end
 
   test "showing existing variant record"  do
@@ -52,13 +52,13 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsWithStrictLoadi
       get rails_blob_representation_proxy_url(
         filename: @blob.filename,
         signed_blob_id: @blob.signed_id,
-        variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
     end
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
     @blob.reload # became free of strict_loading?
-    image = read_image(@blob.variant(resize: "100x100"))
+    image = read_image(@blob.variant(resize_to_limit: [100, 100]))
     assert_equal 100, image.width
     assert_equal 67, image.height
   end
@@ -73,14 +73,14 @@ class ActiveStorage::Representations::ProxyControllerWithPreviewsTest < ActionDi
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,
       signed_blob_id: @blob.signed_id,
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_response :ok
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
     assert_predicate @blob.preview_image, :attached?
 
-    image = read_image(@blob.preview_image.variant(resize: "100x100").processed)
+    image = read_image(@blob.preview_image.variant(resize_to_limit: [100, 100]).processed)
     assert_equal 77, image.width
     assert_equal 100, image.height
   end
@@ -89,7 +89,7 @@ class ActiveStorage::Representations::ProxyControllerWithPreviewsTest < ActionDi
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,
       signed_blob_id: "invalid",
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_response :not_found
   end
@@ -107,7 +107,7 @@ end
 class ActiveStorage::Representations::ProxyControllerWithPreviewsWithStrictLoadingTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "report.pdf", content_type: "application/pdf"
-    @blob.preview(resize: "100x100").processed
+    @blob.preview(resize_to_limit: [100, 100]).processed
   end
 
   test "showing existing preview record" do
@@ -115,7 +115,7 @@ class ActiveStorage::Representations::ProxyControllerWithPreviewsWithStrictLoadi
       get rails_blob_representation_proxy_url(
         filename: @blob.filename,
         signed_blob_id: @blob.signed_id,
-        variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
     end
 
     assert_response :ok
@@ -123,7 +123,7 @@ class ActiveStorage::Representations::ProxyControllerWithPreviewsWithStrictLoadi
     @blob.reload # became free of strict_loading?
     assert_predicate @blob.preview_image, :attached?
 
-    image = read_image(@blob.preview_image.variant(resize: "100x100").processed)
+    image = read_image(@blob.preview_image.variant(resize_to_limit: [100, 100]).processed)
     assert_equal 77, image.width
     assert_equal 100, image.height
   end

--- a/activestorage/test/controllers/representations/redirect_controller_test.rb
+++ b/activestorage/test/controllers/representations/redirect_controller_test.rb
@@ -12,13 +12,13 @@ class ActiveStorage::Representations::RedirectControllerWithVariantsTest < Actio
     get rails_blob_representation_url(
       filename: @blob.filename,
       signed_blob_id: @blob.signed_id,
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_redirected_to(/racecar\.jpg/)
     follow_redirect!
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
-    image = read_image(@blob.variant(resize: "100x100"))
+    image = read_image(@blob.variant(resize_to_limit: [100, 100]))
     assert_equal 100, image.width
     assert_equal 67, image.height
   end
@@ -27,7 +27,7 @@ class ActiveStorage::Representations::RedirectControllerWithVariantsTest < Actio
     get rails_blob_representation_url(
       filename: @blob.filename,
       signed_blob_id: "invalid",
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_response :not_found
   end
@@ -45,7 +45,7 @@ end
 class ActiveStorage::Representations::RedirectControllerWithVariantsWithStrictLoadingTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "racecar.jpg"
-    @blob.variant(resize: "100x100").processed
+    @blob.variant(resize_to_limit: [100, 100]).processed
   end
 
   test "showing existing variant record inline" do
@@ -53,7 +53,7 @@ class ActiveStorage::Representations::RedirectControllerWithVariantsWithStrictLo
       get rails_blob_representation_url(
         filename: @blob.filename,
         signed_blob_id: @blob.signed_id,
-        variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
     end
 
     assert_redirected_to(/racecar\.jpg/)
@@ -61,7 +61,7 @@ class ActiveStorage::Representations::RedirectControllerWithVariantsWithStrictLo
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
     @blob.reload # became free of strict_loading?
-    image = read_image(@blob.variant(resize: "100x100"))
+    image = read_image(@blob.variant(resize_to_limit: [100, 100]))
     assert_equal 100, image.width
     assert_equal 67, image.height
   end
@@ -76,14 +76,14 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsTest < Actio
     get rails_blob_representation_url(
       filename: @blob.filename,
       signed_blob_id: @blob.signed_id,
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_predicate @blob.preview_image, :attached?
     assert_redirected_to(/report\.png/)
     follow_redirect!
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
-    image = read_image(@blob.preview_image.variant(resize: "100x100"))
+    image = read_image(@blob.preview_image.variant(resize_to_limit: [100, 100]))
     assert_equal 77, image.width
     assert_equal 100, image.height
   end
@@ -92,7 +92,7 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsTest < Actio
     get rails_blob_representation_url(
       filename: @blob.filename,
       signed_blob_id: "invalid",
-      variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
 
     assert_response :not_found
   end
@@ -110,7 +110,7 @@ end
 class ActiveStorage::Representations::RedirectControllerWithPreviewsWithStrictLoadingTest < ActionDispatch::IntegrationTest
   setup do
     @blob = create_file_blob filename: "report.pdf", content_type: "application/pdf"
-    @blob.preview(resize: "100x100").processed
+    @blob.preview(resize_to_limit: [100, 100]).processed
   end
 
   test "showing existing preview record inline" do
@@ -118,7 +118,7 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsWithStrictLo
       get rails_blob_representation_url(
         filename: @blob.filename,
         signed_blob_id: @blob.signed_id,
-        variation_key: ActiveStorage::Variation.encode(resize: "100x100"))
+        variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
     end
 
     assert_predicate @blob.preview_image, :attached?
@@ -127,7 +127,7 @@ class ActiveStorage::Representations::RedirectControllerWithPreviewsWithStrictLo
     assert_match(/^inline/, response.headers["Content-Disposition"])
 
     @blob.reload # became free of strict_loading?
-    image = read_image(@blob.preview_image.variant(resize: "100x100"))
+    image = read_image(@blob.preview_image.variant(resize_to_limit: [100, 100]))
     assert_equal 77, image.width
     assert_equal 100, image.height
   end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -212,7 +212,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
   test "purge deletes variants from external service with the purge_later" do
     blob = create_file_blob
-    variant = blob.variant(resize: "100>").processed
+    variant = blob.variant(resize_to_limit: [100, nil]).processed
 
     blob.purge
     assert_enqueued_with(job: ActiveStorage::PurgeJob, args: [variant.image.blob])

--- a/activestorage/test/models/preview_test.rb
+++ b/activestorage/test/models/preview_test.rb
@@ -6,7 +6,7 @@ require "database/setup"
 class ActiveStorage::PreviewTest < ActiveSupport::TestCase
   test "previewing a PDF" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
-    preview = blob.preview(resize: "640x280").processed
+    preview = blob.preview(resize_to_limit: [640, 280]).processed
 
     assert_predicate preview.image, :attached?
     assert_equal "report.png", preview.image.filename.to_s
@@ -19,7 +19,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
 
   test "previewing a cropped PDF" do
     blob = create_file_blob(filename: "cropped.pdf", content_type: "application/pdf")
-    preview = blob.preview(resize: "640x280").processed
+    preview = blob.preview(resize_to_limit: [640, 280]).processed
 
     assert_predicate preview.image, :attached?
     assert_equal "cropped.png", preview.image.filename.to_s
@@ -32,7 +32,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
 
   test "previewing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
-    preview = blob.preview(resize: "640x280").processed
+    preview = blob.preview(resize_to_limit: [640, 280]).processed
 
     assert_predicate preview.image, :attached?
     assert_equal "video.jpg", preview.image.filename.to_s
@@ -47,7 +47,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
     blob = create_file_blob
 
     assert_raises ActiveStorage::UnpreviewableError do
-      blob.preview resize: "640x280"
+      blob.preview resize_to_limit: [640, 280]
     end
   end
 
@@ -56,7 +56,7 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
 
     # prevent_writes option is required because there is no automatic write protection anymore
     ActiveRecord::Base.connected_to(role: ActiveRecord.reading_role, prevent_writes: true) do
-      blob.preview(resize: "640x280").processed
+      blob.preview(resize_to_limit: [640, 280]).processed
     end
 
     assert blob.reload.preview_image.attached?
@@ -64,14 +64,14 @@ class ActiveStorage::PreviewTest < ActiveSupport::TestCase
 
   test "preview of PDF is created on the same service" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf", service_name: "local_public")
-    preview = blob.preview(resize: "640x280").processed
+    preview = blob.preview(resize_to_limit: [640, 280]).processed
 
     assert_equal "local_public", preview.image.blob.service_name
   end
 
   test "preview of MP4 video is created on the same service" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4", service_name: "local_public")
-    preview = blob.preview(resize: "640x280").processed
+    preview = blob.preview(resize_to_limit: [640, 280]).processed
 
     assert_equal "local_public", preview.image.blob.service_name
   end

--- a/activestorage/test/models/representation_test.rb
+++ b/activestorage/test/models/representation_test.rb
@@ -6,7 +6,7 @@ require "database/setup"
 class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
   test "representing an image" do
     blob = create_file_blob
-    representation = blob.representation(resize: "100x100").processed
+    representation = blob.representation(resize_to_limit: [100, 100]).processed
 
     image = read_image(representation.image)
     assert_equal 100, image.width
@@ -15,7 +15,7 @@ class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
 
   test "representing a PDF" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
-    representation = blob.representation(resize: "640x280").processed
+    representation = blob.representation(resize_to_limit: [640, 280]).processed
 
     image = read_image(representation.image)
     assert_equal 612, image.width
@@ -24,7 +24,7 @@ class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
 
   test "representing an MP4 video" do
     blob = create_file_blob(filename: "video.mp4", content_type: "video/mp4")
-    representation = blob.representation(resize: "640x280").processed
+    representation = blob.representation(resize_to_limit: [640, 280]).processed
 
     image = read_image(representation.image)
     assert_equal 640, image.width
@@ -35,7 +35,7 @@ class ActiveStorage::RepresentationTest < ActiveSupport::TestCase
     blob = create_blob
 
     assert_raises ActiveStorage::UnrepresentableError do
-      blob.representation resize: "100x100"
+      blob.representation resize_to_limit: [100, 100]
     end
   end
 end

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -15,15 +15,15 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "variations have the same key for different types of the same transformation" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant_a = blob.variant(resize: "100x100")
-    variant_b = blob.variant("resize" => "100x100")
+    variant_a = blob.variant(resize_to_limit: [100, 100])
+    variant_b = blob.variant("resize_to_limit" => [100, 100])
 
     assert_equal variant_a.key, variant_b.key
   end
 
   test "resized variation of JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(resize: "100x100").processed
+    variant = blob.variant(resize_to_limit: [100, 100]).processed
     assert_match(/racecar\.jpg/, variant.url)
 
     image = read_image(variant)
@@ -33,7 +33,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized and monochrome variation of JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(resize: "100x100", monochrome: true).processed
+    variant = blob.variant(resize_to_limit: [100, 100], colourspace: "b-w").processed
     assert_match(/racecar\.jpg/, variant.url)
 
     image = read_image(variant)
@@ -44,14 +44,14 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "monochrome with default variant_processor" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(monochrome: true).processed
+    variant = blob.variant(colourspace: "b-w").processed
     image = read_image(variant)
     assert_match(/Gray/, image.colorspace)
   end
 
   test "disabled variation of JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(resize: "100x100", monochrome: false).processed
+    variant = blob.variant(resize_to_limit: [100, 100], colourspace: "srgb").processed
     assert_match(/racecar\.jpg/, variant.url)
 
     image = read_image(variant)
@@ -72,7 +72,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized variation of PSD blob" do
     blob = create_file_blob(filename: "icon.psd", content_type: "image/vnd.adobe.photoshop")
-    variant = blob.variant(resize: "20x20").processed
+    variant = blob.variant(resize_to_limit: [20, 20]).processed
     assert_match(/icon\.png/, variant.url)
 
     image = read_image(variant)
@@ -83,7 +83,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized variation of ICO blob" do
     blob = create_file_blob(filename: "favicon.ico", content_type: "image/vnd.microsoft.icon")
-    variant = blob.variant(resize: "20x20").processed
+    variant = blob.variant(resize_to_limit: [20, 20]).processed
     assert_match(/icon\.png/, variant.url)
 
     image = read_image(variant)
@@ -94,7 +94,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized variation of TIFF blob" do
     blob = create_file_blob(filename: "racecar.tif")
-    variant = blob.variant(resize: "50x50").processed
+    variant = blob.variant(resize_to_limit: [50, 50]).processed
     assert_match(/racecar\.png/, variant.url)
 
     image = read_image(variant)
@@ -105,7 +105,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "resized variation of BMP blob" do
     blob = create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
-    variant = blob.variant(resize: "15x15").processed
+    variant = blob.variant(resize_to_limit: [15, 15]).processed
     assert_match(/colors\.png/, variant.url)
 
     image = read_image(variant)
@@ -117,8 +117,16 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   test "optimized variation of GIF blob" do
     blob = create_file_blob(filename: "image.gif", content_type: "image/gif")
 
-    assert_nothing_raised do
-      blob.variant(layers: "Optimize").processed
+    process_variants_with :vips do
+      assert_nothing_raised do
+        blob.variant(saver: { optimize_gif_frames: true, optimize_gif_transparency: true }).processed
+      end
+    end
+
+    process_variants_with :mini_magick do
+      assert_nothing_raised do
+        blob.variant(layers: "Optimize").processed
+      end
     end
   end
 
@@ -140,14 +148,16 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
 
   test "variation of invariable blob" do
     assert_raises ActiveStorage::InvariableError do
-      create_file_blob(filename: "report.pdf", content_type: "application/pdf").variant(resize: "100x100")
+      create_file_blob(filename: "report.pdf", content_type: "application/pdf").variant(resize_to_limit: [100, 100])
     end
   end
 
   test "url doesn't grow in length despite long variant options" do
-    blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(font: "a" * 10_000).processed
-    assert_operator variant.url.length, :<, 785
+    process_variants_with :mini_magick do
+      blob = create_file_blob(filename: "racecar.jpg")
+      variant = blob.variant(font: "a" * 10_000).processed
+      assert_operator variant.url.length, :<, 785
+    end
   end
 
   test "thumbnail variation of JPEG blob processed with VIPS" do
@@ -183,7 +193,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     end
 
     blob.service.stub(:upload, mock_upload) do
-      blob.variant(resize: "100x100").processed
+      blob.variant(resize_to_limit: [100, 100]).processed
     end
   end
 
@@ -194,7 +204,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     blob.update(content_type: "image/jpg")
 
     assert_nothing_raised do
-      blob.variant(resize: "100x100")
+      blob.variant(resize_to_limit: [100, 100])
     end
 
     assert_nil blob.send(:format)

--- a/activestorage/test/models/variant_with_record_test.rb
+++ b/activestorage/test/models/variant_with_record_test.rb
@@ -14,7 +14,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
 
   test "generating a resized variation of a JPEG blob" do
     blob = create_file_blob(filename: "racecar.jpg")
-    variant = blob.variant(resize: "100x100")
+    variant = blob.variant(resize_to_limit: [100, 100])
 
     assert_difference -> { blob.variant_records.count }, +1 do
       variant.process
@@ -34,10 +34,10 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
     blob = create_file_blob(filename: "racecar.jpg")
 
     assert_difference -> { blob.variant_records.count } do
-      blob.variant(resize: "100x100").process
+      blob.variant(resize_to_limit: [100, 100]).process
     end
 
-    variant = blob.variant(resize: "100x100")
+    variant = blob.variant(resize_to_limit: [100, 100])
 
     assert_no_difference -> { blob.variant_records.count } do
       variant.process
@@ -52,7 +52,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
 
   test "variant of a blob is on the same service" do
     blob = create_file_blob(filename: "racecar.jpg", service_name: "local_public")
-    variant = blob.variant(resize: "100x100").process
+    variant = blob.variant(resize_to_limit: [100, 100]).process
 
     assert_equal "local_public", variant.image.blob.service_name
   end
@@ -62,12 +62,12 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
 
     blob1 = directly_upload_file_blob(filename: "racecar.jpg")
     assert_difference -> { ActiveStorage::VariantRecord.count }, +1 do
-      blob1.representation(resize: "100x100").process
+      blob1.representation(resize_to_limit: [100, 100]).process
     end
 
     blob2 = directly_upload_file_blob(filename: "racecar_rotated.jpg")
     assert_difference -> { ActiveStorage::VariantRecord.count }, +1 do
-      blob2.representation(resize: "100x100").process
+      blob2.representation(resize_to_limit: [100, 100]).process
     end
 
     assert_no_difference -> { ActiveStorage::VariantRecord.count } do
@@ -84,7 +84,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
         # blob x 2
         # variant record x 2
         user.vlogs.map do |vlog|
-          vlog.representation(resize: "100x100").processed
+          vlog.representation(resize_to_limit: [100, 100]).processed
         end
       end
     end
@@ -98,7 +98,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
         # blob x 1
         # variant record x 1
         user.vlogs.includes(blob: :variant_records).map do |vlog|
-          vlog.representation(resize: "100x100").processed
+          vlog.representation(resize_to_limit: [100, 100]).processed
         end
       end
     end
@@ -112,7 +112,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
         # blob x 1
         # variant record x 1
         user.vlogs.with_all_variant_records.map do |vlog|
-          vlog.representation(resize: "100x100").processed
+          vlog.representation(resize_to_limit: [100, 100]).processed
         end
       end
     end
@@ -128,7 +128,7 @@ class ActiveStorage::VariantWithRecordTest < ActiveSupport::TestCase
         # variant record x 1
         User.where(id: user.id).with_attached_vlogs.map do |u|
           u.vlogs.map do |vlog|
-            vlog.representation(resize: "100x100").processed
+            vlog.representation(resize_to_limit: [100, 100]).processed
           end
         end
       end

--- a/activestorage/test/template/image_tag_test.rb
+++ b/activestorage/test/template/image_tag_test.rb
@@ -15,13 +15,13 @@ class ActiveStorage::ImageTagTest < ActionView::TestCase
   end
 
   test "variant" do
-    variant = @blob.variant(resize: "100x100")
+    variant = @blob.variant(resize_to_limit: [100, 100])
     assert_dom_equal %(<img src="#{polymorphic_url variant}" />), image_tag(variant)
   end
 
   test "preview" do
     blob = create_file_blob(filename: "report.pdf", content_type: "application/pdf")
-    preview = blob.preview(resize: "100x100")
+    preview = blob.preview(resize_to_limit: [100, 100])
     assert_dom_equal %(<img src="#{polymorphic_url preview}" />), image_tag(preview)
   end
 

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -151,13 +151,13 @@ class User < ActiveRecord::Base
   has_one_attached :avatar
   has_one_attached :cover_photo, dependent: false, service: :local
   has_one_attached :avatar_with_variants do |attachable|
-    attachable.variant :thumb, resize: "100x100"
+    attachable.variant :thumb, resize_to_limit: [100, 100]
   end
 
   has_many_attached :highlights
   has_many_attached :vlogs, dependent: false, service: :local
   has_many_attached :highlights_with_variants do |attachable|
-    attachable.variant :thumb, resize: "100x100"
+    attachable.variant :thumb, resize_to_limit: [100, 100]
   end
 
   accepts_nested_attributes_for :highlights_attachments, allow_destroy: true

--- a/activestorage/test/urls/rails_storage_proxy_url_test.rb
+++ b/activestorage/test/urls/rails_storage_proxy_url_test.rb
@@ -28,12 +28,12 @@ class RailsStorageProxyUrlTest < ActiveSupport::TestCase
   end
 
   test "rails_blob_path with variant generates proxy path" do
-    variant = @blob.variant(resize: "100x100")
+    variant = @blob.variant(resize_to_limit: [100, 100])
     assert_includes rails_blob_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
   end
 
   test "rails_representation_path generates proxy path" do
-    variant = @blob.variant(resize: "100x100")
+    variant = @blob.variant(resize_to_limit: [100, 100])
     assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/proxy/"
   end
 end

--- a/activestorage/test/urls/rails_storage_redirect_url_test.rb
+++ b/activestorage/test/urls/rails_storage_redirect_url_test.rb
@@ -28,12 +28,12 @@ class RailsStorageRedirectUrlTest < ActiveSupport::TestCase
   end
 
   test "rails_blob_path with variant generates redirect path" do
-    variant = @blob.variant(resize: "100x100")
+    variant = @blob.variant(resize_to_limit: [100, 100])
     assert_includes rails_blob_path(variant, only_path: true), "/rails/active_storage/representations/redirect/"
   end
 
   test "rails_representation_path generates proxy path" do
-    variant = @blob.variant(resize: "100x100")
+    variant = @blob.variant(resize_to_limit: [100, 100])
     assert_includes rails_representation_path(variant, only_path: true), "/rails/active_storage/representations/redirect/"
   end
 end

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -37,7 +37,7 @@ arbitrary files.
 Various features of Active Storage depend on third-party software which Rails 
 will not install, and must be installed separately:
 
-* [ImageMagick](https://imagemagick.org/index.php) or [libvips](https://github.com/libvips/libvips) v8.6+ for image analysis and transformations
+* [libvips](https://github.com/libvips/libvips) or [ImageMagick](https://imagemagick.org/index.php) v8.6+ for image analysis and transformations
 * [ffmpeg](http://ffmpeg.org/) v3.4+ for video/audio analysis and video previews
 * [poppler](https://poppler.freedesktop.org/) or [muPDF](https://mupdf.com/) for PDF previews
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1106,6 +1106,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `config.action_mailer.smtp_timeout`: `5`
 - `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 - `config.active_record.verify_foreign_keys_for_fixtures`: `true`
+- `config.active_storage.variant_processor`: `:vips`
 
 #### For '6.1', defaults from previous versions below and:
 
@@ -1186,6 +1187,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
 - `ActiveSupport.utc_to_local_returns_utc_offset_times`: `false`
 - `config.action_mailer.smtp_timeout`: `nil`
 - `config.active_storage.video_preview_arguments`: `"-y -vframes 1 -f image2"`
+- `config.active_storage.variant_processor`: `:mini_magick`
 
 ### Configuring a Database
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -225,6 +225,8 @@ module Rails
             active_storage.video_preview_arguments =
               "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1'" \
               " -frames:v 1 -f image2"
+
+            active_storage.variant_processor = :vips
           end
 
           if respond_to?(:active_record)

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -60,3 +60,10 @@
 # This default means that all columns will be referenced in INSERT queries
 # regardless of whether they have a default or not.
 # Rails.application.config.active_record.partial_inserts = false
+
+# Change the variant processor for Active Storage.
+# Changing this default means updating all places in your code that
+# generate variants to use image processing macros and ruby-vips
+# operations. See the upgrading guide for detail on the changes required.
+# The `:mini_magick` option is not deprecated; it's fine to keep using it.
+# Rails.application.config.active_storage.variant_processor = :vips

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3121,6 +3121,20 @@ module ApplicationTests
         " -frames:v 1 -f image2"
     end
 
+    test "ActiveStorage.variant_processor uses mini_magick without Rails 7 defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app "development"
+
+      assert_equal :mini_magick, ActiveStorage.variant_processor
+    end
+
+    test "ActiveStorage.variant_processor uses vips by default" do
+      app "development"
+
+      assert_equal :vips, ActiveStorage.variant_processor
+    end
+
     test "hosts include .localhost in development" do
       app "development"
       assert_includes Rails.application.config.hosts, ".localhost"


### PR DESCRIPTION
### Summary
Changes the default variant processor from `:mini_magick` to `:vips`.

### Other Information
For the full, paragraphs long, explanation about my experiences with both and why I believe vips is the better choice, check my [Rails Discussion post](https://discuss.rubyonrails.org/t/make-vips-the-recommended-default-variant-processor-for-active-storage/78368).

**The abridged version:**
I've been running active storage in production since version 5.2 for image galleries. I've noticed that the combination of Active Storage creating variants through an HTTP request in the web server, ImageMagick high resource needs, and servers with low puma concurrency and memory (eg: Heroku), cause increased response times for the entire application.

It took me a long time to understand all this and that using Vips can mitigate the problem. As a form of "conceptual compression", I propose that Rails 7 make vips the default variant processor.

For reference, I've [prepared a gist](https://gist.github.com/brenogazzola/a4369965a1da426d50f11d080fe2e563) with all the steps I had to go through to migrate from the original mini_magick macros and ImageMagick to the image_processing macros and libvips.

EDIT: Another user in the forum has raised another point: Security. The list of known CVEs for vips is considerably smaller than ImageMagick.