### PR TITLE
Accept optional transaction args to #with_lock

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Accept optional transaction args to `ActiveRecord::Locking::Pessimistic#with_lock`
+
+    `#with_lock` now accepts transaction options like `requires_new:`,
+    `isolation:`, and `joinable:`
+
 *   Adds support for deferrable foreign key constraints in PostgreSQL.
 
     By default, foreign key constraints in PostgreSQL are checked after each statement. This works for most use cases,

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -81,9 +81,15 @@ module ActiveRecord
 
       # Wraps the passed block in a transaction, locking the object
       # before yielding. You can pass the SQL locking clause
-      # as argument (see <tt>lock!</tt>).
-      def with_lock(lock = true)
-        transaction do
+      # as an optional argument (see <tt>#lock!</tt>).
+      #
+      # You can also pass options like <tt>requires_new:</tt>, <tt>isolation:</tt>,
+      # and <tt>joinable:</tt> to the wrapping transaction (see
+      # <tt>ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction</tt>).
+      def with_lock(*args)
+        transaction_opts = args.extract_options!
+        lock = args.present? ? args.first : true
+        transaction(**transaction_opts) do
           lock!(lock)
           yield
         end


### PR DESCRIPTION
### Summary

Make #with_lock as expressive as calling `#transaction` and `#lock!`
individually to enable behavior like so:

```ruby
person.with_lock("FOR UPDATE NOWAIT", requires_new: true) do
  ...
end
```

Helps teams who prefer `#with_lock` over `#lock!` to ensure the lock is
taken out within a transaction, even when advanced transaction control
is required without requiring redundant transaction blocks.

### Other Information

This is a nice-to-have in a pretty stable part of ActiveRecord, but it would be helpful for teams who use linters to ensure there's a wrapping transaction before attempting to take out a lock, while still giving them the flexibility to, e.g. require a new nested transaction without double nesting.

Could buy the counterargument that the performance cost of the following is minimal given the default behavior of nested transactions

```ruby
Person.transaction(requires_new: true) do
  person.with_lock do # no additional transaction is taken out because one's already open
    ...
  end
end
```

But I wanted to run it up the flagpole anyway since it feels like a coherent addition to the `#with_lock` method contract, is fully backward compatible, and provides a succinct way to express transaction configuration while advantaging the "safer" block syntax.

Retrospective h/t to @fractaledmind's PR https://github.com/rails/rails/pull/43077 which I just found as I was about to submit this PR (great minds think alike!). Stephen's PR is patching the exact same issue in maybe a more expressive way. The approach I'm submitting avoids coupling to the options that `#transaction` takes and passes them through blind, but it does so via some old school options munging as opposed to named arguments; I'm honestly not sure which I prefer, but if his approach was preferred, the testing approach I took would probably work well in his PR.