### PR TITLE
Remove downcase of restrict_with_error translations

### DIFF
--- a/activemodel/lib/active_model/translation.rb
+++ b/activemodel/lib/active_model/translation.rb
@@ -42,6 +42,17 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human_attribute_name(attribute, options = {})
+      options  = options.dup
+      defaults = []
+
+      defaults << options.delete(:default) if options[:default]
+      defaults << attribute.to_s.split(".").pop.humanize
+
+      options[:default] = defaults
+      translate_attribute_name(attribute, **options)
+    end
+
+    def translate_attribute_name(attribute, options = {})
       options   = { count: 1 }.merge!(options)
       parts     = attribute.to_s.split(".")
       attribute = parts.pop
@@ -60,8 +71,7 @@ module ActiveModel
       end
 
       defaults << :"attributes.#{attribute}"
-      defaults << options.delete(:default) if options[:default]
-      defaults << attribute.humanize
+      defaults.push(*options.delete(:default)) if options[:default]
 
       options[:default] = defaults
       I18n.translate(defaults.shift, **options)

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -110,4 +110,17 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     Person.human_attribute_name("gender", options)
     assert_equal({ default: "Cool gender" }, options)
   end
+
+  def test_translated_model_attribute_name
+    assert_equal "translation missing: en.activemodel.attributes.person.gender", Person.translate_attribute_name("gender")
+  end
+
+  def test_translated_model_attribute_name_with_default
+    assert_equal "Person Name", Person.translate_attribute_name("name", default: "Person Name")
+  end
+
+  def test_translated_model_attribute_name_with_translation
+    I18n.backend.store_translations "en", activemodel: { attributes: { person: { name: "Person Name Attribute" } } }
+    assert_equal "Person Name Attribute", Person.translate_attribute_name("name")
+  end
 end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = owner.class.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name)
             owner.errors.add(:base, :'restrict_dependent_destroy.has_many', record: record)
             throw(:abort)
           end

--- a/activerecord/lib/active_record/associations/has_many_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_association.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         when :restrict_with_error
           unless empty?
-            record = owner.class.human_attribute_name(reflection.name)
+            record = owner.class.translate_attribute_name(reflection.name, default: reflection.name.to_s.humanize.downcase)
             owner.errors.add(:base, :'restrict_dependent_destroy.has_many', record: record)
             throw(:abort)
           end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
         when :restrict_with_error
           if load_target
-            record = owner.class.human_attribute_name(reflection.name)
+            record = owner.class.translate_attribute_name(reflection.name, default: reflection.name.to_s.humanize.downcase)
             owner.errors.add(:base, :'restrict_dependent_destroy.has_one', record: record)
             throw(:abort)
           end

--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
         when :restrict_with_error
           if load_target
-            record = owner.class.human_attribute_name(reflection.name).downcase
+            record = owner.class.human_attribute_name(reflection.name)
             owner.errors.add(:base, :'restrict_dependent_destroy.has_one', record: record)
             throw(:abort)
           end

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1923,14 +1923,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty firm.errors
 
-    assert_equal "Cannot delete record because dependent companies exist", firm.errors[:base].first
+    assert_equal "Cannot delete record because dependent Companies exist", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert firm.companies.exists?(name: "child")
   end
 
   def test_restrict_with_error_with_locale
     I18n.backend = I18n::Backend::Simple.new
-    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { companies: "client companies" } } }
+    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { companies: "Client Companies" } } }
     firm = RestrictedWithErrorFirm.create!(name: "restrict")
     firm.companies.create(name: "child")
 
@@ -1940,11 +1940,26 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty firm.errors
 
-    assert_equal "Cannot delete record because dependent client companies exist", firm.errors[:base].first
+    assert_equal "Cannot delete record because dependent Client Companies exist", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert firm.companies.exists?(name: "child")
   ensure
     I18n.backend.reload!
+  end
+
+  def test_restrict_with_error_without_locale
+    firm = RestrictedWithErrorFirm.create!(name: "restrict")
+    firm.companies.create(name: "child")
+
+    assert_not_empty firm.companies
+
+    firm.destroy
+
+    assert_not_empty firm.errors
+
+    assert_equal "Cannot delete record because dependent Companies exist", firm.errors[:base].first
+    assert RestrictedWithErrorFirm.exists?(name: "restrict")
+    assert firm.companies.exists?(name: "child")
   end
 
   def test_included_in_collection

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -1923,7 +1923,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_not_empty firm.errors
 
