### PR TITLE
Clearer default gemfile

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -253,21 +253,21 @@ module Rails
       def rails_gemfile_entry
         if options.dev?
           [
-            GemfileEntry.path("rails", Rails::Generators::RAILS_DEV_PATH)
+            GemfileEntry.path("rails", Rails::Generators::RAILS_DEV_PATH, "Use local checkout of Rails")
           ]
         elsif options.edge?
           edge_branch = Rails.gem_version.prerelease? ? "main" : [*Rails.gem_version.segments.first(2), "stable"].join("-")
           [
-            GemfileEntry.github("rails", "rails/rails", edge_branch)
+            GemfileEntry.github("rails", "rails/rails", edge_branch, "Use specific branch of Rails")
           ]
         elsif options.main?
           [
-            GemfileEntry.github("rails", "rails/rails", "main")
+            GemfileEntry.github("rails", "rails/rails", "main", "Use main branch of Rails")
           ]
         else
           [GemfileEntry.version("rails",
                             rails_version_specifier,
-                            "Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'")]
+                            %(Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"))]
         end
       end
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -262,7 +262,7 @@ module Rails
           ]
         elsif options.main?
           [
-            GemfileEntry.github("rails", "rails/rails", "main", "Use main branch of Rails")
+            GemfileEntry.github("rails", "rails/rails", "main", "Use main development branch of Rails")
           ]
         else
           [GemfileEntry.version("rails",

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -162,7 +162,7 @@ module Rails
       end
 
       def web_server_gemfile_entry # :doc:
-        GemfileEntry.new "puma", "~> 5.0", "Use the Puma web server. Read more: https://github.com/puma/puma"
+        GemfileEntry.new "puma", "~> 5.0", "Use the Puma web server [https://github.com/puma/puma]"
       end
 
       def include_all_railties? # :doc:
@@ -286,7 +286,7 @@ module Rails
 
       def jbuilder_gemfile_entry
         return [] if options[:skip_jbuilder]
-        comment = "Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder"
+        comment = "Build JSON APIs with ease [https://github.com/rails/jbuilder]"
         GemfileEntry.new "jbuilder", "~> 2.7", comment, {}, options[:api]
       end
 
@@ -294,9 +294,9 @@ module Rails
         return [] if options[:skip_javascript]
 
         if options[:javascript] == "importmap"
-          GemfileEntry.version("importmap-rails", ">= 0.3.4", "Use JavaScript with ESM import maps. Read more: https://github.com/rails/importmap-rails")
+          GemfileEntry.version("importmap-rails", ">= 0.3.4", "Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]")
         else
-          GemfileEntry.version "jsbundling-rails", "~> 0.1.0", "Bundle and transpile JavaScript. Read more: https://github.com/rails/jsbundling-rails"
+          GemfileEntry.version "jsbundling-rails", "~> 0.1.0", "Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]"
         end
       end
 
@@ -304,10 +304,10 @@ module Rails
         return [] if options[:skip_javascript] || options[:skip_hotwire]
 
         turbo_rails_entry =
-          GemfileEntry.version("turbo-rails", ">= 0.7.11", "Hotwire's SPA-like page accelerator. Read more: https://turbo.hotwired.dev")
+          GemfileEntry.version("turbo-rails", ">= 0.7.11", "Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]")
 
         stimulus_rails_entry =
-          GemfileEntry.version("stimulus-rails", ">= 0.4.0", "Hotwire's modest JavaScript framework. Read more: https://stimulus.hotwired.dev")
+          GemfileEntry.version("stimulus-rails", ">= 0.4.0", "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]")
 
         [ turbo_rails_entry, stimulus_rails_entry ]
       end
@@ -320,9 +320,9 @@ module Rails
         return [] unless options[:css]
 
         if !using_node? && options[:css] == "tailwind"
-          GemfileEntry.version("tailwindcss-rails", ">= 0.4.3", "Use Tailwind CSS. See: https://github.com/rails/tailwindcss-rails")
+          GemfileEntry.version("tailwindcss-rails", ">= 0.4.3", "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]")
         else
-          GemfileEntry.version("cssbundling-rails", ">= 0.1.0", "Bundle and process CSS with Tailwind, PostCSS, or Sass. Read more: https://github.com/rails/cssbundling-rails")
+          GemfileEntry.version("cssbundling-rails", ">= 0.1.0", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]")
         end
       end
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -158,7 +158,7 @@ module Rails
         return [] if options[:skip_active_record]
         gem_name, gem_version = gem_for_database
         GemfileEntry.version gem_name, gem_version,
-                            "Use #{options[:database]} as the database for Active Record"
+          "Use #{options[:database]} as the database for Active Record"
       end
 
       def web_server_gemfile_entry # :doc:

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -162,8 +162,7 @@ module Rails
       end
 
       def web_server_gemfile_entry # :doc:
-        comment = "Use Puma as the app server"
-        GemfileEntry.new("puma", "~> 5.0", comment)
+        GemfileEntry.new "puma", "~> 5.0", "Use the Puma web server. Read more: https://github.com/puma/puma"
       end
 
       def include_all_railties? # :doc:
@@ -295,9 +294,9 @@ module Rails
         return [] if options[:skip_javascript]
 
         if options[:javascript] == "importmap"
-          GemfileEntry.version("importmap-rails", ">= 0.3.4", "Manage modern JavaScript using ESM without transpiling or bundling")
+          GemfileEntry.version("importmap-rails", ">= 0.3.4", "Use JavaScript with ESM import maps. Read more: https://github.com/rails/importmap-rails")
         else
-          GemfileEntry.version "jsbundling-rails", "~> 0.1.0", "Bundle and transpile JavaScript with a JavaScript bundler. Read more: https://github.com/rails/jsbundling-rails"
+          GemfileEntry.version "jsbundling-rails", "~> 0.1.0", "Bundle and transpile JavaScript. Read more: https://github.com/rails/jsbundling-rails"
         end
       end
 
@@ -308,7 +307,7 @@ module Rails
           GemfileEntry.version("turbo-rails", ">= 0.7.11", "Hotwire's SPA-like page accelerator. Read more: https://turbo.hotwired.dev")
 
         stimulus_rails_entry =
-          GemfileEntry.version("stimulus-rails", ">= 0.4.0", "Hotwire's modest JavaScript framework for the HTML you already have. Read more: https://stimulus.hotwired.dev")
+          GemfileEntry.version("stimulus-rails", ">= 0.4.0", "Hotwire's modest JavaScript framework. Read more: https://stimulus.hotwired.dev")
 
         [ turbo_rails_entry, stimulus_rails_entry ]
       end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -53,6 +53,7 @@ group :development do
   # Display speed badges w/ SQL times + flame graphs. Read more: https://github.com/MiniProfiler/rack-mini-profiler
   # gem "rack-mini-profiler", "~> 2.0"
 <%- end -%>
+
   # Speed up rails commands in dev on slow machines / big apps. See: https://github.com/rails/spring
   # gem "spring"
 end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -50,11 +50,10 @@ end
 <% end -%>
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
-  # Access an interactive console on exception pages or by calling "console" anywhere in the code.
+  # Jump into a console on exception pages or by calling "console"
   gem "web-console", ">= 4.1.0"
 
-  # Display speed badge on every html page with SQL times and flame graphs.
-  # Note: Interferes with etag cache testing. Can be configured to work on production: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
+  # Display speed badges w/ SQL times + flame graphs. Read more: https://github.com/MiniProfiler/rack-mini-profiler
   # gem "rack-mini-profiler", "~> 2.0"
 <%- end -%>
   # Speed up rails commands in dev on slow machines / big apps. See: https://github.com/rails/spring
@@ -66,7 +65,6 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 3.26"
   gem "selenium-webdriver"
-  # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"
 end
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -34,6 +34,9 @@ gem "bootsnap", ">= 1.4.4", require: false
 # gem "rack-cors"
 
 <%- end -%>
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+
 <% if RUBY_ENGINE == "ruby" -%>
 group :development, :test do
   # Start debugger with binding.b -- Read more: https://github.com/ruby/debug
@@ -61,7 +64,4 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
-
 <%- end -%>
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -2,12 +2,8 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby <%= "\"#{RUBY_VERSION}\"" -%>
-
-<% unless gemfile_entries.first&.comment -%>
-
-<% end -%>
 <% gemfile_entries.each do |gem| -%>
-<% if gem.comment -%>
+<% if gem.comment %>
 
 # <%= gem.comment %>
 <% end -%>

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -12,10 +12,7 @@ ruby <%= "\"#{RUBY_VERSION}\"" -%>
 # <%= gem.comment %>
 <% end -%>
 <%= gem.commented_out ? "# " : "" %>gem "<%= gem.name %>"<%= %(, "#{gem.version}") if gem.version -%>
-<% if gem.options.any? -%>
-, <%= gem.options.map { |k,v|
-  "#{k}: #{v.inspect.gsub('"', '\'')}" }.join(", ") %>
-<% end -%>
+<% if gem.options.any? -%>, <%= gem.options.map { |k,v| "#{k}: #{v.inspect}" }.join(", ") %><% end -%>
 <% end -%>
 <% unless options.skip_sprockets? %>
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -36,7 +36,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 <%- end -%>
 <% if RUBY_ENGINE == "ruby" -%>
 group :development, :test do
-  # See https://github.com/ruby/debug for usage
+  # Start debugger with binding.b -- Read more: https://github.com/ruby/debug
   gem "debug", ">= 1.0.0", platforms: %i[ mri mingw x64_mingw ]
 end
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -53,7 +53,7 @@ group :development do
   # gem "rack-mini-profiler", "~> 2.0"
 <%- end -%>
 
-  # Speed up rails commands in dev on slow machines / big apps. See: https://github.com/rails/spring
+  # Speed up commands on slow machines / big apps. See: https://github.com/rails/spring
   # gem "spring"
 end
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -19,7 +19,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", ">= 1.4.4", require: false
 
 <%- end -%>
-# Use Active Model has_secure_password
+# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 <% unless options.skip_sprockets? -%>
 
@@ -28,7 +28,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 <% end -%>
 <% unless skip_active_storage? -%>
 
-# Use Active Storage variant
+# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 <% end -%>
 <%- if options.api? -%>
@@ -39,27 +39,27 @@ gem "bootsnap", ">= 1.4.4", require: false
 <% if RUBY_ENGINE == "ruby" -%>
 
 group :development, :test do
-  # Start debugger with binding.b -- Read more: https://github.com/ruby/debug
+  # Start debugger with binding.b [https://github.com/ruby/debug]
   gem "debug", ">= 1.0.0", platforms: %i[ mri mingw x64_mingw ]
 end
 <% end -%>
 
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
-  # Jump into a console on exception pages or by calling "console"
+  # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console", ">= 4.1.0"
 
-  # Display speed badges w/ SQL times + flame graphs. Read more: https://github.com/MiniProfiler/rack-mini-profiler
+  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler", "~> 2.0"
 
 <%- end -%>
-  # Speed up commands on slow machines / big apps. See: https://github.com/rails/spring
+  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
 end
 
 <%- if depends_on_system_test? -%>
 group :test do
-  # Adds support for Capybara system testing and selenium driver
+  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara", ">= 3.26"
   gem "selenium-webdriver"
   gem "webdrivers"

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -9,41 +9,41 @@ ruby <%= "\"#{RUBY_VERSION}\"" -%>
 <% end -%>
 <%= gem.commented_out ? "# " : "" %>gem "<%= gem.name %>"<%= %(, "#{gem.version}") if gem.version -%>
 <% if gem.options.any? -%>, <%= gem.options.map { |k,v| "#{k}: #{v.inspect}" }.join(", ") %><% end -%>
-<% end -%>
-<% unless options.skip_sprockets? %>
+<% end %>
 
-# Use Sass to process CSS
-# gem "sassc-rails", "~> 2.1"
-<% end -%>
-
-# Use Active Model has_secure_password
-# gem "bcrypt", "~> 3.1.7"
-<% unless skip_active_storage? -%>
-
-# Use Active Storage variant
-# gem "image_processing", "~> 1.2"
-<% end -%>
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 
 <% if depend_on_bootsnap? -%>
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 
 <%- end -%>
+# Use Active Model has_secure_password
+# gem "bcrypt", "~> 3.1.7"
+<% unless options.skip_sprockets? -%>
+
+# Use Sass to process CSS
+# gem "sassc-rails", "~> 2.1"
+<% end -%>
+<% unless skip_active_storage? -%>
+
+# Use Active Storage variant
+# gem "image_processing", "~> 1.2"
+<% end -%>
 <%- if options.api? -%>
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem "rack-cors"
-
 <%- end -%>
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
-
 <% if RUBY_ENGINE == "ruby" -%>
+
 group :development, :test do
   # Start debugger with binding.b -- Read more: https://github.com/ruby/debug
   gem "debug", ">= 1.0.0", platforms: %i[ mri mingw x64_mingw ]
 end
-
 <% end -%>
+
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
   # Jump into a console on exception pages or by calling "console"
@@ -51,8 +51,8 @@ group :development do
 
   # Display speed badges w/ SQL times + flame graphs. Read more: https://github.com/MiniProfiler/rack-mini-profiler
   # gem "rack-mini-profiler", "~> 2.0"
-<%- end -%>
 
+<%- end -%>
   # Speed up commands on slow machines / big apps. See: https://github.com/rails/spring
   # gem "spring"
 end

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -21,7 +21,7 @@ gem "bootsnap", ">= 1.4.4", require: false
 <%- end -%>
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
-<% unless options.skip_sprockets? -%>
+<% unless options.skip_sprockets? || options.minimal? -%>
 
 # Use Sass to process CSS
 # gem "sassc-rails", "~> 2.1"

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -32,7 +32,7 @@ end
 
 <% end -%>
 <% if RUBY_ENGINE == "ruby" -%>
-# See https://github.com/ruby/debug for usage
+# Start debugger with binding.b -- Read more: https://github.com/ruby/debug
 # gem "debug", ">= 1.0.0", group: %i[ development test ]
 <% end -%>
 <% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>


### PR DESCRIPTION
Cleanup spacing, comments, and order in the default Gemfile. Properly separating different gems. A default generation now looks like this:

```ruby
source "https://rubygems.org"
git_source(:github) { |repo| "https://github.com/#{repo}.git" }

ruby "2.7.2"

# Use local checkout of Rails
gem "rails", path: "/Users/dhh/Work/rails/rails"

# Use sqlite3 as the database for Active Record
gem "sqlite3", "~> 1.4"

# Use the Puma web server [https://github.com/puma/puma]
gem "puma", "~> 5.0"

# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
gem "importmap-rails", ">= 0.3.4"

# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
gem "turbo-rails", ">= 0.7.11"

# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
gem "stimulus-rails", ">= 0.4.0"

# Build JSON APIs with ease [https://github.com/rails/jbuilder]
gem "jbuilder", "~> 2.7"

# Use Redis adapter to run Action Cable in production
# gem "redis", "~> 4.0"

# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
# gem "bcrypt", "~> 3.1.7"

# Use Sass to process CSS
# gem "sassc-rails", "~> 2.1"

# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
# gem "image_processing", "~> 1.2"

group :development, :test do
  # Start debugger with binding.b [https://github.com/ruby/debug]
  gem "debug", ">= 1.0.0", platforms: %i[ mri mingw x64_mingw ]
end

group :development do
  # Use console on exceptions pages [https://github.com/rails/web-console]
  gem "web-console", ">= 4.1.0"

  # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
  # gem "rack-mini-profiler", "~> 2.0"

  # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
  # gem "spring"
end

group :test do
  # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
  gem "capybara", ">= 3.26"
  gem "selenium-webdriver"
  gem "webdrivers"
end
```