### PR TITLE
[WFC] calling for mapping of enum returns class with list of values, but al…

### DIFF
--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -176,7 +176,7 @@ module ActiveRecord
     # I don't know where to put it or what to call it
     class TemporaryNameEnum
       delegate_missing_to :@values
-      attr_reader :prefix, :suffix, :scopes, :options
+      attr_reader :values, :prefix, :suffix, :scopes, :options
 
       def initialize(values = ActiveSupport::HashWithIndifferentAccess.new, prefix: nil, suffix: nil, **options)
         @values = values
@@ -205,12 +205,8 @@ module ActiveRecord
       def _enum(name, values, prefix: nil, suffix: nil, scopes: true, **options)
         assert_valid_enum_definition_values(values)
 
-        if prefix == true
-          prefix = name 
-        end
-        if suffix == true
-          suffix = name 
-        end
+        prefix = name if prefix == true
+        suffix = name if suffix == true
 
         enum_values = TemporaryNameEnum.new(prefix: prefix, suffix: suffix, scopes: scopes, name: name, **options)
         name = name.to_s

--- a/activerecord/test/cases/enum_test.rb
+++ b/activerecord/test/cases/enum_test.rb
@@ -344,6 +344,20 @@ class EnumTest < ActiveRecord::TestCase
     assert_equal 2, Book.statuses[:published]
   end
 
+  test "access prefix and suffix through mapping" do
+    # no prefix or suffix
+    assert_nil Book.statuses.prefix
+    assert_nil Book.statuses.suffix
+
+    # default prefix or suffix
+    assert_equal :author_visibility, Book.author_visibilities.prefix
+    assert_equal :font_size, Book.font_sizes.suffix
+
+    # custom prefix or suffix
+    assert_equal :in, Book.languages.prefix
+    assert_equal :to_read, Book.difficulties.suffix
+  end
+
   test "building new objects with enum scopes" do
     assert_predicate Book.written.build, :written?
     assert_predicate Book.read.build, :read?


### PR DESCRIPTION
…so with prefix and suffix available too

### Summary

When wanting to find information in regards to enums that have been set on a class the prefix and suffix values are not obtainable once set.
This PR is to change the pluralised class method (eg: `Book.statuses`, `conversation.comment_statuses`) to return an instance of a new class (Name yet unknown) that will hold the enums values, prefix, suffix and other values.
The instances of this new class will respond to the same methods as ActiveSupport::HashWithIndifference so as to not break current implementations.

### Other Information

This PR is not in a final state, but more a suggested expansion of functionality looking for comment.
