### PR TITLE
Yield query to ActiveRecord::Relation#scoping block

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   `ActiveRecord::Relation#scoping` yields the relation as a block argument:
+
+    ```ruby
+    Comment.where(post_id: 1).scoping do |scope|
+      if params[:sort] == "asc"
+        scope.first
+      else
+        scope.last
+      end
+    end
+    ```
+
+    *Sean Doyle*
+
 *   Fix `ActiveRecord::InternalMetadata` to not be broken by `config.active_record.record_timestamps = false`
 
     Since the model always create the timestamp columns, it has to set them, otherwise it breaks

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -417,6 +417,17 @@ module ActiveRecord
     #   end
     #   # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 1 ORDER BY "comments"."id" ASC LIMIT 1
     #
+    #   The block also yields the chained query as a block parameter:
+    #
+    #   Comment.where(post_id: 1).scoping do |scope|
+    #     if params[:sort] == "asc"
+    #       scope.first
+    #     else
+    #       scope.last
+    #     end
+    #   end
+    #   # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 1 ORDER BY "comments"."id" ASC LIMIT 1
+    #
     # If <tt>all_queries: true</tt> is passed, scoping will apply to all queries
     # for the relation including +update+ and +delete+ on instances.
     # Once +all_queries+ is set to true it cannot be set to false in a
@@ -429,9 +440,9 @@ module ActiveRecord
       if global_scope?(registry) && all_queries == false
         raise ArgumentError, "Scoping is set to apply to all queries and cannot be unset in a nested block."
       elsif already_in_scope?(registry)
-        yield
+        yield self
       else
-        _scoping(self, registry, all_queries) { yield }
+        _scoping(self, registry, all_queries) { yield self }
       end
     end
 

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -69,6 +69,9 @@ class RelationScopingTest < ActiveRecord::TestCase
     Developer.where("salary = 100000").scoping do
       assert_equal developer, Developer.order("name").first
     end
+    Developer.where("salary = 100000").scoping do |query|
+      assert_equal developer, query.order("name").first
+    end
   end
 
   def test_scoped_find_last
@@ -76,6 +79,10 @@ class RelationScopingTest < ActiveRecord::TestCase
 
     Developer.order("salary").scoping do
       assert_equal highest_salary, Developer.last
+    end
+
+    Developer.order("salary").scoping do |query|
+      assert_equal highest_salary, query.last
     end
   end
 


### PR DESCRIPTION
### Summary

Extend the `ActiveRecord::Relation#scoping` method to yield itself to
blocks:

```ruby
Comment.where(post_id: 1).scoping do |scope|
  if params[:sort] == "asc"
    scope.first
  else
    scope.last
  end
end # => SELECT "comments".* FROM "comments" WHERE "comments"."post_id" = 1 ORDER BY "comments"."id" ASC LIMIT 1
```
