### PR TITLE
Create shared examples for dependency tracker tests

### DIFF
--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -55,11 +55,8 @@ class DependencyTrackerTest < ActionView::TestCase
   end
 end
 
-class RipperTrackerTest < Minitest::Test
-  def make_tracker(name, template)
-    ActionView::DependencyTracker::RipperTracker.new(name, template)
-  end
-
+# Tests run with both ERBTracker and RipperTracker
+module SharedTrackerTests
   def test_dependency_of_erb_template_with_number_in_filename
     template = FakeTemplate.new("<%= render 'messages/message123' %>", :erb)
     tracker = make_tracker("messages/_message123", template)
@@ -71,7 +68,7 @@ class RipperTrackerTest < Minitest::Test
     template = FakeTemplate.new("<%= render partial: 'messages/show', layout: 'messages/layout' %>", :erb)
     tracker = make_tracker("multiple/_dependencies", template)
 
-    assert_equal ["messages/show", "messages/layout"], tracker.dependencies
+    assert_equal ["messages/layout", "messages/show"], tracker.dependencies.sort
   end
 
   def test_dependency_of_template_layout_standalone
@@ -208,6 +205,22 @@ class RipperTrackerTest < Minitest::Test
     tracker = make_tracker("interpolation/_string", template)
 
     assert_equal ["single/\#{quote}"], tracker.dependencies
+  end
+end
+
+class ERBTrackerTest < Minitest::Test
+  include SharedTrackerTests
+
+  def make_tracker(name, template)
+    ActionView::DependencyTracker::ERBTracker.new(name, template)
+  end
+end
+
+class RipperTrackerTest < Minitest::Test
+  include SharedTrackerTests
+
+  def make_tracker(name, template)
+    ActionView::DependencyTracker::RipperTracker.new(name, template)
   end
 
   def test_dependencies_skip_unknown_options


### PR DESCRIPTION
### Summary

Following recent changes in #42458 and #42947 

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Breaks out dependency tracker tests into a `SharedTrackerTests` module so they can be run with both `ERBTracker` and the new `RipperTracker`. In theory `ERBTracker` will be removed in the future and replaced with `RipperTracker`, but for now both classes are present and `ERBTracker` is the default.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

Credit for this nice shared-examples-in-minitest pattern goes to @ParamagicDev :heart:

CC @HParker @jhawthorn 

