### PR TITLE
Fix docs spacing [ci-skip]

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -277,7 +277,6 @@ body {
 
 #mainCol {
   max-width: 630px;
-  margin-left: 2em;
 }
 
 #subCol {
@@ -299,7 +298,7 @@ body {
     position: static;
     width: inherit;
     margin-left: -1em;
-    margin-right: 0;
+    margin-right: -1em;
     padding-right: 1.25em;
   }
 }
@@ -313,6 +312,10 @@ body {
   max-width: 960px;
 }
 
+#footer p:last-child {
+  margin-bottom: 0;
+}
+
 #header .wrapper, #topNav .wrapper, #feature .wrapper {padding-left: 1em; max-width: 960px;}
 #feature .wrapper {max-width: 720px; padding-right: 23em; position: relative; z-index: 0;}
 
@@ -321,7 +324,7 @@ body {
 }
 
 @media screen and (max-width: 800px) {
-  #feature .wrapper, #container .wrapper { padding-right: 0; }
+  #feature .wrapper, #container .wrapper { padding-right: 1em; }
 }
 
 /* Links

--- a/guides/assets/stylesheets/main.rtl.css
+++ b/guides/assets/stylesheets/main.rtl.css
@@ -273,7 +273,6 @@ body {
 
 #mainCol {
   max-width: 630px;
-  margin-right: 2em;
 }
 
 #subCol {
@@ -295,7 +294,7 @@ body {
     position: static;
     width: inherit;
     margin-right: -1em;
-    margin-left: 0;
+    margin-left: -1em;
     padding-left: 1.25em;
   }
 }
@@ -309,6 +308,10 @@ body {
   max-width: 960px;
 }
 
+#footer p:last-child {
+  margin-bottom: 0;
+}
+
 #header .wrapper, #topNav .wrapper, #feature .wrapper {padding-right: 1em; max-width: 960px;}
 #feature .wrapper {max-width: 720px; padding-left: 23em; position: relative; z-index: 0;}
 
@@ -317,7 +320,7 @@ body {
 }
 
 @media screen and (max-width: 800px) {
-  #feature .wrapper, #container .wrapper { padding-left: 0; }
+  #feature .wrapper, #container .wrapper { padding-left: 1em; }
 }
 
 /* Links


### PR DESCRIPTION
### Summary

Adjust the docs spacing for the main content and footer.

- Adjust the main content's left and right spacing (1em).
- Remove the bottom margin of the footer's last paragraph.

**Original**

<img src="https://user-images.githubusercontent.com/28077042/133912723-9e93acd9-ec30-4257-b833-7619a13b0de6.png" width="300">

![image](https://user-images.githubusercontent.com/28077042/133912793-aa46db66-b9cd-47ab-b4ec-1b46c81f224b.png)

**Updated**

<img src="https://user-images.githubusercontent.com/28077042/133912714-2a2c2112-9b8a-412c-b342-045e4a52aa5f.png" width="300">

![image](https://user-images.githubusercontent.com/28077042/133912801-be6fb36a-5469-4586-9369-ca57211272a7.png)


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
