### PR TITLE
Fix `NameError` when an invalid `:on` option is given to a route

### DIFF
--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1861,7 +1861,7 @@ module ActionDispatch
           end
 
           def map_match(paths, options)
-            if options[:on] && !VALID_ON_OPTIONS.include?(options[:on])
+            if (on = options[:on]) && !VALID_ON_OPTIONS.include?(on)
               raise ArgumentError, "Unknown scope #{on.inspect} given to :on"
             end
 

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -193,6 +193,16 @@ module ActionDispatch
         end
       end
 
+      def test_raising_error_when_invalid_on_option_is_given
+        fakeset = FakeSet.new
+        mapper = Mapper.new fakeset
+        error = assert_raise ArgumentError do
+          mapper.get "/foo", on: :invalid_option
+        end
+
+        assert_equal "Unknown scope :invalid_option given to :on", error.message
+      end
+
       def test_scope_does_not_destructively_mutate_default_options
         fakeset = FakeSet.new
         mapper = Mapper.new fakeset


### PR DESCRIPTION
### Summary

This PR fixes `NameError` when an invalid value is given to `:on` option.
I've encountered this error in Rails 6.0 and it's reproduced in the main branch as well.

```bash
/Users/9sako6/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/rails-366c8f081d8b/actionpack/lib/action_dispatch/routing/mapper.rb:1865:in `map_match': undefined local variable or method `on' for #<ActionDispatch::Routing::Mapper:0x00007fd78a132bf8> (NameError)
```