### PR TITLE
Fix inconsistent heading level in guides [ci-skip]

### DIFF
--- a/guides/source/3_2_release_notes.md
+++ b/guides/source/3_2_release_notes.md
@@ -162,7 +162,7 @@ Railties
 
 * Remove old `config.paths.app.controller` API in favor of `config.paths["app/controller"]`.
 
-#### Deprecations
+### Deprecations
 
 * `Rails::Plugin` is deprecated and will be removed in Rails 4.0. Instead of adding plugins to `vendor/plugins` use gems or bundler with path or git dependencies.
 

--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -595,7 +595,7 @@ consumer.subscriptions.create("AppearanceChannel", {
 })
 ```
 
-##### Client-Server Interaction
+#### Client-Server Interaction
 
 1. **Client** connects to the **Server** via `App.cable =
 ActionCable.createConsumer("ws://cable.example.com")`. (`cable.js`). The

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -22,7 +22,7 @@ What is Action Mailer?
 Action Mailer allows you to send emails from your application using mailer classes
 and views.
 
-#### Mailers are similar to controllers
+### Mailers are similar to controllers
 
 They inherit from [`ActionMailer::Base`][] and live in `app/mailers`. Mailers also work
 very similarly to controllers. Some examples of similarities are enumerated below.

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1608,7 +1608,7 @@ end
 
 This assertion is quite powerful. For more advanced usage, refer to its [documentation](https://github.com/rails/rails-dom-testing/blob/master/lib/rails/dom/testing/assertions/selector_assertions.rb).
 
-#### Additional View-Based Assertions
+### Additional View-Based Assertions
 
 There are more assertions that are primarily used in testing views:
 


### PR DESCRIPTION
### Summary
Fixed a few instances in the guides where heading levels were skipped.
