### PR TITLE
Add preserve_chars to parameterize

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   The `preserve_chars:` option is added to `ActiveSupport::Inflector#parameterize`.
+
+    It allows specifying special characters to preserve when parameterizing a string.
+
+    ```ruby
+    parameterize("apple+orange lemon--", preserve_chars: ["+"]) # => "apple+orange-lemon"
+    parameterize("blue+green@yellow--", preserve_chars: ["+", "@"]) # => "blue+green@yellow"
+    ```
+
+    *David Ratajczak*
+
 *   Faster tests by parallelizing only when overhead is justified by the number
     of them.
 

--- a/activesupport/test/inflector_test.rb
+++ b/activesupport/test/inflector_test.rb
@@ -347,6 +347,11 @@ class InflectorTest < ActiveSupport::TestCase
     assert_equal("fuenf-autos", ActiveSupport::Inflector.parameterize(word, locale: :de))
   end
 
+  def test_parameterize_with_multiple_preserve_chars
+    word = "test@preserve+chars--"
+    assert_equal("test@preserve+chars", ActiveSupport::Inflector.parameterize(word, preserve_chars: ["+", "@"]))
+  end
+
   def test_classify
     ClassNameToTableName.each do |class_name, table_name|
       assert_equal(class_name, ActiveSupport::Inflector.classify(table_name))


### PR DESCRIPTION
### Summary

The `preserve_chars:` option is added to `ActiveSupport::Inflector#parameterize`.

It allows specifying special characters to preserve when parameterizing a string.

```ruby
parameterize("apple+orange lemon--", preserve_chars: ["+"]) # => "apple+orange-lemon"
parameterize("blue+green@yellow--", preserve_chars: ["+", "@"]) # => "blue+green@yellow"
```

---

When using `parameterize` to sanitize strings for file names or purposes outside of URLs, it's useful to have the ability to preserve some characters, such as "+".

This shifts `parameterize` even further away from its initial purpose, but feels like a nice quality of life change for other teams using parameterize for a variety of purposes. Curious to see if others feel this will be helpful. 🙇🏻‍♂️ 