### PR TITLE
[ActiveStorage] Custom Metadata

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Setting custom metadata on blobs are now persisted to remote storage.
+
+    *joshuamsager*
+
 *   Support direct uploads to multiple services.
 
     *Dmitry Tsepelev*

--- a/activestorage/lib/active_storage/service.rb
+++ b/activestorage/lib/active_storage/service.rb
@@ -128,12 +128,12 @@ module ActiveStorage
     # The URL will be valid for the amount of seconds specified in +expires_in+.
     # You must also provide the +content_type+, +content_length+, and +checksum+ of the file
     # that will be uploaded. All these attributes will be validated by the service upon upload.
-    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
+    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, custom_metadata: {})
       raise NotImplementedError
     end
 
     # Returns a Hash of headers for +url_for_direct_upload+ requests.
-    def headers_for_direct_upload(key, filename:, content_type:, content_length:, checksum:)
+    def headers_for_direct_upload(key, filename:, content_type:, content_length:, checksum:, custom_metadata: {})
       {}
     end
 
@@ -150,6 +150,9 @@ module ActiveStorage
         raise NotImplementedError
       end
 
+      def custom_metadata_headers(metadata)
+        raise NotImplementedError
+      end
 
       def instrument(operation, payload = {}, &block)
         ActiveSupport::Notifications.instrument(

--- a/activestorage/lib/active_storage/service/disk_service.rb
+++ b/activestorage/lib/active_storage/service/disk_service.rb
@@ -72,7 +72,7 @@ module ActiveStorage
       end
     end
 
-    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
+    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, custom_metadata: {})
       instrument :url, key: key do |payload|
         verified_token_with_expiration = ActiveStorage.verifier.generate(
           {

--- a/activestorage/lib/active_storage/service/gcs_service.rb
+++ b/activestorage/lib/active_storage/service/gcs_service.rb
@@ -16,14 +16,14 @@ module ActiveStorage
       @public = public
     end
 
-    def upload(key, io, checksum: nil, content_type: nil, disposition: nil, filename: nil)
+    def upload(key, io, checksum: nil, content_type: nil, disposition: nil, filename: nil, custom_metadata: {})
       instrument :upload, key: key, checksum: checksum do
         # GCS's signed URLs don't include params such as response-content-type response-content_disposition
         # in the signature, which means an attacker can modify them and bypass our effort to force these to
         # binary and attachment when the file's content type requires it. The only way to force them is to
         # store them as object's metadata.
         content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
-        bucket.create_file(io, key, md5: checksum, cache_control: @config[:cache_control], content_type: content_type, content_disposition: content_disposition)
+        bucket.create_file(io, key, md5: checksum, cache_control: @config[:cache_control], content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata)
       rescue Google::Cloud::InvalidArgumentError
         raise ActiveStorage::IntegrityError
       end
@@ -43,11 +43,12 @@ module ActiveStorage
       end
     end
 
-    def update_metadata(key, content_type:, disposition: nil, filename: nil)
+    def update_metadata(key, content_type:, disposition: nil, filename: nil, custom_metadata: {})
       instrument :update_metadata, key: key, content_type: content_type, disposition: disposition do
         file_for(key).update do |file|
           file.content_type = content_type
           file.content_disposition = content_disposition_with(type: disposition, filename: filename) if disposition && filename
+          file.metadata = custom_metadata
         end
       end
     end
@@ -86,7 +87,7 @@ module ActiveStorage
       end
     end
 
-    def url_for_direct_upload(key, expires_in:, checksum:, **)
+    def url_for_direct_upload(key, expires_in:, checksum:, custom_metadata: {}, **)
       instrument :url, key: key do |payload|
         headers = {}
         version = :v2
@@ -98,6 +99,8 @@ module ActiveStorage
           # whereas v2 has no limit
           version = :v4
         end
+
+        headers.merge!(custom_metadata_headers(custom_metadata))
 
         args = {
           content_md5: checksum,
@@ -120,11 +123,10 @@ module ActiveStorage
       end
     end
 
-    def headers_for_direct_upload(key, checksum:, filename: nil, disposition: nil, **)
+    def headers_for_direct_upload(key, checksum:, filename: nil, disposition: nil, custom_metadata: {}, **)
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
-      headers = { "Content-MD5" => checksum, "Content-Disposition" => content_disposition }
-
+      headers = { "Content-MD5" => checksum, "Content-Disposition" => content_disposition, **custom_metadata_headers(custom_metadata) }
       if @config[:cache_control].present?
         headers["Cache-Control"] = @config[:cache_control]
       end
@@ -222,6 +224,10 @@ module ActiveStorage
           response = iam_client.sign_service_account_blob(resource, request)
           response.signed_blob
         end
+      end
+
+      def custom_metadata_headers(metadata)
+        metadata.transform_keys { |key| "x-goog-meta-#{key}" }
       end
   end
 end

--- a/activestorage/lib/active_storage/service/s3_service.rb
+++ b/activestorage/lib/active_storage/service/s3_service.rb
@@ -23,14 +23,14 @@ module ActiveStorage
       @upload_options[:acl] = "public-read" if public?
     end
 
-    def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, **)
+    def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, custom_metadata: {}, **)
       instrument :upload, key: key, checksum: checksum do
         content_disposition = content_disposition_with(filename: filename, type: disposition) if disposition && filename
 
         if io.size < multipart_upload_threshold
-          upload_with_single_part key, io, checksum: checksum, content_type: content_type, content_disposition: content_disposition
+          upload_with_single_part key, io, checksum: checksum, content_type: content_type, content_disposition: content_disposition, custom_metadata: custom_metadata
         else
-          upload_with_multipart key, io, content_type: content_type, content_disposition: content_disposition
+          upload_with_multipart key, io, content_type: content_type, content_disposition: content_disposition, custom_metadata: custom_metadata
         end
       end
     end
@@ -77,11 +77,11 @@ module ActiveStorage
       end
     end
 
-    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:)
+    def url_for_direct_upload(key, expires_in:, content_type:, content_length:, checksum:, custom_metadata: {})
       instrument :url, key: key do |payload|
         generated_url = object_for(key).presigned_url :put, expires_in: expires_in.to_i,
           content_type: content_type, content_length: content_length, content_md5: checksum,
