### PR TITLE
Raise an error in generators if type options are invalid

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Raise an error in generators if type options are invalid.
+
+    An error is now raised in bin/rails when trying to generate a model with an
+    invalid option for the attribute type.
+
+        started_at:date{1}   # raises "Options not supported for type 'date'."
+        name:string{foo}     # raises "Expected an integer option instead of 'foo' for type 'string'."
+        post:belongs_to{foo} # raises "Unknown option 'foo' for type 'belongs_to'."
+
+    *Petrik de Heus*
+
 *   Fix `config_for` error when there's only a shared root array.
 
     *Loïc Delmaire*

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -68,6 +68,38 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
     assert_match message, e.message
   end
 
+  def test_field_type_with_unclosed_options_brace_raises_error
+    e = assert_raise Rails::Generators::Error do
+      create_generated_attribute "integer{1", "age"
+    end
+    message = "Could not parse type 'integer{1'"
+    assert_match message, e.message
+  end
+
+  def test_field_type_with_unsupported_options_raises_error
+    e = assert_raise Rails::Generators::Error do
+      create_generated_attribute "integer{abc}", "age"
+    end
+    message = "Expected an integer option instead of 'abc' for type 'integer'"
+    assert_match message, e.message
+  end
+
+  def test_field_type_without_options_raises_error
+    e = assert_raise Rails::Generators::Error do
+      create_generated_attribute "boolean{1}", "name"
+    end
+    message = "Options not supported for type 'boolean'"
+    assert_match message, e.message
+  end
+
+  def test_field_type_with_unsupported_option_for_belongs_to_raises_error
+    e = assert_raise Rails::Generators::Error do
+      assert_equal create_generated_attribute("belongs_to{unknown}", "post").attr_options, 1
+    end
+    message = "Unknown option 'unknown' for type 'belongs_to'"
+    assert_match message, e.message
+  end
+
   def test_field_type_with_unknown_index_type_raises_error
     index_type = :unknown
     e = assert_raise Rails::Generators::Error do


### PR DESCRIPTION
### Summary
Generators allow passing options to attribute types.
For example:
```ruby
# generate a string column with limit: 40
name:string{40}
# generate a decimal column with precision: 10, scale: 2
'price:decimal{10, 2}'
# generate a polymorphic reference
post:belongs_to{polymorphic}
```
The current implementation doesn't work well with invalid values:
```ruby
# this will complain about "unknown type 'string{foo}'"
name:string{foo}
# this will generate a reference with foo: true, bar: true
'post:belongs_to{foo,bar}'
```
This refactoring tries to make the type and option parsing more strict.
It raises an error if:
* the type could not be parsed
* the type doesn't support options
* the options are invalid (String instead of Integer)
* the options are unknown

```ruby
# this will raise "Could not parse type 'belongs_to{foo'."
post:belongs_to{foo
# this wil raise "Options not supported for type 'date'."
started_at:date{1}
# this will raise "Expected an integer instead of 'foo' for type 'string'."
name:string{foo}
# this will raise "Unknown option 'foo' for type 'belongs_to'."
'post:belongs_to{foo,bar}'
```

It also separates the parsing from the mapping definition.
This allows adding option support to more types, without requiring
changes to the parsing code.