### PR TITLE
Add aliases for polymorphic associations

### DIFF
--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -8,7 +8,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.valid_options(options)
       valid = super + [:polymorphic, :counter_cache, :optional, :default]
-      valid += [:foreign_type] if options[:polymorphic]
+      valid += [:foreign_type, :types] if options[:polymorphic]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
       valid
     end

--- a/activerecord/test/cases/associations/belongs_to_polymorphic_association_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_polymorphic_association_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/review"
+require "models/show"
+require "models/album"
+require "models/manga"
+require "models/restaurant"
+require "models/restaurant/menu"
+require "models/library"
+require "models/library/staff_member"
+
+class BelongsToPolymorphicAssociationTest < ActiveRecord::TestCase
+  fixtures :reviews, :albums, :shows, :mangas, :restaurants, "restaurant/menus", :libraries, "library/staff_members"
+
+  setup do
+    @album_review      = reviews(:album_review)
+    @show_review       = reviews(:show_review)
+    @manga_review      = reviews(:manga_review)
+    @restaurant_review = reviews(:restaurant_review)
+    @menu_review       = reviews(:menu_review)
+    @library_review    = reviews(:library_review)
+    @staff_review      = reviews(:staff_review)
+  end
+
+  test "should be able to use aliases to access polymorphic associations" do
+    assert_equal "This album is crushin!", @album_review.content
+    assert_equal "The Off-Season", @album_review.album.name
+
+    assert_equal "So disappointed by the end...", @show_review.content
+    assert_equal "Game Of Thrones", @show_review.show.name
+
+    assert_equal "Masterpiece", @manga_review.content
+    assert_equal "Shingeki No Kyojin", @manga_review.manga.name
+
+    assert_equal "We can chill to code without buying. That's neat!", @restaurant_review.content
+    assert_equal "La Felicità", @restaurant_review.restaurant.name
+
+    assert_equal "Not for me", @menu_review.content
+    assert_equal "Happy Meal", @menu_review.restaurant_menu.name
+
+    assert_equal "Awesome library! They're even lending robots to teach kids how to code!", @library_review.content
+    assert_equal "L'Eclipse", @library_review.library.name
+
+    assert_equal "The Best One!", @staff_review.content
+    assert_equal "Dorothy", @staff_review.library_staff_member.name
+
+    assert @album_review.reload_album
+    assert @show_review.reload_show
+    assert @manga_review.reload_manga
+    assert @restaurant_review.reload_restaurant
+    assert @menu_review.reload_restaurant_menu
+    assert @library_review.reload_library
+    assert @staff_review.reload_library_staff_member
+
+    assert_nil @album_review.show
+    assert_nil @show_review.restaurant_menu
+    assert_nil @manga_review.library_staff_member
+    assert_nil @restaurant_review.manga
+    assert_nil @menu_review.library
+    assert_nil @library_review.restaurant
+    assert_nil @staff_review.album
+  end
+end

--- a/activerecord/test/fixtures/albums.yml
+++ b/activerecord/test/fixtures/albums.yml
@@ -1,0 +1,2 @@
+the_off_season:
+  name: The Off-Season

--- a/activerecord/test/fixtures/libraries.yml
+++ b/activerecord/test/fixtures/libraries.yml
@@ -1,0 +1,2 @@
+eclipse:
+  name: L'Eclipse

--- a/activerecord/test/fixtures/library/staff_members.yml
+++ b/activerecord/test/fixtures/library/staff_members.yml
@@ -1,0 +1,23 @@
+dorothy:
+  name: Dorothy
+
+delphine:
+  name: Delphine
+
+chaima:
+  name: Chaïma
+
+rabia:
+  name: Rabia
+
+isabelle:
+  name: Isabelle
+
+nelly:
+  name: Nelly
+
+jimmy:
+  name: Jimmy
+
+fanny:
+  name: Fanny

--- a/activerecord/test/fixtures/mangas.yml
+++ b/activerecord/test/fixtures/mangas.yml
@@ -1,0 +1,11 @@
+snk:
+  name: Shingeki No Kyojin
+
+death_note:
+  name: Death Note
+
+jujutsu_kaizen:
+  name: Jujutsu Kaizen
+
+tokyo_revengers:
+  name: Tokyo Revengers

