### PR TITLE
Remove deprecated ActiveModel::Errors#<<

### DIFF
--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -20,11 +20,11 @@ class ActiveModelHelperTest < ActionView::TestCase
     super
 
     @post = Post.new
-    assert_deprecated { @post.errors[:author_name] << "can't be empty" }
-    assert_deprecated { @post.errors[:body] << "foo" }
-    assert_deprecated { @post.errors[:category] << "must exist" }
-    assert_deprecated { @post.errors[:published] << "must be accepted" }
-    assert_deprecated { @post.errors[:updated_at] << "bar" }
+    @post.errors.add(:author_name, "can't be empty")
+    @post.errors.add(:body, "foo")
+    @post.errors.add(:category, "must exist")
+    @post.errors.add(:published, "must be accepted")
+    @post.errors.add(:updated_at, "bar")
 
     @post.author_name = ""
     @post.body        = "Back to the hill and over it again!"

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1341,7 +1341,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_time_zone_select_with_priority_zones_and_errors
     @firm = Firm.new("D")
     @firm.extend ActiveModel::Validations
-    assert_deprecated { @firm.errors[:time_zone] << "invalid" }
+    @firm.errors.add(:time_zone)
     zones = [ ActiveSupport::TimeZone.new("A"), ActiveSupport::TimeZone.new("D") ]
     html = time_zone_select("firm", "time_zone", zones)
     assert_dom_equal "<div class=\"field_with_errors\">" \

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -656,14 +656,6 @@ module ActiveModel
       super(content.freeze)
     end
 
-    def <<(message)
-      ActiveSupport::Deprecation.warn("Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.")
-
-      @errors.add(@attribute, message)
-      __setobj__ @errors.messages_for(@attribute)
-      self
-    end
-
     def clear
       ActiveSupport::Deprecation.warn("Calling `clear` to an ActiveModel::Errors message array in order to delete all errors is deprecated. Please call `ActiveModel::Errors#delete` instead.")
 

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -39,7 +39,7 @@ class ErrorsTest < ActiveModel::TestCase
 
   def test_include?
     errors = ActiveModel::Errors.new(Person.new)
-    assert_deprecated { errors[:foo] << "omg" }
+    errors.add(:foo, "omg")
     assert_includes errors, :foo, "errors should include :foo"
     assert_includes errors, "foo", "errors should include 'foo' as :foo"
   end

--- a/activemodel/test/cases/validations_test.rb
+++ b/activemodel/test/cases/validations_test.rb
@@ -74,7 +74,7 @@ class ValidationsTest < ActiveModel::TestCase
 
   def test_errors_on_nested_attributes_expands_name
     t = Topic.new
-    assert_deprecated { t.errors["replies.name"] << "can't be blank" }
+    t.errors.add("replies.name", "can't be blank")
     assert_equal ["Replies name can't be blank"], t.errors.full_messages
   end
 

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -759,7 +759,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_push_with_invalid_join_record
     repair_validations(Contract) do
-      Contract.validate { |r| r.errors[:base] << "Invalid Contract" }
+      Contract.validate { |r| r.errors.add(:base, "Invalid Contract") }
 
       firm = companies(:first_firm)
       lifo = Developer.new(name: "lifo")
@@ -1213,7 +1213,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_create_should_not_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       assert_deprecated { Category.create(name: "Fishing", authors: [Author.first]) }
     end
   end
@@ -1225,7 +1225,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_create_bang_should_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       assert_raises(ActiveRecord::RecordInvalid) do
         assert_deprecated { Category.create!(name: "Fishing", authors: [Author.first]) }
       end
@@ -1234,7 +1234,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_save_bang_should_raise_exception_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       c = Category.new(name: "Fishing", authors: [Author.first])
       assert_raises(ActiveRecord::RecordInvalid) do
         assert_deprecated { c.save! }
@@ -1244,7 +1244,7 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_save_returns_falsy_when_join_record_has_errors
     repair_validations(Categorization) do
-      Categorization.validate { |r| r.errors[:base] << "Invalid Categorization" }
+      Categorization.validate { |r| r.errors.add(:base, "Invalid Categorization") }
       c = Category.new(name: "Fishing", authors: [Author.first])
       assert_deprecated { assert_not c.save }
     end


### PR DESCRIPTION
### Summary

Remove deprecated ActiveModel::Errors#<<

This is the first of many removal for deprecated codes in `Errors`.

I split them to smaller chunks to make review easier.

### Other Information

> If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

I wonder if we should have a single CHANGELOG after every deprecations are removed. Thus I didn't include CHANGELOG here for now.