### PR TITLE
Guard against subscriber exceptions in ActiveSupport::Notifications

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -213,9 +213,10 @@ module ActiveRecord
     def test_exceptions_from_notifications_are_not_translated
       original_error = StandardError.new("This StandardError shouldn't get translated")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { raise original_error }
-      actual_error = assert_raises(StandardError) do
+      wrapped_error = assert_raises(ActiveSupport::Notifications::InstrumentationSubscriberError) do
         @connection.execute("SELECT * FROM posts")
       end
+      actual_error = wrapped_error.exceptions.first
 
       assert_equal original_error, actual_error
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -489,11 +489,13 @@ class QueryCacheTest < ActiveRecord::TestCase
       payload[:sql].downcase!
     end
 
-    assert_raises FrozenError do
+    error = assert_raises ActiveSupport::Notifications::InstrumentationSubscriberError do
       ActiveRecord::Base.cache do
         assert_queries(1) { Task.find(1); Task.find(1) }
       end
     end
+
+    assert error.exceptions.first.is_a?(FrozenError)
   ensure
     ActiveSupport::Notifications.unsubscribe subscriber
   end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -89,7 +89,7 @@ module ActiveSupport
 
         listeners.each do |s|
           yield s
-        rescue => e
+        rescue Exception => e
           exceptions ||= []
           exceptions << e
         end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -7,6 +7,16 @@ require "active_support/core_ext/object/try"
 
 module ActiveSupport
   module Notifications
+    class InstrumentationSubscriberError < RuntimeError
+      attr_reader :exceptions
+
+      def initialize(exceptions)
+        @exceptions = exceptions
+        exception_class_names = exceptions.map { |e| e.class.name }
+        super "Exception(s) occurred within instrumentation subscribers: #{exception_class_names.join(', ')}"
+      end
+    end
+
     # This is a default queue implementation that ships with Notifications.
     # It just pushes events to all registered log subscribers.
     #
@@ -59,19 +69,32 @@ module ActiveSupport
       end
 
       def start(name, id, payload)
-        listeners_for(name).each { |s| s.start(name, id, payload) }
+        iterate_guarding_exceptions(listeners_for(name)) { |s| s.start(name, id, payload) }
       end
 
       def finish(name, id, payload, listeners = listeners_for(name))
-        listeners.each { |s| s.finish(name, id, payload) }
+        iterate_guarding_exceptions(listeners) { |s| s.finish(name, id, payload) }
       end
 
       def publish(name, *args)
-        listeners_for(name).each { |s| s.publish(name, *args) }
+        iterate_guarding_exceptions(listeners_for(name)) { |s| s.publish(name, *args) }
       end
 
       def publish_event(event)
-        listeners_for(event.name).each { |s| s.publish_event(event) }
+        iterate_guarding_exceptions(listeners_for(event.name)) { |s| s.publish_event(event) }
+      end
+
+      def iterate_guarding_exceptions(listeners)
+        exceptions = nil
+
+        listeners.each do |s|
+          yield s
+        rescue => e
+          exceptions ||= []
+          exceptions << e
+        end
+      ensure
+        raise InstrumentationSubscriberError.new(exceptions) unless exceptions.nil?
       end
 
       def listeners_for(name)

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -5,7 +5,8 @@ require_relative "../abstract_unit"
 module ActiveSupport
   module Notifications
     class EventedTest < ActiveSupport::TestCase
-      class BadListenerException < RuntimeError; end
+      # we expect all exception types to be handled, so test with the most basic type
+      class BadListenerException < Exception; end
 
       class Listener
         attr_reader :events

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -5,6 +5,8 @@ require_relative "../abstract_unit"
 module ActiveSupport
   module Notifications
     class EventedTest < ActiveSupport::TestCase
+      class BadListenerException < RuntimeError; end
+
       class Listener
         attr_reader :events
 
@@ -24,6 +26,24 @@ module ActiveSupport
       class ListenerWithTimedSupport < Listener
         def call(name, start, finish, id, payload)
           @events << [:call, name, start, finish, id, payload]
