### PR TITLE
Check basic auth credentials before authenticate

### DIFF
--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -103,7 +103,7 @@ module ActionController
       end
 
       def has_basic_credentials?(request)
-        request.authorization.present? && (auth_scheme(request).downcase == "basic")
+        request.authorization.present? && (auth_scheme(request).downcase == "basic") && user_name_and_password(request).length == 2
       end
 
       def user_name_and_password(request)

--- a/actionpack/test/controller/http_basic_authentication_test.rb
+++ b/actionpack/test/controller/http_basic_authentication_test.rb
@@ -112,6 +112,11 @@ class HttpBasicAuthenticationTest < ActionController::TestCase
     assert_no_match(/\n/, result)
   end
 
+  test "has_basic_credentials? should fail with credentials without colon" do
+    @request.env["HTTP_AUTHORIZATION"] = "Basic #{::Base64.encode64("David Goliath")}"
+    assert_not ActionController::HttpAuthentication::Basic.has_basic_credentials?(@request)
+  end
+
   test "successful authentication with uppercase authorization scheme" do
     @request.env["HTTP_AUTHORIZATION"] = "BASIC #{::Base64.encode64("lifo:world")}"
     get :index


### PR DESCRIPTION
### Summary

If you send a request to a controller protected by basic authentication with wrong credentials (without the colon) you will get the error: `NoMethodError: undefined method 'bytesize' for nil:NilClass`.

For example:
```ruby
class UsersController < ApplicationController
   http_basic_authenticate_with name: "king", password: "secret"

   def index
     render plain: "Something"
   end
end
```
```bash
credentials=$(echo -n king secret | base64)
curl 'http://localhost:3000/users' -H "Authorization: Basic $credentials"
```

Stacktrace:
```
NoMethodError: undefined method `bytesize' for nil:NilClass
  from activesupport (6.1.4.1) lib/active_support/security_utils.rb:34:in `secure_compare'
  from actionpack (6.1.4.1) lib/action_controller/metal/http_authentication.rb:82:in `block in http_basic_authenticate_or_request_with'
  from actionpack (6.1.4.1) lib/action_controller/metal/http_authentication.rb:101:in `authenticate'
  from actionpack (6.1.4.1) lib/action_controller/metal/http_authentication.rb:91:in `authenticate_with_http_basic'
  from actionpack (6.1.4.1) lib/action_controller/metal/http_authentication.rb:87:in `authenticate_or_request_with_http_basic'
  from actionpack (6.1.4.1) lib/action_controller/metal/http_authentication.rb:78:in `http_basic_authenticate_or_request_with'
  from actionpack (6.1.4.1) lib/action_controller/metal/http_authentication.rb:73:in `block in http_basic_authenticate_with'
```