### PR TITLE
Support svg unpaired tags in tag helper

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
-*   No changes.
+*   Support svg unpaired tags for `tag` helper.
+
+        tag.svg { tag.use('href' => "#cool-icon") }
+        # => <svg><use href="#cool-icon"></svg>
+
+    *Oleksii Vasyliev*
 
 
 ## Rails 7.0.0.alpha1 (September 15, 2021) ##

--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -45,7 +45,8 @@ module ActionView
         include CaptureHelper
         include OutputSafetyHelper
 
-        VOID_ELEMENTS = %i(area base br col embed hr img input keygen link meta param source track wbr).to_set
+        HTML_VOID_ELEMENTS = %i(area base br col circle embed hr img input keygen link meta param source track wbr).to_set
+        SVG_VOID_ELEMENTS = %i(animate animateMotion animateTransform circle ellipse line path polygon polyline rect set stop use view).to_set
 
         def initialize(view_context)
           @view_context = view_context
@@ -66,7 +67,7 @@ module ActionView
 
         def tag_string(name, content = nil, escape_attributes: true, **options, &block)
           content = @view_context.capture(self, &block) if block_given?
-          if VOID_ELEMENTS.include?(name) && content.nil?
+          if (HTML_VOID_ELEMENTS.include?(name) || SVG_VOID_ELEMENTS.include?(name)) && content.nil?
             "<#{name.to_s.dasherize}#{tag_options(options, escape_attributes)}>".html_safe
           else
             content_tag_string(name.to_s.dasherize, content || "", options, escape_attributes)

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -21,6 +21,7 @@ class TagHelperTest < ActionView::TestCase
   def test_tag_builder_void_tag
     assert_equal "<br>", tag.br
     assert_equal "<br class=\"some_class\">", tag.br(class: "some_class")
+    assert_equal "<svg><use href=\"#cool-icon\"></svg>", tag.svg { tag.use("href" => "#cool-icon") }
   end
 
   def test_tag_builder_void_tag_with_forced_content


### PR DESCRIPTION
### Summary

Currently `tag` helper works incorrectly for unpaired svg tags - it always add close pair to its.

Example:

```ruby
tag.svg { tag.use("href" => "#cool-icon") }
```

Before:

```html
<svg><use href="#cool-icon"></use></svg>
```

After:

```html
<svg><use href="#cool-icon"></svg>
```