### PR TITLE
make Time.with_zone the prefered alias instead of Time.use_zone

### DIFF
--- a/activejob/lib/active_job/timezones.rb
+++ b/activejob/lib/active_job/timezones.rb
@@ -6,7 +6,7 @@ module ActiveJob
 
     included do
       around_perform do |job, block|
-        Time.use_zone(job.timezone, &block)
+        Time.with_zone(job.timezone, &block)
       end
     end
   end

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -147,7 +147,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
   end
 
   test "should maintain time with zone" do
-    Time.use_zone "Alaska" do
+    Time.with_zone "Alaska" do
       time_with_zone = Time.new(2002, 10, 31, 2, 2, 2).in_time_zone
       assert_instance_of ActiveSupport::TimeWithZone, perform_round_trip([time_with_zone]).first
       assert_arguments_unchanged time_with_zone

--- a/activejob/test/cases/job_serialization_test.rb
+++ b/activejob/test/cases/job_serialization_test.rb
@@ -59,7 +59,7 @@ class JobSerializationTest < ActiveSupport::TestCase
   end
 
   test "serialize stores the current timezone" do
-    Time.use_zone "Hawaii" do
+    Time.with_zone "Hawaii" do
       job = HelloJob.new
       assert_equal "Hawaii", job.serialize["timezone"]
     end

--- a/activejob/test/cases/timezones_test.rb
+++ b/activejob/test/cases/timezones_test.rb
@@ -25,7 +25,7 @@ class TimezonesTest < ActiveSupport::TestCase
   test "perform_now passes down current timezone to the job" do
     Time.zone = "America/New_York"
 
-    Time.use_zone("London") do
+    Time.with_zone("London") do
       job = TimezoneDependentJob.new("2018-01-01T00:00:00Z")
       assert_equal "London", job.timezone
       job.perform_now

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -274,7 +274,7 @@ class BasicsTest < ActiveRecord::TestCase
   def test_preserving_time_objects_with_time_with_zone_conversion_to_default_timezone_utc
     with_env_tz eastern_time_zone do
       with_timezone_config default: :utc do
-        Time.use_zone "Central Time (US & Canada)" do
+        Time.with_zone "Central Time (US & Canada)" do
           time = Time.zone.local(2000)
           topic = Topic.create("written_on" => time)
           saved_time = Topic.find(topic.id).reload.written_on
@@ -302,7 +302,7 @@ class BasicsTest < ActiveRecord::TestCase
   def test_preserving_time_objects_with_time_with_zone_conversion_to_default_timezone_local
     with_env_tz eastern_time_zone do
       with_timezone_config default: :local do
-        Time.use_zone "Central Time (US & Canada)" do
+        Time.with_zone "Central Time (US & Canada)" do
           time = Time.zone.local(2000)
           topic = Topic.create("written_on" => time)
           saved_time = Topic.find(topic.id).reload.written_on
@@ -982,7 +982,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     def test_default_in_utc_with_time_zone
       with_timezone_config default: :utc do
-        Time.use_zone "Central Time (US & Canada)" do
+        Time.with_zone "Central Time (US & Canada)" do
           default = Default.new
 
           assert_equal Date.new(2004, 1, 1), default.fixed_date

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   make `Time.with_zone` the prefered alias instead of `Time.use_zone`
+
+    *Dorian Marié*
+
 *   Faster tests by parallelizing only when overhead is justified by the number
     of them.
 

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -32,7 +32,7 @@ class Time
     #
     #     def set_time_zone
     #       if logged_in?
-    #         Time.use_zone(current_user.time_zone) { yield }
+    #         Time.with_zone(current_user.time_zone) { yield }
     #       else
     #         yield
     #       end
@@ -51,7 +51,7 @@ class Time
     #     private
     #
     #     def set_time_zone
-    #       Time.use_zone(current_user.timezone) { yield }
+    #       Time.with_zone(current_user.timezone) { yield }
     #     end
     #   end
     #
@@ -59,7 +59,8 @@ class Time
     # objects that have already been created, e.g. any model timestamp
     # attributes that have been read before the block will remain in
     # the application's default timezone.
-    def use_zone(time_zone)
+    # This method is also aliased as +use_zone+
+    def with_zone(time_zone)
       new_zone = find_zone!(time_zone)
       begin
         old_zone, ::Time.zone = ::Time.zone, new_zone
@@ -68,6 +69,7 @@ class Time
         ::Time.zone = old_zone
       end
     end
+    alias :use_zone :with_zone
 
     # Returns a TimeZone instance matching the time zone provided.
     # Accepts the time zone in any format supported by <tt>Time.zone=</tt>.

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -30,7 +30,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
   end
 
   def test_in_time_zone
