### PR TITLE
Exclude added flash types from action_methods

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Exclude additional flash types from `ActionController::Base.action_methods`.
+
+    Ensures that additional flash types defined on ActionController::Base subclasses
+    are not listed as actions on that controller.
+
+        class MyController < ApplicationController
+          add_flash_types :hype
+        end
+
+        MyController.action_methods.include?('hype') # => false
+
+    *Gavin Morrice*
+
 *   Deleting an item from the Middleware stack will raise if the item is not found
 
     Previously, calling `config.middleware.delete(ItemNotInMiddleware)` would fail silently.

--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -41,6 +41,10 @@ module ActionController #:nodoc:
           self._flash_types += [type]
         end
       end
+
+      def action_methods #:nodoc:
+        @action_methods ||= super - _flash_types.map(&:to_s).to_set
+      end
     end
 
     private

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -224,6 +224,13 @@ class FlashTest < ActionController::TestCase
     @controller = original_controller
   end
 
+  def test_additional_flash_types_are_not_listed_in_actions_set
+    test_controller_with_flash_type_foo = Class.new(TestController) do
+      add_flash_types :foo
+    end
+    assert_not_includes test_controller_with_flash_type_foo.action_methods, "foo"
+  end
+
   def test_add_flash_type_to_subclasses
     test_controller_with_flash_type_foo = Class.new(TestController) do
       add_flash_types :foo


### PR DESCRIPTION
Exclude additional flash types from action_methods.

Fixes #33593
Copy of stale PR #33594

When new flash types are added to ApplicationController, these
should not appear in the action_methods set, since they're
not actions. This commit corrects this behaviour.

``` ruby
class MyController < ApplicationController
  add_flash_types :hype
end

# Currently:
MyController.action_methods.include?('hype') # => true

# This commit
MyController.action_methods.include?('hype') # => false
```
