### PR TITLE
Remove some Node/Yarn mentions from guides [ci-skip]

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -45,7 +45,7 @@ happens after every keystroke, and avoids the need to use execCommand at all.
 
 ## Installation
 
-Run `bin/rails action_text:install` to add the Yarn package and copy over the necessary migration. Also, you need to set up Active Storage for embedded images and other attachments. Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
+Run `bin/rails action_text:install` to add the JavaScript package and copy over the necessary migration. Also, you need to set up Active Storage for embedded images and other attachments. Please refer to the [Active Storage Overview](active_storage_overview.html) guide.
 
 NOTE: ActionText uses polymorphic relationships with the `action_text_rich_texts` table so that it can be shared with all models that have rich text attributes. If your models with ActionText content use UUID values for identifiers, all models that use ActionText attributes will need to use UUID values for their unique identifiers. The generated migration for ActionText will also need to be updated to specify `type: :uuid` for the `:record` `references` line.
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -83,8 +83,6 @@ proper prerequisites installed. These include:
 
 * Ruby
 * SQLite3
-* Node.js
-* Yarn
 
 #### Installing Ruby
 
@@ -120,31 +118,6 @@ $ sqlite3 --version
 ```
 
 The program should report its version.
-
-#### Installing Node.js and Yarn
-
-Finally, you'll need Node.js and Yarn installed to manage your application's JavaScript.
-
-Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and
-verify it's installed correctly with the following command:
-
-```bash
-$ node --version
-```
-
-The version of your Node.js runtime should be printed out. Make sure it's greater
-than 8.16.0.
-
-To install Yarn, follow the installation
-instructions at the [Yarn website](https://classic.yarnpkg.com/en/docs/install).
-
-Running this command should print out Yarn version:
-
-```bash
-$ yarn --version
-```
-
-If it says something like "1.22.0", Yarn has been installed correctly.
 
 #### Installing Rails
 
@@ -234,14 +207,6 @@ $ bin/rails server
 
 TIP: If you are using Windows, you have to pass the scripts under the `bin`
 folder directly to the Ruby interpreter e.g. `ruby bin\rails server`.
-
-TIP: JavaScript asset compression requires you
-have a JavaScript runtime available on your system, in the absence
-of a runtime you will see an `execjs` error during asset compression.
-Usually macOS and Windows come with a JavaScript runtime installed.
-`therubyrhino` is the recommended runtime for JRuby users and is added by
-default to the `Gemfile` in apps generated under JRuby. You can investigate
-all the supported runtimes at [ExecJS](https://github.com/rails/execjs#readme).
 
 This will start up Puma, a web server distributed with Rails by default. To see
 your application in action, open a browser window and navigate to

--- a/guides/source/webpacker.md
+++ b/guides/source/webpacker.md
@@ -47,11 +47,48 @@ If you are familiar with Sprockets, the following guide might give you some idea
 Installing Webpacker
 --------------------
 
-To use Webpacker, you must install the Yarn package manager, version 1.x or up, and you must have Node.js installed, version 10.13.0 and up.
+To use Webpacker, you must have Node.js and the Yarn package manager installed.
 
 NOTE: Webpacker depends on NPM and Yarn. NPM, the Node package manager registry, is the primary repository for publishing and downloading open-source JavaScript projects, both for Node.js and browser runtimes. It is analogous to rubygems.org for Ruby gems. Yarn is a command-line utility that enables the installation and management of JavaScript dependencies, much like Bundler does for Ruby.
 
-To include Webpacker in a new project, add `--webpack` to the `rails new` command. To add Webpacker to an existing project, add the `webpacker` gem to the project's `Gemfile`, run `bundle install`, and then run `bin/rails webpacker:install`.
+### Installing Node.js
+
+Find the Node.js installation instructions at the [Node.js website](https://nodejs.org/en/download/) and
+verify it's installed correctly with the following command:
+
+```bash
+$ node --version
+```
+
+The version of your Node.js runtime should be printed out. Make sure it's greater
+than 8.16.0.
+
+### Installing Yarn
+
+To install Yarn, follow the installation
+instructions at the [Yarn website](https://classic.yarnpkg.com/en/docs/install).
+
+Running the following command should print out the Yarn version:
+
+```bash
+$ yarn --version
+```
+
+If it says something like "1.22.0", Yarn has been installed correctly.
+
+### Installing Webpacker
+
+To include Webpacker in a new project, add `--webpack` to the `rails new` command:
+
+```bash
+$ rails new --webpack
+```
+
+To add Webpacker to an existing project, add the `webpacker` gem to the project's `Gemfile`, run `bundle install`, and then run:
+
+```bash
+$ bin/rails webpacker:install
+```
 
 Installing Webpacker creates the following local files:
 


### PR DESCRIPTION
### Summary

The Getting Started guide currently mentions installing Node and Yarn,
but these are no longer required dependencies for getting started.

The ActionText install instructions also mentions "Yarn package", which
isn't used anymore by default. Instead we can use a more generic
"Javascript package".

The Javascript asset compression tip, seems outdated as well.

### Other Information

The development_dependencies_install guides still mention Yarn but I'm
not sure those can be deleted yet.