### PR TITLE
Execute `field_error_proc` within view

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Execute the `ActionView::Base.field_error_proc` within the context of the
+    `ActionView::Base` instance:
+
+    ```ruby
+    config.action_view.field_error_proc = proc { |html| content_tag(:div, html, class: "field_with_errors") }
+    ```
+
+    *Sean Doyle*
+
 *   Add `:day_format` option to `date_select`
 
         date_select("article", "written_on", day_format: ->(day) { day.ordinalize })

--- a/actionview/lib/action_view/base.rb
+++ b/actionview/lib/action_view/base.rb
@@ -142,7 +142,7 @@ module ActionView # :nodoc:
     include Helpers, ::ERB::Util, Context
 
     # Specify the proc used to decorate input tags that refer to attributes with errors.
-    cattr_accessor :field_error_proc, default: Proc.new { |html_tag, instance| "<div class=\"field_with_errors\">#{html_tag}</div>".html_safe }
+    cattr_accessor :field_error_proc, default: Proc.new { |html_tag, instance| content_tag :div, html_tag, class: "field_with_errors" }
 
     # How to complete the streaming when an exception occurs.
     # This is our best guess: first try to close the attribute, then the tag.

--- a/actionview/lib/action_view/helpers/active_model_helper.rb
+++ b/actionview/lib/action_view/helpers/active_model_helper.rb
@@ -27,7 +27,7 @@ module ActionView
 
       def error_wrapping(html_tag)
         if object_has_errors?
-          Base.field_error_proc.call(html_tag, self)
+          @template_object.instance_exec(html_tag, self, &Base.field_error_proc)
         else
           html_tag
         end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1083,6 +1083,14 @@ Controls whether or not templates should be reloaded on each request. Defaults t
 
 #### `config.action_view.field_error_proc`
 
+* `config.action_view.field_error_proc` provides an HTML generator for
+  displaying errors that come from Active Model. The block is evaluated within
+  the context of an Action View template. The default is
+
+    ```ruby
+    Proc.new { |html_tag, instance| content_tag :div, html_tag, class: "field_with_errors" }
+    ```
+
 Provides an HTML generator for displaying errors that come from Active Model. The default is
 
 ```ruby


### PR DESCRIPTION
### Summary

Instead of treating it as an anonymous block, execute the
`ActionView::Base.field_error_proc` within the context of the
`ActionView::Base` instance.

This enables consumer applications to continue to override the proc as
they see fit, but frees them from declaring templating logic within a
`config/initializers/*.rb`, `config/environments/*.rb` or
`config/application.rb` file.
    
This makes it possible to replace something like:
    
```ruby
config.action_view.field_error_proc = proc do |html_tag, instance|
  <<~HTML.html_safe
    #{html_tag}
    <span class="errors">#{instance.error_message.to_sentence}</span>
  HTML
end
```

With inline calls to Action View helpers like:

```ruby
config.action_view.field_error_proc = proc do |html_tag, instance|
  safe_join [ html_tag, tag.span(instance.error_message.to_sentence, class: "errors") ]
end
```

Or with a view partial rendering, like:

```ruby
config.action_view.field_error_proc = proc do |html_tag, instance|
  render partial: "application/field_with_errors", locals: { html_tag: html_tag, instance: instance }
end
```

Then, elsewhere in `app/views/application/field_with_errors.html.erb`:

```erb
<%= html_tag %>
<span class="errors"><%= instance.error_message.to_sentence %></span>
```