### PR TITLE
Remove empty section from the instrumentation guides [ci skip]

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -106,22 +106,9 @@ Rails framework hooks
 
 Within the Ruby on Rails framework, there are a number of hooks provided for common events. These are detailed below.
 
-Action Controller
------------------
+### Action Controller
 
-### write_fragment.action_controller
-
-| Key    | Value            |
-| ------ | ---------------- |
-| `:key` | The complete key |
-
-```ruby
-{
-  key: 'posts/1-dashboard-view'
-}
-```
-
-### read_fragment.action_controller
+#### write_fragment.action_controller
 
 | Key    | Value            |
 | ------ | ---------------- |
@@ -133,7 +120,7 @@ Action Controller
 }
 ```
 
-### expire_fragment.action_controller
+#### read_fragment.action_controller
 
 | Key    | Value            |
 | ------ | ---------------- |
@@ -145,7 +132,7 @@ Action Controller
 }
 ```
 
-### exist_fragment?.action_controller
+#### expire_fragment.action_controller
 
 | Key    | Value            |
 | ------ | ---------------- |
@@ -157,7 +144,19 @@ Action Controller
 }
 ```
 
-### write_page.action_controller
+#### exist_fragment?.action_controller
+
+| Key    | Value            |
+| ------ | ---------------- |
+| `:key` | The complete key |
+
+```ruby
+{
+  key: 'posts/1-dashboard-view'
+}
+```
+
+#### write_page.action_controller
 
 | Key     | Value             |
 | ------- | ----------------- |
@@ -169,7 +168,7 @@ Action Controller
 }
 ```
 
-### expire_page.action_controller
+#### expire_page.action_controller
 
 | Key     | Value             |
 | ------- | ----------------- |
@@ -181,7 +180,7 @@ Action Controller
 }
 ```
 
-### start_processing.action_controller
+#### start_processing.action_controller
 
 | Key           | Value                                                     |
 | ------------- | --------------------------------------------------------- |
@@ -205,7 +204,7 @@ Action Controller
 }
 ```
 
-### process_action.action_controller
+#### process_action.action_controller
 
 | Key             | Value                                                     |
 | --------------- | --------------------------------------------------------- |
@@ -238,7 +237,7 @@ Action Controller
 }
 ```
 
-### send_file.action_controller
+#### send_file.action_controller
 
 | Key     | Value                     |
 | ------- | ------------------------- |
@@ -246,11 +245,11 @@ Action Controller
 
 INFO. Additional keys may be added by the caller.
 
-### send_data.action_controller
+#### send_data.action_controller
 
 `ActionController` does not add any specific information to the payload. All options are passed through to the payload.
 
-### redirect_to.action_controller
+#### redirect_to.action_controller
 
 | Key         | Value                         |
 | ----------- | ----------------------------- |
@@ -266,7 +265,7 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-### halted_callback.action_controller
+#### halted_callback.action_controller
 
 | Key       | Value                         |
 | --------- | ----------------------------- |
@@ -278,26 +277,24 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-### unpermitted_parameters.action_controller
+#### unpermitted_parameters.action_controller
 
 | Key           | Value                                                                 |
 | ------------- | --------------------------------------------------------------------- |
 | `:keys`       | The unpermitted keys                                                  |
 | `:context`    | Hash with the following keys: :controller, :action, :params, :request |
 
-Action Dispatch
----------------
+### Action Dispatch
 
-### process_middleware.action_dispatch
+#### process_middleware.action_dispatch
 
 | Key           | Value                  |
 | ------------- | ---------------------- |
 | `:middleware` | Name of the middleware |
 
-Action View
------------
+### Action View
 
-### render_template.action_view
+#### render_template.action_view
 
 | Key           | Value                 |
 | ------------- | --------------------- |
@@ -311,7 +308,7 @@ Action View
 }
 ```
 
-### render_partial.action_view
+#### render_partial.action_view
 
 | Key           | Value                 |
 | ------------- | --------------------- |
