### PR TITLE
Replace "blocked host" error with generic 403 in production

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Replace "blocked host" error page with generic 403 Forbidden in production environment.
+
+    Fixes #42813.
+
+    *Ajax Manohar*
+
 *   Deprecate `poltergeist` and `webkit` (capybara-webkit) driver registration for system testing (they will be removed in Rails 7.1). Add `cuprite` instead.
 
     [Poltergeist](https://github.com/teampoltergeist/poltergeist) and [capybara-webkit](https://github.com/thoughtbot/capybara-webkit) are already not maintained. These usage in Rails are removed for avoiding confusing users.

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -62,7 +62,7 @@ module ActionDispatch
       request = Request.new(env)
 
       format = request.xhr? ? "text/plain" : "text/html"
-      template = DebugView.new(host: request.host)
+      template = DebugView.new(host: request.host, env: Rails.env)
       body = template.render(template: "rescues/blocked_host", layout: "rescues/layout")
 
       [403, {

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
@@ -1,7 +1,16 @@
-<header>
-  <h1>Blocked host: <%= @host %></h1>
-</header>
-<main role="main" id="container">
-  <h2>To allow requests to <%= @host %>, add the following to your environment configuration:</h2>
-  <pre>config.hosts &lt;&lt; "<%= @host %>"</pre>
-</main>
+<% if @env == "production" %>
+  <header>
+    <h1>403 Forbidden</h1>
+  </header>
+  <main role="main" id="container">
+    <h2>You do not have access to this resource.</h2>
+  </main>
+<% else %>
+  <header>
+    <h1>Blocked host: <%= @host %></h1>
+  </header>
+  <main role="main" id="container">
+    <h2>To allow requests to <%= @host %>, add the following to your environment configuration:</h2>
+    <pre>config.hosts &lt;&lt; "<%= @host %>"</pre>
+  </main>
+<% end %>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.text.erb
@@ -1,5 +1,11 @@
-Blocked host: <%= @host %>
+<% if @env == "production" %>
+  403 Forbidden
 
-To allow requests to <%= @host %>, add the following to your environment configuration:
+  You do not have access to this resource.
+<% else %>
+  Blocked host: <%= @host %>
 
-  config.hosts << "<%= @host %>"
+  To allow requests to <%= @host %>, add the following to your environment configuration:
+
+    config.hosts << "<%= @host %>"
+<% end %>

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -15,6 +15,18 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_match "Blocked host: www.example.com", response.body
   end
 
+  test "displays generic 403 page in production when blocking hosts" do
+    Rails.stub(:env, "production") do
+      @app = ActionDispatch::HostAuthorization.new(App, %w(only.com))
+
+      get "/"
+
+      assert_response :forbidden
+      assert_match "403 Forbidden", response.body
+      assert_no_match "Blocked host: www.example.com", response.body
+    end
+  end
+
   test "allows all requests if hosts is empty" do
     @app = ActionDispatch::HostAuthorization.new(App, nil)
 


### PR DESCRIPTION
### Summary

Addresses #42813 by showing a generic `Forbidden` page instead of detailed information about blocked hosts on production.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
