### PR TITLE
Address `ActionDispatch::Session::SessionRestoreError` at `CookieStoreTest`

### DIFF
--- a/actionpack/test/dispatch/session/cookie_store_test.rb
+++ b/actionpack/test/dispatch/session/cookie_store_test.rb
@@ -4,6 +4,7 @@ require "abstract_unit"
 require "stringio"
 require "active_support/key_generator"
 require "active_support/messages/rotation_configuration"
+require "fixtures/session_autoload_test/session_autoload_test/foo"
 
 class CookieStoreTest < ActionDispatch::IntegrationTest
   SessionKey = "_myapp_session"


### PR DESCRIPTION
This pull request addresses `ActionDispatch::Session::SessionRestoreError` at `CookieStoreTest`.

Fix #43033

```ruby
% cd actionpack
% bin/test test/dispatch/session/cookie_store_test.rb -n test_deserializes_unloaded_classes_on_get_id
Run options: -n test_deserializes_unloaded_classes_on_get_id --seed 20545

E

Error:
CookieStoreTest#test_deserializes_unloaded_classes_on_get_id:
ActionDispatch::Session::SessionRestoreError: Session contains objects whose class definition isn't available.
Remember to require the classes for all objects kept in the session.
(Original exception: uninitialized constant SessionAutoloadTest [NameError])

    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/inflector/methods.rb:280:in `constantize'
    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/core_ext/string/inflections.rb:74:in `constantize'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:58:in `rescue in stale_session_check!'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:52:in `stale_session_check!'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb:88:in `block in unpacked_cookie_data'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/request.rb:69:in `fetch_header'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb:87:in `unpacked_cookie_data'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb:81:in `block in extract_session_id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb:53:in `stale_session_check!'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb:80:in `extract_session_id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/request/session.rb:65:in `block in id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/request/session.rb:64:in `fetch'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/request/session.rb:64:in `id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/request/session.rb:84:in `id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:39:in `get_session_id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/abstract_controller/base.rb:214:in `process_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal/rendering.rb:53:in `process_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/abstract_controller/callbacks.rb:221:in `block in process_action'
    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/abstract_controller/callbacks.rb:220:in `process_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal/rescue.rb:22:in `process_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal/instrumentation.rb:65:in `block in process_action'
    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:207:in `block in instrument'
    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:207:in `instrument'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal/instrumentation.rb:64:in `process_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/abstract_controller/base.rb:151:in `process'
    /Users/yahonda/src/github.com/rails/rails/actionview/lib/action_view/rendering.rb:39:in `process'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal.rb:188:in `dispatch'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_controller/metal.rb:251:in `dispatch'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/route_set.rb:49:in `dispatch'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/route_set.rb:32:in `serve'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/journey/router.rb:50:in `block in serve'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/journey/router.rb:32:in `each'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/journey/router.rb:32:in `serve'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/routing/route_set.rb:845:in `call'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:266:in `context'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/session/abstract/id.rb:260:in `call'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/head.rb:12:in `call'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-2.2.3/lib/rack/method_override.rb:24:in `call'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/cookies.rb:693:in `call'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
    /Users/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/callbacks.rb:99:in `run_callbacks'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb:28:in `call'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:96:in `call'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-test-1.1.0/lib/rack/mock_session.rb:29:in `request'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-test-1.1.0/lib/rack/test.rb:266:in `process_request'
    /Users/yahonda/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rack-test-1.1.0/lib/rack/test.rb:119:in `request'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:279:in `process'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:16:in `get'
    /Users/yahonda/src/github.com/rails/rails/actionpack/lib/action_dispatch/testing/integration.rb:370:in `get'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:395:in `get'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:170:in `block (2 levels) in test_deserializes_unloaded_classes_on_get_id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:167:in `with_autoload_path'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:168:in `block in test_deserializes_unloaded_classes_on_get_id'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:413:in `block in with_test_route_set'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/abstract_unit.rb:153:in `with_routing'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:399:in `with_test_route_set'
    /Users/yahonda/src/github.com/rails/rails/actionpack/test/dispatch/session/cookie_store_test.rb:167:in `test_deserializes_unloaded_classes_on_get_id'

bin/test test/dispatch/session/cookie_store_test.rb:166

Finished in 0.212116s, 4.7144 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
%
```

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
