### PR TITLE
Add explicit rendering to DiskController#update

### DIFF
--- a/activestorage/app/controllers/active_storage/disk_controller.rb
+++ b/activestorage/app/controllers/active_storage/disk_controller.rb
@@ -23,6 +23,7 @@ class ActiveStorage::DiskController < ActiveStorage::BaseController
     if token = decode_verified_token
       if acceptable_content?(token)
         named_disk_service(token[:service_name]).upload token[:key], request.body, checksum: token[:checksum]
+        head :no_content
       else
         head :unprocessable_entity
       end


### PR DESCRIPTION
This avoids unhelpful messages in the logs:
```
No template found for ActiveStorage::DiskController#update, rendering head :no_content
```

