### PR TITLE
Restore the behavior of journey root node methods

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -5,7 +5,6 @@ require "action_dispatch/journey/visitors"
 module ActionDispatch
   module Journey # :nodoc:
     class Ast # :nodoc:
-      delegate :find_all, :left, :right, :to_s, :to_sym, :type, to: :tree
       attr_reader :names, :path_params, :tree, :wildcard_options, :terminals
       alias :root :tree
 

--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -4,11 +4,11 @@ module ActionDispatch
   module Journey # :nodoc:
     module Path # :nodoc:
       class Pattern # :nodoc:
-        attr_reader :ast, :names, :requirements, :anchored
-        alias :spec :ast
+        attr_reader :ast, :names, :requirements, :anchored, :spec
 
         def initialize(ast, requirements, separators, anchored)
           @ast          = ast
+          @spec         = ast.root
           @requirements = requirements
           @separators   = separators
           @anchored     = anchored

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -5,7 +5,7 @@ module ActionDispatch
   module Journey
     class Route
       attr_reader :app, :path, :defaults, :name, :precedence, :constraints,
-                  :internal, :scope_options, :ast_root
+                  :internal, :scope_options, :ast
 
       alias :conditions :constraints
 
@@ -65,13 +65,12 @@ module ActionDispatch
         @_required_defaults = required_defaults
         @required_parts    = nil
         @parts             = nil
-        @decorated_ast     = nil
         @precedence        = precedence
         @path_formatter    = @path.build_formatter
         @scope_options     = scope_options
         @internal          = internal
 
-        @ast_root = @path.ast.root
+        @ast = @path.ast.root
         @path.ast.route = self
       end
 
@@ -80,10 +79,6 @@ module ActionDispatch
         parts
         required_defaults
         nil
-      end
-
-      def ast
-        path.ast
       end
 
       # Needed for `bin/rails routes`. Picks up succinctly defined requirements
@@ -140,7 +135,7 @@ module ActionDispatch
       end
 
       def glob?
-        ast.glob?
+        path.ast.glob?
       end
 
       def dispatcher?

--- a/actionpack/lib/action_dispatch/journey/router.rb
+++ b/actionpack/lib/action_dispatch/journey/router.rb
@@ -77,7 +77,7 @@ module ActionDispatch
 
       def visualizer
         tt     = GTG::Builder.new(ast).transition_table
-        groups = partitioned_routes.first.map(&:ast_root).group_by(&:to_s)
+        groups = partitioned_routes.first.map(&:ast).group_by(&:to_s)
         asts   = groups.values.map(&:first)
         tt.visualizer(asts)
       end

--- a/actionpack/lib/action_dispatch/journey/routes.rb
+++ b/actionpack/lib/action_dispatch/journey/routes.rb
@@ -50,7 +50,7 @@ module ActionDispatch
 
       def ast
         @ast ||= begin
-          nodes = anchored_routes.map(&:ast_root)
+          nodes = anchored_routes.map(&:ast)
           Nodes::Or.new(nodes)
         end
       end

--- a/actionpack/test/journey/route_test.rb
+++ b/actionpack/test/journey/route_test.rb
@@ -24,7 +24,7 @@ module ActionDispatch
         path  = path_from_string "/:controller(/:action(/:id(.:format)))"
         route = Route.new(name: "name", app: app, path: path)
 
-        route.ast.root.grep(Nodes::Terminal).each do |node|
+        route.ast.grep(Nodes::Terminal).each do |node|
           assert_equal route, node.memo
         end
       end


### PR DESCRIPTION
https://github.com/rails/rails/pull/39935 changed the behavior of
`Path::Pattern#spec` and `Route#ast` to return an `Ast` rather than the
root `Node`. After eager loading, however, we clear out the `Ast` to
limit retained memory and these methods return `nil`.

While these methods are not public and they aren't used internally after
eager loading, having them return `nil` makes it difficult for
applications that had been using these methods to get access to the
root `Node`. (See https://github.com/rails/rails/pull/39935#pullrequestreview-728095174)

This commit restores the behavior of these two methods to return the
root `Node`. The `Ast` is still available via `Path::Pattern#ast`, and
we still clear it out after eager loading.

Now that spec is a `Node` and not an `Ast` masquerading as one, we can
get rid of the delegate methods on `Ast.

Since `Route#ast` now returns the root `Node`, the newly added
`Route#ast_root` is no longer necessary so I've removed it.

I also removed the unused `@decorated_ast` method, which should have
been removed in https://github.com/rails/rails/pull/39935.

cc @rafaelfranca 