### PR TITLE
Avoid eager loading in Relation#pretty_print

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Avoid loading every records in `ActiveRecord::Relation#pretty_print`
+
+    ```ruby
+    # Before
+    pp Foo.all # Loads the whole table.
+
+    # After
+    pp Foo.all # Shows 10 items and an ellipsis.
+    ```
+
+    *Ulysse Buonomo*
+
 *   Change `QueryMethods#in_order_of` to drop records not listed in values.
 
     `in_order_of` now filters down to the values provided, to match the behavior of the `Enumerable` version.

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -773,8 +773,13 @@ module ActiveRecord
       end
     end
 
-    def pretty_print(q)
-      q.pp(records)
+    def pretty_print(pp)
+      subject = loaded? ? records : annotate("loading for pp")
+      entries = subject.take([limit_value, 11].compact.min)
+
+      entries[10] = "..." if entries.size == 11
+
+      pp.pp(entries)
     end
 
     # Returns true if relation is blank.


### PR DESCRIPTION
## Summary

We mimic the behaviour used with `#inspect`, only fetching up to 11
elements if records are not loaded already.

Here's the issue reproduction:

```ruby
require "activerecord"

ActiveRecord::Base.establish_connection YOUR_DB_URL_THERE

ActiveRecord::Migration.new.tap do |m|
  m.create_table :foos do |t|
    t.text :name
  end
end

class Foo < ActiveRecord::Base
end

100.times { Foo.create(name: "foo#{_1}") }

pp Foo.all # loads the whole table.
```

### Other Information

Since I'm not yet fully understanding ruby's handling of these unnammed classes (`Class.new`), I've checked if this was not leaking:

```ruby
require "get_process_mem"

before = GetProcessMem.new.mb

10_000_000.times do |i|
  ellipsis = Class.new { def pretty_print(q); q.text("..."); end }.new
  p GetProcessMem.new.mb - before if i % 10_000 == 0
end

GC.start

p GetProcessMem.new.mb - before
```

And at some point memory stops growing, yet the GC does not get back all the memory. Shall I consider making it a private constant? Or just add a simple string at the end, yet it is less elegant IMHO

Also, is this relevant to AR's changelog ? I've not seen anything related to inspect or pretty_print, hence I've not added any entry