### PR TITLE
Add autocomplete="off" to all generated hidden fields (fixes #42610)

### DIFF
--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -34,7 +34,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="content" id="trix_input_1" />' \
+        '<input type="hidden" name="content" id="trix_input_1" autocomplete="off" />' \
         '<trix-editor input="trix_input_1" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -48,7 +48,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" autocomplete="off" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -62,7 +62,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" autocomplete="off" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="custom-class" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -76,7 +76,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[not_an_attribute]" id="message_not_an_attribute_trix_input_message" />' \
+        '<input type="hidden" name="message[not_an_attribute]" id="message_not_an_attribute_trix_input_message" autocomplete="off" />' \
         '<trix-editor id="message_not_an_attribute" input="message_not_an_attribute_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -90,7 +90,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[content]" id="trix_input_2" />' \
+        '<input type="hidden" name="message[content]" id="trix_input_2" autocomplete="off" />' \
         '<trix-editor id="message_content" input="trix_input_2" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -104,7 +104,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" autocomplete="off" />' \
         '<trix-editor placeholder="Content" id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -120,7 +120,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" />' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" autocomplete="off" />' \
         '<trix-editor placeholder="Story title" id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -134,7 +134,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;" />' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" value="&lt;h1&gt;hello world&lt;/h1&gt;" autocomplete="off" />' \
         '<trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -148,7 +148,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" form="other_form" />' \
+        '<input type="hidden" name="message[title]" id="message_title_trix_input_message" form="other_form" autocomplete="off" />' \
         '<trix-editor id="message_title" input="message_title_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -162,7 +162,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" autocomplete="off" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",
@@ -176,7 +176,7 @@ class ActionText::FormHelperTest < ActionView::TestCase
 
     assert_dom_equal \
       '<form action="/messages" accept-charset="UTF-8" method="post">' \
-        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" />' \
+        '<input type="hidden" name="message[content]" id="message_content_trix_input_message" autocomplete="off" />' \
         '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/blobs/:signed_id/:filename">' \
         "</trix-editor>" \
       "</form>",

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -1101,7 +1101,8 @@ module ActionView
             type: "hidden",
             id: input_id_from_type(type),
             name: input_name_from_type(type),
-            value: value
+            value: value,
+            autocomplete: "off"
           }.merge!(@html_options.slice(:disabled))
           select_options[:disabled] = "disabled" if @options[:disabled]
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -277,7 +277,7 @@ module ActionView
       #   # => <input id="collected_input" name="collected_input" onchange="alert('Input collected!')"
       #   #    type="hidden" value="" />
       def hidden_field_tag(name, value = nil, options = {})
-        text_field_tag(name, value, options.merge(type: :hidden))
+        text_field_tag(name, value, options.merge(type: :hidden, autocomplete: "off"))
       end
 
       # Creates a file upload field. If you are using file uploads then you will also need
@@ -866,7 +866,7 @@ module ActionView
         # Use raw HTML to ensure the value is written as an HTML entity; it
         # needs to be the right character regardless of which encoding the
         # browser infers.
-        '<input name="utf8" type="hidden" value="&#x2713;" />'.html_safe
+        '<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />'.html_safe
       end
 
       private

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -141,7 +141,7 @@ module ActionView
             select = content_tag("select", add_options(option_tags, options, value), html_options)
 
             if html_options["multiple"] && options.fetch(:include_hidden, true)
-              tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "") + select
+              tag("input", disabled: html_options["disabled"], name: html_options["name"], type: "hidden", value: "", autocomplete: "off") + select
             else
               select
             end

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -57,7 +57,7 @@ module ActionView
           end
 
           def hidden_field_for_checkbox(options)
-            @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value)) : "".html_safe
+            @unchecked_value ? tag("input", options.slice("name", "disabled", "form").merge!("type" => "hidden", "value" => @unchecked_value, "autocomplete" => "off")) : "".html_safe
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/hidden_field.rb
+++ b/actionview/lib/action_view/helpers/tags/hidden_field.rb
@@ -4,6 +4,10 @@ module ActionView
   module Helpers
     module Tags # :nodoc:
       class HiddenField < TextField # :nodoc:
+        def render
+          @options[:autocomplete] = "off"
+          super
+        end
       end
     end
   end

--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -354,7 +354,8 @@ module ActionView
         inner_tags = method_tag.safe_concat(button).safe_concat(request_token_tag)
         if params
           to_form_params(params).each do |param|
-            inner_tags.safe_concat tag(:input, type: "hidden", name: param[:name], value: param[:value])
+            inner_tags.safe_concat tag(:input, type: "hidden", name: param[:name], value: param[:value],
+                                       autocomplete: "off")
           end
         end
         content_tag("form", inner_tags, form_options)
@@ -752,14 +753,14 @@ module ActionView
         def token_tag(token = nil, form_options: {})
           if token != false && defined?(protect_against_forgery?) && protect_against_forgery?
             token ||= form_authenticity_token(form_options: form_options)
-            tag(:input, type: "hidden", name: request_forgery_protection_token.to_s, value: token)
+            tag(:input, type: "hidden", name: request_forgery_protection_token.to_s, value: token, autocomplete: "off")
           else
             ""
           end
         end
 
         def method_tag(method)
-          tag("input", type: "hidden", name: "_method", value: method.to_s)
+          tag("input", type: "hidden", name: "_method", value: method.to_s, autocomplete: "off")
         end
 
         # Returns an array of hashes each containing :name and :value keys

--- a/actionview/test/activerecord/form_helper_activerecord_test.rb
+++ b/actionview/test/activerecord/form_helper_activerecord_test.rb
@@ -51,7 +51,7 @@ class FormHelperActiveRecordTest < ActionView::TestCase
 
     expected = whole_form("/developers/123", "edit_developer_123", "edit_developer", method: "patch") do
       '<input id="developer_projects_attributes_abc_name" name="developer[projects_attributes][abc][name]" type="text" value="project #321" />' \
-          '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" />'
+          '<input id="developer_projects_attributes_abc_id" name="developer[projects_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -59,10 +59,10 @@ class FormHelperActiveRecordTest < ActionView::TestCase
 
   private
     def hidden_fields(method = nil)
-      txt = +%{<input name="utf8" type="hidden" value="&#x2713;" />}
+      txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
       end
 
       txt

--- a/actionview/test/template/active_model_helper_test.rb
+++ b/actionview/test/template/active_model_helper_test.rb
@@ -81,21 +81,21 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_date_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><select id="post_updated_at_1i" name="post[updated_at(1i)]">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" />\n</div>),
+      %(<div class="field_with_errors"><select id="post_updated_at_1i" name="post[updated_at(1i)]">\n<option selected="selected" value="2004">2004</option>\n<option value="2005">2005</option>\n</select>\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" autocomplete="off" />\n</div>),
       date_select("post", "updated_at", discard_month: true, discard_day: true, start_year: 2004, end_year: 2005)
     )
   end
 
   def test_datetime_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" autocomplete="off" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="1" autocomplete="off" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
       datetime_select("post", "updated_at", discard_year: true, discard_month: true, discard_day: true, minute_step: 60)
     )
   end
 
   def test_time_select_with_errors
     assert_dom_equal(
-      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
+      %(<div class="field_with_errors"><input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="2004" autocomplete="off" />\n<input id="post_updated_at_2i" name="post[updated_at(2i)]" type="hidden" value="6" autocomplete="off" />\n<input id="post_updated_at_3i" name="post[updated_at(3i)]" type="hidden" value="15" autocomplete="off" />\n<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n<option selected="selected" value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n</select>\n : <select id="post_updated_at_5i" name="post[updated_at(5i)]">\n<option selected="selected" value="00">00</option>\n</select>\n</div>),
       time_select("post", "updated_at", minute_step: 60)
     )
   end
