### PR TITLE
Fixes #43266 Add `bigint` to `NATIVE_DATABASE_TYPES` in mysql & postgres adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -31,6 +31,7 @@ module ActiveRecord
         string:      { name: "varchar", limit: 255 },
         text:        { name: "text" },
         integer:     { name: "int", limit: 4 },
+        bigint:      { name: "bigint" },
         float:       { name: "float", limit: 24 },
         decimal:     { name: "decimal" },
         datetime:    { name: "datetime" },

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -125,6 +125,7 @@ module ActiveRecord
         string:      { name: "character varying" },
         text:        { name: "text" },
         integer:     { name: "integer", limit: 4 },
+        bigint:      { name: "bigint" },
         float:       { name: "float" },
         decimal:     { name: "decimal" },
         datetime:    {}, # set dynamically based on datetime_type


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/43266

Bigint was not treated as native database datatype for `postgres` & `mysql`. This PR adds `bigint` to `NATIVE_DATABASE_TYPES`.

Previous:
```ruby
ActiveRecord::Base.connection.valid_type?(:bigint)
#  => false
```

After this fix:
```ruby
ActiveRecord::Base.connection.valid_type?(:bigint)
#  => true
```

<!--
### Other Information
 If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
