### PR TITLE
Add SSL support for postgresql in `bin/rails dbconsole`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add SSL support for postgresql in `bin/rails dbconsole`.
+
+    Fixes #43114.
+
+    *Michael Bayucot*
+
 *   The setter `config.autoloader=` has been deleted. `zeitwerk` is the only
     available autoloading mode.
 

--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -44,10 +44,14 @@ module Rails
         find_cmd_and_exec(["mysql", "mysql5"], *args)
 
       when /^postgres|^postgis/
-        ENV["PGUSER"]     = config[:username] if config[:username]
-        ENV["PGHOST"]     = config[:host] if config[:host]
-        ENV["PGPORT"]     = config[:port].to_s if config[:port]
-        ENV["PGPASSWORD"] = config[:password].to_s if config[:password] && @options[:include_password]
+        ENV["PGUSER"]         = config[:username] if config[:username]
+        ENV["PGHOST"]         = config[:host] if config[:host]
+        ENV["PGPORT"]         = config[:port].to_s if config[:port]
+        ENV["PGPASSWORD"]     = config[:password].to_s if config[:password] && @options[:include_password]
+        ENV["PGSSLMODE"]      = config[:sslmode].to_s if config[:sslmode]
+        ENV["PGSSLCERT"]      = config[:sslcert].to_s if config[:sslcert]
+        ENV["PGSSLKEY"]       = config[:sslkey].to_s if config[:sslkey]
+        ENV["PGSSLROOTCERT"]  = config[:sslrootcert].to_s if config[:sslrootcert]
         find_cmd_and_exec("psql", db_config.database)
 
       when "sqlite3"

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -140,6 +140,16 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
     assert_not_equal "q1w2e3", ENV["PGPASSWORD"]
   end
 
+  def test_postgresql_with_ssl
+    start(adapter: "postgresql", database: "db", sslmode: "verify-full", sslcert: "client.crt", sslkey: "client.key", sslrootcert: "root.crt")
+    assert_not aborted
+    assert_equal ["psql", "db"], dbconsole.find_cmd_and_exec_args
+    assert_equal "verify-full", ENV["PGSSLMODE"]
+    assert_equal "client.crt", ENV["PGSSLCERT"]
+    assert_equal "client.key", ENV["PGSSLKEY"]
+    assert_equal "root.crt", ENV["PGSSLROOTCERT"]
+  end
+
   def test_postgresql_include_password
     start({ adapter: "postgresql", database: "db", username: "user", password: "q1w2e3" }, ["-p"])
     assert_not aborted


### PR DESCRIPTION
Summary

 Add `PGSSLMODE`, `PGSSLCERT`, `PGSSLKEY` and `PGSSLROOTCERT` to ENV from database config
    when running `bin/rails dbconsole` with postgresql.

    ```yaml
    # config/database.yml

    production:
      sslmode: verify-full
      sslcert: client.crt
      sslkey: client.key
      sslrootcert: ca.crt
    ```

    Environment variables

    ```
    PGSSLMODE=verify-full
    PGSSLCERT=client.crt
    PGSSLKEY=client.key
    PGSSLROOTCERT=ca.crt
    ```

Fixes #43114