### PR TITLE
Document Active Storage implicit transformations [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -850,6 +850,12 @@ location.
 <%= image_tag user.avatar.variant(resize_to_limit: [100, 100]) %>
 ```
 
+If a variant is requested, Active Storage will automatically apply 
+transformations depending on the image's format:
+
+1. Content types that are `variable` and not considered [`web images`], will be converted to PNG.
+2. If `quality` is not specified, the variant processor's default quality for the format will be used.  
+
 The default processor for Active Storage is MiniMagick, but you can also use
 [Vips][]. To switch to Vips, add the following to `config/application.rb`:
 
@@ -870,6 +876,8 @@ specific:
 ```
 
 [`variant`]: https://api.rubyonrails.org/classes/ActiveStorage/Blob/Representable.html#method-i-variant
+[`web images`]: https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/engine.rb#L47
+[`variable`]: https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/engine.rb#L34
 [Vips]: https://www.rubydoc.info/gems/ruby-vips/Vips/Image
 
 ### Previewing Files


### PR DESCRIPTION
### Summary
When a `variant` is requested, Active Storage automatically applies a couple of transformations, but those are not explained anywhere:

1. Content types that are not considered `web images`, but are `variable`, will be converted to PNG.
2. If no `quality` is specified, the variant processor's default quality for the format will be used.  

This PR adds this to the guide.

### Other Information
I've opened #42686 to make this behavior more explicit, fine tune it for web images and allow developers to change the defaults.

Item 2 specifically might cause unexpected results, as demonstrated below. The `demo2.jpg` image ends up with a larger file size despite being `demo.jpg` shrunk down, because ImageMagick uses quality 92 by default:

```
$ cd /tmp
$ wget https://s3.sa-east-1.amazonaws.com/cdn.festalab.com.br/development/demo.heic
$ exiftool demo.heic | grep "Image Size"
Image Size                 : 4032x3024

$ convert demo.heic -quality 50 demo.jpg 
$ convert demo.jpg -resize "3000x" demo2.jpg
$ du -h demo*
2.0M    demo.heic
696K    demo.jpg
704K    demo2.jpg
```
