### PR TITLE
Disable Active Record partial_inserts by default in Rails 7.0

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,11 +1,27 @@
+*   `partial_inserts` is now disabled by default in new apps.
+
+    This will be the default for new apps in Rails 7. To opt in:
+
+    ```ruby
+    config.active_record.partial_inserts = false
+    ```
+
+    If a migration remove the default value of a column, this option
+    would cause old processes to no longer be able to create new records.
+
+    If you need to remove a column, you should first use `ignored_columns`
+    to stop using it.
+
+    *Jean Boussier*
+
 *   Rails can now verify foreign keys after loading fixtures in tests.
 
     This will be the default for new apps in Rails 7. To opt in:
-    
+
     ```ruby
     config.active_record.verify_foreign_keys_for_fixtures = true
     ```
-    
+
     Tests will not run if there is a foreign key constraint violation in your fixture data.
 
     The feature is supported by SQLite and PostgreSQL, other adapters can also add support for it.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -229,6 +229,7 @@ module Rails
 
           if respond_to?(:active_record)
             active_record.verify_foreign_keys_for_fixtures = true
+            active_record.partial_inserts = false
           end
         else
           raise "Unknown version #{target_version.to_s.inspect}"


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/42355

[The justification for `partial_inserts` back in 2012](https://github.com/rails/rails/commit/144e8691cbfb8bba77f18cfe68d5e7fd48887f5e) was:

> This is more efficient, and also means that it will be safe to remove database columns without getting subsequent errors in running app processes (so long as the code in those processes doesn't contain any references to the removed column).

But since then `ignored_columns` is a much more reliable way to safely remove a column, and I doubt the reduced query size really help much.

Additionally, `partial_inserts` prevent removing the default value of a column in a safe way.

cc @matthieuprat