### PR TITLE
Allow opting out from setting any SameSite option

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -451,6 +451,9 @@ module ActionDispatch
 
           cookies_same_site_protection = request.cookies_same_site_protection
           options[:same_site] ||= cookies_same_site_protection.call(request)
+          # This allows devs to have a non-nil default set in `cookies_same_site_protection` but
+          # still out-out from setting any SameSite value in some specific cookie setting `same_site: :nil`.
+          options[:same_site] = nil if options[:same_site] == :nil
 
           if options[:domain] == :all || options[:domain] == "all"
             # If there is a provided tld length then we use it otherwise default domain regexp.


### PR DESCRIPTION
### Summary

This change allows devs to have a non-`nil` default set in `cookies_same_site_protection` but still opt-out from setting any specific SameSite value in some specific cookie by setting `same_site: :nil`.

## Other Information

I want to embrace Rails 6.1's new `config.action_dispatch.cookies_same_site_protection = :lax` default value for _most_ of our cookies, but I'd like our session cookie (using the `CookieStore`) to still avoid setting any `SameSite` option for now. The main reason having to do with Apple Sign In and Omniauth not playing nice with `Lax` (because Apple uses POST instead of GET) but you can read more about it [here](https://github.com/nhosoya/omniauth-apple/issues/54#issuecomment-893767778) if you're interested interested.

The way I was trying to do this was with the following settings:

```ruby
# config/application.rb
# This is not needed explicitly in Rails 6.1+ because it's the default but it's here to help with the explanation.
config.action_dispatch.cookies_same_site_protection = :lax
# Specifically for the session cookie, avoid setting any explicit `SameSite` value letting the browser use its default.
config.session_store :cookie_store, key: "_myapp_session", same_site: nil
```

**But that didn't work** and `lax` was applied even for the session cookie. With this patch, I could use `same_site: :nil` and it'd work.

Regardless of why I need it, I do think it's a useful option and the current code doesn't seem to allow avoiding to set ANY `SameSite` value on a cookie by cookie basis, once a default has been set. It's either all or nothing.

I think with this little change I would be able to still configure a default to be used whenever I don't set `:same_site` explicitly, but I can use the "special" `:nil` value if I want to make sure that cookie doesn't set any explicit value regardless of the configured default. I'm not a fan of the `:nil` special value but couldn't think of anything better than that.

I guess another possibility would be to allow the `cookies_same_site_protection` proc to read the cookie name (we'd need to pass `options` on top of the `request`, I guess) so that the dev can decide to use a different default value depending on the cookie name. but this would be a bigger change, potentially not backward-compatible.

I assume you'd need an accompanying automated test in order to merge this but I wanted to get some opinions about this before dedicating more time on it.