### PR TITLE
Fix crash in `ActionController::Instrumentation` with invalid HTTP formats

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
+++ b/actionpack/lib/action_dispatch/middleware/show_exceptions.rb
@@ -40,6 +40,7 @@ module ActionDispatch
         request.set_header "action_dispatch.exception", wrapper.unwrapped_exception
         request.set_header "action_dispatch.original_path", request.path_info
         request.set_header "action_dispatch.original_request_method", request.raw_request_method
+        fallback_to_html_format_if_invalid_mime_type(request)
         request.path_info = "/#{status}"
         request.request_method = "GET"
         response = @exceptions_app.call(request.env)
@@ -52,6 +53,15 @@ module ActionDispatch
           "If you are the administrator of this website, then please read this web " \
           "application's log file and/or the web server's log file to find out what " \
           "went wrong."]]
+      end
+
+      def fallback_to_html_format_if_invalid_mime_type(request)
+        # If the MIME type for the request is invalid then the
+        # @exceptions_app may not be able to handle it. To make it
+        # easier to handle, we switch to HTML.
+        request.formats
+      rescue ActionDispatch::Http::MimeNegotiation::InvalidType
+        request.set_header "HTTP_ACCEPT", "text/html"
       end
 
       def pass_response(status)

--- a/railties/test/application/middleware/exceptions_test.rb
+++ b/railties/test/application/middleware/exceptions_test.rb
@@ -65,6 +65,35 @@ module ApplicationTests
       assert_equal 405, last_response.status
     end
 
+    test "renders unknown http formats as 406 when routes are used as the custom exceptions app" do
+      controller :foo, <<-RUBY
+        class FooController < ActionController::Base
+          def index
+            render plain: "rendering index!"
+          end
+
+          def not_acceptable
+            render json: { error: "some error message" }, status: :not_acceptable
+          end
+        end
+      RUBY
+
+      app_file "config/routes.rb", <<-RUBY
+        Rails.application.routes.draw do
+          get "/foo", to: "foo#index"
+          match "/406", to: "foo#not_acceptable", via: :all
+        end
+      RUBY
+
+      add_to_config "config.exceptions_app = self.routes"
+      add_to_config "config.action_dispatch.show_exceptions = true"
+      add_to_config "config.consider_all_requests_local = false"
+
+      get "/foo", {}, { "HTTP_ACCEPT" => "invalid" }
+      assert_equal 406, last_response.status
+      assert_not_equal "rendering index!", last_response.body
+    end
+
     test "uses custom exceptions app" do
       add_to_config <<-RUBY
         config.exceptions_app = lambda do |env|


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/43094

