### PR TITLE
Do not hook the classic autoloader anymore

### DIFF
--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -46,8 +46,6 @@ end
 ActionPackTestSuiteUtils.require_helpers("#{__dir__}/fixtures/helpers")
 ActionPackTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers")
 
-ActiveSupport::Dependencies.hook!
-
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -87,8 +87,8 @@ end
 class HelpersTypoControllerTest < ActiveSupport::TestCase
   def test_helper_typo_error_message
     e = assert_raise(NameError) { HelpersTypoController.helper "admin/users" }
-    # This message is better if autoloading.
-    assert_equal "uninitialized constant Admin::UsersHelper\nDid you mean?  Admin::UsersHelpeR", e.message
+    assert_includes e.message, "uninitialized constant Admin::UsersHelper"
+    assert_includes e.message, "Did you mean?  Admin::UsersHelpeR"
   end
 end
 

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -34,8 +34,6 @@ end
 ActionViewTestSuiteUtils.require_helpers("#{__dir__}/fixtures/helpers")
 ActionViewTestSuiteUtils.require_helpers("#{__dir__}/fixtures/alternate_helpers")
 
-ActiveSupport::Dependencies.hook!
-
 Thread.abort_on_exception = true
 
 # Show backtraces for deprecated behavior for quicker cleanup.

--- a/actionview/test/actionpack/abstract/helper_test.rb
+++ b/actionview/test/actionpack/abstract/helper_test.rb
@@ -71,10 +71,8 @@ module AbstractController
       end
 
       def test_declare_missing_helper
-        e = assert_raise NameError do
-          AbstractHelpers.helper :missing
-        end
-        assert_equal "uninitialized constant MissingHelper", e.message
+        e = assert_raise(NameError) { AbstractHelpers.helper :missing }
+        assert_includes e.message, "uninitialized constant MissingHelper"
       end
 
       def test_helpers_with_module_through_block
@@ -103,7 +101,7 @@ module AbstractController
     class InvalidHelpersTest < ActiveSupport::TestCase
       def test_controller_raise_error_about_missing_helper
         e = assert_raise(NameError) { AbstractHelpers.helper(:missing) }
-        assert_equal "uninitialized constant MissingHelper", e.message
+        assert_includes e.message, "uninitialized constant MissingHelper"
       end
     end
   end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -50,6 +50,10 @@ module ActiveSupport # :nodoc:
 
     # :nodoc:
 
+    def eager_load?(path)
+      Dependencies._eager_load_paths.member?(path)
+    end
+
     # All files ever loaded.
     mattr_accessor :history, default: Set.new
 

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -293,11 +293,6 @@ module ActiveSupport # :nodoc:
         end
     end
 
-    def unhook!
-      ModuleConstMissing.exclude_from(Module)
-      Loadable.exclude_from(Object)
-    end
-
     def load?
       mechanism == :load
     end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -293,11 +293,6 @@ module ActiveSupport # :nodoc:
         end
     end
 
-    def hook!
-      Loadable.include_into(Object)
-      ModuleConstMissing.include_into(Module)
-    end
-
     def unhook!
       ModuleConstMissing.exclude_from(Module)
       Loadable.exclude_from(Object)
@@ -697,5 +692,3 @@ module ActiveSupport # :nodoc:
       end
   end
 end
-
-ActiveSupport::Dependencies.hook!

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -37,10 +37,6 @@ module ActiveSupport
           l = verbose ? logger || Rails.logger : nil
           Rails.autoloaders.each { |autoloader| autoloader.logger = l }
         end
-
-        def unhook!
-          :no_op
-        end
       end
 
       module Inflector
@@ -103,7 +99,6 @@ module ActiveSupport
           end
 
           def decorate_dependencies
-            Dependencies.unhook!
             Dependencies.singleton_class.prepend(Decorations)
           end
       end

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -98,22 +98,6 @@ class DependenciesTest < ActiveSupport::TestCase
       ActiveSupport::Dependencies.new_constants_in("Illegal-Name") { }
     end
   end
-
-  def test_hook_called_multiple_times
-    assert_nothing_raised { ActiveSupport::Dependencies.hook! }
-  end
-
-  def test_load_and_require_stay_private
-    assert_includes Object.private_methods, :load
-    assert_includes Object.private_methods, :require
-
-    ActiveSupport::Dependencies.unhook!
-
-    assert_includes Object.private_methods, :load
-    assert_includes Object.private_methods, :require
-  ensure
-    ActiveSupport::Dependencies.hook!
-  end
 end
 
 class RequireDependencyTest < ActiveSupport::TestCase

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -245,13 +245,6 @@ module Rails
           end
         end
       end
