### PR TITLE
Deprecate `poltergeist` and `webkit` driver registration. Add `cuprite`.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Remove logic of `poltergeist` and `webkit` (capybara-webkit) driver registration for system testing. Add `cuprite` instead.
+
+    [Poltergeist](https://github.com/teampoltergeist/poltergeist) and [capybara-webkit](https://github.com/thoughtbot/capybara-webkit) are already not maintained. These usage in Rails are removed for avoiding confusing users.
+
+    [Cuprite](https://github.com/rubycdp/cuprite) is a good alternative to Poltergeist. Some guide descriptions are replaced from Poltergeist to Cuprite.
+
+    *Yusuke Iwaki*
+
 *   Add `Middleware#remove` to delete middleware or raise if not found.
 
     `Middleware#remove` works just like `Middleware#delete` but will

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Remove logic of `poltergeist` and `webkit` (capybara-webkit) driver registration for system testing. Add `cuprite` instead.
+*   Deprecate `poltergeist` and `webkit` (capybara-webkit) driver registration for system testing (they will be removed in Rails 7.1). Add `cuprite` instead.
 
     [Poltergeist](https://github.com/teampoltergeist/poltergeist) and [capybara-webkit](https://github.com/thoughtbot/capybara-webkit) are already not maintained. These usage in Rails are removed for avoiding confusing users.
 

--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -72,8 +72,8 @@ module ActionDispatch
   # Headless browsers such as headless Chrome and headless Firefox are also supported.
   # You can use these browsers by setting the +:using+ argument to +:headless_chrome+ or +:headless_firefox+.
   #
-  # To use a headless driver, like Poltergeist, update your Gemfile to use
-  # Poltergeist instead of Selenium and then declare the driver name in the
+  # To use a headless driver, like Cuprite, update your Gemfile to use
+  # Cuprite instead of Selenium and then declare the driver name in the
   # +application_system_test_case.rb+ file. In this case, you would leave out
   # the +:using+ option because the driver is headless, but you can still use
   # +:screen_size+ to change the size of the browser screen, also you can use
@@ -81,10 +81,10 @@ module ActionDispatch
   # driver documentation to learn about supported options.
   #
   #   require "test_helper"
-  #   require "capybara/poltergeist"
+  #   require "capybara/cuprite"
   #
   #   class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  #     driven_by :poltergeist, screen_size: [1400, 1400], options:
+  #     driven_by :cuprite, screen_size: [1400, 1400], options:
   #       { js_errors: true }
   #   end
   #
@@ -140,7 +140,7 @@ module ActionDispatch
     #
     # Examples:
     #
-    #   driven_by :poltergeist
+    #   driven_by :cuprite
     #
     #   driven_by :selenium, screen_size: [800, 800]
     #

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -9,6 +9,14 @@ module ActionDispatch
         @options = options[:options] || {}
         @capabilities = capabilities
 
+        if [:poltergeist, :webkit].include?(name)
+          ActiveSupport::Deprecation.warn <<~MSG.squish
+            Poltergeist and capybara-webkit are not maintained already.
+            Driver registration of :poltergeist or :webkit is deprecated and will be removed in Rails 7.1.
+            You can still use :selenium, and also :cuprite is available for alternative to Poltergeist.
+          MSG
+        end
+
         if name == :selenium
           require "selenium/webdriver"
           @browser = Browser.new(options[:using])
@@ -26,7 +34,7 @@ module ActionDispatch
 
       private
         def registerable?
-          [:selenium, :cuprite, :rack_test].include?(@name)
+          [:selenium, :poltergeist, :webkit, :cuprite, :rack_test].include?(@name)
         end
 
         def register
@@ -35,6 +43,8 @@ module ActionDispatch
           Capybara.register_driver @name do |app|
             case @name
             when :selenium then register_selenium(app)
+            when :poltergeist then register_poltergeist(app)
+            when :webkit then register_webkit(app)
             when :cuprite then register_cuprite(app)
             when :rack_test then register_rack_test(app)
             end
@@ -48,6 +58,16 @@ module ActionDispatch
         def register_selenium(app)
           Capybara::Selenium::Driver.new(app, browser: @browser.type, **browser_options).tap do |driver|
             driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(*@screen_size)
+          end
+        end
+
+        def register_poltergeist(app)
+          Capybara::Poltergeist::Driver.new(app, @options.merge(window_size: @screen_size))
+        end
+
+        def register_webkit(app)
+          Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
+            driver.resize_window_to(driver.current_window_handle, *@screen_size)
           end
         end
 

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -26,7 +26,7 @@ module ActionDispatch
 
       private
         def registerable?
-          [:selenium, :poltergeist, :webkit, :rack_test].include?(@name)
+          [:selenium, :cuprite, :rack_test].include?(@name)
         end
 
         def register
@@ -35,8 +35,7 @@ module ActionDispatch
           Capybara.register_driver @name do |app|
             case @name
             when :selenium then register_selenium(app)
-            when :poltergeist then register_poltergeist(app)
-            when :webkit then register_webkit(app)
+            when :cuprite then register_cuprite(app)
             when :rack_test then register_rack_test(app)
             end
           end
@@ -52,14 +51,8 @@ module ActionDispatch
           end
         end
 
-        def register_poltergeist(app)
-          Capybara::Poltergeist::Driver.new(app, @options.merge(window_size: @screen_size))
-        end
-
-        def register_webkit(app)
-          Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash.merge(@options)).tap do |driver|
-            driver.resize_window_to(driver.current_window_handle, *@screen_size)
-          end
+        def register_cuprite(app)
+          Capybara::Cuprite::Driver.new(app, @options.merge(window_size: @screen_size))
         end
 
         def register_rack_test(app)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -37,6 +37,24 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
+  test "initializing the driver with a poltergeist" do
+    driver = assert_deprecated do
+      ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
+    end
+    assert_equal :poltergeist, driver.instance_variable_get(:@name)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ js_errors: false }), driver.instance_variable_get(:@options)
+  end
+
+  test "initializing the driver with a webkit" do
+    driver = assert_deprecated do
+      ActionDispatch::SystemTesting::Driver.new(:webkit, screen_size: [1400, 1400], options: { skip_image_loading: true })
+    end
+    assert_equal :webkit, driver.instance_variable_get(:@name)
+    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
+    assert_equal ({ skip_image_loading: true }), driver.instance_variable_get(:@options)
+  end
+
   test "initializing the driver with a cuprite" do
     driver = ActionDispatch::SystemTesting::Driver.new(:cuprite, screen_size: [1400, 1400], options: { js_errors: false })
     assert_equal :cuprite, driver.instance_variable_get(:@name)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -37,18 +37,11 @@ class DriverTest < ActiveSupport::TestCase
     assert_equal ({ url: "http://example.com/wd/hub" }), driver.instance_variable_get(:@options)
   end
 
