### PR TITLE
Show contents of session for ActionDispatch::Request::Session#inspect

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Show contents of session for ActionDispatch::Request::Session#inspect
+
+    This shortens inspect to show the class name and the contents.
+
+        session["foo"] = "bar"
+        session.inspect => "#<ActionDispatch::Request::Session:0x1234 {"foo"=>"bar"}>"
+
+    *Petrik de Heus*
+
 *   Exclude additional flash types from `ActionController::Base.action_methods`.
 
     Ensures that additional flash types defined on ActionController::Base subclasses

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -210,11 +210,8 @@ module ActionDispatch
       end
 
       def inspect
-        if loaded?
-          super
-        else
-          "#<#{self.class}:0x#{(object_id << 1).to_s(16)} not yet loaded>"
-        end
+        contents = loaded? ? to_hash : "not yet loaded"
+        "#<#{self.class}:0x#{(object_id << 1).to_s(16)} #{contents}>"
       end
 
       def exists?

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -130,6 +130,13 @@ module ActionDispatch
         assert_nil session.dig("one", :two)
       end
 
+      def test_inspect
+        session = Session.create(store, req, {})
+        session["foo"] = "bar"
+
+        assert_match(%r(#<ActionDispatch::Request::Session:0x[0-9a-f]+ {"foo"=>"bar"}>), session.inspect)
+      end
+
       private
         def store
           Class.new {


### PR DESCRIPTION
### Summary

When debugging it can be useful to more clearly see the contents of the
session.

This shortens inspect to show the class name and the contents.

    session["foo"] = "bar"
    session.inspect # => "#<ActionDispatch::Request::Session:0x1234 {"foo"=>"bar"}>"

Instead of showing something like:
```
#<ActionDispatch::Request::Session:0x00007f99218ae168 
@by=#<ActionDispatch::Session::CookieStore:0x00007f991d1f1400 @app=#
<ActionDispatch::ContentSecurityPolicy::Middleware:0x00007f991d1f14f0 @app=#
<ActionDispatch::PermissionsPolicy::Middleware:0x00007f991d1f1540 @app=#<Rack::Head:0x00007f991d1f15e0 @app=#
<Rack::ConditionalGet:0x00007f991d1f1630 @app=#<Rack::ETag:0x00007f991d1f16d0 @app=#
<Rack::TempfileReaper:0x00007f991d1f1720 @app=#<ActionDispatch::Routing::RouteSet:0x00007f991e1a03d8>>, 
@cache_control="max-age=0, private, must-revalidate", @no_cache_control="no-cache">>>>>, @default_options=
{:path=>"/", :domain=>nil, :expire_after=>nil, :secure=>false, :httponly=>true, :defer=>false, :renew=>false}, 
@key="_rails_actionable_errors_session", @cookie_only=true, @same_site=nil>, @req=#<ActionDispatch::Request GET 
"http://localhost:3000/posts" for 127.0.0.1>, @delegate={"session_id"=>"6d8bcd861c32badb3ad29568614516e0", 
"x"=>"123"}, @loaded=true, @exists=nil, @enabled=true>
```