@@ -109,14 +109,14 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_check_box_with_errors
     assert_dom_equal(
-      %(<input name="post[published]" type="hidden" value="0" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
+      %(<input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
       check_box("post", "published")
     )
   end
 
   def test_check_boxes_with_errors
     assert_dom_equal(
-      %(<input name="post[published]" type="hidden" value="0" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div><input name="post[published]" type="hidden" value="0" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
+      %(<input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div><input name="post[published]" type="hidden" value="0" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="1" name="post[published]" id="post_published" /></div>),
       check_box("post", "published") + check_box("post", "published")
     )
   end
@@ -137,21 +137,21 @@ class ActiveModelHelperTest < ActionView::TestCase
 
   def test_collection_check_boxes_with_errors
     assert_dom_equal(
-      %(<input type="hidden" name="post[category][]" value="" /><div class="field_with_errors"><input type="checkbox" value="ruby" name="post[category][]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="checkbox" value="java" name="post[category][]" id="post_category_java" /></div><label for="post_category_java">java</label>),
+      %(<input type="hidden" name="post[category][]" value="" autocomplete="off" /><div class="field_with_errors"><input type="checkbox" value="ruby" name="post[category][]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="checkbox" value="java" name="post[category][]" id="post_category_java" /></div><label for="post_category_java">java</label>),
       collection_check_boxes("post", "category", [:ruby, :java], :to_s, :to_s)
     )
   end
 
   def test_collection_radio_buttons_with_errors
     assert_dom_equal(
-      %(<input type="hidden" name="post[category]" value="" /><div class="field_with_errors"><input type="radio" value="ruby" name="post[category]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java" /></div><label for="post_category_java">java</label>),
+      %(<input type="hidden" name="post[category]" value="" autocomplete="off" /><div class="field_with_errors"><input type="radio" value="ruby" name="post[category]" id="post_category_ruby" /></div><label for="post_category_ruby">ruby</label><div class="field_with_errors"><input type="radio" value="java" name="post[category]" id="post_category_java" /></div><label for="post_category_java">java</label>),
       collection_radio_buttons("post", "category", [:ruby, :java], :to_s, :to_s)
     )
   end
 
   def test_hidden_field_does_not_render_errors
     assert_dom_equal(
-      %(<input id="post_author_name" name="post[author_name]" type="hidden" value="" />),
+      %(<input id="post_author_name" name="post[author_name]" type="hidden" value="" autocomplete="off" />),
       hidden_field("post", "author_name")
     )
   end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -414,11 +414,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_month_with_hidden
-    assert_dom_equal "<input type=\"hidden\" id=\"date_month\" name=\"date[month]\" value=\"8\" />\n", select_month(8, use_hidden: true)
+    assert_dom_equal "<input type=\"hidden\" id=\"date_month\" name=\"date[month]\" value=\"8\" autocomplete=\"off\" />\n", select_month(8, use_hidden: true)
   end
 
   def test_select_month_with_hidden_and_field_name
-    assert_dom_equal "<input type=\"hidden\" id=\"date_mois\" name=\"date[mois]\" value=\"8\" />\n", select_month(8, use_hidden: true, field_name: "mois")
+    assert_dom_equal "<input type=\"hidden\" id=\"date_mois\" name=\"date[mois]\" value=\"8\" autocomplete=\"off\" />\n", select_month(8, use_hidden: true, field_name: "mois")
   end
 
   def test_select_month_with_html_options
@@ -529,11 +529,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_year_with_hidden
-    assert_dom_equal "<input type=\"hidden\" id=\"date_year\" name=\"date[year]\" value=\"2007\" />\n", select_year(2007, use_hidden: true)
+    assert_dom_equal "<input type=\"hidden\" id=\"date_year\" name=\"date[year]\" value=\"2007\" autocomplete=\"off\" />\n", select_year(2007, use_hidden: true)
   end
 
   def test_select_year_with_hidden_and_field_name
-    assert_dom_equal "<input type=\"hidden\" id=\"date_anno\" name=\"date[anno]\" value=\"2007\" />\n", select_year(2007, use_hidden: true, field_name: "anno")
+    assert_dom_equal "<input type=\"hidden\" id=\"date_anno\" name=\"date[anno]\" value=\"2007\" autocomplete=\"off\" />\n", select_year(2007, use_hidden: true, field_name: "anno")
   end
 
   def test_select_year_with_html_options
@@ -737,11 +737,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_minute_with_hidden
-    assert_dom_equal "<input type=\"hidden\" id=\"date_minute\" name=\"date[minute]\" value=\"8\" />\n", select_minute(8, use_hidden: true)
+    assert_dom_equal "<input type=\"hidden\" id=\"date_minute\" name=\"date[minute]\" value=\"8\" autocomplete=\"off\" />\n", select_minute(8, use_hidden: true)
   end
 
   def test_select_minute_with_hidden_and_field_name
-    assert_dom_equal "<input type=\"hidden\" id=\"date_minuto\" name=\"date[minuto]\" value=\"8\" />\n", select_minute(8, use_hidden: true, field_name: "minuto")
+    assert_dom_equal "<input type=\"hidden\" id=\"date_minuto\" name=\"date[minuto]\" value=\"8\" autocomplete=\"off\" />\n", select_minute(8, use_hidden: true, field_name: "minuto")
   end
 
   def test_select_minute_with_html_options
@@ -907,9 +907,9 @@ class DateHelperTest < ActionView::TestCase
 
   def test_select_date_with_incomplete_order
     # Since the order is incomplete nothing will be shown
-    expected = +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="1" />\n)
+    expected = +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off" />\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="1" autocomplete="off" />\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), start_year: 2003, end_year: 2005, prefix: "date[first]", order: [:day])
   end
@@ -1130,7 +1130,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8" selected="selected">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n)
     expected << "</select>\n"
 
-    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" />\n)
+    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" autocomplete="off" />\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_day: true, start_year: 2003, end_year: 2005, prefix: "date[first]")
   end
@@ -1140,16 +1140,16 @@ class DateHelperTest < ActionView::TestCase
     expected << %(<option value="2003" selected="selected">2003</option>\n<option value="2004">2004</option>\n<option value="2005">2005</option>\n)
     expected << "</select>\n"
 
-    expected << %(<input type="hidden" id="date_first_month" name="date[first][month]" value="8" />\n)
-    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" />\n)
+    expected << %(<input type="hidden" id="date_first_month" name="date[first][month]" value="8" autocomplete="off" />\n)
+    expected << %(<input type="hidden" id="date_first_day" name="date[first][day]" value="1" autocomplete="off" />\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", discard_month: true, discard_day: true, start_year: 2003, end_year: 2005, prefix: "date[first]")
   end
 
   def test_select_date_with_hidden
-    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003"/>\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
+    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off"/>\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off" />\n)
 
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), prefix: "date[first]", use_hidden: true)
     assert_dom_equal expected, select_date(Time.mktime(2003, 8, 16), date_separator: " / ", prefix: "date[first]", use_hidden: true)
@@ -1571,11 +1571,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_datetime_with_hidden
-    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
-    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" />\n)
-    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" />\n)
+    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off" />\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off" />\n)
+    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" autocomplete="off" />\n)
+    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" autocomplete="off" />\n)
 
     assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), prefix: "date[first]", use_hidden: true)
     assert_dom_equal expected, select_datetime(Time.mktime(2003, 8, 16, 8, 4, 18), datetime_separator: "&mdash;", date_separator: "/",
@@ -1583,9 +1583,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1602,9 +1602,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_ampm
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">12 AM</option>\n<option value="01">01 AM</option>\n<option value="02">02 AM</option>\n<option value="03">03 AM</option>\n<option value="04">04 AM</option>\n<option value="05">05 AM</option>\n<option value="06">06 AM</option>\n<option value="07">07 AM</option>\n<option value="08" selected="selected">08 AM</option>\n<option value="09">09 AM</option>\n<option value="10">10 AM</option>\n<option value="11">11 AM</option>\n<option value="12">12 PM</option>\n<option value="13">01 PM</option>\n<option value="14">02 PM</option>\n<option value="15">03 PM</option>\n<option value="16">04 PM</option>\n<option value="17">05 PM</option>\n<option value="18">06 PM</option>\n<option value="19">07 PM</option>\n<option value="20">08 PM</option>\n<option value="21">09 PM</option>\n<option value="22">10 PM</option>\n<option value="23">11 PM</option>\n)
@@ -1620,9 +1620,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_separator
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
     expected << "</select>\n"
@@ -1638,9 +1638,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_seconds
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1662,9 +1662,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_seconds_and_separator
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1686,9 +1686,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_html_options
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]" class="selector">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1709,9 +1709,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_default_prompt
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="">Hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1733,9 +1733,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_custom_prompt
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]">\n)
     expected << %(<option value="">Choose hour</option>\n<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1758,9 +1758,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_generic_with_css_classes
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]" class="hour">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1782,9 +1782,9 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_custom_with_css_classes
-    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" />\n)
-    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" />\n)
-    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" />\n)
+    expected = +%(<input name="date[year]" id="date_year" value="2003" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[month]" id="date_month" value="8" type="hidden" autocomplete="off" />\n)
+    expected << %(<input name="date[day]" id="date_day" value="16" type="hidden" autocomplete="off" />\n)
 
     expected << %(<select id="date_hour" name="date[hour]" class="my-hour">\n)
     expected << %(<option value="00">00</option>\n<option value="01">01</option>\n<option value="02">02</option>\n<option value="03">03</option>\n<option value="04">04</option>\n<option value="05">05</option>\n<option value="06">06</option>\n<option value="07">07</option>\n<option value="08" selected="selected">08</option>\n<option value="09">09</option>\n<option value="10">10</option>\n<option value="11">11</option>\n<option value="12">12</option>\n<option value="13">13</option>\n<option value="14">14</option>\n<option value="15">15</option>\n<option value="16">16</option>\n<option value="17">17</option>\n<option value="18">18</option>\n<option value="19">19</option>\n<option value="20">20</option>\n<option value="21">21</option>\n<option value="22">22</option>\n<option value="23">23</option>\n)
@@ -1806,11 +1806,11 @@ class DateHelperTest < ActionView::TestCase
   end
 
   def test_select_time_with_hidden
-    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" />\n)
-    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" />\n)
-    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" />\n)
-    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" />\n)
-    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" />\n)
+    expected =  +%(<input id="date_first_year" name="date[first][year]" type="hidden" value="2003" autocomplete="off" />\n)
+    expected << %(<input id="date_first_month" name="date[first][month]" type="hidden" value="8" autocomplete="off" />\n)
+    expected << %(<input id="date_first_day" name="date[first][day]" type="hidden" value="16" autocomplete="off" />\n)
+    expected << %(<input id="date_first_hour" name="date[first][hour]" type="hidden" value="8" autocomplete="off" />\n)
+    expected << %(<input id="date_first_minute" name="date[first][minute]" type="hidden" value="4" autocomplete="off" />\n)
 
     assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), prefix: "date[first]", use_hidden: true)
     assert_dom_equal expected, select_time(Time.mktime(2003, 8, 16, 8, 4, 18), time_separator: ":", prefix: "date[first]", use_hidden: true)
