### PR TITLE
Avoid use of exceptions to detect invalid floats

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Improves the performance of ActionView::Helpers::NumberHelper formatters by avoiding the use of
+    exceptions as flow control.
+
+    *Mike Dalessio*
+
 *   `preload_link_tag` properly inserts `as` attributes for files with `image` MIME types, such as JPG or SVG.
 
     *Nate Berkopec*

--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -448,9 +448,8 @@ module ActionView
         end
 
         def parse_float(number, raise_error)
-          Float(number)
-        rescue ArgumentError, TypeError
-          raise InvalidNumberError, number if raise_error
+          result = Float(number, exception: false)
+          raise InvalidNumberError, number if result.nil? && raise_error
         end
     end
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Improves the performance of ActiveSupport::NumberHelper formatters by avoiding the use of
+    exceptions as flow control.
+
+    *Mike Dalessio*
+
 *   Removed rescue block from `ActiveSupport::Cache::RedisCacheStore#handle_exception`
 
     Previously, if you provided a `error_handler` to `redis_cache_store`, any errors thrown by

--- a/activesupport/lib/active_support/number_helper.rb
+++ b/activesupport/lib/active_support/number_helper.rb
@@ -99,8 +99,6 @@ module ActiveSupport
     #   number_to_currency(1234567890.506, locale: :fr)  # => "1 234 567 890,51 €"
     #   number_to_currency('123a456')                    # => "$123a456"
     #
-    #   number_to_currency("123a456", raise: true)       # => InvalidNumberError
-    #
     #   number_to_currency(-0.456789, precision: 0)
     #   # => "$0"
     #   number_to_currency(-1234567890.50, negative_format: '(%u%n)')

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -174,9 +174,7 @@ module ActiveSupport
         end
 
         def valid_float?
-          Float(number)
-        rescue ArgumentError, TypeError
-          false
+          Float(number, exception: false)
         end
     end
   end


### PR DESCRIPTION
### Summary

Improves the performance of ActiveSupport::NumberHelper and ActionView::Helpers::NumberHelper formatters by avoiding the use of exceptions as flow control.

### Other Information

Note that `Float(..., exception: false)` is only available as of Ruby 2.7.

### Benchmarks

I benchmarked this by calling `ActiveSupport::NumberHelper.number_to_rounded` with:

- a Float
- a valid number string
- an invalid number string

Here are the results:

```
Calculating -------------------------------------
           old float     13.865k (±22.7%) i/s -    123.120k in   9.884256s
Calculating -------------------------------------
           new float     13.700k (±24.1%) i/s -    119.756k in   9.890457s

Comparison:
           old float:    13865.4 i/s
           new float:    13700.1 i/s - same-ish: difference falls within error
```

```
Calculating -------------------------------------
           old valid     13.731k (±24.8%) i/s -    120.903k in   9.884648s
Calculating -------------------------------------
           new valid     13.801k (±24.0%) i/s -    121.491k in   9.894559s

Comparison:
           new valid:    13801.3 i/s
           old valid:    13731.4 i/s - same-ish: difference falls within error
```

```
Calculating -------------------------------------
         old invalid    204.829k (±20.9%) i/s -      1.437M in   9.384316s
Calculating -------------------------------------
         new invalid    624.895k (±20.5%) i/s -      4.312M in   8.345591s

Comparison:
         new invalid:   624895.1 i/s
         old invalid:   204829.2 i/s - 3.05x  (± 0.00) slower
```

The new signature is comparable or slightly faster for Floats and valid strings, and much wow faster on invalid strings.