### PR TITLE
Minor improvements to Encryptable records

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -46,10 +46,10 @@ module ActiveRecord
         #   encryption is used, they will be used to generate additional ciphertexts to check in the queries.
         def encrypts(*names, key_provider: nil, key: nil, deterministic: false, downcase: false, ignore_case: false, previous: [], **context_properties)
           self.encrypted_attributes ||= Set.new # not using :default because the instance would be shared across classes
+          scheme = scheme_for key_provider: key_provider, key: key, deterministic: deterministic, downcase: downcase, \
+              ignore_case: ignore_case, previous: previous, **context_properties
 
           names.each do |name|
-            scheme = scheme_for key_provider: key_provider, key: key, deterministic: deterministic, downcase: downcase, \
-              ignore_case: ignore_case, previous: previous, **context_properties
             encrypt_attribute name, scheme
           end
         end

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -133,7 +133,7 @@ module ActiveRecord
           end
 
           def validate_column_size(attribute_name)
-            if table_exists? && limit = columns_hash[attribute_name.to_s]&.limit
+            if limit = columns_hash[attribute_name.to_s]&.limit
               validates_length_of attribute_name, maximum: limit
             end
           end


### PR DESCRIPTION
This includes two minor changes to Active Record encryption that were suggested by @hahmed in [this conversation](https://github.com/rails/rails/pull/43009#discussion_r688996386):

- Remove `table_exists?` check that became redundant after https://github.com/rails/rails/pull/43009
- Reuse encryption scheme across attributes in the same encryption declaration

