### PR TITLE
Pluralize the heading on the index page generated with scaffold

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
@@ -1,6 +1,6 @@
 <p id="notice"><%%= notice %></p>
 
-<h1><%= human_name %></h1>
+<h1><%= human_name.pluralize %></h1>
 
 <div id="<%= plural_table_name %>">
   <%%= render @<%= plural_table_name %> %>


### PR DESCRIPTION
### Summary

In previous versions of Rails the heading on the index page that the `scaffold` command generated was plural (i.e. scaffolding User would create `<h1>Users</h1>` in `index.html.erb`) but a recent PR caused a very minor regression where now the heading is singular (scaffolding User now creates `<h1>User</h1>`). This PR fixes that.