-          whitelist_headers: ["content-length"], **upload_options
+          metadata: custom_metadata, whitelist_headers: ["content-length"], **upload_options
 
         payload[:url] = generated_url
 
@@ -89,10 +89,10 @@ module ActiveStorage
       end
     end
 
-    def headers_for_direct_upload(key, content_type:, checksum:, filename: nil, disposition: nil, **)
+    def headers_for_direct_upload(key, content_type:, checksum:, filename: nil, disposition: nil, custom_metadata: {}, **)
       content_disposition = content_disposition_with(type: disposition, filename: filename) if filename
 
-      { "Content-Type" => content_type, "Content-MD5" => checksum, "Content-Disposition" => content_disposition }
+      { "Content-Type" => content_type, "Content-MD5" => checksum, "Content-Disposition" => content_disposition, **custom_metadata_headers(custom_metadata) }
     end
 
     private
@@ -110,16 +110,16 @@ module ActiveStorage
       MAXIMUM_UPLOAD_PARTS_COUNT = 10000
       MINIMUM_UPLOAD_PART_SIZE   = 5.megabytes
 
-      def upload_with_single_part(key, io, checksum: nil, content_type: nil, content_disposition: nil)
-        object_for(key).put(body: io, content_md5: checksum, content_type: content_type, content_disposition: content_disposition, **upload_options)
+      def upload_with_single_part(key, io, checksum: nil, content_type: nil, content_disposition: nil, custom_metadata: {})
+        object_for(key).put(body: io, content_md5: checksum, content_type: content_type, content_disposition: content_disposition, metadata: custom_metadata, **upload_options)
       rescue Aws::S3::Errors::BadDigest
         raise ActiveStorage::IntegrityError
       end
 
