### PR TITLE
Add `beginning_of_week` option to `weekday_options_for_select`

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -597,15 +597,18 @@ module ActionView
       # Returns a string of option tags for the days of the week.
       #
       # Options:
-      # * <tt>:index_as_value</tt> - Defaults to false, set to true to use the index of the weekday as the value.
+      # * <tt>:index_as_value</tt> - Defaults to false, set to true to use the indexes from
+      # `I18n.translate("date.day_names")` as the values. By default, Sunday is always 0.
       # * <tt>:day_format</tt> - The I18n key of the array to use for the weekday options.
       # Defaults to :day_names, set to :abbr_day_names for abbreviations.
+      # * <tt>:beginning_of_week</tt> - Defaults to Date.beginning_of_week.
       #
       # NOTE: Only the option tags are returned, you have to wrap this call in
       # a regular HTML select tag.
-      def weekday_options_for_select(selected = nil, index_as_value: false, day_format: :day_names)
+      def weekday_options_for_select(selected = nil, index_as_value: false, day_format: :day_names, beginning_of_week: Date.beginning_of_week)
         day_names = I18n.translate("date.#{day_format}")
-        day_names = day_names.map.with_index.to_h if index_as_value
+        day_names = day_names.map.with_index.to_a if index_as_value
+        day_names = day_names.rotate(Date::DAYS_INTO_WEEK.fetch(beginning_of_week))
 
         options_for_select(day_names, selected)
       end

--- a/actionview/lib/action_view/helpers/tags/weekday_select.rb
+++ b/actionview/lib/action_view/helpers/tags/weekday_select.rb
@@ -15,7 +15,8 @@ module ActionView
             weekday_options_for_select(
               value || @options[:selected],
               index_as_value: @options.fetch(:index_as_value, false),
-              day_format: @options.fetch(:day_format, :day_names)
+              day_format: @options.fetch(:day_format, :day_names),
+              beginning_of_week: @options.fetch(:beginning_of_week, Date.beginning_of_week)
             ),
             @options,
             @html_options

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1510,42 +1510,65 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_weekday_options_for_select_with_no_params
     assert_dom_equal(
-      "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>",
+      "<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option>",
       weekday_options_for_select
     )
   end
 
   def test_weekday_options_for_select_with_index_as_value
     assert_dom_equal(
-      "<option value=\"0\">Sunday</option>\n<option value=\"1\">Monday</option>\n<option value=\"2\">Tuesday</option>\n<option value=\"3\">Wednesday</option>\n<option value=\"4\">Thursday</option>\n<option value=\"5\">Friday</option>\n<option value=\"6\">Saturday</option>",
+      "<option value=\"1\">Monday</option>\n<option value=\"2\">Tuesday</option>\n<option value=\"3\">Wednesday</option>\n<option value=\"4\">Thursday</option>\n<option value=\"5\">Friday</option>\n<option value=\"6\">Saturday</option>\n<option value=\"0\">Sunday</option>",
       weekday_options_for_select(index_as_value: true)
     )
   end
 
   def test_weekday_options_for_select_with_abberviated_day_names
     assert_dom_equal(
-      "<option value=\"Sun\">Sun</option>\n<option value=\"Mon\">Mon</option>\n<option value=\"Tue\">Tue</option>\n<option value=\"Wed\">Wed</option>\n<option value=\"Thu\">Thu</option>\n<option value=\"Fri\">Fri</option>\n<option value=\"Sat\">Sat</option>",
+      "<option value=\"Mon\">Mon</option>\n<option value=\"Tue\">Tue</option>\n<option value=\"Wed\">Wed</option>\n<option value=\"Thu\">Thu</option>\n<option value=\"Fri\">Fri</option>\n<option value=\"Sat\">Sat</option>\n<option value=\"Sun\">Sun</option>",
       weekday_options_for_select(day_format: :abbr_day_names)
     )
   end
 
+  def test_weekday_options_for_select_with_beginning_of_week_set_to_sunday
+    assert_dom_equal(
+      "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>",
+      weekday_options_for_select(beginning_of_week: :sunday)
+    )
+  end
+
+  def test_weekday_options_for_select_with_beginning_of_week_set_to_saturday
+    assert_dom_equal(
+      "<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>",
+      weekday_options_for_select(beginning_of_week: :saturday)
+    )
+  end
+
+  def test_weekday_options_for_select_with_beginning_of_week_set_elsewhere
+    Date.beginning_of_week = :sunday
+    assert_dom_equal(
+      "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>",
+      weekday_options_for_select
+    )
+    Date.beginning_of_week = :monday
+  end
+
   def test_weekday_options_for_select_with_selected_value
     assert_dom_equal(
-      "<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>",
+      "<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option>",
       weekday_options_for_select("Friday")
     )
   end
 
   def test_weekday_select
     assert_dom_equal(
-      "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option></select>",
       weekday_select(:model, :weekday)
     )
   end
 
   def test_weekday_select_with_selected_value
     assert_dom_equal(
-      "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      "<select name=\"model[weekday]\" id=\"model_weekday\"><option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option selected=\"selected\" value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option></select>",
       weekday_select(:model, :weekday, selected: "Friday")
     )
   end
@@ -1558,7 +1581,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal(
-      "<select id=\"digest_send_day\" name=\"digest[send_day]\"><option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      "<select id=\"digest_send_day\" name=\"digest[send_day]\"><option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option></select>",
       output_buffer
     )
   end
@@ -1572,7 +1595,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal(
-      "<select name=\"digest[send_day]\" id=\"digest_send_day\"><option value=\"Sunday\">Sunday</option>\n<option selected=\"selected\" value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option></select>",
+      "<select name=\"digest[send_day]\" id=\"digest_send_day\"><option selected=\"selected\" value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option></select>",
       output_buffer
     )
   end


### PR DESCRIPTION
### Summary

In #42979 the suggestion was made to include an option to allow users to set "Monday" as the first day on the list.

```ruby
weekday_options_for_select(begin_on_monday: true)
# => "<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n
# <option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n
# <option value=\"Friday\">Friday</option>\n<option value=\"Saturday\">Saturday</option>\n
# <option value=\"Sunday\">Sunday</option>"
```

**NOTE**: If you are using indexes as values Sundays value will remain 0 for consistency with Ruby and the I18n day names array.

```ruby
weekday_options_for_select(begin_on_monday: true, index_as_value: true)
# => "<option value=\"1\">Monday</option>\n<option value=\"2\">Tuesday</option>\n
# <option value=\"3\">Wednesday</option>\n<option value=\"4\">Thursday</option>\n
# <option value=\"5\">Friday</option>\n<option value=\"6\">Saturday</option>\n
# <option value=\"0\">Sunday</option>"
```



