### PR TITLE
Refactor ActiveRecord::QueryLogs hook point

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -323,6 +323,9 @@ module ActiveRecord
   singleton_class.attr_accessor :verify_foreign_keys_for_fixtures
   self.verify_foreign_keys_for_fixtures = false
 
+  singleton_class.attr_accessor :query_transformers
+  self.query_transformers = []
+
   def self.eager_load!
     super
     ActiveRecord::Locking.eager_load!

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -741,6 +741,13 @@ module ActiveRecord
           end
         end
 
+        def transform_query(sql)
+          ActiveRecord.query_transformers.each do |transformer|
+            sql = transformer.call(sql)
+          end
+          sql
+        end
+
         def translate_exception(exception, message:, sql:, binds:)
           # override in derived class
           case exception

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -35,6 +35,7 @@ module ActiveRecord
         # Note: the PG::Result object is manually memory managed; if you don't
         # need it specifically, you may want consider the <tt>exec_query</tt> wrapper.
         def execute(sql, name = nil)
+          sql = transform_query(sql)
           check_if_write_query(sql)
 
           materialize_transactions

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -696,6 +696,7 @@ module ActiveRecord
         FEATURE_NOT_SUPPORTED = "0A000" # :nodoc:
 
         def execute_and_clear(sql, name, binds, prepare: false, async: false)
+          sql = transform_query(sql)
           check_if_write_query(sql)
 
           if !prepare || without_prepared_statement?(binds)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -19,6 +19,7 @@ module ActiveRecord
         end
 
         def execute(sql, name = nil) # :nodoc:
+          sql = transform_query(sql)
           check_if_write_query(sql)
 
           materialize_transactions
@@ -32,6 +33,7 @@ module ActiveRecord
         end
 
         def exec_query(sql, name = nil, binds = [], prepare: false, async: false) # :nodoc:
+          sql = transform_query(sql)
           check_if_write_query(sql)
 
           materialize_transactions
@@ -104,6 +106,7 @@ module ActiveRecord
           end
 
           def execute_batch(statements, name = nil)
+            statements = statements.map { |sql| transform_query(sql) }
             sql = combine_multi_statements(statements)
 
             check_if_write_query(sql)

--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -118,13 +118,14 @@ module ActiveRecord
         inline_tags.pop
       end
 
-      def add_query_log_tags_to_sql(sql) # :nodoc:
-        comments.each do |comment|
-          unless sql.include?(comment)
-            sql = prepend_comment ? "#{comment} #{sql}" : "#{sql} #{comment}"
-          end
+      def call(sql) # :nodoc:
+        parts = self.comments
+        if prepend_comment
+          parts << sql
+        else
+          parts.unshift(sql)
         end
-        sql
+        parts.join(" ")
       end
 
       private
@@ -197,16 +198,6 @@ module ActiveRecord
         def inline_tag_content
           inline_tags.join
         end
-    end
-
-    module ExecutionMethods
-      def execute(sql, *args, **kwargs)
-        super(ActiveRecord::QueryLogs.add_query_log_tags_to_sql(sql), *args, **kwargs)
-      end
-
-      def exec_query(sql, *args, **kwargs)
-        super(ActiveRecord::QueryLogs.add_query_log_tags_to_sql(sql), *args, **kwargs)
-      end
     end
   end
 end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -360,6 +360,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
     initializer "active_record.query_log_tags_config" do |app|
       config.after_initialize do
         if app.config.active_record.query_log_tags_enabled
+          ActiveRecord.query_transformers << ActiveRecord::QueryLogs
           ActiveRecord::QueryLogs.taggings.merge!(
             application:  Rails.application.class.name.split("::").first,
             pid:          -> { Process.pid },
@@ -374,12 +375,6 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
           if app.config.active_record.cache_query_log_tags
             ActiveRecord::QueryLogs.cache_query_log_tags = true
-          end
-
-          ActiveSupport.on_load(:active_record) do
-            ConnectionAdapters::AbstractAdapter.descendants.each do |klass|
-              klass.prepend(QueryLogs::ExecutionMethods) if klass.descendants.empty?
-            end
           end
         end
       end

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -18,7 +18,7 @@ module ApplicationTests
       app_file "app/controllers/users_controller.rb", <<-RUBY
         class UsersController < ApplicationController
           def index
-            render inline: ActiveRecord::QueryLogs.add_query_log_tags_to_sql("")
+            render inline: ActiveRecord::QueryLogs.call("")
           end
 
           def dynamic_content
@@ -30,7 +30,7 @@ module ApplicationTests
       app_file "app/jobs/user_job.rb", <<-RUBY
         class UserJob < ActiveJob::Base
           def perform
-            ActiveRecord::QueryLogs.add_query_log_tags_to_sql("")
+            ActiveRecord::QueryLogs.call("")
           end
 
           def dynamic_content
@@ -57,7 +57,7 @@ module ApplicationTests
     test "does not modify the query execution path by default" do
       boot_app
 
-      assert_equal ActiveRecord::Base.connection.method(:execute).owner, ActiveRecord::ConnectionAdapters::SQLite3::DatabaseStatements
+      assert_not_includes ActiveRecord.query_transformers, ActiveRecord::QueryLogs
     end
 
     test "prepends the query execution path when enabled" do
@@ -65,7 +65,7 @@ module ApplicationTests
 
       boot_app
 
-      assert_equal ActiveRecord::Base.connection.method(:execute).owner, ActiveRecord::QueryLogs::ExecutionMethods
+      assert_includes ActiveRecord.query_transformers, ActiveRecord::QueryLogs
     end
 
     test "controller and job tags are defined by default" do


### PR DESCRIPTION
Ref: #42240

Hooking into `execute` and `exec_query` is problematic because some adapters like MySQL2 have `exec_query` call `execute` which forces QueryLogs to first check wether the comment was already applied.

Using a prepended module is also a bit problematic because it means it has to be prepended to the "final" adapter classes
but if the user application has a custom adapter that inherits from a built-in one, the built-in one no longer have QueryLogs
working.

So instead this PR introduce `ActiveRecord.query_transformers`, and the adpters are responsible for applying to transformers only once.