### PR TITLE
Delete AS::Dependencies.autoloaded?

### DIFF
--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -70,11 +70,6 @@ module ActiveSupport # :nodoc:
     def clear
     end
 
-    # Is the provided constant path defined?
-    def qualified_const_defined?(path)
-      Object.const_defined?(path, false)
-    end
-
     # Search for a file in autoload_paths matching the provided suffix.
     def search_for_file(path_suffix)
       path_suffix += ".rb" unless path_suffix.end_with?(".rb")
@@ -85,33 +80,5 @@ module ActiveSupport # :nodoc:
       end
       nil # Gee, I sure wish we had first_match ;-)
     end
-
-    # Determine if the given constant has been automatically loaded.
-    def autoloaded?(desc)
-      return false if desc.is_a?(Module) && real_mod_name(desc).nil?
-      name = to_constant_name desc
-      return false unless qualified_const_defined?(name)
-      autoloaded_constants.include?(name)
-    end
-
-    # Convert the provided const desc to a qualified constant name (as a string).
-    # A module, class, symbol, or string may be provided.
-    def to_constant_name(desc) # :nodoc:
-      case desc
-      when String then desc.delete_prefix("::")
-      when Symbol then desc.to_s
-      when Module
-        real_mod_name(desc) ||
-          raise(ArgumentError, "Anonymous modules have no name to be referenced by")
-      else raise TypeError, "Not a valid constant descriptor: #{desc.inspect}"
-      end
-    end
-
-    private
-      # Returns the original name of a class or module even if `name` has been
-      # overridden.
-      def real_mod_name(mod)
-        UNBOUND_METHOD_MODULE_NAME.bind_call(mod)
-      end
   end
 end

--- a/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
+++ b/activesupport/lib/active_support/dependencies/zeitwerk_integration.rb
@@ -20,11 +20,6 @@ module ActiveSupport
           Rails.autoloaders.main.unloadable_cpaths
         end
 
-        def autoloaded?(object)
-          cpath = object.is_a?(Module) ? real_mod_name(object) : object.to_s
-          Rails.autoloaders.main.unloadable_cpath?(cpath)
-        end
-
         def verbose=(verbose)
           l = verbose ? logger || Rails.logger : nil
           Rails.autoloaders.each { |autoloader| autoloader.logger = l }

--- a/activesupport/test/dependencies_test.rb
+++ b/activesupport/test/dependencies_test.rb
@@ -34,25 +34,6 @@ class DependenciesTest < ActiveSupport::TestCase
     end
     assert_includes "uninitialized constant ImaginaryObject", e.message
   end
-
-  def test_qualified_const_defined
-    assert ActiveSupport::Dependencies.qualified_const_defined?("Object")
-    assert ActiveSupport::Dependencies.qualified_const_defined?("::Object")
-    assert ActiveSupport::Dependencies.qualified_const_defined?("::Object::Kernel")
-    assert ActiveSupport::Dependencies.qualified_const_defined?("::ActiveSupport::TestCase")
-  end
-
-  def test_qualified_const_defined_should_not_call_const_missing
-    ModuleWithMissing.missing_count = 0
-    assert_not ActiveSupport::Dependencies.qualified_const_defined?("ModuleWithMissing::A")
-    assert_equal 0, ModuleWithMissing.missing_count
-    assert_not ActiveSupport::Dependencies.qualified_const_defined?("ModuleWithMissing::A::B")
-    assert_equal 0, ModuleWithMissing.missing_count
-  end
-
-  def test_qualified_const_defined_explodes_with_invalid_const_name
-    assert_raises(NameError) { ActiveSupport::Dependencies.qualified_const_defined?("invalid") }
-  end
 end
 
 class RequireDependencyTest < ActiveSupport::TestCase

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -62,14 +62,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert RESTfulController
   end
 
-  test "autoloaded? and overridden class names" do
-    invalid_constant_name = Module.new do
-      def self.name
-        "MyModule::SchemaMigration"
-      end
-    end
-    assert_not deps.autoloaded?(invalid_constant_name)
-  end
 
   test "the once autoloader can autoload from initializers" do
     app_file "extras0/x.rb", "X = 0"
@@ -126,10 +118,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
 
     assert Post
 
-    assert deps.autoloaded?("Post")
-    assert deps.autoloaded?(Post)
-    assert_not deps.autoloaded?("User")
-
     assert_equal ["Post"], deps.autoloaded_constants
   end
 
@@ -141,10 +129,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
 
     assert Foo
 
-    assert_not deps.autoloaded?("Foo")
-    assert_not deps.autoloaded?(Foo)
-    assert_not deps.autoloaded?("Bar")
-
     assert_empty deps.autoloaded_constants
   end
 
@@ -154,10 +138,6 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     boot("production")
 
     assert Post
-
-    assert_not deps.autoloaded?("Post")
-    assert_not deps.autoloaded?(Post)
-    assert_not deps.autoloaded?("User")
 
     assert_empty deps.autoloaded_constants
   end


### PR DESCRIPTION
Once we refactored `AS::DescendantsTracker` to not be coupled to `AS::Dependencies` in #43071, `AS::Dependencies.autoloaded?` became a private orphan method.

We delete it here, and in cascade `qualified_const_defined?`, `to_constant_name` and `real_mod_name` get deleted too.