### PR TITLE
Set timestamps on `insert_all`/`upsert_all` record creation

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -12,6 +12,7 @@ module ActiveRecord
 
       @model, @connection, @inserts, @keys = model, model.connection, inserts, inserts.first.keys.map(&:to_s)
       @on_duplicate, @returning, @unique_by = on_duplicate, returning, unique_by
+      @record_timestamps = model.record_timestamps
 
       disallow_raw_sql!(returning)
       disallow_raw_sql!(on_duplicate)
@@ -64,12 +65,26 @@ module ActiveRecord
       inserts.map do |attributes|
         attributes = attributes.stringify_keys
         attributes.merge!(scope_attributes) if scope_attributes
+        attributes.reverse_merge!(timestamps_for_create) if record_timestamps?
 
         verify_attributes(attributes)
 
-        keys.map do |key|
+        keys_including_timestamps.map do |key|
           yield key, attributes[key]
         end
+      end
+    end
+
+    def record_timestamps?
+      @record_timestamps
+    end
+
+    # TODO: Consider remaining this method, as it only conditionally extends keys, not always
+    def keys_including_timestamps
+      @keys_including_timestamps ||= if record_timestamps?
+        keys + model.all_timestamp_attributes_in_model
+      else
+        keys
       end
     end
 
@@ -134,7 +149,7 @@ module ActiveRecord
 
 
       def verify_attributes(attributes)
-        if keys != attributes.keys.to_set
+        if keys_including_timestamps != attributes.keys.to_set
           raise ArgumentError, "All objects being inserted must have the same keys"
         end
       end
@@ -148,10 +163,14 @@ module ActiveRecord
                              "by wrapping them in Arel.sql()."
       end
 
+      def timestamps_for_create
+        model.all_timestamp_attributes_in_model.index_with(connection.high_precision_current_timestamp)
+      end
+
       class Builder # :nodoc:
         attr_reader :model
 
-        delegate :skip_duplicates?, :update_duplicates?, :keys, to: :insert_all
+        delegate :skip_duplicates?, :update_duplicates?, :keys, :keys_including_timestamps, :record_timestamps?, to: :insert_all
 
         def initialize(insert_all)
           @insert_all, @model, @connection = insert_all, insert_all.model, insert_all.connection
@@ -162,9 +181,10 @@ module ActiveRecord
         end
 
         def values_list
-          types = extract_types_from_columns_on(model.table_name, keys: keys)
+          types = extract_types_from_columns_on(model.table_name, keys: keys_including_timestamps)
 
           values_list = insert_all.map_key_with_value do |key, value|
+            next value if Arel::Nodes::SqlLiteral === value
             connection.with_yaml_fallback(types[key].serialize(value))
           end
 
@@ -196,7 +216,7 @@ module ActiveRecord
         end
 
         def touch_model_timestamps_unless(&block)
-          return "" unless update_duplicates?
+          return "" unless update_duplicates? && record_timestamps?
 
           model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
             if touch_timestamp_attribute?(column_name)
@@ -219,7 +239,7 @@ module ActiveRecord
           end
 
           def columns_list
-            format_columns(insert_all.keys)
+            format_columns(insert_all.keys_including_timestamps)
           end
 
           def extract_types_from_columns_on(table_name, keys:)

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -196,6 +196,8 @@ module ActiveRecord
         end
 
         def touch_model_timestamps_unless(&block)
+          return "" unless update_duplicates?
+
           model.timestamp_attributes_for_update_in_model.filter_map do |column_name|
             if touch_timestamp_attribute?(column_name)
               "#{column_name}=(CASE WHEN (#{updatable_columns.map(&block).join(" AND ")}) THEN #{model.quoted_table_name}.#{column_name} ELSE #{connection.high_precision_current_timestamp} END),"
@@ -213,7 +215,7 @@ module ActiveRecord
           attr_reader :connection, :insert_all
 
           def touch_timestamp_attribute?(column_name)
-            update_duplicates? && !insert_all.updatable_columns.include?(column_name)
+            insert_all.updatable_columns.exclude?(column_name)
           end
 
           def columns_list

--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -7,12 +7,12 @@ module ActiveRecord
     attr_reader :model, :connection, :inserts, :keys
     attr_reader :on_duplicate, :returning, :unique_by, :update_sql
 
-    def initialize(model, inserts, on_duplicate:, returning: nil, unique_by: nil)
+    def initialize(model, inserts, on_duplicate:, returning: nil, unique_by: nil, record_timestamps: nil)
       raise ArgumentError, "Empty list of attributes passed" if inserts.blank?
 
       @model, @connection, @inserts, @keys = model, model.connection, inserts, inserts.first.keys.map(&:to_s)
       @on_duplicate, @returning, @unique_by = on_duplicate, returning, unique_by
