### PR TITLE
Document that @rails/ujs is deprecated

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -453,16 +453,6 @@ module ActionView
       # * <tt>:disabled</tt> - If true, the user will not be able to use this input.
       # * Any other key creates standard HTML options for the tag.
       #
-      # ==== Data attributes
-      #
-      # * <tt>confirm: 'question?'</tt> - If present the unobtrusive JavaScript
-      #   drivers will provide a prompt with the question specified. If the user accepts,
-      #   the form is processed normally, otherwise no action is taken.
-      # * <tt>:disable_with</tt> - Value of this parameter will be used as the value for a
-      #   disabled version of the submit button when the form is submitted. This feature is
-      #   provided by the unobtrusive JavaScript driver. To disable this feature for a single submit tag
-      #   pass <tt>:data => { disable_with: false }</tt> Defaults to value attribute.
-      #
       # ==== Examples
       #   submit_tag
       #   # => <input name="commit" data-disable-with="Save changes" type="submit" value="Save changes" />
@@ -473,14 +463,27 @@ module ActionView
       #   submit_tag "Save edits", disabled: true
       #   # => <input disabled="disabled" name="commit" data-disable-with="Save edits" type="submit" value="Save edits" />
       #
-      #   submit_tag "Complete sale", data: { disable_with: "Submitting..." }
-      #   # => <input name="commit" data-disable-with="Submitting..." type="submit" value="Complete sale" />
-      #
       #   submit_tag nil, class: "form_submit"
       #   # => <input class="form_submit" name="commit" type="submit" />
       #
       #   submit_tag "Edit", class: "edit_button"
       #   # => <input class="edit_button" data-disable-with="Edit" name="commit" type="submit" value="Edit" />
+      #
+      # ==== Deprecated: Rails UJS attributes
+      #
+      # Prior to Rails 7, Rails shipped with the JavaScript library called @rails/ujs on by default. Following Rails 7,
+      # this library is no longer on by default. This library integrated with the following options:
+      #
+      # * <tt>confirm: 'question?'</tt> - If present the unobtrusive JavaScript
+      #   drivers will provide a prompt with the question specified. If the user accepts,
+      #   the form is processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be used as the value for a
+      #   disabled version of the submit button when the form is submitted. This feature is
+      #   provided by the unobtrusive JavaScript driver. To disable this feature for a single submit tag
+      #   pass <tt>:data => { disable_with: false }</tt> Defaults to value attribute.
+      #
+      #   submit_tag "Complete sale", data: { disable_with: "Submitting..." }
+      #   # => <input name="commit" data-disable-with="Submitting..." type="submit" value="Complete sale" />
       #
       #   submit_tag "Save", data: { confirm: "Are you sure?" }
       #   # => <input name='commit' type='submit' value='Save' data-disable-with="Save" data-confirm="Are you sure?" />
@@ -506,17 +509,6 @@ module ActionView
       #   use this input.
       # * Any other key creates standard HTML options for the tag.
       #
-      # ==== Data attributes
-      #
-      # * <tt>confirm: 'question?'</tt> - If present, the
-      #   unobtrusive JavaScript drivers will provide a prompt with
-      #   the question specified. If the user accepts, the form is
-      #   processed normally, otherwise no action is taken.
-      # * <tt>:disable_with</tt> - Value of this parameter will be
-      #   used as the value for a disabled version of the submit
-      #   button when the form is submitted. This feature is provided
-      #   by the unobtrusive JavaScript driver.
-      #
       # ==== Examples
       #   button_tag
       #   # => <button name="button" type="submit">Button</button>
@@ -536,6 +528,20 @@ module ActionView
       #   # => <button name="button" type="button">
       #   #     <strong>Ask me!</strong>
       #   #    </button>
+      #
+      # ==== Deprecated: Rails UJS attributes
+      #
+      # Prior to Rails 7, Rails shipped with a JavaScript library called @rails/ujs on by default. Following Rails 7,
+      # this library is no longer on by default. This library integrated with the following options:
+      #
+      # * <tt>confirm: 'question?'</tt> - If present, the
+      #   unobtrusive JavaScript drivers will provide a prompt with
+      #   the question specified. If the user accepts, the form is
+      #   processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be
+      #   used as the value for a disabled version of the submit
+      #   button when the form is submitted. This feature is provided
+      #   by the unobtrusive JavaScript driver.
       #
       #   button_tag "Save", data: { confirm: "Are you sure?" }
       #   # => <button name="button" type="submit" data-confirm="Are you sure?">Save</button>

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -103,17 +103,8 @@ module ActionView
       #   completion of the Ajax request and performing JavaScript operations once
       #   they're complete
       #
-      # ==== Data attributes
-      #
-      # * <tt>confirm: 'question?'</tt> - This will allow the unobtrusive JavaScript
-      #   driver to prompt with the question specified (in this case, the
-      #   resulting text would be <tt>question?</tt>. If the user accepts, the
-      #   link is processed normally, otherwise no action is taken.
-      # * <tt>:disable_with</tt> - Value of this parameter will be used as the
-      #   name for a disabled version of the link. This feature is provided by
-      #   the unobtrusive JavaScript driver.
-      #
       # ==== Examples
+      #
       # Because it relies on +url_for+, +link_to+ supports both older-style controller/action/id arguments
       # and newer RESTful routes. Current Rails style favors RESTful routes whenever possible, so base
       # your application on resources and use
@@ -186,15 +177,27 @@ module ActionView
       #   link_to("Destroy", "http://www.example.com", method: :delete)
       #   # => <a href='http://www.example.com' rel="nofollow" data-method="delete">Destroy</a>
       #
-      # You can also use custom data attributes using the <tt>:data</tt> option:
-      #
-      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
-      #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
-      #
       # Also you can set any link attributes such as <tt>target</tt>, <tt>rel</tt>, <tt>type</tt>:
       #
       #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank", rel: "nofollow"
       #   # => <a href="http://www.rubyonrails.org/" target="_blank" rel="nofollow">External link</a>
+      #
+      # ==== Deprecated: Rails UJS attributes
+      #
+      # Prior to Rails 7, Rails shipped with a JavaScript library called @rails/ujs on by default. Following Rails 7,
+      # this library is no longer on by default. This library integrated with the following options:
+      #
+      # * <tt>confirm: 'question?'</tt> - This will allow the unobtrusive JavaScript
+      #   driver to prompt with the question specified (in this case, the
+      #   resulting text would be <tt>question?</tt>. If the user accepts, the
+      #   link is processed normally, otherwise no action is taken.
+      # * <tt>:disable_with</tt> - Value of this parameter will be used as the
+      #   name for a disabled version of the link. This feature is provided by
+      #   the unobtrusive JavaScript driver.
+      #
+      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
+      #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
+      #
       def link_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options, name = options, name, block if block_given?
         options ||= {}


### PR DESCRIPTION
Recommended replacements: Turbo + Stimulus. Will want to add some standard library stimulus controllers to replicate confirm/disable_with – or perhaps even add the latter to Turbo? Either way, rails/ujs was a grab bag of stuff, it doesn't work well with Turbo because there's overlap, and we shouldn't be recommending it going forward.

But this is a soft deprecation. Lots of apps have used this all over. Not going to nag them to remove it. It'll just fade into the sunset.