### PR TITLE
Add missing migrate command to Getting Started Guide section 8.3

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1721,6 +1721,12 @@ $ bin/rails generate migration AddStatusToArticles status:string
 $ bin/rails generate migration AddStatusToComments status:string
 ```
 
+And next, let's update the database with the generated migrations:
+
+```bash
+$ bin/rails db:migrate
+```
+
 TIP: To learn more about migrations, see [Active Record Migrations](
 active_record_migrations.html).
 


### PR DESCRIPTION
### Summary

This PR adds a missing `bin/rails db:migrate` command right after:

```
$ bin/rails generate migration AddStatusToArticles status:string
$ bin/rails generate migration AddStatusToComments status:string
```
on Getting Started Guide section 8.3. Without the migrate command, the application throws an SQLite3::SQLException `Table comments has no column named status`

![image](https://user-images.githubusercontent.com/2728804/134193210-a94f15ab-e59f-4125-bf22-3f30c578bd81.png)


It fixes the bug https://github.com/rails/rails/issues/43275

Closes #43275