### PR TITLE
Add reference to console1984 in encryption docs

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -372,8 +372,7 @@ This makes for a more performant decryption since, instead of trying lists of ke
 
 ## Protected Console Accesses
 
-The gem [`console1984`](https://github.com/basecamp/console1984) lets you protect access to encrypted data during Rails console sessions. 
-
+Anyone with access to the Rails console can decrypt encrypted data. To protect access to encrypted data during Rails console sessions you can use the [`console1984`](https://github.com/basecamp/console1984) gem.
 ## API
 
 ### Basic API

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -370,6 +370,10 @@ config.active_record.encryption.store_key_references = true
 
 This makes for a more performant decryption since, instead of trying lists of keys, the system can now locate keys directly. The price to pay is storage: encrypted data will be a bit bigger in size.
 
+## Protected Console Accesses
+
+The gem [`console1984`](https://github.com/basecamp/console1984) lets you protect access to encrypted data during Rails console sessions. 
+
 ## API
 
 ### Basic API


### PR DESCRIPTION
Add a reference to [`console1984`](https://github.com/basecamp/console1984) in encryption docs.

I think the reference is relevant as protecting internal access to sensitive data is a big reason to use AR encryption in the first place.