### PR TITLE
Make active record encryption work with store attributes

### DIFF
--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -13,6 +13,7 @@ module ActiveRecord
       attr_reader :scheme, :cast_type
 
       delegate :key_provider, :downcase?, :deterministic?, :previous_schemes, :with_context, :fixed?, to: :scheme
+      delegate :accessor, to: :cast_type
 
       # === Options
       #

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -47,6 +47,12 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_encrypted_attribute(traffic_light, :state, states)
   end
 
+  test "encrypts store attributes with accessors" do
+    traffic_light = EncryptedTrafficLightWithStoreState.create!(color: "red", long_state: %i[ green red ])
+    assert_equal "red", traffic_light.color
+    assert_encrypted_attribute(traffic_light, :state, { "color" => "red" })
+  end
+
   test "can configure a custom key provider on a per-record-class basis through the :key_provider option" do
     post = EncryptedPost.create!(title: "The Starfleet is here!", body: "take cover!")
     assert_encrypted_attribute(post, :body, "take cover!")

--- a/activerecord/test/models/traffic_light_encrypted.rb
+++ b/activerecord/test/models/traffic_light_encrypted.rb
@@ -6,3 +6,8 @@ require "models/traffic_light"
 class EncryptedTrafficLight < TrafficLight
   encrypts :state
 end
+
+class EncryptedTrafficLightWithStoreState < TrafficLight
+  store :state, accessors: %i[ color ]
+  encrypts :state
+end


### PR DESCRIPTION
Active Record encryption was failing to work with [store attributes](https://api.rubyonrails.org/classes/ActiveRecord/Store.html).

Fix: https://github.com/rails/rails/issues/43012

cc @georgeclaghorn 
