### PR TITLE
Use `polymorphic_class_for` over `constantize`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix 2 cases that inferred polymorphic class from the association's `foreign_type`
+    using `String#constantize` instead of the model's `polymorphic_class_for`.
+
+    When updating a polymorphic association, the old `foreign_type` was not inferred correctly when:
+    1. `touch`ing the previously associated record
+    2. updating the previously associated record's `counter_cache`
+
+    *Jimmy Bourassa*
+
 *   Add config option for ignoring tables when dumping the schema cache.
 
     Applications can now be configured to ignore certain tables when dumping the schema cache.

--- a/activerecord/lib/active_record/associations/belongs_to_association.rb
+++ b/activerecord/lib/active_record/associations/belongs_to_association.rb
@@ -55,7 +55,8 @@ module ActiveRecord
 
       def decrement_counters_before_last_save
         if reflection.polymorphic?
-          model_was = owner.attribute_before_last_save(reflection.foreign_type)&.constantize
+          model_type_was = owner.attribute_before_last_save(reflection.foreign_type)
+          model_was = owner.class.polymorphic_class_for(model_type_was) if model_type_was
         else
           model_was = klass
         end

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -49,7 +49,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
         if reflection.polymorphic?
           foreign_type = reflection.foreign_type
           klass = changes[foreign_type] && changes[foreign_type].first || o.public_send(foreign_type)
-          klass = klass.constantize
+          klass = o.class.polymorphic_class_for(klass)
         else
           klass = association.klass
         end


### PR DESCRIPTION
Changelog entry:

```
*   Fix 2 cases that inferred polymorphic class from the association's `foreign_type`
    using `String#constantize` instead of the model's `polymorphic_class_for`.

    When updating a polymorphic association, the old `foreign_type` was not inferred correctly when:
    1. `touch`ing the previously associated record
    2. updating the previously associated record's `counter_cache`

    *Jimmy Bourassa*
```

### Summary

This commit fixes 2 cases where `constantize` was used instead of
of calling `polymorphic_class_for` to retrieve the class associated
with a given string for polymorphic `belongs_to`.

Before the patch, the added tests would fail because the string isn't a
a valid constant name:

```
ARCONN=sqlite3 bundle exec ruby -Itest test/cases/associations/belongs_to_associations_test.rb -n /test_polymorphic_with_custom_name/
Using sqlite3
Run options: -n /test_polymorphic_with_custom_name/ --seed 13806

# Running:

E

Error:
BelongsToAssociationsTest#test_polymorphic_with_custom_name_touch_old_belongs_to_model:
NameError: wrong constant name polymorphic_car
    activesupport/lib/active_support/inflector/methods.rb:280:in `const_get'
    activesupport/lib/active_support/inflector/methods.rb:280:in `constantize'
    activesupport/lib/active_support/core_ext/string/inflections.rb:74:in `constantize'
    activerecord/lib/active_record/associations/belongs_to_association.rb:58:in `decrement_counters_before_last_save'
    [...]

rails test test/cases/associations/belongs_to_associations_test.rb:1363

E

Error:
BelongsToAssociationsTest#test_polymorphic_with_custom_name_counter_cache:
NameError: wrong constant name polymorphic_car
    activesupport/lib/active_support/inflector/methods.rb:280:in `const_get'
    activesupport/lib/active_support/inflector/methods.rb:280:in `constantize'
    activesupport/lib/active_support/core_ext/string/inflections.rb:74:in `constantize'
    activerecord/lib/active_record/associations/belongs_to_association.rb:58:in `decrement_counters_before_last_save'
    [...]

rails test test/cases/associations/belongs_to_associations_test.rb:1353

Finished in 0.098519s, 20.3007 runs/s, 10.1503 assertions/s.
2 runs, 1 assertions, 0 failures, 2 errors, 0 skips
```

### Qs

- Does this warrant a CHANGELOG entry? Seems like a minor bugfix.