### PR TITLE
Improve setting custom loggers to LogSubscribers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Allow setting a logger to a subclass of `ActiveSupport::LogSubscriber`
+
+    Any subclass of `ActiveSupport::LogSubscriber` may have a custom logger set
+    to it, without altering the one set on the base class or any other
+    subclasses:
+
+    ```ruby
+    MySubscriber.logger = Logger.new('myfile.log')
+    ```
+
+    If not set, it still defaults to `ActiveSupport::LogSubscriber.logger`,
+    which in turn defaults to `Rails.logger` when in Rails.
+
+    Fixes [#42745](https://github.com/rails/rails/issues/42745).
+
+    *Sergio Nogueira Filho*
+
 *   Faster tests by parallelizing only when overhead is justified by the number
     of them.
 

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -81,7 +81,10 @@ module ActiveSupport
 
     class << self
       def logger
-        @logger ||= if defined?(Rails) && Rails.respond_to?(:logger)
+        return @logger if @logger
+        return superclass.logger if self != LogSubscriber
+
+        if defined?(Rails) && Rails.respond_to?(:logger)
           Rails.logger
         end
       end
@@ -104,7 +107,7 @@ module ActiveSupport
     end
 
     def logger
-      LogSubscriber.logger
+      self.class.logger
     end
 
     def start(name, id, payload)

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -139,4 +139,14 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     assert_equal 1, @logger.logged(:error).size
     assert_match 'Could not log "puke.my_log_subscriber" event. RuntimeError: puke', @logger.logged(:error).last
   end
+
+  def test_event_is_sent_to_set_logger
+    logger = MockLogger.new
+    MyLogSubscriber.logger = logger
+    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+    instrument "some_event.my_log_subscriber"
+    wait
+    assert_equal %w(some_event.my_log_subscriber), logger.logged(:info)
+    MyLogSubscriber.logger = nil
+  end
 end


### PR DESCRIPTION
### Summary

Currently, a custom logger may only be set to `LogSubscriber`s by setting it globally with `ActiveSupport::LogSubscriber.logger=`. Setting `logger=` on any subclass has no effect and raises no error.

This change allows any subclass of `ActiveSupport::LogSubscriber` to have a custom logger set to it, without altering the one set on the base class. This was achieved by:

- calling `self.class.logger` instead of `LogSubscriber.logger` in `#logger`
- defaulting `.logger` on any subclass to the one from its superclass
- removing memoization from `.logger` to prevent memoizing a default from its superclass before it's been assigned

Fixes https://github.com/rails/rails/issues/42745

### Other Information

This isn't necessarily a bug as one could argue the current behavior is intended, with the right way of having a custom logger being an override of `#logger`. But then [this documentation page](https://api.rubyonrails.org/classes/ActiveSupport/LogSubscriber.html) would need an update. I'd be happy to change this PR to update the documentation instead, if that's the case.