### PR TITLE
Update guide to use the appropriate `concurrent-ruby` class

### DIFF
--- a/actioncable/test/client_test.rb
+++ b/actioncable/test/client_test.rb
@@ -201,7 +201,7 @@ class ClientTest < ActionCable::TestCase
   end
 
   def concurrently(enum)
-    enum.map { |*x| Concurrent::Future.execute { yield(*x) } }.map(&:value!)
+    enum.map { |*x| Concurrent::Promises.future { yield(*x) } }.map(&:value!)
   end
 
   def test_single_client

--- a/guides/source/threading_and_code_execution.md
+++ b/guides/source/threading_and_code_execution.md
@@ -289,7 +289,7 @@ Another example, using Concurrent Ruby:
 ```ruby
 Rails.application.executor.wrap do
   futures = 3.times.collect do |i|
-    Concurrent::Future.execute do
+    Concurrent::Promises.future do
       Rails.application.executor.wrap do
         # do work here
       end


### PR DESCRIPTION
### Summary
Concurrent Ruby's README states that `Concurrent::Future` is being deprecated and users should prefer using `Promises` factory instead. I updated the guide to reflect this 

### Other Information
https://github.com/ruby-concurrency/concurrent-ruby#deprecated
