### PR TITLE
Fix invalid parts after sum of Durations

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -39,9 +39,10 @@ module ActiveSupport
 
       def +(other)
         if Duration === other
-          seconds   = value + other._parts.fetch(:seconds, 0)
-          new_parts = other._parts.merge(seconds: seconds)
-          new_value = value + other.value
+          other_parts = other._parts.empty? ? { seconds: other.value } : other._parts
+          seconds     = value + other_parts.fetch(:seconds, 0)
+          new_parts   = other_parts.merge(seconds: seconds)
+          new_value   = value + other.value
 
           Duration.new(new_value, new_parts, other.variable?)
         else
@@ -51,8 +52,9 @@ module ActiveSupport
 
       def -(other)
         if Duration === other
-          seconds   = value - other._parts.fetch(:seconds, 0)
-          new_parts = other._parts.transform_values(&:-@)
+          other_parts = other._parts.empty? ? { seconds: other.value } : other._parts
+          seconds   = value - other_parts.fetch(:seconds, 0)
+          new_parts = other_parts.transform_values(&:-@)
           new_parts = new_parts.merge(seconds: seconds)
           new_value = value - other.value
 
@@ -259,14 +261,16 @@ module ActiveSupport
     # Adds another Duration or a Numeric to this Duration. Numeric values
     # are treated as seconds.
     def +(other)
+      new_parts = @parts.empty? ? { seconds: value } : @parts
       if Duration === other
-        parts = @parts.merge(other._parts) do |_key, value, other_value|
+        other_parts = other._parts.empty? ? { seconds: other.value } : other._parts
+        parts = new_parts.merge(other_parts) do |_key, value, other_value|
           value + other_value
         end
         Duration.new(value + other.value, parts, @variable || other.variable?)
       else
-        seconds = @parts.fetch(:seconds, 0) + other
-        Duration.new(value + other, @parts.merge(seconds: seconds), @variable)
+        seconds = new_parts.fetch(:seconds, 0) + other
+        Duration.new(value + other, new_parts.merge(seconds: seconds), @variable)
       end
     end
 

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -111,6 +111,14 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "0 seconds",                       (10 % 5.seconds).inspect
     assert_equal "10 minutes",                      (10.minutes + 0.seconds).inspect
     assert_equal "3600 seconds",                    (1.day / 24).inspect
+    assert_equal "361 seconds",                     (1.second + 1.hour / 10).inspect
+    assert_equal "361 seconds",                     (1.hour / 10 + 1.second).inspect
+    assert_equal "361 seconds",                     (1.hour / 10 + 1).inspect
+    assert_equal "361 seconds",                     (1 + 1.hour / 10).inspect
+    assert_equal "1 minute and 361 seconds",        (1.minute + 361).inspect
+    assert_equal "1 minute and 361 seconds",        (361 + 1.minute).inspect
+    assert_equal "361.5 seconds",                   (361 + 0.5.seconds).inspect
+    assert_equal "361.5 seconds",                   (0.5.seconds + 361).inspect
   end
 
   def test_inspect_ignores_locale
@@ -136,6 +144,11 @@ class DurationTest < ActiveSupport::TestCase
     assert_instance_of ActiveSupport::Duration, 1.second + 1.second
     assert_equal 2.seconds, 1.second + 1
     assert_instance_of ActiveSupport::Duration, 1.second + 1
+  end
+
+  def test_plus_parts
+    assert_equal({ seconds: 361 }, (1.second + 1.hour / 10).parts)
+    assert_equal({ seconds: 361 }, (1.hour / 10 + 1.second).parts)
   end
 
   def test_minus
@@ -449,6 +462,7 @@ class DurationTest < ActiveSupport::TestCase
 
     assert_equal({ days: 1, seconds: 10 }, (scalar + 1.day).parts)
     assert_equal({ days: -1, seconds: 10 }, (scalar + -1.day).parts)
+    assert_equal({ seconds: 370 }, (scalar + (1.hour / 10)).parts)
   end
 
   def test_scalar_minus
@@ -478,6 +492,7 @@ class DurationTest < ActiveSupport::TestCase
 
     assert_equal({ days: -1, seconds: 10 }, (scalar - 1.day).parts)
     assert_equal({ days: 1, seconds: 10 }, (scalar - -1.day).parts)
+    assert_equal({ seconds: -350 }, (scalar - (1.hour / 10)).parts)
   end
 
   def test_scalar_multiply


### PR DESCRIPTION
## Summary
Closes #42802 

Nowadays when performing a division of AS Duration, it may happen that the "`duration._parts`" end up being empty but that doesn't mean that the duration has less than 1 second. This is because the Division of a Duration and an Integer create a Duration object with parts formed by Integers and not by Floats.

As an example: 
```
pry(main)> (1.hour / 10).parts
=> {}
pry(main)> (1.hour * 0.1).parts
=> {:hours=>0.1}
```

Apart from that, the `def +(other)` method doesn't handle sum of objects with empty `._parts` as it just ignores them, so:

`(1.hour / 10 + 1000.seconds).inspect`
would be equal to 
`(1000.seconds).inspect`
.

## Proposed solution: 
In the proposed solution, the empty parts are treated as the real value of the duration expressed in seconds, which is similar to what the `inspect` method does.

```
def inspect #:nodoc:
      return "#{value} seconds" if @parts.empty?
      ...
```

I'm still not sure if I'm missing some edge cases, so any feedback would be awesome 😄 

### Other possible solution: 


Another option would have been to manage Floats instead of Integers while doing a division. This would bean rewriting the `def /(other)` method to:
```
# Divides this Duration by a Numeric and returns a new Duration.
    def /(other)
      if Scalar === other
        Duration.new(value / other.value, @parts.transform_values { |number| number.to_f / other.value }, @variable)
      elsif Duration === other
        value.to_f / other.value
      elsif Numeric === other
        Duration.new(value / other, @parts.transform_values { |number| number.to_f / other }, @variable)
      else
        raise_type_error(other)
      end
    end
```
But this has its drawbacks as it affects the result of the Division that in the tests is specifically tested that the result of the Division is an `Integer`. Also, this would mean that the result of doing `(1.day / 24).inspect`
would be `"0.041666666666666664 days`.

