### PR TITLE
Improve description of ActiveRecord.joins [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -500,7 +500,7 @@ module ActiveRecord
       self
     end
 
-    # Performs a joins on +args+. The given symbol(s) should match the name of
+    # Performs JOINs on +args+. The given symbol(s) should match the name of
     # the association(s).
     #
     #   User.joins(:posts)
@@ -538,7 +538,7 @@ module ActiveRecord
       self
     end
 
-    # Performs a left outer joins on +args+:
+    # Performs LEFT OUTER JOINs on +args+:
     #
     #   User.left_outer_joins(:posts)
     #   => SELECT "users".* FROM "users" LEFT OUTER JOIN "posts" ON "posts"."user_id" = "users"."id"


### PR DESCRIPTION
### Summary

Joins is the plural of join. So "a joins" doesn't seem correct.

To make it clear joins is a SQL term, we can also upcase it just like the
descriptions for GROUP, HAVING and SELECT.

https://github.com/rails/rails/blob/6ec669b65d5cd47c984661920d670faccbf0920a/activerecord/lib/active_record/relation/query_methods.rb#L830-L831

https://github.com/rails/rails/blob/6ec669b65d5cd47c984661920d670faccbf0920a/activerecord/lib/active_record/relation/query_methods.rb#L258