@@ -323,7 +320,7 @@ Action View
 }
 ```
 
-### render_collection.action_view
+#### render_collection.action_view
 
 | Key           | Value                                 |
 | ------------- | ------------------------------------- |
@@ -341,10 +338,9 @@ Action View
 }
 ```
 
-Active Record
-------------
+### Active Record
 
-### sql.active_record
+#### sql.active_record
 
 | Key                  | Value                                    |
 | -------------------- | ---------------------------------------- |
@@ -369,7 +365,7 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
-### instantiation.active_record
+#### instantiation.active_record
 
 | Key              | Value                                     |
 | ---------------- | ----------------------------------------- |
@@ -383,10 +379,9 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
-Action Mailer
--------------
+### Action Mailer
 
-### deliver.action_mailer
+#### deliver.action_mailer
 
 | Key                   | Value                                                |
 | --------------------- | ---------------------------------------------------- |
@@ -414,7 +409,7 @@ Action Mailer
 }
 ```
 
-### process.action_mailer
+#### process.action_mailer
 
 | Key           | Value                    |
 | ------------- | ------------------------ |
@@ -430,10 +425,9 @@ Action Mailer
 }
 ```
 
-Active Support
---------------
+### Active Support
 
-### cache_read.active_support
+#### cache_read.active_support
 
 | Key                | Value                                             |
 | ------------------ | ------------------------------------------------- |
@@ -442,7 +436,7 @@ Active Support
 | `:hit`             | If this read is a hit                             |
 | `:super_operation` | :fetch is added when a read is used with `#fetch` |
 
-### cache_generate.active_support
+#### cache_generate.active_support
 
 This event is only used when `#fetch` is called with a block.
 
@@ -460,7 +454,7 @@ INFO. Options passed to fetch will be merged with the payload when writing to th
 }
 ```
 
-### cache_fetch_hit.active_support
+#### cache_fetch_hit.active_support
 
 This event is only used when `#fetch` is called with a block.
 
@@ -478,7 +472,7 @@ INFO. Options passed to fetch will be merged with the payload.
 }
 ```
 
-### cache_write.active_support
+#### cache_write.active_support
 
 | Key      | Value                   |
 | -------- | ----------------------- |
@@ -494,7 +488,7 @@ INFO. Cache stores may add their own keys
 }
 ```
 
-### cache_delete.active_support
+#### cache_delete.active_support
 
 | Key      | Value                   |
 | -------- | ----------------------- |
@@ -508,7 +502,7 @@ INFO. Cache stores may add their own keys
 }
 ```
 
-### cache_exist?.active_support
+#### cache_exist?.active_support
 
 | Key      | Value                   |
 | -------- | ----------------------- |
@@ -522,24 +516,23 @@ INFO. Cache stores may add their own keys
 }
 ```
 
-Active Job
-----------
+### Active Job
 
-### enqueue_at.active_job
-
-| Key          | Value                                  |
-| ------------ | -------------------------------------- |
-| `:adapter`   | QueueAdapter object processing the job |
-| `:job`       | Job object                             |
-
-### enqueue.active_job
+#### enqueue_at.active_job
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-### enqueue_retry.active_job
+#### enqueue.active_job
+
+| Key          | Value                                  |
+| ------------ | -------------------------------------- |
+| `:adapter`   | QueueAdapter object processing the job |
+| `:job`       | Job object                             |
+
+#### enqueue_retry.active_job
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
@@ -548,21 +541,21 @@ Active Job
 | `:error`     | The error that caused the retry        |
 | `:wait`      | The delay of the retry                 |
 
-### perform_start.active_job
+#### perform_start.active_job
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-### perform.active_job
+#### perform.active_job
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-### retry_stopped.active_job
+#### retry_stopped.active_job
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
@@ -570,7 +563,7 @@ Active Job
 | `:job`       | Job object                             |
 | `:error`     | The error that caused the retry        |
 
-### discard.active_job
+#### discard.active_job
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
@@ -578,10 +571,9 @@ Active Job
 | `:job`       | Job object                             |
 | `:error`     | The error that caused the discard      |
 
