### PR TITLE
Human-friendly output when inspecting ActiveModel with attributes

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Add better `#inspect` output for `ActiveModel::Model` classes and instances with
+    attributes.
+
+    *Ted Johansson*
+
 *   Fix dirty check for Float::NaN and BigDecimal::NaN.
 
     Float::NaN and BigDecimal::NaN in Ruby are [special values](https://bugs.ruby-lang.org/issues/1720) 

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -549,6 +549,28 @@ module ActiveModel
       end
     end
 
+    # Returns an <tt>#inspect</tt>-like string for the value of the
+    # attribute +attr_name+. String attributes are truncated up to 50
+    # characters. Other attributes return the value of <tt>#inspect</tt>
+    # without modification.
+    #
+    #   person = Person.new(name: 'David Heinemeier Hansson ' * 3)
+    #
+    #   person.attribute_for_inspect(:name)
+    #   # => "\"David Heinemeier Hansson David Heinemeier Hansson ...\""
+    #
+    #   person.attribute_for_inspect(:created_at)
+    #   # => "\"2012-10-22 00:15:07.000000000 +0000\""
+    #
+    #   person.attribute_for_inspect(:tag_ids)
+    #   # => "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]"
+    def attribute_for_inspect(attr_name)
+      attr_name = attr_name.to_s
+      attr_name = self.class.attribute_aliases[attr_name] || attr_name
+      value = _read_attribute(attr_name)
+      format_for_inspect(attr_name, value)
+    end
+
     private
       def attribute_method?(attr_name)
         respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)
@@ -567,6 +589,20 @@ module ActiveModel
 
       def _read_attribute(attr)
         __send__(attr)
+      end
+
+      def format_for_inspect(name, value)
+        if value.nil?
+          value.inspect
+        else
+          if value.is_a?(String) && value.length > 50
+            "#{value[0, 50]}...".inspect
+          elsif value.is_a?(Date) || value.is_a?(Time)
+            %("#{value.to_s(:inspect)}")
+          else
+            value.inspect
+          end
+        end
       end
 
       module AttrNames # :nodoc:

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/date/conversions"
+require "active_support/core_ext/date_time/conversions"
 require "concurrent/map"
 
 module ActiveModel

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -54,7 +54,7 @@ module ActiveModel
       #  Person.inspect
       #  # => Person(name: string, age: integer)
       def inspect
-        attr_types = self.attribute_types.map { |name, type| "#{name}: #{type.type || 'value'}" }
+        attr_types = attribute_types.map { |name, type| "#{name}: #{type.type || 'value'}" }
 
         "#{super}(#{attr_types.join(', ')})"
       end

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -42,6 +42,23 @@ module ActiveModel
         attribute_types.keys
       end
 
+      # Returns a string representation including attributes
+      #
+      #   class Person
+      #     include ActiveModel::Attributes
+      #
+      #     attribute :name, :string
+      #     attribute :age, :integer
+      #   end
+      #
+      #  Person.inspect
+      #  # => Person(name: string, age: integer)
+      def inspect
+        attr_types = self.attribute_types.map { |name, type| "#{name}: #{type.type || 'value'}" }
+
+        "#{super}(#{attr_types.join(', ')})"
+      end
+
       private
         def define_method_attribute=(name, owner:)
           ActiveModel::AttributeMethods::AttrNames.define_attribute_accessor_method(

--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -134,6 +134,26 @@ module ActiveModel
       @attributes.keys
     end
 
+    # Returns a string representation including attributes
+    #
+    #   class Person
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     attribute :age, :integer
+    #   end
+    #
+    #  person = Person.new(name: "David", age: 41)
+    #  person.inspect
+    #  # => #<Person name: "David", age: 41>
+    def inspect
+      inspection = attributes.map do |name, value|
+        "#{name}: #{format_for_inspect(name, value)}"
+      end.join(", ")
+
+      "#<#{self.class} #{inspection}>"
+    end
+
     def freeze
       @attributes = @attributes.clone.freeze unless frozen?
       super

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -14,6 +14,7 @@ module ActiveModel
       attribute :string_with_default, :string, default: "default string"
       attribute :date_field, :date, default: -> { Date.new(2016, 1, 1) }
       attribute :boolean_field, :boolean
+      attribute :value_field
     end
 
     class ChildModelForAttributesTest < ModelForAttributesTest
@@ -31,7 +32,8 @@ module ActiveModel
                "decimal_field: decimal, " \
                "string_with_default: string, " \
                "date_field: date, " \
-               "boolean_field: boolean" \
+               "boolean_field: boolean, " \
+               "value_field: value" \
                ")"
 
       assert_equal output, ModelForAttributesTest.inspect
@@ -66,7 +68,8 @@ module ActiveModel
         integer_field: 1.1,
         string_field: 1.1,
         decimal_field: 1.1,
-        boolean_field: 1.1
+        boolean_field: 1.1,
+        value_field: 1.1
       )
 
       expected_attributes = {
@@ -75,7 +78,8 @@ module ActiveModel
         decimal_field: BigDecimal("1.1"),
         string_with_default: "default string",
         date_field: Date.new(2016, 1, 1),
-        boolean_field: true
+        boolean_field: true,
+        value_field: 1.1
       }.stringify_keys
 
       assert_equal expected_attributes, data.attributes
