### PR TITLE
Avoid scoping update transaction when calling update! on a relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Avoid scoping update callbacks in `ActiveRecord::Relation#update!`.
+
+    Making it consistent with how scoping is applied only to the query in `ActiveRecord::Relation#update`
+    and not also to the callbacks from the update itself.
+
+    *Dylan Thacker-Smith*
+
 *   Fix 2 cases that inferred polymorphic class from the association's `foreign_type`
     using `String#constantize` instead of the model's `polymorphic_class_for`.
 

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -498,6 +498,14 @@ module ActiveRecord
       end
     end
 
+    def update!(id = :all, attributes) # :nodoc:
+      if id == :all
+        each { |record| record.update!(attributes) }
+      else
+        klass.update!(id, attributes)
+      end
+    end
+
     # Updates the counters of the records in the current relation.
     #
     # ==== Parameters

--- a/activerecord/test/cases/relation/update_all_test.rb
+++ b/activerecord/test/cases/relation/update_all_test.rb
@@ -173,6 +173,24 @@ class UpdateAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_update_bang_on_relation
+    topic1 = TopicWithCallbacks.create! title: "arel", author_name: nil
+    topic2 = TopicWithCallbacks.create! title: "activerecord", author_name: nil
+    topic3 = TopicWithCallbacks.create! title: "ar", author_name: nil
+    topics = TopicWithCallbacks.where(id: [topic1.id, topic2.id])
+    topics.update!(title: "adequaterecord")
+
+    assert_equal TopicWithCallbacks.count, TopicWithCallbacks.topic_count
+
+    assert_equal "adequaterecord", topic1.reload.title
+    assert_equal "adequaterecord", topic2.reload.title
+    assert_equal "ar", topic3.reload.title
+    # Testing that the before_update callbacks have run
+    assert_equal "David", topic1.reload.author_name
+    assert_equal "David", topic2.reload.author_name
+    assert_nil topic3.reload.author_name
+  end
+
   def test_update_all_cares_about_optimistic_locking
     david = people(:david)
 


### PR DESCRIPTION
## Problem

https://github.com/rails/rails/issues/33470 reported unexpected scoping when calling ActiveRecord::Relation#update which not only applied the relation's scope to the query for the records to update, but the scope also affected the Active Record callbacks that get triggered from the update.  Unfortunately, the fix for that was done just for `update` and not also for `update!`.

## Solution

The fix for https://github.com/rails/rails/issues/33470 was to define ActiveRecord::Relation#update to avoid method_missing being called on the relation, which is where the scoping was being applied.  Similarly, this PR defines ActiveRecord::Relation#update! which makes these methods consistent in how scoping is applied again.