### PR TITLE
Adds Yes/No to ActiveModel::Type::Boolean options.

### DIFF
--- a/activemodel/lib/active_model/type/boolean.rb
+++ b/activemodel/lib/active_model/type/boolean.rb
@@ -23,6 +23,8 @@ module ActiveModel
         "FALSE", :FALSE,
         "off", :off,
         "OFF", :OFF,
+        "no", :no,
+        "NO", :NO,
       ].to_set.freeze
 
       def type # :nodoc:

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -19,6 +19,8 @@ module ActiveModel
         assert type.cast("TRUE")
         assert type.cast("on")
         assert type.cast("ON")
+        assert type.cast("yes")
+        assert type.cast("YES")
         assert type.cast(" ")
         assert type.cast("\u3000\r\n")
         assert type.cast("\u0000")
@@ -30,6 +32,8 @@ module ActiveModel
         assert type.cast(:TRUE)
         assert type.cast(:on)
         assert type.cast(:ON)
+        assert type.cast(:yes)
+        assert type.cast(:YES)
 
         # explicitly check for false vs nil
         assert_equal false, type.cast(false)
@@ -41,6 +45,8 @@ module ActiveModel
         assert_equal false, type.cast("FALSE")
         assert_equal false, type.cast("off")
         assert_equal false, type.cast("OFF")
+        assert_equal false, type.cast("no")
+        assert_equal false, type.cast("no")
         assert_equal false, type.cast(:"0")
         assert_equal false, type.cast(:f)
         assert_equal false, type.cast(:F)
@@ -48,6 +54,8 @@ module ActiveModel
         assert_equal false, type.cast(:FALSE)
         assert_equal false, type.cast(:off)
         assert_equal false, type.cast(:OFF)
+        assert_equal false, type.cast(:no)
+        assert_equal false, type.cast(:NO)
       end
     end
   end

--- a/activemodel/test/cases/type/boolean_test.rb
+++ b/activemodel/test/cases/type/boolean_test.rb
@@ -46,7 +46,7 @@ module ActiveModel
         assert_equal false, type.cast("off")
         assert_equal false, type.cast("OFF")
         assert_equal false, type.cast("no")
-        assert_equal false, type.cast("no")
+        assert_equal false, type.cast("NO")
         assert_equal false, type.cast(:"0")
         assert_equal false, type.cast(:f)
         assert_equal false, type.cast(:F)


### PR DESCRIPTION
### Summary

My experience shows that end users tend to understand Yes/No pair better than True/False. This is a very common case in my projects when consuming CSV files provided by users, for example. As it seems to me that Yes/No are not ambiguous terms, I'm hoping ActiveModel could handle them without any major risks to existing codebases.

### Other Information

I looked at the documentation and I believe it doesn't need to be changed, but I'm glad to make further changes as seen fit.
I believe this is self containing? Happy to edit if I'm missing any information.
