### PR TITLE
Updated Arel::Predications, added case_sensitive

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add case_sensitive to Arel::Predications `does_not_match_any` and `does_not_match_all` methods
+
+    *Patrick van de Glind*
+
 *   Add config option for ignoring tables when dumping the schema cache.
 
     Applications can now be configured to ignore certain tables when dumping the schema cache.

--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -142,12 +142,12 @@ module Arel # :nodoc: all
       Nodes::NotRegexp.new self, quoted_node(other), case_sensitive
     end
 
-    def does_not_match_any(others, escape = nil)
-      grouping_any :does_not_match, others, escape
+    def does_not_match_any(others, escape = nil, case_sensitive = true)
+      grouping_any :does_not_match, others, escape, case_sensitive
     end
 
-    def does_not_match_all(others, escape = nil)
-      grouping_all :does_not_match, others, escape
+    def does_not_match_all(others, escape = nil, case_sensitive = true)
+      grouping_all :does_not_match, others, escape, case_sensitive
     end
 
     def gteq(right)


### PR DESCRIPTION
to does_not_match_any and does_not_match_all

### Summary

I had a need for Arel::Predications does_not_match_any and does_not_match_all functions today
and noticed those were the only matching method's that did not have the case_sensitive argument.

Added the argument and created a sample project to test the output, worked like a charm.

### Other Information

No other information, thank you for continuous improvement to Rails!
