### PR TITLE
order Supports Postgres JSON operators

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   `order` now supports Postgres JSON operators.
+
+    `order` raises `ActiveRecord::UnknownAttributeReference` when it can't identify the syntax of
+     the given string. Now it identifies the `->>` operator in Postgres instead of raising an error.
+
+    Old syntax:
+    ```ruby
+        Event.order(Arel.sql("payload->>'kind'"))
+    ```
+
+    New syntax:
+    ```ruby
+        Event.order("payload->>'kind'")
+    ```
+
+    Fixes #43014
+
+    *Rachael Wright-Munn*
+
 *   Add config option for ignoring tables when dumping the schema cache.
 
     Applications can now be configured to ignore certain tables when dumping the schema cache.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -103,8 +103,8 @@ module ActiveRecord
           \A
           (
             (?:
-              # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
-              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
+              # "schema_name"."table_name"."column_name"::type_name ->> json_col | function(one or no argument)::type_name
+              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?)\s?(->>\s?(\d+ | '\w+'))? | \w+\((?:|\g<2>)\)(?:::\w+)?
             )
             (?:\s+ASC|\s+DESC)?
             (?:\s+NULLS\s+(?:FIRST|LAST))?

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -159,6 +159,13 @@ irb> event.payload
 ## Query based on JSON document
 # The -> operator returns the original JSON type (which might be an object), whereas ->> returns text
 irb> Event.where("payload->>'kind' = ?", "user_renamed")
+
+## Order based on JSON document
+# Postgres orders only on text values. ->> and #>> return text which can be ordered.
+# By default, order only supports -> for unnested json.
+irb> Event.order("payload->'kind'")
+# If you have nested json, a function, or an array, use Arel.
+irb> Event.order(Arel.sql("payload #>> '{change,0}'"))
 ```
 
 ### Range Types


### PR DESCRIPTION
### Summary
closes #43014

Today, when Postgres JSON operators are used, they are treated as potentially user input, and filtered out to protect against SQL injection attacks. There is a [regex pattern](https://github.com/rails/rails/blob/d9e188dbab81b412f73dfb7763318d52f360af49/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb#L102-L114) that is used to check if the string is a column, or function wrapping a column. This regex is already separated into the postgres adapter.

This PR adds one operator (->> column_name) so that order works more like where clauses do.

There's also documentation added to the JSON guide about ordering using JSON operators

### Other Information

Postgres supports 3 different [JSON operators](https://www.postgresql.org/docs/9.3/functions-json.html), but we only support one. Here's why.

Operator | Description	| Example | Why?
--- | --- | --- | ---
-> |	Get JSON array element | '[1,2,3]'::json->2 | returns unorderable field
-> |	Get JSON object field |	'{"a":1,"b":2}'::json->'b' | returns unorderable field
->> |	Get JSON array element as text |	'[1,2,3]'::json->>2 | Supported!
->> |	Get JSON object field as text |	'{"a":1,"b":2}'::json->>'b' | Supported!
#> |	Get JSON object at specified path |	'{"a":[1,2,3],"b":[4,5,6]}'::json#>'{a,2}' | returns unorderable field
#>> |	Get JSON object at specified path as text |	'{"a":[1,2,3],"b":[4,5,6]}'::json#>>'{a,2}' | Let's not support nested json
