### PR TITLE
Pass log_rescued_responses as environment config

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -10,7 +10,6 @@ module ActionDispatch
   # This middleware is responsible for logging exceptions and
   # showing a debugging page in case the request is local.
   class DebugExceptions
-    cattr_accessor :log_rescued_responses, instance_accessor: false, default: true
     cattr_reader :interceptors, instance_accessor: false, default: []
 
     def self.register_interceptor(object = nil, &block)
@@ -180,8 +179,7 @@ module ActionDispatch
       end
 
       def log_rescued_responses?(request)
-        per_request = request.get_header("action_dispatch.log_rescued_responses")
-        per_request.nil? ? @@log_rescued_responses : per_request
+        request.get_header("action_dispatch.log_rescued_responses")
       end
   end
 end

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -48,7 +48,6 @@ module ActionDispatch
         self.ignore_accept_header = app.config.action_dispatch.ignore_accept_header
         self.return_only_media_type_on_content_type = app.config.action_dispatch.return_only_request_media_type_on_content_type
         ActionDispatch::Request::Utils.perform_deep_munge = app.config.action_dispatch.perform_deep_munge
-        ActionDispatch::DebugExceptions.log_rescued_responses = app.config.action_dispatch.log_rescued_responses
       end
 
       ActiveSupport.on_load(:action_dispatch_response) do

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -274,6 +274,7 @@ module Rails
           "action_dispatch.secret_key_base" => secret_key_base,
           "action_dispatch.show_exceptions" => config.action_dispatch.show_exceptions,
           "action_dispatch.show_detailed_exceptions" => config.consider_all_requests_local,
+          "action_dispatch.log_rescued_responses" => config.action_dispatch.log_rescued_responses,
           "action_dispatch.logger" => Rails.logger,
           "action_dispatch.backtrace_cleaner" => Rails.backtrace_cleaner,
           "action_dispatch.key_generator" => key_generator,

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3244,20 +3244,20 @@ module ApplicationTests
       assert_equal false, ActionDispatch::Request.return_only_media_type_on_content_type
     end
 
-    test "ActionDispatch::DebugExceptions.log_rescued_responses is true by default" do
+    test "action_dispatch.log_rescued_responses is true by default" do
       app "development"
 
-      assert_equal true, ActionDispatch::DebugExceptions.log_rescued_responses
+      assert_equal true, Rails.application.env_config["action_dispatch.log_rescued_responses"]
     end
 
-    test "ActionDispatch::DebugExceptions.log_rescued_responses can be configured" do
+    test "action_dispatch.log_rescued_responses can be configured" do
       add_to_config <<-RUBY
         config.action_dispatch.log_rescued_responses = false
       RUBY
 
       app "development"
 
-      assert_equal false, ActionDispatch::DebugExceptions.log_rescued_responses
+      assert_equal false, Rails.application.env_config["action_dispatch.log_rescued_responses"]
     end
 
     test "logs a warning when running SQLite3 in production" do


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/42801.

This lets us remove the reference to DebugExceptions from the Action Dispatch railtie, which was causing load order issues since it depends on ActionDispatch::Request.