### PR TITLE
Allow passing callbacks inside :optional to belongs_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Allow passing callbacks inside `:optional` to `belongs_to`
+
+    If you need to specify dynamic condition for `:optinal` you can use method name
+    or lambda (similar to how validations work):
+
+    ```ruby
+    class Book < ApplicationRecord
+      belongs_to :author, optional: :unknown_author?
+      # or
+      belongs_to :author, optional: -> { unknown_author? || draft? }
+    end
+    ```
+
+    *Dmitry Tsepelev*
+
 *   Add database config option `database_tasks`
 
     If you would like to connect to an external database without any database

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -110,20 +110,27 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.define_validations(model, reflection)
+      validation_options = { message: :required }
+
       if reflection.options.key?(:required)
         reflection.options[:optional] = !reflection.options.delete(:required)
       end
 
-      if reflection.options[:optional].nil?
-        required = model.belongs_to_required_by_default
-      else
-        required = !reflection.options[:optional]
-      end
+      required =
+        case reflection.options[:optional]
+        when nil
+          model.belongs_to_required_by_default
+        when true, false
+          !reflection.options[:optional]
+        else
+          validation_options[:unless] = reflection.options[:optional]
+          true
+        end
 
       super
 
       if required
-        model.validates_presence_of reflection.name, message: :required
+        model.validates_presence_of reflection.name, validation_options
       end
     end
 

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -149,6 +149,51 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     ActiveRecord::Base.belongs_to_required_by_default = original_value
   end
 
+  def test_optional_relation_with_method_call
+    original_value = ActiveRecord::Base.belongs_to_required_by_default
+    ActiveRecord::Base.belongs_to_required_by_default = true
+
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "accounts"
+      def self.name; "Temp"; end
+      attribute :with_optional_company, :boolean, default: true
+      belongs_to :company, optional: :with_optional_company?
+    end
+
+    account = model.new
+    assert_predicate account, :valid?
+
+    account.with_optional_company = false
+    assert_predicate account, :invalid?
+  ensure
+    ActiveRecord::Base.belongs_to_required_by_default = original_value
+  end
+
+  def test_optional_relation_with_proc
+    original_value = ActiveRecord::Base.belongs_to_required_by_default
+    ActiveRecord::Base.belongs_to_required_by_default = true
+
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "accounts"
+      def self.name; "Temp"; end
+      belongs_to :company, optional: -> { true }
+    end
+
+    account = model.new
+    assert_predicate account, :valid?
+
+    model2 = Class.new(ActiveRecord::Base) do
+      self.table_name = "accounts"
+      def self.name; "Temp"; end
+      belongs_to :company, optional: -> { false }
+    end
+
+    account2 = model2.new
+    assert_predicate account2, :invalid?
+  ensure
+    ActiveRecord::Base.belongs_to_required_by_default = original_value
+  end
+
   def test_not_optional_relation
     original_value = ActiveRecord::Base.belongs_to_required_by_default
     ActiveRecord::Base.belongs_to_required_by_default = true

--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1130,7 +1130,13 @@ If you set the `:validate` option to `true`, then new associated objects will be
 ##### `:optional`
 
 If you set the `:optional` option to `true`, then the presence of the associated
-object won't be validated. By default, this option is set to `false`.
+object won't be validated. By default, this option is set to `false`. For a fine–grained control, you can pass a method name or lambda to check the condition dynamically:
+
+```ruby
+class Book < ApplicationRecord
+  belongs_to :author, optional: :unknown_author?
+end
+```
 
 #### Scopes for `belongs_to`
 


### PR DESCRIPTION
### Summary

This PR allows to pass procs, lambdas, method names etc (i.e., anything [CallTemplate](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/callbacks.rb#L375 accepts) to `belongs_to ..., optional:`. This might be helpful for cases when you need more control on the generated validation.

For instance, imagine an app where users have profiles belonging to different organizations; you generally want profile always have user attached except cases when the organization is demo (and used only for demonstration, so profiles belonging to it are not real people):

```ruby
class Profile < ApplicationRecord
  belongs_to :organization
  belongs_to :user, optional: -> { organization.is_demo? }
end
```