### PR TITLE
Fix links inconsistency on Active Storage overview guide [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -586,9 +586,8 @@ require a higher level of protection consider implementing
 To generate a permanent URL for a blob, you can pass the blob to the
 [`url_for`][ActionView::RoutingUrlFor#url_for] view helper. This generates a
 URL with the blob's [`signed_id`][ActiveStorage::Blob#signed_id]
-that is routed to the blob's [`RedirectController`][ActiveStorage::Blobs::RedirectController]
+that is routed to the blob's [`RedirectController`][`ActiveStorage::Blobs::RedirectController`]
 
-[ActiveStorage::Blobs::RedirectController]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
 ```ruby
 url_for(user.avatar)
 # => /rails/active_storage/blobs/:signed_id/my-avatar.png

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -720,10 +720,10 @@ config.active_storage.draw_routes = false
 
 to prevent files being accessed with the publicly accessible URLs.
 
-[`ActiveStorage::Blobs::RedirectController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/redirect_controller.rb
-[`ActiveStorage::Blobs::ProxyController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
-[`ActiveStorage::Representations::RedirectController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/redirect_controller.rb
-[`ActiveStorage::Representations::ProxyController`]: https://github.com/rails/rails/blob/main/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+[`ActiveStorage::Blobs::RedirectController`]: https://api.rubyonrails.org/classes/ActiveStorage/Blobs/RedirectController.html
+[`ActiveStorage::Blobs::ProxyController`]: https://api.rubyonrails.org/classes/ActiveStorage/Blobs/ProxyController.html
+[`ActiveStorage::Representations::RedirectController`]: https://api.rubyonrails.org/classes/ActiveStorage/Representations/RedirectController.html
+[`ActiveStorage::Representations::ProxyController`]: https://api.rubyonrails.org/classes/ActiveStorage/Representations/ProxyController.html
 
 Downloading Files
 -----------------
@@ -1386,7 +1386,7 @@ Implementing Support for Other Cloud Services
 
 If you need to support a cloud service other than these, you will need to
 implement the Service. Each service extends
-[`ActiveStorage::Service`](https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/service.rb)
+[`ActiveStorage::Service`](https://api.rubyonrails.org/classes/ActiveStorage/Service.html)
 by implementing the methods necessary to upload and download files to the cloud.
 
 Purging Unattached Uploads


### PR DESCRIPTION
### Summary

- Keep RedirectController links consistent as discussed in https://github.com/rails/rails/pull/42703/files#r667270569
- Change links from github.com to api.rubyonrails.org

### Details

**Keep RedirectController links consistent**

There are two links defined to RedirectController, with backticks and
without them.

This commit removes the link without backticks for the sake of
consistency as discussed [here](https://github.com/rails/rails/pull/42703/files#r667270569).

**Change links from github.com to api.rubyonrails.org**

The guide's guidelines do not mention anything against linking to the Github
repo, but it describes [how to link][] to api.rubyonrails.org works.

So I guess that it's better to link "api.rubyonrails.org" when is possible,
for instance: classes, modules, and methods.

[how to link]: https://guides.rubyonrails.org/ruby_on_rails_guides_guidelines.html#linking-to-the-api