### PR TITLE
Don't patch Object for fork in Ruby 3.0

### DIFF
--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -20,11 +20,7 @@ module ActiveSupport
 
     module CoreExtPrivate
       include CoreExt
-
-      private
-        def fork(...)
-          super
-        end
+      private :fork
     end
 
     @pid = Process.pid

--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -40,7 +40,7 @@ module ActiveSupport
 
       def hook!
         if Process.respond_to?(:fork)
-          ::Object.prepend(CoreExtPrivate)
+          ::Object.prepend(CoreExtPrivate) if RUBY_VERSION < "3.0"
           ::Kernel.prepend(CoreExtPrivate)
           ::Kernel.singleton_class.prepend(CoreExt)
           ::Process.singleton_class.prepend(CoreExt)


### PR DESCRIPTION
### Summary

As mentioned in https://github.com/rails/rails/commit/7ca163d8c39d18aacf75993d6cca4ffdf7bfd56f#r56922428, we don't need to do a special case to override `Object#fork` with Ruby 3.0. That's because the underlying issues have been fixed in Ruby (https://github.com/ruby/ruby/commit/41582d5866ae34c57094f70f95c3d31f4a1fa4ff, https://bugs.ruby-lang.org/issues/9573).

### Other Information

I also reverted 332a2909d417fdc0f42ab7672a3cd0aaaf8752d6 which is no longer necessary since Ruby 2.7 is required.

cc @byroot @rafaelfranca