### PR TITLE
Make ActiveRecord::QueryLogs default behavior to return the context content

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -174,7 +174,7 @@ module ActiveRecord
             key, value_input = tag
 
             val = case value_input
-                  when nil then tag_value(key) if taggings.has_key? key
+                  when nil then tag_value(key)
                   when Proc then instance_exec(&value_input)
                   else value_input
             end
@@ -184,12 +184,14 @@ module ActiveRecord
         end
 
         def tag_value(key)
-          value = taggings[key]
-
-          if value.respond_to?(:call)
-            instance_exec(&taggings[key])
+          if value = taggings[key]
+            if value.respond_to?(:call)
+              instance_exec(&taggings[key])
+            else
+              value
+            end
           else
-            value
+            context[key]
           end
         end
 

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -137,6 +137,18 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord::QueryLogs.update_context(application_name: nil)
   end
 
+  def test_default_tag_behavior
+    ActiveRecord::QueryLogs.tags = [:application, :foo]
+    ActiveRecord::QueryLogs.set_context(foo: "bar") do
+      assert_sql(%r{/\*application:active_record,foo:bar\*/}) do
+        Dashboard.first
+      end
+    end
+    assert_sql(%r{/\*application:active_record\*/}) do
+      Dashboard.first
+    end
+  end
+
   def test_inline_tags_only_affect_block
     # disable regular comment tags
     ActiveRecord::QueryLogs.tags = []


### PR DESCRIPTION
This should cover the vast majority of use cases, e.g.

```ruby
config.active_record.query_log_tags = [:api_client_id]

ActiveRecord::QueryLogs.set_context(api_client_id: api_client.id) do
  # ...
end
```

@keeran @kaspth @eileencodes 