### PR TITLE
Fix in_order_of for integer enums

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix `ActiveRecord::QueryMethods#in_order_of` behavior for integer enums
+
+    `ActiveRecord::QueryMethods#in_order_of` didn't work as expected for enums stored as integers in the database when passing an array of strings or symbols as the order argument. This unexpected behavior occurred because the string or symbol values were not casted to match the integers in the database.
+
+    The following example now works as expected:
+
+    ```rb
+    class Book < ApplicationRecord
+      enum status: [:proposed, :written, :published]
+    end
+
+    Book.in_order_of(:status, %w[written published proposed])
+    ```
+
+    *Alexandre Ruban*
+
 *   Add option to lazily load the schema cache on the connection.
 
     Previously, the only way to load the schema cache in Active Record was through the Railtie on boot. This option provides the ability to load the schema cache on the connection after it's been established. Loading the cache lazily on the connection can be beneficial for Rails applications that use multiple databases because it will load the cache at the time the connection is established. Currently Railties doesn't have access to the connections before boot.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -432,6 +432,7 @@ module ActiveRecord
       references = column_references([column])
       self.references_values |= references unless references.empty?
 
+      values = values.map { |value| type_caster.type_cast_for_database(column, value) }
       column = order_column(column.to_s) if column.is_a?(Symbol)
 
       spawn.order!(connection.field_ordered_value(column, values))

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/post"
+require "models/book"
 
 class FieldOrderedValuesTest < ActiveRecord::TestCase
   fixtures :posts
@@ -11,6 +12,30 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     posts = Post.in_order_of(:id, order).limit(3)
 
     assert_equal(order, posts.map(&:id))
+  end
+
+  def test_in_order_of_with_enums_values
+    Book.destroy_all
+    Book.create!(status: :proposed)
+    Book.create!(status: :written)
+    Book.create!(status: :published)
+
+    order = %w[written published proposed]
+    books = Book.in_order_of(:status, order)
+
+    assert_equal(order, books.map(&:status))
+  end
+
+  def test_in_order_of_with_enums_keys
+    Book.destroy_all
+    Book.create!(status: :proposed)
+    Book.create!(status: :written)
+    Book.create!(status: :published)
+
+    order = [Book.statuses[:written], Book.statuses[:published], Book.statuses[:proposed]]
+    books = Book.in_order_of(:status, order)
+
+    assert_equal(order, books.map { |book| Book.statuses[book.status] })
   end
 
   def test_in_order_of_expression


### PR DESCRIPTION
Closes #43317

### Summary

Using `in_order_of` with enums stored as integers in the database doesn't work as expected: 

```rb
class User < ApplicationRecord
  enum role: [:normal_user, :admin, :super_user]
end

# Currently, this doesn't return the expected result
User.in_order_of(:role, %w[super_user normal_user admin])
```

This is because the strings "super_user", "normal_user" and "admin" are compared with integers in the database. To be able to compare those strings with the integers in the database, we need to convert the strings to match the integers in the database with `type_cast_for_database`.