### PR TITLE
Link headers can have arbitrary attributes

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -80,10 +80,9 @@ module ActionView
           "<#{name}#{tag_options}>#{PRE_CONTENT_STRINGS[name]}#{content}</#{name}>".html_safe
         end
 
-        def tag_options(options, escape = true)
+        def tag_options(options, escape = true, sep = " ")
           return if options.blank?
           output = +""
-          sep    = " "
           options.each_pair do |key, value|
             type = TAG_TYPES[key]
             if type == :data && value.is_a?(Hash)

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -625,7 +625,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_preload_links_added_to_preload_header
     with_preload_links_header do
       preload_link_tag("sprite.svg")
-      expected = "</sprite.svg>; rel=\"preload\" as=\"image\" type=\"image/svg+xml\""
+      expected = "</sprite.svg>; rel=\"preload\"; as=\"image\"; type=\"image/svg+xml\""
       assert_equal expected, @response.headers["Link"]
     end
   end
@@ -633,7 +633,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_preload_links_added_to_preload_header_media
     with_preload_links_header do
       preload_link_tag("sprite.svg", media: "(min-width: 1024px)")
-      expected = "</sprite.svg>; rel=\"preload\" as=\"image\" type=\"image/svg+xml\" media=\"(min-width: 1024px)\""
+      expected = "</sprite.svg>; rel=\"preload\"; as=\"image\"; media=\"(min-width: 1024px)\"; type=\"image/svg+xml\""
       assert_equal expected, @response.headers["Link"]
     end
   end

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -548,7 +548,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css")
       javascript_include_tag("http://example.com/all.js")
-      expected = "<http://example.com/style.css>; rel=preload; as=style; nopush,<http://example.com/all.js>; rel=preload; as=script; nopush"
+      expected = "<http://example.com/style.css>; rel=\"preload\"; as=\"style\"; nopush,<http://example.com/all.js>; rel=\"preload\"; as=\"script\"; nopush"
       assert_equal expected, @response.headers["Link"]
     end
   end
@@ -583,7 +583,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css", nopush: false)
       javascript_include_tag("http://example.com/all.js", nopush: false)
-      expected = "<http://example.com/style.css>; rel=preload; as=style,<http://example.com/all.js>; rel=preload; as=script"
+      expected = "<http://example.com/style.css>; rel=\"preload\"; as=\"style\",<http://example.com/all.js>; rel=\"preload\"; as=\"script\""
       assert_equal expected, @response.headers["Link"]
     end
   end
@@ -592,7 +592,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css", crossorigin: "use-credentials")
       javascript_include_tag("http://example.com/all.js", crossorigin: true)
-      expected = "<http://example.com/style.css>; rel=preload; as=style; crossorigin=use-credentials; nopush,<http://example.com/all.js>; rel=preload; as=script; crossorigin=anonymous; nopush"
+      expected = "<http://example.com/style.css>; rel=\"preload\"; as=\"style\"; crossorigin=\"use-credentials\"; nopush,<http://example.com/all.js>; rel=\"preload\"; as=\"script\"; crossorigin=\"anonymous\"; nopush"
       assert_equal expected, @response.headers["Link"]
     end
   end
@@ -600,7 +600,7 @@ class AssetTagHelperTest < ActionView::TestCase
   def test_should_set_preload_links_with_rel_modulepreload
     with_preload_links_header do
       javascript_include_tag("http://example.com/all.js", type: "module")
-      expected = "<http://example.com/all.js>; rel=modulepreload; as=script; nopush"
+      expected = "<http://example.com/all.js>; rel=\"modulepreload\"; as=\"script\"; nopush"
       assert_equal expected, @response.headers["Link"]
     end
   end
@@ -609,7 +609,7 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       stylesheet_link_tag("http://example.com/style.css", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
       javascript_include_tag("http://example.com/all.js", integrity: "sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs")
-      expected = "<http://example.com/style.css>; rel=preload; as=style; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush,<http://example.com/all.js>; rel=preload; as=script; integrity=sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs; nopush"
+      expected = "<http://example.com/style.css>; rel=\"preload\"; as=\"style\"; integrity=\"sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs\"; nopush,<http://example.com/all.js>; rel=\"preload\"; as=\"script\"; integrity=\"sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs\"; nopush"
       assert_equal expected, @response.headers["Link"]
     end
   end
@@ -619,6 +619,22 @@ class AssetTagHelperTest < ActionView::TestCase
       stylesheet_link_tag("http://example.com/style.css")
       javascript_include_tag("http://example.com/all.js")
       assert_nil @response.headers["Link"]
+    end
+  end
+
+  def test_preload_links_added_to_preload_header
+    with_preload_links_header do
+      preload_link_tag("sprite.svg")
+      expected = "</sprite.svg>; rel=\"preload\" as=\"image\" type=\"image/svg+xml\""
+      assert_equal expected, @response.headers["Link"]
+    end
+  end
+
+  def test_preload_links_added_to_preload_header_media
+    with_preload_links_header do
+      preload_link_tag("sprite.svg", media: "(min-width: 1024px)")
+      expected = "</sprite.svg>; rel=\"preload\" as=\"image\" type=\"image/svg+xml\" media=\"(min-width: 1024px)\""
+      assert_equal expected, @response.headers["Link"]
     end
   end
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2616,7 +2616,7 @@ module ApplicationTests
 
       get "/"
       assert_match %r[<script src="/application.js"></script>], last_response.body
-      assert_equal "</application.js>; rel=preload; as=script; nopush", last_response.headers["Link"]
+      assert_equal "</application.js>; rel=\"preload\"; as=\"script\"; nopush", last_response.headers["Link"]
     end
 
     test "javascript_include_tag doesn't set the Link header when disabled" do


### PR DESCRIPTION
I was working with `preload_link_tag` when I noticed that `media` attributes don't make it into the `preload` HTTP header that Rails generates.

Given: 

```ruby
preload_link_tag("sprite.svg", media: "(min-width: 1024px)")
```

You get a link header like:

```
</sprite.svg>; rel=preload as=image type=image/svg+xml
```

This causes an unintended preload request on windows <1024px. 

I have a few thoughts:

1. All attributes that are legal on a link tag are valid in a Link header, so it's weird that we whitelist them. I think the reason we allowlist them today is just whale legs from the original implementation. We have had several PRs over the years to add headers that people wanted (integrity, etc). We should just allow all attributes to make it into the header.
2. I think we could clean up the code here with how we generate preload link headers. I've taken a pass in this PR.
3. ~~I'm not sure why we always turn preload link tags into link headers in the first place. Link headers are functionally equivalent to a link tag, so it feels unneccessary. Could we just remove this entirely for link headers?~~ Clarified below that we have to keep it.
4. ~~`preload_link_tag` has always dropped/ignored the nopush attribute. I think this is a bug.~~ Making another PR.

I could use some help with the cleanup I've attempted here. Using `tag.attributes` means that my generated header uses quoted strings instead of tokens. Is there some way to clean this up but keep the tokens? Maybe, if like I propose, we stop allowlisting attributes, we should quote-string because people could put weird stuff in their attributes?