### PR TITLE
Add ability to ignore tables in the schema cache

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Add config option for ignoring tables when dumping the schema cache.
+
+    Applications can now be configured to ignore certain tables when dumping the schema cache.
+
+    The configuration option can table an array of tables:
+
+    ```ruby
+    config.active_record.schema_cache_ignored_tables = ["ignored_table", "another_ignored_table"]
+    ```
+
+    Or a regex:
+
+    ```ruby
+    config.active_record.schema_cache_ignored_tables = [/^_/]
+    ```
+
+    *Eileen M. Uchitelle*
+
 *   Make schema cache methods return consistent results.
 
     Previously the schema cache methods `primary_keys`, `columns, `columns_hash`, and `indexes`

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -170,6 +170,12 @@ module ActiveRecord
   autoload :TestDatabases, "active_record/test_databases"
   autoload :TestFixtures, "active_record/fixtures"
 
+  # A list of tables or regex's to match tables to ignore when
+  # dumping the schema cache. For example if this is set to +[/^_/]+
+  # the schema cache will not dump tables named with an underscore.
+  singleton_class.attr_accessor :schema_cache_ignored_tables
+  self.schema_cache_ignored_tables = []
+
   singleton_class.attr_accessor :legacy_connection_handling
   self.legacy_connection_handling = true
 

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -86,6 +86,7 @@ module ActiveRecord
 
       # A cached lookup for table existence.
       def data_source_exists?(name)
+        return if ignored_table?(name)
         prepare_data_sources if @data_sources.empty?
         return @data_sources[name] if @data_sources.key? name
 
@@ -108,6 +109,10 @@ module ActiveRecord
 
       # Get the columns for a table
       def columns(table_name)
+        if ignored_table?(table_name)
+          raise ActiveRecord::StatementInvalid, "Table '#{table_name}' doesn't exist"
+        end
+
         @columns.fetch(table_name) do
           @columns[deep_deduplicate(table_name)] = deep_deduplicate(connection.columns(table_name))
         end
@@ -166,7 +171,7 @@ module ActiveRecord
 
       def dump_to(filename)
         clear!
-        connection.data_sources.each { |table| add(table) }
+        tables_to_cache.each { |table| add(table) }
         open(filename) { |f|
           if filename.include?(".dump")
             f.write(Marshal.dump(self))
@@ -190,6 +195,18 @@ module ActiveRecord
       end
 
       private
+        def tables_to_cache
+          connection.data_sources.reject do |table|
+            ignored_table?(table)
+          end
+        end
+
+        def ignored_table?(table_name)
+          ActiveRecord.schema_cache_ignored_tables.any? do |ignored|
+            ignored === table_name
+          end
+        end
+
         def reset_version!
           @version = connection.migration_context.current_version
         end
@@ -216,7 +233,9 @@ module ActiveRecord
         end
 
         def prepare_data_sources
-          connection.data_sources.each { |source| @data_sources[source] = true }
+          tables_to_cache.each do |source|
+            @data_sources[source] = true
+          end
         end
 
         def open(filename)


### PR DESCRIPTION
In cases where an application uses pt-osc or lhm they may have
temporary tables being used for migrations. Those tables shouldn't be
included by the schema cache because it makes the cache bigger and those
tables shouldn't ever be queried by the application. This feature allows
applications to configure a list of or regex of tables to ignore. The
behavior for ignored tables for each method in the schema cache
(`columns`, `columns_hash`, `primary_keys`, and `indexes`) matches the
behavior of a non-existent table.

To use in an application configure `config.active_record.schema_cache_ignored_tables`
to an array of tables or regex's. Those tables will not be included in
the schema cache dump.

cc/ @rafaelfranca @casperisfine @tenderlove - I think this will work for your schema cache. Note that in our app I found we actually weren't ensuring that `primary_keys`, `columns`, `columns_hash` and `indexes` were behaving the same as a non-existent table which meant that if these tables were ever queried then they'd populate the cache in-memory. Since these tables are not supposed to be queried this technically shouldn't change behavior when your app opts into this.