### PR TITLE
Fix codespell `hiearchy ==> hierarchy` error.

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -318,7 +318,7 @@ Of course, if the application eager loads on boot, that is already accomplished.
 
 ### Enumerate the leaves of the hierarchy
 
-Since the leaves of the hierarchy connect all the hiearchy nodes upwards, following super classes, as soon as the root of the hierarchy is loaded, you can force loading them all:
+Since the leaves of the hierarchy connect all the hierarchy nodes upwards, following super classes, as soon as the root of the hierarchy is loaded, you can force loading them all:
 
 ```ruby
 unless Rails.application.config.eager_load


### PR DESCRIPTION
# Summary

Fix Codespell CI issue introduced in https://github.com/rails/rails/commit/53000f3a2df5c59252d019bbb8d46728b291ec74

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->
