### PR TITLE
Used already defined method parallelized? and fixed semantics of test name.

### DIFF
--- a/activesupport/lib/active_support/testing/parallelize_executor.rb
+++ b/activesupport/lib/active_support/testing/parallelize_executor.rb
@@ -61,7 +61,7 @@ module ActiveSupport
         end
 
         def execution_info
-          if should_parallelize?
+          if parallelized?
             "Running #{tests_count} tests in parallel using #{parallel_executor.size} #{parallelize_with}"
           else
             "Running #{tests_count} tests in a single process (parallelization threshold is #{ActiveSupport.test_parallelization_minimum_number_of_tests})"

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -571,7 +571,7 @@ module ApplicationTests
       assert_no_match "create_table(:users)", output
     end
 
-    def test_avoid_paralleling_when_number_of_tests_if_below_threshold
+    def test_avoid_parallelizing_when_number_of_tests_is_below_threshold
       exercise_parallelization_regardless_of_machine_core_count(with: :processes, threshold: 100)
 
       file_name = create_parallel_processes_test_file


### PR DESCRIPTION
### Summary

- Related to https://github.com/rails/rails/pull/42761
- Used `parallelized?` method instead of calling a method `should_parallelize?` to figure out if parallezation is enabled.
- Fixed semantics of the test name corresponding to the change


