### PR TITLE
Update service.rb

### DIFF
--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -36,7 +36,7 @@ module ActiveStorage
   #
   #   ActiveStorage::Blob.service = ActiveStorage::Service.configure(
   #     :local,
-  #     { local: {service: Disk,  root: "/tmp/foo/storage" %>}
+  #     { local: {service: "Disk",  root: "/tmp/foo/storage"} }
   #   )
   class Service
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -35,8 +35,8 @@ module ActiveStorage
   # can configure the service to use like this:
   #
   #   ActiveStorage::Blob.service = ActiveStorage::Service.configure(
-  #     :Disk,
-  #     root: Pathname("/foo/bar/storage")
+  #     :local,
+  #     { local: {service: Disk,  root: "/tmp/foo/storage" %>}
   #   )
   class Service
     extend ActiveSupport::Autoload

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -36,7 +36,7 @@ module ActiveStorage
   #
   #   ActiveStorage::Blob.service = ActiveStorage::Service.configure(
   #     :local,
-  #     { local: {service: "Disk",  root: "/tmp/foo/storage"} }
+  #     { local: {service: "Disk",  root: Pathname("/tmp/foo/storage") } }
   #   )
   class Service
     extend ActiveSupport::Autoload


### PR DESCRIPTION
### Summary

The documentation for using the Active Storage from outside of the Ruby on Rails application is not according to the implementation. According to the implementation, we are looking for the name in the configuration which is a hash( same as loading a `storage.yml`)

### Other Information

Only suggesting the change in documentation.
