### PR TITLE
Added Rubocop rule that throws error when using Digest 42665 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rails
+  - ./rubocop/linters/digest_with_open_ssl.rb
 
 AllCops:
   TargetRubyVersion: 2.7
@@ -38,6 +39,8 @@ Rails/IndexBy:
 Rails/IndexWith:
   Enabled: true
 
+DigestWithOpenSSL:
+  Enabled: true
 # Prefer &&/|| over and/or.
 Style/AndOr:
   Enabled: true

--- a/rubocop/Rakefile
+++ b/rubocop/Rakefile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+task :package
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
+  t.verbose = true
+end
+
+task default: :test

--- a/rubocop/linters/digest_with_open_ssl.rb
+++ b/rubocop/linters/digest_with_open_ssl.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Linters
+    class DigestWithOpenSSL < RuboCop::Cop::Base
+      MSG = "Digest may only be called from OpenSSL"
+
+      def_node_matcher :digest_open_call?, <<~PATTERN
+        (const nil? :Digest)
+      PATTERN
+
+      def on_const(node)
+        return unless digest_open_call?(node)
+        add_offense(node)
+      end
+    end
+  end
+end

--- a/rubocop/test/digest_with_open_ssl_test.rb
+++ b/rubocop/test/digest_with_open_ssl_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "rubocop"
+require "rubocop/config"
+
+module RuboCop
+  module Linters
+    class DigestWithOpenSSL < ::ActiveSupport::TestCase
+      test "invalid syntax" do
+        system_response = capture_subprocess_io do
+          system("bundle exec rubocop rubocop/test/fixtures/incorrect_digest_open_ssl.rb")
+        end
+        assert(system_response.first.include?("5 offenses detected"))
+      end
+
+      test "valid syntax" do
+        system_response = capture_subprocess_io do
+          system("bundle exec rubocop rubocop/test/fixtures/correct_digest_open_ssl.rb")
+        end
+        assert(system_response.first.include?("no offenses detected"))
+      end
+    end
+  end
+end

--- a/rubocop/test/fixtures/correct_digest_open_ssl.rb
+++ b/rubocop/test/fixtures/correct_digest_open_ssl.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+OpenSSL::Digest
+OpenSSL::Digest::SHA1
+OpenSSL::Digest::SHA256.new
+OpenSSL::Digest::MD5.hexdigest(["test", "digest"]).join(":")
+some_method(OpenSSL::Digest::SHA256.new)
+ActionController::HttpAuthentication::Digest::ControllerMethods

--- a/rubocop/test/fixtures/incorrect_digest_open_ssl.rb
+++ b/rubocop/test/fixtures/incorrect_digest_open_ssl.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Digest
+Digest::SHA1
+Digest::SHA256.new
+Digest::MD5.hexdigest(["test", "digest"]).join(":")
+some_method(Digest::SHA256.new)


### PR DESCRIPTION
### Summary
Solves Issue #42665.
Added a new folder that contains a new rubocop linter rule. There is no direct way to add a RuboCop Rule to a project. I inherited `RuboCop::Cop::Base`
Another thing of note is the test cases. RuboCop Test Helpers are in Rspec , so I could not use them. Instead I tried capturing via `system` and check if the output is valid 

