### PR TITLE
allow pg query param syntax

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -80,6 +80,23 @@
 
     *Kevin Newton*
 
+*   Allow configuring Postgres password through the socket URL.
+
+    For example:
+    ```ruby
+    ActiveRecord::DatabaseConfigurations::UrlConfig.new(
+      :production, :production, 'postgres:///?user=user&password=secret&dbname=app', {}
+    ).configuration_hash
+    ```
+
+    will now return,
+
+    ```ruby
+    { :user=>"user", :password=>"secret", :dbname=>"app", :adapter=>"postgresql" }
+    ```
+
+    *Abeid Ahmed*
+
 *   Fix `eager_loading?` when ordering with `Symbol`
 
     `eager_loading?` is triggered correctly when using `order` with symbols.

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -67,7 +67,7 @@ module ActiveRecord
               database: uri.opaque
             )
           else
-            query_hash.merge(
+            query_hash.reverse_merge(
               adapter: @adapter,
               username: uri.user,
               password: uri.password,

--- a/activerecord/test/cases/database_configurations/resolver_test.rb
+++ b/activerecord/test/cases/database_configurations/resolver_test.rb
@@ -62,6 +62,18 @@ module ActiveRecord
           }, pool_config.configuration_hash)
         end
 
+        def test_url_sub_key_merges_correctly_when_query_param
+          hash = { "url" => "abstract:///?user=user&password=passwd&dbname=app" }
+          pool_config = resolve_db_config :production, "production" => hash
+
+          assert_equal({
+            adapter:  "abstract",
+            user:     "user",
+            password: "passwd",
+            dbname:   "app"
+          }, pool_config.configuration_hash)
+        end
+
         def test_url_host_no_db
           pool_config = resolve_db_config "abstract://foo?encoding=utf8"
           assert_equal({


### PR DESCRIPTION
### Summary

Previously, 
```ruby
ActiveRecord::DatabaseConfigurations::UrlConfig.new(:production, :production, 'postgres:///?user=user&password=passwd&dbname=theapp_production', {}).configuration_hash
``` 
was returning `{ :user=>"user", :dbname=>"theapp_production", :adapter=>"postgresql" }`. The `password` attribute was returning `nil` because `uri.password` was `nil` and merging the hashes resulted in the above result. 

This PR fixes it and now returns `{ :user=>"user", :password=>"passwd", :dbname=>"theapp_production", :adapter=>"postgresql" }`.

Issue #42797 mentions this. It also states that `postgres://user:passwd@/theapp_production` is a valid Postgres URI. Currently, if you run 
```ruby
ActiveRecord::DatabaseConfigurations::UrlConfig.new(:production, :production, 'postgres://user:passwd@/theapp_production', {})
```
it throws an error `/home/abeid/.rbenv/versions/3.0.1/lib/ruby/3.0.0/uri/generic.rb:207:in 'initialize': the scheme postgres does not accept registry part: user:passwd@ (or bad hostname?) (URI::InvalidURIError)` because the URI is not a valid [RFC 2396](https://datatracker.ietf.org/doc/html/rfc2396) implementation. Any ideas on how to fix this?

Thank you.