### PR TITLE
Fix weak links on guides [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -850,11 +850,14 @@ location.
 <%= image_tag user.avatar.variant(resize_to_limit: [100, 100]) %>
 ```
 
-If a variant is requested, Active Storage will automatically apply 
+If a variant is requested, Active Storage will automatically apply
 transformations depending on the image's format:
 
-1. Content types that are [`variable`] and not considered [`web images`], will be converted to PNG.
-2. If `quality` is not specified, the variant processor's default quality for the format will be used.  
+1. Content types that are variable (as dictated by `config.active_storage.variable_content_types`)
+  and not considered web images (as dictated by `config.active_storage.web_image_content_types`),
+  will be converted to PNG.
+
+2. If `quality` is not specified, the variant processor's default quality for the format will be used.
 
 The default processor for Active Storage is MiniMagick, but you can also use
 [Vips][]. To switch to Vips, add the following to `config/application.rb`:
@@ -876,8 +879,6 @@ specific:
 ```
 
 [`variant`]: https://api.rubyonrails.org/classes/ActiveStorage/Blob/Representable.html#method-i-variant
-[`web images`]: https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/engine.rb#L47
-[`variable`]: https://github.com/rails/rails/blob/main/activestorage/lib/active_storage/engine.rb#L34
 [Vips]: https://www.rubydoc.info/gems/ruby-vips/Vips/Image
 
 ### Previewing Files

--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -271,9 +271,10 @@ Advanced Usage
 --------------
 
 The application template is evaluated in the context of a
-`Rails::Generators::AppGenerator` instance. It uses the `apply` action
-provided by
-[Thor](https://github.com/erikhuda/thor/blob/master/lib/thor/actions.rb#L207).
+`Rails::Generators::AppGenerator` instance. It uses the
+[`apply`](https://rdoc.info/github/wycats/thor/Thor/Actions#apply-instance_method)
+action provided by Thor.
+
 This means you can extend and change the instance to match your needs.
 
 For example by overwriting the `source_paths` method to contain the


### PR DESCRIPTION
### Summary

Fix weak links on guides:

- Link to RDOC instead of Github file lines
- Replace weak links with configuration names