### PR TITLE
Prevent error when authenticating user with a blank password digest

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -118,7 +118,7 @@ module ActiveModel
         #   user.authenticate_password('mUc3m00RsqyRe') # => user
         define_method("authenticate_#{attribute}") do |unencrypted_password|
           attribute_digest = public_send("#{attribute}_digest")
-          BCrypt::Password.new(attribute_digest).is_password?(unencrypted_password) && self
+          attribute_digest.present? && BCrypt::Password.new(attribute_digest).is_password?(unencrypted_password) && self
         end
 
         alias_method :authenticate, :authenticate_password if attribute == :password

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -212,6 +212,11 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal @user, @user.authenticate_recovery_password("42password")
   end
 
+  test "authenticate should return false and not raise when password digest is blank" do
+    @user.password_digest = " "
+    assert_equal false, @user.authenticate(" ")
+  end
+
   test "Password digest cost defaults to bcrypt default cost when min_cost is false" do
     ActiveModel::SecurePassword.min_cost = false
 


### PR DESCRIPTION
### Summary

If we used `has_secure_password validations: false` in the model and we created a user without a password then we called `@user.authenticate(params[:password])` this will raise an error:

> BCrypt::Errors::InvalidHash: invalid hash

because `password_digest` is currently `nil` for that user.

After this change, `authenticate` will return `false` if `password_digest` is `blank` instead of raising the error from `BCrypt`.
