### PR TITLE
Fix migration generator foreign key inside engine

### DIFF
--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -181,7 +181,7 @@ module Rails
         # Convert attributes array into GeneratedAttribute objects.
         def parse_attributes!
           self.attributes = (attributes || []).map do |attr|
-            Rails::Generators::GeneratedAttribute.parse(attr)
+            Rails::Generators::GeneratedAttribute.parse(attr, namespace: class_path)
           end
         end
 

--- a/railties/test/generators/namespaced_generators_test.rb
+++ b/railties/test/generators/namespaced_generators_test.rb
@@ -113,6 +113,30 @@ class NamespacedModelGeneratorTest < NamespacedGeneratorTestCase
     assert_no_migration "db/migrate/create_test_app_images"
   end
 
+  def test_migration_with_namespaced_foreign_key
+    run_generator ["Book", "author:belongs_to"]
+
+    assert_migration "db/migrate/create_test_app_books.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/t.belongs_to :author,.*\sforeign_key: {:to_table=>"test_app_authors"}/, change)
+      end
+    end
+  end
+
+  def test_migration_with_namespaced_foreign_key_without_pluralization
+    ActiveRecord::Base.pluralize_table_names = false
+
+    run_generator ["Book", "author:belongs_to"]
+
+    assert_migration "db/migrate/create_test_app_book.rb" do |content|
+      assert_method :change, content do |change|
+        assert_match(/t.belongs_to :author,.*\sforeign_key: {:to_table=>"test_app_author"}/, change)
+      end
+    end
+  ensure
+    ActiveRecord::Base.pluralize_table_names = true
+  end
+
   def test_migration_with_nested_namespace
     run_generator ["Admin::Gallery::Image"]
     assert_no_migration "db/migrate/create_images"


### PR DESCRIPTION
### Summary


Fixes https://github.com/rails/rails/issues/42656 by adding `to_table` instruction to the foreign key, referencing the correct table name.

We thought of two possible approaches:

1. Adjusting the generated migration file
2. Not changing the migration but the execution of the migration file to correctly reference the foreign key table

We chose to implement the first approach because it was simpler, backwards compatible, and less intrusive compared to the other approach.

If this approach is agreed upon, we will continue working on the To-Do list.

### To-Do:
- [ ] Changelog
- [ ] Documentation
- [ ] Bug template (if needed)