### PR TITLE
Turn off rack-mini-profiler by default due to interference with etag cache testing

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -51,9 +51,9 @@ group :development do
   <%- else -%>
   gem "web-console", ">= 4.1.0"
   <%- end -%>
-  # Display performance information such as SQL time and flame graphs for each request in your browser.
-  # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem "rack-mini-profiler", "~> 2.0"
+  # Display speed badge on every html page with SQL times and flame graphs.
+  # Note: Interferes with etag cache testing. Can be configured to work on production: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  # gem "rack-mini-profiler", "~> 2.0"
 <%- end -%>
 <% if depend_on_listen? -%>
   gem "listen", "~> 3.3"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -1281,7 +1281,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     assert_no_gem "webpacker", app_root
     assert_no_gem "jbuilder", app_root
-    assert_no_gem "rack-mini-profiler", app_root
     assert_no_gem "spring", app_root
     assert_no_gem "web-console", app_root
   end


### PR DESCRIPTION
So turn it off by default, but continue to suggest it.