### PR TITLE
Address `bundle exec blade build` failure with ruby 3.1.0dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,6 +176,9 @@ if RUBY_VERSION >= "3.1"
   gem "net-imap", require: false
   gem "net-pop", require: false
 
+  # digest gem, which is one of the default gems has bumped to 3.0.1.pre for ruby 3.1.0dev.
+  gem "digest", "~> 3.0.1.pre", require: false
+
   # matrix was removed from default gems in Ruby 3.1, but is used by the `capybara` gem.
   # So we need to add it as a dependency until `capybara` is fixed: https://github.com/teamcapybara/capybara/pull/2468
   gem "matrix", require: false


### PR DESCRIPTION
### Summary

This commit addresses the CI failures with ruby 3.1.0dev.
https://buildkite.com/rails/rails/builds/79716#ef77b273-93d2-4372-a7fc-165dca6cadef since Ruby ruby 3.1.0dev bumps the digest gem version to 3.0.1.pre via https://github.com/ruby/ruby/commit/478f0ddb5f37085588485d3d00024a146af7bc44

- Without this commit

```ruby
$ ruby -v
ruby 3.1.0dev (2021-07-29T03:51:10Z master 64adeeadaa) [x86_64-linux]
$ bundle exec blade build
bundler: failed to load command: blade (/home/yahonda/.rbenv/versions/3.1.0-dev/bin/blade)
/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:300:in `check_for_activated_spec!': You have already activated digest 3.0.1.pre, but your Gemfile requires digest 3.0.0. Since digest is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports digest as a default gem. (Gem::LoadError)
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:29:in `block in setup'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/spec_set.rb:158:in `each'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/spec_set.rb:158:in `each'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:24:in `map'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:24:in `setup'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler.rb:149:in `setup'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/setup.rb:10:in `block in <top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/ui/shell.rb:136:in `with_level'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/ui/shell.rb:88:in `silence'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/setup.rb:10:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/cli/exec.rb:61:in `require_relative'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/cli/exec.rb:61:in `kernel_load'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/cli/exec.rb:28:in `run'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/cli.rb:481:in `exec'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/cli.rb:31:in `dispatch'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/cli.rb:25:in `start'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/bundler-2.3.0.dev/libexec/bundle:49:in `block in <top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/bundler-2.3.0.dev/libexec/bundle:37:in `<top (required)>'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/bin/bundle:23:in `load'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/bin/bundle:23:in `<main>'
$
```

- With this commit

```ruby
$ bundle exec blade build
Building assets…
$
```

