### PR TITLE
Remove "transversal" from the Active Support definition

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -3,7 +3,8 @@
 Active Support Core Extensions
 ==============================
 
-Active Support is the Ruby on Rails component responsible for providing Ruby language extensions, utilities, and other transversal stuff.
+Active Support is the Ruby on Rails component responsible for providing Ruby
+language extensions and utilities.
 
 It offers a richer bottom-line at the language level, targeted both at the development of Rails applications, and at the development of Ruby on Rails itself.
 

--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -119,9 +119,9 @@
       name: Active Support Core Extensions
       url: active_support_core_extensions.html
       description: >
-        Active Support provides Ruby language extensions, utilities, and other
-        transversal stuff. It enriches the Ruby language for the development of
-        Rails applications, and for the development of Ruby on Rails itself.
+        Active Support provides Ruby language extensions and utilities.
+        It enriches the Ruby language for the development of Rails
+        applications, and for the development of Ruby on Rails itself.
     -
       name: Action Mailer Basics
       url: action_mailer_basics.html


### PR DESCRIPTION
### Summary

In the guides Active Support is defined as providing "transversal stuff".
This is not a commonly used term and might intimidate beginners.
