### PR TITLE
Add require to failing multi_db test

### DIFF
--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -478,6 +478,7 @@ module ApplicationTests
       end
 
       test "db:schema:load:name sets the connection back to its original state" do
+        require "#{app_path}/config/environment"
         Dir.chdir(app_path) do
           dummy_task = <<~RUBY
             task foo: :environment do


### PR DESCRIPTION
This test was added this morning but started failing related to the removal of the classic autoloader (also from this morning 😅). This adds the require of environment.rb that similar tests here already had.

<img width="1101" alt="Screen Shot 2021-08-23 at 11 28 55 AM" src="https://user-images.githubusercontent.com/131752/130498610-457f5c6f-24dd-4595-9798-de3d564a8235.png">