-Action Cable
-------------
+### Action Cable
 
-### perform_action.action_cable
+#### perform_action.action_cable
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
@@ -589,7 +581,7 @@ Action Cable
 | `:action`        | The action                |
 | `:data`          | A hash of data            |
 
-### transmit.action_cable
+#### transmit.action_cable
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
@@ -597,19 +589,19 @@ Action Cable
 | `:data`          | A hash of data            |
 | `:via`           | Via                       |
 
-### transmit_subscription_confirmation.action_cable
+#### transmit_subscription_confirmation.action_cable
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
 | `:channel_class` | Name of the channel class |
 
-### transmit_subscription_rejection.action_cable
+#### transmit_subscription_rejection.action_cable
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
 | `:channel_class` | Name of the channel class |
 
-### broadcast.action_cable
+#### broadcast.action_cable
 
 | Key             | Value                |
 | --------------- | -------------------- |
@@ -617,10 +609,9 @@ Action Cable
 | `:message`      | A hash of message    |
 | `:coder`        | The coder            |
 
-Active Storage
---------------
+### Active Storage
 
-### service_upload.active_storage
+#### service_upload.active_storage
 
 | Key          | Value                        |
 | ------------ | ---------------------------- |
@@ -628,14 +619,14 @@ Active Storage
 | `:service`   | Name of the service          |
 | `:checksum`  | Checksum to ensure integrity |
 
-### service_streaming_download.active_storage
+#### service_streaming_download.active_storage
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
-### service_download_chunk.active_storage
+#### service_download_chunk.active_storage
 
 | Key          | Value                           |
 | ------------ | ------------------------------- |
@@ -643,28 +634,28 @@ Active Storage
 | `:service`   | Name of the service             |
 | `:range`     | Byte range attempted to be read |
 
-### service_download.active_storage
+#### service_download.active_storage
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
-### service_delete.active_storage
+#### service_delete.active_storage
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
-### service_delete_prefixed.active_storage
+#### service_delete_prefixed.active_storage
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:prefix`    | Key prefix          |
 | `:service`   | Name of the service |
 
-### service_exist.active_storage
+#### service_exist.active_storage
 
 | Key          | Value                       |
 | ------------ | --------------------------- |
@@ -672,7 +663,7 @@ Active Storage
 | `:service`   | Name of the service         |
 | `:exist`     | File or blob exists or not  |
 
-### service_url.active_storage
+#### service_url.active_storage
 
 | Key          | Value               |
 | ------------ | ------------------- |
@@ -680,7 +671,7 @@ Active Storage
 | `:service`   | Name of the service |
 | `:url`       | Generated URL       |
 
-### service_update_metadata.active_storage
+#### service_update_metadata.active_storage
 
 | Key             | Value                          |
 | --------------- | ------------------------------ |
@@ -691,27 +682,25 @@ Active Storage
 
 INFO. The only ActiveStorage service that provides this hook so far is GCS.
 
-### preview.active_storage
+#### preview.active_storage
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 
-### transform.active_storage
+#### transform.active_storage
 
-Railties
---------
+### Railties
 
-### load_config_initializer.railties
+#### load_config_initializer.railties
 
 | Key            | Value                                                 |
 | -------------- | ----------------------------------------------------- |
 | `:initializer` | Path to loaded initializer from `config/initializers` |
 
-Rails
------
+### Rails
 
-### deprecation.rails
+#### deprecation.rails
 
 | Key          | Value                           |
 | ------------ | ------------------------------- |


### PR DESCRIPTION
### Summary

There is an almost empty section here https://guides.rubyonrails.org/active_support_instrumentation.html#rails-framework-hooks which looks a bit weird. 

I thought of having `Rails framework hooks` be the parent section for each of the Rails "components" (ActionController, etc) but given the length of each "component", then I changed my mind and thought that it might be better to just remove the title of the empty section but keep its message.

![image](https://user-images.githubusercontent.com/6373536/127174057-621112cb-60ed-48ea-b1ce-fd6be8fe231d.png)
 