### PR TITLE
Avoid logging delayed job arguments if log_arguments set to false

### DIFF
--- a/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "delayed_job"
+require "active_support/core_ext/string/inflections"
 
 module ActiveJob
   module QueueAdapters
@@ -35,12 +36,21 @@ module ActiveJob
         end
 
         def display_name
-          "#{job_data['job_class']} [#{job_data['job_id']}] from DelayedJob(#{job_data['queue_name']}) with arguments: #{job_data['arguments']}"
+          base_name = "#{job_data["job_class"]} [#{job_data["job_id"]}] from DelayedJob(#{job_data["queue_name"]})"
+
+          return base_name unless log_arguments?
+
+          "#{base_name} with arguments: #{job_data["arguments"]}"
         end
 
         def perform
           Base.execute(job_data)
         end
+
+        private
+          def log_arguments?
+            job_data["job_class"].constantize.log_arguments?
+          end
       end
     end
   end

--- a/activejob/test/cases/delayed_job_adapter_test.rb
+++ b/activejob/test/cases/delayed_job_adapter_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "active_job/queue_adapters/delayed_job_adapter"
+
+class DelayedJobAdapterTest < ActiveSupport::TestCase
+  test "does not log arguments when log_arguments is set to false on a job" do
+    job_id = SecureRandom.uuid
+
+    job_wrapper = ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(
+      "job_class" => DisableLogJob.to_s,
+      "queue_name" => "default",
+      "job_id" => job_id,
+      "arguments" => { "some" => { "job" => "arguments" } }
+    )
+
+    assert_equal "DisableLogJob [#{job_id}] from DelayedJob(default)", job_wrapper.display_name
+  end
+
+  test "logs arguments when log_arguments is set to true on a job" do
+    job_id = SecureRandom.uuid
+    arguments = { "some" => { "job" => "arguments" } }
+
+    job_wrapper = ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper.new(
+      "job_class" => HelloJob.to_s,
+      "queue_name" => "default",
+      "job_id" => job_id,
+      "arguments" => arguments
+    )
+
+    assert_equal "HelloJob [#{job_id}] from DelayedJob(default) with arguments: #{arguments}",
+                 job_wrapper.display_name
+  end
+end


### PR DESCRIPTION
### Summary
Builds on the work done in https://github.com/rails/rails/pull/37660 - the arguments are stilled logged by `ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper` - this PR prevents those arguments from being logged when `log_arguments` is set to false on the running job.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
