### PR TITLE
Address `FixturesWithForeignKeyViolationsTest#test_does_not_raise_if_no_fk_violations` error

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
@@ -17,7 +17,7 @@ require "models/hotel"
 require "models/department"
 
 class HasManyThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
-  fixtures :posts, :authors, :comments, :pirates
+  fixtures :posts, :authors, :comments, :pirates, :author_addresses
 
   def setup
     @author = authors(:mary)

--- a/activerecord/test/cases/relation/and_test.rb
+++ b/activerecord/test/cases/relation/and_test.rb
@@ -5,7 +5,7 @@ require "models/author"
 
 module ActiveRecord
   class AndTest < ActiveRecord::TestCase
-    fixtures :authors
+    fixtures :authors, :author_addresses
 
     def test_and
       david, mary, bob = authors(:david, :mary, :bob)

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -10,7 +10,7 @@ require "models/categorization"
 
 module ActiveRecord
   class WhereChainTest < ActiveRecord::TestCase
-    fixtures :posts, :comments, :authors, :humans, :essays
+    fixtures :posts, :comments, :authors, :humans, :essays, :author_addresses
 
     def test_associated_with_association
       Post.where.associated(:author).tap do |relation|


### PR DESCRIPTION
### Summary

This pull request fixes the CI error at https://buildkite.com/rails/rails/builds/80548#e6a190c0-2ba5-41cf-8ebd-11ca6c4f6612

- This commit addresses the following error

```ruby
$ bin/test test/cases/relation/and_test.rb test/cases/fixtures_test.rb -n "/^(?:ActiveRecord::AndTest#(?:test_and)|FixturesWithForeignKeyViolationsTest#(?:test_does_not_raise_if_no_fk_violations))$/" --seed 1987
Using sqlite3
Run options: -n "/^(?:ActiveRecord::AndTest#(?:test_and)|FixturesWithForeignKeyViolationsTest#(?:test_does_not_raise_if_no_fk_violations))$/" --seed 1987

.E

Error:
FixturesWithForeignKeyViolationsTest#test_does_not_raise_if_no_fk_violations:
RuntimeError: Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations.
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:641:in `block in insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:629:in `each'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:629:in `insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:615:in `read_and_insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:567:in `create_fixtures'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:846:in `block (2 levels) in test_does_not_raise_if_no_fk_violations'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:34:in `assert_nothing_raised'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:845:in `block in test_does_not_raise_if_no_fk_violations'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:859:in `with_verify_foreign_keys_for_fixtures'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:844:in `test_does_not_raise_if_no_fk_violations'

bin/test test/cases/fixtures_test.rb:837

Finished in 0.022298s, 89.6940 runs/s, 44.8470 assertions/s.
2 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```
