### PR TITLE
Prints a warning when non-proc used for default value

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -10,6 +10,11 @@ module ActiveModel
       end
 
       def from_user(name, value_before_type_cast, type, original_attribute = nil)
+        unless value_before_type_cast.is_a?(Proc)
+          ActiveSupport::Deprecation.warn "Static ActiveModel default values will be removed in "\
+            "Rails 7.0. Please use a Proc instead. Static "\
+            "variable used for attribute=#{name} value=#{value_before_type_cast}"
+        end
         FromUser.new(name, value_before_type_cast, type, original_attribute)
       end
 

--- a/activemodel/test/cases/attribute_test.rb
+++ b/activemodel/test/cases/attribute_test.rb
@@ -12,6 +12,12 @@ module ActiveModel
       assert @type.verify
     end
 
+    test "from_user + static default value" do
+      assert_deprecated do
+        Attribute.from_user(:an_attribute, [], Type::Integer.new)
+      end
+    end
+
     test "from_database + read type casts from database" do
       @type.expect(:deserialize, "type cast from database", ["a value"])
       attribute = Attribute.from_database(nil, "a value", @type)


### PR DESCRIPTION
It addresses issue https://github.com/rails/rails/issues/42959
Mutable default values for ActiveModel attribute can cause confusion. 
Let's raise a deprecation warning for the time being with the intention of stopping this behaviour all together.