### PR TITLE
Requires selenium-webdriver 4.0.0

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -66,7 +66,7 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara", ">= 3.26"
-  gem "selenium-webdriver"
+  gem "selenium-webdriver", ">= 4.0.0.rc1"
   gem "webdrivers"
 end
 <%- end -%>


### PR DESCRIPTION
### Summary

It modifies the "rails new" generator to produce a Gemfile with "selenium-webdriver", ">= 4.0.0.rc1"

### Other Information

`selenium-webdriver` added support for Ruby 3.0, but there is only an RC version available right now.

Related to https://github.com/rails/rails/issues/43248