### PR TITLE
[GUIDES] Fix ActiveJob custom serializer typo [ci-skip]

### DIFF
--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -451,7 +451,7 @@ end
 and add this serializer to the list:
 
 ```ruby
-# config/initializer/custom_serializers.rb
+# config/initializers/custom_serializers.rb
 Rails.application.config.active_job.custom_serializers << MoneySerializer
 ```
 

--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -128,7 +128,7 @@ This is key for classes and modules that are cached in places that survive reloa
 For example, Active Job serializers are stored inside Active Job:
 
 ```ruby
-# config/initializer/custom_serializers.rb
+# config/initializers/custom_serializers.rb
 Rails.application.config.active_job.custom_serializers << MoneySerializer
 ```
 
@@ -151,7 +151,7 @@ There, the module object stored in `MyDecoration` by the time the initializer ru
 Classes and modules from the autoload once paths can be autoloaded in `config/initializers`. So, with that configuration this works:
 
 ```ruby
-# config/initializer/custom_serializers.rb
+# config/initializers/custom_serializers.rb
 Rails.application.config.active_job.custom_serializers << MoneySerializer
 ```
 


### PR DESCRIPTION
### Summary
Correct `config/initializer/custom_serializers.rb` to
`config/initializers/custom_serializers.rb`.

### Other information
- Fix typo in guides/source/active_job_basics.md
- Fix 2 typos in guides/source/autoloading_and_reloading_constants.md