### PR TITLE
Render copy-to-clipboard text in element attribute [ci-skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -194,7 +194,7 @@ body {
 
   #topNav a, #footer a {
     color: #F1938C;
-  }  
+  }
 }
 
 @media screen and (max-width: 1024px) {
@@ -255,12 +255,6 @@ body {
 
 .clipboard-button:active {
   background: #ccc;
-}
-
-.clipboard-content {
-  opacity:0;
-  position:absolute;
-  z-index:-1;
 }
 
 #header {

--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -253,12 +253,6 @@ body {
   background: #ccc;
 }
 
-.clipboard-content {
-  opacity:0;
-  position:absolute;
-  z-index:-1;
-}
-
 #header {
   background: #c52f24 url(../images/header_tile.gif) repeat-x;
   color: #FFF;

--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -14,12 +14,10 @@ module RailsGuides
         formatter = Rouge::Formatters::HTML.new
         lexer = ::Rouge::Lexer.find_fancy(lexer_language(language))
         formatted_code = formatter.format(lexer.lex(code))
-        clipboard_id = "clipboard-#{SecureRandom.hex(16)}"
         <<~HTML
           <div class="code_container">
           <pre><code class="highlight #{lexer_language(language)}">#{formatted_code}</code></pre>
-          <textarea class="clipboard-content" id="#{clipboard_id}">#{clipboard_content(code, language)}</textarea>
-          <button class="clipboard-button" data-clipboard-target="##{clipboard_id}">Copy</button>
+          <button class="clipboard-button" data-clipboard-text="#{clipboard_content(code, language)}">Copy</button>
           </div>
         HTML
       end
@@ -95,7 +93,7 @@ module RailsGuides
             code = code.lines.grep(prompt_regexp).join.gsub(prompt_regexp, "")
           end
 
-          ERB::Util.h(code)
+          ERB::Util.html_escape(code)
         end
 
         def convert_notes(body)


### PR DESCRIPTION
Rendering copy-to-clipboard text in an invisible element causes invisible extraneous matches when searching text on the page (e.g. with Ctrl+F).  Rendering in an [element attribute](https://github.com/zenorocha/clipboard.js#copy-text-from-attribute) avoids this problem.

**Before:**

![before-6-matches](https://user-images.githubusercontent.com/771968/126824543-cc93cb34-8a85-4475-b0d4-317258038eb3.png)

**After:**

![after-3-matches](https://user-images.githubusercontent.com/771968/126824566-d0dfd9c4-0f92-4291-8c16-65b3bb58dcbd.png)
