### PR TITLE
Fixes DisabledSessionError with new rails api app

### DIFF
--- a/railties/lib/rails/welcome_controller.rb
+++ b/railties/lib/rails/welcome_controller.rb
@@ -3,6 +3,7 @@
 require "rails/application_controller"
 
 class Rails::WelcomeController < Rails::ApplicationController # :nodoc:
+  skip_forgery_protection
   layout false
 
   def index

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -734,5 +734,18 @@ module ApplicationTests
       get "/url"
       assert_equal "/foo", last_response.body
     end
+
+    test "request to rails/welcome for api_only app is successful" do
+      add_to_config <<-RUBY
+        config.api_only = true
+        config.action_dispatch.show_exceptions = false
+        config.action_controller.allow_forgery_protection = true
+      RUBY
+
+      app "development"
+
+      get "/"
+      assert_equal 200, last_response.status
+    end
   end
 end


### PR DESCRIPTION
### Summary

When creating a new rails api app on edge rails and running `bin/rails s`, an exception occurs which is not a great experience when creating a new rails api app.

To fix this issue, the authenticity token check for the internal welcome controller is skipped.

Exception: `ActionController::RequestForgeryProtection::DisabledSessionError in Rails::WelcomeController#index`

This issue was prob not caught before because the generator which is used to build the app sets `allow_forgery_protection` to false here https://github.com/rails/rails/blob/e9ed23786d8e4f65e80df9f09c83d6353c881fa8/railties/test/isolation/abstract_unit.rb#L208

### Other Information

To reproduce;
1. Pull down rails main
2. `$ bundle exec rails new ~/projects/api_error_on_welcome_app --dev --api`
3. cd into your app and run `$ bin/rails s`
4. Visit the root url, which shows the exception below:

<img width="1440" alt="Screenshot 2021-07-24 at 23 32 26" src="https://user-images.githubusercontent.com/658005/126882498-27c536d6-ce3a-4739-9826-5822463bda76.png">