### PR TITLE
Update resolve_link_as to include SVG

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -536,6 +536,8 @@ module ActionView
             "style"
           elsif extname == "vtt"
             "track"
+          elsif extname == "svg"
+            "image"
           elsif (type = mime_type.to_s.split("/")[0]) && type.in?(%w(audio video font))
             type
           end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -255,6 +255,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(preload_link_tag '//example.com/font.woff2', crossorigin: 'use-credentials') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials" />),
     %(preload_link_tag '/media/audio.ogg', nopush: true) => %(<link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg" />),
     %(preload_link_tag '/style.css', integrity: 'sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs') => %(<link rel="preload" href="/style.css" as="style" type="text/css" integrity="sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs">),
+    %(preload_link_tag '/sprite.svg', as: 'image') => %(<link rel="preload" href="/sprite.svg" as="image" type="image/svg+xml">)
   }
 
   VideoPathToTag = {

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -255,7 +255,7 @@ class AssetTagHelperTest < ActionView::TestCase
     %(preload_link_tag '//example.com/font.woff2', crossorigin: 'use-credentials') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials" />),
     %(preload_link_tag '/media/audio.ogg', nopush: true) => %(<link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg" />),
     %(preload_link_tag '/style.css', integrity: 'sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs') => %(<link rel="preload" href="/style.css" as="style" type="text/css" integrity="sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs">),
-    %(preload_link_tag '/sprite.svg', as: 'image') => %(<link rel="preload" href="/sprite.svg" as="image" type="image/svg+xml">)
+    %(preload_link_tag '/sprite.svg') => %(<link rel="preload" href="/sprite.svg" as="image" type="image/svg+xml">)
   }
 
   VideoPathToTag = {


### PR DESCRIPTION
### Summary

Preloading SVGs is useful when using sprites such as bootstrap-icons. Without this code change, the browser will ignore SVGs (thus not preloading them) due to this error:

`Preload of /packs/media/images/81d035675e31079ea9da.svg was ignored due to unknown “as” or “type” values, or non-matching “media” attribute.`

### Other Information

I'm making this PR because it is easy to forget adding 'as image' to preload_pack_asset.  This code change does that automatically. 