-    Time.use_zone "Alaska" do
+    Time.with_zone "Alaska" do
       assert_equal ActiveSupport::TimeWithZone.new(@utc, ActiveSupport::TimeZone["Alaska"]), @twz.in_time_zone
     end
   end
@@ -1095,29 +1095,29 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
   end
 
   def test_in_time_zone
-    Time.use_zone "Alaska" do
+    Time.with_zone "Alaska" do
       assert_equal "Fri, 31 Dec 1999 15:00:00.000000000 AKST -09:00", @t.in_time_zone.inspect
       assert_equal "Fri, 31 Dec 1999 15:00:00.000000000 AKST -09:00", @dt.in_time_zone.inspect
     end
-    Time.use_zone "Hawaii" do
+    Time.with_zone "Hawaii" do
       assert_equal "Fri, 31 Dec 1999 14:00:00.000000000 HST -10:00", @t.in_time_zone.inspect
       assert_equal "Fri, 31 Dec 1999 14:00:00.000000000 HST -10:00", @dt.in_time_zone.inspect
     end
-    Time.use_zone nil do
+    Time.with_zone nil do
       assert_equal @t, @t.in_time_zone
       assert_equal @dt, @dt.in_time_zone
     end
   end
 
   def test_nil_time_zone
-    Time.use_zone nil do
+    Time.with_zone nil do
       assert_not_respond_to @t.in_time_zone, :period, "no period method"
       assert_not_respond_to @dt.in_time_zone, :period, "no period method"
     end
   end
 
   def test_in_time_zone_with_argument
-    Time.use_zone "Eastern Time (US & Canada)" do # Time.zone will not affect #in_time_zone(zone)
+    Time.with_zone "Eastern Time (US & Canada)" do # Time.zone will not affect #in_time_zone(zone)
       assert_equal "Fri, 31 Dec 1999 15:00:00.000000000 AKST -09:00", @t.in_time_zone("Alaska").inspect
       assert_equal "Fri, 31 Dec 1999 15:00:00.000000000 AKST -09:00", @dt.in_time_zone("Alaska").inspect
       assert_equal "Fri, 31 Dec 1999 14:00:00.000000000 HST -10:00", @t.in_time_zone("Hawaii").inspect
@@ -1149,32 +1149,32 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
     assert_equal @dt.in_time_zone.localtime, @dt.in_time_zone.utc.to_time.getlocal
   end
 
-  def test_use_zone
+  def test_with_zone
     Time.zone = "Alaska"
-    Time.use_zone "Hawaii" do
+    Time.with_zone "Hawaii" do
       assert_equal ActiveSupport::TimeZone["Hawaii"], Time.zone
     end
     assert_equal ActiveSupport::TimeZone["Alaska"], Time.zone
   end
 
-  def test_use_zone_with_exception_raised
+  def test_with_zone_with_exception_raised
     Time.zone = "Alaska"
     assert_raise RuntimeError do
-      Time.use_zone("Hawaii") { raise RuntimeError }
+      Time.with_zone("Hawaii") { raise RuntimeError }
     end
     assert_equal ActiveSupport::TimeZone["Alaska"], Time.zone
   end
 
-  def test_use_zone_raises_on_invalid_timezone
+  def test_with_zone_raises_on_invalid_timezone
     Time.zone = "Alaska"
     assert_raise ArgumentError do
-      Time.use_zone("No such timezone exists") { }
+      Time.with_zone("No such timezone exists") { }
     end
     assert_equal ActiveSupport::TimeZone["Alaska"], Time.zone
   end
 
   def test_time_at_precision
-    Time.use_zone "UTC" do
+    Time.with_zone "UTC" do
       time = "2019-01-01 00:00:00Z".to_time.end_of_month
       assert_equal Time.at(time), Time.at(time.in_time_zone)
     end
@@ -1204,7 +1204,7 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
   end
 
   def test_time_zone_setter_is_thread_safe
-    Time.use_zone "Paris" do
+    Time.with_zone "Paris" do
       t1 = Thread.new { Time.zone = "Alaska" }.join
       t2 = Thread.new { Time.zone = "Hawaii" }.join
       assert t1.stop?, "Thread 1 did not finish running"

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -171,7 +171,7 @@ class TimeZoneTest < ActiveSupport::TestCase
 
   def test_travel_to_a_date
     with_env_tz do
-      Time.use_zone("Hawaii") do
+      Time.with_zone("Hawaii") do
         date = Date.new(2014, 2, 18)
         time = date.midnight
 


### PR DESCRIPTION
### Summary

Time.with_zone is more consistent with I18n.with_locale for instance

I wanted to create a new alias but thought this should be the prefered way so I used it in the tests and in other part of rails's source code.

For instance, I wanted find this method so I tried `Time.with_zone` and it didn't exist so I implemented it myself in my app, now I know it exist but it will have better discoverability