### PR TITLE
Add job_id and exception message to ActiveJob retry/discard logging

### DIFF
--- a/activejob/lib/active_job/log_subscriber.rb
+++ b/activejob/lib/active_job/log_subscriber.rb
@@ -75,9 +75,9 @@ module ActiveJob
 
       info do
         if ex
-          "Retrying #{job.class} in #{wait.to_i} seconds, due to a #{ex.class}."
+          "Retrying #{job.class} (Job ID: #{job.job_id}) after #{job.executions} attempts in #{wait.to_i} seconds, due to a #{ex.class} (#{ex.message})."
         else
-          "Retrying #{job.class} in #{wait.to_i} seconds."
+          "Retrying #{job.class} (Job ID: #{job.job_id}) after #{job.executions} attempts in #{wait.to_i} seconds."
         end
       end
     end
@@ -87,7 +87,7 @@ module ActiveJob
       ex = event.payload[:error]
 
       error do
-        "Stopped retrying #{job.class} due to a #{ex.class}, which reoccurred on #{job.executions} attempts."
+        "Stopped retrying #{job.class} (Job ID: #{job.job_id}) due to a #{ex.class} (#{ex.message}), which reoccurred on #{job.executions} attempts."
       end
     end
 
@@ -96,7 +96,7 @@ module ActiveJob
       ex = event.payload[:error]
 
       error do
-        "Discarded #{job.class} due to a #{ex.class}."
+        "Discarded #{job.class} (Job ID: #{job.job_id}) due to a #{ex.class} (#{ex.message})."
       end
     end
 

--- a/activejob/test/cases/logging_test.rb
+++ b/activejob/test/cases/logging_test.rb
@@ -267,19 +267,19 @@ class LoggingTest < ActiveSupport::TestCase
   def test_enqueue_retry_logging
     perform_enqueued_jobs do
       RetryJob.perform_later "DefaultsError", 2
-      assert_match(/Retrying RetryJob in 3 seconds, due to a DefaultsError\./, @logger.messages)
+      assert_match(/Retrying RetryJob \(Job ID: .*?\) after \d+ attempts in 3 seconds, due to a DefaultsError.*\./, @logger.messages)
     end
   end
 
   def test_enqueue_retry_logging_on_retry_job
     perform_enqueued_jobs { RescueJob.perform_later "david" }
-    assert_match(/Retrying RescueJob in 0 seconds\./, @logger.messages)
+    assert_match(/Retrying RescueJob \(Job ID: .*?\) after \d+ attempts in 0 seconds\./, @logger.messages)
   end
 
   def test_retry_stopped_logging
     perform_enqueued_jobs do
       RetryJob.perform_later "CustomCatchError", 6
-      assert_match(/Stopped retrying RetryJob due to a CustomCatchError, which reoccurred on \d+ attempts\./, @logger.messages)
+      assert_match(/Stopped retrying RetryJob \(Job ID: .*?\) due to a CustomCatchError.*, which reoccurred on \d+ attempts\./, @logger.messages)
     end
   end
 
@@ -287,14 +287,14 @@ class LoggingTest < ActiveSupport::TestCase
     perform_enqueued_jobs do
       RetryJob.perform_later "DefaultsError", 6
     rescue DefaultsError
-      assert_match(/Stopped retrying RetryJob due to a DefaultsError, which reoccurred on \d+ attempts\./, @logger.messages)
+      assert_match(/Stopped retrying RetryJob \(Job ID: .*?\) due to a DefaultsError.*, which reoccurred on \d+ attempts\./, @logger.messages)
     end
   end
 
   def test_discard_logging
     perform_enqueued_jobs do
       RetryJob.perform_later "DiscardableError", 2
-      assert_match(/Discarded RetryJob due to a DiscardableError\./, @logger.messages)
+      assert_match(/Discarded RetryJob \(Job ID: .*?\) due to a DiscardableError.*\./, @logger.messages)
     end
   end
 end


### PR DESCRIPTION
In other log messages like perform/performed and ActiveJob error logging, the job ID and exception message were already included, eg:

    Error performing TestFailureJob (Job ID: d70ad13e-e58b-409c-a8cc-e0447fc792b5) from Resque(default) in 1446.56ms: RuntimeError (Error Message):

But log messages related to retry/discard behavior from ActiveJob::Exceptions did not include the Job ID or exception message. We now include them, in a consistent format with other existing messages.

Job ID is especially useful because, while other ActiveJob-related log messages get the Job ID via tagged logging, retry-related log messages do not currently end up tagged with Job ID. And it's really useful to use Job ID to be able to collect all the log lines related to a particular job, put the error messages together with the retry and subsequent perform messages.

We also include job.executions in the enqueue_retry log message because it was available and useful, to know if this is the 1st retry or 2nd or whatever. Previously job.executions was included in retry_stopped logging, but not enqueue_retry.
