### PR TITLE
Trigger full sweep when testing garbage collection

### DIFF
--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -90,9 +90,9 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     listener_threads = Thread.list - previous_threads
 
     wait # Wait for listener thread to start processing events.
-    GC.start
+    4.times { GC.start } # Trigger full sweep.
 
-    assert_not_predicate checker_ref, :weakref_alive?
+    assert_not checker_ref.weakref_alive?
     assert_empty Thread.list & listener_threads
   end
 

--- a/activesupport/test/evented_file_update_checker_test.rb
+++ b/activesupport/test/evented_file_update_checker_test.rb
@@ -92,16 +92,17 @@ class EventedFileUpdateCheckerTest < ActiveSupport::TestCase
     # stack when running GC.
     Thread.new do
       previous_threads = Thread.list
-      checker_ref = WeakRef.new(ActiveSupport::EventedFileUpdateChecker.new([], tmpdir => ".rb") { })
+      checker = ActiveSupport::EventedFileUpdateChecker.new([], tmpdir => ".rb") { }
+      checker_ref = WeakRef.new(checker)
       listener_threads = Thread.list - previous_threads
 
-      assert_not_empty listener_threads
       wait # Wait for listener thread to start processing events.
     end.join
 
     4.times { GC.start }
 
     assert_not checker_ref.weakref_alive?
+    assert_not_empty listener_threads
     assert_empty Thread.list & listener_threads
   end
 


### PR DESCRIPTION
This ensures that the checker will be collected if it can be collected.

This addresses intermittent CI failures such as: https://buildkite.com/rails/rails/builds/79596#0051e91f-12bd-420f-979f-dd9c9ddb6f5b/1076-1085

---

I cannot reproduce the failure locally, so I am unsure whether this will completely fix it, but it is worth trying.