@@ -1880,7 +1880,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1"/>' + "\n"
+    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" autocomplete="off"/>' + "\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="" label=" "></option>\n<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1898,7 +1898,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1915,8 +1915,8 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 2, 29)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" />\n"
-    expected << "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_2i\" name=\"post[written_on(2i)]\" value=\"2\" autocomplete=\"off\" />\n"
+    expected << "<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
 
     expected << %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
     expected << %{<option value="1999">1999</option>\n<option value="2000">2000</option>\n<option value="2001">2001</option>\n<option value="2002">2002</option>\n<option value="2003">2003</option>\n<option value="2004" selected="selected">2004</option>\n<option value="2005">2005</option>\n<option value="2006">2006</option>\n<option value="2007">2007</option>\n<option value="2008">2008</option>\n<option value="2009">2009</option>\n}
@@ -1929,7 +1929,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -1948,7 +1948,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Date.new(2004, 6, 15)
 
-    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" disabled=\"disabled\" name=\"post[written_on(3i)]\" value=\"1\" />\n"
+    expected = +"<input type=\"hidden\" id=\"post_written_on_3i\" disabled=\"disabled\" name=\"post[written_on(3i)]\" value=\"1\" autocomplete=\"off\" />\n"
 
     expected << %{<select id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -2116,7 +2116,7 @@ class DateHelperTest < ActionView::TestCase
     start_year = Time.now.year - 5
     end_year   = Time.now.year + 5
 
-    expected = '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1"/>' + "\n"
+    expected = '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1" autocomplete="off"/>' + "\n"
     expected << %{<select id="post_written_on_1i" name="post[written_on(1i)]">\n}
     expected << "<option value=\"\" label=\" \"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
@@ -2140,8 +2140,8 @@ class DateHelperTest < ActionView::TestCase
     expected << "<option value=\"\" label=\" \"></option>\n"
     start_year.upto(end_year) { |i| expected << %(<option value="#{i}">#{i}</option>\n) }
     expected << "</select>\n"
-    expected << '<input name="post[written_on(2i)]" type="hidden" id="post_written_on_2i" value="1"/>' + "\n"
-    expected << '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1"/>' + "\n"
+    expected << '<input name="post[written_on(2i)]" type="hidden" id="post_written_on_2i" value="1" autocomplete="off"/>' + "\n"
+    expected << '<input name="post[written_on(3i)]" type="hidden" id="post_written_on_3i" value="1" autocomplete="off"/>' + "\n"
 
     assert_dom_equal expected, date_select("post", "written_on", discard_month: true, include_blank: true)
   end
@@ -2149,7 +2149,7 @@ class DateHelperTest < ActionView::TestCase
   def test_date_select_with_nil_and_blank_and_discard_year
     @post = Post.new
 
-    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" />' + "\n"
+    expected = '<input id="post_written_on_1i" name="post[written_on(1i)]" type="hidden" value="1" autocomplete="off" />' + "\n"
 
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << "<option value=\"\" label=\" \"></option>\n"
@@ -2287,7 +2287,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<select id="post_written_on_2i" name="post[written_on(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6" selected="selected">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
+    expected << %{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
 
     assert_dom_equal expected, date_select("post", "written_on", order: [:day, :month, :year], discard_year: true, date_separator: " / ")
   end
@@ -2376,9 +2376,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2395,9 +2395,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 12}>#{sprintf("%02d", i)}</option>\n) }
@@ -2414,9 +2414,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="1" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="1" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="1" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="1" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="1" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="1" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}">#{sprintf("%02d", i)}</option>\n) }
@@ -2448,9 +2448,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2471,9 +2471,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="selector">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2494,9 +2494,9 @@ class DateHelperTest < ActionView::TestCase
       concat f.time_select(:written_on, {}, { class: "selector" })
     end
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="selector">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2513,9 +2513,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2540,9 +2540,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     expected << %(<option value="">Hour</option>\n)
@@ -2561,9 +2561,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]">\n)
     expected << %(<option value="">Choose hour</option>\n)
@@ -2582,9 +2582,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="hour">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2603,9 +2603,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" name="post[written_on(4i)]" class="my-hour">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2624,9 +2624,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.written_on = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_written_on_1i" disabled="disabled" name="post[written_on(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_written_on_3i" disabled="disabled" name="post[written_on(3i)]" value="15" />\n}
+    expected = +%{<input type="hidden" id="post_written_on_1i" disabled="disabled" name="post[written_on(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_2i" disabled="disabled" name="post[written_on(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_written_on_3i" disabled="disabled" name="post[written_on(3i)]" value="15" autocomplete="off" />\n}
 
     expected << %(<select id="post_written_on_4i" disabled="disabled" name="post[written_on(4i)]">\n)
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -2701,7 +2701,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 16, 35)
 
-    expected = '<input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="1"/>' + "\n"
+    expected = '<input id="post_updated_at_1i" name="post[updated_at(1i)]" type="hidden" value="1" autocomplete="off" />' + "\n"
 
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
     expected << %{<option value="1">January</option>\n<option value="2">February</option>\n<option value="3">March</option>\n<option value="4">April</option>\n<option value="5">May</option>\n<option value="6">June</option>\n<option value="7">July</option>\n<option value="8">August</option>\n<option value="9">September</option>\n<option value="10">October</option>\n<option value="11">November</option>\n<option value="12">December</option>\n}
@@ -3173,7 +3173,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
     expected << %{<select id="post_updated_at_2i" name="post[updated_at(2i)]">\n}
     1.upto(12) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 6}>#{Date::MONTHNAMES[i]}</option>\n) }
     expected << "</select>\n"
@@ -3201,8 +3201,8 @@ class DateHelperTest < ActionView::TestCase
     expected = +%{<select id="post_updated_at_1i" name="post[updated_at(1i)]">\n}
     1999.upto(2009) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 2004}>#{i}</option>\n) }
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" autocomplete="off" />\n}
 
     expected << " &mdash; "
 
