### PR TITLE
Makes the array syntax consistent with other use cases

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -32,7 +32,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
         t.datetime :created_at, null: false
       end
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
@@ -40,7 +40,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.belongs_to :blob, null: false, index: false, type: foreign_key_type
       t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end


### PR DESCRIPTION
Makes the array syntax consistent with other use cases from **the same file**. Because I always wanted to do this and I did this in every app I created. (The reason being, the code was looking like it's done by different people, which is true but why not make it consistent while we can.)

https://github.com/rails/rails/blob/4b4895e60d3c378c6070f2eebe0a20b607f47080/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb#L21

https://github.com/rails/rails/blob/4b4895e60d3c378c6070f2eebe0a20b607f47080/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb#L35

https://github.com/rails/rails/blob/4b4895e60d3c378c6070f2eebe0a20b607f47080/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb#L43