### PR TITLE
improve PG index schema queries

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -74,7 +74,7 @@ module ActiveRecord
             FROM pg_class t
             INNER JOIN pg_index d ON t.oid = d.indrelid
             INNER JOIN pg_class i ON d.indexrelid = i.oid
-            LEFT JOIN pg_namespace n ON n.oid = i.relnamespace
+            LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
             WHERE i.relkind IN ('i', 'I')
               AND i.relname = #{index[:name]}
               AND t.relname = #{table[:name]}
@@ -92,7 +92,7 @@ module ActiveRecord
             FROM pg_class t
             INNER JOIN pg_index d ON t.oid = d.indrelid
             INNER JOIN pg_class i ON d.indexrelid = i.oid
-            LEFT JOIN pg_namespace n ON n.oid = i.relnamespace
+            LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
             WHERE i.relkind IN ('i', 'I')
               AND d.indisprimary = 'f'
               AND t.relname = #{scope[:name]}


### PR DESCRIPTION
### Summary

this is safe because it's impossible to create an index in a schema besides the the schema that the table is in. it's far more performant if you have many schemas/tables in a single database because pg_class has an index on (relname, relnamespace), whereas pg_index has no such index.

### Other Information

in a database with 725 schemas, 112k tables, and 808k indexes (across all schemas), this takes the runtime from ~28ms to ~2ms.

EXPLAIN ANALYZE before:

```
                                                                                QUERY PLAN                                                                                
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Unique  (cost=956.18..956.20 rows=1 width=160) (actual time=28.329..28.345 rows=20 loops=1)
   ->  Sort  (cost=956.18..956.19 rows=1 width=160) (actual time=28.328..28.331 rows=20 loops=1)
         Sort Key: i.relname, d.indisunique, d.indkey, (pg_get_indexdef(d.indexrelid)), t.oid, (obj_description(i.oid, 'pg_class'::name)) COLLATE "C"
         Sort Method: quicksort  Memory: 33kB
         ->  Nested Loop  (cost=1.68..956.17 rows=1 width=160) (actual time=0.665..28.306 rows=20 loops=1)
               Join Filter: (i.relnamespace = n.oid)
               Rows Removed by Join Filter: 6780
               ->  Index Scan using pg_namespace_nspname_index on pg_namespace n  (cost=0.28..2.49 rows=1 width=4) (actual time=0.006..0.007 rows=1 loops=1)
                     Index Cond: (nspname = '<redacted>'::name)
               ->  Nested Loop  (cost=1.41..952.99 rows=35 width=108) (actual time=0.024..26.464 rows=6800 loops=1)
                     ->  Nested Loop  (cost=0.98..921.44 rows=49 width=36) (actual time=0.017..8.867 rows=6800 loops=1)
                           ->  Index Scan using pg_class_relname_nsp_index on pg_class t  (cost=0.55..112.76 rows=99 width=4) (actual time=0.009..0.353 rows=340 loops=1)
                                 Index Cond: (relname = '<redacted>'::name)
                           ->  Index Scan using pg_index_indrelid_index on pg_index d  (cost=0.42..8.13 rows=4 width=36) (actual time=0.004..0.021 rows=20 loops=340)
                                 Index Cond: (indrelid = t.oid)
                                 Filter: (NOT indisprimary)
                                 Rows Removed by Filter: 1
                     ->  Index Scan using pg_class_oid_index on pg_class i  (cost=0.43..0.64 rows=1 width=72) (actual time=0.002..0.002 rows=1 loops=6800)
                           Index Cond: (oid = d.indexrelid)
                           Filter: (relkind = ANY ('{i,I}'::"char"[]))
 Planning Time: 0.491 ms
 Execution Time: 28.387 ms
```


after

```
                                                                               QUERY PLAN                                                                                
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Unique  (cost=14.38..14.40 rows=1 width=160) (actual time=1.354..1.366 rows=20 loops=1)
   ->  Sort  (cost=14.38..14.39 rows=1 width=160) (actual time=1.353..1.356 rows=20 loops=1)
         Sort Key: i.relname, d.indisunique, d.indkey, (pg_get_indexdef(d.indexrelid)), t.oid, (obj_description(i.oid, 'pg_class'::name)) COLLATE "C"
         Sort Method: quicksort  Memory: 33kB
         ->  Nested Loop  (cost=1.68..14.37 rows=1 width=160) (actual time=0.231..1.337 rows=20 loops=1)
               ->  Nested Loop  (cost=1.25..13.48 rows=1 width=36) (actual time=0.024..0.049 rows=20 loops=1)
                     ->  Nested Loop  (cost=0.83..5.31 rows=1 width=4) (actual time=0.017..0.018 rows=1 loops=1)
                           ->  Index Scan using pg_namespace_nspname_index on pg_namespace n  (cost=0.28..2.49 rows=1 width=4) (actual time=0.006..0.007 rows=1 loops=1)
                                 Index Cond: (nspname = '<redacted>'::name)
                           ->  Index Scan using pg_class_relname_nsp_index on pg_class t  (cost=0.55..2.77 rows=1 width=8) (actual time=0.009..0.009 rows=1 loops=1)
                                 Index Cond: ((relname = '<redacted>'::name) AND (relnamespace = n.oid))
                     ->  Index Scan using pg_index_indrelid_index on pg_index d  (cost=0.42..8.13 rows=4 width=36) (actual time=0.007..0.024 rows=20 loops=1)
                           Index Cond: (indrelid = t.oid)
                           Filter: (NOT indisprimary)
                           Rows Removed by Filter: 1
               ->  Index Scan using pg_class_oid_index on pg_class i  (cost=0.43..0.64 rows=1 width=68) (actual time=0.003..0.003 rows=1 loops=20)
                     Index Cond: (oid = d.indexrelid)
                     Filter: (relkind = ANY ('{i,I}'::"char"[]))
 Planning Time: 0.476 ms
 Execution Time: 1.415 m
```
