### PR TITLE
Update `ActiveRecord::Batches#in_batches` to make use of `ActiveRecord::Base.implicit_order_column` when present.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Specifying `implicit_order_column` now allows for use of
+    `ActiveRecord::Batches#in_batches` on tables without an auto-incrementing
+    primary key. When using `implicit_order_column` on a non-unique
+    column the batch size represents the number of unique values, of that
+    column, that will be processed in the batch not the number of records.
+
+    *Jack Hall*
+
 *   Two change tracking methods are added for `belongs_to` associations.
 
     The `association_changed?` method (assuming an association named `:association`) returns true


### PR DESCRIPTION
### Summary

When using `ActiveRecord::Batches#in_batches` ActiveRecord sorts records by primary key. This causes unpredictable behavior and errors when the primary key is not an auto-incrementing data type, like a UUID. 

This change follows up on changes made in some earlier PRs (linked below) that made changes to the +first+ and +last+ finder calls. It updates `ActiveRecord::Batches#in_batches` so that it sorts by the `implicit_order_column` when that attribute has been configured. This allows for the batch processing of records that do not have an auto-incrementing primary key. Currently batch processing of a ActiveRecord model that has a UUID primary key does not consistently succeed.

Related PRs:
- https://github.com/rails/rails/pull/34480
- https://github.com/rails/rails/pull/37626

### Other Information

The only slight difference in batch processing behavior comes when using batches with an `implicit_order_column` that is non-unique. In that case the batch size will represent the number of unique values to be processed in the batch not the number of records. For Example:

  If the models's `implicit_order_column` has values of:
  ```
  [:a, :b, :c, :c, :d, :e, :f]
  ```
  And the user calls `Model.in_batches(of: 3)` the first batch will contain four records, `[:a, :b, :c, :c]`, and the second batch will contain the three remaining records, `[:d, :e, :f]`. No records will be skipped, barring any race conditions, but the number of records processed may vary between batches.

While working on this patch I attempted to include subsorting by the primary key to remove this difference in behavior, but could not come up with something that worked and didn't change the interface to the `#in_batches` method. I think changes could be made to the ActiveRecord `PredicateBuilder` to allow for subsorting, but that is currently outside my comfort zone so I opted to not attempt those changes at this time. I feel that allowing batch processing even with this caveat is better than the current behavior. 

This is my first time submitting a PR to Rails, so please let me know if I missed any steps, need to make additional changes, or add additional testing.
