### PR TITLE
Fix default scope with all_queries on reload test name

### DIFF
--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -208,7 +208,7 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_match(/mentor_id/, reload_sql)
   end
 
-  def test_nilable_default_scope_with_all_queries_runs_on_destroy
+  def test_nilable_default_scope_with_all_queries_runs_on_reload
     dev = DeveloperWithDefaultNilableMentorScopeAllQueries.create!(name: "Nikita")
     reload_sql = capture_sql { dev.reload }.first
 


### PR DESCRIPTION
### Summary

Just a test name fix. Currently it duplicates the test name above

Thanks @yahonda for [catching this](https://github.com/rails/rails/commit/43d83b4423353b7b13182ae5a0892b0ad48c363b#r56980680) ❤️ 


