### PR TITLE
Add `skip_nil:` support to `RedisCacheStore`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `skip_nil:` support to `RedisCacheStore`
+
+    *Joey Paris*
+
 *   `ActiveSupport::Cache::MemoryStore#write(name, val, unless_exist:true)` now
     correctly writes expired keys.
 

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -145,8 +145,15 @@ module ActiveSupport
       #
       # Race condition TTL is not set by default. This can be used to avoid
       # "thundering herd" cache writes when hot cache entries are expired.
-      # See ActiveSupport::Cache::Store#fetch for more.
-      def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: default_coder, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
+      # See <tt>ActiveSupport::Cache::Store#fetch</tt> for more.
+      #
+      # Setting <tt>skip_nil: true</tt> will not cache nil results:
+      #
+      #   cache.fetch('foo') { nil }
+      #   cache.fetch('bar', skip_nil: true) { nil }
+      #   cache.exist?('foo') # => true
+      #   cache.exist?('bar') # => false
+      def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: default_coder, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, skip_nil: false, **redis_options)
         @redis_options = redis_options
 
         @max_key_bytesize = MAX_KEY_BYTESIZE
@@ -155,7 +162,7 @@ module ActiveSupport
         super namespace: namespace,
           compress: compress, compress_threshold: compress_threshold,
           expires_in: expires_in, race_condition_ttl: race_condition_ttl,
-          coder: coder
+          coder: coder, skip_nil: skip_nil
       end
 
       def redis

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -119,6 +119,23 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       assert_same @cache.redis, redis_instance
     end
 
+    test "fetch caches nil" do
+      cache = build
+      cache.write("foo", nil)
+      assert_not_called(cache, :write) do
+        assert_nil cache.fetch("foo") { "baz" }
+      end
+    end
+
+    test "skip_nil is passed to ActiveSupport::Cache" do
+      cache = build(skip_nil: true)
+      cache.clear
+      assert_not_called(cache, :write) do
+        assert_nil cache.fetch("foo") { nil }
+        assert_equal false, cache.exist?("foo")
+      end
+    end
+
     private
       def build(**kwargs)
         ActiveSupport::Cache::RedisCacheStore.new(driver: DRIVER, **kwargs).tap(&:redis)


### PR DESCRIPTION
### Summary

`ActiveSupport::Cache` accepts `skip_nil:` when initializing a cache to add to the default parameters of `fetch` requests. This pull request allows `RedisCacheStore` to also accept a default value for `skip_nil:`.

### Other Information

I copied the `skip_nil:` documentation from `ActiveSupport::Cache`, there might be a better way to write it so I'm definitely open to suggestions.
