### PR TITLE
Fix :nodoc: [ci skip]

### DIFF
--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -198,7 +198,7 @@ module ActiveSupport
         notifier.publish(name, *args)
       end
 
-      def publish_event(event) # :nodoc;
+      def publish_event(event) # :nodoc:
         notifier.publish_event(event)
       end
 


### PR DESCRIPTION
### Summary

Found a typo and once it's fixed it will no longer show up here https://edgeapi.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-publish_event