-  test "initializing the driver with a poltergeist" do
-    driver = ActionDispatch::SystemTesting::Driver.new(:poltergeist, screen_size: [1400, 1400], options: { js_errors: false })
-    assert_equal :poltergeist, driver.instance_variable_get(:@name)
+  test "initializing the driver with a cuprite" do
+    driver = ActionDispatch::SystemTesting::Driver.new(:cuprite, screen_size: [1400, 1400], options: { js_errors: false })
+    assert_equal :cuprite, driver.instance_variable_get(:@name)
     assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
     assert_equal ({ js_errors: false }), driver.instance_variable_get(:@options)
-  end
-
-  test "initializing the driver with a webkit" do
-    driver = ActionDispatch::SystemTesting::Driver.new(:webkit, screen_size: [1400, 1400], options: { skip_image_loading: true })
-    assert_equal :webkit, driver.instance_variable_get(:@name)
-    assert_equal [1400, 1400], driver.instance_variable_get(:@screen_size)
-    assert_equal ({ skip_image_loading: true }), driver.instance_variable_get(:@options)
   end
 
   test "define extra capabilities using chrome" do
@@ -153,6 +146,6 @@ class DriverTest < ActiveSupport::TestCase
     assert ActionDispatch::SystemTesting::Driver.new(:selenium).instance_variable_get(:@browser)
 
     assert_nil ActionDispatch::SystemTesting::Driver.new(:rack_test).instance_variable_get(:@browser)
-    assert_nil ActionDispatch::SystemTesting::Driver.new(:poltergeist).instance_variable_get(:@browser)
+    assert_nil ActionDispatch::SystemTesting::Driver.new(:cuprite).instance_variable_get(:@browser)
   end
 end

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -825,15 +825,15 @@ system tests should live.
 
 If you want to change the default settings you can change what the system
 tests are "driven by". Say you want to change the driver from Selenium to
-Poltergeist. First add the `poltergeist` gem to your `Gemfile`. Then in your
+Cuprite. First add the `cuprite` gem to your `Gemfile`. Then in your
 `application_system_test_case.rb` file do the following:
 
 ```ruby
 require "test_helper"
-require "capybara/poltergeist"
+require "capybara/cuprite"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :poltergeist
+  driven_by :cuprite
 end
 ```
 


### PR DESCRIPTION
### Summary

Poltergeist and capybara-webkit are already not maintained.

* https://github.com/teampoltergeist/poltergeist
* https://github.com/thoughtbot/capybara-webkit

I just happend to find the usages of them here: https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/system_testing/driver.rb

Most users actually use Selenium with Headless Chrome in these years, and it is not encouraged to use poltergeist or capybara-webkit at this moment.

Cuprite is a good alternative driver to Poltergeist: https://evilmartians.com/chronicles/system-of-a-test-setting-up-end-to-end-rails-testing
Some guide descriptions of Poltergeist would be better to replace into Cuprite.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