-      def upload_with_multipart(key, io, content_type: nil, content_disposition: nil)
+      def upload_with_multipart(key, io, content_type: nil, content_disposition: nil, custom_metadata: {})
         part_size = [ io.size.fdiv(MAXIMUM_UPLOAD_PARTS_COUNT).ceil, MINIMUM_UPLOAD_PART_SIZE ].max
 
-        object_for(key).upload_stream(content_type: content_type, content_disposition: content_disposition, part_size: part_size, **upload_options) do |out|
+        object_for(key).upload_stream(content_type: content_type, content_disposition: content_disposition, part_size: part_size, metadata: custom_metadata, **upload_options) do |out|
           IO.copy_stream(io, out)
         end
       end
@@ -142,6 +142,10 @@ module ActiveStorage
           yield object.get(range: "bytes=#{offset}-#{offset + chunk_size - 1}").body.string.force_encoding(Encoding::BINARY)
           offset += chunk_size
         end
+      end
+
+      def custom_metadata_headers(metadata)
+        metadata.transform_keys { |key| "x-amz-meta-#{key}" }
       end
   end
 end

--- a/activestorage/test/controllers/direct_uploads_controller_test.rb
+++ b/activestorage/test/controllers/direct_uploads_controller_test.rb
@@ -22,7 +22,10 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         "my_key_1": "my_value_1",
         "my_key_2": "my_value_2",
         "platform": "my_platform",
-        "library_ID": "12345"
+        "library_ID": "12345",
+        custom: {
+          "my_key_3": "my_value_3"
+        }
       }
 
       ActiveStorage::DirectUploadToken.stub(:verify_direct_upload_token, "s3") do
@@ -39,7 +42,7 @@ if SERVICE_CONFIGURATIONS[:s3] && SERVICE_CONFIGURATIONS[:s3][:access_key_id].pr
         assert_equal "text/plain", details["content_type"]
         assert_match SERVICE_CONFIGURATIONS[:s3][:bucket], details["direct_upload"]["url"]
         assert_match(/s3(-[-a-z0-9]+)?\.(\S+)?amazonaws\.com/, details["direct_upload"]["url"])
-        assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt" }, details["direct_upload"]["headers"])
+        assert_equal({ "Content-Type" => "text/plain", "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-amz-meta-my_key_3" => "my_value_3" }, details["direct_upload"]["headers"])
       end
     end
   end
@@ -67,7 +70,10 @@ if SERVICE_CONFIGURATIONS[:gcs]
         "my_key_1": "my_value_1",
         "my_key_2": "my_value_2",
         "platform": "my_platform",
-        "library_ID": "12345"
+        "library_ID": "12345",
+        custom: {
+          "my_key_3": "my_value_3"
+        }
       }
 
       ActiveStorage::DirectUploadToken.stub(:verify_direct_upload_token, "gcs") do