--- a/activerecord/test/fixtures/restaurant/menus.yml
+++ b/activerecord/test/fixtures/restaurant/menus.yml
@@ -1,0 +1,2 @@
+happy_meal:
+  name: Happy Meal

--- a/activerecord/test/fixtures/restaurants.yml
+++ b/activerecord/test/fixtures/restaurants.yml
@@ -1,0 +1,2 @@
+felicita:
+  name: La Felicità

--- a/activerecord/test/fixtures/reviews.yml
+++ b/activerecord/test/fixtures/reviews.yml
@@ -1,0 +1,27 @@
+album_review:
+  content: This album is crushin!
+  reviewable: the_off_season (Album)
+
+show_review:
+  content: So disappointed by the end...
+  reviewable: game_of_thrones (Show)
+
+manga_review:
+  content: Masterpiece
+  reviewable: snk (Manga)
+
+restaurant_review:
+  content: We can chill to code without buying. That's neat!
+  reviewable: felicita (Restaurant)
+
+menu_review:
+  content: Not for me
+  reviewable: happy_meal (Restaurant::Menu)
+
+library_review:
+  content: Awesome library! They're even lending robots to teach kids how to code!
+  reviewable: eclipse (Library)
+
+staff_review:
+  content: The Best One!
+  reviewable: dorothy (Library::StaffMember)

--- a/activerecord/test/fixtures/shows.yml
+++ b/activerecord/test/fixtures/shows.yml
@@ -1,0 +1,8 @@
+game_of_thrones:
+  name: Game Of Thrones
+
+peaky_blinders:
+  name: Peaky Blinders
+
+new_amsterdam:
+  name: New Amsterdam

--- a/activerecord/test/models/album.rb
+++ b/activerecord/test/models/album.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Album < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/models/library.rb
+++ b/activerecord/test/models/library.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Library < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/models/library/staff_member.rb
+++ b/activerecord/test/models/library/staff_member.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Library::StaffMember < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/models/manga.rb
+++ b/activerecord/test/models/manga.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Manga < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/models/restaurant.rb
+++ b/activerecord/test/models/restaurant.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Restaurant < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/models/restaurant/menu.rb
+++ b/activerecord/test/models/restaurant/menu.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Restaurant::Menu < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/models/review.rb
+++ b/activerecord/test/models/review.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Review < ActiveRecord::Base
+  belongs_to :reviewable, polymorphic: true, types: %w( Album Show Manga Restaurant Restaurant::Menu Library Library::StaffMember )
+end

--- a/activerecord/test/models/show.rb
+++ b/activerecord/test/models/show.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Show < ActiveRecord::Base
+  has_many :reviews, as: :reviewable
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -1273,6 +1273,39 @@ ActiveRecord::Schema.define do
     t.integer :id
     t.datetime :created_at
   end
+
+  create_table :reviews, force: true do |t|
+    t.text :content
+    t.references :reviewable, polymorphic: true
+  end
+
+  create_table :albums, force: true do |t|
+    t.string :name
+  end
+
+  create_table :shows, force: true do |t|
+    t.string :name
+  end
+
+  create_table :mangas, force: true do |t|
+    t.string :name
+  end
+
+  create_table :restaurants, force: true do |t|
+    t.string :name
+  end
+
+  create_table :restaurant_menus, force: true do |t|
+    t.string :name
+  end
+
+  create_table :libraries, force: true do |t|
+    t.string :name
+  end
+
+  create_table :library_staff_members, force: true do |t|
+    t.string :name
+  end
 end
 
 Course.connection.create_table :courses, force: true do |t|


### PR DESCRIPTION
### Summary
As with [delegated types](https://edgeapi.rubyonrails.org/classes/ActiveRecord/DelegatedType.html#method-i-delegated_type), I'd like to define polymorphic associations like this:
```ruby
# app/models/review.rb
class Review < ActiveRecord::Base
  belongs_to :reviewable, polymorphic: true, types: %w( Album Restaurant )
end

# app/models/album.rb
class Album < ActiveRecord::Base
  has_many :reviews, as: :reviewable
end

# app/models/restaurant.rb
class Restaurant < ActiveRecord::Base
  has_many :reviews, as: :reviewable
end
```
And access them this way:
```ruby
Review#album
Review#album=
Review#reload_album

Review#restaurant
Review#restaurant=
Review#reload_restaurant
```
I'll be waiting for your feedback to improve the code. Here's the initial issue: #42868.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
