### PR TITLE
Improve casing in encryption guide headings [ci-skip]

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -17,7 +17,7 @@ After reading this guide you will know:
 
 Active Record supports application-level encryption. It works by declaring which attributes should be encrypted and seamlessly encrypting and decrypting them when necessary. The encryption layer is placed between the database and the application. The application will access unencrypted data but the database will store it encrypted.
 
-## Basic usage
+## Basic Usage
 
 ### Setup
 
@@ -35,7 +35,7 @@ active_record_encryption:
 
 NOTE: These generated keys and salt are 32 bytes length. If you generate these yourself, the minimum lengths you should use are 12 bytes for the primary key (this will be used to derive the AES 32 bytes key) and 20 bytes for the salt.
 
-### Declaration of encrypted attributes
+### Declaration of Encrypted Attributes
 
 Encryptable attributes are defined at the model level. These are regular Active Record attributes backed by a column with the same name.
 
@@ -62,7 +62,7 @@ Encryption takes additional space in the column. You can estimate the worst-case
 
 NOTE: The reason for the additional space are Base 64 encoding and additional metadata stored with the encrypted values.
 
-### Deterministic and non-deterministic encryption
+### Deterministic and Non-deterministic Encryption
 
 By default, Active Record Encryption uses a non-deterministic approach to encryption. This means that encrypting the same content with the same password twice will result in different ciphertexts. This is good for security, since it makes crypto-analysis of encrypted content much harder, but it makes querying the database impossible.
 
@@ -106,11 +106,11 @@ config.active_record.encryption.encrypt_fixtures = true
 
 When enabled, all the encryptable attributes will be encrypted according to the encryption settings defined in the model.
 
-#### Action text fixtures
+#### Action Text Fixtures
 
 To encrypt action text fixtures you should place them in `fixtures/action_text/encrypted_rich_texts.yml`.
 
-### Supported types
+### Supported Types
 
 `active_record.encryption` will serialize values using the underlying type before encrypting them, but *they must be serializable as strings*. Structured types like `serialized` are supported out of the box.
 
@@ -130,7 +130,7 @@ class Article < ApplicationRecord
 end
 ```
 
-### Ignoring case
+### Ignoring Case
 
 You might need to ignore case when querying deterministically encrypted data. There are two options that can help you here.
 
@@ -150,7 +150,7 @@ class Label
 end
 ```
 
-### Support for unencrypted data
+### Support for Unencrypted Data
 
 To ease migrations of unencrypted data, the library includes the option `config.active_record.encryption.support_unencrypted_data`. When set to `true`:
 
@@ -159,7 +159,7 @@ To ease migrations of unencrypted data, the library includes the option `config.
 
 **This options is meant to be used in transition periods** while clear data and encrypted data need to coexist. Their value is `false` by default, which is the recommended goal for any application: errors will be raised when working with unencrypted data.
 
-### Support for previous encryption schemes
+### Support for Previous Encryption Schemes
 
 Changing encryption properties of attributes can break existing data. For example, imagine you want to make a "deterministic" attribute "not deterministic". If you just change the declaration in the model, reading existing ciphertexts will fail because they are different now.
 
@@ -173,7 +173,7 @@ You can configure previous encryption schemes:
 * Globally
 * On a per-attribute basis
 
-#### Global previous encryption schemes
+#### Global Previous Encryption Schemes
 
 You can add previous encryption schemes by adding them as list of properties using the `previous` config property in your `application.rb`:
 
@@ -181,7 +181,7 @@ You can add previous encryption schemes by adding them as list of properties usi
 config.active_record.encryption.previous = [ { key_provider: MyOldKeyProvider.new } ]
 ```
 
-#### Per-attribute encryption schemes
+#### Per-attribute Encryption Schemes
 
 Use `:previous` when declaring the attribute:
 
@@ -191,7 +191,7 @@ class Article
 end
 ```
 
-#### Encryption schemes and deterministic attributes
+#### Encryption Schemes and Deterministic Attributes
 
 When adding previous encryption schemes:
 
@@ -200,11 +200,11 @@ When adding previous encryption schemes:
 
 The reason is that, with deterministic encryption, you normally want ciphertexts to remain constant. You can change this behavior by setting `deterministic: { fixed: false }`. In that case, it will use the *newest* encryption scheme for encrypting new data.
 
-### Unique constraints
+### Unique Constraints
 
 NOTE: Unique constraints can only be used with data encrypted deterministically.
 
-#### Unique validations
+#### Unique Validations
 
 Unique validations are supported normally as long as extended queries are enabled (`config.active_record.encryption.extend_queries = true`).
 
@@ -219,7 +219,7 @@ They will also work when combining encrypted and unencrypted data, and when conf
 
 NOTE: If you want to ignore case make sure to use `downcase:` or `ignore_case:` in the `encrypts` declaration. Using the `case_sensitive:` option in the validation won't work.
 
-#### Unique indexes
+#### Unique Indexes
 
 To support unique indexes on deterministically-encrypted columns, you need to make sure their ciphertext doesn't ever change.
 
@@ -231,7 +231,7 @@ class Person
 end
 ```
 
