### PR TITLE
Support setting custom class and column for polymorphic belongs_to association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Support setting custom association class and column for polymorphic `belongs_to` association.
+
+    This change introduced a new option for polymorphic `belongs_to` association: `association_primary_key`. That you can set the model name and column name to lookup the association.
+
+    ```ruby
+    class Mentor
+      belongs_to :teacher, polymorphic: true, association_primary_key: { "User" => :uuid }
+    end
+    ```
+
+    *Juanito Fatas*
+
 *   Avoid scoping update callbacks in `ActiveRecord::Relation#update!`.
 
     Making it consistent with how scoping is applied only to the query in `ActiveRecord::Relation#update`

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -8,7 +8,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
 
     def self.valid_options(options)
       valid = super + [:polymorphic, :counter_cache, :optional, :default]
-      valid += [:foreign_type] if options[:polymorphic]
+      if options[:polymorphic]
+        valid += [:foreign_type]
+        valid += [:association_primary_key]
+      end
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
       valid
     end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -491,7 +491,7 @@ module ActiveRecord
             saved = record.save(validate: !autosave) if record.new_record? || (autosave && record.changed_for_autosave?)
 
             if association.updated?
-              association_id = record.public_send(reflection.options[:primary_key] || :id)
+              association_id = record.public_send(reflection.association_primary_key(record.class))
               self[reflection.foreign_key] = association_id
               association.loaded!
             end

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -719,6 +719,7 @@ module ActiveRecord
         if primary_key = options[:primary_key]
           @association_primary_key ||= -primary_key.to_s
         else
+          (klass && options.dig(:association_primary_key, klass.name)&.to_s) ||
           primary_key(klass || self.klass)
         end
       end

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1565,6 +1565,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
 end
 
 class TestAutosaveAssociationOnABelongsToPolymorphicAssociation < ActiveRecord::TestCase
+  self.use_transactional_tests = false
   fixtures :posts
 
   def setup

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1564,6 +1564,31 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   end
 end
 
+class TestAutosaveAssociationOnABelongsToPolymorphicAssociation < ActiveRecord::TestCase
+  fixtures :posts
+
+  def setup
+    super
+    @connection = ActiveRecord::Base.connection
+    @connection.create_table(:actors) do |t|
+      t.string :uuid
+    end
+  end
+
+  def teardown
+    @connection.drop_table(:actors)
+  end
+
+  def test_should_save_custom_belongs_to_polymorphic_association_with_custom_primary_key
+    actor = Actor.create! uuid: "93eca10a-102b-405a-84de-4a324035db9d"
+    comment = Comment.new(post: posts(:welcome), body: "nice")
+    comment.moderator = actor
+
+    comment.save!
+    assert_not_nil comment.reload.moderator
+  end
+end
+
 module AutosaveAssociationOnACollectionAssociationTests
   def test_should_automatically_save_the_associated_models
     new_names = ["Grace OMalley", "Privateers Greed"]

--- a/activerecord/test/cases/reflection_test.rb
+++ b/activerecord/test/cases/reflection_test.rb
@@ -27,6 +27,7 @@ require "models/cake_designer"
 require "models/drink_designer"
 require "models/recipe"
 require "models/user_with_invalid_relation"
+require "models/comment"
 
 class ReflectionTest < ActiveRecord::TestCase
   include ActiveRecord::Reflection
@@ -359,6 +360,10 @@ class ReflectionTest < ActiveRecord::TestCase
       define_method(:source_reflection) { reflection }
     }.new(reflection)
     assert_raises(ActiveRecord::UnknownPrimaryKey) { through.association_primary_key }
+  end
+
+  def test_association_primary_key_custom_primary_key_for_polymorphic_association
+    assert_equal "uuid", Comment.reflect_on_association(:moderator).association_primary_key(Actor).to_s
   end
 
   def test_active_record_primary_key

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -2,6 +2,7 @@
 
 # `counter_cache` requires association class before `attr_readonly`.
 class Post < ActiveRecord::Base; end
+class Actor < ActiveRecord::Base; end
 
 class Comment < ActiveRecord::Base
   scope :limit_by, lambda { |l| limit(l) }
@@ -16,6 +17,7 @@ class Comment < ActiveRecord::Base
   belongs_to :author,   polymorphic: true
   belongs_to :resource, polymorphic: true
   belongs_to :origin, polymorphic: true
+  belongs_to :moderator, polymorphic: true, association_primary_key: { "Actor" => :uuid }
   belongs_to :company, foreign_key: "company"
 
   has_many :ratings

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -242,6 +242,8 @@ ActiveRecord::Schema.define do
     t.datetime :deleted_at
     t.integer :comments
     t.integer :company
+    t.string :moderator_type
+    t.string :moderator_id
   end
 
   create_table :companies, force: true do |t|


### PR DESCRIPTION
### Summary

Introduce a `association_primary_key` option to specify custom association class and column to look up for polymorphic `belongs_to` association. 

A use case would be a `AuditLog` class that has an `Actor` of `User` model. And we need `Actor`’s `uuid` column instead of the assumed primary key `id`.

```ruby
Class AuditLog
  belongs_to :actor, polymorphic: true, association_primary_key: {  "User" => :uuid }
end
```


#### Run Tests locally:

```zsh
cd activerecord
bundle exec rake test TEST=test/cases/reflection_test.rb
bundle exec rake test TEST=test/cases/autosave_association_test.rb
```

Note I did not use the real UUID type in the test, because SQLite3 needs some more work to have UUID.

#### Todos

- [ ] Rubocop ran on unrelated change, I am happy to fix all offenses if it is desirable
- [x] Tests passed 👉🏼 MySQL tests => d7497e9
- [x] CHANGELOG

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
