### PR TITLE
Make preload_link_tag work with images

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `preload_link_tag` properly inserts `as` attributes for files with `image` MIME types, such as JPG or SVG.
+
+    *Nate Berkopec*
+
 *   Add `weekday_options_for_select` and `weekday_select` helper methods. Also adds `weekday_select` to `FormBuilder`.
 
     *Drew Bragg*, *Dana Kashubeck*, *Kasper Timm Hansen*

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -536,9 +536,7 @@ module ActionView
             "style"
           elsif extname == "vtt"
             "track"
-          elsif extname == "svg"
-            "image"
-          elsif (type = mime_type.to_s.split("/")[0]) && type.in?(%w(audio video font))
+          elsif (type = mime_type.to_s.split("/")[0]) && type.in?(%w(audio video font image))
             type
           end
         end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -255,7 +255,8 @@ class AssetTagHelperTest < ActionView::TestCase
     %(preload_link_tag '//example.com/font.woff2', crossorigin: 'use-credentials') => %(<link rel="preload" href="//example.com/font.woff2" as="font" type="font/woff2" crossorigin="use-credentials" />),
     %(preload_link_tag '/media/audio.ogg', nopush: true) => %(<link rel="preload" href="/media/audio.ogg" as="audio" type="audio/ogg" />),
     %(preload_link_tag '/style.css', integrity: 'sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs') => %(<link rel="preload" href="/style.css" as="style" type="text/css" integrity="sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs">),
-    %(preload_link_tag '/sprite.svg') => %(<link rel="preload" href="/sprite.svg" as="image" type="image/svg+xml">)
+    %(preload_link_tag '/sprite.svg') => %(<link rel="preload" href="/sprite.svg" as="image" type="image/svg+xml">),
+    %(preload_link_tag '/mb-icon.png') => %(<link rel="preload" href="/mb-icon.png" as="image" type="image/png">)
   }
 
   VideoPathToTag = {


### PR DESCRIPTION
Prior to this change, `preload_link_tag` with an image would generate a tag without an `as` attribute. If the `as` attribute doesn't get set, browsers tend to ignore the `link` tag (confirmed in Chrome), making the tag useless.

This change fixes the issue.

After a quick look at the [valid values for as](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload#what_types_of_content_can_be_preloaded) in a preload tag, I don't think there are any other ones missing that could be detected from the file's mime type or extension.