### PR TITLE
Allow ActiveStorage.default_url_options for DiskService

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   DiskService can use ActiveStorage::Current.url_options or
+    ActiveStorage.default_url_options (in that order) as url options.
 
+    *José Galisteo*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -62,6 +62,7 @@ module ActiveStorage
 
   mattr_accessor :service_urls_expire_in, default: 5.minutes
   mattr_accessor :urls_expire_in
+  mattr_accessor :default_url_options
 
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
   mattr_accessor :draw_routes, default: true

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -97,6 +97,7 @@ module ActiveStorage
         ActiveStorage.content_types_to_serve_as_binary = app.config.active_storage.content_types_to_serve_as_binary || []
         ActiveStorage.service_urls_expire_in = app.config.active_storage.service_urls_expire_in || 5.minutes
         ActiveStorage.urls_expire_in = app.config.active_storage.urls_expire_in
+        ActiveStorage.default_url_options = app.config.active_storage.default_url_options
         ActiveStorage.content_types_allowed_inline = app.config.active_storage.content_types_allowed_inline || []
         ActiveStorage.binary_content_type = app.config.active_storage.binary_content_type || "application/octet-stream"
         ActiveStorage.video_preview_arguments = app.config.active_storage.video_preview_arguments || "-y -vframes 1 -f image2"

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -133,7 +133,7 @@ module ActiveStorage
         )
 
         if url_options.blank?
-          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.url_options."
+          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.url_options or Rails.application.routes.default_url_options."
         end
 
         url_helpers.rails_disk_service_url(verified_key_with_expiration, filename: filename, **url_options)
@@ -170,7 +170,7 @@ module ActiveStorage
       end
 
       def url_options
-        ActiveStorage::Current.url_options
+        ActiveStorage::Current.url_options || Rails.application.routes.default_url_options
       end
   end
 end

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -133,7 +133,7 @@ module ActiveStorage
         )
 
         if url_options.blank?
-          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.url_options or Rails.application.routes.default_url_options."
+          raise ArgumentError, "Cannot generate URL for #{filename} using Disk service, please set ActiveStorage::Current.url_options or ActiveStorage.default_url_options."
         end
 
         url_helpers.rails_disk_service_url(verified_key_with_expiration, filename: filename, **url_options)
@@ -170,7 +170,7 @@ module ActiveStorage
       end
 
       def url_options
-        ActiveStorage::Current.url_options || Rails.application.routes.default_url_options
+        ActiveStorage::Current.url_options || ActiveStorage.default_url_options
       end
   end
 end

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -29,14 +29,8 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
   end
 
   test "URL generation" do
-    original_url_options = Rails.application.routes.default_url_options.dup
-    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
-    begin
-      assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
-        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
-    ensure
-      Rails.application.routes.default_url_options = original_url_options
-    end
+    assert_match(/^https:\/\/example.com\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+      @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 
   test "URL generation without ActiveStorage::Current.url_options set" do

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -35,38 +35,29 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
 
   test "URL generation with default_url_options" do
     ActiveStorage::Current.url_options = nil
-    original_url_options = Rails.application.routes.default_url_options.dup
-    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+    ActiveStorage.default_url_options = { protocol: "http", host: "test.example.com", port: 3001 }
 
-    begin
-      assert_match(/^http:\/\/test.example.com:3001\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
-        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
-    ensure
-      Rails.application.routes.default_url_options = original_url_options
-    end
+    assert_match(/^http:\/\/test.example.com:3001\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+      @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 
   test "URL generate having ActiveStorage::Current.url_options precedence over default_url_options" do
     ActiveStorage::Current.url_options = { protocol: "https", host: "current.example.com", port: 3002 }
-    original_url_options = Rails.application.routes.default_url_options.dup
-    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "default.example.com", port: 3001)
+    ActiveStorage.default_url_options = { protocol: "http", host: "default.example.com", port: 3001 }
 
-    begin
-      assert_match(/^https:\/\/current.example.com:3002\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
-        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
-    ensure
-      Rails.application.routes.default_url_options = original_url_options
-    end
+    assert_match(/^https:\/\/current.example.com:3002\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+      @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 
-  test "URL generation without ActiveStorage::Current.url_options set" do
+  test "URL generation without ActiveStorage::Current.url_options or ActiveStorage.default_url_options set" do
     ActiveStorage::Current.url_options = nil
+    ActiveStorage.default_url_options = nil
 
     error = assert_raises ArgumentError do
       @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
     end
 
-    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options or Rails.application.routes.default_url_options.", error.message)
+    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options or ActiveStorage.default_url_options.", error.message)
   end
 
   test "URL generation keeps working with ActiveStorage::Current.host set" do

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -33,6 +33,32 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
       @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
   end
 
+  test "URL generation with default_url_options" do
+    ActiveStorage::Current.url_options = nil
+    original_url_options = Rails.application.routes.default_url_options.dup
+    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)
+
+    begin
+      assert_match(/^http:\/\/test.example.com:3001\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+    ensure
+      Rails.application.routes.default_url_options = original_url_options
+    end
+  end
+
+  test "URL generate having ActiveStorage::Current.url_options precedence over default_url_options" do
+    ActiveStorage::Current.url_options = { protocol: "https", host: "current.example.com", port: 3002 }
+    original_url_options = Rails.application.routes.default_url_options.dup
+    Rails.application.routes.default_url_options.merge!(protocol: "http", host: "default.example.com", port: 3001)
+
+    begin
+      assert_match(/^https:\/\/current.example.com:3002\/rails\/active_storage\/disk\/.*\/avatar\.png$/,
+        @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png"))
+    ensure
+      Rails.application.routes.default_url_options = original_url_options
+    end
+  end
+
   test "URL generation without ActiveStorage::Current.url_options set" do
     ActiveStorage::Current.url_options = nil
 
@@ -40,7 +66,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
       @service.url(@key, expires_in: 5.minutes, disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")
     end
 
-    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options.", error.message)
+    assert_equal("Cannot generate URL for avatar.png using Disk service, please set ActiveStorage::Current.url_options or Rails.application.routes.default_url_options.", error.message)
   end
 
   test "URL generation keeps working with ActiveStorage::Current.host set" do


### PR DESCRIPTION
### Summary

`DiskService` can use `ActiveStorage::Current.url_options` or `ActiveStorage.default_url_options` (in that order) as url options.

Related to: https://github.com/rails/rails/issues/40855 https://github.com/rails/rails/issues/37841 https://github.com/rails/rails/issues/33549 https://github.com/rails/rails/issues/32590 https://github.com/rails/rails/issues/13372

### Why

Setting `ActiveStorage::Current.host` or `ActiveStorage::Current.url_options` is useful when generate the URLs from `ActionController`. But if you need to generate the URLs in a background job or rake task, it seems cumbersome to have to define it in another place. Also for my experience can be a bit confusing to other developers.

I think that we can use `ActiveStorage::Current.url_options || ActiveStorage.default_url_options` as source for `url_options`. This approach allows override global `ActiveStorage.default_url_options` with `ActiveStorage::SetCurrent` if needed.

### Other Information

If the PR receives positive feedback, I will update the guidelines in this or another PR.