@@ -3221,9 +3221,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_2i" name="post[updated_at(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_3i" name="post[updated_at(3i)]" value="1" autocomplete="off" />\n}
 
     expected << %{<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -3240,9 +3240,9 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]" value="2004" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]" value="6" />\n}
-    expected << %{<input type="hidden" id="post_updated_at_3i" disabled="disabled" name="post[updated_at(3i)]" value="1" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" disabled="disabled" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_2i" disabled="disabled" name="post[updated_at(2i)]" value="6" autocomplete="off" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_3i" disabled="disabled" name="post[updated_at(3i)]" value="1" autocomplete="off" />\n}
 
     expected << %{<select id="post_updated_at_4i" disabled="disabled" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
@@ -3291,7 +3291,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<select id="post_updated_at_4i" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_updated_at_5i" name="post[updated_at(5i)]" value="16" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_5i" name="post[updated_at(5i)]" value="16" autocomplete="off" />\n}
 
     assert_dom_equal expected, datetime_select("post", "updated_at", discard_minute: true)
   end
@@ -3315,7 +3315,7 @@ class DateHelperTest < ActionView::TestCase
     expected << %{<select id="post_updated_at_4i" disabled="disabled" name="post[updated_at(4i)]">\n}
     0.upto(23) { |i| expected << %(<option value="#{sprintf("%02d", i)}"#{' selected="selected"' if i == 15}>#{sprintf("%02d", i)}</option>\n) }
     expected << "</select>\n"
-    expected << %{<input type="hidden" id="post_updated_at_5i" disabled="disabled" name="post[updated_at(5i)]" value="16" />\n}
+    expected << %{<input type="hidden" id="post_updated_at_5i" disabled="disabled" name="post[updated_at(5i)]" value="16" autocomplete="off" />\n}
 
     assert_dom_equal expected, datetime_select("post", "updated_at", discard_minute: true, disabled: true)
   end
@@ -3351,7 +3351,7 @@ class DateHelperTest < ActionView::TestCase
     @post = Post.new
     @post.updated_at = Time.local(2004, 6, 15, 15, 16, 35)
 
-    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" />\n}
+    expected = +%{<input type="hidden" id="post_updated_at_1i" name="post[updated_at(1i)]" value="2004" autocomplete="off" />\n}
     expected << %{<select id="post_updated_at_3i" name="post[updated_at(3i)]">\n}
     1.upto(31) { |i| expected << %(<option value="#{i}"#{' selected="selected"' if i == 15}>#{i}</option>\n) }
     expected << "</select>\n"

--- a/actionview/test/template/form_collections_helper_test.rb
+++ b/actionview/test/template/form_collections_helper_test.rb
@@ -218,21 +218,21 @@ class FormCollectionsHelperTest < ActionView::TestCase
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     with_collection_radio_buttons :user, :category_ids, collection, :id, :name
 
-    assert_select "input[type=hidden][name='user[category_ids]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[category_ids]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection radio buttons generates a hidden field using the given :name in :html_options" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     with_collection_radio_buttons :user, :category_ids, collection, :id, :name, {}, { name: "user[other_category_ids]" }
 
-    assert_select "input[type=hidden][name='user[other_category_ids]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[other_category_ids]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection radio buttons generates a hidden field with index if it was provided" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     with_collection_radio_buttons :user, :category_ids, collection, :id, :name, index: 322
 
-    assert_select "input[type=hidden][name='user[322][category_ids]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[322][category_ids]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection radio buttons does not generate a hidden field if include_hidden option is false" do
@@ -262,21 +262,21 @@ class FormCollectionsHelperTest < ActionView::TestCase
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     with_collection_check_boxes :user, :category_ids, collection, :id, :name
 
-    assert_select "input[type=hidden][name='user[category_ids][]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[category_ids][]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection check boxes generates a hidden field using the given :name in :html_options" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     with_collection_check_boxes :user, :category_ids, collection, :id, :name, {}, { name: "user[other_category_ids][]" }
 
-    assert_select "input[type=hidden][name='user[other_category_ids][]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[other_category_ids][]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection check boxes generates a hidden field with index if it was provided" do
     collection = [Category.new(1, "Category 1"), Category.new(2, "Category 2")]
     with_collection_check_boxes :user, :category_ids, collection, :id, :name, index: 322
 
-    assert_select "input[type=hidden][name='user[322][category_ids][]'][value='']", count: 1
+    assert_select "input[type=hidden][name='user[322][category_ids][]'][value=''][autocomplete='off']", count: 1
   end
 
   test "collection check boxes does not generate a hidden field if include_hidden option is false" do

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -39,11 +39,11 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     (+"").tap do |txt|
       unless skip_enforcing_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
       end
     end
   end
@@ -354,7 +354,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_title'>The Title</label>" \
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />" \
       "<select name='post[category]' id='post_category'><option value='animal'>animal</option>\n<option value='economy'>economy</option>\n<option value='sports'>sports</option></select>" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
@@ -394,7 +394,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label>The Title</label>" \
       "<input name='post[title]' type='text' value='Hello World' />" \
       "<textarea name='post[body]'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' />" \
       "<select name='post[category]'><option value='animal'>animal</option>\n<option value='economy'>economy</option>\n<option value='sports'>sports</option></select>" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />"
@@ -471,8 +471,8 @@ class FormWithActsLikeFormForTest < FormWithTest
     end.new
 
     form_with(model: obj, scope: "other_name", url: "/", id: "edit-other-name") do |f|
-      assert_dom_equal '<input type="hidden" name="other_name[private_property]" id="other_name_private_property">', f.hidden_field(:private_property)
-      assert_dom_equal '<input type="hidden" name="other_name[protected_property]"  id="other_name_protected_property">', f.hidden_field(:protected_property)
+      assert_dom_equal '<input type="hidden" name="other_name[private_property]" id="other_name_private_property" autocomplete="off">', f.hidden_field(:private_property)
+      assert_dom_equal '<input type="hidden" name="other_name[protected_property]"  id="other_name_protected_property" autocomplete="off">', f.hidden_field(:protected_property)
     end
   end
 
@@ -501,7 +501,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
       "<label for='post_active_true'>true</label>" \
       "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
@@ -523,7 +523,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<label for='post_active_true'>" \
       "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
       "true</label>" \
@@ -549,14 +549,14 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<label for='post_active_true'>" \
       "<input name='post[active]' type='radio' value='true' id='post_active_true' />" \
       "true</label>" \
       "<label for='post_active_false'>" \
       "<input checked='checked' name='post[active]' type='radio' value='false' id='post_active_false' />" \
       "false</label>" \
-      "<input name='post[id]' type='hidden' value='1' id='post_id' />"
+      "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -571,7 +571,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input type='hidden' name='post[1][active]' value='' />" \
+      "<input type='hidden' name='post[1][active]' value='' autocomplete='off' />" \
       "<input name='post[1][active]' type='radio' value='true' id='post_1_active_true' />" \
       "<label for='post_1_active_true'>true</label>" \
       "<input checked='checked' name='post[1][active]' type='radio' value='false' id='post_1_active_false' />" \
@@ -590,7 +590,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
       "<label for='post_tag_ids_1'>Tag 1</label>" \
       "<input name='post[tag_ids][]' type='checkbox' value='2' id='post_tag_ids_2' />" \
@@ -614,7 +614,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<label for='post_tag_ids_1'>" \
       "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
       "Tag 1</label>" \
@@ -644,7 +644,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<label for='post_tag_ids_1'>" \
       "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='1' id='post_tag_ids_1' />" \
       "Tag 1</label>" \
@@ -654,7 +654,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_tag_ids_3'>" \
       "<input checked='checked' name='post[tag_ids][]' type='checkbox' value='3' id='post_tag_ids_3' />" \
       "Tag 3</label>" \
-      "<input name='post[id]' type='hidden' value='1' id='post_id' />"
+      "<input name='post[id]' type='hidden' value='1' id='post_id' autocomplete='off' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -670,7 +670,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts") do
-      "<input name='post[1][tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[1][tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<input checked='checked' name='post[1][tag_ids][]' type='checkbox' value='1' id='post_1_tag_ids_1' />" \
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
@@ -757,7 +757,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='other_name_title' class='post_title'>Title</label>" \
       "<input name='other_name[title]' value='Hello World' type='text' id='other_name_title' />" \
       "<textarea name='other_name[body]' id='other_name_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='other_name[secret]' value='0' type='hidden' />" \
+      "<input name='other_name[secret]' value='0' type='hidden' autocomplete='off' />" \
       "<input name='other_name[secret]' checked='checked' value='1' type='checkbox' id='other_name_secret' />" \
       "<input name='commit' value='Create post' data-disable-with='Create post' type='submit' />"
     end
@@ -775,7 +775,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/", "create-post", method: "delete") do
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret'/>"
     end
 
@@ -792,7 +792,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/", "create-post", method: "delete") do
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
@@ -823,7 +823,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/", "create-post", method: "patch") do
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
@@ -843,7 +843,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/", "create-post", method: "patch", local: true) do
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
@@ -914,7 +914,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/", "create-post") do
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
     end
 
@@ -933,7 +933,7 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<label for='post_123_title'>Title</label>" \
       "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title' />" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' />" \
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret' />"
     end
 
@@ -950,7 +950,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       "<input name='post[][title]' type='text' value='Hello World' id='post__title' />" \
       "<textarea name='post[][body]' id='post__body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' />" \
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret' />"
     end
 
@@ -1360,7 +1360,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" />'
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1379,7 +1379,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" />'
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1434,7 +1434,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" />'
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1453,7 +1453,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" />' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />' \
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />'
     end
 
@@ -1475,9 +1475,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" />'
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1502,7 +1502,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" />' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
@@ -1555,7 +1555,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[author_attributes][name]" type="text" value="author #321" id="post_author_attributes_name" />' \
-      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" />' \
+      '<input name="post[author_attributes][id]" type="hidden" value="321" id="post_author_attributes_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
@@ -1578,9 +1578,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" />'
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1601,9 +1601,9 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" />' \
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />'
     end
 
@@ -1646,7 +1646,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id"/>' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off"/>' \
       '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
     end
 
@@ -1681,9 +1681,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" />'
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1702,9 +1702,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" />'
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1737,9 +1737,9 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #1" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="1" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="comment #2" id="post_comments_attributes_1_name" />' \
-      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" />'
+      '<input name="post[comments_attributes][1][id]" type="hidden" value="2" id="post_comments_attributes_1_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1760,7 +1760,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[title]" type="text" value="Hello World" id="post_title" />' \
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name" />' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" />' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off" />' \
       '<input name="post[comments_attributes][1][name]" type="text" value="new comment" id="post_comments_attributes_1_name" />'
     end
 
@@ -1779,7 +1779,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name" />' \
-      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" />'
+      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1796,7 +1796,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name" />' \
-      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" />'
+      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1819,7 +1819,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[comments_attributes][abc][name]" type="text" value="comment #321" id="post_comments_attributes_abc_name" />' \
-      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" />'
+      '<input name="post[comments_attributes][abc][id]" type="hidden" value="321" id="post_comments_attributes_abc_id" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1906,16 +1906,16 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       '<input name="post[comments_attributes][0][name]" type="text" value="comment #321" id="post_comments_attributes_0_name" />' \
       '<input name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314" id="post_comments_attributes_0_relevances_attributes_0_value" />' \
-      '<input name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" id="post_comments_attributes_0_relevances_attributes_0_id"/>' \
-      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id"/>' \
+      '<input name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" id="post_comments_attributes_0_relevances_attributes_0_id" autocomplete="off"/>' \
+      '<input name="post[comments_attributes][0][id]" type="hidden" value="321" id="post_comments_attributes_0_id" autocomplete="off"/>' \
       '<input name="post[tags_attributes][0][value]" type="text" value="tag #123" id="post_tags_attributes_0_value"/>' \
       '<input name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141" id="post_tags_attributes_0_relevances_attributes_0_value"/>' \
-      '<input name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" id="post_tags_attributes_0_relevances_attributes_0_id"/>' \
-      '<input name="post[tags_attributes][0][id]" type="hidden" value="123" id="post_tags_attributes_0_id"/>' \
+      '<input name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" id="post_tags_attributes_0_relevances_attributes_0_id" autocomplete="off"/>' \
+      '<input name="post[tags_attributes][0][id]" type="hidden" value="123" id="post_tags_attributes_0_id" autocomplete="off"/>' \
       '<input name="post[tags_attributes][1][value]" type="text" value="tag #456" id="post_tags_attributes_1_value"/>' \
       '<input name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415" id="post_tags_attributes_1_relevances_attributes_0_value"/>' \
-      '<input name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" id="post_tags_attributes_1_relevances_attributes_0_id"/>' \
-      '<input name="post[tags_attributes][1][id]" type="hidden" value="456" id="post_tags_attributes_1_id"/>'
+      '<input name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" id="post_tags_attributes_1_relevances_attributes_0_id" autocomplete="off"/>' \
+      '<input name="post[tags_attributes][1][id]" type="hidden" value="456" id="post_tags_attributes_1_id" autocomplete="off"/>'
     end
 
     assert_dom_equal expected, output_buffer
@@ -1947,7 +1947,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
 
     assert_dom_equal expected, output_buffer
@@ -1963,7 +1963,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<input name='post[123][title]' type='text' value='Hello World' id='post_123_title' />" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' />" \
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[123][secret]' checked='checked' type='checkbox' value='1' id='post_123_secret' />"
 
     assert_dom_equal expected, output_buffer
@@ -1979,7 +1979,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<input name='post[][title]' type='text' value='Hello World' id='post__title' />" \
       "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' />" \
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[][secret]' checked='checked' type='checkbox' value='1' id='post__secret' />"
 
     assert_dom_equal expected, output_buffer
@@ -1995,7 +1995,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<input name='post[abc][title]' type='text' value='Hello World' id='post_abc_title' />" \
       "<textarea name='post[abc][body]' id='post_abc_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[abc][secret]' type='hidden' value='0' />" \
+      "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[abc][secret]' checked='checked' type='checkbox' value='1' id='post_abc_secret' />"
 
     assert_dom_equal expected, output_buffer
@@ -2011,7 +2011,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
 
     assert_dom_equal expected, output_buffer
@@ -2027,7 +2027,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />"
 
     assert_dom_equal expected, output_buffer
@@ -2072,7 +2072,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", "create-post", method: "patch") do
       "<input name='post[title]' type='text' value='Hello World' id='post_title' />" \
       "<textarea name='post[body]' id='post_body' >\nBack to the hill and over it again!</textarea>" \
-      "<input name='parent_post[secret]' type='hidden' value='0' />" \
+      "<input name='parent_post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='parent_post[secret]' checked='checked' type='checkbox' value='1' id='parent_post_secret' />"
     end
 
@@ -2133,7 +2133,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'/><br/>" \
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2152,7 +2152,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected = whole_form("/posts/123", method: "patch") do
       "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title' /><br/>" \
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2211,7 +2211,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     expected =
       "<label for='title'>Title:</label> <input name='post[title]' type='text' value='Hello World' id='post_title'/><br/>" \
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' /><br/>"
 
     assert_dom_equal expected, output_buffer
   end
@@ -2387,11 +2387,11 @@ class FormWithActsLikeFormForTest < FormWithTest
       if options.fetch(:skip_enforcing_utf8, false)
         txt = +""
       else
-        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" />}
+        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
       end
 
       txt

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -580,11 +580,11 @@ class FormHelperTest < ActionView::TestCase
 
   def test_hidden_field
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="Hello World" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="Hello World" autocomplete="off" />',
       hidden_field("post", "title")
     )
     assert_dom_equal(
-      '<input id="post_secret" name="post[secret]" type="hidden" value="1" />',
+      '<input id="post_secret" name="post[secret]" type="hidden" value="1" autocomplete="off" />',
       hidden_field("post", "secret?")
     )
   end
@@ -592,19 +592,19 @@ class FormHelperTest < ActionView::TestCase
   def test_hidden_field_with_escapes
     @post.title = "<b>Hello World</b>"
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="&lt;b&gt;Hello World&lt;/b&gt;" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="&lt;b&gt;Hello World&lt;/b&gt;" autocomplete="off" />',
       hidden_field("post", "title")
     )
   end
 
   def test_hidden_field_with_nil_value
-    expected = '<input id="post_title" name="post[title]" type="hidden" />'
+    expected = '<input id="post_title" name="post[title]" type="hidden" autocomplete="off" />'
     assert_dom_equal expected, hidden_field("post", "title", value: nil)
   end
 
   def test_hidden_field_with_options
     assert_dom_equal(
-      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" />',
+      '<input id="post_title" name="post[title]" type="hidden" value="Something Else" autocomplete="off" />',
       hidden_field("post", "title", value: "Something Else")
     )
   end
@@ -622,7 +622,7 @@ class FormHelperTest < ActionView::TestCase
 
   def test_check_box_checked_if_object_value_is_same_that_check_value
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
   end
@@ -630,14 +630,14 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_not_checked_if_object_value_is_same_that_unchecked_value
     @post.secret = 0
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
   end
 
   def test_check_box_checked_if_option_checked_is_present
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret", "checked" => "checked")
     )
   end
@@ -645,12 +645,12 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_checked_if_object_value_is_true
     @post.secret = true
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
 
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret?")
     )
   end
@@ -658,19 +658,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_checked_if_object_value_includes_checked_value
     @post.secret = ["0"]
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
 
     @post.secret = ["1"]
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
 
     @post.secret = Set.new(["1"])
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret")
     )
   end
