### PR TITLE
Add database specific setup and reset tasks for multidb configurations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added support for multiple databases to `rails db:setup` and `rails db:reset`.
+
+    *Ryan Hall*
+
 *   Add `ActiveRecord::Relation#structurally_compatible?`.
 
     Adds a query method by which a user can tell if the relation that they're

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -306,7 +306,16 @@ db_namespace = namespace :db do
     db_namespace["_dump"].invoke
   end
 
-  desc "Drops and recreates the database from db/schema.rb for the current environment and loads the seeds."
+  namespace :reset do
+    task all: ["db:drop", "db:setup"]
+
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Drops and recreates the #{name} database from its schema for the current environment and loads the seeds."
+      task name => ["db:drop:#{name}", "db:setup:#{name}"]
+    end
+  end
+
+  desc "Drops and recreates all databases from their schema for the current environment and loads the seeds."
   task reset: [ "db:drop", "db:setup" ]
 
   # desc "Retrieves the charset for the current environment's database"
@@ -365,7 +374,16 @@ db_namespace = namespace :db do
     end
   end
 
-  desc "Creates the database, loads the schema, and initializes with the seed data (use db:reset to also drop the database first)"
+  namespace :setup do
+    task all: ["db:create", :environment, "db:schema:load", :seed]
+
+    ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
+      desc "Creates the #{name} database, loads the schema, and initializes with the seed data (use db:reset:#{name} to also drop the database first)"
+      task name => ["db:create:#{name}", :environment, "db:schema:load:#{name}", "db:seed"]
+    end
+  end
+
+  desc "Creates all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)"
   task setup: ["db:create", :environment, "db:schema:load", :seed]
 
   desc "Runs setup if database does not exist, or runs migrations if it does"

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -180,6 +180,9 @@ rails db:migrate:primary                 # Migrate primary database for current 
 rails db:migrate:status                  # Display status of migrations
 rails db:migrate:status:animals          # Display status of migrations for animals database
 rails db:migrate:status:primary          # Display status of migrations for primary database
+rails db:reset                           # Drops and recreates all databases from their schema for the current environment and loads the seeds
+rails db:reset:animals                   # Drops and recreates the animals database from its schema for the current environment and loads the seeds
+rails db:reset:primary                   # Drops and recreates the primary database from its schema for the current environment and loads the seeds
 rails db:rollback                        # Rolls the schema back to the previous version (specify steps w/ STEP=n)
 rails db:rollback:animals                # Rollback animals database for current environment (specify steps w/ STEP=n)
 rails db:rollback:primary                # Rollback primary database for current environment (specify steps w/ STEP=n)
@@ -189,6 +192,9 @@ rails db:schema:dump:primary             # Creates a db/schema.rb file that is p
 rails db:schema:load                     # Loads a database schema file (either db/schema.rb or db/structure.sql  ...
 rails db:schema:load:animals             # Loads a database schema file (either db/schema.rb or db/structure.sql  ...
 rails db:schema:load:primary             # Loads a database schema file (either db/schema.rb or db/structure.sql  ...
+rails db:setup                           # Creates all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
+rails db:setup:animals                   # Creates the animals database, loads the schema, and initializes with the seed data (use db:reset:animals to also drop the database first)
+rails db:setup:primary                   # Creates the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
 ```
 
 Running a command like `bin/rails db:create` will create both the primary and animals databases.


### PR DESCRIPTION
### Summary

This is an attempt at enabling database specific `setup` and `reset` tasks. We use multiple databases pretty extensively and would like to avoid resetting all databases at once. This change adds database specific `setup` and `reset` tasks under each namespace. The default `setup` and `reset` tasks remain unchanged aside from their descriptions.

One thing that may be problematic is that the `db:seed` task is database agnostic, which means that the database scoped tasks will end up seeding everything. Would it be possible to seed only a specific database? At first glance, it doesn't seem like this is the case because the seed files could reference any active record model.

This results in the following tasks for an example configuration with two databases: primary and events.

```
rails db:reset                                  # Drops and recreates all databases from their schema for the current environment and loads the seeds
rails db:reset:events                           # Drops and recreates the events database from its schema for the current environment and loads the seeds
rails db:reset:primary                          # Drops and recreates the primary database from its schema for the current environment and loads the seeds
rails db:setup                                  # Creates all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)
rails db:setup:events                           # Creates the events database, loads the schema, and initializes with the seed data (use db:reset:events to also drop the database first)
rails db:setup:primary                          # Creates the primary database, loads the schema, and initializes with the seed data (use db:reset:primary to also drop the database first)
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
