### PR TITLE
`ActiveRecord::InternalMetadata.[]`: Simplify `pluck(:value).first` to `pick(:value)`

### DIFF
--- a/activerecord/lib/active_record/internal_metadata.rb
+++ b/activerecord/lib/active_record/internal_metadata.rb
@@ -32,7 +32,7 @@ module ActiveRecord
       def [](key)
         return unless enabled?
 
-        where(key: key).pluck(:value).first
+        where(key: key).pick(:value)
       end
 
       # Creates an internal metadata table with columns +key+ and +value+


### PR DESCRIPTION
### Summary

This PR simplifies the query for `ActiveRecord::InternalMetadata.[]`. Because the method only looks at 1 record, `pick(:value)` may be preferred over `pluck(:value).first`.

Before:
```ruby
ActiveRecord::InternalMetadata[:environment]
# SELECT "ar_internal_metadata"."value" FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1  [["key", "environment"]]
#=> "development"
```

After:
```ruby
ActiveRecord::InternalMetadata[:environment]
# SELECT "ar_internal_metadata"."value" FROM "ar_internal_metadata" WHERE "ar_internal_metadata"."key" = $1 LIMIT $2  [["key", "environment"], ["LIMIT", 1]]
#=> "development"
```