@@ -686,13 +686,13 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_string
     @post.secret = "on"
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      '<input name="post[secret]" type="hidden" value="off" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="on" />',
       check_box("post", "secret", {}, "on", "off")
     )
 
     @post.secret = "off"
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
+      '<input name="post[secret]" type="hidden" value="off" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="on" />',
       check_box("post", "secret", {}, "on", "off")
     )
   end
@@ -700,13 +700,13 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_boolean
     @post.secret = false
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="true" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      '<input name="post[secret]" type="hidden" value="true" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="false" />',
       check_box("post", "secret", {}, false, true)
     )
 
     @post.secret = true
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="true" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
+      '<input name="post[secret]" type="hidden" value="true" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="false" />',
       check_box("post", "secret", {}, false, true)
     )
   end
@@ -714,19 +714,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_integer
     @post.secret = 0
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 1
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 2
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
   end
@@ -734,19 +734,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_float
     @post.secret = 0.0
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 1.1
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = 2.2
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
   end
@@ -754,19 +754,19 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_explicit_checked_and_unchecked_values_when_object_value_is_big_decimal
     @post.secret = BigDecimal(0)
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = BigDecimal(1)
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
 
     @post.secret = BigDecimal(2.2, 1)
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="1" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
+      '<input name="post[secret]" type="hidden" value="1" autocomplete="off" /><input id="post_secret" name="post[secret]" type="checkbox" value="0" />',
       check_box("post", "secret", {}, 0, 1)
     )
   end
