### PR TITLE
Add support for HTML attributes of optgroups to select helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Choices of `select` can optionally contain html attributes as the last element of the child arrays when using grouped/nested collections
+
+        <%= form.select :foo, [["North America", [["United States","US"],["Canada","CA"]], { disabled: "disabled" }]] %>
+        # => <select><optgroup label="North America" disabled="disabled"><option value="US">United States</option><option value="CA">Canada</option></optgroup></select>
+
+    *Chris Gunther*
 
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -500,6 +500,8 @@ module ActionView
       #   <tt><optgroup></tt> label while the second value must be an array of options. The second value can be a
       #   nested array of text-value pairs. See <tt>options_for_select</tt> for more info.
       #    Ex. ["North America",[["United States","US"],["Canada","CA"]]]
+      #   An optional third value can be provided as HTML attributes for the <tt>optgroup</tt>.
+      #    Ex. ["North America",[["United States","US"],["Canada","CA"]], { disabled: "disabled" }]
       # * +selected_key+ - A value equal to the +value+ attribute for one of the <tt><option></tt> tags,
       #   which will have the +selected+ attribute set. Note: It is possible for this value to match multiple options
       #   as you might have the same option in multiple groups. Each will then get <tt>selected="selected"</tt>.

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -34,7 +34,7 @@ module ActionView
           #   [nil, []]
           #   { nil => [] }
           def grouped_choices?
-            !@choices.blank? && @choices.first.respond_to?(:last) && Array === @choices.first.last
+            !@choices.blank? && @choices.first.respond_to?(:second) && Array === @choices.first.second
           end
       end
     end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -590,6 +590,24 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_with_grouped_collection_as_nested_array_and_html_attributes
+    @post = Post.new
+
+    countries_by_continent = [
+      ["<Africa>", [["<South Africa>", "<sa>"], ["Somalia", "so"]], data: { foo: "bar" }],
+      ["Europe",   [["Denmark", "dk"], ["Ireland", "ie"]], disabled: "disabled"],
+    ]
+
+    assert_dom_equal(
+      [
+        '<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;" data-foo="bar"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>',
+        '<option value="so">Somalia</option></optgroup><optgroup label="Europe" disabled="disabled"><option value="dk">Denmark</option>',
+        '<option value="ie">Ireland</option></optgroup></select>',
+      ].join("\n"),
+      select("post", "origin", countries_by_continent)
+    )
+  end
+
   def test_select_with_boolean_method
     @post = Post.new
     @post.allow_comments = false


### PR DESCRIPTION
PR #11517 updated `grouped_options_for_select` to allow passing HTML attributes of the optgroup as the last element of each array, which is called internally by `select` when it detects grouped choices.

However, the `select` helper detected grouped choices by seeing if the [last element is an Array](https://github.com/rails/rails/blob/6ec669b65d5cd47c984661920d670faccbf0920a/actionview/lib/action_view/helpers/tags/select.rb#L37), meaning if you passed a hash of HTML attributes, it would no longer treat the choices as grouped. This conflicted with `grouped_options_for_select`, which assumes the individual options are the [second element](https://github.com/rails/rails/blob/6ec669b65d5cd47c984661920d670faccbf0920a/actionview/lib/action_view/helpers/form_options_helper.rb#L546), not the last element.

Now there's agreement between `select` and `grouped_options_for_select` in expecting the individual option choices to be the second element, allowing the hash of HTML attributes to exist as the last element and properly trigger grouped options.

Since this mismatch existed since v4.1 (when #11517 was merged), if this can be backported to at least v6.1, that'd be much appreciated to avoid having to wait for v7.0 to be released to take advantage of.

Thanks!
