### PR TITLE
Fix text contrast for guide header and footer [ci-skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -185,11 +185,16 @@ body {
   }
   .more-info:after {
     content: " |";
+    color: #8a8a8a;
   }
 
   .more-info:last-child:after {
     content: "";
   }
+
+  #topNav a, #footer a {
+    color: #F1938C;
+  }  
 }
 
 @media screen and (max-width: 1024px) {


### PR DESCRIPTION
### Summary
Links in the header and footer of the guides currently have a
contrast ratio of 4.1:1 which is below the 4.5:1 ratio required
to pass the minimum Web Content Accessibility Guidelines (WCAG) 2.1
standard.

[WCAG 2.1 Understanding Success Criterion 1.4.3: Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)

Red text on a dark grey background (#22222) is generally considered
hard to read so the links were changed to the pink color from the
Rails Guides logo. Using pink avoids adding yet another shade of red
to the guideline color palette and as an added bonus has a contrast
ratio of 7.04:1 which meets the 7:1 ratio of the enhanced contrast
success criterion.

[Understanding Success Criterion 1.4.6: Contrast (Enhanced)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced)

### Other Information

Before:
![image](https://user-images.githubusercontent.com/65072/125912795-6f1a1943-6d59-469e-b80f-7e897c992ed9.png)

After:
![image](https://user-images.githubusercontent.com/65072/125912903-95370a35-8b38-4a3e-833a-b5e1f043a7c1.png)

Alternate implementation using #F05151 for the link color which has a contrast ratio of 4.54:1
![image](https://user-images.githubusercontent.com/65072/125914536-49d212ae-52d3-473f-a48d-5f5a9051bc68.png)




