### PR TITLE
Rename ActiveModel::Serialization#attribute_names

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -150,7 +150,7 @@ module ActiveModel
 
     # Returns an array of attribute names as strings
     def attribute_names # :nodoc:
-      attributes.keys
+      instance_variable_defined?(:@attributes) ? @attributes.keys : attributes.keys
     end
 
     private

--- a/activemodel/test/cases/serialization_test.rb
+++ b/activemodel/test/cases/serialization_test.rb
@@ -41,6 +41,17 @@ class SerializationTest < ActiveModel::TestCase
     end
   end
 
+  class UserWithAttributes
+    include ActiveModel::Attributes
+    include ActiveModel::Serialization
+
+    attribute :name, :string
+
+    def attributes
+      nil
+    end
+  end
+
   setup do
     @user = User.new("David", "david@example.com", "male")
     @user.address = Address.new
@@ -180,5 +191,12 @@ class SerializationTest < ActiveModel::TestCase
                 "address" => { "street" => "123 Lane" },
                 "friends" => [{ "name" => "Joe" }, { "name" => "Sue" }] }
     assert_equal expected, @user.serializable_hash(include: [address: { only: "street" }, friends: { only: "name" }])
+  end
+
+  def test_with_attributes_variable
+    user_with_attributes = UserWithAttributes.new
+    user_with_attributes.name = "Avery"
+    expected = { "name" => "Avery" }
+    assert_equal expected, user_with_attributes.serializable_hash
   end
 end


### PR DESCRIPTION
### Summary

This method conflicts with `ActiveModel::Attributes#attribute_names`, which can cause issues in classes that mix in both of these modules. This change resolves the naming conflict by renaming `ActiveModel::Serialization#attribute_names` to `ActiveModel::Serialization#attribute_keys`.

---

We saw this pop up in the following scenario:

```ruby
class OurClass
  include ActiveModel::Attributes
  include ActiveModel::Serializers::JSON

  def some_method
    attributes_names # expects behavior from Attributes#attribute_names, but gets Seralization#attribute_names
  end
end
```