### PR TITLE
Add 'resource' to the list of generators which create a new model migration

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -281,7 +281,7 @@ end
 
 ### Model Generators
 
-The model and scaffold generators will create migrations appropriate for adding
+The model, resource and scaffold generators will create migrations appropriate for adding
 a new model. This migration will already contain instructions for creating the
 relevant table. If you tell Rails what columns you want, then statements for
 adding these columns will also be created. For example, running:
@@ -340,7 +340,7 @@ get to work!
 ### Creating a Table
 
 The [`create_table`][] method is one of the most fundamental, but most of the time,
-will be generated for you from using a model or scaffold generator. A typical
+will be generated for you from using a model, resource or scaffold generator. A typical
 use would be
 
 ```ruby


### PR DESCRIPTION
### Summary
As `rails g resource <resource-name>` creates a new-model migration similar to model and scaffold generators, simply added it to the other generators.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- I### Other Information

f there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
