### PR TITLE
Fix several broken specs in activejob/test/integration/queuing_test.rb

### DIFF
--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 require "helper"
-require_relative "../support/integration/helper"
 require "jobs/logging_job"
 require "jobs/hello_job"
 require "jobs/provider_jid_job"
 require "active_support/core_ext/numeric/time"
+
+require_relative "../support/integration/helper"
 
 class QueuingTest < ActiveSupport::TestCase
   test "should run jobs enqueued on a listening queue" do

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "helper"
+require 'helper'
+require_relative '../support/integration/helper'
 require "jobs/logging_job"
 require "jobs/hello_job"
 require "jobs/provider_jid_job"

--- a/activejob/test/integration/queuing_test.rb
+++ b/activejob/test/integration/queuing_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'helper'
-require_relative '../support/integration/helper'
+require "helper"
+require_relative "../support/integration/helper"
 require "jobs/logging_job"
 require "jobs/hello_job"
 require "jobs/provider_jid_job"


### PR DESCRIPTION
### Summary

When setting up a fresh install of rails-dev-box and running the specs on Vagrant to get a green baseline, I noticed multiple errors to the effect of:

```
Error:
QueuingTest#test_should_supply_a_wrapped_class_name_to_DelayedJob:
NoMethodError: undefined method `adapter_is?' for #<QueuingTest:0x00005650cd5ff1d0>
    /vagrant/rails/activejob/test/integration/queuing_test.rb:54:in `block in <class:QueuingTest>'
```

The total # of passing and failing specs on this initial run was:
```
378 runs, 785 assertions, 0 failures, 14 errors, 27 skips
```

After some investigation, I determined that `queueing-test.rb` was attempting to import `activejob/test/support/integration/helper.rb` via a simple `require 'helper'`, since this `helper.rb` in turn imports the missing method `adapter_is?` via `require_relative "test_case_helpers"`.

The `require_relative` seemed to be referencing the right filepath, so I checked the value of $LOAD_PATH from within `queueing_test.rb`, and I did not see the parent folder of `helper.rb`, i.e. `activejob/test/support/integration/`.

I was confused why we weren't seeing a `LoadError` due to a missing file, so I added a debugger line before the `require 'helper'` method so I could require it manually in the REPL and observe the results.  The return value
was `false`, indicating that it had already been `require`d.  I subsequently noted that the $LOAD_PATH *does* include `activejob/test/`, and that this folder *does* have a file named `helper.rb`, so I assumed this is the actual file being loaded, and may have even been loaded prior to this 2nd `require`'s execution (hence the `false` return value).  I checked  this file and confirmed that it did *not* require `"test_case_helpers"`, which would explain why the `adapter_is?` method was missing.

As a first attempt at a solution, I simply supplemented the existing `require 'helper'` line with:

```
require_relative '../support/integration/helper'
```

This seemed to help, as the new spec results came to:

```
378 runs, 777 assertions, 2 failures, 1 errors, 40 skips
```

It seems there are still those two failing specs and 1 error:

```
Error:
QueueAdapterJobTest#test_queue_adapter_is_test_adapter:
NameError: uninitialized constant QueueAdapterJobTest::QueueAdapterJob
Did you mean?  QueueAdapterTest
    /vagrant/rails/activejob/test/cases/test_helper_test.rb:2024:in `test_queue_adapter_is_test_adapter'
    minitest (5.14.4) lib/minitest/test.rb:98:in `block (3 levels) in run'
    minitest (5.14.4) lib/minitest/test.rb:195:in `capture_exceptions'
    minitest (5.14.4) lib/minitest/test.rb:95:in `block (2 levels) in run'
    minitest (5.14.4) lib/minitest.rb:272:in `time_it'
    minitest (5.14.4) lib/minitest/test.rb:94:in `block in run'
    minitest (5.14.4) lib/minitest.rb:367:in `on_signal'
    minitest (5.14.4) lib/minitest/test.rb:211:in `with_info_handler'
    minitest (5.14.4) lib/minitest/test.rb:93:in `run'
    minitest (5.14.4) lib/minitest.rb:1029:in `run_one_method'
    minitest (5.14.4) lib/minitest.rb:341:in `run_one_method'
    minitest (5.14.4) lib/minitest.rb:328:in `block (2 levels) in run'
    minitest (5.14.4) lib/minitest.rb:327:in `each'
    minitest (5.14.4) lib/minitest.rb:327:in `block in run'
    minitest (5.14.4) lib/minitest.rb:367:in `on_signal'
    minitest (5.14.4) lib/minitest.rb:354:in `with_info_handler'
    minitest (5.14.4) lib/minitest.rb:326:in `run'
    /vagrant/rails/railties/lib/rails/test_unit/line_filtering.rb:10:in `run'
    minitest (5.14.4) lib/minitest.rb:164:in `block in __run'
    minitest (5.14.4) lib/minitest.rb:164:in `map'
    minitest (5.14.4) lib/minitest.rb:164:in `__run'
    minitest (5.14.4) lib/minitest.rb:141:in `run'
    minitest (5.14.4) lib/minitest.rb:68:in `block in autorun'


