### PR TITLE
Reduce allocations and retentions in Journey TransitionTable

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -11,7 +11,7 @@ module ActionDispatch
         attr_reader :memos
 
         DEFAULT_EXP = /[^.\/?]+/
-        DEFAULT_EXP_ANCHORED = Regexp.new(/\A#{DEFAULT_EXP}\Z/)
+        DEFAULT_EXP_ANCHORED = /\A#{DEFAULT_EXP}\Z/
 
         def initialize
           @stdparam_states = {}
@@ -165,7 +165,11 @@ module ActionDispatch
           case sym
           when Regexp
             # we must match the whole string to a token boundary
-            sym = Regexp.new(/\A#{sym}\Z/)
+            if sym == DEFAULT_EXP
+              sym = DEFAULT_EXP_ANCHORED
+            else
+              sym = /\A#{sym}\Z/
+            end
           when Symbol
             # account for symbols in the constraints the same as strings
             sym = sym.to_s


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/42522

`DEFAULT_EXP` is by far the most common regexp being anchored. By special casing it, we can re-use the existing `DEFAULT_EXP_ANCHORED` regexp, and avoid keeping lots of copies of it in memory. Every time we hit, we also avoid having to compile the regexp, so it's faster.

We also replace the `Regexp.new(/\A#{sym}\Z/)` pattern by just`/\A#{sym}\Z/`, as it was compiling and instantiating an extra regexp for no good reason.

Tested on our app:

Allocated Regexp
Before `16.12 MB / 25115 objects`
After `11.33 MB / ? objects`

Retained Regexp
Before: `10.89 MB / 16545 objects`
After: `8.55 MB  / 12410 objects`

cc @composerinteralia @jhawthorn 