### PR TITLE
[ActiveRecord] Accept pool_class option

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/pool_config.rb
+++ b/activerecord/lib/active_record/connection_adapters/pool_config.rb
@@ -51,7 +51,16 @@ module ActiveRecord
       def pool
         ActiveSupport::ForkTracker.check!
 
-        @pool || synchronize { @pool ||= ConnectionAdapters::ConnectionPool.new(self) }
+        @pool || synchronize { @pool ||= pool_class.new(self) }
+      end
+
+      def pool_class
+        klass = db_config.configuration_hash.fetch(:pool_class, ConnectionAdapters::ConnectionPool)
+        if klass.is_a?(String)
+          klass.constantize
+        else
+          klass
+        end
       end
 
       def discard_pool!

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -739,6 +739,36 @@ module ActiveRecord
         assert_not_nil found_conn
       end
 
+      class DummyPool
+        def initialize(pool_config)
+        end
+
+        DUMMY_CONN = Object.new
+
+        def checkout
+          DUMMY_CONN
+        end
+      end
+
+      def test_pool_klass
+        config = @db_config.configuration_hash.merge(pool_class: DummyPool)
+        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
+        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config)
+
+        pool = pool_config.pool
+        assert_instance_of DummyPool, pool
+        assert_equal DummyPool::DUMMY_CONN, pool.checkout
+      end
+
+      def test_pool_klass_name
+        config = @db_config.configuration_hash.merge(pool_class: DummyPool.name)
+        db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(@db_config.env_name, @db_config.name, config)
+        pool_config = ActiveRecord::ConnectionAdapters::PoolConfig.new(ActiveRecord::Base, db_config)
+
+        pool = pool_config.pool
+        assert_instance_of DummyPool, pool
+      end
+
       private
         def with_single_connection_pool
           config = @db_config.configuration_hash.merge(pool: 1)


### PR DESCRIPTION
Context: https://github.com/rails/rails/issues/42271

There's lots of exciting work going in Ruby 3.0 with fibers, non-blocking IO and support for custom schedulers. Eventually we'd like to run Rails apps with ActiveRecord in non-blocking servers like Falcon. Those servers would require the code **not** to rely on thread-local variables, which ActiveRecord connection pool does right now.

This PR is an attempt to allow AR to take `pool_class` as an option to DB configuration. It will allow @ioquatix and the async ruby team to implement a fiber-local connection pool, and to run ActiveRecord on non-blocking servers.

https://github.com/rails/rails/compare/main...kirs:async-rb is a quick and dirty example how a custom connection pool implementation might look like.