### PR TITLE
Add `weekday_options_for_select` method

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `weekday_options_for_select` and `weekday_select` helper methods. Also adds `weekday_select` to `FormBuilder`.
+
+    *Drew Bragg*, *Dana Kashubeck*, *Kasper Timm Hansen*
+
 *   Add `caching?` helper that returns whether the current code path is being cached and `uncacheable!` to denote helper methods that can't participate in fragment caching.
 
     *Ben Toews*, *John Hawthorn*, *Kasper Timm Hansen*, *Joel Hawksley*

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -297,6 +297,12 @@ module ActionView
         Tags::TimeZoneSelect.new(object, method, self, priority_zones, options, html_options).render
       end
 
+      # Returns select and option tags for the given object and method, using
+      # #weekday_options_for_select to generate the list of option tags.
+      def weekday_select(object, method, options = {}, html_options = {}, &block)
+        Tags::WeekdaySelect.new(object, method, self, options, html_options, &block).render
+      end
+
       # Accepts a container (hash, array, enumerable, your type) and returns a string of option tags. Given a container
       # where the elements respond to first and last (such as a two-element array), the "lasts" serve as option values and
       # the "firsts" as option text. Hashes are turned into this form automatically, so the keys become "firsts" and values
@@ -593,6 +599,22 @@ module ActionView
         zone_options.safe_concat options_for_select(convert_zones[zones], selected)
       end
 
+      # Returns a string of option tags for the days of the week.
+      #
+      # Options:
+      # * <tt>:index_as_value</tt> - Defaults to false, set to true to use the index of the weekday as the value.
+      # * <tt>:day_format</tt> - The I18n key of the array to use for the weekday options.
+      # Defaults to :day_names, set to :abbr_day_names for abbreviations.
+      #
+      # NOTE: Only the option tags are returned, you have to wrap this call in
+      # a regular HTML select tag.
+      def weekday_options_for_select(selected = nil, index_as_value: false, day_format: :day_names)
+        day_names = I18n.translate("date.#{day_format}")
+        day_names = day_names.map.with_index.to_h if index_as_value
+
+        options_for_select(day_names, selected)
+      end
+
       # Returns radio button tags for the collection of existing return values
       # of +method+ for +object+'s class. The value returned from calling
       # +method+ on the instance +object+ will be selected. If calling +method+
@@ -857,6 +879,18 @@ module ActionView
       # Please refer to the documentation of the base helper for details.
       def time_zone_select(method, priority_zones = nil, options = {}, html_options = {})
         @template.time_zone_select(@object_name, method, priority_zones, objectify_options(options), @default_html_options.merge(html_options))
+      end
+
+      # Wraps ActionView::Helpers::FormOptionsHelper#weekday_select for form builders:
+      #
+      #   <%= form_for @user do |f| %>
+      #     <%= f.weekday_select :weekday, include_blank: true %>
+      #     <%= f.submit %>
+      #   <% end %>
+      #
+      # Please refer to the documentation of the base helper for details.
+      def weekday_select(method, options = {}, html_options = {})
+        @template.weekday_select(@object_name, method, objectify_options(options), @default_html_options.merge(html_options))
       end
 
       # Wraps ActionView::Helpers::FormOptionsHelper#collection_check_boxes for form builders:

--- a/actionview/lib/action_view/helpers/tags.rb
+++ b/actionview/lib/action_view/helpers/tags.rb
@@ -38,6 +38,7 @@ module ActionView
         autoload :TimeZoneSelect
         autoload :UrlField
         autoload :WeekField
+        autoload :WeekdaySelect
       end
     end
   end

--- a/actionview/lib/action_view/helpers/tags/weekday_select.rb
+++ b/actionview/lib/action_view/helpers/tags/weekday_select.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ActionView
+  module Helpers
+    module Tags # :nodoc:
+      class WeekdaySelect < Base # :nodoc:
+        def initialize(object_name, method_name, template_object, options, html_options)
+          @html_options = html_options
+
+          super(object_name, method_name, template_object, options)
+        end
+
+        def render
+          select_content_tag(
+            weekday_options_for_select(
+              value || @options[:selected],
+              index_as_value: @options.fetch(:index_as_value, false),
+              day_format: @options.fetch(:day_format, :day_names)
+            ),
+            @options,
+            @html_options
+          )
+        end
+      end
+    end
+  end
+end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -31,6 +31,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     Continent   = Struct.new("Continent", :continent_name, :countries)
     Country     = Struct.new("Country", :country_id, :country_name)
     Album       = Struct.new("Album", :id, :title, :genre)
+    Digest      = Struct.new("Digest", :send_day)
   end
 
   class Firm
