### PR TITLE
API Docs: Use Arel.sql examples that require Arel.sql

### DIFF
--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -470,12 +470,12 @@ module ActiveRecord
   #
   # For example, the following code would raise this exception:
   #
-  #   Post.order("length(title)").first
+  #   Post.order("REPLACE(title, 'misc', 'zzzz') asc").pluck(:id)
   #
   # The desired result can be accomplished by wrapping the known-safe string
   # in Arel.sql:
   #
-  #   Post.order(Arel.sql("length(title)")).first
+  #   Post.order(Arel.sql("REPLACE(title, 'misc', 'zzzz') asc")).pluck(:id)
   #
   # Again, such a workaround should *not* be used when passing user-provided
   # values, such as request parameters or model attributes to query methods.

--- a/activerecord/lib/arel.rb
+++ b/activerecord/lib/arel.rb
@@ -29,7 +29,7 @@ module Arel
 
   # Wrap a known-safe SQL string for passing to query methods, e.g.
   #
-  #   Post.order(Arel.sql("length(title)")).last
+  #   Post.order(Arel.sql("REPLACE(title, 'misc', 'zzzz') asc")).pluck(:id)
   #
   # Great caution should be taken to avoid SQL injection vulnerabilities.
   # This method should not be used with unsafe values such as request


### PR DESCRIPTION
### Summary

This is a documentation-only change that addresses issue https://github.com/rails/rails/issues/42950

### Other Information

`Arel.sql` documentation is updated in addition to `ActiveRecord::UnknownAttributeReference`, as the `Arel.sql` documentation also provides an example that doesn't really require it.

I considered adding more details about what's allowed (functions with zero or one arg, `asc`, `desc`, and column names), but opted against it for now because it wasn't discussed in the issue and because the docs got out of date with the existing level of detail.

This is my first Rails PR, so I certainly may have missed updating something that I was supposed to.