### PR TITLE
Support gem comments in Rails templates

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -104,5 +104,9 @@
 
     *Gannon McGibbon*
 
+*   Add support for comments above gem declaration in Rails application templates, e.g. `gem("nokogiri", comment: "For XML")`.
+
+    *Linas Juškevičius*
+
 
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -45,7 +45,7 @@ module Rails
 
         in_root do
           str = []
-          unless comment.nil?
+          if comment
             comment.each_line do |comment_line|
               str << indentation
               str << "# #{comment_line}"

--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -18,6 +18,7 @@ module Rails
       #   gem "technoweenie-restful-authentication", lib: "restful-authentication", source: "http://gems.github.com/"
       #   gem "rails", "3.0", git: "https://github.com/rails/rails"
       #   gem "RedCloth", ">= 4.1.0", "< 4.2.0"
+      #   gem "rspec", comment: "Put this comment above the gem declaration"
       def gem(*args)
         options = args.extract_options!
         name, *versions = args
@@ -25,6 +26,9 @@ module Rails
         # Set the message to be shown in logs. Uses the git repo if one is given,
         # otherwise use name (version).
         parts, message = [ quote(name) ], name.dup
+
+        # Output a comment above the gem declaration.
+        comment = options.delete(:comment)
 
         if versions = versions.any? ? versions : options.delete(:version)
           _versions = Array(versions)
@@ -40,9 +44,17 @@ module Rails
         parts << quote(options) unless options.empty?
 
         in_root do
-          str = "gem #{parts.join(", ")}"
-          str = indentation + str
-          append_file_with_newline "Gemfile", str, verbose: false
+          str = []
+          unless comment.nil?
+            comment.each_line do |comment_line|
+              str << indentation
+              str << "# #{comment_line}"
+            end
+            str << "\n"
+          end
+          str << indentation
+          str << "gem #{parts.join(", ")}"
+          append_file_with_newline "Gemfile", str.join, verbose: false
         end
       end
 

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -116,6 +116,22 @@ class ActionsTest < Rails::Generators::TestCase
     assert_file "Gemfile", /gem "rspec", github: "dchelimsky\/rspec", tag: "1\.2\.9\.rc1"/
   end
 
+  def test_gem_should_put_the_comment_before_gem_declaration
+    run_generator
+
+    action :gem, "rspec", comment: "Use RSpec"
+
+    assert_file "Gemfile", /# Use RSpec\ngem "rspec"/
+  end
+
+  def test_gem_should_support_multiline_comments
+    run_generator
+
+    action :gem, "rspec", comment: "Use RSpec\nReplaces minitest"
+
+    assert_file "Gemfile", /# Use RSpec\n# Replaces minitest\ngem "rspec"/
+  end
+
   def test_gem_with_non_string_options
     run_generator
 
@@ -154,6 +170,26 @@ class ActionsTest < Rails::Generators::TestCase
     end
 
     assert_file "Gemfile", /\n\ngroup :development, :test do\n  gem "rspec-rails"\nend\n\ngroup :test do\n  gem "fakeweb"\nend\n\z/
+  end
+
+  def test_gem_group_should_indent_comments
+    run_generator
+
+    action :gem_group, :test do
+      gem "fakeweb", comment: "Fake requests"
+    end
+
+    assert_file "Gemfile", /\n\ngroup :test do\n  # Fake requests\n  gem "fakeweb"\nend\n\z/
+  end
+
+  def test_gem_group_should_indent_multiline_comments
+    run_generator
+
+    action :gem_group, :test do
+      gem "fakeweb", comment: "Fake requests\nNeeded in tests"
+    end
+
+    assert_file "Gemfile", /\n\ngroup :test do\n  # Fake requests\n  # Needed in tests\n  gem "fakeweb"\nend\n\z/
   end
 
   def test_github_should_create_an_indented_block


### PR DESCRIPTION
### Summary

The default Rails template adds plenty of comments to gem declarations. Custom templates should have a way to do so, too.

This implements comment support, including multiline.