### PR TITLE
SQLite3 support use returning statement

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -620,6 +620,10 @@ module ActiveRecord
             relation
           end
         end
+
+        def suppress_composite_primary_key(pk)
+          pk unless pk.is_a?(Array)
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -1169,6 +1169,11 @@ module ActiveRecord
         def default_prepared_statements
           true
         end
+
+        def extract_table_ref_from_insert_sql(sql)
+          sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
+          $1.strip if $1
+        end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -168,10 +168,6 @@ module ActiveRecord
           def last_insert_id_result(sequence_name)
             exec_query("SELECT currval(#{quote(sequence_name)})", "SQL")
           end
-
-          def suppress_composite_primary_key(pk)
-            pk unless pk.is_a?(Array)
-          end
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1017,11 +1017,6 @@ module ActiveRecord
           SQL
         end
 
-        def extract_table_ref_from_insert_sql(sql)
-          sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
-          $1.strip if $1
-        end
-
         def arel_visitor
           Arel::Visitors::PostgreSQL.new(self)
         end

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -86,7 +86,8 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (Only PostgreSQL and SQLite3 version >= 3.35.0)
+      #   An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -176,7 +177,8 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (Only PostgreSQL and SQLite3 version >= 3.35.0)
+      #   An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL
@@ -242,7 +244,8 @@ module ActiveRecord
       # ==== Options
       #
       # [:returning]
-      #   (PostgreSQL only) An array of attributes to return for all successfully
+      #   (Only PostgreSQL and SQLite3 version >= 3.35.0)
+      #   An array of attributes to return for all successfully
       #   inserted records, which by default is the primary key.
       #   Pass <tt>returning: %w[ id name ]</tt> for both id and name
       #   or <tt>returning: false</tt> to omit the underlying <tt>RETURNING</tt> SQL


### PR DESCRIPTION
### Summary

[SQLite(3.35.0) release information](https://www.sqlite.org/releaselog/3_35_0.html)
The SQLite add support for the RETURNING clause on DELETE, INSERT, and UPDATE statements.
This PR used this feature, as follows:
 - `ActiveRecord::InsertAll` support use to returning of feature if your SQLite version >= 3.35.0.
 - `ActiveRecord::ConnectionAdapters::AbstractAdapter#exec_insert` support return primary key of value directly. If you want to keep original behavior, you can set `insert_returning: false` in connection configuration of database.

_PS: English is not my native language; please excuse typing errors._