### PR TITLE
Address LegacyDeliveryJobTest#test_should_send_mail_correctly failure with ruby 3.1.0dev

### DIFF
--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -171,7 +171,7 @@ module ActionMailer
         parameters.find do |key, name|
           return true if key == :keyreq && name == :args
 
-          key == :keyrest
+          key == :keyrest and name != :**
         end
       end
   end


### PR DESCRIPTION
### Summary

This commit addresses LegacyDeliveryJobTest#test_should_send_mail_correctly failure with Ruby 3.1.0 master branch
since https://buildkite.com/rails/rails/builds/79922#1152cdb4-a52a-4144-b4f1-5399ecd00a3e

* Steps to reproduce

```ruby
$ ruby -v
ruby 3.1.0dev (2021-09-20T11:16:45Z master b61064b821) [x86_64-linux]
$ cd actionmailer
$ bin/test test/legacy_delivery_job_test.rb -n test_should_send_mail_correctly
Run options: -n test_should_send_mail_correctly --seed 34109

F

Failure:
LegacyDeliveryJobTest#test_should_send_mail_correctly [/home/yahonda/src/github.com/rails/rails/actionmailer/test/legacy_delivery_job_test.rb:78]:
No performed job found with {:job=>LegacyDeliveryJobTest::LegacyDeliveryJob, :args=>["DelayedMailer", "test_message", "deliver_now", 1, 2, 3]}

Potential matches: {"job_class"=>"LegacyDeliveryJobTest::LegacyDeliveryJob", "job_id"=>"37a3bde7-6580-4ae1-9213-8fa69a108fd8", "provider_job_id"=>nil, "queue_name"=>"test_queue", "priority"=>nil, "arguments"=>["DelayedMailer", "test_message", "deliver_now", {"args"=>[1, 2, 3], "_aj_ruby2_keywords"=>["args"]}], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>nil, "enqueued_at"=>"2021-09-20T13:56:30Z", :job=>LegacyDeliveryJobTest::LegacyDeliveryJob, :args=>["DelayedMailer", "test_message", "deliver_now", {:args=>[1, 2, 3]}], :queue=>"test_queue", :priority=>nil}

bin/test test/legacy_delivery_job_test.rb:66

Finished in 0.182945s, 5.4661 runs/s, 5.4661 assertions/s.
1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
$
```

This behavior change has been introduced via https://github.com/ruby/ruby/pull/4705 .
Here are how `perform` method parameters are handled with Ruby 3.0.2 and Ruby 3.1.0-dev

* Ruby 3.1.0dev

```ruby
% ruby -v
ruby 3.1.0dev (2021-09-18T16:05:40Z master f9fd04ffbc) [x86_64-darwin21]
% irb
irb(main):001:1* def perform(mailer, mail_method, delivery_method, *args)
irb(main):002:0> end
=> :perform
irb(main):003:0> method(:perform).parameters
=> [[:req, :mailer], [:req, :mail_method], [:req, :delivery_method], [:rest, :args]]
irb(main):004:0> ruby2_keywords(:perform)
=> nil
irb(main):005:0> method(:perform).parameters
=> [[:req, :mailer], [:req, :mail_method], [:req, :delivery_method], [:rest, :args], [:keyrest, :**]]
irb(main):006:0>
```

* Ruby 3.0.2

```ruby
% ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin21]
% irb
irb(main):001:1* def perform(mailer, mail_method, delivery_method, *args)
irb(main):002:0> end
=> :perform
irb(main):003:0> method(:perform).parameters
=> [[:req, :mailer], [:req, :mail_method], [:req, :delivery_method], [:rest, :args]]
irb(main):004:0> ruby2_keywords(:perform)
=> nil
irb(main):005:0> method(:perform).parameters
=> [[:req, :mailer], [:req, :mail_method], [:req, :delivery_method], [:rest, :args]]
irb(main):006:0>
```
