### PR TITLE
Fix `thread_mattr_accessor` `default` option behavior

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   `default` option of `thread_mattr_accessor` now applies through inheritance and
+    also across new threads.
+
+    Previously, the `default` value provided was set only at the moment of defining
+    the attribute writer, which would cause the attribute to be uninitialized in
+    descendants and in other threads.
+
+    Fixes #43312.
+
+    *Thierry Deo*
+
 *   Redis cache store is now compatible with redis-rb 5.0.
 
     *Jean Boussier*


### PR DESCRIPTION
### Summary

This makes the value supplier to the `default` option of
`thread_mattr_accessor` to be set in descendant classes
as well as in any new Thread that starts.

Previously, the `default` value provided was set only at the
moment of defining the attribute writer, which would cause
the attribute to be uninitialized in descendants and in other threads.

For instance:

    class Processor
      thread_mattr_accessor :mode, default: :smart
    end

    class SubProcessor < Processor
    end

    SubProcessor.mode # => :smart
    Thread.new do
      Processor.mode # => :smart
    end.join

when in the past, those two calls would have returned `nil`.

Fixes #43312

### Other Information

This logic comes with a performance impact on the reader,
here is the benchmark:

    Warming up --------------------------------------
            original   238.780k i/100ms
             patched   162.765k i/100ms
    Calculating -------------------------------------
            original    2.376M (± 9.4%) i/s -  11.939M in 5.078355s
             patched    1.635M (±16.4%) i/s -   7.813M in 5.008433s

    Comparison:
            original:  2375953.1 i/s
             patched:  1634668.2 i/s - 1.45x  (± 0.00) slower

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
