### PR TITLE
Call rescue_from_handler when channels are implicitly unsubscribed

### DIFF
--- a/actioncable/lib/action_cable/connection/base.rb
+++ b/actioncable/lib/action_cable/connection/base.rb
@@ -185,7 +185,11 @@ module ActionCable
 
           server.remove_connection(self)
 
-          subscriptions.unsubscribe_from_all
+          begin
+            subscriptions.unsubscribe_from_all
+          rescue Exception => e
+            rescue_with_handler(e) || raise
+          end
           unsubscribe_from_internal_channel
 
           disconnect if respond_to?(:disconnect)


### PR DESCRIPTION
### Summary

When you explicitly unsubscribe from a channel and an error is raised in the `unsubscribed` command, Action Cable ensures it behaves like a rescuable.

https://github.com/rails/rails/blob/a3f9568cb60298573e36cc2fb2cf4716372a2017/actioncable/lib/action_cable/connection/subscriptions.rb#L15-L26

On the other hand, when the `unsubscribed` is implicitly called on the socket close, it doesn't handle exceptions.

https://github.com/rails/rails/blob/a3f9568cb60298573e36cc2fb2cf4716372a2017/actioncable/lib/action_cable/connection/base.rb#L183-L192

In both cases, Action Cable should ensure the `rescue_from` handlers are called, I guess.
I focused on this problem.

Ref: https://guides.rubyonrails.org/action_cable_overview.html#server-side-components-connections-exception-handling

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
