### PR TITLE
Fix kwargs delegation in `PerThreadRegistry#method_missing`

### DIFF
--- a/activesupport/lib/active_support/per_thread_registry.rb
+++ b/activesupport/lib/active_support/per_thread_registry.rb
@@ -56,5 +56,6 @@ module ActiveSupport
 
         send(name, *args, &block)
       end
+      ruby2_keywords(:method_missing)
   end
 end

--- a/activesupport/test/per_thread_registry_test.rb
+++ b/activesupport/test/per_thread_registry_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+class PerThreadRegistryTest < ActiveSupport::TestCase
+  class TestRegistry
+    extend ActiveSupport::PerThreadRegistry
+
+    def foo(x:); x; end
+  end
+
+  def test_method_missing_with_kwargs
+    assert_equal 1, TestRegistry.foo(x: 1)
+  end
+end


### PR DESCRIPTION
Without this fix, the delegation will raise the ArgumentError:

```
% bin/test -w test/per_thread_registry_test.rb
Running 1 tests in a single process (parallelization threshold is 50)
Run options: --seed 23992

# Running:

E

Error:
PerThreadRegistryTest#test_method_missing_with_kwargs:
ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: x)
    /Users/kamipo/src/github.com/rails/rails/activesupport/test/per_thread_registry_test.rb:9:in `foo'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/per_thread_registry.rb:55:in `foo'
    /Users/kamipo/src/github.com/rails/rails/activesupport/lib/active_support/per_thread_registry.rb:57:in `method_missing'
    /Users/kamipo/src/github.com/rails/rails/activesupport/test/per_thread_registry_test.rb:13:in `test_method_missing_with_kwargs'
```
