### PR TITLE
Active job basic doc grammatical mistakes fixed [ci-skip] 

### DIFF
--- a/activejob/README.md
+++ b/activejob/README.md
@@ -2,8 +2,8 @@
 
 Active Job is a framework for declaring jobs and making them run on a variety
 of queuing backends. These jobs can be everything from regularly scheduled
-clean-ups, to billing charges, to mailings. Anything that can be chopped up into
-small units of work and run in parallel, really.
+clean-ups, to billing charges, to mailings — anything that can be chopped up into
+small units of work and run in parallel.
 
 It also serves as the backend for Action Mailer's #deliver_later functionality
 that makes it easy to turn any mailing into a job for running later. That's

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -114,7 +114,7 @@ Job Execution
 -------------
 
 For enqueuing and executing jobs in production you need to set up a queuing backend,
-that is to say you need to decide on a 3rd-party queuing library that Rails should use.
+that is to say, you need to decide on a 3rd-party queuing library that Rails should use.
 Rails itself only provides an in-process queuing system, which only keeps the jobs in RAM.
 If the process crashes or the machine is reset, then all outstanding jobs are lost with the
 default async backend. This may be fine for smaller apps or non-critical jobs, but most


### PR DESCRIPTION
Active Job basic guide entire page grammatical and punctuation issues fixed.