### PR TITLE
Add mandatory 'stored' option to generated column example

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -562,7 +562,7 @@ create_table :documents do |t|
   t.string :body
 
   t.virtual :textsearchable_index_col,
-            type: :tsvector, as: "to_tsvector('english', title || ' ' || body)"
+            type: :tsvector, as: "to_tsvector('english', title || ' ' || body)", stored: true
 end
 
 add_index :documents, :textsearchable_index_col, using: :gin, name: 'documents_idx'


### PR DESCRIPTION
### Summary

The [current implementation](https://github.com/rails/rails/pull/41856/files#diff-5b1b920fc3bebbb1d4c144b302603e5003a1d9e5a493e3234bf764b9e26fbe30R68-R75
) from #41856 required `stored: true` to be passed when using `t.virtual()` according to 

### Other Information

Another similar typo got a suggestion (https://github.com/rails/rails/pull/39368#discussion_r529766769) which was [accepted in #41856](https://github.com/rails/rails/pull/41856/files#diff-353f4f101b1bb04938d761b6e29c88e0f147084e9e276854a77ae5d9a9a3b2a8R9). I believe this is a similar case.


P.s. Thanks to all contributors and participants of #39368, #41856 to bring generated column support to Postgres <3