### PR TITLE
Fix `eager_loading?` when ordering with `Symbol`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix `eager_loading?` when ordering with `Symbol`
+
+    `eager_loading?` is triggered correctly when using `order` with symbols.
+
+    ```ruby
+    scope = Post.includes(:comments).order(:"comments.label")
+    => true
+    ```
+
+    *Jacopo Beschi*
+
 *   Two change tracking methods are added for `belongs_to` associations.
 
     The `association_changed?` method (assuming an association named `:association`) returns true

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1550,7 +1550,7 @@ module ActiveRecord
       def column_references(order_args)
         references = order_args.flat_map do |arg|
           case arg
-          when String
+          when String, Symbol
             arg
           when Hash
             arg.keys

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1714,6 +1714,16 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_predicate scope, :eager_loading?
   end
 
+  def test_order_triggers_eager_loading_when_ordering_using_symbols
+    scope = Post.includes(:comments).order(:"comments.label")
+    assert_predicate scope, :eager_loading?
+  end
+
+  def test_order_doesnt_trigger_eager_loading_when_ordering_using_owner_table_and_symbols
+    scope = Post.includes(:comments).order(:"posts.title")
+    assert_not_predicate scope, :eager_loading?
+  end
+
   def test_order_triggers_eager_loading_when_ordering_using_hash_syntax
     scope = Post.includes(:comments).order({ "comments.label": :ASC })
     assert_predicate scope, :eager_loading?


### PR DESCRIPTION
### Summary

`eager_loading?` is triggered correctly when using `order` with symbols.

```ruby
scope = Post.includes(:comments).order(:"comments.label")
=> true
```
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
