### PR TITLE
Remove outdated comment in `ActiveRecord::Associations::AssociationScope#add_constraints`

### DIFF
--- a/activerecord/lib/active_record/associations/association_scope.rb
+++ b/activerecord/lib/active_record/associations/association_scope.rb
@@ -123,8 +123,6 @@ module ActiveRecord
 
           chain_head = chain.first
           chain.reverse_each do |reflection|
-            # Exclude the scope of the association itself, because that
-            # was already merged in the #scope method.
             reflection.constraints.each do |scope_chain_item|
               item = eval_scope(reflection, scope_chain_item, owner)
 


### PR DESCRIPTION
This comment was correct when it was added in 65843e1. In that commit, `ActiveRecord::Associations::AssociationScope#scope` applies the nearest association's scope, and `#add_constraints` skips it.

c8d8899 made the comment incorrect. It modified `#scope` not to apply the nearest association's scope and `#add_constraints` to apply scopes for the entire association chain.