### PR TITLE
Remove mechanism to disable test parallelization based on number of test files

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -87,12 +87,7 @@ module ActiveSupport
   end
 
   cattr_accessor :test_order # :nodoc:
-  cattr_accessor :test_parallelization_disabled, default: false # :nodoc:
   cattr_accessor :test_parallelization_threshold, default: 50 # :nodoc:
-
-  def self.disable_test_parallelization!
-    self.test_parallelization_disabled = true unless ENV["PARALLEL_WORKERS"]
-  end
 
   def self.cache_format_version
     Cache.format_version

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -80,7 +80,7 @@ module ActiveSupport
         workers = Concurrent.physical_processor_count if workers == :number_of_processors
         workers = ENV["PARALLEL_WORKERS"].to_i if ENV["PARALLEL_WORKERS"]
 
-        return if workers <= 1 || ActiveSupport.test_parallelization_disabled
+        return if workers <= 1
 
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
       end

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -47,8 +47,6 @@ module Rails
 
           tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]
           tests.exclude(default_test_exclude_glob) if patterns.empty?
-          # Disable parallel testing if there's only one test file to run.
-          ActiveSupport.disable_test_parallelization! if tests.size <= 1
           tests.to_a.each { |path| require File.expand_path(path) }
         end
 


### PR DESCRIPTION
#42761 and #42789 made the system to disable paralleling testing from #41684 redundant.

Rails will now skip parallel testing based on the actual number of tests run, whether they come from one file or multiple files.

CC @eileencodes 
