### PR TITLE
Avoid unnecessary double string split in ActiveSupport::MessageVerifier#verified

### DIFF
--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "openssl"
 require "base64"
 require "active_support/core_ext/object/blank"
 require "active_support/security_utils"
@@ -103,10 +104,13 @@ module ActiveSupport
 
     class InvalidSignature < StandardError; end
 
+    SEPARATOR = "--" # :nodoc:
+    SEPARATOR_LENGTH = SEPARATOR.length # :nodoc:
+
     def initialize(secret, digest: nil, serializer: nil)
       raise ArgumentError, "Secret should not be nil." unless secret
       @secret = secret
-      @digest = digest || "SHA1"
+      @digest = digest&.to_s || "SHA1"
       @serializer = serializer || Marshal
     end
 
@@ -120,10 +124,8 @@ module ActiveSupport
     #   tampered_message = signed_message.chop # editing the message invalidates the signature
     #   verifier.valid_message?(tampered_message) # => false
     def valid_message?(signed_message)
-      return if signed_message.nil? || !signed_message.valid_encoding? || signed_message.blank?
-
-      data, digest = signed_message.split("--")
-      data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))
+      data, digest = get_data_and_digest_from(signed_message)
+      digest_matches_data?(digest, data)
     end
 
     # Decodes the signed message using the +MessageVerifier+'s secret.
@@ -148,9 +150,9 @@ module ActiveSupport
     #   incompatible_message = "test--dad7b06c94abba8d46a15fafaef56c327665d5ff"
     #   verifier.verified(incompatible_message) # => TypeError: incompatible marshal file format
     def verified(signed_message, purpose: nil, **)
-      if valid_message?(signed_message)
+      data, digest = get_data_and_digest_from(signed_message)
+      if digest_matches_data?(digest, data)
         begin
-          data = signed_message.split("--")[0]
           message = Messages::Metadata.verify(decode(data), purpose)
           @serializer.load(message) if message
         rescue ArgumentError => argument_error
@@ -185,7 +187,7 @@ module ActiveSupport
     #   verifier.generate 'a private message' # => "BAhJIhRwcml2YXRlLW1lc3NhZ2UGOgZFVA==--e2d724331ebdee96a10fb99b089508d1c72bd772"
     def generate(value, expires_at: nil, expires_in: nil, purpose: nil)
       data = encode(Messages::Metadata.wrap(@serializer.dump(value), expires_at: expires_at, expires_in: expires_in, purpose: purpose))
-      "#{data}--#{generate_digest(data)}"
+      "#{data}#{SEPARATOR}#{generate_digest(data)}"
     end
 
     private
@@ -198,8 +200,38 @@ module ActiveSupport
       end
 
       def generate_digest(data)
-        require "openssl" unless defined?(OpenSSL)
-        OpenSSL::HMAC.hexdigest(OpenSSL::Digest.const_get(@digest).new, @secret, data)
+        OpenSSL::HMAC.hexdigest(@digest, @secret, data)
+      end
+
+      def digest_length_in_hex
+        # In hexadecimal (AKA base16) it takes 4 bits to represent a character,
+        # hence we multiply the digest's length (in bytes) by 8 to get it in
+        # bits and divide by 4 to get its number of characters it hex. Well, 8
+        # divided by 4 is 2.
+        @digest_length_in_hex ||= OpenSSL::Digest.new(@digest).digest_length * 2
+      end
+
+      def separator_index_for(signed_message)
+        index = signed_message.length - digest_length_in_hex - SEPARATOR_LENGTH
+        return if index.negative? || signed_message[index, SEPARATOR_LENGTH] != SEPARATOR
+
+        index
+      end
+
+      def get_data_and_digest_from(signed_message)
+        return if signed_message.nil? || !signed_message.valid_encoding? || signed_message.empty?
+
+        separator_index = separator_index_for(signed_message)
+        return if separator_index.nil?
+
+        data = signed_message[0...separator_index]
+        digest = signed_message[separator_index + SEPARATOR_LENGTH..-1]
+
+        [data, digest]
+      end
+
+      def digest_matches_data?(digest, data)
+        data.present? && digest.present? && ActiveSupport::SecurityUtils.secure_compare(digest, generate_digest(data))
       end
   end
 end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

`ActiveSupport::MessageVerifier#verified` is causing `signed_message` to be split twice: first inside `#valid_message?` and then inside `#verified`. This is ultimately unnecessary.

### Benchmark

I renamed the current implementation of `#valid_message?` and `#verified` to `#valid_message_old?` and `#verified_old` respectively, with the latter modified to call `#valid_message_old?`. I then ran the following benchmark:

```ruby
data = SecureRandom.alphanumeric(SIZE)
signed_message = ActiveSupport::MessageVerifier.new("Hey, I'm a secret!").generate(data)

GC.start

Benchmark.ips do |x|
  x.time = 10
  x.warmup = 2

  x.report('new verified') do
    @verifier.verified(signed_message)
  end
  x.report('old verified') do
    @verifier.verified_old(signed_message)
  end

  x.compare!
end

Benchmark.ips do |x|
  x.time = 10
  x.warmup = 2

  x.report('new valid message') do
    @verifier.valid_message?(signed_message)
  end
  x.report('old valid message') do
    @verifier.valid_message_old?(signed_message)
  end

  x.compare!
end
```

With `SIZE = 2**12` (4 kB, approximately the maximum size of a cookie):
```
Comparison:
        new verified:    28808.8 i/s
        old verified:    25400.1 i/s - 1.13x  (± 0.00) slower

Comparison:
        new verified:    37774.6 i/s
        old verified:    32482.2 i/s - 1.16x  (± 0.00) slower

Comparison:
        new verified:    38709.1 i/s
        old verified:    33416.9 i/s - 1.16x  (± 0.00) slower

Comparison:
        new verified:    38629.5 i/s
        old verified:    32879.7 i/s - 1.17x  (± 0.00) slower

Comparison:
   old valid message:    70262.7 i/s
   new valid message:    69663.3 i/s - same-ish: difference falls within error

Comparison:
   old valid message:    69522.6 i/s
   new valid message:    68408.8 i/s - same-ish: difference falls within error

Comparison:
   new valid message:    69642.7 i/s
   old valid message:    69283.1 i/s - same-ish: difference falls within error

Comparison:
   new valid message:    69779.8 i/s
   old valid message:    69510.5 i/s - same-ish: difference falls within error
```

With `SIZE = 2**22` (4 MB):
```
Comparison:
        new verified:       75.0 i/s
        old verified:       49.9 i/s - 1.50x  (± 0.00) slower

Comparison:
        new verified:       70.0 i/s
        old verified:       49.1 i/s - 1.43x  (± 0.00) slower

Comparison:
        new verified:       74.6 i/s
        old verified:       49.7 i/s - 1.50x  (± 0.00) slower

Comparison:
        new verified:       40.1 i/s
        old verified:       32.2 i/s - 1.25x  (± 0.00) slower

Comparison:
   new valid message:      133.3 i/s
   old valid message:      131.3 i/s - same-ish: difference falls within error

Comparison:
   old valid message:      131.5 i/s
   new valid message:      131.4 i/s - same-ish: difference falls within error

Comparison:
   new valid message:      133.3 i/s
   old valid message:      132.1 i/s - same-ish: difference falls within error

Comparison:
   new valid message:      132.6 i/s
   old valid message:      130.7 i/s - same-ish: difference falls within error
```

As expected, with a larger signed message, a greater speedup.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

None.
