### PR TITLE
specify how to enable zeitwerk by itself

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -603,6 +603,14 @@ config.load_defaults 6.0
 
 enables `zeitwerk` autoloading mode on CRuby. In that mode, autoloading, reloading, and eager loading are managed by [Zeitwerk](https://github.com/fxn/zeitwerk).
 
+If you are using defaults from a previous Rails version, you can enable zeitwerk like so:
+
+```ruby
+# config/application.rb
+
+config.autoloader = :zeitwerk
+```
+
 #### Public API
 
 In general, applications do not need to use the API of Zeitwerk directly. Rails sets things up according to the existing contract: `config.autoload_paths`, `config.cache_classes`, etc.


### PR DESCRIPTION
current docs confusingly say how to upgrade _all_ defaults, in the zeitwerk section

edit: i later discovered this is partly described here: https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#how-to-use-the-classic-autoloader-in-rails-6

maybe that section should be moved up?