### PR TITLE
Make InheritableOptions deep transform nested hashes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
-*   No changes.
+*   `ActiveSupport::InheritableOptions` changed to deep transform any nested hashes.
+
+    *Breno Gazzola*
 
 
 ## Rails 7.0.0.alpha1 (September 15, 2021) ##

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -82,7 +82,7 @@ module ActiveSupport
         # use the faster _get when dealing with OrderedOptions
         super() { |h, k| parent._get(k) }
       elsif parent
-        super() { |h, k| parent[k] }
+        super() { |h, k| parent[k].kind_of?(Hash) ? InheritableOptions.new(parent[k]) : parent[k] }
       else
         super()
       end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -72,6 +72,26 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_equal :baz, child.foo
   end
 
+  def test_inheritable_options_nested_hash
+    a = ActiveSupport::InheritableOptions.new(foo: { bar: 1 })
+
+    assert_equal 1, a.foo.bar
+    assert_equal a.foo.bar, a.foo.bar!
+
+    b = ActiveSupport::OrderedOptions.new
+    b[:bar] = 1
+    a = ActiveSupport::InheritableOptions.new(foo: b)
+
+    assert_equal 1, a.foo.bar
+    assert_equal a.foo.bar, a.foo.bar!
+
+    b = ActiveSupport::InheritableOptions.new(bar: 1)
+    a = ActiveSupport::InheritableOptions.new(foo: b)
+
+    assert_equal 1, a.foo.bar
+    assert_equal a.foo.bar, a.foo.bar!
+  end
+
   def test_inheritable_options_inheritable_copy
     original = ActiveSupport::InheritableOptions.new
     copy     = original.inheritable_copy


### PR DESCRIPTION
Changes `InheritedOptions` so that it will also transform nested hashes in the values. 

We'd like to use a setup similar to how the credentials work, but it relies on the internal `deep_transform` method and `InheritedOptions` only transforms the first level of keys in a hash.

@ghiculescu marking you because I noticed that when you needed this behavior in `EncryptedConfiguration` you created the `deep_transform` method instead of making the change here, so you might know something I don't that would make this new behavior undesirable.