### PR TITLE
Fix flaky tests, add a template per case on asset debugging tests

### DIFF
--- a/railties/test/application/asset_debugging_test.rb
+++ b/railties/test/application/asset_debugging_test.rb
@@ -85,14 +85,18 @@ module ApplicationTests
         image_submit_tag:       %r{<input type="image" src="/images/#{contents}" />}
       }
 
+      class ::PostsController < ActionController::Base
+        def index
+          render params[:view_method]
+        end
+      end
+
       cases.each do |(view_method, tag_match)|
-        app_file "app/views/posts/index.html.erb", "<%= #{view_method} '#{contents}', skip_pipeline: true %>"
+        app_file "app/views/posts/#{view_method}.html.erb", "<%= #{view_method} '#{contents}', skip_pipeline: true %>"
 
         app "development"
 
-        class ::PostsController < ActionController::Base ; end
-
-        get "/posts?debug_assets=true"
+        get "/posts?debug_assets=true&view_method=#{view_method}"
 
         body = last_response.body
         assert_match(tag_match, body, "Expected `#{view_method}` to produce a match to #{tag_match}, but did not: #{body}")
@@ -111,14 +115,18 @@ module ApplicationTests
         stylesheet_url:  %r{http://example.org/stylesheets/#{contents}},
       }
 
+      class ::PostsController < ActionController::Base
+        def index
+          render params[:view_method]
+        end
+      end
+
       cases.each do |(view_method, tag_match)|
-        app_file "app/views/posts/index.html.erb", "<%= #{view_method} '#{contents}', skip_pipeline: true %>"
+        app_file "app/views/posts/#{view_method}.html.erb", "<%= #{view_method} '#{contents}', skip_pipeline: true %> "
 
         app "development"
 
-        class ::PostsController < ActionController::Base ; end
-
-        get "/posts?debug_assets=true"
+        get "/posts?debug_assets=true&view_method=#{view_method}"
 
         body = last_response.body
         assert_match(tag_match, body, "Expected `#{view_method}` to produce a match to #{tag_match}, but did not: #{body}")
@@ -130,14 +138,19 @@ module ApplicationTests
         /\/assets\/application-.*.\.js/ => {},
         /application.js/                => { skip_pipeline: true },
       }
-      cases.each do |(tag_match, options_hash)|
-        app_file "app/views/posts/index.html.erb", "<%= asset_path('application.js', #{options_hash}) %>"
+
+      class ::PostsController < ActionController::Base
+        def index
+          render params[:version]
+        end
+      end
+
+      cases.each_with_index do |(tag_match, options_hash), index|
+        app_file "app/views/posts/version_#{index}.html.erb", "<%= asset_path('application.js', #{options_hash}) %>"
 
         app "development"
 
-        class ::PostsController < ActionController::Base ; end
-
-        get "/posts?debug_assets=true"
+        get "/posts?debug_assets=true&version=version_#{index}"
 
         body = last_response.body.strip
         assert_match(tag_match, body, "Expected `asset_path` with `#{options_hash}` to produce a match to #{tag_match}, but did not: #{body}")
@@ -150,14 +163,18 @@ module ApplicationTests
         public_compute_asset_path: /application.js/,
       }
 
+      class ::PostsController < ActionController::Base
+        def index
+          render params[:view_method]
+        end
+      end
+
       cases.each do |(view_method, tag_match)|
-        app_file "app/views/posts/index.html.erb", "<%= #{ view_method } 'application.js' %>"
+        app_file "app/views/posts/#{view_method}.html.erb", "<%= #{ view_method } 'application.js' %>"
 
         app "development"
 
-        class ::PostsController < ActionController::Base ; end
-
-        get "/posts?debug_assets=true"
+        get "/posts?debug_assets=true&view_method=#{view_method}"
 
         body = last_response.body.strip
         assert_match(tag_match, body, "Expected `#{view_method}` to produce a match to #{ tag_match }, but did not: #{ body }")


### PR DESCRIPTION
It avoids the problem when the file checker is not able to detect changes
on the files during testing.


### Summary

`railties/test/application/asset_debugging_test.rb` are failing from time to time on CI. After some investigations, I discovered that it is caused due how `FileUpdateChecker` works. `FileUpdateChecker` requires 1 second to detect file changes in a file.

This PR avoids the problem of creating a new template per case.

### Other Information

It is a PR for debugging the issue https://github.com/rails/rails/pull/43174

Alternative approaches:
- https://github.com/rails/rails/pull/43185
- https://github.com/rails/rails/pull/43178