+        end
+      end
+
+      class BadStartListener < Listener
+        def start(name, id, payload)
+          raise BadListenerException
+        end
+
+        def finish(name, id, payload)
+        end
+      end
+
+      class BadFinishListener < Listener
+        def start(name, id, payload)
+        end
+
+        def finish(name, id, payload)
+          raise BadListenerException
         end
       end
 
@@ -61,6 +81,54 @@ module ActiveSupport
         notifier.start  "world", 1, {}
         notifier.finish  "world", 1, {}
         notifier.finish  "hello", 1, {}
+
+        assert_equal 4, listener.events.length
+        assert_equal [
+          [:start,  "hello", 1, {}],
+          [:start,  "world", 1, {}],
+          [:finish,  "world", 1, {}],
+          [:finish,  "hello", 1, {}],
+        ], listener.events
+      end
+
+      def test_listen_start_exception_consistency
+        notifier = Fanout.new
+        listener = Listener.new
+        notifier.subscribe nil, BadStartListener.new
+        notifier.subscribe nil, listener
+
+        assert_raises InstrumentationSubscriberError do
+          notifier.start  "hello", 1, {}
+        end
+        assert_raises InstrumentationSubscriberError do
+          notifier.start  "world", 1, {}
+        end
+        notifier.finish  "world", 1, {}
+        notifier.finish  "hello", 1, {}
+
+        assert_equal 4, listener.events.length
+        assert_equal [
+          [:start,  "hello", 1, {}],
+          [:start,  "world", 1, {}],
+          [:finish,  "world", 1, {}],
+          [:finish,  "hello", 1, {}],
+        ], listener.events
+      end
+
+      def test_listen_finish_exception_consistency
+        notifier = Fanout.new
+        listener = Listener.new
+        notifier.subscribe nil, BadFinishListener.new
+        notifier.subscribe nil, listener
+
+        notifier.start  "hello", 1, {}
+        notifier.start  "world", 1, {}
+        assert_raises InstrumentationSubscriberError do
+          notifier.finish  "world", 1, {}
+        end
+        assert_raises InstrumentationSubscriberError do
+          notifier.finish  "hello", 1, {}
+        end
 
         assert_equal 4, listener.events.length
         assert_equal [


### PR DESCRIPTION
### Summary

Currently the fanout loops in `ActiveSupport::Notifications::Fanout` to send notifications to subscribers performs no exception handling, meaning any exceptions in a subscriber immediately break out of the notification loop.

This means notifications are delivered to an arbitrary subset of the listeners, depending on subscription order. Additionally, some of these listeners (especially the ones defined in the `Fanout` class) rely on a `Thread.current` stack to store information about start events for when finish events are later emitted. If an exception occurs during either the start or finish process in one listener, other listeners will unfortunately be left uncalled, leaving a consistency problem because the stack will still contain the elements that are complete but never had `#finish` called due to an earlier exception.

This PR improves this situation by ensuring that fanout events will always run on all listeners, with any exceptions accumulated and then wrapped in an `InstrumentationSubscriberError`. This means an erroring `#finish` subscriber (the most likely) will cause all working instrumentation to succeed, before a `InstrumentationSubscriberError` is finally raised for any broken ones. This ensures that the minimal number of subscribers are impacted, and in the case of the `Thread.current` stack, also ensures that the stack is cleaned up for all the `Timed`, `MonotonicTimed`, etc listener classes defined here.

Callers can catch `InstrumentationSubscriberError` and inspect the `exceptions` attribute to find the original exceptions from subscribers and handle them accordingly.

This PR touches the same code paths as https://github.com/rails/rails/pull/43241, and will be trivial to adjust for that PR by specifying the iteration type like `iterate_guarding_exceptions(..., :each)` and `iterate_guarding_exceptions(..., :map)`, but I left this additional complexity out of this PR so it was simpler, and can update the other PR as needed if this one is accepted.