### PR TITLE
Add container around page content

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `<main>` element around page content to be used as container
+
+    *Vernes Pendić*
+
 *   Show Rake task description if command is run with -h.
 
     Adding `-h` (or `--help`) to a Rails command that's a Rake task, now returns
@@ -7,7 +11,7 @@
     
 *   Add missing `plugin new` command to help.
 
-    *Petrik de Heus
+    *Petrik de Heus*
 
 *   Fix `config_for` error when there's only a shared root array.
 

--- a/railties/lib/rails/templates/layouts/application.html.erb
+++ b/railties/lib/rails/templates/layouts/application.html.erb
@@ -44,8 +44,10 @@
   </style>
 </head>
 <body>
+<main>
 
 <%= yield %>
 
+</main>
 </body>
 </html>


### PR DESCRIPTION
### Summary

Using a wrapper element serving as a container for page content is a common practice. It's used as a means to center content, add padding or just frame the content. Almost every web application has it. This PR adds a `<main>` element around page content that can later on be used for any of the mentioned uses.