### PR TITLE
Add a test to catch regressions for render_to_string

### DIFF
--- a/actionpack/test/controller/render_json_test.rb
+++ b/actionpack/test/controller/render_json_test.rb
@@ -28,10 +28,6 @@ class RenderJsonTest < ActionController::TestCase
       render json: nil
     end
 
-    def render_json_render_to_string
-      render plain: render_to_string(json: "[]")
-    end
-
     def render_json_hello_world
       render json: ActiveSupport::JSON.encode(hello: "world")
     end
@@ -80,11 +76,6 @@ class RenderJsonTest < ActionController::TestCase
     get :render_json_nil
     assert_equal "null", @response.body
     assert_equal "application/json", @response.media_type
-  end
-
-  def test_render_json_render_to_string
-    get :render_json_render_to_string
-    assert_equal "[]", @response.body
   end
 
   def test_render_json

--- a/actionpack/test/controller/render_to_string_test.rb
+++ b/actionpack/test/controller/render_to_string_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "controller/fake_models"
+require "active_support/logger"
+
+class RenderToStringTest < ActionController::TestCase
+  class TestController < ActionController::Base
+    protect_from_forgery
+
+    def self.controller_path
+      "test"
+    end
+
+    def render_plain_text_response_with_inline_template
+      render plain: render_to_string(inline: "hello")
+    end
+
+    def render_json_response_with_partial
+      render json: { hello: render_to_string(partial: "partial") }
+    end
+
+    def render_json_render_to_string
+      render plain: render_to_string(json: "[]")
+    end
+
+    def test_render_json_render_to_string
+      get :render_json_render_to_string
+      assert_equal "[]", @response.body
+    end
+
+    def render_plain_text_response_with_inline_template_and_xml_format
+      render_to_string(inline: "<language>Ruby</language>", formats: [:xml])
+      render plain: "Hello"
+    end
+
+    def render_head_ok_with_inline_template_and_xml_format
+      render_to_string(inline: "<language>Ruby</language>", formats: [:xml])
+      head :ok
+    end
+  end
+
+  tests TestController
+
+  def test_render_plain_text_response
+    get :render_plain_text_response_with_inline_template
+    assert_equal "hello", @response.body
+    assert_equal "text/plain", @response.media_type
+  end
+
+  def test_render_json_response
+    get :render_json_response_with_partial
+    assert_equal '{"hello":"partial html"}', @response.body
+    assert_equal "application/json", @response.media_type
+  end
+
+  def render_json_render_to_string
+    render plain: render_to_string(json: "[]")
+    assert_equal "text/plain", @response.media_type
+  end
+
+  def test_response_type_does_not_change_by_render_to_string_with_xml_format
+    get :render_plain_text_response_with_inline_template_and_xml_format
+    assert_equal "Hello", @response.body
+    assert_equal "text/plain", @response.media_type
+  end
+
+  def test_response_ok_for_render_to_string_with_xml_format
+    get :render_head_ok_with_inline_template_and_xml_format
+    assert_equal "text/html", @response.media_type
+    assert_response :ok
+  end
+end


### PR DESCRIPTION
### Summary

Adds a test to catch any regressions for the `render_to_string` for subsequent renders.

The original issue reported here https://github.com/rails/rails/issues/14173 mentions that subsequent renders, changes the content_type. Example:

```
def locations
    @locations = Location.all
    stream = render_to_string(template: "locations/index", formats: [:xml])
    render nothing: true
  end
```

I don't believe that's an issue anymore, as per my comment https://github.com/rails/rails/issues/14173#issuecomment-888684777.

In this PR I added a test to catch any regressions. 

Maybe we could say this PR is not needed and just close the original issue? 

### Other Information

Closes https://github.com/rails/rails/issues/14173