### PR TITLE
Speed up template lookups by avoiding splats and ===

### DIFF
--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -122,21 +122,29 @@ module ActionView
       attr_reader :view_paths, :html_fallback_for_js
 
       def find(name, prefixes = [], partial = false, keys = [], options = {})
-        @view_paths.find(*args_for_lookup(name, prefixes, partial, keys, options))
+        name, prefixes = normalize_name(name, prefixes)
+        details, details_key = detail_args_for(options)
+        @view_paths.find(name, prefixes, partial, details, details_key, keys)
       end
       alias :find_template :find
 
       def find_all(name, prefixes = [], partial = false, keys = [], options = {})
-        @view_paths.find_all(*args_for_lookup(name, prefixes, partial, keys, options))
+        name, prefixes = normalize_name(name, prefixes)
+        details, details_key = detail_args_for(options)
+        @view_paths.find_all(name, prefixes, partial, details, details_key, keys)
       end
 
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
-        @view_paths.exists?(*args_for_lookup(name, prefixes, partial, keys, options))
+        name, prefixes = normalize_name(name, prefixes)
+        details, details_key = detail_args_for(options)
+        @view_paths.exists?(name, prefixes, partial, details, details_key, keys)
       end
       alias :template_exists? :exists?
 
       def any?(name, prefixes = [], partial = false)
-        @view_paths.exists?(*args_for_any(name, prefixes, partial))
+        name, prefixes = normalize_name(name, prefixes)
+        details, details_key = detail_args_for_any
+        @view_paths.exists?(name, prefixes, partial, details, details_key, [])
       end
       alias :any_templates? :any?
 
@@ -145,12 +153,6 @@ module ActionView
       # instance objects as we wish.
       def build_view_paths(paths)
         ActionView::PathSet.new(Array(paths))
-      end
-
-      def args_for_lookup(name, prefixes, partial, keys, details_options)
-        name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(details_options)
-        [name, prefixes, partial || false, details, details_key, keys]
       end
 
       # Compute details hash and key according to user options (e.g. passed from #render).
@@ -165,12 +167,6 @@ module ActionView
         end
 
         [user_details, details_key]
-      end
-
-      def args_for_any(name, prefixes, partial)
-        name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for_any
-        [name, prefixes, partial || false, details, details_key]
       end
 
       def detail_args_for_any

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -58,7 +58,7 @@ module ActionView #:nodoc:
 
     private
       def _find_all(path, prefixes, args)
-        prefixes = [prefixes] if String === prefixes
+        prefixes = Array(prefixes)
         prefixes.each do |prefix|
           paths.each do |resolver|
             templates = resolver.find_all(path, prefix, *args)

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -44,28 +44,31 @@ module ActionView #:nodoc:
       METHOD
     end
 
-    def find(*args)
-      find_all(*args).first || raise(MissingTemplate.new(self, *args))
+    def find(path, prefixes, partial, details, details_key, locals)
+      find_all(path, prefixes, partial, details, details_key, locals).first ||
+        raise(MissingTemplate.new(self, path, prefixes, partial, details, details_key, locals))
     end
 
-    def find_all(path, prefixes = [], *args)
-      _find_all path, prefixes, args
+    def find_all(path, prefixes, partial, details, details_key, locals)
+      search_combinations(prefixes) do |resolver, prefix|
+        templates = resolver.find_all(path, prefix, partial, details, details_key, locals)
+        return templates unless templates.empty?
+      end
+      []
     end
 
-    def exists?(path, prefixes, *args)
-      find_all(path, prefixes, *args).any?
+    def exists?(path, prefixes, partial, details, details_key, locals)
+      find_all(path, prefixes, partial, details, details_key, locals).any?
     end
 
     private
-      def _find_all(path, prefixes, args)
+      def search_combinations(prefixes)
         prefixes = Array(prefixes)
         prefixes.each do |prefix|
           paths.each do |resolver|
-            templates = resolver.find_all(path, prefix, *args)
-            return templates unless templates.empty?
+            yield resolver, prefix
           end
         end
-        []
       end
 
       def typecast(paths)

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -221,7 +221,7 @@ class TestMissingTemplate < ActiveSupport::TestCase
   test "if a single prefix is passed as a string and the lookup fails, MissingTemplate accepts it" do
     e = assert_raise ActionView::MissingTemplate do
       details = { handlers: [], formats: [], variants: [], locale: [] }
-      @lookup_context.view_paths.find("foo", "parent", true, details)
+      @lookup_context.view_paths.find("foo", "parent", true, details, nil, [])
     end
     assert_match %r{Missing partial parent/_foo with .*\n\nSearched in:\n  \* "/Path/to/views"\n}, e.message
   end


### PR DESCRIPTION
Method calls involving splats are slower, and this previously did several levels of splats, which was also hard to grok (I'd struggled with this in the past). Though this PR adds a little repetition I think it's a net benefit (I also expect the definitions of `find`/`find_all`/`exists` to become more different in the future).

This also replaces a `===` check with a call to `Array()` which is faster and IMO cleaner.

<details>
<summary><b>Benchmark</b></summary>

``` ruby
require "benchmark/ips"
require "action_view"
require "action_pack"
require "action_controller"

class TestController < ActionController::Base
end

ActionView::Base.logger = nil

TestController.view_paths = [File.expand_path("actionview/test/fixtures")]
controller_view = TestController.new.view_context
LOOKUP_CONTEXT = TestController.new.lookup_context

result = Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.report("find_all found") do
    # Single candidate
    LOOKUP_CONTEXT.find_all("basic", ["test"], false)
  end

  x.report("find_all missing") do
    LOOKUP_CONTEXT.find_all("no_template_here", ["test"], true)
  end

  x.report("exists missing") do
    LOOKUP_CONTEXT.exists?("no_template_here", ["test"], true)
  end

  x.report("find_all many results") do
    LOOKUP_CONTEXT.find_all("hello_world", ["test"], false)
  end
end
```

</details>

**Before**

```
$ be ruby lookup_benchmark.rb
Warming up --------------------------------------
      find_all found    44.100k i/100ms
    find_all missing    45.622k i/100ms
      exists missing    41.121k i/100ms
find_all many results
                        43.849k i/100ms
Calculating -------------------------------------
      find_all found    437.937k (± 0.4%) i/s -      2.205M in   5.035045s
    find_all missing    455.570k (± 0.3%) i/s -      2.281M in   5.007187s
      exists missing    410.674k (± 0.3%) i/s -      2.056M in   5.006581s
find_all many results
                        438.060k (± 0.3%) i/s -      2.192M in   5.004969s
```

**After**

```
$ be ruby lookup_benchmark.rb
Warming up --------------------------------------
      find_all found    47.950k i/100ms
    find_all missing    50.592k i/100ms
      exists missing    50.084k i/100ms
find_all many results
                        48.004k i/100ms
Calculating -------------------------------------
      find_all found    484.917k (± 0.3%) i/s -      2.445M in   5.043091s
    find_all missing    507.769k (± 0.5%) i/s -      2.580M in   5.081569s
      exists missing    502.863k (± 0.6%) i/s -      2.554M in   5.079695s
find_all many results
                        483.612k (± 0.6%) i/s -      2.448M in   5.062523s
```
