### PR TITLE
Use loaded records where possible when preloading

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -23,11 +23,7 @@ module ActiveRecord
           end
 
           def records_for(loaders)
-            ids = loaders.flat_map(&:owner_keys).uniq
-
-            scope.where(association_key_name => ids).load do |record|
-              loaders.each { |l| l.set_inverse(record) }
-            end
+            LoaderRecords.new(loaders, self).records
           end
 
           def load_records_in_batch(loaders)
@@ -38,6 +34,52 @@ module ActiveRecord
               loader.run
             end
           end
+
+          def load_records_for_keys(keys, &block)
+            scope.where(association_key_name => keys).load(&block)
+          end
+        end
+
+        class LoaderRecords
+          def initialize(loaders, loader_query)
+            @loader_query = loader_query
+            @loaders = loaders
+            @keys_to_load = Set.new
+            @already_loaded_records_by_key = {}
+
+            populate_keys_to_load_and_already_loaded_records
+          end
+
+          def records
+            load_records + already_loaded_records
+          end
+
+          private
+            attr_reader :loader_query, :loaders, :keys_to_load, :already_loaded_records_by_key
+
+            def populate_keys_to_load_and_already_loaded_records
+              loaders.each do |loader|
+                loader.owners_by_key.each do |key, owners|
+                  if loaded_owner = owners.find { |owner| loader.loaded?(owner) }
+                    already_loaded_records_by_key[key] = loader.target_for(loaded_owner)
+                  else
+                    keys_to_load << key
+                  end
+                end
+              end
+
+              @keys_to_load.subtract(already_loaded_records_by_key.keys)
+            end
+
+            def load_records
+              loader_query.load_records_for_keys(keys_to_load) do |record|
+                loaders.each { |l| l.set_inverse(record) }
+              end
+            end
+
+            def already_loaded_records
+              already_loaded_records_by_key.values.flatten
+            end
         end
 
         attr_reader :klass
@@ -57,12 +99,8 @@ module ActiveRecord
           @klass.table_name
         end
 
-        def data_available?
-          already_loaded?
-        end
-
         def future_classes
-          if run? || already_loaded?
+          if run?
             []
           else
             [@klass]
@@ -81,11 +119,6 @@ module ActiveRecord
           return self if run?
           @run = true
 
-          if already_loaded?
-            fetch_from_preloaded_records
-            return self
-          end
-
           records = records_by_owner
 
           owners.each do |owner|
@@ -96,23 +129,15 @@ module ActiveRecord
         end
 
         def records_by_owner
-          ensure_loaded unless defined?(@records_by_owner)
+          load_records unless defined?(@records_by_owner)
 
           @records_by_owner
         end
 
         def preloaded_records
-          ensure_loaded unless defined?(@preloaded_records)
+          load_records unless defined?(@preloaded_records)
 
           @preloaded_records
-        end
-
-        def ensure_loaded
-          if already_loaded?
-            fetch_from_preloaded_records
-          else
-            load_records
-          end
         end
 
         # The name of the key on the associated records
@@ -124,8 +149,19 @@ module ActiveRecord
           LoaderQuery.new(scope, association_key_name)
         end
 
-        def owner_keys
-          @owner_keys ||= owners_by_key.keys
+        def owners_by_key
+          @owners_by_key ||= owners.each_with_object({}) do |owner, result|
+            key = convert_key(owner[owner_key_name])
+            (result[key] ||= []) << owner if key
+          end
+        end
+
+        def loaded?(owner)
+          owner.association(reflection.name).loaded?
+        end
+
+        def target_for(owner)
+          Array.wrap(owner.association(reflection.name).target)
         end
 
         def scope
@@ -185,36 +221,20 @@ module ActiveRecord
         private
           attr_reader :owners, :reflection, :preload_scope, :model
 
-          def already_loaded?
-            @already_loaded ||= owners.all? { |o| o.association(reflection.name).loaded? }
-          end
-
-          def fetch_from_preloaded_records
-            @records_by_owner = owners.index_with do |owner|
-              Array(owner.association(reflection.name).target)
-            end
-
-            @preloaded_records = records_by_owner.flat_map(&:last)
-          end
-
           # The name of the key on the model which declares the association
           def owner_key_name
             reflection.join_foreign_key
           end
 
           def associate_records_to_owner(owner, records)
+            return if loaded?(owner)
+
             association = owner.association(reflection.name)
+
             if reflection.collection?
               association.target = records
             else
               association.target = records.first
-            end
-          end
-
-          def owners_by_key
-            @owners_by_key ||= owners.each_with_object({}) do |owner, result|
-              key = convert_key(owner[owner_key_name])
-              (result[key] ||= []) << owner if key
             end
           end
 

--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -16,10 +16,7 @@ module ActiveRecord
 
             loaders.each { |loader| loader.associate_records_from_unscoped(@available_records[loader.klass]) }
 
-            already_loaded = loaders.select(&:data_available?)
-            if already_loaded.any?
-              already_loaded.each(&:run)
-            elsif loaders.any?
+            if loaders.any?
               future_tables = branches.flat_map do |branch|
                 branch.future_classes - branch.runnable_loaders.map(&:klass)
               end.map(&:table_name).uniq


### PR DESCRIPTION
Prior to this commit the preloader would avoid querying if a particular
association was already loaded for all the owner records being
preloaded:

```rb
assert post1.association(:author).loaded?
assert post2.association(:author).loaded?

assert_no_queries do
  ActiveRecord::Associations::Preloader.new(records: [post1, post2], associations: :author).call
end
```

But if only some of the owners had the association loaded we'd load it for
all of them:

```rb
assert post1.association(:author).loaded?
assert_not post2.association(:author).loaded?

ActiveRecord::Associations::Preloader.new(records: [post1, post2], associations: :author).call
#=> SELECT "authors".* FROM "authors" WHERE "authors"."id" IN (?, ?)
```

With this commit, we only load the association for owners that don't
already have it loaded:

```rb
assert post1.association(:author).loaded?
assert_not post2.association(:author).loaded?

ActiveRecord::Associations::Preloader.new(records: [post1, post2], associations: :author).call
#=> SELECT "authors".* FROM "authors" WHERE "authors"."id" = ?
```

This limits the data returned from the query, and the number of new
records we need to instantiate. (In the above examples we fetch only
one record instead of two).

This also makes the `available_records` option useful for more cases.
Prior to this commit we'd use the `available_records` to set the
association target on any owner where it was available, but if available
records weren't provided for ALL of the owners we'd end up fetching them
all. With this commit passing incomplete `available_records` can still
limit the amount of data we query for.

Because of the way we group queries, this also means we can use already
loaded associations for on one type to avoid or limit queries on another
type. (See test_preload_grouped_queries_with_already_loaded_records)

Implementation details
---

This commit gets rid of the special cases for all owners being loaded,
deleting the `already_loaded?` method entirely.

The gathering of already loaded records that used to happen in
`fetch_from_preloaded_records` now happens all the time, within
`LoaderRecords`.

The purpose of the `LoaderRecords` class is to find all the records,
either by looking for already loaded ones, or by loading them. It puts
together a list `already_loaded_records` and of `keys_to_load`, then
passes those off to `LoaderQuery` to do the actual loading.

cc @jhawthorn 