### PR TITLE
feat: Allow specifying a tag that isnt just `form`

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -918,14 +918,16 @@ module ActionView
         end
 
         def form_tag_html(html_options)
+          tag = html_options["tag"] || "form"
           extra_tags = extra_tags_for_form(html_options)
-          tag(:form, html_options, true) + extra_tags
+          tag(tag, html_options, true) + extra_tags
         end
 
         def form_tag_with_body(html_options, content)
+          tag = html_options["tag"] || "form"
           output = form_tag_html(html_options)
           output << content.to_s if content
-          output.safe_concat("</form>")
+          output.safe_concat("</#{tag}>")
         end
 
         # see http://www.w3.org/TR/html4/types.html#type-name

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -918,16 +918,16 @@ module ActionView
         end
 
         def form_tag_html(html_options)
-          tag = html_options["tag"] || "form"
+          wrapper_tag = html_options.delete("wrapper_tag") || "form"
           extra_tags = extra_tags_for_form(html_options)
-          tag(tag, html_options, true) + extra_tags
+          tag(wrapper_tag, html_options, true) + extra_tags
         end
 
         def form_tag_with_body(html_options, content)
-          tag = html_options["tag"] || "form"
+          wrapper_tag = html_options["wrapper_tag"] || "form"
           output = form_tag_html(html_options)
           output << content.to_s if content
-          output.safe_concat("</#{tag}>")
+          output.safe_concat("</#{wrapper_tag}>")
         end
 
         # see http://www.w3.org/TR/html4/types.html#type-name


### PR DESCRIPTION
# Purpose:

When using <https://shoelace.style> I wanted to hook in and create my own form builder. The problem is that there is no nice way to override the base form_with to use a different element (in this case `<sl-form>`)

## What this does

This allows a user calling `form_with` to specify an HTML tag to use a different form tag.

## Example

```erb
<%= form_with model: Model, html: { wrapper_tag: "sl-form" } do |f| %>
<% end %>
```

will then generate the following html:

```html
<sl-form></sl-form>
```

instead of the typical `<form></form>`

## Questions / Considerations

Im not sure if theres a more semantic or appropriate way to make this happen as the `tag` attribute will appear on the parent form, but I figured I could submit this small PR and at least start a discussion. I apologize if this is outside the scope of Rails / the form builder.

EDIT:

Thank you to @brenogazzola for the recommendation to delete the `"wrapper_tag"` from html_options. Now it no longer appears as an attribute on the parent element.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
