### PR TITLE
Enable passing env var paths to cli -m option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -148,7 +148,7 @@ module Rails
           when /^https?:\/\//
             options[:template]
           when String
-            File.expand_path(options[:template], Dir.pwd)
+            File.expand_path(`echo #{options[:template]}`.strip)
           else
             options[:template]
           end

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -720,6 +720,25 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_match(/It works from file!/, run_generator([destination_root, "-m", "lib/template.rb"]))
   end
 
+  def test_template_from_url
+    url = "https://raw.githubusercontent.com/rails/rails/f95c0b7e96/railties/test/fixtures/lib/template.rb"
+    FileUtils.cd(Rails.root)
+    assert_match(/It works from file!/, run_generator([destination_root, "-m", url]))
+  end
+
+  def test_template_from_abs_path
+    absolute_path = File.expand_path(Rails.root, "fixtures")
+    FileUtils.cd(Rails.root)
+    assert_match(/It works from file!/, run_generator([destination_root, "-m", "#{absolute_path}/lib/template.rb"]))
+  end
+
+  def test_template_from_env_var_path
+    ENV["FIXTURES_HOME"] = File.expand_path(Rails.root, "fixtures")
+    FileUtils.cd(Rails.root)
+    assert_match(/It works from file!/, run_generator([destination_root, "-m", "$FIXTURES_HOME/lib/template.rb"]))
+    ENV.delete("FIXTURES_HOME")
+  end
+
   def test_usage_read_from_file
     assert_called(File, :read, returns: "USAGE FROM FILE") do
       assert_equal "USAGE FROM FILE", Rails::Generators::AppGenerator.desc


### PR DESCRIPTION
## Summary

Currently, if you add the --template/-m option to a railsrc file, you lose the ability to define the path to your rails template using an environment variable, which you have when passing that option from the command line.

This patch adds that ability by shelling out to interpret the passed path.

Resolves #43070 

## Tests

### Before

```sh
for test in test_template_from_dir_pwd test_template_from_url test_template_from_abs_path test_template_from_env_var_path; do
  bin/test test/generators/app_generator_test.rb -n $test
done

# Run options: -n test_template_from_dir_pwd --seed 15955
# # Running: .
# Finished in 0.140834s, 7.1006 runs/s, 14.2011 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# Run options: -n test_template_from_url --seed 2093
# # Running: .
# Finished in 0.224223s, 4.4598 runs/s, 8.9197 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# Run options: -n test_template_from_abs_path --seed 60513
# # Running: .
# Finished in 0.126309s, 7.9171 runs/s, 15.8342 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# Run options: -n test_template_from_env_var_path --seed 55959
# # Running:
# The template [/Users/jmromer/Desktop/rails/railties/test/fixtures/$FIXTURES_HOME/lib/template.rb] could not be loaded.
# F
# Failure:
# AppGeneratorTest#test_template_from_env_var_path [/Users/jmromer/Desktop/rails/railties/test/generators/app_generator_test.rb:738]:
# Expected /It works from file!/ to match "[...]".
# bin/test test/generators/app_generator_test.rb:735
# Finished in 0.183747s, 5.4423 runs/s, 10.8845 assertions/s.
# 1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
```


### After

```sh
for test in test_template_from_dir_pwd test_template_from_url test_template_from_abs_path test_template_from_env_var_path; do
  bin/test test/generators/app_generator_test.rb -n $test
done

# Run options: -n test_template_from_dir_pwd --seed 57397
# # Running: .
# Finished in 0.113180s, 8.8355 runs/s, 17.6710 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# Run options: -n test_template_from_url --seed 18895
# # Running: .
# Finished in 0.197273s, 5.0691 runs/s, 10.1382 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# Run options: -n test_template_from_abs_path --seed 39560
# # Running: .
# Finished in 0.114038s, 8.7690 runs/s, 17.5380 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips

# Run options: -n test_template_from_env_var_path --seed 19237
# # Running: .
# Finished in 0.109273s, 9.1514 runs/s, 18.3028 assertions/s.
# 1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```
