### PR TITLE
Slimmer ActiveModel::Errors#inspect message

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -14,5 +14,8 @@
 
     *Lukas Pokorny*
 
+*   Make ActiveModel::Errors#inspect slimmer for readability
+
+    *lulalala*
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -571,6 +571,12 @@ module ActiveModel
       add_from_legacy_details_hash(data["details"]) if data.key?("details")
     end
 
+    def inspect # :nodoc:
+      inspection = @errors.inspect
+
+      "#<#{self.class.name} #{inspection}>"
+    end
+
     private
       def normalize_arguments(attribute, type, **options)
         # Evaluate proc first

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -880,4 +880,11 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal({}, errors.messages)
     assert_equal({}, errors.details)
   end
+
+  test "inspect" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:base)
+
+    assert_equal(%(#<ActiveModel::Errors [#{errors.first.inspect}]>), errors.inspect)
+  end
 end


### PR DESCRIPTION
### Summary

For `ActiveModel::Errors`, only show `@errors` array and hide `@base`.

`@base` is not the core information developers are looking for in an `Errors` object, and they would have access to `@base` before getting access to `errors` anyways.

In the past we would see a very long string, and only to find out at the very end it is empty:

```log
#<ActiveModel::Errors:0x00007ff68cda24f8 @base=#<Foo id: 6, created_at: "2021-07-09 04:28:48.056662000 +0000", 
updated_at: "2021-07-09 04:28:48.168576000 +0000", email: "user@example.com", name: "Foo Bar", company: "Foo",  
activated_at: "2021-07-09 04:28:39.039853000 +0000">, @errors=[]>
```

Now it would just be

```log
#<ActiveModel::Errors []>
```

Or if it is not empty:

```log
#<ActiveModel::Errors [#<ActiveModel::Error attribute=base, type=invalid, options={}>]>
```

### Other Information

I thought since `ActiveModel::Errors` is now wrapping around the array, it makes sense to display the information as an array.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