-    assert_equal "Cannot delete record because dependent Companies exist", firm.errors[:base].first
+    assert_equal "Cannot delete record because dependent companies exist", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert firm.companies.exists?(name: "child")
   end
@@ -1945,21 +1945,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert firm.companies.exists?(name: "child")
   ensure
     I18n.backend.reload!
-  end
-
-  def test_restrict_with_error_without_locale
-    firm = RestrictedWithErrorFirm.create!(name: "restrict")
-    firm.companies.create(name: "child")
-
-    assert_not_empty firm.companies
-
-    firm.destroy
-
-    assert_not_empty firm.errors
-
-    assert_equal "Cannot delete record because dependent Companies exist", firm.errors[:base].first
-    assert RestrictedWithErrorFirm.exists?(name: "restrict")
-    assert firm.companies.exists?(name: "child")
   end
 
   def test_included_in_collection

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -221,7 +221,7 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm.destroy
 
     assert_not_empty firm.errors
-    assert_equal "Cannot delete record because a dependent Account exists", firm.errors[:base].first
+    assert_equal "Cannot delete record because a dependent account exists", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert_predicate firm.account, :present?
   end
@@ -242,20 +242,6 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     assert_predicate firm.account, :present?
   ensure
     I18n.backend.reload!
-  end
-
-  def test_restrict_with_error_without_locale
-    firm = RestrictedWithErrorFirm.create!(name: "restrict")
-    firm.create_account(credit_limit: 10)
-
-    assert_not_nil firm.account
-
-    firm.destroy
-
-    assert_not_empty firm.errors
-    assert_equal "Cannot delete record because a dependent Account exists", firm.errors[:base].first
-    assert RestrictedWithErrorFirm.exists?(name: "restrict")
-    assert_predicate firm.account, :present?
   end
 
   def test_successful_build_association

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -221,14 +221,14 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm.destroy
 
     assert_not_empty firm.errors
-    assert_equal "Cannot delete record because a dependent account exists", firm.errors[:base].first
+    assert_equal "Cannot delete record because a dependent Account exists", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert_predicate firm.account, :present?
   end
 
   def test_restrict_with_error_with_locale
     I18n.backend = I18n::Backend::Simple.new
-    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { account: "firm account" } } }
+    I18n.backend.store_translations "en", activerecord: { attributes: { restricted_with_error_firm: { account: "Firm Account" } } }
     firm = RestrictedWithErrorFirm.create!(name: "restrict")
     firm.create_account(credit_limit: 10)
 
@@ -237,11 +237,25 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
     firm.destroy
 
     assert_not_empty firm.errors
-    assert_equal "Cannot delete record because a dependent firm account exists", firm.errors[:base].first
+    assert_equal "Cannot delete record because a dependent Firm Account exists", firm.errors[:base].first
     assert RestrictedWithErrorFirm.exists?(name: "restrict")
     assert_predicate firm.account, :present?
   ensure
     I18n.backend.reload!
+  end
+
+  def test_restrict_with_error_without_locale
+    firm = RestrictedWithErrorFirm.create!(name: "restrict")
+    firm.create_account(credit_limit: 10)
+
+    assert_not_nil firm.account
+
+    firm.destroy
+
+    assert_not_empty firm.errors
+    assert_equal "Cannot delete record because a dependent Account exists", firm.errors[:base].first
+    assert RestrictedWithErrorFirm.exists?(name: "restrict")
+    assert_predicate firm.account, :present?
   end
 
   def test_successful_build_association


### PR DESCRIPTION
### Summary

This reverts the downcase of defined translations for `restrict_with_error`. The downcase might apply for the english language, but in case sensitive languages this behaviour is incorrect.

However, removing the downcase, this change upcases previous spellings for undefined translations. 

Related open Issue: https://github.com/rails/rails/issues/21064

### Other Information

Another idea to fix this might be to make the `default` option inside `ActiveModel::Translation.human_attribute_name` work instead of overwriting it, although this could impact the usage in other places.