### PR TITLE
Fix bug with TypeMap default values

### DIFF
--- a/activerecord/lib/active_record/type/type_map.rb
+++ b/activerecord/lib/active_record/type/type_map.rb
@@ -40,7 +40,7 @@ module ActiveRecord
       end
 
       protected
-        def perform_fetch(lookup_key)
+        def perform_fetch(lookup_key, &block)
           matching_pair = @mapping.reverse_each.detect do |key, _|
             key === lookup_key
           end
@@ -48,7 +48,7 @@ module ActiveRecord
           if matching_pair
             matching_pair.last.call(lookup_key)
           elsif @parent
-            @parent.perform_fetch(lookup_key)
+            @parent.perform_fetch(lookup_key, &block)
           else
             yield lookup_key
           end

--- a/activerecord/test/cases/type/type_map_test.rb
+++ b/activerecord/test/cases/type/type_map_test.rb
@@ -143,6 +143,13 @@ module ActiveRecord
         assert_equal boolean, mapping.lookup("boolean")
       end
 
+      def test_parent_fallback_for_default_type
+        parent = klass.new
+        mapping = klass.new(parent)
+
+        assert_kind_of Value, mapping.lookup(:undefined)
+      end
+
       private
         def klass
           TypeMap


### PR DESCRIPTION
https://github.com/rails/rails/pull/42773 introduced a regression where looking up an unregistered type on a TypeMap with a parent (e.g. [mysql2 TYPE_MAP_WITH_BOOLEAN](https://github.com/rails/rails/blob/88ec15b850790a06bd8dcfe59ca05d865f458c7c/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L618)) would cause a `LocalJumpError`

This commit fixes the error by forwarding the default block when fetching from the parent TypeMap.
