### PR TITLE
Replace minitest-reporters with minitest-ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,8 +110,8 @@ instance_eval File.read local_gemfile if File.exist? local_gemfile
 
 group :test do
   gem "minitest-bisect"
+  gem "minitest-ci", require: false
   gem "minitest-retry"
-  gem "minitest-reporters"
 
   platforms :mri do
     gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,6 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     amq-protocol (2.3.2)
-    ansi (1.5.0)
     ast (2.4.2)
     aws-eventstream (1.1.1)
     aws-partitions (1.469.0)
@@ -316,11 +315,8 @@ GEM
     minitest-bisect (1.5.1)
       minitest-server (~> 1.0)
       path_expander (~> 1.1)
-    minitest-reporters (1.4.3)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
+    minitest-ci (3.4.0)
+      minitest (>= 5.0.6)
     minitest-retry (0.2.2)
       minitest (>= 5.0)
     minitest-server (1.0.6)
@@ -562,7 +558,7 @@ DEPENDENCIES
   libxml-ruby
   listen (~> 3.3)
   minitest-bisect
-  minitest-reporters
+  minitest-ci
   minitest-retry
   mysql2 (~> 0.5)!
   nokogiri (>= 1.8.1, != 1.11.0)

--- a/tools/test_common.rb
+++ b/tools/test_common.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 if ENV["BUILDKITE"]
-  require "minitest/reporters"
-  require "fileutils"
+  require "minitest-ci"
 
-  module Minitest
-    def self.plugin_rails_ci_junit_format_test_report_for_buildkite_init(*)
-      dir = File.join(__dir__, "../test-reports/#{ENV['BUILDKITE_JOB_ID']}")
-      reporter << Minitest::Reporters::JUnitReporter.new(dir, false)
-      FileUtils.mkdir_p(dir)
-    end
-  end
-
-  Minitest.load_plugins
-  Minitest.extensions.unshift "rails_ci_junit_format_test_report_for_buildkite"
+  Minitest::Ci.report_dir = File.join(__dir__, "../test-reports/#{ENV['BUILDKITE_JOB_ID']}")
 end


### PR DESCRIPTION
### Summary 
minitest-reporters is used to create JUnit XML reports on CI. But it was always being loaded and it could mess things up. As seen here -> https://github.com/rails/rails/pull/42999/commits/50b39bfc2e96d713df5ac5cd30445b459cc4da80

On #42999 the order of [Gem files changed](https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L97-L99) somehow and minitest ended up loading minitest-reporters before rails minitest plugin. Making [this code](https://github.com/rails/rails/blob/main/railties/lib/minitest/rails_plugin.rb#L61-L69) not load Rails::TestUnitReporter because minitest-reporters introduced a [different reporter wrapping minitest default ones](https://github.com/minitest-reporters/minitest-reporters/blob/master/lib/minitest/minitest_reporter_plugin.rb#L79). 

As minitest-reporters should be only used on CI and I couldn't find a way to fix that easily without monkey patching or fixing it upstream. I've tried replacing it with minitest-ci which loads itself differently.

minitest-ci is now only loaded on BuildKite and should not interfere with rails minitest plugin now. And also keeps JUnit reports working and they were before.

### Other Information

I added this on top of #42999 to check how many specs are fixed by this. But this patch can be applied to the main. 

Hope this is a good way forward 🙌 