-      @record_timestamps = model.record_timestamps
+      @record_timestamps = record_timestamps.nil? ? model.record_timestamps : record_timestamps
 
       disallow_raw_sql!(returning)
       disallow_raw_sql!(on_duplicate)

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -63,8 +63,8 @@ module ActiveRecord
       # go through Active Record's type casting and serialization.
       #
       # See <tt>ActiveRecord::Persistence#insert_all</tt> for documentation.
-      def insert(attributes, returning: nil, unique_by: nil)
-        insert_all([ attributes ], returning: returning, unique_by: unique_by)
+      def insert(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
+        insert_all([ attributes ], returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
       end
 
       # Inserts multiple records into the database in a single SQL INSERT
@@ -131,8 +131,8 @@ module ActiveRecord
       #     { id: 1, title: "Rework" },
       #     { id: 2, title: "Eloquent Ruby" }
       #   ])
-      def insert_all(attributes, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by).execute
+      def insert_all(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
+        InsertAll.new(self, attributes, on_duplicate: :skip, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps).execute
       end
 
       # Inserts a single record into the database in a single SQL INSERT
@@ -141,8 +141,8 @@ module ActiveRecord
       # go through Active Record's type casting and serialization.
       #
       # See <tt>ActiveRecord::Persistence#insert_all!</tt> for more.
-      def insert!(attributes, returning: nil)
-        insert_all!([ attributes ], returning: returning)
+      def insert!(attributes, returning: nil, record_timestamps: nil)
+        insert_all!([ attributes ], returning: returning, record_timestamps: record_timestamps)
       end
 
       # Inserts multiple records into the database in a single SQL INSERT
@@ -188,8 +188,8 @@ module ActiveRecord
       #     { id: 1, title: "Rework", author: "David" },
       #     { id: 1, title: "Eloquent Ruby", author: "Russ" }
       #   ])
-      def insert_all!(attributes, returning: nil)
-        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning).execute
+      def insert_all!(attributes, returning: nil, record_timestamps: nil)
+        InsertAll.new(self, attributes, on_duplicate: :raise, returning: returning, record_timestamps: record_timestamps).execute
       end
 
       # Updates or inserts (upserts) a single record into the database in a
@@ -198,8 +198,8 @@ module ActiveRecord
       # go through Active Record's type casting and serialization.
       #
       # See <tt>ActiveRecord::Persistence#upsert_all</tt> for documentation.
-      def upsert(attributes, on_duplicate: :update, returning: nil, unique_by: nil)
-        upsert_all([ attributes ], on_duplicate: on_duplicate, returning: returning, unique_by: unique_by)
+      def upsert(attributes, on_duplicate: :update, returning: nil, unique_by: nil, record_timestamps: nil)
+        upsert_all([ attributes ], on_duplicate: on_duplicate, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
       end
 
       # Updates or inserts (upserts) multiple records into the database in a
@@ -261,8 +261,8 @@ module ActiveRecord
       #   ], unique_by: :isbn)
       #
       #   Book.find_by(isbn: "1").title # => "Eloquent Ruby"
-      def upsert_all(attributes, on_duplicate: :update, returning: nil, unique_by: nil)
-        InsertAll.new(self, attributes, on_duplicate: on_duplicate, returning: returning, unique_by: unique_by).execute
+      def upsert_all(attributes, on_duplicate: :update, returning: nil, unique_by: nil, record_timestamps: nil)
+        InsertAll.new(self, attributes, on_duplicate: on_duplicate, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps).execute
       end
 
       # Given an attributes hash, +instantiate+ returns a new instance of

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -394,15 +394,15 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal updated_on, Book.find(101).updated_on
   end
 
-  def test_upsert_all_does_not_implicitly_set_timestamps_on_create_even_when_model_record_timestamps_is_true
+  def test_upsert_all_implicitly_sets_timestamps_on_create_when_model_record_timestamps_is_true
     with_record_timestamps(Ship, true) do
       Ship.upsert_all [{ id: 101, name: "RSS Boaty McBoatface" }]
 
       ship = Ship.find(101)
-      assert_nil ship.created_at
-      assert_nil ship.created_on
-      assert_nil ship.updated_at
-      assert_nil ship.updated_on
+      assert_equal Time.new.year, ship.created_at.year
+      assert_equal Time.new.year, ship.created_on.year
+      assert_equal Time.new.year, ship.updated_at.year
+      assert_equal Time.new.year, ship.updated_on.year
     end
   end
 
@@ -434,7 +434,7 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
-  def test_upsert_all_implicitly_sets_timestamps_on_update_even_when_model_record_timestamps_is_false
+  def test_upsert_all_does_not_implicitly_set_timestamps_on_update_when_model_record_timestamps_is_false
     skip unless supports_insert_on_duplicate_update?
 
     with_record_timestamps(Ship, false) do
@@ -445,8 +445,8 @@ class InsertAllTest < ActiveRecord::TestCase
       ship = Ship.find(101)
       assert_nil ship.created_at
       assert_nil ship.created_on
-      assert_equal Time.now.year, ship.updated_at.year
-      assert_equal Time.now.year, ship.updated_on.year
+      assert_nil ship.updated_at
+      assert_nil ship.updated_on
     end
   end
 

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -406,6 +406,18 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_upsert_all_does_not_implicitly_set_timestamps_on_create_when_model_record_timestamps_is_true_but_overridden
+    with_record_timestamps(Ship, true) do
+      Ship.upsert_all [{ id: 101, name: "RSS Boaty McBoatface" }], record_timestamps: false
+
+      ship = Ship.find(101)
+      assert_nil ship.created_at
+      assert_nil ship.created_on
+      assert_nil ship.updated_at
+      assert_nil ship.updated_on
+    end
+  end
+
   def test_upsert_all_does_not_implicitly_set_timestamps_on_create_when_model_record_timestamps_is_false
     with_record_timestamps(Ship, false) do
       Ship.upsert_all [{ id: 101, name: "RSS Boaty McBoatface" }]
@@ -415,6 +427,18 @@ class InsertAllTest < ActiveRecord::TestCase
       assert_nil ship.created_on
       assert_nil ship.updated_at
       assert_nil ship.updated_on
+    end
+  end
+
+  def test_upsert_all_implicitly_sets_timestamps_on_create_when_model_record_timestamps_is_false_but_overridden
+    with_record_timestamps(Ship, false) do
+      Ship.upsert_all [{ id: 101, name: "RSS Boaty McBoatface" }], record_timestamps: true
+
+      ship = Ship.find(101)
+      assert_equal Time.now.year, ship.created_at.year
+      assert_equal Time.now.year, ship.created_on.year
+      assert_equal Time.now.year, ship.updated_at.year
+      assert_equal Time.now.year, ship.updated_on.year
     end
   end
 
@@ -434,6 +458,22 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_upsert_all_does_not_implicitly_set_timestamps_on_update_when_model_record_timestamps_is_true_but_overridden
+    skip unless supports_insert_on_duplicate_update?
+
+    with_record_timestamps(Ship, true) do
+      travel_to(Date.new(2016, 4, 17)) { Ship.create! id: 101, name: "RSS Boaty McBoatface" }
+
+      Ship.upsert_all [{ id: 101, name: "RSS Sir David Attenborough" }], record_timestamps: false
+
+      ship = Ship.find(101)
+      assert_equal 2016, ship.created_at.year
+      assert_equal 2016, ship.created_on.year
+      assert_equal 2016, ship.updated_at.year
+      assert_equal 2016, ship.updated_on.year
+    end
+  end
+
   def test_upsert_all_does_not_implicitly_set_timestamps_on_update_when_model_record_timestamps_is_false
     skip unless supports_insert_on_duplicate_update?
 
@@ -447,6 +487,22 @@ class InsertAllTest < ActiveRecord::TestCase
       assert_nil ship.created_on
       assert_nil ship.updated_at
       assert_nil ship.updated_on
+    end
+  end
+
+  def test_upsert_all_implicitly_sets_timestamps_on_update_when_model_record_timestamps_is_false_but_overridden
+    skip unless supports_insert_on_duplicate_update?
+
+    with_record_timestamps(Ship, false) do
+      Ship.create! id: 101, name: "RSS Boaty McBoatface"
+
+      Ship.upsert_all [{ id: 101, name: "RSS Sir David Attenborough" }], record_timestamps: true
+
+      ship = Ship.find(101)
+      assert_nil ship.created_at
+      assert_nil ship.created_on
+      assert_equal Time.now.year, ship.updated_at.year
+      assert_equal Time.now.year, ship.updated_on.year
     end
   end
 

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -442,6 +442,14 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_upsert_all_respects_created_at_precision_when_touched_implicitly
+    skip unless supports_datetime_with_precision?
+
+    Book.upsert_all [{ id: 101, name: "Out of the Silent Planet", published_on: Date.new(1938, 4, 8) }]
+
+    assert_not_predicate Book.find(101).created_at.usec, :zero?, "created_at should have sub-second precision"
+  end
+
   def test_upsert_all_implicitly_sets_timestamps_on_update_when_model_record_timestamps_is_true
     skip unless supports_insert_on_duplicate_update?
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This provides the option to set timestamp columns (`created_at`, `created_on`, `updated_at`, `updated_on`) automatically when using `insert_all` or `upsert_all` (and related methods) results in a created record. Currently, the only clean way to ensure they are set is to either set a default on the columns themselves, or to provide them explicitly as attributes while also customizing the `on_duplicate` SQL so as not to overwrite `created_at` on existing records.

Builds on #42993.

### Other Information

This is still a work in progress and needs some cleanup (`TODO`s, etc.) but I think is ready for preliminary review on the approach.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

## ⚠️ Before Merging
- [x] Rebase on `main` after #42993 has been merged
- [ ] Add CHANGELOG entry
- [ ] Update documentation (and guides?)
- [ ] Address TODO comments and open questions.
