### PR TITLE
Add `Middleware#remove` to delete middleware or raise if not found.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `Middleware#remove` to delete middleware or raise if not found.
+
+    `Middleware#remove` works just like `Middleware#delete` but will
+    raise an error if the middleware isn't found.
+
+    *Alex Ghiculescu*, *Petrik de Heus*
+
 *   Exclude additional flash types from `ActionController::Base.action_methods`.
 
     Ensures that additional flash types defined on ActionController::Base subclasses
@@ -10,13 +17,6 @@
         MyController.action_methods.include?('hype') # => false
 
     *Gavin Morrice*
-
-*   Deleting an item from the Middleware stack will raise if the item is not found
-
-    Previously, calling `config.middleware.delete(ItemNotInMiddleware)` would fail silently.
-    Now it will raise, same as `config.middleware.move(0, ItemNotInMiddleware)` does.
-
-    *Alex Ghiculescu*
 
 *   OpenSSL constants are now used for Digest computations.
 

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -130,7 +130,11 @@ module ActionDispatch
     ruby2_keywords(:swap)
 
     def delete(target)
-      middlewares.reject! { |m| m.name == target.name } || (raise "No such middleware to delete: #{target.inspect}")
+      middlewares.reject! { |m| m.name == target.name }
+    end
+
+    def remove(target)
+      delete(target) || (raise "No such middleware to remove: #{target.inspect}")
     end
 
     def move(target, source)

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -37,6 +37,24 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     end
   end
 
+  test "delete ignores middleware not in the stack" do
+    assert_no_difference "@stack.size" do
+      @stack.delete BazMiddleware
+    end
+  end
+
+  test "remove deletes the middleware" do
+    assert_difference "@stack.size", -1 do
+      @stack.remove FooMiddleware
+    end
+  end
+
+  test "remove requires the middleware to be in the stack" do
+    assert_raises RuntimeError do
+      @stack.remove BazMiddleware
+    end
+  end
+
   test "use should push middleware as class onto the stack" do
     assert_difference "@stack.size" do
       @stack.use BazMiddleware
@@ -102,12 +120,6 @@ class MiddlewareStackTest < ActiveSupport::TestCase
   test "move requires the moved middleware to be in the stack" do
     assert_raises RuntimeError do
       @stack.move(0, BazMiddleware)
-    end
-  end
-
-  test "delete requires the middleware to be in the stack" do
-    assert_raises RuntimeError do
-      @stack.delete(BazMiddleware)
     end
   end
 


### PR DESCRIPTION
### Summary

`Middleware#remove` works just like `Middleware#delete` but will
raise an error if the middleware isn't found.

This partly reverts 07558ff57c32ac96ec75d744e304944c36282b1b, where `delete` would raise an error.
It might be expected that `delete` fails silently for some environments.
Or maybe you want to make sure a middleware isn't present.

See: https://github.com/rails/rails/pull/42655#issuecomment-878523252

cc @jhawthorn 

Co-authored-by: Alex Ghiculescu <alexghiculescu@gmail.com>