### PR TITLE
Default to ERB Tracker

### DIFF
--- a/actionview/lib/action_view/dependency_tracker.rb
+++ b/actionview/lib/action_view/dependency_tracker.rb
@@ -35,6 +35,6 @@ module ActionView
       @trackers.delete(handler)
     end
 
-    register_tracker :erb, RipperTracker
+    register_tracker :erb, ERBTracker
   end
 end


### PR DESCRIPTION
### Summary

This leaves Ripper tracker as an optional view dependency tracker, but uses the current ERBTracker by default.

Eventually the default can change to the Ripper tracker, but this makes it an optional update for now.