### PR TITLE
Prevent infinite recursion in Object.as_json

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Fix stack overflow error on default Object#as_json method when objects contain references to each other.
+    Back references in instance variables will now be omitted in lieu of of getting a SystemStackError.
+
+    *Brian Durand*
+
 *   Faster tests by parallelizing only when overhead is justified by the number
     of them.
 

--- a/activesupport/test/core_ext/object/json_test.rb
+++ b/activesupport/test/core_ext/object/json_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/object/json"
+
+class ObjectAsJsonTests < ActiveSupport::TestCase
+  class Sample
+    def initialize(attributes)
+      attributes.each do |name, value|
+        instance_variable_set("@#{name}", value)
+      end
+    end
+  end
+
+  class SampleWithHash
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def to_hash
+      @attributes
+    end
+  end
+
+  def test_simple_poro
+    object = Sample.new(name: "foo", value: "bar")
+    assert_equal({ "name" => "foo", "value" => "bar" }, object.as_json)
+  end
+
+  def test_with_to_hash
+    hash = { foo: "bar" }
+    object = SampleWithHash.new(hash)
+    assert_equal(hash.as_json, object.as_json)
+  end
+
+  def test_nested_objects
+    children = []
+    object = Sample.new(name: "parent", children: children)
+    child_1 = Sample.new(name: "child_1")
+    child_2 = Sample.new(name: "child_2")
+    children.concat([child_1, child_2])
+    assert_equal({ "name" => "parent", "children" => [{ "name" => "child_1" }, { "name" => "child_2" }] }, object.as_json)
+  end
+
+  def test_nested_objects_with_backreferences
+    children = []
+    object = Sample.new(name: "parent", children: children)
+    child_1 = Sample.new(name: "child_1", parent: object)
+    child_2 = Sample.new(name: "child_2", parent: child_1)
+    child_3 = Sample.new(name: "child_3")
+    child_4 = Sample.new(name: "child_4", parent: { owner: child_3 })
+    children.concat([child_1, child_2, child_4])
+    expected_hash = {
+      "name" => "parent",
+      "children" => [
+        { "name" => "child_1" },
+        { "name" => "child_2", "parent" => { "name" => "child_1" } },
+        { "name" => "child_4", "parent" => { "owner" => { "name" => "child_3" } } },
+      ]
+    }
+    assert_equal(expected_hash, object.as_json)
+  end
+end


### PR DESCRIPTION
### Summary

The fallback implementation for `as_json` on Object just dumps the instance variables as name value pairs in a Hash. However, this is very susceptible to infinite recursion when dumping an object that maintains references to other objects that then maintain back references to the original object.

So, for example, a tree structure where the parent has a list of the children and each child has a reference to its parent results in a `SystemStackError` when calling as_json on any node.

The fix is to maintain a state of the current stack of objects being used to construct the as_json hash. If an object has already been referenced in the current call to `Object#as_json`, it is left out of the hash in lieu of having it raise a stack level too deep error.

### Other Information

This change won't affect the serialization of any current objects since the only only objects impacted would be ones that raise an error when calling `as_json`.

A real world case of why this is needed would be, for example, a logging system that dumps objects to a log stream as JSON objects. Without this change, there are some objects that can't be logged, but you don't know what they are until you get an error because all objects implement `as_json`.

The tests provide cases that break without this change. A simple case that can be run in the rails console is:

```ruby
# Rake tasks contain a reference to an application and that application has a list of all tasks
# resulting in a circular reference.
task = Rake::Task.define_task(:foo){ puts "foo" }
task.as_json
```