### PR TITLE
Add an option to configure parallelization threshold at the test case level

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,13 +1,23 @@
-*   Parallelize tests only when overhead is justified by the number of them
+*   Faster tests by parallelizing only when overhead is justified by the number
+    of them.
 
     Running tests in parallel adds overhead in terms of database
     setup and fixture loading. Now, Rails will only parallelize test executions when
     there are enough tests to make it worth it.
 
-    This threshold is 50 by default, and is configurable via:
+    This threshold is 50 by default, and is configurable via config setting in
+    your test.rb:
 
     ```ruby
-    config.active_support.test_parallelization_minimum_number_of_tests = 100
+    config.active_support.test_parallelization_threshold = 100
+    ```
+
+    It's also configurable at the test case level:
+
+    ```ruby
+    class ActiveSupport::TestCase
+        parallelize threshold: 100
+    end
     ```
 
     *Jorge Manrubia*

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -88,7 +88,7 @@ module ActiveSupport
 
   cattr_accessor :test_order # :nodoc:
   cattr_accessor :test_parallelization_disabled, default: false # :nodoc:
-  cattr_accessor :test_parallelization_minimum_number_of_tests, default: 50 # :nodoc:
+  cattr_accessor :test_parallelization_threshold, default: 50 # :nodoc:
 
   def self.disable_test_parallelization!
     self.test_parallelization_disabled = true unless ENV["PARALLEL_WORKERS"]

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -72,13 +72,17 @@ module ActiveSupport
       #
       # The threaded parallelization uses minitest's parallel executor directly.
       # The processes parallelization uses a Ruby DRb server.
-      def parallelize(workers: :number_of_processors, with: :processes)
+      #
+      # Because parallelization presents an overhead, it is only enabled when the
+      # number of tests to run is above the +threshold+ param. The default value is
+      # 50, and it's configurable via +config.active_support.test_parallelization_threshold+.
+      def parallelize(workers: :number_of_processors, with: :processes, threshold: ActiveSupport.test_parallelization_threshold)
         workers = Concurrent.physical_processor_count if workers == :number_of_processors
         workers = ENV["PARALLEL_WORKERS"].to_i if ENV["PARALLEL_WORKERS"]
 
         return if workers <= 1 || ActiveSupport.test_parallelization_disabled
 
-        Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with)
+        Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
       end
 
       # Set up hook for parallel testing. This can be used if you have multiple

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -573,10 +573,20 @@ create as changes are not automatically rolled back after the test completes.
 
 Running tests in parallel adds an overhead in terms of database setup and
 fixture loading. Because of this, Rails won't parallelize executions that involve
-fewer than 50 tests. You can configure this threshold in your `test.rb`:
+fewer than 50 tests.
+
+You can configure this threshold in your `test.rb`:
 
 ```ruby
-config.active_support.test_parallelization_minimum_number_of_tests = 100
+config.active_support.test_parallelization_threshold = 100
+```
+
+And also when setting up parallelization at the test case level:
+
+```ruby
+class ActiveSupport::TestCase
+  parallelize threshold: 100
+end
 ```
 
 The Test Database

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2421,18 +2421,18 @@ module ApplicationTests
       assert_equal OpenSSL::Digest::SHA256, ActiveSupport::KeyGenerator.hash_digest_class
     end
 
-    test "ActiveSupport.test_parallelization_minimum_number_of_tests can be configured via config.active_support.test_parallelization_minimum_number_of_tests" do
+    test "ActiveSupport.test_parallelization_threshold can be configured via config.active_support.test_parallelization_threshold" do
       remove_from_config '.*config\.load_defaults.*\n'
 
       app_file "config/environments/test.rb", <<-RUBY
         Rails.application.configure do
-          config.active_support.test_parallelization_minimum_number_of_tests = 1234
+          config.active_support.test_parallelization_threshold = 1234
         end
       RUBY
 
       app "test"
 
-      assert_equal 1234, ActiveSupport.test_parallelization_minimum_number_of_tests
+      assert_equal 1234, ActiveSupport.test_parallelization_threshold
     end
 
     test "custom serializers should be able to set via config.active_job.custom_serializers in an initializer" do

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -1166,8 +1166,6 @@ module ApplicationTests
           require_relative "../config/environment"
           require "rails/test_help"
 
-          ActiveSupport.test_parallelization_minimum_number_of_tests = #{threshold}
-
           class ActiveSupport::TestCase
             <%- if force -%>
             # Force parallelization, even with single files
@@ -1175,7 +1173,7 @@ module ApplicationTests
             <%- end -%>
 
             # Run tests in parallel with specified workers
-            parallelize(workers: 2, with: :<%= with %>)
+            parallelize(workers: 2, with: :<%= with %>, threshold: #{threshold})
 
             # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
             fixtures :all


### PR DESCRIPTION
This adds an additional method to configure the parallelization threshold added in #42761 .

```ruby
class ActiveSupport::TestCase
  parallelize threshold: 100
end
```

Before this, the only way of configuring the threshold was via a config setting in `test.rb`:

```
config.active_support.test_parallelization_minimum_number_of_tests = 100
```

This also renames the config setting `test_parallelization_minimum_number_of_tests` -> `test_parallelization_threshold`, which is more consistent with the naming in other places and IMO a better name. It's a breaking change but, given this feature was just merged today, I hope that's ok. I can create aliases if not.

CC @dhh who suggested the idea, @eileencodes