### PR TITLE
Allow overriding button_to authenticity token

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Allow `ActionView::Helpers::UrlHelper#button_to` to render with a
+    custom authenticity token, or render without an authenticity
+    token when `authenticity_token: false` is passed.
+
+        <%= button_to "New", "https://example.com", authenticity_token: false %>
+        <%# => <form class="button_to" method="post" action="https://example.com">
+            =>   <button type="submit">External Resource</button>
+            => </form>
+        %>
+
+    *Jacopo Beschi*, *Jacob Herrington*
+
 *   Support `fields model: [@nested, @model]` the same way as `form_with model:
     [@nested, @model]`.
 

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -261,6 +261,8 @@ module ActionView
       # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
       #   be placed
       # * <tt>:params</tt> - \Hash of parameters to be rendered as hidden fields within the form.
+      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form. Override with a custom
+      #   authenticity token or pass false to skip the authenticity token field altogether.
       #
       # ==== Data attributes
       #
@@ -290,6 +292,11 @@ module ActionView
       #   #      <button type="submit">New</button>
       #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"/>
       #   #      <input type="hidden" name="time" value="2021-04-08 14:06:09 -0500">
+      #   #    </form>"
+      #
+      #   <%= button_to "New", "https://example.com", authenticity_token: false %>
+      #   # => "<form class="button_to" method="post" action="https://example.com">
+      #   #      <button type="submit">External Resource</button>
       #   #    </form>"
       #
       #   <%= button_to [:make_happy, @user] do %>
@@ -358,6 +365,9 @@ module ActionView
 
         request_token_tag = if form_method == "post"
           request_method = method.empty? ? "post" : method
+          if remote && authenticity_token.blank?
+            authenticity_token = FormTagHelper.embed_authenticity_token_in_remote_forms
+          end
           token_tag(authenticity_token, form_options: { action: url, method: request_method })
         else
           ""

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -440,6 +440,42 @@ class UrlHelperTest < ActiveSupport::TestCase
     )
   end
 
+  def test_button_to_with_custom_autenticity_token
+    self.request_forgery = true
+
+    assert_dom_equal(
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="form_token" value="custom_secret" autocomplete="off" /></form>},
+      button_to("Hello", "http://www.example.com", authenticity_token: "custom_secret")
+    )
+  ensure
+    self.request_forgery = false
+  end
+
+  def test_button_to_with_no_autenticity_token
+    self.request_forgery = true
+
+    assert_dom_equal(
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button></form>},
+      button_to("Hello", "http://www.example.com", authenticity_token: false)
+    )
+  ensure
+    self.request_forgery = false
+  end
+
+  def test_button_to_remote_fallbacks_to_embed_authenticity_token_in_remote_forms
+    original = ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms
+    ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms = false
+    self.request_forgery = true
+
+    assert_dom_equal(
+      %{<form action="http://www.example.com" class="button_to" method="post" data-remote="true"><button type="submit">Hello</button></form>},
+      button_to("Hello", "http://www.example.com", remote: true)
+    )
+  ensure
+    ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms = original
+    self.request_forgery = false
+  end
+
   def test_link_tag_with_straight_url
     assert_dom_equal %{<a href="http://www.example.com">Hello</a>}, link_to("Hello", "http://www.example.com")
   end


### PR DESCRIPTION
### Summary

Allows developers to pass an `authenticity_token` argument to `button_to` that mimics the behavior in the form generating methods.

For example:

```ruby
<%= button_to "New", "https://example.com", authenticity_token: false %>
<%# => <form class="button_to" method="post" action="https://example.com">
    =>   <button type="submit">External Resource</button>
    => </form>
%>
```

Fixes #41820

Co-authored-by: jacobherrington <jacobherringtondeveloper@gmail.com>

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

This is a rework from https://github.com/rails/rails/pull/41888

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
