### PR TITLE
Add Error Actions to ActiveRecord::NoDatabaseError

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -212,6 +212,15 @@ module ActiveRecord
 
   # Raised when a given database does not exist.
   class NoDatabaseError < StatementInvalid
+    include ActiveSupport::ActionableError
+
+    action "Run database setup (create, load schema, seed)" do
+      ActiveRecord::Tasks::DatabaseTasks.prepare_all
+    end
+    
+    action "Run database create" do
+      ActiveRecord::Tasks::DatabaseTasks.create_current
+    end
   end
 
   # Raised when creating a database if it exists.


### PR DESCRIPTION
### Summary

We love the actionable error for pending migrations and thought it would be beneficial to extend the functionality to ActiveRecord::NoDatabaseError. This is particularly helpful when you've pulled down a repo, fire up a server, but forget to run `db:setup`. This would create a shortcut to click a button instead of having to stop the server, run the `db:setup` and restart.

Kudos to @soberstadt for the help and the idea!

### Other Information

I don't know if this needs testing assuming the methods we are calling are already tested...

### Demo
```ruby
# requires a config/database.yml:
# development:
#   adapter: postgresql
#   database: single_file 

require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "rails", github: "dbenton/rails", branch: "main"
  gem "actionpack"
  gem "railties"
  gem "pg"
end

require "action_controller/railtie"
require "active_record/railtie"
require "rails/command"
require "rails/commands/server/server_command"

class HelloWorldApp < Rails::Application
  config.eager_load = "development"
  config.consider_all_requests_local = true

  routes.append do
    get "/" => "hello#world"
  end
end

class HelloController < ActionController::Base
  def world
    ActiveRecord::Migration.check_pending!
    render :plain => "Hello world!"
  end
end

class World < ActiveRecord::Base
end

HelloWorldApp.initialize!
Rails::Server.new(app: HelloWorldApp, Host: "0.0.0.0", Port: 3000).start
```
<img width="932" alt="Screen Shot 2021-08-05 at 4 50 53 PM" src="https://user-images.githubusercontent.com/25228573/128419457-2ed9f455-ed1f-4f51-b9d4-1503c41a1958.png">

