### PR TITLE
Don't blindly cast Int to nil if it's not castable

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -43,4 +43,10 @@
 
     *lulalala*
 
+*   Fix ActiveModel::Type::Integer#cast_value to not blindly cast values to NULL
+
+    Fixes #43039.
+
+    *Sam Brownlow*
+
 Please check [6-1-stable](https://github.com/rails/rails/blob/6-1-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/type/integer.rb
+++ b/activemodel/lib/active_model/type/integer.rb
@@ -44,7 +44,7 @@ module ActiveModel
         end
 
         def cast_value(value)
-          value.to_i rescue nil
+          value.to_i
         end
 
         def ensure_in_range(value)

--- a/activemodel/test/cases/type/integer_test.rb
+++ b/activemodel/test/cases/type/integer_test.rb
@@ -20,22 +20,18 @@ module ActiveModel
         assert_nil type.cast(nil)
       end
 
-      test "random objects cast to nil" do
+      test "casting objects without to_i raises NoMethodError" do
         type = Type::Integer.new
-        assert_nil type.cast([1, 2])
-        assert_nil type.cast(1 => 2)
-        assert_nil type.cast(1..2)
+        assert_raises(NoMethodError) { type.cast(::Object.new) }
+        assert_raises(NoMethodError) { type.cast([1, 2]) }
+        assert_raises(NoMethodError) { type.cast(1 => 2) }
+        assert_raises(NoMethodError) { type.cast(1..2) }
       end
 
-      test "casting objects without to_i" do
+      test "casting nan and infinity raises FloatDomainError" do
         type = Type::Integer.new
-        assert_nil type.cast(::Object.new)
-      end
-
-      test "casting nan and infinity" do
-        type = Type::Integer.new
-        assert_nil type.cast(::Float::NAN)
-        assert_nil type.cast(1.0 / 0.0)
+        assert_raises(FloatDomainError) { type.cast(::Float::NAN) }
+        assert_raises(FloatDomainError) { type.cast(::Float::INFINITY) }
       end
 
       test "casting booleans for database" do


### PR DESCRIPTION
CHANGELOG

This fixes Issue #43039

The current logic within ActiveModel::Type::Integer#cast_value is:

```ruby
def cast_value(value)
  value.to_i rescue nil
end
```

^ [source](https://github.com/rails/rails/blob/cb0c746b7d757d8491f2db1539cf9377b3eb833e/activemodel/lib/active_model/type/integer.rb#L46-L48)

This introduces the ability to silently corrupt the contents of a
  database via the mishandling of types:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(
  adapter: "sqlite3",
  database: ":memory:"
)
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Comment < ActiveRecord::Base; end

class BugTest < Minitest::Test
  def test_improper_insert
    post_id = { id: 123 }
    comment = Comment.create!(post_id: post_id)

    # this FAILS
    assert_equal(post_id.present?, comment.post_id.present?)
  end
end
```

Instead of doing a blind "try ... catch ...", we should instead raise an
  error when a value supplied to an integer column is incapable of
  being cast as an integer via value.to_i

This proposed integer behavior aligns with the current behavior within
  ActiveModel::Type::Float#cast_value:

```ruby
def cast_value(value)
  case value
  when ::Float then value
  when "Infinity" then ::Float::INFINITY
  when "-Infinity" then -::Float::INFINITY
  when "NaN" then ::Float::NAN
  else value.to_f
  end
end
```

^ [source](https://github.com/rails/rails/blob/cb0c746b7d757d8491f2db1539cf9377b3eb833e/activemodel/lib/active_model/type/float.rb#L24-L32)