### PR TITLE
Fix railties/CHANGELOG.md for cookie_serializer

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -10,7 +10,7 @@
     or `config/initializers/cookies_serializer.rb`
 
     The default value for `cookies_serializer` (`:json`) has been moved to `config.load_defaults("7.0")`.
-    The new framework defaults file sets the serializer to `:marshal`.
+    The new framework defaults file can be used to upgrade the serializer.
 
     *Alex Ghiculescu*
 


### PR DESCRIPTION
### Summary

The framework defaults file sets the serializer to `:hybrid` instead of
`:marshal`, but we can just remove the actual setting from the CHANGELOG
and referer to the defaults file instead. [ci-skip]

https://github.com/rails/rails/blob/ceb4b94baaf17f3a9f4ea795c83ec6c67211f737/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt#L85