### PR TITLE
Add possibility to disable remote input elements upon change

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow remote input elements to be disabled by adding a `data-disable` attribute
+
+    *Vincent Rolea*
+
 *   Add `weekday_options_for_select` and `weekday_select` helper methods. Also adds `weekday_select` to `FormBuilder`.
 
     *Drew Bragg*, *Dana Kashubeck*, *Kasper Timm Hansen*

--- a/actionview/app/assets/javascripts/rails-ujs/start.coffee
+++ b/actionview/app/assets/javascripts/rails-ujs/start.coffee
@@ -35,6 +35,8 @@ Rails.start = ->
   delegate document, Rails.linkDisableSelector, 'ajax:stopped', enableElement
   delegate document, Rails.buttonDisableSelector, 'ajax:complete', enableElement
   delegate document, Rails.buttonDisableSelector, 'ajax:stopped', enableElement
+  delegate document, Rails.inputChangeSelector, 'ajax:complete', enableElement
+  delegate document, Rails.inputChangeSelector, 'ajax:stopped', enableElement
 
   delegate document, Rails.linkClickSelector, 'click', preventInsignificantClick
   delegate document, Rails.linkClickSelector, 'click', handleDisabledElement
@@ -51,6 +53,7 @@ Rails.start = ->
 
   delegate document, Rails.inputChangeSelector, 'change', handleDisabledElement
   delegate document, Rails.inputChangeSelector, 'change', handleConfirm
+  delegate document, Rails.inputChangeSelector, 'change', disableElement
   delegate document, Rails.inputChangeSelector, 'change', handleRemote
 
   delegate document, Rails.formSubmitSelector, 'submit', handleDisabledElement

--- a/actionview/test/ujs/public/test/data-disable.js
+++ b/actionview/test/ujs/public/test/data-disable.js
@@ -28,6 +28,14 @@ module('data-disable', {
       'data-url': '/echo',
       'data-disable': 'true'
     }))
+
+    $('#qunit-fixture').append($('<input/>', {
+      'type': 'checkbox',
+      'value': '1',
+      'data-remote': true,
+      'data-url': '/echo',
+      'data-disable': 'true'
+    }))
   },
   teardown: function() {
     $(document).unbind('iframe:loaded')
@@ -267,6 +275,77 @@ asyncTest('right/mouse-wheel-clicking on a link does not disable the link', 10, 
   link.triggerNative('click', { button: 2 })
   App.checkEnabledState(link, 'Click me')
   start()
+})
+
+asyncTest('input[data-remote][date-disable] disables and re-enables', 6, function() {
+  var checkbox = $('input[data-remote][data-disable]')
+
+  App.checkEnabledState(checkbox, '1')
+
+  checkbox
+    .bindNative('ajax:send', function() {
+      App.checkDisabledState(checkbox, '1')
+    })
+    .bindNative('ajax:complete', function() {
+      setTimeout( function() {
+        App.checkEnabledState(checkbox, '1')
+        start()
+      }, 15)
+    })
+    .triggerNative('change')
+})
+
+asyncTest('input[data-remote][data-disable] re-enables when `ajax:before` event is cancelled', 6, function() {
+  var checkbox = $('input[data-remote][data-disable]')
+
+  App.checkEnabledState(checkbox, '1')
+
+  checkbox
+    .bindNative('ajax:before', function(e) {
+      App.checkDisabledState(checkbox, '1')
+      e.preventDefault()
+    })
+    .triggerNative('change')
+
+  setTimeout(function() {
+    App.checkEnabledState(checkbox, '1')
+    start()
+  }, 30)
+})
+
+asyncTest('input[data-remote][data-disable] re-enables when `ajax:beforeSend` event is cancelled', 6, function() {
+  var checkbox = $('input[data-remote][data-disable]')
+
+  App.checkEnabledState(checkbox, '1')
+
+  checkbox
+    .bindNative('ajax:beforeSend', function(e) {
+      App.checkDisabledState(checkbox, '1')
+      e.preventDefault()
+    })
+    .triggerNative('click')
+
+  setTimeout(function() {
+    App.checkEnabledState(checkbox, '1')
+    start()
+  }, 30)
+})
+
+asyncTest('input[data-remote][data-disable] re-enables when `ajax:error` event is triggered', 6, function() {
+  var checkbox = $('input[data-remote][data-disable]').attr('data-url', '/error')
+
+  App.checkEnabledState(checkbox, '1')
+
+  checkbox
+    .bindNative('ajax:send', function() {
+      App.checkDisabledState(checkbox, '1')
+    })
+    .triggerNative('change')
+
+  setTimeout(function() {
+    App.checkEnabledState(checkbox, '1')
+    start()
+  }, 30)
 })
 
 asyncTest('button[data-remote][data-disable] disables and re-enables', 6, function() {


### PR DESCRIPTION
### Summary

As of today, one can create "auto-saving" forms in rails by adding relevant data-attributes to inputs such as `data-remote: true` and `data-url="/endpoint"`. It is particularly handy when building forms such as Notifications settings forms:

```html+erb
<%= check_box_tag :notify_upon_mention, 
                                   "1", 
                                   notifying_upon_mention?, 
                                   data: {
                                     remote: true,
                                     url: notification_settings_path,
                                     method: "post",
                                   } %> 
<%= label_tag :notify_upon_mention, "Notify me when people @mention me" %>
```

To prevent double click issues and give visual feedback to the user (request pending) one might want to disable the element upon submission. One might assume that adding the `data-disable` attribute to the element would work (as it is currently the case for remote forms), unfortunately it is not the case.

This PR  extends the current behavior for remote input elements in `rails-ujs` by adding the possibility to add a `data-disable` attribute, so they can be disabled whilst the ajax request proceeds : 

```html+erb
<!--  this checkbox will be disabled when its value is changed -->
<%= check_box_tag :notify_upon_mention, 
                                   "1", 
                                   notifying_upon_mention?, 
                                   data: {
                                     remote: true,
                                     url: notification_settings_path,
                                     method: "post",
                                     disable: true
                                   } %> 
<%= label_tag :notify_upon_mention, "Notify me when people @mention me" %>
```



