### PR TITLE
Correct Inflector.humanize keep_id_suffix argument docs

### DIFF
--- a/activesupport/lib/active_support/core_ext/string/inflections.rb
+++ b/activesupport/lib/active_support/core_ext/string/inflections.rb
@@ -260,7 +260,7 @@ class String
   #   'author_id'.humanize                          # => "Author"
   #   'author_id'.humanize(capitalize: false)       # => "author"
   #   '_id'.humanize                                # => "Id"
-  #   'author_id'.humanize(keep_id_suffix: true)    # => "Author Id"
+  #   'author_id'.humanize(keep_id_suffix: true)    # => "Author id"
   #
   # See ActiveSupport::Inflector.humanize.
   def humanize(capitalize: true, keep_id_suffix: false)

--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -123,7 +123,7 @@ module ActiveSupport
     #   humanize('author_id')                        # => "Author"
     #   humanize('author_id', capitalize: false)     # => "author"
     #   humanize('_id')                              # => "Id"
-    #   humanize('author_id', keep_id_suffix: true)  # => "Author Id"
+    #   humanize('author_id', keep_id_suffix: true)  # => "Author id"
     #
     # If "SSL" was defined to be an acronym:
     #


### PR DESCRIPTION
The "id" word is not capitalized. Observe:

    irb(main):001:0> ActiveSupport::Inflector.humanize('author_id', keep_id_suffix: true)
    => "Author id"