### PR TITLE
Add #not_exists? method in ActiveRecord::FinderMethods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `ActiveRecord::FinderMethods#not_exists?`.
+
+    Convenient method that returns the opposite of `ActiveRecord::FinderMethods#exists?`.
+
+    ```ruby
+    !User.where(name: 'David').exists?
+    # same as
+    User.where(name: 'David').not_exists?
+    ```
+
+    *Guillaume Briday*
+
 *   Reestablish connection to previous database after after running `db:schema:load:name`
 
     After running `db:schema:load:name` the previous connection is restored.

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
-      :exists?, :any?, :many?, :none?, :one?,
+      :exists?, :not_exists?, :any?, :many?, :none?, :one?,
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,
       :create_or_find_by, :create_or_find_by!,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -346,6 +346,11 @@ module ActiveRecord
       skip_query_cache_if_necessary { connection.select_rows(relation.arel, "#{name} Exists?").size == 1 }
     end
 
+    # Same as #exists? but returns the opposite result.
+    def not_exists?(conditions = :none)
+      !exists?(conditions)
+    end
+
     # Returns true if the relation contains the given record or false otherwise.
     #
     # No query is performed if the relation is loaded; the given record is

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -185,6 +185,22 @@ class FinderTest < ActiveRecord::TestCase
     assert_raise(NoMethodError) { Topic.exists?([1, 2]) }
   end
 
+  def test_not_exists
+    assert_equal false, Topic.not_exists?(1)
+    assert_equal false, Topic.not_exists?("1")
+    assert_equal false, Topic.not_exists?(title: "The First Topic")
+    assert_equal false, Topic.not_exists?(heading: "The First Topic")
+    assert_equal false, Topic.not_exists?(author_name: "Mary", approved: true)
+    assert_equal false, Topic.not_exists?(["parent_id = ?", 1])
+    assert_equal false, Topic.not_exists?(id: [1, 9999])
+
+    assert_equal true, Topic.not_exists?(45)
+    assert_equal true, Topic.not_exists?(9999999999999999999999999999999)
+    assert_equal true, Topic.not_exists?(Topic.new.id)
+
+    assert_raise(NoMethodError) { Topic.not_exists?([1, 2]) }
+  end
+
   def test_exists_with_scope
     davids = Author.where(name: "David")
     assert_equal true, davids.exists?


### PR DESCRIPTION
### Summary

Adding a convenient method that it the opposite of `ActiveRecord::FinderMethods#exists?`.

```ruby
!User.where(name: 'David').exists?

# same as

User.where(name: 'David').not_exists?
```

### Other Information

I can add more tests if needed but I use the `exists?` method that is already very well tested so I don't find think it's necessary, what do you think?
