### PR TITLE
Avoid instance_exec for controller callbacks

### DIFF
--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -35,6 +35,20 @@ module AbstractController
                        skip_after_callbacks_if_terminated: true
     end
 
+    class ActionFilter
+      def initialize(actions)
+        @actions = Array(actions).map(&:to_s).to_set
+      end
+
+      def match?(controller)
+        @actions.include?(controller.action_name)
+      end
+
+      alias after  match?
+      alias before match?
+      alias around match?
+    end
+
     module ClassMethods
       # If +:only+ or +:except+ are used, convert the options into the
       # +:if+ and +:unless+ options of ActiveSupport::Callbacks.
@@ -62,8 +76,7 @@ module AbstractController
 
       def _normalize_callback_option(options, from, to) # :nodoc:
         if from = options.delete(from)
-          _from = Array(from).map(&:to_s).to_set
-          from = proc { |c| _from.include? c.action_name }
+          from = ActionFilter.new(from)
           options[to] = Array(options[to]).unshift(from)
         end
       end


### PR DESCRIPTION
When a proc is passed to a callback (either as a condition or as the callback itself) it is evaluated using instance_exec on the controller instance. Calling instance_exec creates a new singleton class for the object, which then will require new inline method caches.

This commit avoids creating the extra controller singleton classes when `:only` or `:except` are passed to a callback.

I made an exaggerated benchmark showing the effect: https://gist.github.com/jhawthorn/bded5bc1d5f1afd4cdd7fb5b800312e1