### PR TITLE
Rename `Middleware#remove` to `Middleware#delete!`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Rename `config.middleware.remove` to `config.middleware.delete!`
+
+    *Dino Maric*
+
 *   Raise error on unpermitted open redirects.
 
     Add `allow_other_host` options to `redirect_to`.

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -133,8 +133,8 @@ module ActionDispatch
       middlewares.reject! { |m| m.name == target.name }
     end
 
-    def remove(target)
-      delete(target) || (raise "No such middleware to remove: #{target.inspect}")
+    def delete!(target)
+      delete(target) || (raise "No such middleware to delete: #{target.inspect}")
     end
 
     def move(target, source)

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -43,15 +43,15 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     end
   end
 
-  test "remove deletes the middleware" do
+  test "delete! deletes the middleware" do
     assert_difference "@stack.size", -1 do
-      @stack.remove FooMiddleware
+      @stack.delete! FooMiddleware
     end
   end
 
-  test "remove requires the middleware to be in the stack" do
+  test "delete! requires the middleware to be in the stack" do
     assert_raises RuntimeError do
-      @stack.remove BazMiddleware
+      @stack.delete! BazMiddleware
     end
   end
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -205,6 +205,10 @@ And to remove browser related middleware,
 config.middleware.delete Rack::MethodOverride
 ```
 
+NOTE: Calling `config.middleware.delete` would fail silently if the item is not
+present in the middleware stack. Use `config.middleware.delete!` if you wish
+exception to be raised.
+
 ### Internal Middleware Stack
 
 Much of Action Controller's functionality is implemented as Middlewares. The following list explains the purpose of each of them:


### PR DESCRIPTION
Renames the method for clearer API and adds the NOTE to the guides.

Fixes #42862 

r? @p8  