### PR TITLE
Return just the address if name is blank

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `email_address_with_name` returns just the address if name is blank.
+
+    *Thomas Hutterer*
+
+
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
 *   No changes.

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -563,10 +563,12 @@ module ActionMailer
       end
 
       # Returns an email in the format "Name <email@example.com>".
+      #
+      # If the name is a blank string, it returns just the address.
       def email_address_with_name(address, name)
         Mail::Address.new.tap do |builder|
           builder.address = address
-          builder.display_name = name
+          builder.display_name = name.presence
         end.to_s
       end
 
@@ -638,6 +640,8 @@ module ActionMailer
     end
 
     # Returns an email in the format "Name <email@example.com>".
+    #
+    # If the name is a blank string, it returns just the address.
     def email_address_with_name(address, name)
       self.class.email_address_with_name(address, name)
     end

--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -89,6 +89,11 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("Mikel <mikel@test.lindsaar.net>", email["Reply-To"].value)
   end
 
+  test "mail() using email_address_with_name with blank string as name" do
+    email = BaseMailer.with_blank_name
+    assert_equal("sunny@example.com", email["To"].value)
+  end
+
   # Custom headers
   test "custom headers" do
     email = BaseMailer.welcome

--- a/actionmailer/test/mailers/base_mailer.rb
+++ b/actionmailer/test/mailers/base_mailer.rb
@@ -31,6 +31,11 @@ class BaseMailer < ActionMailer::Base
     mail(template_name: "welcome", to: to)
   end
 
+  def with_blank_name
+    to = email_address_with_name("sunny@example.com", "")
+    mail(template_name: "welcome", to: to)
+  end
+
   def html_only(hash = {})
     mail(hash)
   end

--- a/guides/source/action_mailer_basics.md
+++ b/guides/source/action_mailer_basics.md
@@ -390,6 +390,8 @@ def welcome_email
 end
 ```
 
+If the name is a blank string, it returns just the address.
+
 [`email_address_with_name`]: https://api.rubyonrails.org/classes/ActionMailer/Base.html#method-i-email_address_with_name
 
 ### Mailer Views


### PR DESCRIPTION
### Summary

This changes the behavior of ActionMailer's `email_address_with_name` when the provided name is a blank string like `""` or `"    "`. Instead of returning something like `" <foo@example.com>"`, it now just returns the email address as provided, e.g. `"foo@example.com"`.

I'm not 100% sure if the old behavior could actually confuse and stop all (or some?) mail server from sending out emails like this, but I definitely found it unexpected and odd looking when using `ActionMailer::Base.email_address_with_name` to display email messages in an UI, where both the values for address and name came from an API that returned a `""` for missing names. 
