### PR TITLE
Fix erb code highlighting in upgrade guide [ci-skip]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -333,7 +333,7 @@ Because of this you must manually invalidate your affected cache keys.
 
 For example, if you have something like this in a view:
 
-```ruby
+```erb
 <% @products.each do |product| %>
   <% cache product do %>
     <%= image_tag product.cover_photo.variant(resize: "200x") %>
@@ -343,7 +343,7 @@ For example, if you have something like this in a view:
 
 You can invalidate the cache either by touching the product, or changing the cache key:
 
-```ruby
+```erb
 <% @products.each do |product| %>
   <% cache ["v2", product] do %>
     <%= image_tag product.cover_photo.variant(resize_to_limit: [200, nill]) %>


### PR DESCRIPTION
### Summary

In the latest update the code highlighting got changed to `ruby`.
This changes it back to `erb`.

### Before with ruby

<img width="662" alt="image" src="https://user-images.githubusercontent.com/28561/134066694-d25d141d-0292-485c-8e59-9668389f074d.png">


### After with erb

<img width="666" alt="image" src="https://user-images.githubusercontent.com/28561/134066650-4c9c833b-37f8-4152-a03f-cb3205db3934.png">
