### PR TITLE
Stop ignoring tmp/storage/.keep

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/gitignore.tt
+++ b/railties/lib/rails/generators/rails/app/templates/gitignore.tt
@@ -31,6 +31,9 @@
 /storage/*
 <% if keeps? -%>
 !/storage/.keep
+/tmp/storage/*
+!/tmp/storage/
+!/tmp/storage/.keep
 <% end -%>
 <% end -%>
 <% unless options.api? -%>


### PR DESCRIPTION
### Summary

Similar to a254922efabfc53ee4adacccb9b301a0832227ef

https://github.com/rails/rails/blob/915b9cdbb766c472db19396718d3a1d17ac36c94/railties/lib/rails/generators/rails/app/app_generator.rb#L231 generates tmp/storage/.keep file which is intended to be managed by git

### Other Information

n/a