### PR TITLE
Fix flaky tests, add sleep and touch on app_file

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -419,10 +419,16 @@ module TestHelpers
 
     def app_file(path, contents, mode = "w")
       file_name = "#{app_path}/#{path}"
+
+      # Lets wait a bit to allow FileUpdateChecker detects the file change.
+      sleep 1 if File.exist?(file_name)
       FileUtils.mkdir_p File.dirname(file_name)
       File.open(file_name, mode) do |f|
         f.puts contents
       end
+
+      # Force touch to ensure the FileUpdateChecker detects the file change
+      FileUtils.touch(file_name)
       file_name
     end
 


### PR DESCRIPTION
### Summary

`railties/test/application/asset_debugging_test.rb` are failing from time to time on CI. After some investigations, I discovered that it is caused due how `FileUpdateChecker` works.

This PR adds a `sleep 1` if the file already exists and touches the file to ensure that FileUpdateChecker notices the change.

### Other Information

It is a PR for debugging the issue https://github.com/rails/rails/pull/43174

Alternative approaches:
- https://github.com/rails/rails/pull/43188
- https://github.com/rails/rails/pull/43178