### PR TITLE
Tweak unreachable assertion tests in the block of `assert_raises`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rails
@@ -290,4 +291,7 @@ Performance/DeletePrefix:
   Enabled: true
 
 Performance/DeleteSuffix:
+  Enabled: true
+
+Minitest/UnreachableAssertion:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "json", ">= 2.0.0"
 
 group :rubocop do
   gem "rubocop", ">= 0.90", require: false
+  gem "rubocop-minitest", require: false
   gem "rubocop-packaging", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.9.1)
       parser (>= 3.0.1.1)
+    rubocop-minitest (0.15.0)
+      rubocop (>= 0.90, < 2.0)
     rubocop-packaging (0.5.1)
       rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.11.4)
@@ -577,6 +579,7 @@ DEPENDENCIES
   rexml
   rouge
   rubocop (>= 0.90)
+  rubocop-minitest
   rubocop-packaging
   rubocop-performance
   rubocop-rails

--- a/actionmailbox/test/unit/router_test.rb
+++ b/actionmailbox/test/unit/router_test.rb
@@ -132,11 +132,11 @@ module ActionMailbox
     end
 
     test "missing route" do
+      inbound_email = create_inbound_email_from_mail(to: "going-nowhere@example.com", subject: "This is a reply")
       assert_raises(ActionMailbox::Router::RoutingError) do
-        inbound_email = create_inbound_email_from_mail(to: "going-nowhere@example.com", subject: "This is a reply")
         @router.route inbound_email
-        assert inbound_email.bounced?
       end
+      assert inbound_email.bounced?
     end
 
     test "invalid address" do

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -36,7 +36,7 @@ module ActionDispatch
 
         assert_equal "/foo", url_helpers.foo_path
         assert_raises NoMethodError do
-          assert_equal "/bar", url_helpers.bar_path
+          url_helpers.bar_path
         end
 
         draw do
@@ -77,7 +77,7 @@ module ActionDispatch
 
         assert_equal "/foo", url_helpers.foo_path
         assert_raises NoMethodError do
-          assert_equal "/bar", url_helpers.bar_path
+          url_helpers.bar_path
         end
       end
 
@@ -95,7 +95,7 @@ module ActionDispatch
         end
 
         assert_raises ArgumentError do
-          assert_equal "http://example.com/foo", url_helpers.foo_url(only_path: false)
+          url_helpers.foo_url(only_path: false)
         end
       end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -4806,7 +4806,7 @@ class TestRouteDefaults < ActionDispatch::IntegrationTest
 
   def test_route_options_are_required_for_url_for
     assert_raises(ActionController::UrlGenerationError) do
-      assert_equal "/posts/1", url_for(controller: "posts", action: "show", id: 1, only_path: true)
+      url_for(controller: "posts", action: "show", id: 1, only_path: true)
     end
 
     assert_equal "/posts/1", url_for(controller: "posts", action: "show", id: 1, bucket_type: "post", only_path: true)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -391,7 +391,7 @@ module RenderTestCases
   def test_without_compiled_method_container_is_deprecated
     view = ActionView::Base.with_view_paths(ActionController::Base.view_paths)
     assert_raises(NotImplementedError) do
-      assert_equal "Hello world!", view.render(template: "test/hello_world")
+      view.render(template: "test/hello_world")
     end
   end
 

--- a/activejob/test/cases/exceptions_test.rb
+++ b/activejob/test/cases/exceptions_test.rb
@@ -33,15 +33,14 @@ class ExceptionsTest < ActiveSupport::TestCase
 
     assert_raises SecondRetryableErrorOfTwo do
       RetryJob.perform_later(exceptions_to_raise, 5)
-
-      assert_equal [
-        "Raised FirstRetryableErrorOfTwo for the 1st time",
-        "Raised FirstRetryableErrorOfTwo for the 2nd time",
-        "Raised FirstRetryableErrorOfTwo for the 3rd time",
-        "Raised SecondRetryableErrorOfTwo for the 4th time",
-        "Raised SecondRetryableErrorOfTwo for the 5th time",
-      ], JobBuffer.values
     end
+
+    assert_equal [
+      "Raised FirstRetryableErrorOfTwo for the 1st time",
+      "Raised FirstRetryableErrorOfTwo for the 2nd time",
+      "Raised FirstRetryableErrorOfTwo for the 3rd time",
+      "Raised SecondRetryableErrorOfTwo for the 4th time"
+    ], JobBuffer.values
   end
 
   test "keeps a separate attempts counter for each individual retry_on declaration" do

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -511,7 +511,7 @@ module ApplicationTests
       get "/bar"
       assert_equal 404, last_response.status
       assert_raises NoMethodError do
-        assert_equal "/bar", Rails.application.routes.url_helpers.bar_path
+        Rails.application.routes.url_helpers.bar_path
       end
 
       app_file "config/routes.rb", <<-RUBY
@@ -560,19 +560,19 @@ module ApplicationTests
       get "/bar"
       assert_equal 404, last_response.status
       assert_raises NoMethodError do
-        assert_equal "/bar", Rails.application.routes.url_helpers.bar_path
+        Rails.application.routes.url_helpers.bar_path
       end
 
       get "/custom"
       assert_equal 404, last_response.status
       assert_raises NoMethodError do
-        assert_equal "http://www.apple.com", Rails.application.routes.url_helpers.custom_url
+        Rails.application.routes.url_helpers.custom_url
       end
 
       get "/mapping"
       assert_equal 404, last_response.status
       assert_raises NoMethodError do
-        assert_equal "/profile", Rails.application.routes.url_helpers.polymorphic_path(User.new)
+        Rails.application.routes.url_helpers.polymorphic_path(User.new)
       end
     end
 
@@ -645,7 +645,7 @@ module ApplicationTests
       assert_equal "/users", Rails.application.routes.url_helpers.polymorphic_path(User.new)
 
       assert_raises NoMethodError do
-        assert_equal "http://www.microsoft.com", Rails.application.routes.url_helpers.microsoft_url
+        Rails.application.routes.url_helpers.microsoft_url
       end
     end
 


### PR DESCRIPTION
### Summary

I found an unexpected use of assertion in the block of `assert_raise` when I implemented https://github.com/rubocop/rubocop-minitest/pull/137.
It is expected to be asserted after an exception is raised in `assert_raise` block, but in actually it is not asserted after an
exception is raised. Therefore, this PR removes or updates assertions that have not been asserted after an exception has raised.

### Other Information

This PR will add `rubocop-minitest` and enable `Minitest/UnreachableAssertion` cop to able similar auto-detection, but will remove `rubocop-minitest` from this PR if you don't like it.
