### PR TITLE
Only create active_storage_variant_records table if needed

### DIFF
--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,12 +1,14 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
-    # Use Active Record's configured type for primary key
-    create_table :active_storage_variant_records, id: primary_key_type do |t|
-      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
-      t.string :variation_digest, null: false
+    unless table_exists?(:active_storage_variant_records)
+      # Use Active Record's configured type for primary key
+      create_table :active_storage_variant_records, id: primary_key_type do |t|
+        t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+        t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+        t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+        t.foreign_key :active_storage_blobs, column: :blob_id
+      end
     end
   end
 


### PR DESCRIPTION
### Summary
The table for `active_storage_variant_records` is defined in two places. In the [migration](https://github.com/rails/rails/blob/753633abdfc72743419ba86ef4981679098365e5/activestorage/db/migrate/20170806125915_create_active_storage_tables.rb#L39) folder and in the [update_migration](https://github.com/gingermusketeer/rails/blob/753633abdfc72743419ba86ef4981679098365e5/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb) folder. This means that the table may already exist when the update migration is run.

If this happens then the migration will fail as it does not check to see if the table already exists. This change prevents the error.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Fixes the issue raised in #43231.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