@@ -786,11 +786,11 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_multiple_behavior
     @post.comment_ids = [2, 3]
     assert_dom_equal(
-      '<input name="post[comment_ids][]" type="hidden" value="0" /><input id="post_comment_ids_1" name="post[comment_ids][]" type="checkbox" value="1" />',
+      '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off" /><input id="post_comment_ids_1" name="post[comment_ids][]" type="checkbox" value="1" />',
       check_box("post", "comment_ids", { multiple: true }, 1)
     )
     assert_dom_equal(
-      '<input name="post[comment_ids][]" type="hidden" value="0" /><input checked="checked" id="post_comment_ids_3" name="post[comment_ids][]" type="checkbox" value="3" />',
+      '<input name="post[comment_ids][]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_comment_ids_3" name="post[comment_ids][]" type="checkbox" value="3" />',
       check_box("post", "comment_ids", { multiple: true }, 3)
     )
   end
@@ -798,25 +798,25 @@ class FormHelperTest < ActionView::TestCase
   def test_check_box_with_multiple_behavior_and_index
     @post.comment_ids = [2, 3]
     assert_dom_equal(
-      '<input name="post[foo][comment_ids][]" type="hidden" value="0" /><input id="post_foo_comment_ids_1" name="post[foo][comment_ids][]" type="checkbox" value="1" />',
+      '<input name="post[foo][comment_ids][]" type="hidden" value="0" autocomplete="off" /><input id="post_foo_comment_ids_1" name="post[foo][comment_ids][]" type="checkbox" value="1" />',
       check_box("post", "comment_ids", { multiple: true, index: "foo" }, 1)
     )
     assert_dom_equal(
-      '<input name="post[bar][comment_ids][]" type="hidden" value="0" /><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3" />',
+      '<input name="post[bar][comment_ids][]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_bar_comment_ids_3" name="post[bar][comment_ids][]" type="checkbox" value="3" />',
       check_box("post", "comment_ids", { multiple: true, index: "bar" }, 3)
     )
   end
 
   def test_checkbox_disabled_disables_hidden_field
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" disabled="disabled"/><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" disabled="disabled" autocomplete="off"/><input checked="checked" disabled="disabled" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret", disabled: true)
     )
   end
 
   def test_checkbox_form_html5_attribute
     assert_dom_equal(
-      '<input form="new_form" name="post[secret]" type="hidden" value="0" /><input checked="checked" form="new_form" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      '<input form="new_form" name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" form="new_form" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret", form: "new_form")
     )
   end
@@ -1336,7 +1336,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "name" => "really!")
     )
     assert_dom_equal(
-      '<input name="i mean it" type="hidden" value="0" /><input checked="checked" id="post_secret" name="i mean it" type="checkbox" value="1" />',
+      '<input name="i mean it" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="i mean it" type="checkbox" value="1" />',
       check_box("post", "secret", "name" => "i mean it")
     )
     assert_dom_equal(
@@ -1363,7 +1363,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "id" => "really!")
     )
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" id="i mean it" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="i mean it" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret", "id" => "i mean it")
     )
     assert_dom_equal(
@@ -1390,7 +1390,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "id" => nil)
     )
     assert_dom_equal(
-      '<input name="post[secret]" type="hidden" value="0" /><input checked="checked" name="post[secret]" type="checkbox" value="1" />',
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[secret]" type="checkbox" value="1" />',
       check_box("post", "secret", "id" => nil)
     )
     assert_dom_equal(
@@ -1429,7 +1429,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "index" => 5)
     )
     assert_dom_equal(
-      '<input name="post[5][secret]" type="hidden" value="0" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" id="post_5_secret" />',
+      '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" id="post_5_secret" />',
       check_box("post", "secret", "index" => 5)
     )
     assert_dom_equal(
@@ -1456,7 +1456,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post", "body", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
-      '<input name="post[5][secret]" type="hidden" value="0" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" />',
+      '<input name="post[5][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[5][secret]" type="checkbox" value="1" />',
       check_box("post", "secret", "index" => 5, "id" => nil)
     )
     assert_dom_equal(
@@ -1488,7 +1488,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post[]", "body")
     )
     assert_dom_equal(
-      %{<input name="post[#{pid}][secret]" type="hidden" value="0" /><input checked="checked" id="post_#{pid}_secret" name="post[#{pid}][secret]" type="checkbox" value="1" />},
+      %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_#{pid}_secret" name="post[#{pid}][secret]" type="checkbox" value="1" />},
       check_box("post[]", "secret")
     )
     assert_dom_equal(
@@ -1512,7 +1512,7 @@ class FormHelperTest < ActionView::TestCase
       text_area("post[]", "body", id: nil)
     )
     assert_dom_equal(
-      %{<input name="post[#{pid}][secret]" type="hidden" value="0" /><input checked="checked" name="post[#{pid}][secret]" type="checkbox" value="1" />},
+      %{<input name="post[#{pid}][secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" name="post[#{pid}][secret]" type="checkbox" value="1" />},
       check_box("post[]", "secret", id: nil)
     )
     assert_dom_equal(
@@ -1563,7 +1563,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_title'>The Title</label>" \
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
       "<button name='button' type='submit'>Create post</button>" \
@@ -1593,7 +1593,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_title'>The Title</label>" \
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
       "<button name='button' type='submit'>Create post</button>" \
@@ -1667,7 +1667,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<input id='post_active_true' name='post[active]' type='radio' value='true' />" \
       "<label for='post_active_true'>true</label>" \
       "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" \
@@ -1689,7 +1689,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<label for='post_active_true'>" \
       "<input id='post_active_true' name='post[active]' type='radio' value='true' />" \
       "true</label>" \
@@ -1715,14 +1715,14 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post_1", "new_post") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<label for='post_active_true'>" \
       "<input id='post_active_true' name='post[active]' type='radio' value='true' />" \
       "true</label>" \
       "<label for='post_active_false'>" \
       "<input checked='checked' id='post_active_false' name='post[active]' type='radio' value='false' />" \
       "false</label>" \
-      "<input id='post_id' name='post[id]' type='hidden' value='1' />"
+      "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1737,7 +1737,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "foo_new_post", "new_post") do
-      "<input type='hidden' name='post[active]' value='' />" \
+      "<input type='hidden' name='post[active]' value='' autocomplete='off' />" \
       "<input id='foo_post_active_true' name='post[active]' type='radio' value='true' />" \
       "<label for='foo_post_active_true'>true</label>" \
       "<input checked='checked' id='foo_post_active_false' name='post[active]' type='radio' value='false' />" \
@@ -1756,7 +1756,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input type='hidden' name='post[1][active]' value='' />" \
+      "<input type='hidden' name='post[1][active]' value='' autocomplete='off' />" \
       "<input id='post_1_active_true' name='post[1][active]' type='radio' value='true' />" \
       "<label for='post_1_active_true'>true</label>" \
       "<input checked='checked' id='post_1_active_false' name='post[1][active]' type='radio' value='false' />" \
@@ -1775,7 +1775,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
       "<label for='post_tag_ids_1'>Tag 1</label>" \
       "<input id='post_tag_ids_2' name='post[tag_ids][]' type='checkbox' value='2' />" \
@@ -1799,7 +1799,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<label for='post_tag_ids_1'>" \
       "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
       "Tag 1</label>" \
@@ -1829,7 +1829,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post_1", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<label for='post_tag_ids_1'>" \
       "<input checked='checked' id='post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
       "Tag 1</label>" \
@@ -1839,7 +1839,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_tag_ids_3'>" \
       "<input checked='checked' id='post_tag_ids_3' name='post[tag_ids][]' type='checkbox' value='3' />" \
       "Tag 3</label>" \
-      "<input id='post_id' name='post[id]' type='hidden' value='1' />"
+      "<input id='post_id' name='post[id]' type='hidden' value='1' autocomplete='off' />"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1855,7 +1855,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "foo_new_post", "new_post") do
-      "<input name='post[tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<input checked='checked' id='foo_post_tag_ids_1' name='post[tag_ids][]' type='checkbox' value='1' />" \
       "<label for='foo_post_tag_ids_1'>Tag 1</label>"
     end
