### PR TITLE
Remove leak when using CurrentAttributes in thread variables

### DIFF
--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -144,6 +144,7 @@ module ActiveSupport
       end
 
       def _use_thread_variables=(value) # :nodoc:
+        clear_all
         @@use_thread_variables = value
       end
       @@use_thread_variables = false


### PR DESCRIPTION
The test for CurrentAttributes using thread-local variables leaks an instance in Thread.current.

Usually instances are reset in the test helper but the objects remain: [activesupport/lib/active_support/current_attributes/test_helper.rb:11](https://github.com/etiennebarrie/rails/blob/39b382cf78c9981a1b6f44537d2f2200fb555270/activesupport/lib/active_support/current_attributes/test_helper.rb#L11)

In this situation we use `clear_all` to make sure we don't leave instances behind when the configuration is changed.


See also https://github.com/rails/rails/pull/42877 https://github.com/rails/rails/pull/42880

cc @byroot 