### PR TITLE
Don't overwrite default opts in rich_text_area_tag

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
-*   No changes.
+*   Allow passing in a custom `direct_upload_url` or `blob_url_template` to `rich_text_area_tag`
 
+    *Lucas Mansur*
 
 ## Rails 7.0.0.alpha1 (September 15, 2021) ##
 

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -13,6 +13,8 @@ module ActionText
     # ==== Options
     # * <tt>:class</tt> - Defaults to "trix-content" so that default styles will be applied.
     #   Setting this to a different value will prevent default styles from being applied.
+    # * <tt>[:data][:direct_upload_url]</tt> - Defaults to +rails_direct_uploads_url+.
+    # * <tt>[:data][:blob_url_template]</tt> - Defaults to <tt>rails_service_blob_url(":signed_id", ":filename")</tt>.
     #
     # ==== Example
     #
@@ -27,8 +29,8 @@ module ActionText
       options[:class] ||= "trix-content"
 
       options[:data] ||= {}
-      options[:data][:direct_upload_url] = main_app.rails_direct_uploads_url
-      options[:data][:blob_url_template] = main_app.rails_service_blob_url(":signed_id", ":filename")
+      options[:data][:direct_upload_url] ||= main_app.rails_direct_uploads_url
+      options[:data][:blob_url_template] ||= main_app.rails_service_blob_url(":signed_id", ":filename")
 
       editor_tag = content_tag("trix-editor", "", options)
       input_tag = hidden_field_tag(name, value.try(:to_trix_html) || value, id: options[:input], form: form)
@@ -59,6 +61,8 @@ module ActionView::Helpers
     # ==== Options
     # * <tt>:class</tt> - Defaults to "trix-content" which ensures default styling is applied.
     # * <tt>:value</tt> - Adds a default value to the HTML input tag.
+    # * <tt>[:data][:direct_upload_url]</tt> - Defaults to +rails_direct_uploads_url+.
+    # * <tt>[:data][:blob_url_template]</tt> - Defaults to +rails_service_blob_url(":signed_id", ":filename")+.
     #
     # ==== Example
     #   form_with(model: @message) do |form|

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -154,4 +154,32 @@ class ActionText::FormHelperTest < ActionView::TestCase
       "</form>",
       output_buffer
   end
+
+  test "form with rich text area with data[direct_upload_url]" do
+    form_with model: Message.new, scope: :message do |form|
+      form.rich_text_area :content, data: { direct_upload_url: "http://test.host/direct_uploads" }
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
+
+  test "form with rich text area with data[blob_url_template]" do
+    form_with model: Message.new, scope: :message do |form|
+      form.rich_text_area :content, data: { blob_url_template: "http://test.host/blobs/:signed_id/:filename" }
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/blobs/:signed_id/:filename">' \
+        "</trix-editor>" \
+      "</form>",
+      output_buffer
+  end
 end


### PR DESCRIPTION
You may want to use your own controller to authenticate requests or
perform server-side validations.
