### PR TITLE
Allow a validation error to have a `full_message` that doesn't include the error's `message`

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -155,9 +155,15 @@ module ActiveModel
     #   error = ActiveModel::Error.new(person, :name, :too_short, count: 5)
     #   error.full_message
     #   # => "Name is too short (minimum is 5 characters)"
+    #
+    #   Override the entire full message instead of combining `attribute` and `message` with either
+    # * <tt>activemodel.errors.models.person.attributes.name.full_messages.too_short</tt>
+    # * <tt>activemodel.errors.models.person.full_messages.too_short</tt>
+    # * <tt>activemodel.errors.messages.full_messages.too_short</tt>
+    # * <tt>activemodel.errors.attributes.name.full_messages.too_short</tt>
+    # * <tt>errors.messages.full_messages.too_short</tt>
     def full_message
-      generate_message_with_full_messages_scope ||
-        self.class.full_message(attribute, message, @base)
+      generate_message_with_full_messages_scope || self.class.full_message(attribute, message, @base)
     end
 
     # See if error matches provided +attribute+, +type+ and +options+.

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -156,7 +156,7 @@ module ActiveModel
     #   error.full_message
     #   # => "Name is too short (minimum is 5 characters)"
     def full_message
-      innermost_error.generate_message_with_full_messages_scope ||
+      generate_message_with_full_messages_scope ||
         self.class.full_message(attribute, message, @base)
     end
 
@@ -203,14 +203,6 @@ module ActiveModel
     protected
       def attributes_for_hash
         [@base, @attribute, @raw_type, @options.except(*CALLBACKS_OPTIONS)]
-      end
-
-      def innermost_error
-        result = self
-        while result.respond_to?(:inner_error)
-          result = result.inner_error
-        end
-        result
       end
 
       def generate_message_with_full_messages_scope

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -218,7 +218,7 @@ module ActiveModel
           attribute,
           "full_messages.#{raw_type}",
           base,
-          options.except(CALLBACKS_OPTIONS).merge(raise: true)
+          options.except(*CALLBACKS_OPTIONS, :message).merge(raise: true)
         )
       rescue I18n::MissingTranslationData
       end

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -218,7 +218,7 @@ module ActiveModel
           attribute,
           "full_messages.#{raw_type}",
           base,
-          options.except(*CALLBACKS_OPTIONS, :message).merge(raise: true)
+          options.except(*CALLBACKS_OPTIONS).except(:message).merge(raise: true)
         )
       rescue I18n::MissingTranslationData
       end

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -216,8 +216,8 @@ module ActiveModel
 
         self.class.generate_message(
           attribute,
-          "full_messages.#{@raw_type}",
-          @base,
+          "full_messages.#{raw_type}",
+          base,
           options.except(CALLBACKS_OPTIONS).merge(raise: true)
         )
       rescue I18n::MissingTranslationData

--- a/activemodel/lib/active_model/nested_error.rb
+++ b/activemodel/lib/active_model/nested_error.rb
@@ -17,6 +17,6 @@ module ActiveModel
     attr_reader :inner_error
 
     extend Forwardable
-    def_delegators :@inner_error, :message
+    def_delegators :@inner_error, :message, :generate_message_with_full_messages_scope
   end
 end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -2,7 +2,6 @@
 
 require "cases/helper"
 require "models/person"
-require "byebug"
 
 class I18nValidationTest < ActiveModel::TestCase
   def setup

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/person"
+require "byebug"
 
 class I18nValidationTest < ActiveModel::TestCase
   def setup
@@ -59,11 +60,11 @@ class I18nValidationTest < ActiveModel::TestCase
       errors: { models: { person: { attributes: { title: { full_messages: { blank: "A person must have a title" } } } } } }
     })
 
-    person = person_class.new
-    error = ActiveModel::Error.new(person, :title, :blank)
-    person.errors.import(error, attribute: "person[0].contacts.title")
-    assert_equal ["A person must have a title"], person.errors.full_messages
+    error = ActiveModel::Error.new(@person, :title, :blank)
+    @person.errors.import(error, attribute: "person[0].contacts.title")
+    assert_equal ["A person must have a title"], @person.errors.full_messages
   end
+
   def test_errors_full_messages_doesnt_use_attribute_format_without_config
     ActiveModel::Error.i18n_customize_full_message = false
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This change allows us to specify a separate `full_message` for a validation error that is totally distinct from the error's `message`. 

Why?

Suppose we have a form for creating a person and we want to show an error message under the `title` field. We might want the message to be "is required".

But in another context - maybe in a flash message - we might want to show the full error message. 

Currently, we can show a full message that _includes_ the "is required" message, but what if we want the full message to be "A person must have a title"?

This PR lets us do that by setting a full message phrase like this:
```yml
en:
  activemodel:
    errors:
      models:
        person:
          attributes:
            title:
              full_messages:
                blank: "A person must have a title"
```

And at the same time, we can still set the "is required" message like this:
```yml
en:
  activemodel:
    errors:
      models:
        person:
          attributes:
            title:
              blank: "is required"
              full_messages:
                blank: "A person must have a title"
```

How?

`Error#full_message` now first checks for a phrase under the `full_messages` key. If a phrase has been set for any of the following, it will be used (and a phrase set for a key higher up this list will take precedence):
```
activemodel.errors.models.#{model}.attributes.#{attribute}.full_messages.#{type}
activemodel.errors.models.#{model}.full_messages.#{type}
activemodel.errors.messages.full_messages.#{type}
activemodel.errors.attributes.name.full_messages.#{type}
errors.messages.full_messages.#{type}
```

This works by re-using `Error.generate_message`, except that:
- the `type` argument we pass in is scoped for `full_messages`, so each key we check for ends with `full_messages.#{type}`
- we raise an error if no `full_messages` phrase can be found, so we can then rescue the error and fall back to the standard `Error.full_message` method, which combines `attribute` and `message`
- we exclude `message` from `options`, because if a `message` has been specified and gets passed through as an option, it will be used instead of raising an error when no `full_messages` phrase is found

Also, we cannot use `Error.generate_message` on a _nested_ error, because it will try to fetch a `value` from the `base` model using an attribute like "person.contacts.title". Instead, we generate the message (with the `full_messages` scope) on the _innermost_ error. For example, if a `person` has a nested error on `person.contacts.title`, we will check for a `full_messages` phrase on the _contact's_ error. Ideally, maybe we'd be able to have different full messages (and messages...) for nested errors without delegating to the inner error, but that would be a wider change to how `Error.generate_message` works.

### Other Information

I definitely think it would be useful to have the option of setting a `full_message` that is completely distinct from the standard `message`... Whether this implementation is the right way to achieve that, I'm not sure, but it was the simplest change I could see when I dug into the problem. Would love to know if there's a better way 😅.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
