### PR TITLE
"Middleware#remove" is renamed "Middleware#delete!"

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -3,7 +3,7 @@
     `Middleware#delete!` works just like `Middleware#delete` but will
     raise an error if the middleware isn't found.
 
-    *Alex Ghiculescu*, *Petrik de Heus*,  *Junichi Sato*
+    *Alex Ghiculescu*, *Petrik de Heus*, *Junichi Sato*
 
 *   Raise error on unpermitted open redirects.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add `Middleware#delete!` to delete middleware or raise if not found.
+
+    `Middleware#delete!` works just like `Middleware#delete` but will
+    raise an error if the middleware isn't found.
+
+    *Alex Ghiculescu*, *Petrik de Heus*,  *Junichi Sato*
+
 *   Raise error on unpermitted open redirects.
 
     Add `allow_other_host` options to `redirect_to`.
@@ -12,13 +19,6 @@
     [Cuprite](https://github.com/rubycdp/cuprite) is a good alternative to Poltergeist. Some guide descriptions are replaced from Poltergeist to Cuprite.
 
     *Yusuke Iwaki*
-
-*   Add `Middleware#remove` to delete middleware or raise if not found.
-
-    `Middleware#remove` works just like `Middleware#delete` but will
-    raise an error if the middleware isn't found.
-
-    *Alex Ghiculescu*, *Petrik de Heus*
 
 *   Exclude additional flash types from `ActionController::Base.action_methods`.
 

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -129,10 +129,18 @@ module ActionDispatch
     end
     ruby2_keywords(:swap)
 
+    # Deletes a middleware from the middleware stack.
+    #
+    # Returns an array of middlewares not including the deleted item, or
+    # returns nil if the target is not found.
     def delete(target)
       middlewares.reject! { |m| m.name == target.name }
     end
 
+    # Deletes a middleware from the middleware stack.
+    #
+    # Returns an array of middlewares not including the deleted item, or
+    # raises +RuntimeError+ if the target is not found.
     def delete!(target)
       delete(target) || (raise "No such middleware to remove: #{target.inspect}")
     end

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -133,7 +133,7 @@ module ActionDispatch
       middlewares.reject! { |m| m.name == target.name }
     end
 
-    def remove(target)
+    def delete!(target)
       delete(target) || (raise "No such middleware to remove: #{target.inspect}")
     end
 

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -139,7 +139,7 @@ module ActionDispatch
 
     # Deletes a middleware from the middleware stack.
     #
-    # Returns an array of middlewares not including the deleted item, or
+    # Returns the array of middlewares not including the deleted item, or
     # raises +RuntimeError+ if the target is not found.
     def delete!(target)
       delete(target) || (raise "No such middleware to remove: #{target.inspect}")

--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -131,7 +131,7 @@ module ActionDispatch
 
     # Deletes a middleware from the middleware stack.
     #
-    # Returns an array of middlewares not including the deleted item, or
+    # Returns the array of middlewares not including the deleted item, or
     # returns nil if the target is not found.
     def delete(target)
       middlewares.reject! { |m| m.name == target.name }

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -43,15 +43,15 @@ class MiddlewareStackTest < ActiveSupport::TestCase
     end
   end
 
-  test "remove deletes the middleware" do
+  test "delete! deletes the middleware" do
     assert_difference "@stack.size", -1 do
-      @stack.remove FooMiddleware
+      @stack.delete! FooMiddleware
     end
   end
 
-  test "remove requires the middleware to be in the stack" do
+  test "delete! requires the middleware to be in the stack" do
     assert_raises RuntimeError do
-      @stack.remove BazMiddleware
+      @stack.delete! BazMiddleware
     end
   end
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -205,6 +205,13 @@ And to remove browser related middleware,
 config.middleware.delete Rack::MethodOverride
 ```
 
+If you want an error to be raised when you try to delete a non-existent item, use `delete!` instead.
+
+```ruby
+# config/application.rb
+config.middleware.delete! ActionDispatch::Executor
+```
+
 ### Internal Middleware Stack
 
 Much of Action Controller's functionality is implemented as Middlewares. The following list explains the purpose of each of them:


### PR DESCRIPTION
### Summary
This commit intends to clarify the difference between
`Middleware#delete` and `Middleware#delete!`.

The former method silently fails when the target item is
not found, while the latter raises an error.

The functionality of `delete!` has been introduced in 688ed70
and given a name `remove`. This commit only renames it.

Also, a brief description of `delete!` method is now
provided for guides so that users can acknowledge the difference.

Resolves #42862