-### Filtering params named as encrypted columns
+### Filtering Params Named as Encrypted Columns
 
 By default, encrypted columns are configured to be [automatically filtered in Rails logs](https://guides.rubyonrails.org/action_controller_overview.html#parameters-filtering). You can disable this behavior by adding this to your `application.rb`:
 
@@ -258,11 +258,11 @@ And you can disable this behavior and preserve the encoding in all cases with:
 config.active_record.encryption.forced_encoding_for_deterministic_encryption = nil
 ```
 
-## Key management
+## Key Management
 
 Key management strategies are implemented by key providers. You can configure key providers globally or on a per-attribute basis.
 
-### Built-in key providers
+### Built-in Key Providers
 
 #### DerivedSecretKeyProvider
 
@@ -289,7 +289,7 @@ config.active_record.encryption.key_provider = ActiveRecord::Encryption::Envelop
 
 As with other built-in key providers, you can provide a list of primary keys in `active_record.encryption.primary_key`, to implement key-rotation schemes.
 
-### Custom key providers
+### Custom Key Providers
 
 For more advanced key-management schemes, you can configure a custom key provider in an initializer:
 
@@ -316,7 +316,7 @@ Both methods return `ActiveRecord::Encryption::Key` objects:
 
 A key can include arbitrary tags that will be stored unencrypted with the message. You can use `ActiveRecord::Encryption::Message#headers` to examine those values when decrypting.
 
-### Model-specific key providers
+### Model-specific Key Providers
 
 You can configure a key provider on a per-class basis with the `:key_provider` option:
 
@@ -326,7 +326,7 @@ class Article < ApplicationRecord
 end
 ```
 
-### Model-specific keys
+### Model-specific Keys
 
 You can configure a given key on a per-class basis with the `:key` option:
 
@@ -338,7 +338,7 @@ end
 
 The key will be used internally to derive the key used to encrypt and decrypt the data.
 
-### Rotating keys
+### Rotating Keys
 
 `active_record.encryption` can work with lists of keys to support implementing key-rotation schemes:
 
@@ -360,7 +360,7 @@ NOTE: Rotating keys is not currently supported for deterministic encryption.
 
 NOTE: Active Record Encryption doesn't provide automatic management of key rotation processes yet. All the pieces are there, but this hasn't been implemented yet.
 
-### Storing key references
+### Storing Key References
 
 There is a setting `active_record.encryption.store_key_references` you can use to make `active_record.encryption` store a reference to the encryption key in the encrypted message itself.
 
@@ -376,20 +376,20 @@ This makes for a more performant decryption since, instead of trying lists of ke
 
 ActiveRecord encryption is meant to be used declaratively, but it presents an API for advanced usage scenarios.
 
-#### Encrypt and decrypt
+#### Encrypt and Decrypt
 
 ```ruby
 article.encrypt # encrypt or re-encrypt all the encryptable attributes
 article.decrypt # decrypt all the encryptable attributes
 ```
 
-#### Read ciphertext
+#### Read Ciphertext
 
 ```ruby
 article.ciphertext_for(:title)
 ```
 
-#### Check if attribute is encrypted or not
+#### Check if Attribute is Encrypted or Not
 
 ```ruby
 article.encrypted_attribute?(:title)
@@ -397,7 +397,7 @@ article.encrypted_attribute?(:title)
 
 ## Configuration
 
-### Configuration options
+### Configuration Options
 
 You can configure Active Record Encryption options by setting them in your `application.rb` (most common scenario) or in a specific environment config file `config/environments/<env name>.rb` if you want to set them on a per-environment basis.
 
@@ -426,7 +426,7 @@ The available config options are:
 
 NOTE: It's recommended to use Rails built-in credentials support to store keys. If you prefer to set them manually via config properties, make sure you don't commit them with your code (e.g: use environment variables).
 
-### Encryption contexts
+### Encryption Contexts
 
 An encryption context defines the encryption components that are used in a given moment. There is a default encryption context based on your global configuration, but you can configure a custom context for a given attribute or when running a specific block of code.
 
@@ -441,7 +441,7 @@ The main components of encryption contexts are:
 
 NOTE: If you decide to build your own `message_serializer`, It's important to use safe mechanisms that can't deserialize arbitrary objects. A common supported scenario is encrypting existing unencrypted data. An attacker can leverage this to enter a tampered payload before encryption takes place and perform RCE attacks. This means custom serializers should avoid `Marshal`, `YAML.load` (use `YAML.safe_load`  instead) or `JSON.load` (use `JSON.parse` instead).
 
-#### Global encryption context
+#### Global Encryption Context
 
 The global encryption context is the one used by default and is configured as other configuration properties in your `application.rb` or environment config files.
 
@@ -450,7 +450,7 @@ config.active_record.encryption.key_provider = ActiveRecord::Encryption::Envelop
 config.active_record_encryption.encryptor = MyEncryptor.new
 ```
 
-#### Per-attribute encryption contexts
+#### Per-attribute Encryption Contexts
 
 You can override encryption context params by passing them in the attribute declaration:
 
@@ -460,7 +460,7 @@ class Attribute
 end
 ```
 
-#### Encryption context when running a block of code
+#### Encryption Context When Running a Block of Code
 
 You can use `ActiveRecord::Encryption.with_encryption_context` to set an encryption context for a given block of code:
 
@@ -470,9 +470,9 @@ ActiveRecord::Encryption.with_encryption_context(encryptor: ActiveRecord::Encryp
 end
 ```
 
-#### Built-in encryption contexts
+#### Built-in Encryption Contexts
 
-##### Disable encryption
+##### Disable Encryption
 
 You can run code without encryption:
 
@@ -483,7 +483,7 @@ end
 ```
 This means that reading encrypted text will return the ciphertext and saved content will be stored unencrypted.
 
-##### Protect encrypted data
+##### Protect Encrypted Data
 
 You can run code without encryption but preventing overwriting encrypted content:
 


### PR DESCRIPTION
### Summary

Update the guide to use the casing as defined in the contribution guide.
https://guides.rubyonrails.org/ruby_on_rails_guides_guidelines.html#headings