### PR TITLE
assert_changes works on including ActiveSupport::Assertions class

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -189,7 +189,7 @@ module ActiveSupport
         error = "#{expression.inspect} didn't change"
         error = "#{error}. It was already #{to}" if before == to
         error = "#{message}.\n#{error}" if message
-        assert_not_equal before, after, error
+        refute_equal before, after, error
 
         unless to == UNTRACKED
           error = "Expected change to #{to}\n"

--- a/activesupport/test/testing/method_call_assertions_test.rb
+++ b/activesupport/test/testing/method_call_assertions_test.rb
@@ -200,4 +200,20 @@ class MethodCallAssertionsTest < ActiveSupport::TestCase
       assert_equal instance, Level.new
     end
   end
+
+  def test_assert_changes_when_assertions_are_included
+    test_unit_class = Class.new(Minitest::Test) do
+      include ActiveSupport::Testing::Assertions
+
+      def test_assert_changes
+        counter = 1
+        assert_changes(-> { counter }) do
+          counter = 2
+        end
+      end
+    end
+
+    test_results = test_unit_class.new(:test_assert_changes).run
+    assert test_results.passed?
+  end
 end


### PR DESCRIPTION
### Summary

Hi beloved rails team. This is my attempt to fix #42869. 

On the two possible approaches that I proposed on the issue, moving the alias to the Assertions module doesn't work because the alias assignment happens on loading the class, which fails because the method that the alias will redirect to doesn't exist yet. So I just renamed the method to use the original one from rails that 

assert_not_equal is an alias for refute_equal that is defined only on the class ActiveSupport::TestCase. This commit ensures ActiveSupport::Testing::Assertions#assert_changes doesn't depends on ActiveSupport::TestCase to work.

### Other Information

As I said on the issue I created, this used to work on 6.0.4 and on previously rails versions, stopped worked after we upgraded to rails 6.1

The code that I'm running started to fail on rails 6.1 is something like

```rb
require "minitest/autorun"
require "active_support/testing/assertions"

describe :assert_changes do
  include ActiveSupport::Testing::Assertions

  it "counts" do
    counter = 1
    assert_changes( -> { counter } ) do
      counter = 2
    end
  end
end
```

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
