### PR TITLE
Update MessageEncryptor guide to show that an exception is raised [ci skip]

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -22,6 +22,11 @@ module ActiveSupport
   #   crypt = ActiveSupport::MessageEncryptor.new(key)                            # => #<ActiveSupport::MessageEncryptor ...>
   #   encrypted_data = crypt.encrypt_and_sign('my secret data')                   # => "NlFBTTMwOUV5UlA1QlNEN2xkY2d6eThYWWh..."
   #   crypt.decrypt_and_verify(encrypted_data)                                    # => "my secret data"
+  # The +decrypt_and_verify+ method will raise an
+  # <tt>ActiveSupport::MessageEncryptor::InvalidMessage</tt> exception if the data
+  # provided cannot be decrypted or verified.
+  #
+  #   crypt.decrypt_and_verify('not encrypted data') # => ActiveSupport::MessageEncryptor::InvalidMessage
   #
   # === Confining messages to a specific purpose
   #


### PR DESCRIPTION
### Summary
Just clarify that `MessageEncryptor` raises `ActiveSupport::MessageEncryptor::InvalidMessage` when submitted invalid data to `decrypt_and_verify`.
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

https://api.rubyonrails.org/v6.1.4/classes/ActiveSupport/MessageEncryptor.html#method-i-decrypt_and_verify

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