@@ -1503,6 +1504,75 @@ class FormOptionsHelperTest < ActionView::TestCase
 
     assert_dom_equal(
       %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
+      output_buffer
+    )
+  end
+
+  def test_weekday_options_for_select_with_no_params
+    assert_dom_equal(
+      "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>",
+      weekday_options_for_select
+    )
+  end
+
+  def test_weekday_options_for_select_with_index_as_value
+    assert_dom_equal(
+      "<option value=\"0\">Sunday</option>\n<option value=\"1\">Monday</option>\n<option value=\"2\">Tuesday</option>\n<option value=\"3\">Wednesday</option>\n<option value=\"4\">Thursday</option>\n<option value=\"5\">Friday</option>\n<option value=\"6\">Saturday</option>",
+      weekday_options_for_select(index_as_value: true)
+    )
+  end
+
+  def test_weekday_options_for_select_with_abberviated_day_names
+    assert_dom_equal(
+      "<option value=\"Sun\">Sun</option>\n<option value=\"Mon\">Mon</option>\n<option value=\"Tue\">Tue</option>\n<option value=\"Wed\">Wed</option>\n<option value=\"Thu\">Thu</option>\n<option value=\"Fri\">Fri</option>\n<option value=\"Sat\">Sat</option>",
+      weekday_options_for_select(day_format: :abbr_day_names)
+    )
+  end
+
+  def test_weekday_options_for_select_with_selected_value
+    assert_dom_equal(
+      "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>",
+      weekday_options_for_select("Friday")
+    )
+  end
+
+  def test_weekday_select
+    assert_dom_equal(
+      "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      weekday_select(:model, :weekday)
+    )
+  end
+
+  def test_weekday_select_with_selected_value
+    assert_dom_equal(
+      "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      weekday_select(:model, :weekday, selected: "Friday")
+    )
+  end
+
+  def test_weekday_select_under_fields_for
+    @digest = Digest.new
+
+    output_buffer = fields_for :digest, @digest do |f|
+      concat f.weekday_select(:send_day)
+    end
+
+    assert_dom_equal(
+      "<select id=\"digest_send_day\" name=\"digest[send_day]\"><option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      output_buffer
+    )
+  end
+
+  def test_weekday_select_under_fields_for_with_value
+    @digest = Digest.new
+    @digest.send_day = "Monday"
+
+    output_buffer = fields_for :digest, @digest do |f|
+      concat f.weekday_select(:send_day)
+    end
+
+    assert_dom_equal(
+      "<select name=\"digest[send_day]\" id=\"digest_send_day\"><option value=\"Sunday\">Sunday</option>\n<option selected=\"selected\" value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
       output_buffer
     )
   end


### PR DESCRIPTION
### Summary

In a majority of the Rails apps I've built I've had to add my own helpers for a weekday select. Given how great Rails is at providing most of the helpers you could ever want, this omission has always been a little surprising to me. Since I just had to work on this again, and another dev shared my surprise at the omission, I thought it was time for a Rails PR.

This PR adds 2 new `FormOptionHelper` methods, a `FormBuilder` method, and a new `Tags::WeekdaySelect` class.

```ruby
weekday_options_for_select
# => "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n
# <option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n
# <option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n
# <option value=\"Saturday\">Saturday</option>"
```
In addition to accepting a `selected` value, `weekday_options_for_select` can have 2 options, `:index_as_value` and/or `:day_format`.
```ruby
weekday_options_for_select(nil, day_format: :abbr_day_names)
# => "<option value=\"Sun\">Sun</option>\n<option value=\"Mon\">Mon</option>\n
# <option value=\"Tue\">Tue</option>\n<option value=\"Wed\">Wed</option>\n
# <option value=\"Thu\">Thu</option>\n<option value=\"Fri\">Fri</option>\n
# <option value=\"Sat\">Sat</option>"

weekday_options_for_select(nil, index_as_value: true)
# => "<option value=\"0\">Sunday</option>\n<option value=\"1\">Monday</option>\n
# <option value=\"2\">Tuesday</option>\n<option value=\"3\">Wednesday</option>\n
# <option value=\"4\">Thursday</option>\n<option value=\"5\">Friday</option>\n
# <option value=\"6\">Saturday</option>"
```

`weekday_options_for_select` is really just a helper method for:
```ruby
weekday_select(:model, :weekday)
# => "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Sunday\">Sunday</option>\n
# <option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n
# <option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n
# <option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>"
```

`weekday_select` is also used in the `FormBuilder` so can use it like this:
```ruby
<%= form_for @digest do |f| %>
  <%= f.weekday_select :weekday %>
  <%= f.submit %>
<% end %>
```
to produce the following HTML:
```html
<select name="digest[weekday]" id="digest_weekday">
  <option value="Sunday">Sunday</option>
  <option value="Monday">Monday</option>
  <option value="Tuesday">Tuesday</option>
  <option value="Wednesday">Wednesday</option>
  <option value="Thursday">Thursday</option>
  <option value="Friday">Friday</option>
  <option value="Saturday">Saturday</option>
</select>
```