### PR TITLE
Fix forceful creation of temporary tables

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix forceful creation of temporary tables
+
+    Before this fix, every attempt to forcefully create a temporary table was
+    issuing a non-temporary table drop with the same table name when using the mysql2 adapter.
+
+    Fixes #42525
+
+    *Lazarus Lazaridis*
+
 *   Accept optional transaction args to `ActiveRecord::Locking::Pessimistic#with_lock`
 
     `#with_lock` now accepts transaction options like `requires_new:`,

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -294,7 +294,8 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
-        td = create_table_definition(table_name, **extract_table_options!(options))
+        table_options = extract_table_options!(options)
+        td = create_table_definition(table_name, **table_options)
 
         if id && !td.as
           pk = primary_key || Base.get_primary_key(table_name.to_s.singularize)
@@ -314,7 +315,7 @@ module ActiveRecord
         yield td if block_given?
 
         if force
-          drop_table(table_name, force: force, if_exists: true)
+          drop_table(table_name, force: force, if_exists: true, temporary: table_options[:temporary])
         else
           schema_cache.clear_data_source_cache!(table_name.to_s)
         end


### PR DESCRIPTION
### Summary

As documented in #42525 in Rails 6.1.3.2, the following code:

```ruby
ActiveRecord::Base.connection.create_table(:foo, force: true, temporary: true) { |t| t.string :name }
```

is issuing a non-temporary table drop with the same name when using the mysql2 adapter:

```sql
DROP TABLE IF EXISTS `foo`
CREATE TEMPORARY TABLE `foo` (`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` varchar(255))
```

This PR fixes the issue by properly passing the `temporary` option (initially provided to the `create_table` call) to the `drop_table` call of the underlying adapter.

### Notes 

1. I've added a related test in `activerecord/test/cases/adapters/mysql2/active_schema_test.rb` but if you believe that there's a better place to host it let me know and I will proceed to the required changes.

2. In the test, I initially wrapped the table creation call in an AR transaction so that the following error would be raised without the fix
  ```ruby
  ActiveRecord::StatementInvalid:
    Mysql2::Error: SAVEPOINT active_record_1 does not exist
  ```
  but reading the rest of the specs, I decided that using the `assert_sql` to check the generated SQL statements would be a better fit. What do you think?

---

Fixes #42525
