### PR TITLE
Add '80 character wrap' to API documentation guidelines

### DIFF
--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -101,6 +101,12 @@ Oxford Comma
 Please use the [Oxford comma](https://en.wikipedia.org/wiki/Serial_comma)
 ("red, white, and blue", instead of "red, white and blue").
 
+Wrap at 80 Characters
+---------------------
+
+Please wrap the lines at around 80 characters. Longer lines are harder to read
+and make comparing documentation changes side-by-side more difficult.
+
 Example Code
 ------------
 


### PR DESCRIPTION
### Summary
Currently there is no documentation we can point to that prescribes
wrapping documentation at 80 characters. Adding it to the API guidelines
helps contributors improve their PR's and allows reviewers to point to
the guides.

The 80 character limit is defined in the "Reviewing issues and PRs"
Basecamp document and is occasionally mentioned in reviews, for example
the following comment by Eileen:

> All new guides should be wrapped to 80 characters.

https://github.com/rails/rails/pull/37885#discussion_r400931085