### PR TITLE
Upgrade azure-storage-blob to support ruby > 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ end
 group :storage do
   gem "aws-sdk-s3", require: false
   gem "google-cloud-storage", "~> 1.11", require: false
-  gem "azure-storage-blob", require: false
+  gem "azure-storage-blob", "~> 2.0", require: false
 
   gem "image_processing", "~> 1.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter (>= 1.3.0)
   aws-sdk-s3
   aws-sdk-sns
-  azure-storage-blob
+  azure-storage-blob (~> 2.0)
   backburner
   bcrypt (~> 3.1.11)
   benchmark-ips

--- a/activestorage/lib/active_storage/service/azure_storage_service.rb
+++ b/activestorage/lib/active_storage/service/azure_storage_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-gem "azure-storage-blob", ">= 1.1"
+gem "azure-storage-blob", ">= 2.0"
 
 require "active_support/core_ext/numeric/bytes"
 require "azure/storage/blob"


### PR DESCRIPTION
### Summary
azure-storage-blob 1.1.0 supports ruby 1.9.3 to 2.5:
https://github.com/Azure/azure-storage-ruby/blob/v1.1.0-blob/blob/README.md

azure-storage-blob 2.0.0 supports ruby 2.3 to 2.7:
https://github.com/Azure/azure-storage-ruby/blob/v2.0.0-blob/blob/README.md