bin/test test/cases/test_helper_test.rb:2023

Failure:
LoggingTest#test_globalid_parameter_logging [/vagrant/rails/activesupport/lib/active_support/testing/assertions.rb:250]:
Expected /Enqueued.*gid:\/\/aj\/Person\/123/ to match "[ActiveJob] [LoggingJob] [LOGGING-JOB-ID] Performing LoggingJob (Job ID: LOGGING-JOB-ID) from Test(default) enqueued at 2021-08-09T00:10:52Z with arguments: #<GlobalID:0x000055561ac5e5c0 @uri=#<URI::GID gid://dummy/Person/123>>\n[ActiveJob] [LoggingJob] [LOGGING-JOB-ID] Dummy, here is it: #<Person:0x000055561ac5f6c8>\n[ActiveJob] [LoggingJob] [LOGGING-JOB-ID] Performed LoggingJob (Job ID: LOGGING-JOB-ID) from Test(default) in 0.19ms\n[ActiveJob] Enqueued LoggingJob (Job ID: LOGGING-JOB-ID) to Test(default) with arguments: #<GlobalID:0x000055561ac069b0 @uri=#<URI::GID gid://dummy/Person/123>>\n".


bin/test test/cases/logging_test.rb:88

Failure:
LoggingTest#test_globalid_nested_parameter_logging [/vagrant/rails/activesupport/lib/active_support/testing/assertions.rb:250]:
Expected /Enqueued.*gid:\/\/aj\/Person\/123/ to match "[ActiveJob] [LoggingJob] [LOGGING-JOB-ID] Performing LoggingJob (Job ID: LOGGING-JOB-ID) from Test(default) enqueued at 2021-08-09T00:10:52Z with arguments: {:person=>#<GlobalID:0x000055561a6ad770 @uri=#<URI::GID gid://dummy/Person/123>>}\n[ActiveJob] [LoggingJob] [LOGGING-JOB-ID] Dummy, here is it: {:person=>#<Person:0x000055561a6cd6b0 @id=\"123\">}\n[ActiveJob] [LoggingJob] [LOGGING-JOB-ID] Performed LoggingJob (Job ID: LOGGING-JOB-ID) from Test(default) in 0.22ms\n[ActiveJob] Enqueued LoggingJob (Job ID: LOGGING-JOB-ID) to Test(default) with arguments: {:person=>#<GlobalID:0x000055561a661668 @uri=#<URI::GID gid://dummy/Person/123>>}\n".
```

I assume these will need to be addressed in order for this PR to be merge-able?  Then again, if there really are 14 errors happening in the `main` version of ActiveJob's spec suite, maybe these errors/failures are not blockers after all?  I'm a noob Rails contributor so I'm really not sure.  I guess we're about to find out! 🤷‍♂️ 

Note that the number of skipped specs goes from 27 to 40 because the line of code which invokes the missing `adapter_is?` method is often something like `skip unless adapter_is?(:resque)` (this taken from `activejob/test/integration/queuing_test.rb:56`, which is one of the spec  failures).

### Other Information

Open issue [here](https://github.com/rails/rails/issues/42974).
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
