### PR TITLE
Avoid double wait in EventedFileUpdateCheckerTest

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -29,7 +29,17 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     sleep 1
   end
 
+  def mkdir(dirs)
+    super
+    wait # wait for the events to fire
+  end
+
   def touch(files)
+    super
+    wait # wait for the events to fire
+  end
+
+  def rm_f(files)
     super
     wait # wait for the events to fire
   end
@@ -97,8 +107,7 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
     assert_not_predicate checker, :updated?
 
-    FileUtils.touch(File.join(actual_dir, "a.rb"))
-    wait
+    touch(File.join(actual_dir, "a.rb"))
 
     assert_predicate checker, :updated?
     assert checker.execute_if_updated
@@ -114,8 +123,7 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
 
     checker = new_checker([], watched_dir => ".rb", not_exist_watched_dir => ".rb") { }
 
-    FileUtils.touch(File.join(watched_dir, "a.rb"))
-    wait
+    touch(File.join(watched_dir, "a.rb"))
     assert_predicate checker, :updated?
     assert checker.execute_if_updated
 
@@ -124,8 +132,7 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     assert_predicate checker, :updated?
     assert checker.execute_if_updated
 
-    FileUtils.touch(File.join(unwatched_dir, "a.rb"))
-    wait
+    touch(File.join(unwatched_dir, "a.rb"))
     assert_not_predicate checker, :updated?
     assert_not checker.execute_if_updated
   end

--- a/activesupport/test/file_update_checker_shared_tests.rb
+++ b/activesupport/test/file_update_checker_shared_tests.rb
@@ -6,7 +6,6 @@ module FileUpdateCheckerSharedTests
   def self.included(kls)
     kls.class_eval do
       extend ActiveSupport::Testing::Declarative
-      include FileUtils
 
       def tmpdir
         @tmpdir
@@ -53,7 +52,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker(tmpfiles) { i += 1 }
 
         touch(tmpfiles)
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -67,7 +65,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker(tmpfiles) { i += 1 }
 
         touch(tmpfiles)
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -81,7 +78,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker(tmpfiles) { i += 1 }
 
         rm_f(tmpfiles)
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -94,7 +90,6 @@ module FileUpdateCheckerSharedTests
         assert_not_predicate checker, :updated?
 
         touch(tmpfiles)
-        wait
 
         assert_predicate checker, :updated?
       end
@@ -108,7 +103,6 @@ module FileUpdateCheckerSharedTests
         assert_not_predicate checker, :updated?
 
         touch(tmpfiles)
-        wait
 
         assert_predicate checker, :updated?
       end
@@ -122,7 +116,6 @@ module FileUpdateCheckerSharedTests
         assert_not_predicate checker, :updated?
 
         rm_f(tmpfiles)
-        wait
 
         assert_predicate checker, :updated?
       end
@@ -139,7 +132,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker(tmpfiles) { i += 1 }
 
         touch(tmpfiles[1..-1])
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -156,7 +148,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker(tmpfiles) { i += 1 }
 
         touch(tmpfiles[1..-1])
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -169,7 +160,6 @@ module FileUpdateCheckerSharedTests
         assert_not_predicate checker, :updated?
 
         touch(tmpfiles)
-        wait
 
         assert_predicate checker, :updated?
         checker.execute
@@ -182,7 +172,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker([], tmpdir => :rb) { i += 1 }
 
         touch(tmpfile("foo.rb"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -194,7 +183,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker([], tmpdir => []) { i += 1 }
 
         touch(tmpfile("foo.rb"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -206,13 +194,11 @@ module FileUpdateCheckerSharedTests
         checker = new_checker([], tmpdir => [:rb, :txt]) { i += 1 }
 
         touch(tmpfile("foo.rb"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
 
         touch(tmpfile("foo.txt"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 2, i
@@ -224,7 +210,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker([], tmpdir => :txt) { i += 1 }
 
         touch(tmpfile("foo.rb"))
-        wait
 
         assert_not checker.execute_if_updated
         assert_equal 0, i
@@ -237,7 +222,6 @@ module FileUpdateCheckerSharedTests
         checker = new_checker([non_existing]) { i += 1 }
 
         touch(non_existing)
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -250,13 +234,11 @@ module FileUpdateCheckerSharedTests
 
         subdir = tmpfile("subdir")
         mkdir(subdir)
-        wait
 
         assert_not checker.execute_if_updated
         assert_equal 0, i
 
         touch(File.join(subdir, "nested.rb"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
@@ -266,25 +248,22 @@ module FileUpdateCheckerSharedTests
         i = 0
 
         subdir = tmpfile("subdir")
-        mkdir(subdir)
+        FileUtils.mkdir(subdir)
 
         checker = new_checker([], tmpdir => :rb, subdir => :txt) { i += 1 }
 
         touch(tmpfile("new.txt"))
-        wait
 
         assert_not checker.execute_if_updated
         assert_equal 0, i
 
         # subdir does not look for Ruby files, but its parent tmpdir does.
         touch(File.join(subdir, "nested.rb"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 1, i
 
         touch(File.join(subdir, "nested.txt"))
-        wait
 
         assert checker.execute_if_updated
         assert_equal 2, i
@@ -297,4 +276,17 @@ module FileUpdateCheckerSharedTests
       end
     end
   end
+
+  private
+    def mkdir(dirs)
+      FileUtils.mkdir(dirs)
+    end
+
+    def touch(files)
+      FileUtils.touch(files)
+    end
+
+    def rm_f(files)
+      FileUtils.rm_f(files)
+    end
 end

--- a/activesupport/test/file_update_checker_test.rb
+++ b/activesupport/test/file_update_checker_test.rb
@@ -10,10 +10,6 @@ class FileUpdateCheckerTest < ActiveSupport::TestCase
     ActiveSupport::FileUpdateChecker.new(files, dirs, &block)
   end
 
-  def wait
-    # noop
-  end
-
   def touch(files)
     sleep 1 # let's wait a bit to ensure there's a new mtime
     super


### PR DESCRIPTION
Waiting after touching the file system is a concern of `EventedFileUpdateCheckerTest`.  Therefore, only call `wait` inside `EventedFileUpdateCheckerTest`.  This avoids calling `wait` an extra time when calling `touch`.

Before:

    $ bin/test test/evented_file_update_checker_test.rb test/file_update_checker_test.rb

    Finished in 43.357019s, 0.9918 runs/s, 2.5371 assertions/s.
    43 runs, 110 assertions, 0 failures, 0 errors, 0 skips

After:

    $ bin/test test/evented_file_update_checker_test.rb test/file_update_checker_test.rb

    Finished in 34.351007s, 1.2518 runs/s, 3.2022 assertions/s.
    43 runs, 110 assertions, 0 failures, 0 errors, 0 skips
