### PR TITLE
Show keyboard focus indicator in guides [ci-skip]

### DIFF
--- a/guides/assets/stylesheets/reset.css
+++ b/guides/assets/stylesheets/reset.css
@@ -15,7 +15,6 @@ table, caption, tbody, tfoot, thead, tr, th, td {
   margin: 0;
   padding: 0;
   border: 0;
-  outline: 0;
   font-size: 100%;
   background: transparent;
 }
@@ -24,12 +23,6 @@ body {line-height: 1; color: black; background: white;}
 a img {border:none;}
 ins {text-decoration: none;}
 del {text-decoration: line-through;}
-
-:focus {
-  -moz-outline:0;
-  outline:0;
-  outline-offset:0;
-}
 
 /* tables still need 'cellspacing="0"' in the markup */
 table {border-collapse: collapse; border-spacing: 0;}


### PR DESCRIPTION
### Summary

Restore the default browser focus indicator to improve the accessibility of the guides for users who rely on a keyboard for navigation.

Currently if you press tab while browsing any of the guides there is no visual indication of which element has focus.

Steps to reproduce:

1. View any guide page in your browser e.g. https://guides.rubyonrails.org/index.html
2. Press the tab key

Before the patch:

![image](https://user-images.githubusercontent.com/65072/125584135-b8e96f7d-560d-40f0-b205-160cb204821e.png)

After the patch:

Chrome 91 on Windows 10
![image](https://user-images.githubusercontent.com/65072/125584744-f8b48b02-de96-4dec-8575-3d86ef710d8c.png)

Firefox 90 on Windows 10
![image](https://user-images.githubusercontent.com/65072/125586600-ff81e33b-1e7f-415a-8807-90856679d302.png)

### Other Information
For more information see:
[Understanding Success Criterion 2.4.7: Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) in the [Web Content Accessibility Guidelines](https://www.w3.org/TR/WCAG21/) (WCAG) 2.1.
