### PR TITLE
Add irregular inflection for valve=>valves to correct invalid singularization

### DIFF
--- a/activesupport/lib/active_support/inflections.rb
+++ b/activesupport/lib/active_support/inflections.rb
@@ -65,6 +65,7 @@ module ActiveSupport
     inflect.irregular("child", "children")
     inflect.irregular("sex", "sexes")
     inflect.irregular("move", "moves")
+    inflect.irregular("valve", "valves")
     inflect.irregular("zombie", "zombies")
 
     inflect.uncountable(%w(equipment information rice money species series fish sheep jeans police))

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -376,6 +376,7 @@ module InflectorTestCases
     "move"   => "moves",
     "cow"    => "kine", # Test inflections with different starting letters
     "zombie" => "zombies",
-    "genus"  => "genera"
+    "genus"  => "genera",
+    "valve"  => "valves"
   }
 end


### PR DESCRIPTION
### Summary

`inflect.singular(/([lr])ves$/i, '\1f')` incorrectly singularizes `valves` to `valf`.  

The rule is right for `elves`, `calves`, `halves` and I'm sure others, so I figured it was best to add this as an irregular.


