### PR TITLE
Fix typo in Active Record validations guide, chapter 2 — integer numbers (not integral)

### DIFF
--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -161,7 +161,7 @@ module ActiveModel
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "is not a number").
       # * <tt>:only_integer</tt> - Specifies whether the value has to be an
-      #   integer, e.g. an integral value (default is +false+).
+      #   integer (default is +false+).
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+ (default is
       #   +false+). Notice that for Integer and Float columns empty strings are
       #   converted to +nil+.

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -518,10 +518,10 @@ custom message or call `presence` prior to `length`.
 ### `numericality`
 
 This helper validates that your attributes have only numeric values. By
-default, it will match an optional sign followed by an integral or floating
+default, it will match an optional sign followed by an integer or floating
 point number.
 
-To specify that only integral numbers are allowed,
+To specify that only integer numbers are allowed,
 set `:only_integer` to true. Then it will use the
 
 ```ruby


### PR DESCRIPTION
### Summary

I noticed the term 'integral number' in the validations guide. I'm assuming this was a typo? Tiny change 😁

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
