### PR TITLE
Fix contrast ratio for guide syntax highlighting [ci-skip]

### DIFF
--- a/guides/assets/stylesheets/highlight.css
+++ b/guides/assets/stylesheets/highlight.css
@@ -1,24 +1,24 @@
 .highlight table td { padding: 5px; }
 .highlight table pre { margin: 0; }
 .highlight .cm {
-  color: #999988;
+  color: #6c6c65;
   font-style: italic;
 }
 .highlight .cp {
-  color: #999999;
+  color: #6c6c6c;
   font-weight: bold;
 }
 .highlight .c1 {
-  color: #999988;
+  color: #6c6c65;
   font-style: italic;
 }
 .highlight .cs {
-  color: #999999;
+  color: #6c6c6c;
   font-weight: bold;
   font-style: italic;
 }
 .highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
-  color: #999988;
+  color: #6c6c65;
   font-style: italic;
 }
 .highlight .err {
@@ -37,14 +37,14 @@
   color: #aa0000;
 }
 .highlight .gh {
-  color: #999999;
+  color: #6c6c6c;
 }
 .highlight .gi {
   color: #000000;
   background-color: #ddffdd;
 }
 .highlight .go {
-  color: #888888;
+  color: #6c6c6c;
 }
 .highlight .gp {
   color: #555555;
@@ -53,7 +53,7 @@
   font-weight: bold;
 }
 .highlight .gu {
-  color: #aaaaaa;
+  color: #6c6c6c;
 }
 .highlight .gt {
   color: #aa0000;
@@ -83,77 +83,77 @@
   font-weight: bold;
 }
 .highlight .k, .highlight .kv {
-  color: #07a;
+  color: #0073a6;
 }
 .highlight .mf {
-  color: #009999;
+  color: #007979;
 }
 .highlight .mh {
-  color: #009999;
+  color: #007979;
 }
 .highlight .il {
-  color: #009999;
+  color: #007979;
 }
 .highlight .mi {
-  color: #009999;
+  color: #007979;
 }
 .highlight .mo {
-  color: #009999;
+  color: #007979;
 }
 .highlight .m, .highlight .mb, .highlight .mx {
-  color: #009999;
+  color: #007979;
 }
 .highlight .sb {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .sc {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .sd {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .s2 {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .se {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .sh {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .si {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .sx {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .sr {
-  color: #009926;
+  color: #007e26;
 }
 .highlight .s1 {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .ss {
   color: #990073;
 }
 .highlight .s, .highlight .sa, .highlight .dl {
-  color: #d14;
+  color: #d51144;
 }
 .highlight .na {
-  color: #008080;
+  color: #007979;
 }
 .highlight .bp {
-  color: #999999;
+  color: #6c6c6c;
 }
 .highlight .nb {
-  color: #0086B3;
+  color: #0074a1;
 }
 .highlight .nc {
   color: #445588;
   font-weight: bold;
 }
 .highlight .no {
-  color: #008080;
+  color: #007979;
 }
 .highlight .nd {
   color: #3c5d5d;
@@ -181,16 +181,16 @@
   color: #000080;
 }
 .highlight .vc {
-  color: #008080;
+  color: #007979;
 }
 .highlight .vg {
-  color: #008080;
+  color: #007979;
 }
 .highlight .vi {
   color: #005cc5;
 }
 .highlight .nv, .highlight .vm {
-  color: #008080;
+  color: #007979;
 }
 .highlight .ow {
   color: #000000;
@@ -201,7 +201,7 @@
   font-weight: bold;
 }
 .highlight .w {
-  color: #bbbbbb;
+  color: #6c6c6c;
 }
 .highlight {
   background-color: transparent;


### PR DESCRIPTION
### Summary
The theme used for syntax highlighting has a number of colors that
do not meet the 4.5:1 minimum contrast ratio of the Web Content
Accessibility Guidelines (WCAG) 2.1 standard.

All colors that were below 4.5:1 on a background of #eeeeee have
been adjusted to be at or slightly above 4.5:1 using tweaked
versions of the tools in this repository:

https://github.com/mpchadwick/pygments-high-contrast-stylesheets/

### Other Information

This patch does not address contrast ratio issues with the dark mode theme.

Most of the changes are fairly subtle and how much difference you see will depend on many different factors: display type (retina/non-retina), fonts installed, browser, lighting, etc.

Some of the more noticeable differences (for me) are:

Output of commands:
![image](https://user-images.githubusercontent.com/65072/125922115-881353c5-ee9e-47e4-bad3-e46883aacb02.png)

Comments:
![image](https://user-images.githubusercontent.com/65072/125922942-9297e9ba-0b39-4f85-bdb1-fb0eab56686c.png)

Full list of old/new contrast ratios and colors
![wsl%24_Ubuntu-20 04_home_lloydk_work_pygments-high-contrast-stylesheets_tools_preview html (1)](https://user-images.githubusercontent.com/65072/125923489-030662b1-039a-4641-a8bb-19c0b1b73825.png)


