### PR TITLE
[GUIDES]: Fix ActiveStorage::FixtureSet.blob YAML

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -651,20 +651,20 @@ define a reference node between two different fixtures. Here's an example with
 a `belongs_to`/`has_many` association:
 
 ```yaml
-# fixtures/categories.yml
+# test/fixtures/categories.yml
 about:
   name: About
 ```
 
 ```yaml
-# fixtures/articles.yml
+# test/fixtures/articles.yml
 first:
   title: Welcome to Rails!
   category: about
 ```
 
 ```yaml
-# fixtures/action_text/rich_texts.yml
+# test/fixtures/action_text/rich_texts.yml
 first_content:
   record: first (Article)
   name: content
@@ -691,7 +691,7 @@ end
 ```
 
 ```yaml
-# fixtures/articles.yml
+# test/fixtures/articles.yml
 first:
   title: An Article
 ```
@@ -702,14 +702,12 @@ generate the related `ActiveStorage::Blob` and `ActiveStorage::Attachment`
 records:
 
 ```yaml
-# fixtures/active_storage/blobs.yml
-first_thumbnail_blob: <%= ActiveStorage::FixtureSet.blob(
-  filename: "first.png",
-) %>
+# test/fixtures/active_storage/blobs.yml
+first_thumbnail_blob: <%= ActiveStorage::FixtureSet.blob filename: "first.png" %>
 ```
 
 ```yaml
-# fixtures/active_storage/attachments.yml
+# test/fixtures/active_storage/attachments.yml
 first_thumbnail_attachment:
   name: thumbnail
   record: first (Article)


### PR DESCRIPTION
Resolves incorrect fixture guide YAML paths, and compacts the
`FixtureSet.blob` call to a single line to resolve syntax highlighting
quirks.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
