### PR TITLE
Add `partial_inserts` default configuration for Rails 7.0 in guides/source/configuring.md

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1702,6 +1702,7 @@ Accepts a string for the HTML tag used to wrap attachments. Defaults to `"action
 - `config.action_mailer.smtp_timeout`: `5`
 - `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 - `config.active_record.verify_foreign_keys_for_fixtures`: `true`
+- `config.active_record.partial_inserts`: `false`
 - `config.active_storage.variant_processor`: `:vips`
 - `config.action_controller.wrap_parameters_by_default`: `true`
 


### PR DESCRIPTION
### Summary

Correct the default value of **`partial_inserts`** in [configuring.md](https://github.com/rails/rails/blob/main/guides/source/configuring.md#configactive_recordpartial_inserts) from **`true`** to **`false`**.

**For the Rails 7.0**

As per the [activerecord changelog](https://github.com/rails/rails/blob/main/activerecord/CHANGELOG.md) and code **`load_default`**(loads the configuration for rails) method https://github.com/rails/rails/blob/53000f3a2df5c59252d019bbb8d46728b291ec74/railties/lib/rails/application/configuration.rb#L236 the default value for the **`config.active_record.partial_inserts`** should be **`false`** instead of **`true`**.