@@ -88,7 +92,8 @@ module ActiveModel
         "decimal_field",
         "string_with_default",
         "date_field",
-        "boolean_field"
+        "boolean_field",
+        "value_field"
       ]
 
       assert_equal names, ModelForAttributesTest.attribute_names

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -24,6 +24,19 @@ module ActiveModel
       attribute :string_field, default: "default string"
     end
 
+    test "inspecting the class" do
+      output = "ActiveModel::AttributesTest::ModelForAttributesTest(" \
+               "integer_field: integer, " \
+               "string_field: string, " \
+               "decimal_field: decimal, " \
+               "string_with_default: string, " \
+               "date_field: date, " \
+               "boolean_field: boolean" \
+               ")"
+
+      assert_equal output, ModelForAttributesTest.inspect
+    end
+
     test "properties assignment" do
       data = ModelForAttributesTest.new(
         integer_field: "2.3",

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -39,6 +39,28 @@ module ActiveModel
       assert_equal output, ModelForAttributesTest.inspect
     end
 
+    test "inspecting an instance" do
+      instance = ModelForAttributesTest.new(
+        integer_field: 42,
+        string_field: "Rails FTW",
+        decimal_field: 12.3,
+        boolean_field: true,
+        value_field: "Yay"
+      )
+
+      output = "#<ActiveModel::AttributesTest::ModelForAttributesTest " \
+               "integer_field: 42, " \
+               'string_field: "Rails FTW", ' \
+               "decimal_field: 0.123e2, " \
+               'string_with_default: "default string", ' \
+               'date_field: "2016-01-01", ' \
+               "boolean_field: true, " \
+               'value_field: "Yay"' \
+               ">"
+
+      assert_equal output, instance.inspect
+    end
+
     test "properties assignment" do
       data = ModelForAttributesTest.new(
         integer_field: "2.3",


### PR DESCRIPTION
### Summary

**Background:**

We make liberal use of `ActiveModel` instances with the attributes API to model records originating outside our application. This works great, but the output when printing one of these records is really quite unusable. This PR implements human-readable output for classes' and instances' `#inspect` methods, mirroring that of "proper" ActiveRecord objects.

**Before:**

```ruby
#<ModelForAttributesTest:0x00007ffd77a8dc08
 @attributes=
  #<ActiveModel::AttributeSet:0x00007ffd77a8d988
   @attributes=
    {"integer_field"=>
      #<ActiveModel::Attribute::FromUser:0x00007ffd77a8d8e8
       @name="integer_field",
       @original_attribute=
        #<ActiveModel::Attribute::WithCastValue:0x00007ffd77a8db40
         @name="integer_field",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::Integer:0x00007ffd756be778 @limit=nil, @precision=nil, @range=-2147483648...2147483648, @scale=nil>,
         @value_before_type_cast=nil>,
       @type=#<ActiveModel::Type::Integer:0x00007ffd756be778 @limit=nil, @precision=nil, @range=-2147483648...2147483648, @scale=nil>,
       @value_before_type_cast=42>,
     "string_field"=>
      #<ActiveModel::Attribute::FromUser:0x00007ffd77a8d870
       @name="string_field",
       @original_attribute=
        #<ActiveModel::Attribute::WithCastValue:0x00007ffd77a8dac8
         @name="string_field",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::String:0x00007ffd756bc900 @false="f", @limit=nil, @precision=nil, @scale=nil, @true="t">,
         @value_before_type_cast=nil>,
       @type=#<ActiveModel::Type::String:0x00007ffd756bc900 @false="f", @limit=nil, @precision=nil, @scale=nil, @true="t">,
       @value_before_type_cast="Rails FTW">,
     "decimal_field"=>
      #<ActiveModel::Attribute::FromUser:0x00007ffd77a8d7d0
       @name="decimal_field",
       @original_attribute=
        #<ActiveModel::Attribute::WithCastValue:0x00007ffd77a8da78
         @name="decimal_field",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::Decimal:0x00007ffd76fa3040 @limit=nil, @precision=nil, @scale=nil>,
         @value_before_type_cast=nil>,
       @type=#<ActiveModel::Type::Decimal:0x00007ffd76fa3040 @limit=nil, @precision=nil, @scale=nil>,
       @value_before_type_cast=12.3>,
     "string_with_default"=>
      #<ActiveModel::Attribute::UserProvidedDefault:0x00007ffd77a8da50
       @name="string_with_default",
       @original_attribute=
        #<ActiveModel::Attribute::UserProvidedDefault:0x00007ffd76fa0ed0
         @name="string_with_default",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::String:0x00007ffd7882c1c0 @false="f", @limit=nil, @precision=nil, @scale=nil, @true="t">,
         @user_provided_value="default string",
         @value_before_type_cast="default string">,
       @type=#<ActiveModel::Type::String:0x00007ffd76fa1150 @false="f", @limit=nil, @precision=nil, @scale=nil, @true="t">,
       @user_provided_value="default string",
       @value_before_type_cast="default string">,
     "date_field"=>
      #<ActiveModel::Attribute::UserProvidedDefault:0x00007ffd77a8da28
       @name="date_field",
       @original_attribute=
        #<ActiveModel::Attribute::UserProvidedDefault:0x00007ffd76fabb00
         @name="date_field",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::Date:0x00007ffd6f50e640 @limit=nil, @precision=nil, @scale=nil>,
         @user_provided_value=#<Proc:0x00007ffd6f50f1f8 (irb):8 (lambda)>,
         @value_before_type_cast=#<Proc:0x00007ffd6f50f1f8 (irb):8 (lambda)>>,
       @type=#<ActiveModel::Type::Date:0x00007ffd76fabda8 @limit=nil, @precision=nil, @scale=nil>,
       @user_provided_value=#<Proc:0x00007ffd76fa0980 (irb):25 (lambda)>,
       @value_before_type_cast=#<Proc:0x00007ffd76fa0980 (irb):25 (lambda)>>,
     "boolean_field"=>
      #<ActiveModel::Attribute::FromUser:0x00007ffd77a8d730
       @name="boolean_field",
       @original_attribute=
        #<ActiveModel::Attribute::WithCastValue:0x00007ffd77a8da00
         @name="boolean_field",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::Boolean:0x00007ffd76faa6d8 @limit=nil, @precision=nil, @scale=nil>,
         @value_before_type_cast=nil>,
       @type=#<ActiveModel::Type::Boolean:0x00007ffd76faa6d8 @limit=nil, @precision=nil, @scale=nil>,
       @value_before_type_cast=true>,
     "value_field"=>
      #<ActiveModel::Attribute::FromUser:0x00007ffd77a8d618
       @name="value_field",
       @original_attribute=
        #<ActiveModel::Attribute::WithCastValue:0x00007ffd77a8d9b0
         @name="value_field",
         @original_attribute=nil,
         @type=#<ActiveModel::Type::Value:0x00007ffd76fa9c38 @limit=nil, @precision=nil, @scale=nil>,
         @value_before_type_cast=nil>,
       @type=#<ActiveModel::Type::Value:0x00007ffd76fa9c38 @limit=nil, @precision=nil, @scale=nil>,
       @value_before_type_cast="Yay">}>>
```

**After:**

```ruby
#<ModelForAttributesTest
 integer_field: 42,
 string_field: "Rails FTW",
 decimal_field: 0.123e2,
 string_with_default: "default string",
 date_field: "2016-01-01",
 boolean_field: true,
 value_field: "Yay">
```


### Other Information

**Limitations:**

This PR does not add attribute filtering. I originally intended to include that, but filter configuration lives in a very far away place in the inheritance chain, inside `ActiveRecord::Core`, and so requires either quite a bit of rejigging, or a separate filter configuration for `ActiveModel`.

_Note that this PR does not change anything about the output except the formatting. The existing implementation also does not filter any attributes._

For the same reason, there is no attempt to share the formatting functionality at the moment.

I am willing to work on this next with some direction.