### PR TITLE
Don't require ActionDispatch::{Request,Response}

### DIFF
--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -2,8 +2,6 @@
 
 require "active_support/core_ext/array/extract_options"
 require "action_dispatch/middleware/stack"
-require "action_dispatch/http/request"
-require "action_dispatch/http/response"
 
 module ActionController
   # Extend ActionDispatch middleware stack to make it aware of options

--- a/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb
@@ -2,7 +2,6 @@
 
 require "erb"
 require "uri"
-require "action_dispatch/http/request"
 require "active_support/actionable_error"
 
 module ActionDispatch

--- a/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "action_dispatch/http/request"
 require "action_dispatch/middleware/exception_wrapper"
 require "action_dispatch/routing/inspector"
 

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "action_dispatch/http/request"
-
 module ActionDispatch
   # This middleware guards from DNS rebinding attacks by explicitly permitting
   # the hosts a request can be sent to, and is passed the options set in

--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "action_dispatch/http/request"
 require "action_dispatch/middleware/exception_wrapper"
 
 module ActionDispatch

--- a/actionpack/lib/action_dispatch/routing/redirection.rb
+++ b/actionpack/lib/action_dispatch/routing/redirection.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "action_dispatch/http/request"
 require "active_support/core_ext/array/extract_options"
 require "rack/utils"
 require "action_controller/metal/exceptions"

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -3,7 +3,6 @@
 require "active_support/core_ext/time/conversions"
 require "active_support/core_ext/object/blank"
 require "active_support/log_subscriber"
-require "action_dispatch/http/request"
 require "rack/body_proxy"
 
 module Rails


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/7225 these are eager autoloaded, so there's no reason to require them explicitly.

Both classes have configuration applied via load hooks, so requiring them too early could cause load order issues. In particular, an application that referenced any of the middleware that required these classes would be prevented from configuring them afterwards.

This was also a contributing factor to https://github.com/rails/rails/issues/42801.