### PR TITLE
Remove legacy --skip-gemfile option from the days of Bundler opposition

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -30,9 +30,6 @@ module Rails
         class_option :database,            type: :string, aliases: "-d", default: "sqlite3",
                                            desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
-        class_option :skip_gemfile,        type: :boolean, default: false,
-                                           desc: "Don't create a Gemfile"
-
         class_option :skip_git,            type: :boolean, aliases: "-G", default: false,
                                            desc: "Skip .gitignore file"
 
@@ -399,7 +396,7 @@ module Rails
       end
 
       def bundle_install?
-        !(options[:skip_gemfile] || options[:skip_bundle] || options[:pretend])
+        !(options[:skip_bundle] || options[:pretend])
       end
 
       def spring_install?

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -356,7 +356,7 @@ module Rails
           build(:gitattributes)
         end
 
-        build(:gemfile) unless options[:skip_gemfile]
+        build(:gemfile)
         build(:version_control)
         build(:package_json) unless options[:skip_javascript]
       end

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -247,7 +247,7 @@ module Rails
         build(:gemspec)   unless options[:skip_gemspec]
         build(:license)
         build(:gitignore) unless options[:skip_git]
-        build(:gemfile)   unless options[:skip_gemfile]
+        build(:gemfile)
         build(:version_control)
       end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -116,15 +116,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_webpack_installation_skipped(output)
   end
 
-  def test_skip_gemfile
-    generator([destination_root], skip_gemfile: true)
-    output = run_generator_instance
-
-    assert_empty @bundle_commands
-    assert_no_file "Gemfile"
-    assert_webpack_installation_skipped(output)
-  end
-
   def test_assets
     run_generator
 

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -95,14 +95,6 @@ module SharedGeneratorTests
     assert_equal url, applied
   end
 
-  def test_skip_gemfile
-    generator([destination_root], skip_gemfile: true, skip_webpack_install: true)
-    run_generator_instance
-
-    assert_empty @bundle_commands
-    assert_no_file "Gemfile"
-  end
-
   def test_skip_git
     run_generator [destination_root, "--skip-git", "--full"]
     assert_no_file(".gitignore")


### PR DESCRIPTION
Don't have to keep all the monuments to old skirmishes around forever.