### PR TITLE
[#42813] Render host_authorization debug view only for local requests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Update `HostAuthorization` middleware to render debug info only
+    when `config.consider_all_requests_local` is set to true.
+
+    Also, blocked host info is always logged with level `error`.
+
+    Fixes #42813
+
+    *Nikita Vyrko*
+
 *   Use a static error message when raising `ActionDispatch::Http::Parameters::ParseError`
     to avoid inadvertently logging the HTTP request body at the `fatal` level when it contains
     malformed JSON.

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -11,7 +11,10 @@ module ActionDispatch
   #
   # When a request comes to an unauthorized host, the +response_app+
   # application will be executed and rendered. If no +response_app+ is given, a
-  # default one will run, which responds with <tt>403 Forbidden</tt>.
+  # default one will run.
+  # The default response app logs blocked host info with level 'error' and
+  # responds with <tt>403 Forbidden</tt>. The body of the response contains debug info
+  # if +config.consider_all_requests_local+ is set to true, otherwise the body is empty.
   class HostAuthorization
     class Permissions # :nodoc:
       def initialize(hosts)
@@ -56,17 +59,43 @@ module ActionDispatch
         end
     end
 
-    DEFAULT_RESPONSE_APP = -> env do
-      request = Request.new(env)
+    class DefaultResponseApp # :nodoc:
+      RESPONSE_STATUS = 403
 
-      format = request.xhr? ? "text/plain" : "text/html"
-      template = DebugView.new(host: request.host)
-      body = template.render(template: "rescues/blocked_host", layout: "rescues/layout")
+      def call(env)
+        request = Request.new(env)
+        format = request.xhr? ? "text/plain" : "text/html"
 
-      [403, {
-        "Content-Type" => "#{format}; charset=#{Response.default_charset}",
-        "Content-Length" => body.bytesize.to_s,
-      }, [body]]
+        log_error(request)
+        response(format, response_body(request))
+      end
+
+      private
+        def response_body(request)
+          return "" unless request.get_header("action_dispatch.show_detailed_exceptions")
+
+          template = DebugView.new(host: request.host)
+          template.render(template: "rescues/blocked_host", layout: "rescues/layout")
+        end
+
+        def response(format, body)
+          [RESPONSE_STATUS,
+           { "Content-Type" => "#{format}; charset=#{Response.default_charset}",
+             "Content-Length" => body.bytesize.to_s },
+           [body]]
+        end
+
+        def log_error(request)
+          logger = available_logger(request)
+
+          return unless logger
+
+          logger.error("[#{self.class.name}] Blocked host: #{request.host}")
+        end
+
+        def available_logger(request)
+          request.logger || ActionView::Base.logger
+        end
     end
 
     def initialize(app, hosts, deprecated_response_app = nil, exclude: nil, response_app: nil)
@@ -83,7 +112,7 @@ module ActionDispatch
         response_app ||= deprecated_response_app
       end
 
-      @response_app = response_app || DEFAULT_RESPONSE_APP
+      @response_app = response_app || DefaultResponseApp.new
     end
 
     def call(env)


### PR DESCRIPTION
### Summary
Resolves #42813 
The problem is that detailed information is rendered in PROD env in case of blocked host 

`HostAuthorization` middleware has been updated, to:

- Respond with `HostAuthorization` debug view only when the `action_dispatch.show_detailed_exceptions`  header is set, respond with an empty body otherwise.
- Always log the following message `'[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked host: <request.host>'`. The chosen logging level is `error`
