### PR TITLE
Fix failing railties framework tests 

### DIFF
--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -263,7 +263,7 @@ module ApplicationTests
         require "#{app_path}/config/environment"
 
         assert_nil ActiveRecord::Base.connection_pool.schema_cache
-        assert_raises ActiveRecord::ConnectionNotEstablished do
+        assert_raises ActiveRecord::DatabaseConnectionError do
           ActiveRecord::Base.connection.execute("SELECT 1")
         end
       end
@@ -295,7 +295,7 @@ module ApplicationTests
         require "#{app_path}/config/environment"
 
         assert ActiveRecord::Base.connection_pool.schema_cache.data_sources("posts")
-        assert_raises ActiveRecord::ConnectionNotEstablished do
+        assert_raises ActiveRecord::DatabaseConnectionError do
           ActiveRecord::Base.connection.execute("SELECT 1")
         end
       end


### PR DESCRIPTION
## Summary

A couple of FrameworksTest gets "undefined class/module Mysql2:: (ArgumentError)". https://buildkite.com/rails/rails/builds/79982#a24742cc-7394-4ff0-8713-aa64164fd925 introduced by the PR https://github.com/rails/rails/pull/39723 

In the 2 failing tests we are trying to establish a connection to the database using incorrect config so that we can continue with the boot process rather than crash. In the PR I created https://github.com/rails/rails/pull/39723 we now catch incorrect host which is what's being used to simulate unhealthy db for mysql here https://github.com/rails/rails/pull/39723/files#diff-538a9bf3450c3aed556a0d2eacc26839a60becd744cda8c0a247dcb06aa0f02fR50 which is what's causing the test failures.

In this PR we are rescuing the `ActiveRecord::DatabaseConnectionError` in the EncryptableRecord which fixes those failing framework tests. I also rescued the `DatabaseConnectionError` inside the railties but if I remove those the tests still pass, I'm wondering if I should remove that, wdyt @byroot ?

## Other Information

Issue reported here https://github.com/rails/rails/issues/42968
