### PR TITLE
Expose method to check if a location is safe to redirect to

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Add a way to verify a location is internal.
+
+    This is helpful if you are redirecting from a user-submitted param. Rails
+    could already reject unsafe redirects, but it was difficult to provide a
+    fallback location in cases where you still want the redirect.
+
+    ```ruby
+    def return_url
+      url_from(params[:return_to]) || root_path
+    end
+    ```
+
+    *Kasper Timm Hansen*, *dmcge*
+
 *   Allow Capybara driver name overrides in `SystemTestCase::driven_by`
 
     Allow users to prevent conflicts among drivers that use the same driver

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -88,6 +88,10 @@ class RedirectController < ActionController::Base
     redirect_back_or_to "http://www.rubyonrails.org/"
   end
 
+  def safe_redirect_with_fallback
+    redirect_to url_from(params[:return_to]) || "/fallback"
+  end
+
   def redirect_back_with_explicit_fallback_kwarg
     redirect_back(fallback_location: "/things/stuff", status: 307)
   end
@@ -493,6 +497,22 @@ class RedirectTest < ActionController::TestCase
       end
 
       assert_equal "Unsafe redirect to \"http://www.rubyonrails.org/\", pass allow_other_host: true to redirect anyway.", error.message
+    end
+  end
+
+  def test_url_from
+    with_raise_on_open_redirects do
+      get :safe_redirect_with_fallback, params: { return_to: "http://test.host/app" }
+      assert_response :redirect
+      assert_redirected_to "http://test.host/app"
+    end
+  end
+
+  def test_url_from_fallback
+    with_raise_on_open_redirects do
+      get :safe_redirect_with_fallback, params: { return_to: "http://www.rubyonrails.org/" }
+      assert_response :redirect
+      assert_redirected_to "http://test.host/fallback"
     end
   end
 


### PR DESCRIPTION
[Unsafe URL protection](https://github.com/rails/rails/pull/41134) in Rails 7 is great. If you try to redirect somewhere dodgy, your whole action blows up. But there are cases when you don’t that. You sometimes want to redirect to a fallback location.

```ruby
class SignInsController < ApplicationController
  def create
    if SignIn.authenticate(sign_in_params)
      redirect_to return_url
    else
      render :new, status: :unprocessable_entity
    end
  end

  private
    def return_url
      url_from(params[:return_to]) || root_url
    end
end
```

You’d have to implement this currently by either (a) calling private API (`_url_host_allowed?`) or (b) rescuing from the error raised and re-redirecting. Option (b) doesn’t feel quite right to me. Now you have to implement redirecting twice, but you only wanted to change the redirect location. This PR makes (a) viable by promoting a method to public API.

(An alternative is to add another option to `redirect_to`. I started there but couldn’t come up with anything.)