### PR TITLE
Add option to disable schema dump per-database

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add option to disable schema dumb per-database
+
+    Dumping the schema is on by default for all databases in an application. To turn it off for a
+    specific database use the `schema_dump` option:
+
+    ```yaml
+    # config/database.yml
+
+    production:
+      schema_dump: false
+    ```
+
+    *Luis Vasconcellos*, *Eileen M. Uchitelle*
+
 *   Fix `eager_loading?` when ordering with `Hash` syntax
 
     `eager_loading?` is triggered correctly when using `order` with hash syntax

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -26,6 +26,7 @@ module ActiveRecord
     #   connections.
     class HashConfig < DatabaseConfig
       attr_reader :configuration_hash
+
       def initialize(env_name, name, configuration_hash)
         super(env_name, name)
         @configuration_hash = configuration_hash.symbolize_keys.freeze
@@ -102,6 +103,11 @@ module ActiveRecord
       # default will be derived.
       def schema_cache_path
         configuration_hash[:schema_cache_path]
+      end
+
+      # Determines whether to dump the schema for a database.
+      def schema_dump
+        configuration_hash.fetch(:schema_dump, true)
       end
     end
   end

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -121,9 +121,13 @@ db_namespace = namespace :db do
     ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
       # IMPORTANT: This task won't dump the schema if ActiveRecord.dump_schema_after_migration is set to false
       task name do
-        if ActiveRecord.dump_schema_after_migration
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
+
+        if ActiveRecord.dump_schema_after_migration && db_config.schema_dump
+          ActiveRecord::Base.establish_connection(db_config)
           db_namespace["schema:dump:#{name}"].invoke
         end
+
         # Allow this task to be called as many times as required. An example is the
         # migrate:redo task, which calls other two internally that depend on this one.
         db_namespace["_dump:#{name}"].reenable
@@ -433,8 +437,10 @@ db_namespace = namespace :db do
     desc "Creates a database schema file (either db/schema.rb or db/structure.sql, depending on `config.active_record.schema_format`)"
     task dump: :load_config do
       ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env).each do |db_config|
-        ActiveRecord::Base.establish_connection(db_config)
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+        if db_config.schema_dump
+          ActiveRecord::Base.establish_connection(db_config)
+          ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config)
+        end
       end
 
       db_namespace["schema:dump"].reenable

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -102,6 +102,26 @@ module ActiveRecord
         config = HashConfig.new("default_env", "primary", idle_timeout: "0")
         assert_nil config.idle_timeout
       end
+
+      def test_default_schema_dump_value
+        config = HashConfig.new("default_env", "primary", {})
+        assert_equal true, config.schema_dump
+      end
+
+      def test_schema_dump_value_set_to_true
+        config = HashConfig.new("default_env", "primary", { schema_dump: true })
+        assert_equal true, config.schema_dump
+      end
+
+      def test_schema_dump_value_set_to_nil
+        config = HashConfig.new("default_env", "primary", { schema_dump: nil })
+        assert_nil config.schema_dump
+      end
+
+      def test_schema_dump_value_set_to_false
+        config = HashConfig.new("default_env", "primary", { schema_dump: false })
+        assert_equal false, config.schema_dump
+      end
     end
   end
 end

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -425,6 +425,42 @@ module ApplicationTests
         assert_match(/up\s+002\s+Two migration/, output)
       end
 
+      test "schema generation when dump_schema_after_migration and schema_dump are true" do
+        add_to_config("config.active_record.dump_schema_after_migration = true")
+
+        app_file "config/database.yml", <<~EOS
+          development:
+            adapter: sqlite3
+            database: 'dev_db'
+            schema_dump: true
+        EOS
+
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book", "title:string"
+          rails "db:migrate"
+
+          assert File.exist?("db/schema.rb"), "should dump schema when configured to"
+        end
+      end
+
+      test "schema generation when dump_schema_after_migration is true schema_dump is false" do
+        add_to_config("config.active_record.dump_schema_after_migration = true")
+
+        app_file "config/database.yml", <<~EOS
+          development:
+            adapter: sqlite3
+            database: 'dev_db'
+            schema_dump: false
+        EOS
+
+        Dir.chdir(app_path) do
+          rails "generate", "model", "book", "title:string"
+          rails "db:migrate"
+
+          assert_not File.exist?("db/schema.rb"), "should not dump schema when configured not to"
+        end
+      end
+
       test "schema generation when dump_schema_after_migration is set" do
         add_to_config("config.active_record.dump_schema_after_migration = false")
 


### PR DESCRIPTION
cc/ @lfv89 this is a rebased and cleaned up version of #39326. I made sure you were given credit in the changelog and in the commit.

Dumping the schema is on by default for all databases in an application. To turn it off for a
specific database use the `schema_dump` option:

```yaml
  # config/database.yml

  production:
  schema_dump: false
```

Co-authored-by: Luis Vasconcellos <vasconcelloslf@gmail.com>