-
-      # Disable dependency loading during request cycle
-      initializer :disable_dependency_loading do
-        if config.eager_load && config.cache_classes && !config.enable_dependency_loading
-          ActiveSupport::Dependencies.unhook!
-        end
-      end
     end
   end
 end

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -13,18 +13,6 @@ module Rails
         config.generators.templates.unshift(*paths["lib/templates"].existent)
       end
 
-      initializer :ensure_autoload_once_paths_as_subset do
-        extra = ActiveSupport::Dependencies.autoload_once_paths -
-                ActiveSupport::Dependencies.autoload_paths
-
-        unless extra.empty?
-          abort <<-end_error
-            autoload_once_paths must be a subset of the autoload_paths.
-            Extra items in autoload_once_paths: #{extra * ','}
-          end_error
-        end
-      end
-
       initializer :let_zeitwerk_take_over do
         require "active_support/dependencies/zeitwerk_integration"
         ActiveSupport::Dependencies::ZeitwerkIntegration.take_over(enable_reloading: !config.cache_classes)

--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -25,53 +25,6 @@ module Rails
         end
       end
 
-      # This will become an error if/when we remove classic mode. The plan is
-      # autoloaders won't be configured up to this point in the finisher, so
-      # constants just won't be found, raising regular NameError exceptions.
-      initializer :warn_if_autoloaded, before: :let_zeitwerk_take_over do
-        next if config.cache_classes
-        next if ActiveSupport::Dependencies.autoloaded_constants.empty?
-
-        autoloaded    = ActiveSupport::Dependencies.autoloaded_constants
-        constants     = "constant".pluralize(autoloaded.size)
-        enum          = autoloaded.to_sentence
-        have          = autoloaded.size == 1 ? "has" : "have"
-        these         = autoloaded.size == 1 ? "This" : "These"
-        example       = autoloaded.first
-        example_klass = example.constantize.class
-
-        ActiveSupport::DescendantsTracker.clear
-        ActiveSupport::Dependencies.clear
-
-        unload_message = "#{these} autoloaded #{constants} #{have} been unloaded."
-
-        ActiveSupport::Deprecation.warn(<<~WARNING)
-          Initialization autoloaded the #{constants} #{enum}.
-
-          Being able to do this is deprecated. Autoloading during initialization is going
-          to be an error condition in future versions of Rails.
-
-          Reloading does not reboot the application, and therefore code executed during
-          initialization does not run again. So, if you reload #{example}, for example,
-          the expected changes won't be reflected in that stale #{example_klass} object.
-
-          #{unload_message}
-
-          In order to autoload safely at boot time, please wrap your code in a reloader
-          callback this way:
-
-              Rails.application.reloader.to_prepare do
-                # Autoload classes and modules needed at boot time here.
-              end
-
-          That block runs when the application boots, and every time there is a reload.
-          For historical reasons, it may run twice, so it has to be idempotent.
-
-          Check the "Autoloading and Reloading Constants" guide to learn more about how
-          Rails autoloads and reloads.
-        WARNING
-      end
-
       initializer :let_zeitwerk_take_over do
         require "active_support/dependencies/zeitwerk_integration"
         ActiveSupport::Dependencies::ZeitwerkIntegration.take_over(enable_reloading: !config.cache_classes)

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1874,60 +1874,6 @@ module ApplicationTests
       assert_includes $LOAD_PATH, "#{app_path}/custom_eager_load_path"
     end
 
