### PR TITLE
Fix incorrect column name for Customer model

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2154,7 +2154,7 @@ one of those records exists.
 ```ruby
 Customer.exists?(id: [1,2,3])
 # or
-Customer.exists?(name: ['Jane', 'Sergei'])
+Customer.exists?(first_name: ['Jane', 'Sergei'])
 ```
 
 It's even possible to use `exists?` without any arguments on a model or a relation.

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -2038,7 +2038,7 @@ SELECT DISTINCT status FROM orders
 => ["shipped", "being_packed", "cancelled"]
 
 irb> Customer.pluck(:id, :first_name)
-SELECT customers.id, customers.name FROM customers
+SELECT customers.id, customers.first_name FROM customers
 => [[1, "David"], [2, "Fran"], [3, "Jose"]]
 ```
 
@@ -2049,7 +2049,7 @@ Customer.select(:id).map { |c| c.id }
 # or
 Customer.select(:id).map(&:id)
 # or
-Customer.select(:id, :name).map { |c| [c.id, c.first_name] }
+Customer.select(:id, :first_name).map { |c| [c.id, c.first_name] }
 ```
 
 with:


### PR DESCRIPTION
### Summary

The Customer model does not have a "name" column and for those typing out the examples this will throw an exception "ActiveRecord::StatementInvalid (SQLite3::SQLException: no such column: customers.name)". This proposed fix changes "name" to the correct "first_name" column. Thank you for your time and consideration.