### PR TITLE
Move timestamp columns to the top

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
+++ b/activerecord/lib/rails/generators/active_record/migration/templates/create_table_migration.rb.tt
@@ -1,6 +1,10 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :<%= table_name %><%= primary_key_type %> do |t|
+<% if options[:timestamps] -%>
+      t.timestamps
+
+<% end -%>
 <% attributes.each do |attribute| -%>
 <% if attribute.password_digest? -%>
       t.string :password_digest<%= attribute.inject_options %>
@@ -11,9 +15,6 @@ class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Mi
 <% elsif !attribute.virtual? -%>
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
 <% end -%>
-<% end -%>
-<% if options[:timestamps] %>
-      t.timestamps
 <% end -%>
     end
 <% attributes.select(&:token?).each do |attribute| -%>


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/42582

Almost every model gets new columns after creation, leaving the timestamps at
an awkward position between the initial columns and everything else.

For the command `bin/rails g model Book title` it will generate:

```ruby
class CreateBooks < ActiveRecord::Migration[7.0]
  def change
    create_table :books do |t|
      t.timestamps

      t.string :title
    end
  end
end
```