### PR TITLE
Fixed guide to `case_sensitive` option for Activerecord uniqueness validator [skip ci]

### DIFF
--- a/activerecord/lib/active_record/validations/uniqueness.rb
+++ b/activerecord/lib/active_record/validations/uniqueness.rb
@@ -161,7 +161,7 @@ module ActiveRecord
       #   <tt>WHERE</tt> SQL fragment to limit the uniqueness constraint lookup
       #   (e.g. <tt>conditions: -> { where(status: 'active') }</tt>).
       # * <tt>:case_sensitive</tt> - Looks for an exact match. Ignored by
-      #   non-text columns (+true+ by default).
+      #   non-text columns. The default behavior respects the default database collation.
       # * <tt>:allow_nil</tt> - If set to +true+, skips this validation if the
       #   attribute is +nil+ (default is +false+).
       # * <tt>:allow_blank</tt> - If set to +true+, skips this validation if the

--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -689,9 +689,7 @@ end
 
 Should you wish to create a database constraint to prevent possible violations of a uniqueness validation using the `:scope` option, you must create a unique index on both columns in your database. See [the MySQL manual](https://dev.mysql.com/doc/refman/en/multiple-column-indexes.html) for more details about multiple column indexes or [the PostgreSQL manual](https://www.postgresql.org/docs/current/static/ddl-constraints.html) for examples of unique constraints that refer to a group of columns.
 
-There is also a `:case_sensitive` option that you can use to define whether the
-uniqueness constraint will be case sensitive or not. This option defaults to
-true.
+There is also a `:case_sensitive` option that you can use to define whether the uniqueness constraint will be case sensitive, case insensitive, or respects default database collation. This option defaults to respects default database collation.
 
 ```ruby
 class Person < ApplicationRecord


### PR DESCRIPTION
### Summary

The default value for the `case_sensitive` option in Activerecord uniqueness validator is not `true`.
The default behavior respects the default database collation.

See: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/validations/uniqueness.rb#L72-L79
