### PR TITLE
Sprockets shouldn't be in debug mode by default in development

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -62,11 +62,6 @@ Rails.application.configure do
 
   <%- end -%>
   <%- unless options.skip_sprockets? -%>
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
   # Suppress logger output for asset requests.
   config.assets.quiet = true
   <%- end -%>

--- a/railties/test/application/assets_test.rb
+++ b/railties/test/application/assets_test.rb
@@ -472,9 +472,9 @@ module ApplicationTests
       class ::PostsController < ActionController::Base; end
 
       get "/posts", {}, { "HTTPS" => "off" }
-      assert_match('src="http://example.com/assets/application.debug.js', last_response.body)
+      assert_match('src="http://example.com/assets/application.js', last_response.body)
       get "/posts", {}, { "HTTPS" => "on" }
-      assert_match('src="https://example.com/assets/application.debug.js', last_response.body)
+      assert_match('src="https://example.com/assets/application.js', last_response.body)
     end
 
     test "asset URLs should be protocol-relative if no request is in scope" do


### PR DESCRIPTION
As we move to separate files with ESM, we won't be concatenating or even preprocessing large JavaScript at all. Debug mode is thus irrelevant.