### PR TITLE
Don't allow active_storage_blobs.content_type to be NULL

### DIFF
--- a/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
+++ b/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb
@@ -6,7 +6,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
     create_table :active_storage_blobs, id: primary_key_type do |t|
       t.string   :key,          null: false
       t.string   :filename,     null: false
-      t.string   :content_type
+      t.string   :content_type, null: false
       t.text     :metadata
       t.string   :service_name, null: false
       t.bigint   :byte_size,    null: false

--- a/activestorage/db/update_migrate/20210819000000_change_active_storage_blobs_content_type_to_not_be_null.rb
+++ b/activestorage/db/update_migrate/20210819000000_change_active_storage_blobs_content_type_to_not_be_null.rb
@@ -1,0 +1,5 @@
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:active_storage_blobs, :content_type, false)
+  end
+end


### PR DESCRIPTION
### Summary

As of https://github.com/rails/rails/pull/38124 (Jan, 2020), active_storage_blobs.content_type has a default value so it will never be NULL.  Let's enforce that at the database level.