### PR TITLE
Fix action text extra trix content wrapper

### DIFF
--- a/actiontext/lib/action_text/serialization.rb
+++ b/actiontext/lib/action_text/serialization.rb
@@ -15,6 +15,8 @@ module ActionText
           nil
         when self
           content.to_html
+        when ActionText::RichText
+          content.body.to_html
         else
           new(content).to_html
         end

--- a/actiontext/test/unit/model_test.rb
+++ b/actiontext/test/unit/model_test.rb
@@ -60,6 +60,13 @@ class ActionText::ModelTest < ActiveSupport::TestCase
     assert_equal "Hello world", message.content.to_plain_text
   end
 
+  test "duplicating content" do
+    message = Message.create!(subject: "Greetings", content: "<b>Hello!</b>")
+    other_message = Message.create!(subject: "Greetings", content: message.content)
+
+    assert_equal message.content.body.to_html, other_message.content.body.to_html
+  end
+
   test "saving body" do
     message = Message.create(subject: "Greetings", body: "<h1>Hello world</h1>")
     assert_equal "Hello world", message.body.to_plain_text


### PR DESCRIPTION
Closes #42315 

### Summary

When copying an `ActionText::RichText` between two models, an extra `<div class="trix-content">...</div>` was added as described in the issue. This comes from the fact that an `ActionText::RichText` is serialized in a `ActionText::Content`.

```rb
# app/models/action_text/rich_text.rb

module ActionText
  class RichText < Record
    serialize :body, ActionText::Content
  end
end
```

When the serialization happens in the `ActionText::Content.dump` method, we didn't have a case to handle serialization of `ActionText::RichText`, but there is no need to serialize again. We can simply retrieve the HTML body of the `ActionText::Content` associatied with the `ActionText::RichText`.