### PR TITLE
Added ability to download EML file from the mail previews

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added ability to download `.eml` file for the email preview.
+
+    *Igor Kasyanchuk*
+
 *   Configures a default of 5 for both `open_timeout` and `read_timeout` for SMTP Settings.
 
     *André Luis Leal Cardoso Junior*

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -88,8 +88,9 @@ module ActionMailer
 
       if options.show_previews
         app.routes.prepend do
-          get "/rails/mailers"       => "rails/mailers#index", internal: true
-          get "/rails/mailers/*path" => "rails/mailers#preview", internal: true
+          get "/rails/mailers"                => "rails/mailers#index", internal: true
+          get "/rails/mailers/download/*path" => "rails/mailers#download", internal: true
+          get "/rails/mailers/*path"          => "rails/mailers#preview", internal: true
         end
       end
     end

--- a/railties/lib/rails/mailers_controller.rb
+++ b/railties/lib/rails/mailers_controller.rb
@@ -5,8 +5,8 @@ require "rails/application_controller"
 class Rails::MailersController < Rails::ApplicationController # :nodoc:
   prepend_view_path ActionDispatch::DebugView::RESCUES_TEMPLATE_PATH
 
-  around_action :set_locale, only: :preview
-  before_action :find_preview, only: :preview
+  around_action :set_locale, only: [:preview, :download]
+  before_action :find_preview, only: [:preview, :download]
   before_action :require_local!, unless: :show_previews?
 
   helper_method :part_query, :locale_query
@@ -45,6 +45,16 @@ class Rails::MailersController < Rails::ApplicationController # :nodoc:
       else
         raise AbstractController::ActionNotFound, "Email '#{@email_action}' not found in #{@preview.name}"
       end
+    end
+  end
+
+  def download
+    @email_action = File.basename(params[:path])
+    if @preview.email_exists?(@email_action)
+      @email = @preview.call(@email_action, params)
+      send_data @email.to_s, filename: @email_action.dasherize + ".eml"
+    else
+      raise AbstractController::ActionNotFound, "Email '#{@email_action}' not found in #{@preview.name}"
     end
   end
 

--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -120,6 +120,8 @@
         </select>
       </dd>
     <% end %>
+    <dt></dt>
+    <dd><%= link_to 'Download EML', action: :download %></dd>
   </dl>
 </header>
 

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -331,6 +331,10 @@ module ApplicationTests
       get "/rails/mailers/notifier/bar"
       assert_predicate last_response, :not_found?
       assert_match "Email &#39;bar&#39; not found in NotifierPreview", h(last_response.body)
+
+      get "/rails/mailers/download/notifier/bar"
+      assert_predicate last_response, :not_found?
+      assert_match "Email &#39;bar&#39; not found in NotifierPreview", h(last_response.body)
     end
 
     test "mailer preview NullMail" do
@@ -420,6 +424,13 @@ module ApplicationTests
       assert_match "Ruby on Rails &lt;core@rubyonrails.org&gt;", last_response.body
       assert_match "Andrew White &lt;andyw@pixeltrix.co.uk&gt;", last_response.body
       assert_match "David Heinemeier Hansson &lt;david@heinemeierhansson.com&gt;", last_response.body
+
+      get "/rails/mailers/download/notifier/foo"
+      email = Mail.read_from_string(last_response.body)
+      assert_equal "attachment; filename=\"foo.eml\"; filename*=UTF-8''foo.eml", last_response.headers["Content-Disposition"]
+      assert_equal 200, last_response.status
+      assert_equal ["andyw@pixeltrix.co.uk"], email.to
+      assert_equal ["david@heinemeierhansson.com"], email.cc
     end
 
     test "part menu selects correct option" do
@@ -639,6 +650,13 @@ module ApplicationTests
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
       assert_match %r[Hello, World!], last_response.body
+
+      get "/rails/mailers/download/notifier/foo"
+      assert_equal 200, last_response.status
+      email = Mail.read_from_string(last_response.body)
+      assert_equal 2, email.parts.size
+      assert_equal "text/plain; charset=UTF-8", email.parts[0].content_type
+      assert_equal "image/png; filename=pixel.png", email.parts[1].content_type
     end
 
     test "multipart mailer preview with attachment" do


### PR DESCRIPTION
### Summary

It could be useful for developers to download EML file for email. Currently, I'm using mailcatcher or maildev to send email and download ".eml" file there. So I can open it in Outlook for example and see how it looks.

![image](https://user-images.githubusercontent.com/11101/126381934-68b7d813-009a-4b5a-bd8b-f61cd81aec21.png)

### Other Information

I've added few lines in tests to the existing tests because this file is already huge.
