### PR TITLE
Ensure image processing gem is enabled when turning on action text so image uploads work out-of-the-box

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -67,9 +67,11 @@ module ActionText
       end
 
       def enable_image_processing_gem
-        say "Ensure image_processing gem has been enabled so image uploads will work"
-        uncomment_lines Rails.root.join("Gemfile"), /gem "image_processing"/
-        run "bundle install"
+        if (gemfile_path = Rails.root.join("Gemfile")).exist?
+          say "Ensure image_processing gem has been enabled so image uploads will work"
+          uncomment_lines gemfile_path, /gem "image_processing"/
+          run "bundle install"
+        end
       end
 
       def create_migrations

--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -66,6 +66,12 @@ module ActionText
           "app/views/layouts/action_text/contents/_content.html.erb"
       end
 
+      def enable_image_processing_gem
+        say "Ensure image_processing gem has been enabled so image uploads will work"
+        uncomment_lines Rails.root.join("Gemfile"), /gem "image_processing"/
+        run "bundle install"
+      end
+
       def create_migrations
         rails_command "railties:install:migrations FROM=active_storage,action_text", inline: true
       end

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -77,6 +77,18 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/create_action_text_tables.action_text.rb"
   end
 
+  test "uncomments image_processing gem" do
+    gemfile = Pathname("Gemfile").expand_path(destination_root)
+    gemfile.dirname.mkpath
+    gemfile.write(%(# gem "image_processing"))
+
+    run_generator_instance
+    
+    assert_file gemfile do |content|
+      assert_equal %(gem "image_processing"), content
+    end
+  end
+
   test "#yarn_command runs bin/yarn via Ruby" do
     ran = nil
     run_stub = -> (command, *) { ran = command }

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -83,7 +83,7 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     gemfile.write(%(# gem "image_processing"))
 
     run_generator_instance
-    
+
     assert_file gemfile do |content|
       assert_equal %(gem "image_processing"), content
     end


### PR DESCRIPTION
When installing Action Text, we should ensure the image_processing gem is available, such that image uploads will work out-of-the-box.