### PR TITLE
Move forced encoding on deterministic encryption to the default encryptor

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Move the forcing of clear text encoding to the `ActiveRecord::Encryption::Encryptor`.
+
+    Fixes #42699.
+
+    *J Smith*
+
 *   `partial_inserts` is now disabled by default in new apps.
 
     This will be the default for new apps in Rails 7. To opt in:

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -31,8 +31,6 @@ module ActiveRecord
       end
 
       def serialize(value)
-        value = force_encoding_if_needed(value)
-
         if serialize_with_oldest?
           serialize_with_oldest(value)
         else
@@ -51,18 +49,6 @@ module ActiveRecord
       end
 
       private
-        def force_encoding_if_needed(value)
-          if deterministic? && forced_encoding_for_deterministic_encryption && value && value.encoding != forced_encoding_for_deterministic_encryption
-            value.encode(forced_encoding_for_deterministic_encryption, invalid: :replace, undef: :replace)
-          else
-            value
-          end
-        end
-
-        def forced_encoding_for_deterministic_encryption
-          ActiveRecord::Encryption.config.forced_encoding_for_deterministic_encryption
-        end
-
         def previous_schemes_including_clean_text
           previous_schemes.including((clean_text_scheme if support_unencrypted_data?)).compact
         end


### PR DESCRIPTION
### Summary

Moves the forced encoding of clear text to the `ActiveRecord::Encryption::Encryptor` so we can use encryptors that don't necessarily have specific encoding needs. Fixes #42699. 
