### PR TITLE
Puma is the only option used for the web server

### DIFF
--- a/railties/lib/rails/app_updater.rb
+++ b/railties/lib/rails/app_updater.rb
@@ -27,7 +27,6 @@ module Rails
           options[:skip_action_mailer]  = !defined?(ActionMailer::Railtie)
           options[:skip_action_cable]   = !defined?(ActionCable::Engine)
           options[:skip_sprockets]      = !defined?(Sprockets::Railtie)
-          options[:skip_puma]           = !defined?(Puma)
           options[:skip_bootsnap]       = !defined?(Bootsnap)
           options[:skip_spring]         = !defined?(Spring)
           options[:updating]            = true

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -55,9 +55,6 @@ module Rails
         class_option :skip_active_storage, type: :boolean, default: false,
                                            desc: "Skip Active Storage files"
 
-        class_option :skip_puma,           type: :boolean, aliases: "-P", default: false,
-                                           desc: "Skip Puma related files"
-
         class_option :skip_action_cable,   type: :boolean, aliases: "-C", default: false,
                                            desc: "Skip Action Cable files"
 
@@ -168,7 +165,6 @@ module Rails
       end
 
       def web_server_gemfile_entry # :doc:
-        return [] if options[:skip_puma]
         comment = "Use Puma as the app server"
         GemfileEntry.new("puma", "~> 5.0", comment)
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -122,7 +122,7 @@ module Rails
         template "application.rb"
         template "environment.rb"
         template "cable.yml" unless options[:updating] || options[:skip_action_cable]
-        template "puma.rb"   unless options[:updating] || options[:skip_puma]
+        template "puma.rb"   unless options[:updating]
         template "spring.rb" if spring_install?
         template "storage.yml" unless options[:updating] || skip_active_storage?
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -643,12 +643,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "puma", '"~> 5.0"'
   end
 
-  def test_generator_if_skip_puma_is_given
-    run_generator [destination_root, "--skip-puma"]
-    assert_no_file "config/puma.rb"
-    assert_no_gem "puma"
-  end
-
   def test_generator_has_assets_gems
     run_generator
 


### PR DESCRIPTION
Doesn't make sense to remove the configuration needed as an option any more.