@@ -1873,7 +1873,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      "<input name='post[1][tag_ids][]' type='hidden' value='' />" \
+      "<input name='post[1][tag_ids][]' type='hidden' value='' autocomplete='off' />" \
       "<input checked='checked' id='post_1_tag_ids_1' name='post[1][tag_ids][]' type='checkbox' value='1' />" \
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
@@ -1948,7 +1948,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='other_name_title' class='post_title'>Title</label>" \
       "<input name='other_name[title]' id='other_name_title' value='Hello World' type='text' />" \
       "<textarea name='other_name[body]' id='other_name_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='other_name[secret]' value='0' type='hidden' />" \
+      "<input name='other_name[secret]' value='0' type='hidden' autocomplete='off' />" \
       "<input name='other_name[secret]' checked='checked' id='other_name_secret' value='1' type='checkbox' />" \
       "<input name='commit' value='Create post' data-disable-with='Create post' type='submit' />"
     end
@@ -1979,7 +1979,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/", "create-post", "edit_post", method: "delete") do
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
@@ -1996,7 +1996,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/", "create-post", "edit_post", method: "delete") do
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
@@ -2027,7 +2027,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
@@ -2096,7 +2096,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
@@ -2115,7 +2115,7 @@ class FormHelperTest < ActionView::TestCase
       expected = whole_form("/posts", "new_post", "new_post", remote: true) do
         "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
         "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-        "<input name='post[secret]' type='hidden' value='0' />" \
+        "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
         "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
       end
 
@@ -2133,7 +2133,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/", "create-post") do
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
     end
 
@@ -2152,7 +2152,7 @@ class FormHelperTest < ActionView::TestCase
       "<label for='post_123_title'>Title</label>" \
       "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' />" \
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
     end
 
@@ -2169,7 +2169,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post[]", "edit_post[]", method: "patch") do
       "<input name='post[][title]' type='text' id='post__title' value='Hello World' />" \
       "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' />" \
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
     end
 
@@ -2234,7 +2234,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "namespace_edit_post_123", "edit_post", method: "patch") do
       "<input name='post[title]' type='text' id='namespace_post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='namespace_post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='namespace_post_secret' value='1' />"
     end
 
@@ -2683,7 +2683,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -2702,7 +2702,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -2757,7 +2757,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />'
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -2776,7 +2776,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />' \
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />'
     end
 
@@ -2798,9 +2798,9 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -2825,7 +2825,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
@@ -2878,7 +2878,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_author_attributes_name" name="post[author_attributes][name]" type="text" value="author #321" />' \
-      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" />' \
+      '<input id="post_author_attributes_id" name="post[author_attributes][id]" type="hidden" value="321" autocomplete="off" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
@@ -2901,9 +2901,9 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -2924,9 +2924,9 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />' \
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />'
     end
 
@@ -2969,7 +2969,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
@@ -3004,9 +3004,9 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3025,9 +3025,9 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3060,9 +3060,9 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #1" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="1" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="comment #2" />' \
-      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" />'
+      '<input id="post_comments_attributes_1_id" name="post[comments_attributes][1][id]" type="hidden" value="2" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3083,7 +3083,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input name="post[title]" type="text" id="post_title" value="Hello World" />' \
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off" />' \
       '<input id="post_comments_attributes_1_name" name="post[comments_attributes][1][name]" type="text" value="new comment" />'
     end
 
@@ -3102,7 +3102,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" />'
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3119,7 +3119,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" />'
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3142,7 +3142,7 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input id="post_comments_attributes_abc_name" name="post[comments_attributes][abc][name]" type="text" value="comment #321" />' \
-      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" />'
+      '<input id="post_comments_attributes_abc_id" name="post[comments_attributes][abc][id]" type="hidden" value="321" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3229,16 +3229,16 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       '<input id="post_comments_attributes_0_name" name="post[comments_attributes][0][name]" type="text" value="comment #321" />' \
       '<input id="post_comments_attributes_0_relevances_attributes_0_value" name="post[comments_attributes][0][relevances_attributes][0][value]" type="text" value="commentrelevance #314" />' \
-      '<input id="post_comments_attributes_0_relevances_attributes_0_id" name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" />' \
-      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" />' \
+      '<input id="post_comments_attributes_0_relevances_attributes_0_id" name="post[comments_attributes][0][relevances_attributes][0][id]" type="hidden" value="314" autocomplete="off" />' \
+      '<input id="post_comments_attributes_0_id" name="post[comments_attributes][0][id]" type="hidden" value="321" autocomplete="off" />' \
       '<input id="post_tags_attributes_0_value" name="post[tags_attributes][0][value]" type="text" value="tag #123" />' \
       '<input id="post_tags_attributes_0_relevances_attributes_0_value" name="post[tags_attributes][0][relevances_attributes][0][value]" type="text" value="tagrelevance #3141" />' \
-      '<input id="post_tags_attributes_0_relevances_attributes_0_id" name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" />' \
-      '<input id="post_tags_attributes_0_id" name="post[tags_attributes][0][id]" type="hidden" value="123" />' \
+      '<input id="post_tags_attributes_0_relevances_attributes_0_id" name="post[tags_attributes][0][relevances_attributes][0][id]" type="hidden" value="3141" autocomplete="off" />' \
+      '<input id="post_tags_attributes_0_id" name="post[tags_attributes][0][id]" type="hidden" value="123" autocomplete="off" />' \
       '<input id="post_tags_attributes_1_value" name="post[tags_attributes][1][value]" type="text" value="tag #456" />' \
       '<input id="post_tags_attributes_1_relevances_attributes_0_value" name="post[tags_attributes][1][relevances_attributes][0][value]" type="text" value="tagrelevance #31415" />' \
-      '<input id="post_tags_attributes_1_relevances_attributes_0_id" name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" />' \
-      '<input id="post_tags_attributes_1_id" name="post[tags_attributes][1][id]" type="hidden" value="456" />'
+      '<input id="post_tags_attributes_1_relevances_attributes_0_id" name="post[tags_attributes][1][relevances_attributes][0][id]" type="hidden" value="31415" autocomplete="off" />' \
+      '<input id="post_tags_attributes_1_id" name="post[tags_attributes][1][id]" type="hidden" value="456" autocomplete="off" />'
     end
 
     assert_dom_equal expected, output_buffer
@@ -3270,7 +3270,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
     assert_dom_equal expected, output_buffer
@@ -3292,7 +3292,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<input name='post[123][title]' type='text' id='post_123_title' value='Hello World' />" \
       "<textarea name='post[123][body]' id='post_123_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[123][secret]' type='hidden' value='0' />" \
+      "<input name='post[123][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[123][secret]' checked='checked' type='checkbox' id='post_123_secret' value='1' />"
 
     assert_dom_equal expected, output_buffer
@@ -3314,7 +3314,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<input name='post[][title]' type='text' id='post__title' value='Hello World' />" \
       "<textarea name='post[][body]' id='post__body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[][secret]' type='hidden' value='0' />" \
+      "<input name='post[][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[][secret]' checked='checked' type='checkbox' id='post__secret' value='1' />"
 
     assert_dom_equal expected, output_buffer
