### PR TITLE
Add rollup as JavaScript option

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -300,8 +300,10 @@ module Rails
           GemfileEntry.version "webpacker", "~> 6.0.0.rc.5", "Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker"
         when "esbuild"
           GemfileEntry.version "esbuild-rails", "~> 0.1.2", "Transpile app-like JavaScript. Read more: https://github.com/rails/esbuild-rails"
+        when "rollup"
+          GemfileEntry.version "rollupjs-rails", "~> 0.1.0", "Transpile app-like JavaScript. Read more: https://github.com/rails/rollupjs-rails"
         else
-          raise "Unknown JavaScript approach: #{options[:javascript]}"
+          raise "Unknown JavaScript approach: #{options[:javascript]} [options are: importmap, webpack, esbuild, rollup]"
         end
       end
 
@@ -382,6 +384,7 @@ module Rails
         when "importmap" then rails_command "importmap:install"
         when "webpack"   then rails_command "webpacker:install"
         when "esbuild"   then rails_command "esbuild:install"
+        when "rollup"    then rails_command "rollup:install"
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -270,7 +270,7 @@ module Rails
       class_option :version, type: :boolean, aliases: "-v", group: :rails, desc: "Show Rails version number and quit"
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
-      class_option :javascript, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach"
+      class_option :javascript, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
 
       def initialize(*args)


### PR DESCRIPTION
rollup.js is a great JavaScript bundler with lots of plugins and extensions. It's integrated in a very lightweight way via [rollupjs-rails](https://github.com/rails/rollupjs-rails), just like [esbuild-rails](https://github.com/rails/esbuild-rails). This allows for it to be used as part of the new skeleton with -j rollup.