### PR TITLE
Allow #upsert_all without unique_by to use PostgreSQL unique indexes

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -622,6 +622,16 @@ module ActiveRecord
         "INSERT #{insert.into} #{insert.values_list}"
       end
 
+      def conflict_target(insert)
+        if index = insert.unique_by
+          sql = +"(#{format_columns(index.columns)})"
+          sql << " WHERE #{index.where}" if index.where
+          sql
+        elsif update_duplicates?
+          "(#{format_columns(insert.primary_keys)})"
+        end
+      end
+
       def get_database_version # :nodoc:
       end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -469,9 +469,9 @@ module ActiveRecord
         sql = +"INSERT #{insert.into} #{insert.values_list}"
 
         if insert.skip_duplicates?
-          sql << " ON CONFLICT #{insert.conflict_target} DO NOTHING"
+          sql << " ON CONFLICT #{insert.conflict_target(:postgresql)} DO NOTHING"
         elsif insert.update_duplicates?
-          sql << " ON CONFLICT #{insert.conflict_target} DO UPDATE SET "
+          sql << " ON CONFLICT #{insert.conflict_target(:postgresql)} DO UPDATE SET "
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
           else

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -322,9 +322,9 @@ module ActiveRecord
         sql = +"INSERT #{insert.into} #{insert.values_list}"
 
         if insert.skip_duplicates?
-          sql << " ON CONFLICT #{insert.conflict_target(:sqlite)} DO NOTHING"
+          sql << " ON CONFLICT #{conflict_target(insert)} DO NOTHING"
         elsif insert.update_duplicates?
-          sql << " ON CONFLICT #{insert.conflict_target(:sqlite)} DO UPDATE SET "
+          sql << " ON CONFLICT #{conflict_target(insert)} DO UPDATE SET "
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
           else

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -322,9 +322,9 @@ module ActiveRecord
         sql = +"INSERT #{insert.into} #{insert.values_list}"
 
         if insert.skip_duplicates?
-          sql << " ON CONFLICT #{insert.conflict_target} DO NOTHING"
+          sql << " ON CONFLICT #{insert.conflict_target(:sqlite)} DO NOTHING"
         elsif insert.update_duplicates?
-          sql << " ON CONFLICT #{insert.conflict_target} DO UPDATE SET "
+          sql << " ON CONFLICT #{insert.conflict_target(:sqlite)} DO UPDATE SET "
           if insert.raw_update_sql?
             sql << insert.raw_update_sql
           else

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -181,18 +181,6 @@ module ActiveRecord
           end
         end
 
-        def conflict_target(connection_type = :postgresql)
-          if index = insert_all.unique_by
-            sql = +"(#{format_columns(index.columns)})"
-            sql << " WHERE #{index.where}" if index.where
-            sql
-          elsif update_duplicates?
-            return if connection_type == :postgresql
-
-            "(#{format_columns(insert_all.primary_keys)})"
-          end
-        end
-
         def updatable_columns
           quote_columns(insert_all.updatable_columns)
         end

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -181,12 +181,14 @@ module ActiveRecord
           end
         end
 
-        def conflict_target
+        def conflict_target(connection_type = :postgresql)
           if index = insert_all.unique_by
             sql = +"(#{format_columns(index.columns)})"
             sql << " WHERE #{index.where}" if index.where
             sql
           elsif update_duplicates?
+            return if connection_type == :postgresql
+
             "(#{format_columns(insert_all.primary_keys)})"
           end
         end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -227,13 +227,14 @@ module ActiveRecord
       #
       # [:unique_by]
       #   (PostgreSQL and SQLite only) By default rows are considered to be unique
-      #   by every unique index on the table. Any duplicate rows are skipped.
+      #   by every unique index on the table (PostgreSQL) or by the primary key (SQLite).
+      #   Any duplicate rows are updated.
       #
       #   To skip rows according to just one unique index pass <tt>:unique_by</tt>.
       #
       #   Consider a Book model where no duplicate ISBNs make sense, but if any
       #   row has an existing id, or is not unique by another unique index,
-      #   <tt>ActiveRecord::RecordNotUnique</tt> is raised.
+      #   the existing entry is updated with the data passed to #upsert_all.
       #
       #   Unique indexes can be identified by columns or name:
       #


### PR DESCRIPTION
### Summary

When trying to call a `#upsert_all` operation in an `ActiveRecord` model without passing any `:unique_by` parameter, it adds the following statement:

```SQL
ON CONFLICT ("id") DO NOTHING
```

However, PostgreSQL sets the `conflict_target` as an optional parameter. When the parameter is not present, all the uniqueness indexes on the database will be used as the conflict matcher. This way, the proper way to automatically use the uniqueness indexes as stated in the documentation is using the following statement ([see more](https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT))

```SQL
ON CONFLICT DO NOTHING
```

Also, given the `#upsert_all` method is supported by both PostgreSQL and SQLite3, we must keep compatibility with SQLite3, which states that the [`conflict_target` is required on update operations](https://www.sqlite.org/lang_UPSERT.html).

### Other Information

More details under #42918 