### PR TITLE
MemCacheStore: Properly duplicate local cache values in 6.1 mode

### DIFF
--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -7,15 +7,15 @@ module LocalCacheBehavior
     end
     assert_equal @cache.class.name, events[0].payload[:store]
 
-    events = with_instrumentation "read" do
-      @cache.with_local_cache do
+    @cache.with_local_cache do
+      events = with_instrumentation "read" do
         @cache.read("foo")
         @cache.read("foo")
       end
-    end
 
-    expected = [@cache.class.name, "ActiveSupport::Cache::Strategy::LocalCache::LocalStore"]
-    assert_equal expected, events.map { |p| p.payload[:store] }
+      expected = [@cache.class.name, @cache.send(:local_cache).class.name]
+      assert_equal expected, events.map { |p| p.payload[:store] }
+    end
   end
 
   def test_local_writes_are_persistent_on_the_remote_cache

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -268,30 +268,6 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
-  def test_initial_object_mutation_after_fetch
-    if ActiveSupport::Cache.format_version == 6.1
-      skip "Local cache mutation can't be prevented on legacy MemCacheStore"
-    else
-      super
-    end
-  end
-
-  def test_initial_object_mutation_after_write
-    if ActiveSupport::Cache.format_version == 6.1
-      skip "Local cache mutation can't be prevented on legacy MemCacheStore"
-    else
-      super
-    end
-  end
-
-  def test_local_cache_of_read_returns_a_copy_of_the_entry
-    if ActiveSupport::Cache.format_version == 6.1
-      skip "Local cache mutation can't be prevented on legacy MemCacheStore"
-    else
-      super
-    end
-  end
-
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/42649

I found a way to preserve the `deep_dup` behavior in 6.1 mode.
So we no longer need to skip these tests.

cc @ghiculescu 