### PR TITLE
Raise an ArgumentError if unsupported options are passed to add_column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Raise an ArgumentError when `add_column` is given options that are not
+    supported. The old behavior silently ignored any unsupported options.
+
+    *Nick Pezza*
+
 *   Fix 2 cases that inferred polymorphic class from the association's `foreign_type`
     using `String#constantize` instead of the model's `polymorphic_class_for`.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -514,7 +514,7 @@ module ActiveRecord
         def create_column_definition(name, type, options)
           ColumnDefinition.new(name, type, options).tap do |definition|
             unsupported = definition.unsupported_options
-            message = "unknown #{'option'.pluralize(unsupported.size)}: #{unsupported.join(', ')}"
+            message = "Unknown #{'option'.pluralize(unsupported.size)}: #{unsupported.join(', ')}"
 
             raise ArgumentError, message if unsupported.any?
           end

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -9,6 +9,12 @@ module ActiveRecord
 
       self.use_transactional_tests = false
 
+      def test_add_column_with_an_unsupported_option
+        assert_raises ArgumentError do
+          add_column "test_models", "command", :string, index: true
+        end
+      end
+
       def test_add_column_newline_default
         string = "foo\nbar"
         add_column "test_models", "command", :string, default: string

--- a/activerecord/test/cases/migration/column_attributes_test.rb
+++ b/activerecord/test/cases/migration/column_attributes_test.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
       def test_add_column_with_an_unsupported_option
         assert_raises ArgumentError do
-          add_column "test_models", "command", :string, index: true
+          add_column "test_models", "command", :string, unknown: true
         end
       end
 


### PR DESCRIPTION
### Summary

If you pass the `index` argument on add_column it get's ignored. Noticing that an index doesnt get added could be overlooked in the schema.rb changes so this change raises an error when passing an option that isn't supported. Failing loudly seems like a better alternative than ignoring silently.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
