### PR TITLE
Make active storage default transformations configurable

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add the `transformations_by_format` option to Active Storage, which accepts a hash
+    with transformations that should be applied to all images of the specified content_type.
+
+    *Breno Gazzola*
+
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
 *   No changes.

--- a/activestorage/app/models/active_storage/blob/representable.rb
+++ b/activestorage/app/models/active_storage/blob/representable.rb
@@ -100,7 +100,8 @@ module ActiveStorage::Blob::Representable
 
   private
     def default_variant_transformations
-      { format: default_variant_format }
+      defaults = ActiveStorage.transformations_by_format[default_variant_format] || {}
+      defaults.reverse_merge(format: default_variant_format)
     end
 
     def default_variant_format

--- a/activestorage/app/models/active_storage/variation.rb
+++ b/activestorage/app/models/active_storage/variation.rb
@@ -46,7 +46,7 @@ class ActiveStorage::Variation
   end
 
   def default_to(defaults)
-    self.class.new transformations.reverse_merge(defaults)
+    self.class.new defaults.deep_merge(transformations)
   end
 
   # Accepts a File object, performs the +transformations+ against it, and

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -58,6 +58,7 @@ module ActiveStorage
   mattr_accessor :binary_content_type,              default: "application/octet-stream"
   mattr_accessor :content_types_to_serve_as_binary, default: []
   mattr_accessor :content_types_allowed_inline,     default: []
+  mattr_accessor :transformations_by_format,        default: {}
 
   mattr_accessor :service_urls_expire_in, default: 5.minutes
   mattr_accessor :urls_expire_in

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1660,6 +1660,13 @@ config.active_storage.video_preview_arguments = "-vf 'select=eq(n\\,0)+eq(key\\,
 1. `select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015)`: Select the first video frame, plus keyframes, plus frames that meet the scene change threshold.
 2. `loop=loop=-1:size=2,trim=start_frame=1`: To use the first video frame as a fallback when no other frames meet the criteria, loop the first (one or) two selected frames, then drop the first looped frame.
 
+* `config.active_storage.transformations_by_format` can be used to specify transformations that should be applied to all images of a given content_type. For a list of accepted formats, check the `variable_content_types` option. 
+
+    ```ruby
+    config.active_storage.transformations_by_format[:jpg] = { saver: { quality: 80, strip: true } }
+    config.active_storage.transformations_by_format[:png] = { saver: { compression: 9, strip: true } }
+    ```
+
 ### Configuring Action Text
 
 #### `config.action_text.attachment_tag_name`

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3101,6 +3101,35 @@ module ApplicationTests
       assert_includes Rails.application.config.hosts, ".localhost"
     end
 
+    test "ActiveStorage.transformations_by_format is an empty hash by default" do
+      app "development"
+      assert_equal Hash.new, ActiveStorage.transformations_by_format
+    end
+
+    test "ActiveStorage.transformations_by_format can be configured via config.active_storage.transformations_by_format" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_storage.transformations_by_format[:jpg] = { format: "jpg" }
+        end
+      RUBY
+
+      app "development"
+
+      assert_equal({ format: "jpg" }, ActiveStorage.transformations_by_format[:jpg])
+    end
+
+    test "ActiveStorage.transformations_by_format raises an error if a format is not considered a web image" do
+      app_file "config/environments/development.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_storage.transformations_by_format[:webp] = { format: "webp" }
+        end
+      RUBY
+
+      assert_raise ArgumentError do
+        app "development"
+      end
+    end
+
     test "hosts reads multiple values from RAILS_DEVELOPMENT_HOSTS" do
       host = "agoodhost.com"
       another_host = "bananapants.com"


### PR DESCRIPTION
### Summary
This is my second attempt at this feature, following feedback given on https://github.com/rails/rails/pull/42686.

Active Storage has a method called `default_variant_transformations` which currently is only used to choose the format of the variant. This PR adds a configuration option that allows developers to define extra transformations according to the format that will be used.

### Other Information
I've used `format` instead of `content_type` in the config because I fell that `content_type` might make devs think they must use `image/jpg` instead of `jpg` as the key for the config. And also because this code relies on the `default_variant_format` method.