### PR TITLE
Only call `wrap_parameters` if it's defined

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -63,7 +63,7 @@ module ActionController
         extend ::AbstractController::Railties::RoutesHelpers.with(app.routes)
         extend ::ActionController::Railties::Helpers
 
-        wrap_parameters format: [:json] if options.wrap_parameters_by_default
+        wrap_parameters format: [:json] if options.wrap_parameters_by_default && respond_to?(:wrap_parameters)
 
         # Configs used in other initializers
         filtered_options = options.except(


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/43257

The failing tests subclass `ActionController::Metal`. `wrap_paramters` is only defined in `ActionController::Base` and `ActionController::API`.

cc @rafaelfranca @ceritium 