### PR TITLE
Enable default option for Infinity in datetime_select

### DIFF
--- a/actionview/lib/action_view/helpers/tags/date_select.rb
+++ b/actionview/lib/action_view/helpers/tags/date_select.rb
@@ -28,7 +28,13 @@ module ActionView
           end
 
           def datetime_selector(options, html_options)
-            datetime = options.fetch(:selected) { value || default_datetime(options) }
+            datetime = options.fetch(:selected) do
+              if value == Float::INFINITY
+                default_datetime(options)
+              else
+                value || default_datetime(options)
+              end
+            end
             @auto_index ||= nil
 
             options = options.dup

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -3399,6 +3399,33 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, datetime_select("post", "updated_at", default: Time.local(2006, 9, 19, 15, 16, 35))
   end
 
+  def test_datetime_select_with_default_value_as_time
+    @post = Post.new
+    @post.updated_at = (1.0 / 0)
+
+    expected = +%{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
+    2001.upto(2011) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2006}>#{i}</option>\n) }
+    expected << "</select>\n"
+    expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
+    1.upto(12) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 9}>#{Date::MONTHNAMES[i]}</option>\n) }
+    expected << "</select>\n"
+    expected << %{<select id="post_updated_at_3i" name="post[updated_at(3i)]">\n}
+    1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 19}>#{i}</option>\n) }
+    expected << "</select>\n"
+
+    expected << " &mdash; "
+
+    expected << %{<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n}
+    0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
+    expected << "</select>\n"
+    expected << " : "
+    expected << %{<select id="post_updated_at_5i" name="post[updated_at(5i)]">\n}
+    0.upto(59) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 16}>#{sprintf("%02d", i)}</option>\n) }
+    expected << "</select>\n"
+
+    assert_dom_equal expected, datetime_select("post", "updated_at", default: Time.local(2006, 9, 19, 15, 16, 35))
+  end
+
   def test_include_blank_overrides_default_option
     @post = Post.new
     @post.updated_at = nil


### PR DESCRIPTION
### Summary

When infinity is set to datetime value, a year field is empty in datetime_select. It cause application error.
I think to use default option solve this case.
