### PR TITLE
Allow testing `discard_on/retry_on ActiveJob::DeserializationError`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,34 @@
+*   Allow testing `discard_on/retry_on ActiveJob::DeserializationError`
+
+    Previously in `perform_enqueued_jobs`, `deserialize_arguments_if_needed`
+    was called before calling `perform_now`. When a record no longer exists
+    and is serialized using GlobalID this led to raising
+    an `ActiveJob::DeserializationError` before reaching `perform_now` call.
+    This behaviour makes difficult testing the job `discard_on/retry_on` logic.
+
+    Now `deserialize_arguments_if_needed` call is postponed to when `perform_now`
+    is called.
+
+    Example:
+
+    ```ruby
+    class UpdateUserJob < ActiveJob::Base
+      discard_on ActiveJob::DeserializationError
+
+      def perform(user)
+        # ...
+      end
+    end
+
+    # In the test
+    User.destroy_all
+    assert_nothing_raised do
+      perform_enqueued_jobs only: UpdateUserJob
+    end
+    ```
+
+    *Jacopo Beschi*
+
 *   Allow a job to retry indefinitely
 
     The `attempts` parameter of the `retry_on` method now accepts the

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -664,7 +664,7 @@ module ActiveJob
         enqueued_jobs_with(only: only, except: except, queue: queue, at: at) do |payload|
           queue_adapter.enqueued_jobs.delete(payload)
           queue_adapter.performed_jobs << payload
-          instantiate_job(payload).perform_now
+          instantiate_job(payload, skip_deserialize_arguments: true).perform_now
         end.count
       end
 
@@ -684,10 +684,10 @@ module ActiveJob
         end
       end
 
-      def instantiate_job(payload)
+      def instantiate_job(payload, skip_deserialize_arguments: false)
         job = payload[:job].deserialize(payload)
         job.scheduled_at = Time.at(payload[:at]) if payload.key?(:at)
-        job.send(:deserialize_arguments_if_needed)
+        job.send(:deserialize_arguments_if_needed) unless skip_deserialize_arguments
         job
       end
 

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -9,6 +9,7 @@ require "jobs/logging_job"
 require "jobs/nested_job"
 require "jobs/rescue_job"
 require "jobs/raising_job"
+require "jobs/retry_job"
 require "jobs/inherited_job"
 require "jobs/multiple_kwargs_job"
 require "models/person"
@@ -1978,6 +1979,14 @@ class PerformedJobsTest < ActiveJob::TestCase
 
     assert_equal 0, queue_adapter.enqueued_jobs.count
     assert_equal 2, queue_adapter.performed_jobs.count
+  end
+
+  test "perform_enqueued_jobs doesn't raise if discard_on ActiveJob::DeserializationError" do
+    RetryJob.perform_later Person.new(404), 1
+
+    assert_nothing_raised do
+      perform_enqueued_jobs(only: RetryJob)
+    end
   end
 
   test "TestAdapter respect max attempts" do


### PR DESCRIPTION
### Summary

Previously in `perform_enqueued_jobs`, `deserialize_arguments_if_needed` was called before calling `perform_now`. When a record no longer exists and is serialized using GlobalID this led to raising an `ActiveJob::DeserializationError` before reaching `perform_now` call. This behaviour makes difficult testing the job `discard_on/retry_on` logic.

Now `deserialize_arguments_if_needed` call is postponed to when `perform_now` is called.

**Example:**

```ruby
class UpdateUserJob < ActiveJob::Base
  discard_on ActiveJob::DeserializationError
  
  def perform(user)
      # ...
   end
end

# In the test
User.destroy_all
assert_nothing_raised do
  perform_enqueued_jobs only: UpdateUserJob
end
assert_no_enqueued_jobs
```

Before this changes the test will fail, now it passes.
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
