### PR TITLE
Don't show deprecation warning for equal paths

### DIFF
--- a/actionpack/lib/action_dispatch/testing/test_process.rb
+++ b/actionpack/lib/action_dispatch/testing/test_process.rb
@@ -30,13 +30,16 @@ module ActionDispatch
             EOM
           elsif path.exist?
             non_deprecated_path = Pathname(File.absolute_path(path)).relative_path_from(Pathname(File.absolute_path(self.class.file_fixture_path)))
-            ActiveSupport::Deprecation.warn(<<~EOM)
-              Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
-              In Rails 7.0, the path needs to be relative to `file_fixture_path`.
 
-              Please modify the call from
-              `fixture_file_upload("#{original_path}")` to `fixture_file_upload("#{non_deprecated_path}")`.
-            EOM
+            if Pathname(original_path) != non_deprecated_path
+              ActiveSupport::Deprecation.warn(<<~EOM)
+                Passing a path to `fixture_file_upload` relative to `fixture_path` is deprecated.
+                In Rails 7.0, the path needs to be relative to `file_fixture_path`.
+
+                Please modify the call from
+                `fixture_file_upload("#{original_path}")` to `fixture_file_upload("#{non_deprecated_path}")`.
+              EOM
+            end
           else
             path = file_fixture(original_path)
           end

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -973,6 +973,16 @@ XML
     end
   end
 
+  def test_fixture_file_upload_fixture_path_same_as_file_fixture_path
+    TestCaseTest.stub :fixture_path, File.expand_path("../fixtures/multipart", __dir__) do
+      TestCaseTest.stub :file_fixture_path, File.expand_path("../fixtures/multipart", __dir__) do
+        assert_not_deprecated do
+          fixture_file_upload("ruby_on_rails.jpg", "image/jpg")
+        end
+      end
+    end
+  end
+
   def test_fixture_file_upload_ignores_fixture_path_given_full_path
     TestCaseTest.stub :fixture_path, __dir__ do
       uploaded_file = fixture_file_upload("#{FILES_DIR}/ruby_on_rails.jpg", "image/jpeg")


### PR DESCRIPTION
### Summary

Before, if a user set `file_fixture_path` to the same path as `fixture_path`, this would have resulted in a deprecation warning such as:

"Please modify the call from `fixture_file_upload('rails.jpg')` to `fixture_file_upload('rails.jpg')"

If this PR should indeed be a fix and not a mistake, I'd assume it should also be backported?
