### PR TITLE
add section for host header attack prevention in rails security guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -377,21 +377,21 @@ Rails.application.config.hosts << ".product.com"
 ```
 
 You can exclude certain requests from Host Authorization checks by setting
-`config.host_configuration.exclude`:
+`config.host_authorization.exclude`:
 
 ```ruby
 # Exclude requests for the /healthcheck/ path from host checking
-Rails.application.config.host_configuration = {
+Rails.application.config.host_authorization = {
   exclude: ->(request) { request.path =~ /healthcheck/ }
 }
 ```
 
 When a request comes to an unauthorized host, a default Rack application
 will run and respond with `403 Forbidden`. This can be customized by setting
-`config.host_configuration.response_app`. For example:
+`config.host_authorization.response_app`. For example:
 
 ```ruby
-Rails.application.config.host_configuration = {
+Rails.application.config.host_authorization = {
   response_app: -> env do
     [400, { "Content-Type" => "text/plain" }, ["Bad Request"]]
   end

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -953,7 +953,7 @@ So _attack vectors for Header Injection are based on the injection of CRLF chara
 
 DNS rebinding is a method of manipulating resolution of domain names that is commonly used as a form of computer attack. DNS rebinding circumvents the same-origin policy by abusing the Domain Name System (DNS) instead. It rebinds a domain to a different IP address and than compromises the system by executing random code against your Rails app from the changed IP address.
 
-It is recommended to use the ActionDispatch::HostAuthorization middleware to guard against DNS rebinding and other Host header attacks. It is enabled by default in the development environment, you have to activate it in production and other environments by setting the list of allowed hosts. You can also configure exceptions and set your own response app.
+It is recommended to use the `ActionDispatch::HostAuthorization` middleware to guard against DNS rebinding and other Host header attacks. It is enabled by default in the development environment, you have to activate it in production and other environments by setting the list of allowed hosts. You can also configure exceptions and set your own response app.
 
 ```ruby
 Rails.application.config.hosts << "product.com"
@@ -968,7 +968,7 @@ Rails.application.config.host_authorization = {
 }
 ```
 
-You can read more about it in the [ActionDispatch::HostAuthorization middleware documentation](/configuring.html#actiondispatch-hostauthorization)
+You can read more about it in the [`ActionDispatch::HostAuthorization` middleware documentation](/configuring.html#actiondispatch-hostauthorization)
 
 #### Response Splitting
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -949,9 +949,11 @@ Location: http://www.malicious.tld
 
 So _attack vectors for Header Injection are based on the injection of CRLF characters in a header field._ And what could an attacker do with a false redirection? They could redirect to a phishing site that looks the same as yours, but ask to login again (and sends the login credentials to the attacker). Or they could install malicious software through browser security holes on that site. Rails 2.1.2 escapes these characters for the Location field in the `redirect_to` method. _Make sure you do it yourself when you build other header fields with user input._
 
-#### Host header attacks
+#### DNS rebinding and Host header attacks
 
-It is recommended to use the  ActionDispatch::HostAuthorization middleware to guard against DNS rebinding and other Host header attacks. It is enabled by default in the development environment, you have to activate it in production and other environments by setting the list of allowed hosts. You can also configure exceptions and set your own response app.
+DNS rebinding is a method of manipulating resolution of domain names that is commonly used as a form of computer attack. DNS rebinding circumvents the same-origin policy by abusing the Domain Name System (DNS) instead. It rebinds a domain to a different IP address and than compromises the system by executing random code against your Rails app from the changed IP address.
+
+It is recommended to use the ActionDispatch::HostAuthorization middleware to guard against DNS rebinding and other Host header attacks. It is enabled by default in the development environment, you have to activate it in production and other environments by setting the list of allowed hosts. You can also configure exceptions and set your own response app.
 
 ```ruby
 Rails.application.config.hosts << "product.com"

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -949,6 +949,25 @@ Location: http://www.malicious.tld
 
 So _attack vectors for Header Injection are based on the injection of CRLF characters in a header field._ And what could an attacker do with a false redirection? They could redirect to a phishing site that looks the same as yours, but ask to login again (and sends the login credentials to the attacker). Or they could install malicious software through browser security holes on that site. Rails 2.1.2 escapes these characters for the Location field in the `redirect_to` method. _Make sure you do it yourself when you build other header fields with user input._
 
+#### Host header attacks
+
+It is recommended to use the  ActionDispatch::HostAuthorization middleware to guard against DNS rebinding and other Host header attacks. It is enabled by default in the development environment, you have to activate it in production and other environments by setting the list of allowed hosts. You can also configure exceptions and set your own response app.
+
+```ruby
+Rails.application.config.hosts << "product.com"
+
+Rails.application.config.host_configuration = {
+  # Exclude requests for the /healthcheck/ path from host checking
+  exclude: ->(request) { request.path =~ /healthcheck/ }
+  # Add custom Rack application for the response
+  response_app: -> env do
+    [400, { "Content-Type" => "text/plain" }, ["Bad Request"]]
+  end
+}
+```
+
+You can read more about it in the [ActionDispatch::HostAuthorization middleware documentation](/configuring.html#actiondispatch-hostauthorization)
+
 #### Response Splitting
 
 If Header Injection was possible, Response Splitting might be, too. In HTTP, the header block is followed by two CRLFs and the actual data (usually HTML). The idea of Response Splitting is to inject two CRLFs into a header field, followed by another response with malicious HTML. The response will be:

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -956,7 +956,7 @@ It is recommended to use the  ActionDispatch::HostAuthorization middleware to gu
 ```ruby
 Rails.application.config.hosts << "product.com"
 
-Rails.application.config.host_configuration = {
+Rails.application.config.host_authorization = {
   # Exclude requests for the /healthcheck/ path from host checking
   exclude: ->(request) { request.path =~ /healthcheck/ }
   # Add custom Rack application for the response


### PR DESCRIPTION
This PR fixes rails/rails#42817

It is also fixes a related issue in the rails configuration guide about the HostAuthorization middleware - https://edgeguides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization