### PR TITLE
Add --css app generator option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"
 gem "turbo-rails"
 gem "jsbundling-rails"
+gem "cssbundling-rails"
 gem "importmap-rails"
+gem "tailwindcss-rails"
 # require: false so bcrypt is loaded only when has_secure_password is used.
 # This is to avoid Active Model (and by extension the entire framework)
 # being dependent on a binary library.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,8 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cssbundling-rails (0.1.0)
+      rails (>= 6.0.0)
     curses (1.4.2)
     daemons (1.4.0)
     dalli (2.7.11)
@@ -470,6 +472,8 @@ GEM
       rails (>= 6.0.0)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
+    tailwindcss-rails (0.4.3)
+      rails (>= 6.0.0)
     terser (1.1.4)
       execjs (>= 0.3.0, < 3)
     thin (1.8.1)
@@ -530,6 +534,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   connection_pool
+  cssbundling-rails
   dalli
   delayed_job
   delayed_job_active_record
@@ -578,6 +583,7 @@ DEPENDENCIES
   stackprof
   stimulus-rails
   sucker_punch
+  tailwindcss-rails
   terser (>= 1.1.4)
   turbo-rails
   tzinfo-data

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -404,7 +404,7 @@ module Rails
       end
 
       def run_css
-        return unless options[:css] || bundle_install?
+        return if !options[:css] || !bundle_install?
 
         if !using_node? && options[:css] == "tailwind"
           rails_command "tailwindcss:install"

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -271,6 +271,7 @@ module Rails
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
       class_option :javascript, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
+      class_option :css, type: :string, desc: "Choose CSS processor [options: tailwind, postcss, sass]"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
 
       def initialize(*args)
@@ -512,6 +513,7 @@ module Rails
       public_task :generate_bundler_binstub
       public_task :run_javascript
       public_task :run_hotwire
+      public_task :run_css
 
       def run_after_bundle_callbacks
         @after_bundle_callbacks.each(&:call)

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -21,9 +21,6 @@ ruby <%= "\"#{RUBY_VERSION}\"" -%>
 
 # Use Sass to process CSS
 # gem "sassc-rails", "~> 2.1"
-
-# Use Tailwind CSS. See: https://github.com/rails/tailwindcss-rails
-# gem "tailwindcss-rails", "~> 0.4.3"
 <% end -%>
 
 # Use Active Model has_secure_password

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -819,6 +819,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_file "app/javascript/application.js"
   end
 
+  def test_css_option_with_asset_pipeline_tailwind
+    run_generator [destination_root, "--dev", "--css", "tailwind"]
+    assert_gem "tailwindcss-rails"
+    assert_file "app/views/layouts/application.html.erb" do |content|
+      assert_match(/tailwind/, content)
+    end
+  end
+
+  def test_css_option_with_cssbundling_gem
+    run_generator [destination_root, "--dev", "--css", "postcss"]
+    assert_gem "cssbundling-rails"
+    assert_file "app/assets/stylesheets/application.postcss.css"
+  end
+
   def test_bootsnap
     run_generator [destination_root, "--no-skip-bootsnap"]
 


### PR DESCRIPTION
Add `--css` option to the Rails app generator. When passed `tailwind`, it'll use [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) on an importmap/no-JS setup – otherwise [cssbundling-rails](https://github.com/rails/cssbundling-rails). If passed `postcss` or `sass`, it'll always use [cssbundling-rails](https://github.com/rails/cssbundling-rails).