### PR TITLE
[ci skip] Add Bootstrap and Bulma to the CSS processors' list

### DIFF
--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -262,7 +262,7 @@ module Rails
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
       class_option :javascript, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
-      class_option :css, type: :string, desc: "Choose CSS processor [options: tailwind, postcss, sass]"
+      class_option :css, type: :string, desc: "Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass... check https://github.com/rails/cssbundling-rails]"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
 
       def initialize(*args)


### PR DESCRIPTION
Closes #43251

## Summary

When running `rails new --help` the `bootstrap` and `bulma` options for CSS processors were not documented.
The `rails new --css=bootstrap` option already works and the `rails new --css=bulma` option will work in the [cssbundling-rails](https://github.com/rails/cssbundling-rails) next release thanks to [this merged pull request](https://github.com/rails/cssbundling-rails/pull/19).
