### PR TITLE
Fix saving `DateTime::Infinity` and `Date::Infinity` with PostgreSQL.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Fix saving `DateTime::Infinity` and `Date::Infinity` with PostgreSQL.
+
+    Saving `DateTime::Infinity` and `Date::Infinity` now works correctly in PostgreSQL:
+
+    ```ruby
+    Post.create!(date: Date::Infinity.new).date
+    =>
+    Infinity
+    ```
+
+    Please note that providing the class (`DateTime::Infinity`) instead of the instance
+    (`DateTime::Infinity.new`) is not supported.
+
+    *Jacopo Beschi*
+
 *   Fix `eager_loading?` when ordering with `Symbol`
 
     `eager_loading?` is triggered correctly when using `order` with symbols.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/date.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/date.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         class Date < Type::Date # :nodoc:
           def cast_value(value)
             case value
-            when "infinity" then ::Float::INFINITY
+            when "infinity", ::Date::Infinity then ::Float::INFINITY
             when "-infinity" then -::Float::INFINITY
             when / BC$/
               value = value.sub(/^\d+/) { |year| format("%04d", -year.to_i + 1) }

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/date_time.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         class DateTime < Type::DateTime # :nodoc:
           def cast_value(value)
             case value
-            when "infinity" then ::Float::INFINITY
+            when "infinity", ::DateTime::Infinity then ::Float::INFINITY
             when "-infinity" then -::Float::INFINITY
             when / BC$/
               value = value.sub(/^\d+/) { |year| format("%04d", -year.to_i + 1) }

--- a/activerecord/test/cases/adapters/postgresql/infinity_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/infinity_test.rb
@@ -51,6 +51,10 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
     record = PostgresqlInfinity.create!(datetime: Float::INFINITY)
     record.reload
     assert_equal Float::INFINITY, record.datetime
+
+    record = PostgresqlInfinity.create!(datetime: DateTime::Infinity.new)
+    record.reload
+    assert_equal Float::INFINITY, record.datetime
   end
 
   test "type casting infinity on a date column" do
@@ -59,6 +63,10 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
     assert_equal Float::INFINITY, record.date
 
     record = PostgresqlInfinity.create!(date: Float::INFINITY)
+    record.reload
+    assert_equal Float::INFINITY, record.date
+
+    record = PostgresqlInfinity.create!(date: Date::Infinity.new)
     record.reload
     assert_equal Float::INFINITY, record.date
   end
@@ -84,6 +92,10 @@ class PostgresqlInfinityTest < ActiveRecord::PostgreSQLTestCase
       assert_equal record.datetime, record.reload.datetime
 
       record = PostgresqlInfinity.create!(datetime: BigDecimal::INFINITY)
+      assert_equal Float::INFINITY, record.datetime
+      assert_equal record.datetime, record.reload.datetime
+
+      record = PostgresqlInfinity.create!(datetime: DateTime::Infinity.new)
       assert_equal Float::INFINITY, record.datetime
       assert_equal record.datetime, record.reload.datetime
     end


### PR DESCRIPTION
### Summary

Saving `DateTime::Infinity` and `Date::Infinity` now works correctly in PostgreSQL:

```ruby
Post.create!(date: Date::Infinity.new).date
=>
Infinity
```

Please note that providing the class (`DateTime::Infinity`) instead of the instance (`DateTime::Infinity.new`) is not supported.

Fixes https://github.com/rails/rails/issues/40595

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
