### PR TITLE
Load data as Subclasses for STI Models

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Load STI Models in fixtures
+
+    Data from Fixtures now loads based on the specific class for models with
+    Single Table Inheritance. This affects enums defined in subclasses, previously
+    the value of these fields was not parsed and remained `nil`
+
+    *Andres Howard*
+    
 *   `#authenticate` returns false when the password is blank instead of raising an error.
 
     *Muhammad Muhammad Ibrahim*

--- a/activerecord/lib/active_record/fixture_set/table_row.rb
+++ b/activerecord/lib/active_record/fixture_set/table_row.rb
@@ -126,7 +126,7 @@ module ActiveRecord
         end
 
         def resolve_enums
-          model_class.defined_enums.each do |name, values|
+          reflection_class.defined_enums.each do |name, values|
             if @row.include?(name)
               @row[name] = values.fetch(@row[name], @row[name])
             end

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -1331,6 +1331,12 @@ class FoxyFixturesTest < ActiveRecord::TestCase
     assert_equal pirates(:blackbeard), dead_parrots(:deadbird).killer
   end
 
+  def test_resolves_enums_in_sti_subclasses
+    assert_predicate parrots(:george), :australian?
+    assert_predicate parrots(:louis), :african?
+    assert_predicate parrots(:frederick), :african?
+  end
+
   def test_namespaced_models
     assert_includes admin_accounts(:signals37).users, admin_users(:david)
     assert_equal 2, admin_accounts(:signals37).users.size

--- a/activerecord/test/fixtures/parrots.yml
+++ b/activerecord/test/fixtures/parrots.yml
@@ -8,15 +8,18 @@ george:
   name: "Curious George"
   treasures: diamond, sapphire
   parrot_sti_class: LiveParrot
+  breed: australian
 
 louis:
   name: "King Louis"
   treasures: [diamond, sapphire]
   parrot_sti_class: LiveParrot
+  breed: african
 
 frederick:
   name: $LABEL
   parrot_sti_class: LiveParrot
+  breed: african
 
 polly:
   id: 4
@@ -28,6 +31,7 @@ polly:
 DEFAULTS: &DEFAULTS
   treasures: sapphire, ruby
   parrot_sti_class: LiveParrot
+  breed: australian
 
 davey:
   *DEFAULTS

--- a/activerecord/test/models/parrot.rb
+++ b/activerecord/test/models/parrot.rb
@@ -29,6 +29,7 @@ class Parrot < ActiveRecord::Base
 end
 
 class LiveParrot < Parrot
+  enum breed: { african: 0, australian: 1 }
 end
 
 class DeadParrot < Parrot

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -734,6 +734,7 @@ ActiveRecord::Schema.define do
   disable_referential_integrity do
     create_table :parrots, force: :cascade do |t|
       t.string :name
+      t.integer :breed, default: 0
       t.string :color
       t.string :parrot_sti_class
       t.integer :killer_id


### PR DESCRIPTION
Data from Fixtures now loads based on the specific class for models with Single Table Inheritance. This affects enums defined in subclasses, previously the value of these fields was not parsed and remained `nil`

### Summary

With models that use STI, Fixtures now load based on the subclasses. This allows to resolve the enums for each specific class instead of just resolving those of the base class.

The problem was when a subclass defined an enum for a column, and that enum was not in the base class. In such case, fixtures did not load the column correctly, and was assigned a value of `nil`. With this change fixtures load the correct values for those columns.
