### PR TITLE
Fix `RedisCacheStore#write_multi` to properly update the local store.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `RedisCacheStore#write_multi` to properly update the local store.
+
+    `RedisCacheStore` specialises `write_multi` to use `mset` when possible,
+    but it didn't update the local cache accordingly.
+
+    *Jean Boussier*
+
 *   Allow entirely opting out of deprecation warnings.
 
     Previously if you did `app.config.active_support.deprecation = :silence`, some work would

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -63,6 +63,14 @@ module LocalCacheBehavior
     end
   end
 
+  def test_local_cache_of_write_multi
+    @cache.with_local_cache do
+      @cache.write("foo", "bar")
+      @cache.write_multi({ "foo" => "baz" }, expires_in: nil)
+      assert_equal "baz", @cache.read("foo")
+    end
+  end
+
   def test_local_cache_of_read_returns_a_copy_of_the_entry
     @cache.with_local_cache do
       @cache.write(:foo, type: "bar")


### PR DESCRIPTION
`RedisCacheStore` specialises `write_multi` to use `mset` when possible, but it didn't update the local cache accordingly.

Unless I'm mistaken, I think the bug was present in the initial version https://github.com/rails/rails/pull/31134

cc @jeremy 