### PR TITLE
Change diff highlighting background for dark mode

### DIFF
--- a/guides/assets/stylesheets/highlight.css
+++ b/guides/assets/stylesheets/highlight.css
@@ -271,6 +271,6 @@
 
   .highlight .gh { } /* Generic Heading & Diff Header */
   .highlight .gu { color: #75715e; } /* Generic.Subheading & Diff Unified/Comment? */
-  .highlight .gd { color: #f92672; } /* Generic.Deleted & Diff Deleted */
-  .highlight .gi { color: #a6e22e; } /* Generic.Inserted & Diff Inserted */
+  .highlight .gd { color: #f92672; background-color: unset; } /* Generic.Deleted & Diff Deleted */
+  .highlight .gi { color: #a6e22e; background-color: unset; } /* Generic.Inserted & Diff Inserted */
 }


### PR DESCRIPTION
### Summary

The background highlight in dark mode diffs aren't easy to look at right now due to the contrast between the text and background color. This change proposes to `unset` the background color of the text so that it goes up against the black background. Alternatively, a more gentle highlight doesn't look to bad.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

#### Current

![image](https://user-images.githubusercontent.com/19535809/128911052-7e4914e6-fc52-4158-96ac-b1e119ce7bc9.png)

#### `background-color: unset`

![image](https://user-images.githubusercontent.com/19535809/128911076-17dc8f2d-6459-4f1a-9c8e-feb88c436f6a.png)

#### `.gd { background-color: #211 }  .gi { background-color: #121 }`

![image](https://user-images.githubusercontent.com/19535809/128911561-ddf359c7-fa58-45f0-96d3-c91c53e3cc93.png)
