### PR TITLE
Fix generated MIME methods to recognize kwargs

### DIFF
--- a/actionpack/lib/abstract_controller/collector.rb
+++ b/actionpack/lib/abstract_controller/collector.rb
@@ -10,6 +10,7 @@ module AbstractController
         def #{sym}(*args, &block)
           custom(Mime[:#{sym}], *args, &block)
         end
+        ruby2_keywords(:#{sym})
       RUBY
     end
 
@@ -22,7 +23,7 @@ module AbstractController
     end
 
   private
-    def method_missing(symbol, &block)
+    def method_missing(symbol, *args, &block)
       unless mime_constant = Mime[symbol]
         raise NoMethodError, "To respond to a custom format, register it as a MIME type first: " \
           "https://guides.rubyonrails.org/action_controller_overview.html#restful-downloads. " \
@@ -33,10 +34,11 @@ module AbstractController
 
       if Mime::SET.include?(mime_constant)
         AbstractController::Collector.generate_method_for_mime(mime_constant)
-        send(symbol, &block)
+        public_send(symbol, *args, &block)
       else
         super
       end
     end
+    ruby2_keywords(:method_missing)
   end
 end

--- a/actionpack/test/abstract/collector_test.rb
+++ b/actionpack/test/abstract/collector_test.rb
@@ -12,8 +12,8 @@ module AbstractController
         @responses = []
       end
 
-      def custom(mime, *args, &block)
-        @responses << [mime, args, block]
+      def custom(mime, *args, **kwargs, &block)
+        @responses << [mime, args, kwargs, block]
       end
     end
 
@@ -53,12 +53,12 @@ module AbstractController
       test "generated methods call custom with arguments received" do
         collector = MyCollector.new
         collector.html
-        collector.text(:foo)
+        collector.text(:foo, bar: :baz)
         collector.js(:bar) { :baz }
-        assert_equal [Mime[:html], [], nil], collector.responses[0]
-        assert_equal [Mime[:text], [:foo], nil], collector.responses[1]
-        assert_equal [Mime[:js], [:bar]], collector.responses[2][0, 2]
-        assert_equal :baz, collector.responses[2][2].call
+        assert_equal [Mime[:html], [], {}, nil], collector.responses[0]
+        assert_equal [Mime[:text], [:foo], { bar: :baz }, nil], collector.responses[1]
+        assert_equal [Mime[:js], [:bar], {}], collector.responses[2][0, 3]
+        assert_equal :baz, collector.responses[2][3].call
       end
     end
   end


### PR DESCRIPTION
Without this fix, generated MIME methods can't recognize kwargs:

```
% bin/test -w test/abstract/collector_test.rb:53
Running 5 tests in a single process (parallelization threshold is 50)
Run options: --seed 56716

# Running:

F

Failure:
AbstractController::Testing::TestCollector#test_generated_methods_call_custom_with_arguments_received [/Users/kamipo/src/github.com/rails/rails/actionpack/test/abstract/collector_test.rb:59]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Mime::Type:0xXXXXXX @synonyms=[], @symbol=:text, @string="text/plain", @hash=-3828881190283196326>, [:foo], {:bar=>:baz}, nil]
+[#<Mime::Type:0xXXXXXX @synonyms=[], @symbol=:text, @string="text/plain", @hash=-3828881190283196326>, [:foo, {:bar=>:baz}], {}, nil]
```
