### PR TITLE
Filter virtual columns from the attribute names

### DIFF
--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -387,20 +387,22 @@ module ActiveRecord
         attribute_names.index_with { |name| @attributes[name] }
       end
 
-      # Filters the primary keys and readonly attributes from the attribute names.
+      # Filters the primary keys, readonly attributes and virtual columns from the attribute names.
       def attributes_for_update(attribute_names)
         attribute_names &= self.class.column_names
         attribute_names.delete_if do |name|
-          self.class.readonly_attribute?(name)
+          self.class.readonly_attribute?(name) ||
+            column_for_attribute(name).virtual?
         end
       end
 
-      # Filters out the primary keys, from the attribute names, when the primary
+      # Filters out the virtual columns and also primary keys, from the attribute names, when the primary
       # key is to be generated (e.g. the id attribute has no value).
       def attributes_for_create(attribute_names)
         attribute_names &= self.class.column_names
         attribute_names.delete_if do |name|
-          pk_attribute?(name) && id.nil?
+          (pk_attribute?(name) && id.nil?) ||
+            column_for_attribute(name).virtual?
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/column.rb
@@ -87,6 +87,10 @@ module ActiveRecord
           comment.hash
       end
 
+      def virtual?
+        false
+      end
+
       private
         def deduplicated
           @name = -name

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -23,6 +23,16 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       VirtualColumn.create(name: "Rails")
     end
 
+    def test_virtual_column_with_full_inserts
+      partial_inserts_was = VirtualColumn.partial_inserts
+      VirtualColumn.partial_inserts = false
+      assert_nothing_raised do
+        VirtualColumn.create!(name: "Rails")
+      end
+    ensure
+      VirtualColumn.partial_inserts = partial_inserts_was
+    end
+
     def teardown
       @connection.drop_table :virtual_columns, if_exists: true
       VirtualColumn.reset_column_information


### PR DESCRIPTION
### Summary
In a rails 7 app with `config.active_record.partial_inserts = false`,
If you have a model with virtual/generated columns AR tries to insert values into the columns when creating a new record.

This results in a PG::Error

Fixes #43262

### Other Information

This opens up for another question:
Should `VirtualColumn.create(name: "Hello", upper_name: "hello")` raise or just ignore the value for `upper_name`

Thanks to @cristianbica for the help