### PR TITLE
Temporarily disable Azure service tests

### DIFF
--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -27,6 +27,12 @@ rescue Errno::ENOENT
   puts "Missing service configuration file in test/service/configurations.yml"
   {}
 end
+# Azure service tests are currently failing on the main branch.
+# We temporarily disable them while we get things working again.
+if ENV["CI"]
+  SERVICE_CONFIGURATIONS.delete(:azure)
+  SERVICE_CONFIGURATIONS.delete(:azure_public)
+end
 
 require "tmpdir"
 


### PR DESCRIPTION
### Summary

The Azure service tests are currently failing on the main branch, probably because of
configuration. We can temporarily disable them while we get them working again.