### PR TITLE
Fix autosave associations when saving new records with validate: false

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fix autosave associations when saving new records with validate: false.
+
+    When saving a new record autosave wasn't considering the reflection
+    validate option and always validating the association even when the
+    default value of validate was false or it was set explicit to false.
+
+    When `autosave: true` the option was being respected, but when it
+    wasn't the association was always being validated disregarding the
+    value set to `validate`.
+
+    *Marcelo Lauxen*
+
 *   Add `authenticate_by` when using `has_secure_password`.
 
     `authenticate_by` is intended to replace code like the following, which

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -409,7 +409,7 @@ module ActiveRecord
                 if autosave
                   saved = association.insert_record(record, false)
                 elsif !reflection.nested?
-                  association_saved = association.insert_record(record)
+                  association_saved = association.insert_record(record, reflection.validate?)
 
                   if reflection.validate?
                     errors.add(reflection.name) unless association_saved
@@ -452,7 +452,7 @@ module ActiveRecord
                 association.set_inverse_instance(record)
               end
 
-              saved = record.save(validate: !autosave)
+              saved = record.save(validate: !autosave && reflection.validate?)
               raise ActiveRecord::Rollback if !saved && autosave
               saved
             end
@@ -488,7 +488,7 @@ module ActiveRecord
             self[reflection.foreign_key] = nil
             record.destroy
           elsif autosave != false
-            saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
+            saved = record.save(validate: !autosave && reflection.validate?) if record.new_record? || (autosave && record.changed_for_autosave?)
 
             if association.updated?
               association_id = record.public_send(reflection.options[:primary_key] || :id)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -179,15 +179,15 @@ end
 class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
   fixtures :companies, :accounts
 
-  def test_should_save_parent_but_not_invalid_child
+  def test_should_save_parent_and_invalid_child
     firm = Firm.new(name: "GlobalMegaCorp")
     assert_predicate firm, :valid?
 
     firm.build_account_using_primary_key
-    assert_not_predicate firm.build_account_using_primary_key, :valid?
+    assert_not_predicate firm.account_using_primary_key, :valid?
 
     assert firm.save
-    assert_not_predicate firm.account_using_primary_key, :persisted?
+    assert_predicate firm.account_using_primary_key, :persisted?
   end
 
   def test_save_fails_for_invalid_has_one
@@ -211,6 +211,7 @@ class TestDefaultAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCas
     assert_not_predicate firm.unvalidated_account, :valid?
     assert_predicate firm, :valid?
     assert firm.save
+    assert_predicate firm.unvalidated_account, :persisted?
   end
 
   def test_build_before_child_saved
@@ -301,15 +302,15 @@ end
 class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   fixtures :companies, :posts, :tags, :taggings
 
-  def test_should_save_parent_but_not_invalid_child
+  def test_should_save_parent_and_invalid_child
     client = Client.new(name: "Joe (the Plumber)")
     assert_predicate client, :valid?
 
     client.build_firm
-    assert_not_predicate client.firm, :valid?
+    assert_predicate client.firm, :invalid?
 
     assert client.save
-    assert_not_predicate client.firm, :persisted?
+    assert_predicate client.firm, :persisted?
   end
 
   def test_save_fails_for_invalid_belongs_to
@@ -331,6 +332,7 @@ class TestDefaultAutosaveAssociationOnABelongsToAssociation < ActiveRecord::Test
     assert_not_predicate log.unvalidated_developer, :valid?
     assert_predicate log, :valid?
     assert log.save
+    assert_predicate log.unvalidated_developer, :persisted?
   end
 
   def test_assignment_before_parent_saved
@@ -633,7 +635,7 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
     assert_predicate firm, :valid?
     assert_not_predicate client, :valid?
     assert firm.save
-    assert_not_predicate client, :persisted?
+    assert_predicate client, :persisted?
   end
 
   def test_valid_adding_with_validate_false

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -250,18 +250,6 @@ class TimestampTest < ActiveRecord::TestCase
     assert_not_equal previously_owner_updated_at, pet.owner.updated_at
   end
 
-  def test_saving_a_new_record_belonging_to_invalid_parent_with_touch_should_not_raise_exception
-    klass = Class.new(Owner) do
-      def self.name; "Owner"; end
-      validate { errors.add(:base, :invalid) }
-    end
-
-    pet = Pet.new(owner: klass.new)
-    pet.save!
-
-    assert_predicate pet.owner, :new_record?
-  end
-
   def test_saving_a_record_with_a_belongs_to_that_specifies_touching_a_specific_attribute_the_parent_should_update_that_attribute
     klass = Class.new(ActiveRecord::Base) do
       def self.name; "Pet"; end


### PR DESCRIPTION
### Summary

When saving a new record autosave wasn't considering the reflection validate option and always validating the association even when the default value of `validate` was false or was set explicit to false.

Based on the tests that I had to change it seems that this was an intended behavior at the time they were written, but it doesn't make much sense, because if someone sets `validate: false` to an association and `autosave: true` the association gets saved even when it is invalid, but when only `validate: false` is set it doesn't get saved when invalid, which means that we have two different behaviors based on the combination of the options provided to the association.

Fixes #25718 

### Other Information

Executable test case https://gist.github.com/marcelolx/243489f1dc05094f4b18d5ab57a9b6e4