@@ -3336,7 +3336,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<input name='post[abc][title]' type='text' id='post_abc_title' value='Hello World' />" \
       "<textarea name='post[abc][body]' id='post_abc_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[abc][secret]' type='hidden' value='0' />" \
+      "<input name='post[abc][secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[abc][secret]' checked='checked' type='checkbox' id='post_abc_secret' value='1' />"
 
     assert_dom_equal expected, output_buffer
@@ -3352,7 +3352,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
     assert_dom_equal expected, output_buffer
@@ -3368,7 +3368,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='post[secret]' type='hidden' value='0' />" \
+      "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />"
 
     assert_dom_equal expected, output_buffer
@@ -3413,7 +3413,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "create-post", "edit_post", method: "patch") do
       "<input name='post[title]' type='text' id='post_title' value='Hello World' />" \
       "<textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea>" \
-      "<input name='parent_post[secret]' type='hidden' value='0' />" \
+      "<input name='parent_post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='parent_post[secret]' checked='checked' type='checkbox' id='parent_post_secret' value='1' />"
     end
 
@@ -3473,7 +3473,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" \
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -3492,7 +3492,7 @@ class FormHelperTest < ActionView::TestCase
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
       "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" \
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -3551,7 +3551,7 @@ class FormHelperTest < ActionView::TestCase
     expected =
       "<label for='title'>Title:</label> <input name='post[title]' type='text' id='post_title' value='Hello World' /><br/>" \
       "<label for='body'>Body:</label> <textarea name='post[body]' id='post_body'>\nBack to the hill and over it again!</textarea><br/>" \
-      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
+      "<label for='secret'>Secret:</label> <input name='post[secret]' type='hidden' value='0' autocomplete='off' /><input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' /><br/>"
 
     assert_dom_equal expected, output_buffer
   end
@@ -3725,13 +3725,13 @@ class FormHelperTest < ActionView::TestCase
       method = options[:method]
 
       if options.fetch(:enforce_utf8, true)
-        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" />}
+        txt = +%{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
       else
         txt = +""
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
       end
 
       txt

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -700,7 +700,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_with_multiple_to_add_hidden_input
     output_buffer = select(:post, :category, "", {}, { multiple: true })
     assert_dom_equal(
-      "<input type=\"hidden\" name=\"post[category][]\" value=\"\"/><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
+      "<input type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\"/><select multiple=\"multiple\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
     )
   end
@@ -724,7 +724,7 @@ class FormOptionsHelperTest < ActionView::TestCase
   def test_select_with_multiple_and_disabled_to_add_disabled_hidden_input
     output_buffer = select(:post, :category, "", {}, { multiple: true, disabled: true })
     assert_dom_equal(
-      "<input disabled=\"disabled\"type=\"hidden\" name=\"post[category][]\" value=\"\"/><select multiple=\"multiple\" disabled=\"disabled\" id=\"post_category\" name=\"post[category][]\"></select>",
+      "<input disabled=\"disabled\"type=\"hidden\" name=\"post[category][]\" value=\"\" autocomplete=\"off\"/><select multiple=\"multiple\" disabled=\"disabled\" id=\"post_category\" name=\"post[category][]\"></select>",
       output_buffer
     )
   end
@@ -898,7 +898,7 @@ class FormOptionsHelperTest < ActionView::TestCase
 
   def test_required_select_with_multiple_option
     assert_dom_equal(
-      %(<input name="post[category][]" type="hidden" value=""/><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
+      %(<input name="post[category][]" type="hidden" value="" autocomplete="off"/><select id="post_category" multiple="multiple" name="post[category][]" required="required"><option value="abe">abe</option>\n<option value="mus">mus</option>\n<option value="hest">hest</option></select>),
       select("post", "category", %w(abe mus hest), {}, { required: true, multiple: true })
     )
   end
@@ -1086,7 +1086,7 @@ class FormOptionsHelperTest < ActionView::TestCase
     @post = Post.new
     @post.author_name = "Babe"
 
-    expected = "<input type=\"hidden\" name=\"post[author_name][]\" value=\"\"/><select id=\"post_author_name\" name=\"post[author_name][]\" multiple=\"multiple\"><option value=\"\" label=\" \"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>"
+    expected = "<input type=\"hidden\" name=\"post[author_name][]\" value=\"\" autocomplete=\"off\"/><select id=\"post_author_name\" name=\"post[author_name][]\" multiple=\"multiple\"><option value=\"\" label=\" \"></option>\n<option value=\"&lt;Abe&gt;\">&lt;Abe&gt;</option>\n<option value=\"Babe\" selected=\"selected\">Babe</option>\n<option value=\"Cabe\">Cabe</option></select>"
 
     # Should suffix default name with [].
     assert_dom_equal expected, collection_select("post", "author_name", dummy_posts, "author_name", "author_name", { include_blank: true }, { multiple: true })

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -28,11 +28,11 @@ class FormTagHelperTest < ActionView::TestCase
 
     (+"").tap do |txt|
       if enforce_utf8
-        txt << %{<input name="utf8" type="hidden" value="&#x2713;" />}
+        txt << %{<input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" />}
       end
 
       if method && !%w(get post).include?(method.to_s)
-        txt << %{<input name="_method" type="hidden" value="#{method}" />}
+        txt << %{<input name="_method" type="hidden" value="#{method}" autocomplete="off" />}
       end
     end
   end
@@ -213,7 +213,7 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_hidden_field_tag
     actual = hidden_field_tag "id", 3
-    expected = %(<input id="id" name="id" type="hidden" value="3" />)
+    expected = %(<input id="id" name="id" type="hidden" value="3" autocomplete="off" />)
     assert_dom_equal expected, actual
   end
 

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -164,7 +164,7 @@ class UrlHelperTest < ActiveSupport::TestCase
     self.request_forgery = true
 
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" /></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><button type="submit">Hello</button><input name="form_token" type="hidden" value="secret" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com")
     )
   ensure
@@ -250,7 +250,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_method_delete
     assert_dom_equal(
-      %{<form method="post" action="http://www.example.com" class="button_to"><input type="hidden" name="_method" value="delete" /><button type="submit">Hello</button></form>},
+      %{<form method="post" action="http://www.example.com" class="button_to"><input type="hidden" name="_method" value="delete" autocomplete="off" /><button type="submit">Hello</button></form>},
       button_to("Hello", "http://www.example.com", method: :delete)
     )
   end
@@ -271,7 +271,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" /><input type="hidden" name="foo" value="bar" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: { foo: :bar, baz: "quux" })
     )
   end
@@ -308,7 +308,7 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_permitted_strong_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" /><input type="hidden" name="foo" value="bar" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="baz" value="quux" autocomplete="off" /><input type="hidden" name="foo" value="bar" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: FakeParams.new)
     )
   end
@@ -321,14 +321,14 @@ class UrlHelperTest < ActiveSupport::TestCase
 
   def test_button_to_with_nested_hash_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[bar]" value="baz" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[bar]" value="baz" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: { foo: { bar: "baz" } })
     )
   end
 
   def test_button_to_with_nested_array_params
     assert_dom_equal(
-      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[]" value="bar" /></form>},
+      %{<form action="http://www.example.com" class="button_to" method="post"><button type="submit">Hello</button><input type="hidden" name="foo[]" value="bar" autocomplete="off" /></form>},
       button_to("Hello", "http://www.example.com", params: { foo: ["bar"] })
     )
   end


### PR DESCRIPTION
### Summary

Firefox has [a longstanding bug](https://bugzilla.mozilla.org/show_bug.cgi?id=520561) where it may populate hidden inputs without `autocomplete="off"` with completely random values. Since Rails uses hidden fields extensively for e.g. CSRF protection and non-standard HTTP methods via `_method`, Firefox users interacting with otherwise-fine Rails apps will see random "Invalid Authenticity Token" errors and form inputs getting interpreted as the incorrect HTTP method, among other unexpected behavior. Adding `autocomplete="off"` does not appear to have any negative consequences for other browsers, and is valid HTML. There's more discussion and links at: #42610

I recently bundled my workaround for this into a gem for Rails 6.1 apps, [`rails-hidden_autocomplete`](https://github.com/podqueue/rails-hidden_autocomplete), which I've now reworked into this PR so that it can benefit all Rails users & developers, since this bug is currently extremely frustrating to diagnose and fix in real-world apps (see also podqueue/rails-hidden_autocomplete#2).

### Other Information

I appreciate that this change might need to be gated behind a new framework default for ActionView, which I'd be happy to work on adding if that's the consensus.