### PR TITLE
Ensure thread_variables don't leak to fix CI

### DIFF
--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -191,6 +191,7 @@ class CurrentAttributesTest < ActiveSupport::TestCase
     end
     assert_equal 42, enumerator.next
   ensure
+    Session.current = nil
     ActiveSupport::CurrentAttributes._use_thread_variables = false
   end
 end


### PR DESCRIPTION
### Summary

Since 8195cd5f9970960cbd25ba1383f893a977014c81 we see occasional failing CI builds on PRs:
https://buildkite.com/rails/rails/builds/79632 
https://buildkite.com/rails/rails/builds/79596

The following build outputs the thread variables in the failing test:
https://buildkite.com/rails/rails/builds/79664#620bcdde-f4e7-4433-9af4-6186b49b9e18/1076-1084

This probably happens because the thread variables leak.
See for example the following build that asserts the variables don't leak:
https://buildkite.com/rails/rails/builds/79666#cc9ada15-ca01-43ec-9c54-699c4480d51e

As a temporary fix we can at least clear the thread-variables-based CurrentAttributes in the `ensure` block.