### PR TITLE
db:migrate:status: Sort migration ID as integer for consistency.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1177,7 +1177,7 @@ module ActiveRecord
         ["up", version, "********** NO FILE **********"]
       end
 
-      (db_list + file_list).sort_by { |_, version, _| version }
+      (db_list + file_list).sort_by { |_, version, _| version.to_i }
     end
 
     def current_environment # :nodoc:

--- a/activerecord/test/migrations/old_and_new_versions/20210716122844_add_people_description.rb
+++ b/activerecord/test/migrations/old_and_new_versions/20210716122844_add_people_description.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AddPeopleDescription < ActiveRecord::Migration::Current
+  add_column :people, :description, :string
+end

--- a/activerecord/test/migrations/old_and_new_versions/20210716123013_add_people_number_of_legs.rb
+++ b/activerecord/test/migrations/old_and_new_versions/20210716123013_add_people_number_of_legs.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AddPeopleNumberOfLegs < ActiveRecord::Migration::Current
+  add_column :people, :number_of_legs, :integer
+end

--- a/activerecord/test/migrations/old_and_new_versions/230_add_people_hobby.rb
+++ b/activerecord/test/migrations/old_and_new_versions/230_add_people_hobby.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AddPeopleHobby < ActiveRecord::Migration::Current
+  add_column :people, :hobby, :string
+end

--- a/activerecord/test/migrations/old_and_new_versions/231_add_people_last_name.rb
+++ b/activerecord/test/migrations/old_and_new_versions/231_add_people_last_name.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AddPeopleLastName < ActiveRecord::Migration::Current
+  add_column :people, :last_name, :string
+end


### PR DESCRIPTION
### Summary

Fix bug where `rake db:migrate:status` shows migrations in an order inconsistent compared to how they are actually applied in by Rails internally. Normally Rails sorts migrations by their numeric ID, but the code that is used in `db:migrate:status` sorts the string version of the migration ID. This PR fixes that behavior.

#### Current behavior:

```sh
...
   up     20210622175330  recent migration
   up     20210713121403  latest
   up     226             oldest migration
   up     227             second migration
...
```

#### After this PR:

```sh
   up     226             oldest migration
   up     227             second migration
...
   up     589             middle migration 1
   up     590             middle migration 2
   up     20180726163653  middle migration 3
   up     20180731202404  middle migration 4
...
   up     20210622175330  recent migration
   up     20210713121403  latest migration
```

### Other Information

I have a very old Rails project that is currently on 6 but started in 2 or 3; so we have a lot of migrations that are from the time when they were numbered as 3-digit IDs rather than timestamps. We also have these migrations running on many customer systems so we cannot adjust the old IDs or squash them. I noticed that when running `rake db:migrate:status`, the ordering of the migrations was wrong compared to how Rails applies them to a fresh DB. This seems like a bug.
