### PR TITLE
Fixes deprecation warning logged in the test cases 

### DIFF
--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -294,18 +294,20 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "updating an existing record with attachments when appending on assign" do
     append_on_assign do
-      @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
+      assert_deprecated do
+        @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
 
-      assert_difference -> { @user.reload.highlights.count }, +2 do
-        @user.update! highlights: [ create_blob(filename: "whenever.jpg"), create_blob(filename: "wherever.jpg") ]
-      end
+        assert_difference -> { @user.reload.highlights.count }, +2 do
+          @user.update! highlights: [ create_blob(filename: "whenever.jpg"), create_blob(filename: "wherever.jpg") ]
+        end
 
-      assert_no_difference -> { @user.reload.highlights.count } do
-        @user.update! highlights: [ ]
-      end
+        assert_no_difference -> { @user.reload.highlights.count } do
+          @user.update! highlights: [ ]
+        end
 
-      assert_no_difference -> { @user.reload.highlights.count } do
-        @user.update! highlights: nil
+        assert_no_difference -> { @user.reload.highlights.count } do
+          @user.update! highlights: nil
+        end
       end
     end
   end
@@ -760,20 +762,22 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
 
   test "successfully attaches new blobs and destroys attachments marked for destruction via nested attributes" do
     append_on_assign do
-      town_blob = create_blob(filename: "town.jpg")
-      @user.highlights.attach(town_blob)
-      @user.reload
+      assert_deprecated do
+        town_blob = create_blob(filename: "town.jpg")
+        @user.highlights.attach(town_blob)
+        @user.reload
 
-      racecar_blob = fixture_file_upload("racecar.jpg")
-      attachment_id = town_blob.attachments.find_by!(record: @user).id
-      @user.update(
-        highlights: [racecar_blob],
-        highlights_attachments_attributes: [{ id: attachment_id, _destroy: true }]
-      )
+        racecar_blob = fixture_file_upload("racecar.jpg")
+        attachment_id = town_blob.attachments.find_by!(record: @user).id
+        @user.update(
+          highlights: [racecar_blob],
+          highlights_attachments_attributes: [{ id: attachment_id, _destroy: true }]
+        )
 
-      assert @user.reload.highlights.attached?
-      assert_equal 1, @user.highlights.count
-      assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
+        assert @user.reload.highlights.attached?
+        assert_equal 1, @user.highlights.count
+        assert_equal "racecar.jpg", @user.highlights.blobs.first.filename.to_s
+      end
     end
   end
 

--- a/activestorage/test/service/disk_service_test.rb
+++ b/activestorage/test/service/disk_service_test.rb
@@ -51,7 +51,7 @@ class ActiveStorage::Service::DiskServiceTest < ActiveSupport::TestCase
 
   test "URL generation keeps working with ActiveStorage::Current.host set" do
     ActiveStorage::Current.url_options = nil
-    ActiveStorage::Current.host = "https://example.com"
+    assert_deprecated { ActiveStorage::Current.host = "https://example.com" }
 
     original_url_options = Rails.application.routes.default_url_options.dup
     Rails.application.routes.default_url_options.merge!(protocol: "http", host: "test.example.com", port: 3001)


### PR DESCRIPTION
This PR aims to resolve the deprecation warnings logged in the test console 
which are raised after deprecation of `ActiveStorage::Current.host` and 
`ActiveStorage.replace_on_assign_to_many`. 

I could not resolve the VIP warnings. Maybe someone else could 
take a stab at it.


![image](https://user-images.githubusercontent.com/7736232/128907866-d566cce1-984e-4503-8e72-597985f42515.png)
