### PR TITLE
Fixes #43279 by filtering unchanged attributes when default function is available for insert

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Filter unchanged attributes with default function from insert query when `partial_inserts` is disabled.
+
+    *Akshay Birajdar*, *Jacopo Beschi*
+
 *   Add support for FILTER clause (SQL:2003) to Arel.
 
     Currently supported by PostgreSQL 9.4+ and SQLite 3.30+.

--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -229,7 +229,13 @@ module ActiveRecord
         end
 
         def attribute_names_for_partial_inserts
-          partial_inserts? ? changed_attribute_names_to_save : attribute_names
+          if partial_inserts?
+            changed_attribute_names_to_save
+          else
+            attribute_names.reject do |attr_name|
+              !attribute_changed?(attr_name) && column_for_attribute(attr_name).default_function
+            end
+          end
         end
     end
   end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define do
     t.string :name
     t.integer :wheels_count, default: 0, null: false
     t.datetime :wheels_owned_at
+    t.timestamp :manufactured_at, default: -> { "CURRENT_TIMESTAMP" }
   end
 
   create_table :articles, force: true do |t|


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/43279

When `partial_inserts` are disabled, Rails will try to insert all values for columns present. But this can cause issues when a column is backed by a `default_function` with `not null` constraint, Rails will try to insert a `null` value.

This fix will filter/skip the attributes which have not been changed by the user and are backed by `default_function` and hence will avoid the above mentioned scenario for inserts.

<!-- 
### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

`Co-authored-by: Jacopo <beschi.jacopo@gmail.com>`