### PR TITLE
fix #43146 button_to now not works with hash params for url

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -344,8 +344,10 @@ module ActionView
         html_options = convert_options_to_data_attributes(options, html_options)
         html_options["type"] = "submit"
 
-        button = if block_given? || button_to_generates_button_tag
-          content_tag("button", url || name, html_options, &block)
+        button = if block_given?
+          content_tag("button", html_options, &block)
+        elsif button_to_generates_button_tag
+          content_tag("button", name || url, html_options, &block)
         else
           html_options["value"] = name || url
           tag("input", html_options)

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -345,7 +345,7 @@ module ActionView
         html_options["type"] = "submit"
 
         button = if block_given? || button_to_generates_button_tag
-          content_tag("button", name || url, html_options, &block)
+          content_tag("button", url || name, html_options, &block)
         else
           html_options["value"] = name || url
           tag("input", html_options)


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/blob/c236ff686c6fa987924b8eefeec93c2abcc07843/actionview/lib/action_view/helpers/url_helper.rb#L317-L361

In this line 348, name always be the hash `{ action: 'sync' }`, url is `url_for(action: 'sync')`, is string

```ruby
content_tag("button", { action: 'sync' }, { class: 'button is-success' }, &block),
```
html_options becomes `{ action: 'sync' }`, the real html options `{ class: 'button is-success' }` lost,  if use a string as param, the param will be ignore because of block exist