### PR TITLE
FIX: Setting remove_deprecated_time_with_zone_name in new framework defaults

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -10,9 +10,11 @@ module ActiveSupport
     config.eager_load_namespaces << ActiveSupport
 
     initializer "active_support.remove_deprecated_time_with_zone_name" do |app|
-      if app.config.active_support.remove_deprecated_time_with_zone_name
-        require "active_support/time_with_zone"
-        TimeWithZone.singleton_class.remove_method(:name)
+      config.after_initialize do
+        if app.config.active_support.remove_deprecated_time_with_zone_name
+          require "active_support/time_with_zone"
+          TimeWithZone.singleton_class.remove_method(:name)
+        end
       end
     end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3428,6 +3428,23 @@ module ApplicationTests
       assert_nil Rails.application.config.middleware.map(&:name).index("3rd custom middleware")
     end
 
+    test "ActiveSupport::TimeWithZone.name uses default Ruby implementation by default" do
+      app "development"
+      assert_equal false, ActiveSupport::TimeWithZone.methods(false).include?(:name)
+    end
+
+    test "ActiveSupport::TimeWithZone.name can be configured in the new framework defaults" do
+      remove_from_config '.*config\.load_defaults.*\n'
+
+      app_file "config/initializers/new_framework_defaults_7_0.rb", <<-RUBY
+        Rails.application.config.active_support.remove_deprecated_time_with_zone_name = false
+      RUBY
+
+      app "development"
+
+      assert_equal true, ActiveSupport::TimeWithZone.methods(false).include?(:name)
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
Setting `remove_deprecated_time_with_zone_name` didn't work because
the value is checked in a framework initialiser, which runs before application initialiser.

This PR moves the setting inside the `config.after_initialize` block.
I've also added 2 tests for this behaviour.

Fixes #42820

r? @p8 

