### PR TITLE
Bring back support for underscores in config.hosts

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -100,7 +100,7 @@ module ActionDispatch
     end
 
     private
-      HOSTNAME = /[a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9.:]+\]/i
+      HOSTNAME = /[a-z0-9._-]+|\[[a-f0-9]*:[a-f0-9.:]+\]/i
       VALID_ORIGIN_HOST = /\A(#{HOSTNAME})(?::\d+)?\z/
       VALID_FORWARDED_HOST = /(?:\A|,[ ]?)(#{HOSTNAME})(?::\d+)?\z/
 


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/41545
Ref: https://github.com/rails/rails/commit/83a6ac3fee8fd538ce7e0088913ff54f0f9bcb6f

As far as I can tell, accepting underscores shouldn't break the
security measure.

cc @rafaelfranca @tenderlove @TkTech in case I'm wrong about the importance of banning underscores.