### PR TITLE
Update Gemfile.tt with rack-mini-profiler Turbo compatible

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -57,8 +57,9 @@ group :development do
   gem "web-console", ">= 4.1.0"
 
   # Display speed badge on every html page with SQL times and flame graphs.
-  # Note: Interferes with etag cache testing. Can be configured to work on production: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  # gem "rack-mini-profiler", "~> 2.0"
+  # Note: Interferes with etag cache testing. Can be configured to work on production
+  # and with support for Hotwire Turbo: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  # gem "rack-mini-profiler", ">= 2.3.3"
 <%- end -%>
   # Speed up rails commands in dev on slow machines / big apps. See: https://github.com/rails/spring
   # gem "spring"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -58,7 +58,7 @@ group :development do
 
   # Display speed badge on every html page with SQL times and flame graphs.
   # Note: Interferes with etag cache testing. Can be configured to work on production
-  # and with support for Hotwire Turbo: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  # and with support for Hotwire Turbo: https://github.com/MiniProfiler/rack-mini-profiler
   # gem "rack-mini-profiler", ">= 2.3.3"
 <%- end -%>
   # Speed up rails commands in dev on slow machines / big apps. See: https://github.com/rails/spring


### PR DESCRIPTION
### Summary

Since Turbo is part of Rails, it is better to define the minimal version of
rack-mini-profiler that supports it.

Release: https://github.com/MiniProfiler/rack-mini-profiler/commit/e3841878b60258c347a27e5a37556f914d0a698b