@@ -83,7 +89,7 @@ if SERVICE_CONFIGURATIONS[:gcs]
         assert_equal metadata, details["metadata"].transform_keys(&:to_sym)
         assert_equal "text/plain", details["content_type"]
         assert_match %r{storage\.googleapis\.com/#{@config[:bucket]}}, details["direct_upload"]["url"]
-        assert_equal({ "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt" }, details["direct_upload"]["headers"])
+        assert_equal({ "Content-MD5" => checksum, "Content-Disposition" => "inline; filename=\"hello.txt\"; filename*=UTF-8''hello.txt", "x-goog-meta-my_key_3" => "my_value_3" }, details["direct_upload"]["headers"])
       end
     end
   end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -259,10 +259,28 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
   test "updating the content_type updates service metadata" do
     blob = directly_upload_file_blob(filename: "racecar.jpg", content_type: "application/octet-stream")
 
-    expected_arguments = [blob.key, content_type: "image/jpeg"]
+    expected_arguments = [blob.key, content_type: "image/jpeg", custom_metadata: {}]
 
     assert_called_with(blob.service, :update_metadata, expected_arguments) do
       blob.update!(content_type: "image/jpeg")
+    end
+  end
+
+  test "updating the metadata updates service metadata" do
+    blob = directly_upload_file_blob(filename: "racecar.jpg", content_type: "application/octet-stream")
+
+    expected_arguments = [
+      blob.key,
+      {
+        content_type: "application/octet-stream",
+        disposition: :attachment,
+        filename: blob.filename,
+        custom_metadatata: { "test" => true }
+      }
+    ]
+
+    assert_called_with(blob.service, :update_metadata, expected_arguments) do
+      blob.update!(metadata: { custom: { "test" => true } })
     end
   end
 

--- a/activestorage/test/service/azure_storage_service_test.rb
+++ b/activestorage/test/service/azure_storage_service_test.rb
@@ -81,6 +81,19 @@ if SERVICE_CONFIGURATIONS[:azure]
       @service.delete key
     end
 
+    test "upload with custom_metadata" do
+      key  = SecureRandom.base58(24)
+      data = "Foobar"
+
+      @service.upload(key, StringIO.new(data), checksum: OpenSSL::Digest::MD5.base64digest(data), filename: ActiveStorage::Filename.new("test.txt"), custom_metadata: { "foo" => "baz" })
+      url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal("baz", response["x-ms-meta-foo"])
+    ensure
+      @service.delete key
+    end
+
     test "signed URL generation" do
       url = @service.url(@key, expires_in: 5.minutes,
         disposition: :inline, filename: ActiveStorage::Filename.new("avatar.png"), content_type: "image/png")

--- a/activestorage/test/service/s3_service_test.rb
+++ b/activestorage/test/service/s3_service_test.rb
@@ -125,6 +125,26 @@ if SERVICE_CONFIGURATIONS[:s3]
       @service.delete key
     end
 
+    test "upload with custom_metadata" do
+      key      = SecureRandom.base58(24)
+      data     = "Something else entirely!"
+      @service.upload(
+        key,
+        StringIO.new(data),
+        checksum: Digest::MD5.base64digest(data),
+        content_type: "text/plain",
+        custom_metadata: { "foo" => "baz" },
+        filename: "custom_metadata.txt"
+      )
+
+      url = @service.url(key, expires_in: 2.minutes, disposition: :inline, content_type: "text/html", filename: ActiveStorage::Filename.new("test.html"))
+
+      response = Net::HTTP.get_response(URI(url))
+      assert_equal("baz", response["x-amz-meta-foo"])
+    ensure
+      @service.delete key
+    end
+
     test "upload with content disposition" do
       key  = SecureRandom.base58(24)
       data = "Something else entirely!"


### PR DESCRIPTION
### Summary

Enable instances of ActiveRecord to set metadata on an object.

Many cloud storage providers allow setting metadata on objects in storage. This change leverages the existing `metadata` column on `active_storage_blobs` to save _custom_ metadata. 

For example, custom metadata is saved like so in the DB:
```JSON
{
    "analyzed": true,
    "width": 200,
    "height": 200,
    "custom": { "optimized": true }
}
```

Nesting `"custom"` was done intentionally in order to prevent metadata set through rails' analyzer from making it's way to remote storage metadata, without needing to maintain a list of keys in code that the rails' analyzer sets (`:width` and `:height` for images, and `:duration`, `:angle`, `:display_aspect_ratio` for video/audio).


## Notes:
* Setting metadata via direct uploads will require bucket CORS to be updated to include the metadata keys. IE) An app that sets `optimized=true`, would need to add the responseHeader: `X-Goog-Meta-Optimized` to their bucket's CORS policy:
```JSON
[
  {
    "origin": ["MY_ORIGIN"],
    "method": ["PUT"],
    "responseHeader": ["Origin", "Content-Type", "Content-MD5", "Content-Disposition", "X-Goog-Meta-Optimized"],
    "maxAgeSeconds": 3600
  }
]
```

