### PR TITLE
Synchronize System Test and Template text

### DIFF
--- a/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
+++ b/railties/lib/rails/generators/test_unit/scaffold/templates/system_test.rb.tt
@@ -8,12 +8,12 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit <%= plural_table_name %>_url
-    assert_selector "h1", text: "<%= class_name.pluralize.titleize %>"
+    assert_selector "h1", text: "<%= human_name %>"
   end
 
   test "should create <%= human_name %>" do
     visit <%= plural_table_name %>_url
-    click_on "New <%= class_name.titleize %>"
+    click_on "New <%= human_name.downcase %>"
 
     <%- attributes_hash.each do |attr, value| -%>
     <%- if boolean?(attr) -%>
@@ -30,7 +30,8 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
 
   test "should update <%= human_name %>" do
     visit <%= plural_table_name %>_url
-    click_on "Edit", match: :first
+    click_on "Show this <%= human_name.downcase %>", match: :first
+    click_on "Edit this <%= human_name.downcase %>"
 
     <%- attributes_hash.each do |attr, value| -%>
     <%- if boolean?(attr) -%>
@@ -47,9 +48,8 @@ class <%= class_name.pluralize %>Test < ApplicationSystemTestCase
 
   test "should destroy <%= human_name %>" do
     visit <%= plural_table_name %>_url
-    page.accept_confirm do
-      click_on "Destroy", match: :first
-    end
+    click_on "Show this <%= human_name.downcase %>", match: :first
+    click_on "Destroy this <%= human_name.downcase %>"
 
     assert_text "<%= human_name %> was successfully destroyed"
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -179,6 +179,10 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "test/system/product_lines_test.rb" do |content|
       assert_match(/class ProductLinesTest < ApplicationSystemTestCase/, content)
       assert_match(/test "visiting the index"/, content)
+      assert_match(/assert_selector "h1", text: "Product line"/, content)
+      assert_match(/click_on "Show this product line"/, content)
+      assert_match(/click_on "Edit this product line"/, content)
+      assert_match(/click_on "Destroy this product line"/, content)
       assert_no_match(/fill_in/, content)
     end
   end


### PR DESCRIPTION
### Summary

Changes System Test generators to match [index][], [show][], and
[partial][] template text.

Due to the deprecation of UJS, remove the generated `accept_confirm`
call. The out of the box behavior no longer prompts end-users for
confirmation.

[index]: https://github.com/rails/rails/blob/ce546c7d3a867dce11e7b99624160a7388bee1f5/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt#L3
[show]: https://github.com/rails/rails/blob/ce546c7d3a867dce11e7b99624160a7388bee1f5/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt#L6-L9
[partial]: https://github.com/rails/rails/blob/ce546c7d3a867dce11e7b99624160a7388bee1f5/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt#L18
