### PR TITLE
Remove nodoc from EachValidator [ci-skip]

### DIFF
--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -129,7 +129,7 @@ module ActiveModel
   # record, attribute and value.
   #
   # All \Active \Model validations are built on top of this validator.
-  class EachValidator < Validator #:nodoc:
+  class EachValidator < Validator
     attr_reader :attributes
 
     # Returns a new validator instance. All options will be available via the

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1087,7 +1087,7 @@ end
 ```
 
 The easiest way to add custom validators for validating individual attributes
-is with the convenient `ActiveModel::EachValidator`. In this case, the custom
+is with the convenient [`ActiveModel::EachValidator`][]. In this case, the custom
 validator class must implement a `validate_each` method which takes three
 arguments: record, attribute, and value. These correspond to the instance, the
 attribute to be validated, and the value of the attribute in the passed
@@ -1110,6 +1110,7 @@ end
 As shown in the example, you can also combine standard validations with your
 own custom validators.
 
+[`ActiveModel::EachValidator`]: https://api.rubyonrails.org/classes/ActiveModel/EachValidator.html
 [`ActiveModel::Validator`]: https://api.rubyonrails.org/classes/ActiveModel/Validator.html
 
 ### Custom Methods


### PR DESCRIPTION
The Active Record Validations guide recommends using `EachValidator`, and has done so for many years.
