### PR TITLE
Make SafeBuffer#split return Array of SafeBuffers

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Preserve `#html_safe?` on the resulting Array of Strings when calling
+    `ActiveSupport::SafeBuffer#split`.
+
+    *Sean Doyle*
+
 *   Allow entirely opting out of deprecation warnings
 
     Previously if you did `app.config.active_support.deprecation = :silence`, some work would

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -203,6 +203,14 @@ module ActiveSupport # :nodoc:
       super(implicit_html_escape_interpolated_argument(value))
     end
 
+    def split(*)
+      if html_safe?
+        super.map! { |value| SafeBuffer.new(value) }
+      else
+        super
+      end
+    end
+
     def []=(*args)
       if args.length == 3
         super(args[0], args[1], implicit_html_escape_interpolated_argument(args[2]))

--- a/activesupport/test/safe_buffer_test.rb
+++ b/activesupport/test/safe_buffer_test.rb
@@ -203,6 +203,30 @@ class SafeBufferTest < ActiveSupport::TestCase
     assert new_buffer.html_safe?, "should be safe"
   end
 
+  test "#split returns an Array of safe SafeBuffer instances when the original was safe" do
+    @buffer << "a"
+    @buffer << " "
+    @buffer << "b"
+
+    @buffer.split.each do |token|
+      assert_instance_of ActiveSupport::SafeBuffer, token
+      assert_predicate token, :html_safe?
+    end
+  end
+
+  test "#split returns an Array of unsafe SafeBuffer instances when the original was unsafe" do
+    @buffer << "a"
+    @buffer << " "
+    @buffer << "b"
+
+    @buffer.gsub! "b", "c"
+
+    @buffer.split.each do |token|
+      assert_instance_of ActiveSupport::SafeBuffer, token
+      assert_not_predicate token, :html_safe?
+    end
+  end
+
   test "Should continue unsafe on slice" do
     x = "foo".html_safe.gsub!("f", '<script>alert("lolpwnd");</script>')
 


### PR DESCRIPTION
### Summary

When calling `#split` on an instance of `ActiveSupport::SafeBuffer`,
return an Array of instances of `ActiveSupport::SafeBuffer`.

If the original string instance has been marked as safe, splitting it
into its parts should not be a mutative action. Therefore the
safe-marking should also apply to the new instances, similarly to how
using [SafeBuffer#slice][] preserves the safety.

[SafeBuffer#slice]: https://github.com/rails/rails/blob/c3518b4a9c9cbd5fc264231c7b153ac6f6195019/activesupport/test/safe_buffer_test.rb#L200-L204

