### PR TITLE
Fix polymorphic query with primary key alias

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder/polymorphic_array_value.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         def convert_to_id(value)
           case value
           when Base
-            value._read_attribute(primary_key(value))
+            value.read_attribute(primary_key(value))
           when Relation
             value.select(primary_key(value))
           else

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -13,6 +13,7 @@ require "models/comment"
 require "models/edge"
 require "models/essay"
 require "models/price_estimate"
+require "models/sponsor"
 require "models/topic"
 require "models/treasure"
 require "models/vertex"
@@ -216,6 +217,13 @@ module ActiveRecord
       actual = PriceEstimate.where(estimate_of: [treasure_1, treasure_2, car]).to_a.sort
 
       assert_equal expected, actual
+    end
+
+    def test_polymorphic_with_primary_key_alias
+      sponsor = Sponsor.new
+      sponsor.id = 1
+
+      assert_match(sponsor.id.to_s, Sponsor.where(sponsorable_with_pk_alias: sponsor).to_sql)
     end
 
     def test_polymorphic_nested_relation_where

--- a/activerecord/test/models/sponsor.rb
+++ b/activerecord/test/models/sponsor.rb
@@ -7,4 +7,7 @@ class Sponsor < ActiveRecord::Base
   belongs_to :thing, polymorphic: true, foreign_type: :sponsorable_type, foreign_key: :sponsorable_id
   belongs_to :sponsorable_with_conditions, -> { where name: "Ernie" }, polymorphic: true,
              foreign_type: "sponsorable_type", foreign_key: "sponsorable_id"
+
+  alias_attribute :primary_key_alias_for_sponsorable, :id
+  belongs_to :sponsorable_with_pk_alias, polymorphic: true, primary_key: :primary_key_alias_for_sponsorable
 end


### PR DESCRIPTION
`_read_attribute` doesn't handle attributes aleases and primary keys.

Use `read_attribute` in that case.

Fixes rails#42345.