### PR TITLE
Allow with_lock to accept options for transaction method

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -82,8 +82,8 @@ module ActiveRecord
       # Wraps the passed block in a transaction, locking the object
       # before yielding. You can pass the SQL locking clause
       # as argument (see <tt>lock!</tt>).
-      def with_lock(lock = true)
-        transaction do
+      def with_lock(lock = true, requires_new: nil, isolation: nil, joinable: true)
+        transaction(requires_new: requires_new, isolation: isolation, joinable: joinable) do
           lock!(lock)
           yield
         end


### PR DESCRIPTION
### Summary

As the [ActiveRecord documentation notes](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions):

>transaction calls can be nested. By default, this makes all database statements in the nested transaction block become part of the parent transaction. For example, the following behavior may be surprising:
>```ruby
>User.transaction do
>    User.create(username: 'Kotori')
>    User.transaction do
>      User.create(username: 'Nemu')
>      raise ActiveRecord::Rollback
>    end
>end
>```
>creates both “Kotori” and “Nemu”. Reason is the `ActiveRecord::Rollback` exception in the nested block does not issue a ROLLBACK. Since these exceptions are captured in transaction blocks, the parent block does not see it and the real transaction is committed.

I tested this with `with_lock` calls, and it behaved the exact same way. The ActiveRecord documenation states to pass `requires_new: true` into the transaction method to create a properly behaving nested transaction (Rails will use savepoints to implement the behavior), but we can't currently pass this option into the `with_lock` call. This aims to rectify this gap.

If this is a fix that makes sense to the powers that be, I can help write regression tests and documentation as well. As a start, however, I am simply editing this one file in GitHub to gather initial feedback.
