### PR TITLE
index: nil passed to form builder helper actually removes [] infix

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -172,7 +172,7 @@ module ActionView
 
           def name_and_id_index(options)
             if options.key?("index")
-              options.delete("index") || ""
+              options.delete("index")
             elsif @generate_indexed_names
               @auto_index || ""
             end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1446,6 +1446,36 @@ class FormHelperTest < ActionView::TestCase
     )
   end
 
+  def test_index_nil
+    assert_dom_equal(
+      '<input name="post[title]" id="post_title" type="text" value="Hello World" />',
+      text_field("post", "title", "index" => nil)
+    )
+    assert_dom_equal(
+      %{<textarea name="post[body]" id="post_body">\nBack to the hill and over it again!</textarea>},
+      text_area("post", "body", "index" => nil)
+    )
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" name="post[secret]" type="checkbox" value="1" id="post_secret" />',
+      check_box("post", "secret", "index" => nil)
+    )
+  end
+
+  def test_index_empty
+    assert_dom_equal(
+      '<input name="post[][title]" id="post__title" type="text" value="Hello World" />',
+      text_field("post", "title", "index" => "")
+    )
+    assert_dom_equal(
+      %{<textarea name="post[][body]" id="post__body">\nBack to the hill and over it again!</textarea>},
+      text_area("post", "body", "index" => "")
+    )
+    assert_dom_equal(
+      '<input name="post[][secret]" type="hidden" value="0" /><input checked="checked" name="post[][secret]" type="checkbox" value="1" id="post__secret" />',
+      check_box("post", "secret", "index" => "")
+    )
+  end
+
   def test_index_with_nil_id
     assert_dom_equal(
       '<input name="post[5][title]" type="text" value="Hello World" />',


### PR DESCRIPTION
Resolve https://github.com/rails/rails/issues/43194

Don't short circuit value obtained from deleting the `index` key so `nil` is captured instead of turning into empty string `""`.

* This allows you to intentionally leave out the `index` and `[]` infix altogether instead of placing an empty bracket infix (this should and is already done using empty string `""` for index).

### Summary

I can specify an `index: X` option to a form builder helper method such as `text_field`:

```
<%= form.text_field :something, index: 123 %>
```
That will add an infix to the name attribute of the `<input>` element generated, like:

```
<input ... name="some_model[123][something]" ...>
```

There are cases where one might want to leave the brackets empty. This works fine:

```
<%= form.text_field :something, index: "" %>

=> <input ... name="some_model[][something]" ...>
```

But also sometimes you might want to explicitly define there should not be any index bracket. This case is not possible because a `nil` passed to `index` ultimately gets short-circuited to empty string `""`:

```
<%= form.text_field :something, index: nil %>
<%# this is not happening :( %>
=> <input ... name="some_model[something]" ...>

<%# this is what happens currently, something the PR wants to fix so it becomes like above %>
=> <input ... name="some_model[][something]" ...>
```

A workaround is to omit the `index` option from the function arguments. However I ran into a case where the options hash always had the `index` named parameter defined and I had to find myself removing that for every instance, such as using `compact` to remove ALL hash properties whose value is `nil`:
```
<% options = { ..., index: nil } %>
<%= form.text_field :something, options.compact %>
```