### PR TITLE
Pass `ActiveRecord::QueryLogs` as argument rather than `instance_exec`

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -115,9 +115,9 @@ module ActionController
 
         ActiveSupport.on_load(:active_record) do
           ActiveRecord::QueryLogs.taggings.merge!(
-            controller:            -> { context[:controller].controller_name },
-            action:                -> { context[:controller].action_name },
-            namespaced_controller: -> { context[:controller].class.name }
+            controller:            ->(context) { context[:controller].controller_name },
+            action:                ->(context) { context[:controller].action_name },
+            namespaced_controller: ->(context) { context[:controller].class.name }
           )
         end
       end

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -70,7 +70,7 @@ module ActiveJob
         end
 
         ActiveSupport.on_load(:active_record) do
-          ActiveRecord::QueryLogs.taggings[:job] = -> { context[:job].class.name }
+          ActiveRecord::QueryLogs.taggings[:job] = ->(context) { context[:job].class.name }
         end
       end
     end

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -123,7 +123,7 @@ module ApplicationTests
     test "query cache is cleared between requests" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.cache_query_log_tags = true"
-      add_to_config "config.active_record.query_log_tags = [ { dynamic: -> { context[:controller].dynamic_content } } ]"
+      add_to_config "config.active_record.query_log_tags = [ { dynamic: ->(context) { context[:controller].dynamic_content } } ]"
 
       boot_app
 
@@ -141,7 +141,7 @@ module ApplicationTests
     test "query cache is cleared between job executions" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.cache_query_log_tags = true"
-      add_to_config "config.active_record.query_log_tags = [ { dynamic: -> { context[:job].dynamic_content } } ]"
+      add_to_config "config.active_record.query_log_tags = [ { dynamic: ->(context) { context[:job].dynamic_content } } ]"
 
       boot_app
 


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/pull/42240#discussion_r693902611

Otherwise we expose all the interal state of `QueryLogs` as an API.

It also makes the API more friendly to typing frameworks.

Another argument being that `instance_exec` isn't very fast. To be sure I did [a quick bench](https://gist.github.com/casperisfine/6bf9ae1af690d262c2515b8d7fa1458a), even with the extra arity check, we're marginally faster.

@keeran @kaspth 