### PR TITLE
Docs: `ActiveRecord::Base` -> `ApplicationRecord` nested attributes [ci skip]

### DIFF
--- a/activerecord/lib/active_record/nested_attributes.rb
+++ b/activerecord/lib/active_record/nested_attributes.rb
@@ -29,7 +29,7 @@ module ActiveRecord
     # <tt>author_attributes=(attributes)</tt> and
     # <tt>pages_attributes=(attributes)</tt>.
     #
-    #   class Book < ActiveRecord::Base
+    #   class Book < ApplicationRecord
     #     has_one :author
     #     has_many :pages
     #
@@ -43,7 +43,7 @@ module ActiveRecord
     #
     # Consider a Member model that has one Avatar:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #   end
@@ -64,7 +64,7 @@ module ActiveRecord
     #
     # If you want to update the current avatar without providing the id, you must add <tt>:update_only</tt> option.
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar, update_only: true
     #   end
@@ -79,7 +79,7 @@ module ActiveRecord
     # attributes hash, you have to enable it first using the
     # <tt>:allow_destroy</tt> option.
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar, allow_destroy: true
     #   end
@@ -101,7 +101,7 @@ module ActiveRecord
     #
     # Consider a member that has a number of posts:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts
     #   end
@@ -131,7 +131,7 @@ module ActiveRecord
     # hashes if they fail to pass your criteria. For example, the previous
     # example could be rewritten as:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: proc { |attributes| attributes['title'].blank? }
     #   end
@@ -151,12 +151,12 @@ module ActiveRecord
     #
     # Alternatively, +:reject_if+ also accepts a symbol for using methods:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :new_record?
     #   end
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, reject_if: :reject_posts
     #
@@ -190,7 +190,7 @@ module ActiveRecord
     # option. This will allow you to also use the <tt>_destroy</tt> key to
     # destroy existing records:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_many :posts
     #     accepts_nested_attributes_for :posts, allow_destroy: true
     #   end
@@ -249,12 +249,12 @@ module ActiveRecord
     # record, you can use the +validates_presence_of+ method and the +:inverse_of+
     # key as this example illustrates:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_many :posts, inverse_of: :member
     #     accepts_nested_attributes_for :posts
     #   end
     #
-    #   class Post < ActiveRecord::Base
+    #   class Post < ApplicationRecord
     #     belongs_to :member, inverse_of: :posts
     #     validates_presence_of :member
     #   end
@@ -267,7 +267,7 @@ module ActiveRecord
     # child object yourself before assignment, then this module will not
     # overwrite it, e.g.:
     #
-    #   class Member < ActiveRecord::Base
+    #   class Member < ApplicationRecord
     #     has_one :avatar
     #     accepts_nested_attributes_for :avatar
     #


### PR DESCRIPTION
It is not `ActiveRecord::Base` anymore but `ApplicationRecord`.

Accidentally noticed this while reading nested attributes code, decided
to push just for this file but if you think this makes sense I can
change any instance in the source code, in chunks or everything in one
PR :)