-    test "autoloading during initialization gets deprecation message and clearing if config.cache_classes is false" do
-      app_file "lib/c.rb", <<~EOS
-        class C
-          extend ActiveSupport::DescendantsTracker
-        end
-
-        class X < C
-        end
-      EOS
-
-      app_file "app/models/d.rb", <<~EOS
-        require "c"
-
-        class D < C
-        end
-      EOS
-
-      app_file "config/initializers/autoload.rb", "D.class"
-
-      app "development"
-
-      # TODO: Test deprecation message, assert_deprecated { app "development" }
-      # does not collect it.
-
-      assert_equal [X], C.descendants
-      assert_empty ActiveSupport::Dependencies.autoloaded_constants
-    end
-
-    test "autoloading during initialization triggers nothing if config.cache_classes is true" do
-      app_file "lib/c.rb", <<~EOS
-        class C
-          extend ActiveSupport::DescendantsTracker
-        end
-
-        class X < C
-        end
-      EOS
-
-      app_file "app/models/d.rb", <<~EOS
-        require "c"
-
-        class D < C
-        end
-      EOS
-
-      app_file "config/initializers/autoload.rb", "D.class"
-
-      app "production"
-
-      # TODO: Test no deprecation message is issued.
-
-      assert_equal [X, D], C.descendants
-    end
-
     test "load_database_yaml returns blank hash if configuration file is blank" do
       app_file "config/database.yml", ""
       app "development"

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -96,6 +96,54 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_not deps.autoloaded?(invalid_constant_name)
   end
 
+  test "the once autoloader can autoload from initializers" do
+    app_file "extras0/x.rb", "X = 0"
+    app_file "extras1/y.rb", "Y = 0"
+
+    # We should be able to configure autoload_once_paths in
+    # config/application.rb and in config/environments/*.rb.
+    add_to_config 'config.autoload_once_paths << "#{Rails.root}/extras0"'
+    add_to_env_config "development", 'config.autoload_once_paths << "#{Rails.root}/extras1"'
+
+    # Collections should br frozen after bootstrap, and you are ready to
+    # autoload with the once autoloader. In particular, from initializers.
+    $config_autoload_once_paths_is_frozen = false
+    $global_autoload_once_paths_is_frozen = false
+    add_to_config <<~RUBY
+    initializer :test_autoload_once_paths_is_frozen, after: :bootstrap_hook do
+      $config_autoload_once_paths_is_frozen = config.autoload_once_paths.frozen?
+      $global_autoload_once_paths_is_frozen = ActiveSupport::Dependencies.autoload_once_paths.frozen?
+      X
+    end
+    RUBY
+
+    app_file "config/initializers/autoload_Y.rb", "Y"
+
+    # Preconditions.
+    assert_not Object.const_defined?(:X)
+    assert_not Object.const_defined?(:Y)
+
+    boot
+
+    assert Object.const_defined?(:X)
+    assert Object.const_defined?(:Y)
+    assert $config_autoload_once_paths_is_frozen
+    assert $global_autoload_once_paths_is_frozen
+  end
+
+  test "the once autoloader can eager load" do
+    app_file "app/serializers/money_serializer.rb", "MoneySerializer = :dummy_value"
+
+    add_to_config 'config.autoload_once_paths << "#{Rails.root}/app/serializers"'
+    add_to_config 'config.eager_load_paths << "#{Rails.root}/app/serializers"'
+
+    assert_not Object.const_defined?(:MoneySerializer)
+
+    boot("production")
+
+    assert Object.const_defined?(:MoneySerializer)
+  end
+
   test "unloadable constants (main)" do
     app_file "app/models/user.rb", "class User; end"
     app_file "app/models/post.rb", "class Post; end"

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -305,13 +305,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert_equal %i(main_autoloader), $zeitwerk_integration_reload_test
   end
 
-  test "unhooks" do
-    boot
-
-    assert_equal Module, Module.method(:const_missing).owner
-    assert_equal :no_op, deps.unhook!
-  end
-
   test "reloading invokes before_remove_const" do
     $before_remove_const_invoked = false
 


### PR DESCRIPTION
_(This patch belongs to an epic in which we are deleting the `classic` autoloader)_.

Users cannot enable the `classic` autoloader since `config.autoloader=` was deleted in https://github.com/rails/rails/commit/0d523d83657ce7066f25d87f6f094e804590e1e8. However, the classic autoloader was still being setup by Rails and allowed autoloading from initializers to ease the transition in Rails 6.x. Autoloading reloadable constants from initializers has been deprecated since 6.0, and finally the support is dropped together with `classic`.

From now on, trying to autoload a reloadable class or module in initializers raises a `NameError`.

As explained in the documentation included in this patch, you can autoload in initializers constants managed by the `once` autoloader. That covers the valid uses cases.

This leaves orphan code in `ActiveSupport::Dependencies` that later patches will delete.

Also, later patches will edit CHANGELOGs with these and other changes in the epic.