### PR TITLE
Fix `to_json` after `changes_applied` for `ActiveModel::Dirty` object

### DIFF
--- a/activemodel/lib/active_model/dirty.rb
+++ b/activemodel/lib/active_model/dirty.rb
@@ -141,7 +141,7 @@ module ActiveModel
     end
 
     def as_json(options = {}) # :nodoc:
-      options[:except] = [options[:except], "mutations_from_database"].flatten
+      options[:except] = [*options[:except], "mutations_from_database", "mutations_before_last_save"]
       super(options)
     end
 

--- a/activemodel/test/cases/dirty_test.rb
+++ b/activemodel/test/cases/dirty_test.rb
@@ -244,13 +244,19 @@ class DirtyTest < ActiveModel::TestCase
     assert_equal "{\"name\":\"Dmitry\",\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json
   end
 
-  test "to_json should work on model with :except string option " do
+  test "to_json should work on model with :except string option" do
     @model.name = "Dmitry"
     assert_equal "{\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json(except: "name")
   end
 
-  test "to_json should work on model with :except array option " do
+  test "to_json should work on model with :except array option" do
     @model.name = "Dmitry"
     assert_equal "{\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json(except: ["name"])
+  end
+
+  test "to_json should work on model after save" do
+    @model.name = "Dmitry"
+    @model.save
+    assert_equal "{\"name\":\"Dmitry\",\"color\":null,\"size\":null,\"status\":\"initialized\"}", @model.to_json
   end
 end


### PR DESCRIPTION
Follow up to #41677.

Mutation tracking variables are not only `@mutations_from_database` but
also `@mutations_before_last_save`.
