### PR TITLE
Fix: test assets

### DIFF
--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -118,10 +118,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
   def test_assets
     run_generator
 
-    assert_file("app/views/layouts/application.html.erb", /stylesheet_link_tag\s+"application", "data-turbo-track": "reload"/)
-    assert_file("app/views/layouts/application.html.erb", /javascript_pack_tag\s+"application", "data-turbo-track": "reload"/)
+    assert_file "app/views/layouts/application.html.erb" do |content|
+      assert_no_match(/data-turbo-track/, content)
+    end
     assert_file("app/assets/stylesheets/application.css")
-    assert_file("app/javascript/packs/application.js")
+    assert_no_file("app/javascript/packs/application.js")
   end
 
   def test_application_job_file_present


### PR DESCRIPTION
### Summary

According to the #42999 description, we should not have anything related to javascript when a `rails new` skeleton is called.

### Other Information
1) Failure:
AppGeneratorTest#test_assets [test/generators/app_generator_test.rb:121]


related #42999

It's my first time contributing here, so I'm open to suggestions and thank you for your arduous labor. 

I'm not pretty sure if this is the way I should contribute to #42991
I mean opening a PR per test fix (sorry if not).
