### PR TITLE
Fix incomplete :nodoc: directives [ci-skip]

### DIFF
--- a/actionview/lib/action_view/template/error.rb
+++ b/actionview/lib/action_view/template/error.rb
@@ -229,7 +229,7 @@ module ActionView
 
   TemplateError = Template::Error
 
-  class SyntaxErrorInTemplate < TemplateError #:nodoc
+  class SyntaxErrorInTemplate < TemplateError #:nodoc:
     def initialize(template, offending_code_string)
       @offending_code_string = offending_code_string
       super(template)

--- a/activerecord/lib/active_record/attribute_methods/read.rb
+++ b/activerecord/lib/active_record/attribute_methods/read.rb
@@ -34,7 +34,7 @@ module ActiveRecord
 
       # This method exists to avoid the expensive primary_key check internally, without
       # breaking compatibility with the read_attribute API
-      def _read_attribute(attr_name, &block) # :nodoc
+      def _read_attribute(attr_name, &block) # :nodoc:
         @attributes.fetch_value(attr_name, &block)
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -208,24 +208,24 @@ module ActiveRecord
         yield execute(sql, name, async: async)
       end
 
-      def begin_db_transaction
+      def begin_db_transaction # :nodoc:
         execute("BEGIN", "TRANSACTION")
       end
 
-      def begin_isolated_db_transaction(isolation)
+      def begin_isolated_db_transaction(isolation) # :nodoc:
         execute "SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}"
         begin_db_transaction
       end
 
-      def commit_db_transaction #:nodoc:
+      def commit_db_transaction # :nodoc:
         execute("COMMIT", "TRANSACTION")
       end
 
-      def exec_rollback_db_transaction #:nodoc:
+      def exec_rollback_db_transaction # :nodoc:
         execute("ROLLBACK", "TRANSACTION")
       end
 
-      def empty_insert_statement_value(primary_key = nil)
+      def empty_insert_statement_value(primary_key = nil) # :nodoc:
         "VALUES ()"
       end
 

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -48,7 +48,7 @@ module ActiveRecord
           super
         end
 
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
           if without_prepared_statement?(binds)
             execute_and_free(sql, name, async: async) do |result|
               if result
@@ -68,7 +68,7 @@ module ActiveRecord
           end
         end
 
-        def exec_delete(sql, name = nil, binds = [])
+        def exec_delete(sql, name = nil, binds = []) # :nodoc:
           if without_prepared_statement?(binds)
             @lock.synchronize do
               execute_and_free(sql, name) { @connection.affected_rows }

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -47,7 +47,7 @@ module ActiveRecord
           end
         end
 
-        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false)
+        def exec_query(sql, name = "SQL", binds = [], prepare: false, async: false) # :nodoc:
           execute_and_clear(sql, name, binds, prepare: prepare, async: async) do |result|
             types = {}
             fields = result.fields
@@ -64,7 +64,7 @@ module ActiveRecord
           end
         end
 
-        def exec_delete(sql, name = nil, binds = [])
+        def exec_delete(sql, name = nil, binds = []) # :nodoc:
           execute_and_clear(sql, name, binds) { |result| result.cmd_tuples }
         end
         alias :exec_update :exec_delete
@@ -84,7 +84,7 @@ module ActiveRecord
         end
         private :sql_for_insert
 
-        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil)
+        def exec_insert(sql, name = nil, binds = [], pk = nil, sequence_name = nil) # :nodoc:
           if use_insert_returning? || pk == false
             super
           else
@@ -103,22 +103,22 @@ module ActiveRecord
         end
 
         # Begins a transaction.
-        def begin_db_transaction
+        def begin_db_transaction # :nodoc:
           execute("BEGIN", "TRANSACTION")
         end
 
-        def begin_isolated_db_transaction(isolation)
+        def begin_isolated_db_transaction(isolation) # :nodoc:
           begin_db_transaction
           execute "SET TRANSACTION ISOLATION LEVEL #{transaction_isolation_levels.fetch(isolation)}"
         end
 
         # Commits a transaction.
-        def commit_db_transaction
+        def commit_db_transaction # :nodoc:
           execute("COMMIT", "TRANSACTION")
         end
 
         # Aborts a transaction.
-        def exec_rollback_db_transaction
+        def exec_rollback_db_transaction # :nodoc:
           execute("ROLLBACK", "TRANSACTION")
         end
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -31,7 +31,7 @@ module ActiveRecord
           end
         end
 
-        def exec_query(sql, name = nil, binds = [], prepare: false, async: false)
+        def exec_query(sql, name = nil, binds = [], prepare: false, async: false) #:nodoc:
           check_if_write_query(sql)
 
           materialize_transactions
@@ -66,7 +66,7 @@ module ActiveRecord
           end
         end
 
-        def exec_delete(sql, name = "SQL", binds = [])
+        def exec_delete(sql, name = "SQL", binds = []) #:nodoc:
           exec_query(sql, name, binds)
           @connection.changes
         end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -72,7 +72,7 @@ module ActiveRecord
         end
         alias :exec_update :exec_delete
 
-        def begin_isolated_db_transaction(isolation) #:nodoc
+        def begin_isolated_db_transaction(isolation) #:nodoc:
           raise TransactionIsolationError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted
           raise StandardError, "You need to enable the shared-cache mode in SQLite mode before attempting to change the transaction isolation level" unless shared_cache?
 

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -210,7 +210,7 @@ module ActiveRecord
         @connection_class = b
       end
 
-      def self.connection_class # :nodoc
+      def self.connection_class # :nodoc:
         @connection_class ||= false
       end
 


### PR DESCRIPTION
This PR fixes a few incomplete `:nodoc:` directives (`:nodoc` => `:nodoc:`).  While fixing those, I noticed that some `ActiveRecord::ConnectionAdapters::DatabaseStatements` overrides were `:nodoc:`'d in some adapters, but not in others (e.g. `begin_isolated_db_transaction` is `:nodoc:`'d in the SQLite3 adapter, but not in [the Postgres adapter](https://github.com/rails/rails/blob/311d0babfbacd105c2452339e9037e4a50400183/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L110) or [the MySQL adapter](https://github.com/rails/rails/blob/311d0babfbacd105c2452339e9037e4a50400183/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L215)).  Since the omissions were likely oversights, I added `:nodoc:` directives to them and several other `ActiveRecord::ConnectionAdapters::DatabaseStatements` overrides.
