### PR TITLE
Suggest a CSP that's compatible with Turbo + import map

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -17,7 +17,7 @@
 #   end
 #
 #   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator  = ->(r) { Digest::SHA1.hexdigest(request.session.id.to_s) }
+#   config.content_security_policy_nonce_generator = ->(r) { Digest::SHA1.hexdigest(r.session.id.to_s) }
 #   config.content_security_policy_nonce_directives = %w(script-src)
 #
 #   # Report CSP violations to a specified URI. See:

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -17,7 +17,7 @@
 #   end
 #
 #   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(r) { Digest::SHA1.hexdigest(r.session.id.to_s) }
+#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
 #   config.content_security_policy_nonce_directives = %w(script-src)
 #
 #   # Report CSP violations to a specified URI. See:

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -4,24 +4,23 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
+# Rails.application.configure do
+#   config.content_security_policy do |policy|
+#     policy.default_src :self, :https
+#     policy.font_src    :self, :https, :data
+#     policy.img_src     :self, :https, :data
+#     policy.object_src  :none
+#     policy.script_src  :self, :https
+#     policy.style_src   :self, :https
+#     # Specify URI for violation reports
+#     # policy.report_uri "/csp-violation-report-endpoint"
+#   end
+#
+#   # Generate session nonces for permitted importmap and inline scripts
+#   config.content_security_policy_nonce_generator  = ->(r) { Digest::SHA1.hexdigest(request.session.id.to_s) }
+#   config.content_security_policy_nonce_directives = %w(script-src)
+#
+#   # Report CSP violations to a specified URI. See:
+#   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+#   # config.content_security_policy_report_only = true
 # end
-
-# If you are using UJS then enable automatic nonce generation
-# Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
-
-# Set the nonce only to specific directives
-# Rails.application.config.content_security_policy_nonce_directives = %w(script-src)
-
-# Report CSP violations to a specified URI
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true


### PR DESCRIPTION
In order for CSP to work with Turbo and an import map, we need nonces to be generated, but if we use per-request nonces, we'll cause the default etags generated on the basis of the response html to constantly change. This essentially kills the benefit of our default etags. Seems like it's worth the slight security trade-off to suggest using session-based nonces.