### PR TITLE
avoid calling attributes.keys in ActiveModel#serializable_hash

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -123,7 +123,7 @@ module ActiveModel
     #   user.serializable_hash(include: { notes: { only: 'title' }})
     #   # => {"name" => "Napoleon", "notes" => [{"title"=>"Battle of Austerlitz"}]}
     def serializable_hash(options = nil)
-      attribute_names = attributes.keys
+      attribute_names = self.attribute_names
 
       return serializable_attributes(attribute_names) if options.blank?
 
@@ -146,6 +146,23 @@ module ActiveModel
       end
 
       hash
+    end
+
+    # Returns an array of attribute names as strings
+    #
+    #   class Person
+    #     include ActiveModel::Serialization
+    #     attr_accessor :name, :age
+    #     def attributes
+    #       { 'name' => name, 'age' => age }
+    #     end
+    #   end
+    #
+    #   person = Person.new
+    #   person.attribute_names
+    #   # => ["name", "age"]
+    def attribute_names
+      attributes.keys
     end
 
     private


### PR DESCRIPTION
for ActiveRecord objects, it will force the entire attributes hash to
be constructed, which may include expensive deserialization.
ActiveModel already has a simple attribute_names method defined which
returns attributes.keys, exactly like the code we're replacing.
ActiveRecord overrides that method, and returns the names of the
attributes _without_ having to deserialize any values.

this change can save a lot of CPU if you have a serialized column
on a model that you often load from the DB because it's not worth
the effort to customize the SELECT on every relation, but
also rarely expose in any JSON serializations (i.e. have a default
except option for it).