### PR TITLE
Delete AS::Dependencies.(safe_)constantize

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -87,7 +87,7 @@ module ActionDispatch
         controller_param = name.underscore
         const_name = controller_param.camelize << "Controller"
         begin
-          ActiveSupport::Dependencies.constantize(const_name)
+          const_name.constantize
         rescue NameError => error
           if error.missing_name == const_name || const_name.start_with?("#{error.missing_name}::")
             raise MissingController.new(error.message, error.name)

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -239,7 +239,7 @@ module ActiveRecord
             type_name.constantize
           else
             type_candidate = @_type_candidates_cache[type_name]
-            if type_candidate && type_constant = ActiveSupport::Dependencies.safe_constantize(type_candidate)
+            if type_candidate && type_constant = type_candidate.safe_constantize
               return type_constant
             end
 
@@ -249,7 +249,7 @@ module ActiveRecord
             candidates << type_name
 
             candidates.each do |candidate|
-              constant = ActiveSupport::Dependencies.safe_constantize(candidate)
+              constant = candidate.safe_constantize
               if candidate == constant.to_s
                 @_type_candidates_cache[type_name] = candidate
                 return constant

--- a/activerecord/lib/active_record/inheritance.rb
+++ b/activerecord/lib/active_record/inheritance.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/inflector"
 require "active_support/core_ext/hash/indifferent_access"
 
 module ActiveRecord
@@ -181,7 +182,7 @@ module ActiveRecord
       # It is used to find the class correspondent to the value stored in the inheritance column.
       def sti_class_for(type_name)
         if store_full_sti_class && store_full_class_name
-          ActiveSupport::Dependencies.constantize(type_name)
+          type_name.constantize
         else
           compute_type(type_name)
         end
@@ -203,7 +204,7 @@ module ActiveRecord
       # It is used to find the class correspondent to the value stored in the polymorphic type column.
       def polymorphic_class_for(name)
         if store_full_class_name
-          ActiveSupport::Dependencies.constantize(name)
+          name.constantize
         else
           compute_type(name)
         end
@@ -235,7 +236,7 @@ module ActiveRecord
           if type_name.start_with?("::")
             # If the type is prefixed with a scope operator then we assume that
             # the type_name is an absolute reference.
-            ActiveSupport::Dependencies.constantize(type_name)
+            type_name.constantize
           else
             type_candidate = @_type_candidates_cache[type_name]
             if type_candidate && type_constant = ActiveSupport::Dependencies.safe_constantize(type_candidate)

--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/inflector"
 require "cases/helper"
 require "models/author"
 require "models/company"
@@ -68,37 +69,33 @@ class InheritanceTest < ActiveRecord::TestCase
   end
 
   def test_compute_type_no_method_error
-    ActiveSupport::Dependencies.stub(:safe_constantize, proc { raise NoMethodError }) do
-      assert_raises NoMethodError do
-        Company.send :compute_type, "InvalidModel"
-      end
-    end
+    # Done via autoload because you need the exception to happen when the file
+    # is required.
+    model = "RaisesNoMethodError"
+    Object.autoload(model, "#{MODELS_ROOT}/#{model.underscore}")
+    assert_raises(NoMethodError) { Company.send(:compute_type, model) }
+  ensure
+    Object.send(:remove_const, model)
   end
 
   def test_compute_type_on_undefined_method
-    error = nil
-    begin
-      Class.new(Author) do
-        alias_method :foo, :bar
-      end
-    rescue => e
-      error = e
-    end
-
-    ActiveSupport::Dependencies.stub(:safe_constantize, proc { raise e }) do
-      exception = assert_raises NameError do
-        Company.send :compute_type, "InvalidModel"
-      end
-      assert_equal error.message, exception.message
-    end
+    # Done via autoload because you need the exception to happen when the file
+    # is required.
+    model = "InvokesAnUndefinedMethod"
+    Object.autoload(model, "#{MODELS_ROOT}/#{model.underscore}")
+    assert_raises(NameError) { Company.send(:compute_type, model) }
+  ensure
+    Object.send(:remove_const, model)
   end
 
   def test_compute_type_argument_error
-    ActiveSupport::Dependencies.stub(:safe_constantize, proc { raise ArgumentError }) do
-      assert_raises ArgumentError do
-        Company.send :compute_type, "InvalidModel"
-      end
-    end
+    # Done via autoload because you need the exception to happen when the file
+    # is required.
+    model = "RaisesArgumentError"
+    Object.autoload(model, "#{MODELS_ROOT}/#{model.underscore}")
+    assert_raises(ArgumentError) { Company.send(:compute_type, model) }
+  ensure
+    Object.send(:remove_const, model)
   end
 
   def test_should_store_demodulized_class_name_with_store_full_sti_class_option_disabled

