### PR TITLE
Clean up missing dots in changelogs

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -2,7 +2,7 @@
 
     *Ben Toews*, *John Hawthorn*, *Kasper Timm Hansen*, *Joel Hawksley*
 
-*   Add `include_seconds` option for `time_field`
+*   Add `include_seconds` option for `time_field`.
 
         <%= form.time_field :foo, include_seconds: false %>
         # => <input value="16:22" type="time" />

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -32,7 +32,7 @@
 
     *Kevin Newton*
 
-*   Fix `eager_loading?` when ordering with `Symbol`
+*   Fix `eager_loading?` when ordering with `Symbol`.
 
     `eager_loading?` is triggered correctly when using `order` with symbols.
 
@@ -68,7 +68,7 @@
 
     *Luis Vasconcellos*, *Eileen M. Uchitelle*
 
-*   Fix `eager_loading?` when ordering with `Hash` syntax
+*   Fix `eager_loading?` when ordering with `Hash` syntax.
 
     `eager_loading?` is triggered correctly when using `order` with hash syntax
     on an outer table.

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Allow entirely opting out of deprecation warnings
+*   Allow entirely opting out of deprecation warnings.
 
     Previously if you did `app.config.active_support.deprecation = :silence`, some work would
     still be done on each call to `ActiveSupport::Deprecation.warn`. In very hot paths, this could


### PR DESCRIPTION
### Summary

Some recent additions missed the dot at the end of the title.
