### PR TITLE
Set mysql2 adapter prepared_statements default to true

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Set prepared_statements default to true for MySQL2 adapter
+
+    If the prepared_statements config is not set, the default value is true. This is consistent
+    with the other adapters. See #42975.
+
+    Remove the deprecation warning when `prepared_statements` configuration was not 
+    set for the mysql2 adapter introduced in #43141.
+
+    *Thiago Araujo and Stefanni Brasil*
+
 *   Validate options when managing columns and tables in migrations.
 
     If an invalid option is passed to a migration method like `create_table` and `add_column`, an error will be raised

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -3,7 +3,7 @@
     If the prepared_statements config is not set, the default value is true. This is consistent
     with the other adapters. See #42975.
 
-    Remove the deprecation warning when `prepared_statements` configuration was not 
+    Remove the deprecation warning when `prepared_statements` configuration was not
     set for the mysql2 adapter introduced in #43141.
 
     *Thiago Araujo and Stefanni Brasil*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -158,7 +158,7 @@ module ActiveRecord
         @lock = ActiveSupport::Concurrency::LoadInterlockAwareMonitor.new
 
         @prepared_statements = self.class.type_cast_config_to_boolean(
-          @config.fetch(:prepared_statements) { default_prepared_statements }
+          @config.fetch(:prepared_statements, true)
         )
 
         @advisory_locks_enabled = self.class.type_cast_config_to_boolean(
@@ -1156,10 +1156,6 @@ module ActiveRecord
         # Implementations may assume this method will only be called while
         # holding @lock (or from #initialize).
         def configure_connection
-        end
-
-        def default_prepared_statements
-          true
         end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -170,13 +170,6 @@ module ActiveRecord
             super
           end
         end
-
-        def default_prepared_statements
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            The default value of `prepared_statements` for the mysql2 adapter will be changed from +false+ to +true+ in Rails 7.2.
-          MSG
-          false
-        end
     end
   end
 end

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -39,38 +39,6 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     end
   end
 
-  def test_mysql2_prepared_statements_default_deprecation_warning
-    fake_connection = Class.new do
-      def query_options
-        {}
-      end
-
-      def query(*)
-      end
-
-      def close
-      end
-    end.new
-
-    assert_not_deprecated do
-      ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
-        fake_connection,
-        ActiveRecord::Base.logger,
-        nil,
-        { socket: File::NULL }
-      )
-    end
-
-    assert_not_deprecated do
-      ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
-        fake_connection,
-        ActiveRecord::Base.logger,
-        nil,
-        { socket: File::NULL, prepared_statements: false }
-      )
-    end
-  end
-
   def test_mysql2_default_prepared_statements
     fake_connection = Class.new do
       def query_options

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -52,7 +52,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       end
     end.new
 
-    assert_deprecated do
+    assert_not_deprecated do
       ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
         fake_connection,
         ActiveRecord::Base.logger,
@@ -93,7 +93,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
       )
     end
 
-    assert_equal false, adapter.prepared_statements
+    assert_equal true, adapter.prepared_statements
   end
 
   def test_exec_query_nothing_raises_with_no_result_queries

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -282,6 +282,31 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
     @conn.drop_table :foos, if_exists: true
   end
 
+  def test_prepared_statements_defaults
+    fake_connection = Class.new do
+      def query_options
+        {}
+      end
+
+      def query(*)
+      end
+
+      def close
+      end
+    end.new
+
+    config = { socket: File::NULL }
+
+    adapter = ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(
+      fake_connection,
+      ActiveRecord::Base.logger,
+      nil,
+      config
+    )
+
+    assert_equal true, adapter.prepared_statements?
+  end
+
   def test_read_timeout_exception
     db_config = ActiveRecord::Base.configurations.configs_for(env_name: "arunit", name: "primary")
 

--- a/activerecord/test/config.example.yml
+++ b/activerecord/test/config.example.yml
@@ -42,8 +42,6 @@ connections:
       collation: utf8mb4_unicode_ci
 <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
       prepared_statements: true
-<% else %>
-      prepared_statements: false
 <% end %>
 <% if ENV['MYSQL_HOST'] %>
       host: <%= ENV['MYSQL_HOST'] %>
@@ -57,8 +55,6 @@ connections:
       collation: utf8mb4_general_ci
 <% if ENV['MYSQL_PREPARED_STATEMENTS'] %>
       prepared_statements: true
-<% else %>
-      prepared_statements: false
 <% end %>
 <% if ENV['MYSQL_HOST'] %>
       host: <%= ENV['MYSQL_HOST'] %>


### PR DESCRIPTION
### Summary

This is the final step into fixing [prepared statements is not enabled by default with mysql2 adapter](https://github.com/rails/rails/issues/42975).

This PR changes the default prepared_statements value to true for the MySQL2 adapter.

It's the same behavior that others adapters have.

Co-authored-by Thiago Araujo @thdaraujo

---

## Question
Would adding a note about this [configuration on the guides](https://guides.rubyonrails.org/configuring.html#configuring-a-postgresql-database) be helpful? If so, we could add a follow up PR.