### PR TITLE
Add docs for `attr_readonly`

### DIFF
--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -11,6 +11,17 @@ module ActiveRecord
     module ClassMethods
       # Attributes listed as readonly will be used to create a new record but update operations will
       # ignore these fields.
+      #
+      # You can assign a new value to a readonly attribute, but it will be ignored when the record is updated.
+      #
+      # ==== Examples
+      #
+      #   class Post < ActiveRecord::Base
+      #     attr_readonly :title
+      #   end
+      #
+      #   post = Post.create!(title: "Introducing Ruby on Rails!")
+      #   post.update(title: "a different title") # change to title will be ignored
       def attr_readonly(*attributes)
         self._attr_readonly = Set.new(attributes.map(&:to_s)) + (_attr_readonly || [])
       end


### PR DESCRIPTION
From https://github.com/rails/rails/pull/42705#issuecomment-878415276 - explicitly call out that assigning attributes works, but is ignored by saves.

Fixes https://github.com/rails/rails/issues/41520