### PR TITLE
Fix dirty attributes for cyclic autosaves

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Only update dirty attributes once for cyclic autosave callbacks.
+
+    Instead of calling `changes_applied` every time `save` is called,
+    we can skip it if it has already been called once in the current saving
+    cycle.
+
+    *Petrik de Heus*
+
 *   Fix 2 cases that inferred polymorphic class from the association's `foreign_type`
     using `String#constantize` instead of the model's `polymorphic_class_for`.
 

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -183,6 +183,16 @@ module ActiveRecord
       end
 
       private
+        def _changes_applied_for_create
+          changes_applied
+          super
+        end
+
+        def _changes_applied_for_update
+          changes_applied
+          super
+        end
+
         def _touch_row(attribute_names, time)
           @_touch_attr_names = Set.new(attribute_names)
 
@@ -213,15 +223,11 @@ module ActiveRecord
         end
 
         def _update_record(attribute_names = attribute_names_for_partial_updates)
-          affected_rows = super
-          changes_applied
-          affected_rows
+          super
         end
 
         def _create_record(attribute_names = attribute_names_for_partial_inserts)
-          id = super
-          changes_applied
-          id
+          super
         end
 
         def attribute_names_for_partial_updates

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -766,6 +766,8 @@ module ActiveRecord
         @marked_for_destruction   = false
         @destroyed_by_association = nil
         @_start_transaction_state = nil
+        @_save_cycle              = 0
+        @_changes_applied         = {}
 
         klass = self.class
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1003,7 +1003,7 @@ module ActiveRecord
         @_trigger_update_callback = affected_rows == 1
       end
 
-      @previously_new_record = false
+      _changes_applied_for_update
 
       yield(self) if block_given?
 
@@ -1021,8 +1021,7 @@ module ActiveRecord
 
       self.id ||= new_id if @primary_key
 
-      @new_record = false
-      @previously_new_record = true
+      _changes_applied_for_create
 
       yield(self) if block_given?
 
@@ -1055,6 +1054,15 @@ module ActiveRecord
     # +:touch+ option is used.
     def belongs_to_touch_method
       :touch
+    end
+
+    def _changes_applied_for_create
+      @new_record = false
+      @previously_new_record = true
+    end
+
+    def _changes_applied_for_update
+      @previously_new_record = false
     end
   end
 end

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -404,6 +404,8 @@ module ActiveRecord
               attr = attr.with_value_from_user(value) if attr.value != value
               attr
             end
+            @_save_cycle = 0
+            @_changes_applied = {}
             @mutations_from_database = nil
             @mutations_before_last_save = nil
             if @attributes.fetch_value(@primary_key) != restore_state[:id]

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -578,7 +578,7 @@ class PersistenceTest < ActiveRecord::TestCase
     Topic.reset_column_information
   end
 
-  def test_update_after_create
+  def test_update_attribute_after_create
     klass = Class.new(Topic) do
       def self.name; "Topic"; end
       after_create do


### PR DESCRIPTION
### Summary

Calling save on records with autosave associations can cause these
records to be saved more than once. Everytime it's saved the dirty
changes are applied, causing the dirty state to be incorrect.

In the following example `Post` is saved a second time by the autosave
callbacks of `Message`:

```ruby
class Post < ApplicationRecord
  belongs_to :message # autosaves Message
end

class Message < ApplicationRecord
  has_one :post # autosaves Post
end

post = Post.create!(message: Message.new(subject: "Hello, world!"))
post.id_previously_changed? # should be true but returns false
post.previously_new_record? # should be true but returns false
```

`post.id_previously_changed?` is incorrect because for the second save
`ActiveRecord::AttributeMethods::Dirty#_update_record` is called,  which
calls `changes_applied` for the second time, marking the attribute as
unchanged the second time.

https://github.com/rails/rails/blob/53000f3a2df5c59252d019bbb8d46728b291ec74/activerecord/lib/active_record/attribute_methods/dirty.rb#L217

`post.previously_new_record?` is incorrect because for the second save
`ActiveRecord::Persistence#_update_record` is called, which sets
`@previously_new_record` to false.

https://github.com/rails/rails/blob/53000f3a2df5c59252d019bbb8d46728b291ec74/activerecord/lib/active_record/persistence.rb#L1014

To prevent this we can track if the changes have already been applied
once during the current save cycle.

Adding new hook methods
-----------------------

We can move the updating of `@new_record` and `@previously_new_record` in
`ActiveRecord::Persistence` to new hook methods:
`_changes_applied_for_create` and `_changes_applied_for_update`.

In `ActiveRecord::AttributeMethods::Dirty` we can move calling the
`changes_applied` method to these hook methods as well.

If we make sure these hook methods are only called once per save cycle,
we fix the problem.

As `ActiveRecord::AutosaveAssociation` is responsible for the saving
records multiple times, this module should be responsible for making sure the
hook methods are called once.

Tracking if changes have been applied once already
--------------------------------------------------

In https://github.com/rails/rails/pull/41860 we tried to make sure
changes are applied once by setting `@_saving` to `true`, and only
applying changes if it's `false`.

This failed however when explicitly calling
save again in callbacks, for example:

```ruby
class Post < ApplicationRecord
  after_update :update_again, if: :saved_change_to_public?

  def update_again
    update_attribute :body, nil
  end
```

In this case we do want to call `changes_applied` again, but skip
it again when autosaving.

We fix this by considering this another save cycle, that can have
changes applied only once as well. We track this by incrementing
`@_save_cycle` for each save_cycle, and tracking if
`changes_applied` has been called for each separate save_cycle.

### Other information
Fixes: https://github.com/rails/rails/issues/41701
A previous attempt https://github.com/rails/rails/pull/41860 failed when
explictly calling save in callbacks: https://github.com/rails/rails/pull/42104

I'm not sure if we should also fix this for: https://github.com/rails/rails/blob/06ca4042adca6cffc6d8e8037eade32c2a5beeec/activerecord/lib/active_record/attribute_methods/dirty.rb#L217