### PR TITLE
Cancel current postgres query on rollback

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -119,6 +119,8 @@ module ActiveRecord
 
         # Aborts a transaction.
         def exec_rollback_db_transaction # :nodoc:
+          @connection.cancel unless @connection.transaction_status == PG::PQTRANS_IDLE
+          @connection.block
           execute("ROLLBACK", "TRANSACTION")
         end
 


### PR DESCRIPTION
### Summary

If a postgres query is interrupted (Ctrl-C, SIGTERM, etc), the query keeps executing in the database but control flow is returned to ruby. If we were in a transaction, we attempt to rollback the transaction, but since the previous query is still running, the rollback is blocked until the previous query finishes.

Since we're going to rollback anyway, we just cancel the previous query before issuing the rollback. Cancelling when no query is executing is just a no-op.

### Other Information

Related pg gem issue: https://github.com/ged/ruby-pg/issues/390

A bigger question here is whether or not interrupts should just cancel any query in general. Interrupting a transaction after this PR cancels queries but interrupting a bare query would leave the query running and consuming database resources even if the result will just be thrown away.