### PR TITLE
Change 'CamelCase' to 'PascalCase' to better reflect case conventions

### DIFF
--- a/guides/source/active_record_basics.md
+++ b/guides/source/active_record_basics.md
@@ -79,7 +79,7 @@ a class `Book`, you should have a database table called **books**. The Rails
 pluralization mechanisms are very powerful, being capable of pluralizing (and
 singularizing) both regular and irregular words. When using class names composed
 of two or more words, the model class name should follow the Ruby conventions,
-using the CamelCase form, while the table name must use the snake_case form. Examples:
+using the PascalCase form, while the table name must use the snake_case form. Examples:
 
 * Model Class - Singular with the first letter of each word capitalized (e.g.,
 `BookClub`).


### PR DESCRIPTION
### Summary

While reading the guides, I came across text saying: "the model class name should follow the Ruby conventions,
using the CamelCase form". From my experience and having a look around before committing this change, there seems to be a consistent consensus that camelcase is "camelCase" (lowercase first letter) and pascal case is "PascalCase" (every first letter is capitalized). I looked into it to make sure this wasn't just a coding opinion or a potential "tab vs spaces" can of worms. Feel free to discuss if felt otherwise.