### PR TITLE
Create namespaced db tasks for single db applications 

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -174,9 +174,6 @@ module ActiveRecord
 
         database_configs = ActiveRecord::DatabaseConfigurations.new(databases).configs_for(env_name: Rails.env)
 
-        # if this is a single database application we don't want tasks for each primary database
-        return if database_configs.count == 1
-
         database_configs.each do |db_config|
           yield db_config.name
         end


### PR DESCRIPTION
## What

Create namespaced db tasks for single db applications 

### Why

As an application grows in popularity and usage you'll need to scale the application to support your new users and their data[[1](https://guides.rubyonrails.org/active_record_multiple_databases.html)]. DB rake tasks today affect all databases. Ie. `rake db:drop` will drop all databases. same as, `db:migrate`, `db:setup` etc, making it harder to evolve the deployment pipelines for the single DB applications. This change is in favour of "ease of change or scale", having available the namespaced tasks reduce helps to tweak the deployment pipelines.

## Anything else

Alternatively today we have`database_tasks: false` https://github.com/rails/rails/pull/42794 as a workaround 