### PR TITLE
Add fallback host for SystemTestCase driven by RackTest

### DIFF
--- a/actionpack/lib/action_dispatch/system_test_case.rb
+++ b/actionpack/lib/action_dispatch/system_test_case.rb
@@ -115,6 +115,8 @@ module ActionDispatch
     include SystemTesting::TestHelpers::SetupAndTeardown
     include SystemTesting::TestHelpers::ScreenshotHelper
 
+    DEFAULT_HOST = "http://127.0.0.1"
+
     def initialize(*) # :nodoc:
       super
       self.class.driven_by(:selenium) unless self.class.driver?
@@ -166,7 +168,11 @@ module ActionDispatch
               include ActionDispatch.test_app.routes.mounted_helpers
 
               def url_options
-                default_url_options.reverse_merge(host: Capybara.app_host || Capybara.current_session.server_url)
+                default_url_options.reverse_merge(host: app_host)
+              end
+
+              def app_host
+                Capybara.app_host || Capybara.current_session.server_url || DEFAULT_HOST
               end
             end.new
           end

--- a/actionpack/test/dispatch/system_testing/system_test_case_test.rb
+++ b/actionpack/test/dispatch/system_testing/system_test_case_test.rb
@@ -36,6 +36,10 @@ class SetDriverToSeleniumHeadlessFirefoxTest < DrivenBySeleniumWithHeadlessFiref
 end
 
 class SetHostTest < DrivenByRackTest
+  teardown do
+    Capybara.app_host = nil
+  end
+
   test "overrides host" do
     assert_deprecated do
       host! "http://example.com"

--- a/railties/test/application/system_test_case_test.rb
+++ b/railties/test/application/system_test_case_test.rb
@@ -26,7 +26,22 @@ class SystemTestCaseTest < ActiveSupport::TestCase
     assert_not_includes(ActionDispatch::SystemTestCase.runnable_methods, :test_foo_url)
   end
 
-  test "system tests set the Capybara host in the url_options by default" do
+  test "system tests use 127.0.0.1 in the url_options be default" do
+    app_file "config/routes.rb", <<-RUBY
+      Rails.application.routes.draw do
+        get 'foo', to: 'foo#index', as: 'test_foo'
+      end
+    RUBY
+
+    app("test")
+    rack_test_case = Class.new(ActionDispatch::SystemTestCase) do
+      driven_by :rack_test
+    end
+    system_test = rack_test_case.new("my_test")
+    assert_equal("http://127.0.0.1/foo", system_test.test_foo_url)
+  end
+
+  test "system tests use Capybara.app_host in the url_options if present" do
     app_file "config/routes.rb", <<-RUBY
       Rails.application.routes.draw do
         get 'foo', to: 'foo#index', as: 'test_foo'


### PR DESCRIPTION
### Summary

For links to work in SystemTestCases, it requires the `host` to be added
to the `default_url_options`. Since 78c734386cddf5ee533ad1915d3769b9cc1be3a2 this is done by looking at
`Capybara.app_host` or `Capybara.current_session.server_url`.

This works correctly when using the Selenium webdriver, as Capybara sets
either the `Capybara.app_host` or the `Capybara.current_session.server_url`.
However the Capybara RackTest driver uses paths instead of URL's, so it doesn't
set Capybara.app_host or Capybara.current_session.server_url.

For SystemTestCase to work for the RackTest driver a host has to be
available for url options. We can fallback to "http://127.0.0.1" which
was the default before 78c734386cddf5ee533ad1915d3769b9cc1be3a2.

Fixes: #42780