--- a/activerecord/test/config.rb
+++ b/activerecord/test/config.rb
@@ -3,5 +3,6 @@
 TEST_ROOT       = __dir__
 ASSETS_ROOT     = TEST_ROOT + "/assets"
 FIXTURES_ROOT   = TEST_ROOT + "/fixtures"
+MODELS_ROOT     = TEST_ROOT + "/models"
 MIGRATIONS_ROOT = TEST_ROOT + "/migrations"
 SCHEMA_ROOT     = TEST_ROOT + "/schema"

--- a/activerecord/test/models/invokes_an_undefined_method.rb
+++ b/activerecord/test/models/invokes_an_undefined_method.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class InvokesAnUndefinedMethod
+  this_method_is_undefined
+end

--- a/activerecord/test/models/raises_argument_error.rb
+++ b/activerecord/test/models/raises_argument_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RaisesArgumentError
+  raise ArgumentError
+end

--- a/activerecord/test/models/raises_no_method_error.rb
+++ b/activerecord/test/models/raises_no_method_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class RaisesNoMethodError
+  Object.new.calling_a_non_existing_method
+end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -82,12 +82,6 @@ module ActiveSupport # :nodoc:
       nil # Gee, I sure wish we had first_match ;-)
     end
 
-    # Get the reference for class named +name+.
-    # Raises an exception if referenced class does not exist.
-    def constantize(name)
-      Inflector.constantize(name)
-    end
-
     # Get the reference for class named +name+ if one exists.
     # Otherwise returns +nil+.
     def safe_constantize(name)

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -3,7 +3,6 @@
 require "set"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/dependencies/interlock"
-require "active_support/inflector"
 
 module ActiveSupport # :nodoc:
   module Dependencies # :nodoc:
@@ -80,12 +79,6 @@ module ActiveSupport # :nodoc:
         return path if File.file? path
       end
       nil # Gee, I sure wish we had first_match ;-)
-    end
-
-    # Get the reference for class named +name+ if one exists.
-    # Otherwise returns +nil+.
-    def safe_constantize(name)
-      Inflector.safe_constantize(name)
     end
 
     # Determine if the given constant has been automatically loaded.

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "set"
-require "active_support/core_ext/string/inflections"
 require "zeitwerk"
 
 module ActiveSupport
@@ -14,10 +13,6 @@ module ActiveSupport
           rescue Zeitwerk::ReloadingDisabledError
             raise "reloading is disabled because config.cache_classes is true"
           end
-        end
-
-        def safe_constantize(cpath)
-          ActiveSupport::Inflector.safe_constantize(cpath)
         end
 
         def autoloaded_constants

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -16,10 +16,6 @@ module ActiveSupport
           end
         end
 
-        def constantize(cpath)
-          ActiveSupport::Inflector.constantize(cpath)
-        end
-
         def safe_constantize(cpath)
           ActiveSupport::Inflector.safe_constantize(cpath)
         end

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -61,19 +61,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert RESTfulController
   end
 
-  test "safe_constantize returns the value stored in the constant" do
-    app_file "app/models/admin/user.rb", "class Admin::User; end"
-    boot
-
-    assert_same Admin::User, deps.safe_constantize("Admin::User")
-  end
-
-  test "safe_constantize returns nil for unknown constants" do
-    boot
-
-    assert_nil deps.safe_constantize("Admin")
-  end
-
   test "autoloaded? and overridden class names" do
     invalid_constant_name = Module.new do
       def self.name

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -61,19 +61,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert RESTfulController
   end
 
-  test "constantize returns the value stored in the constant" do
-    app_file "app/models/admin/user.rb", "class Admin::User; end"
-    boot
-
-    assert_same Admin::User, deps.constantize("Admin::User")
-  end
-
-  test "constantize raises if the constant is unknown" do
-    boot
-
-    assert_raises(NameError) { deps.constantize("Admin") }
-  end
-
   test "safe_constantize returns the value stored in the constant" do
     app_file "app/models/admin/user.rb", "class Admin::User; end"
     boot


### PR DESCRIPTION
_(This is part of the cleanup in `ActiveSupport::Dependencies` due to the deletion of `classic`.)_

The methods `constantize` and `safe_constantize` of `ActiveSupport::Dependencies` are private. They have nothing to do with autoloading, just forward to the inflector. They were there for historical reasons, but today we no longer need them.

The public interface is in `String`. So

```ruby
model_name.constantize
```

instead of

```ruby
ActiveSupport::Dependencies.constantize(model_name)
```

The majority of the framework already did this, there were only a few occurrences.