### PR TITLE
Reset `has_one` association when the related `belongs_to` association is set

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Reset `has_one` association when the related `belongs_to` association is set.
+
+    When setting a `belongs_to` association the inverse `has_one` association is reset.
+
+    Example:
+
+    ```ruby
+    jimmy = Author.create(name: "Jimmy Tolkien")
+    david = Author.create(name: "DHH")
+    post = jimmy.create_post(title: "The silly medallion", body: "")
+    jimmy.post.update!(author: david)
+    assert_nil jimmy.post
+    ```
+
+    *Jacopo Beschi*
+
 * Add ssl support for postgresql database tasks
 
     Add `PGSSLMODE`, `PGSSLCERT`, `PGSSLKEY` and `PGSSLROOTCERT` to pg_env from database config

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -84,6 +84,7 @@ module ActiveRecord
         def replace(record)
           if record
             raise_on_type_mismatch!(record)
+            reset_inverse_instance(target)
             set_inverse_instance(record)
             @updated = true
           elsif target
@@ -93,6 +94,12 @@ module ActiveRecord
           replace_keys(record, force: true)
 
           self.target = record
+        end
+
+        def reset_inverse_instance(target)
+          if target
+            inverse_association_for(target)&.reset
+          end
         end
 
         def update_counters(by)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -1235,6 +1235,18 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_nil author.post
   end
 
+  def test_changing_an_association_resets_the_stale_inverse_has_one
+    jimmy = Author.create(name: "Jimmy Tolkien")
+    david = Author.create(name: "DHH")
+    post = jimmy.create_post(title: "The silly medallion", body: "")
+    assert_equal post, jimmy.post
+    assert_nil david.post
+
+    jimmy.post.update!(author: david)
+    assert_nil jimmy.post
+    assert_equal post, david.post
+  end
+
   def test_destroying_child_with_unloaded_parent_and_foreign_key_and_touch_is_possible_with_has_many_inversing
     with_has_many_inversing do
       book     = Book.create!


### PR DESCRIPTION
### Summary

When setting a `belongs_to` association the inverse `has_one` association is reset.

Example:

```ruby
jimmy = Author.create(name: "Jimmy Tolkien")
david = Author.create(name: "DHH")
post = jimmy.create_post(title: "The silly medallion", body: "")
jimmy.post.update!(author: david)
assert_nil jimmy.post
```

Fixes #43096

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
