### PR TITLE
Active Record `bin/test` to execute its own adapter specific tests

### DIFF
--- a/activerecord/bin/test
+++ b/activerecord/bin/test
@@ -8,7 +8,7 @@ if adapter_index
 end
 
 COMPONENT_ROOT = File.expand_path("..", __dir__)
-require_relative "../../tools/test"
+require_relative "../test/support/tools"
 
 module Minitest
   def self.plugin_active_record_options(opts, options)

--- a/activerecord/test/cases/adapters/postgresql/datatype_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/datatype_test.rb
@@ -7,7 +7,7 @@ class PostgresqlTime < ActiveRecord::Base
   # Declare attributes to get rid from deprecation warnings on ActiveRecord 6.1
   attribute :time_interval,        :string
   attribute :scaled_time_interval, :interval
-end if current_adapter?(:PostgreSQLAdapter)
+end
 
 class PostgresqlOid < ActiveRecord::Base
 end

--- a/activerecord/test/cases/adapters/postgresql/geometric_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/geometric_test.rb
@@ -16,7 +16,7 @@ class PostgresqlPointTest < ActiveRecord::PostgreSQLTestCase
     attribute :legacy_x, :legacy_point
     attribute :legacy_y, :legacy_point
     attribute :legacy_z, :legacy_point
-  end if current_adapter?(:PostgreSQLAdapter)
+  end
 
   def setup
     @connection = ActiveRecord::Base.connection

--- a/activerecord/test/cases/adapters/postgresql/interval_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/interval_test.rb
@@ -12,7 +12,7 @@ class PostgresqlIntervalTest < ActiveRecord::PostgreSQLTestCase
     attribute :default_term, :interval
     attribute :all_terms,    :interval, array: true
     attribute :legacy_term,  :string
-  end if current_adapter?(:PostgreSQLAdapter)
+  end
 
   class DeprecatedIntervalDataType < ActiveRecord::Base; end
 

--- a/activerecord/test/support/tools.rb
+++ b/activerecord/test/support/tools.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+$: << File.expand_path("test", COMPONENT_ROOT)
+
+require "bundler/setup"
+
+require "rails/test_unit/runner"
+require "rails/test_unit/reporter"
+require "rails/test_unit/line_filtering"
+require "active_support"
+require "active_support/test_case"
+
+require "rake/testtask"
+Rails::TestUnit::Runner.singleton_class.prepend Module.new {
+   private
+     def list_tests(argv)
+       tests = super
+       tests.concat FileList["test/cases/adapters/#{adapter_short}/**/*_test.rb"]
+     end
+
+     def default_test_exclude_glob
+       ENV["DEFAULT_TEST_EXCLUDE"] || "test/cases/adapters/*/*_test.rb"
+     end
+
+     def adapter_short
+       ENV["ARCONN"] || "sqlite3"
+     end
+ }
+
+ActiveSupport::TestCase.extend Rails::LineFiltering
+Rails::TestUnitReporter.app_root = COMPONENT_ROOT
+Rails::TestUnitReporter.executable = "bin/test"
+
+Rails::TestUnit::Runner.parse_options(ARGV)
+Rails::TestUnit::Runner.run(ARGV)

--- a/activerecord/test/support/tools.rb
+++ b/activerecord/test/support/tools.rb
@@ -15,14 +15,14 @@ Rails::TestUnit::Runner.singleton_class.prepend Module.new {
    private
      def list_tests(argv)
        tests = super
-       tests.concat FileList["test/cases/adapters/#{adapter_short}/**/*_test.rb"]
+       tests.concat FileList["test/cases/adapters/#{adapter_name}/**/*_test.rb"]
      end
 
      def default_test_exclude_glob
        ENV["DEFAULT_TEST_EXCLUDE"] || "test/cases/adapters/*/*_test.rb"
      end
 
-     def adapter_short
+     def adapter_name
        ENV["ARCONN"] || "sqlite3"
      end
  }

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -43,10 +43,7 @@ module Rails
         end
 
         def load_tests(argv)
-          patterns = extract_filters(argv)
-
-          tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]
-          tests.exclude(default_test_exclude_glob) if patterns.empty?
+          tests = list_tests(argv)
           tests.to_a.each { |path| require File.expand_path(path) }
         end
 
@@ -93,6 +90,14 @@ module Rails
 
           def path_argument?(arg)
             %r"^[/\\]?\w+[/\\]".match?(arg)
+          end
+
+          def list_tests(argv)
+            patterns = extract_filters(argv)
+
+            tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]
+            tests.exclude(default_test_exclude_glob) if patterns.empty?
+            tests
           end
       end
     end


### PR DESCRIPTION
### Summary

This pull request allows Active Record `bin/test` to execute its own adapter-specific tests.

Here is the background for this change. There are two ways to run unit tests. `bundle exec rake test` and `bin/test`. Active Record `bundle exec rake test` only executes its own adapter-specific tests as follows https://github.com/rails/rails/blob/d0b0c1caa6b824e975f2fe2811f266f1a8f16d15/activerecord/Rakefile#L55-L57. On the other hand, `bin/test` executes all adapter specific tests then some test files need to have `if current_adapter?`, which can be removed.

### Other Information

To make this pull request purpose clear, this pull request has 3 separate commits, which will be squashed if necessary. 