### PR TITLE
Shouldn't double-yield views if a partial called from a layout also yields

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Don't double-render a view, if a partial is called from a layout without a block and calls `yield`
+
+    Previously if a layout rendered a partial without a block, but the partial called `yield`, the
+    relevant view would be rendered twice in the layout: once where the layout `yield`ed, and again
+    from inside the partial. [#43341](https://github.com/rails/rails/pull/43341) contains replication steps.
+
+    This is now fixed, and the view will only be rendered once.
+
+    *Alex Ghiculescu*
+
 *   Allow `link_to` helper to infer link name from `Model#to_s` when it
     is used with a single argument:
 

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -100,8 +100,10 @@ module ActionView
 
         if block && !name.is_a?(Symbol)
           capture(*args, &block)
-        else
+        elsif name
           super
+        else
+          super("_no_block_given_to_partial_")
         end
       end
     end

--- a/actionview/lib/action_view/renderer/streaming_template_renderer.rb
+++ b/actionview/lib/action_view/renderer/streaming_template_renderer.rb
@@ -60,7 +60,7 @@ module ActionView
         # to the buffer, it is not appended to an array, but streamed straight
         # to the client.
         output  = ActionView::StreamingBuffer.new(buffer)
-        yielder = lambda { |*name| view._layout_for(*name) }
+        yielder = lambda { |*name| view._layout_for(*template_name_or_default(*name)) }
 
         ActiveSupport::Notifications.instrument(
           "render_template.action_view",

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -12,6 +12,10 @@ module ActionView
     end
 
     private
+      def template_name_or_default(*name)
+        name.empty? ? :layout : name
+      end
+
       # Determine the template to be rendered using the given options.
       def determine_template(options)
         keys = options.has_key?(:locals) ? options[:locals].keys : []
@@ -73,7 +77,9 @@ module ActionView
         body = if layout
           ActiveSupport::Notifications.instrument("render_layout.action_view", identifier: layout.identifier) do
             view.view_flow.set(:layout, yield(layout))
-            layout.render(view, locals) { |*name| view._layout_for(*name) }
+            layout.render(view, locals) do |*name|
+              view._layout_for(*template_name_or_default(*name))
+            end
           end
         else
           yield

--- a/actionview/test/fixtures/actionpack/layout_tests/layouts/yields_and_has_partial.erb
+++ b/actionview/test/fixtures/actionpack/layout_tests/layouts/yields_and_has_partial.erb
@@ -1,0 +1,17 @@
+yield:
+<%= yield %>
+
+partial:
+<%= render "partial_that_yields" %>
+after partial
+
+partial with block:
+<%= render "partial_that_yields" do %>
+  yielding block
+<% end %>
+after partial with block
+
+partial with empty block:
+<%= render "partial_that_yields" do %>
+<% end %>
+after partial with empty block

--- a/actionview/test/fixtures/actionpack/layout_tests/views/_partial_that_yields.erb
+++ b/actionview/test/fixtures/actionpack/layout_tests/views/_partial_that_yields.erb
@@ -1,0 +1,3 @@
+inside partial that yields
+<%= yield %>
+finished partial that yields

--- a/actionview/test/fixtures/actionpack/layout_tests/views/hello_and_partial.erb
+++ b/actionview/test/fixtures/actionpack/layout_tests/views/hello_and_partial.erb
@@ -1,0 +1,19 @@
+hello_and_partial.erb
+
+yield should render nothing, since empty block given to this view by Rails:
+<%= yield %>
+
+partial without block:
+<%= render "partial_that_yields" %>
+after partial
+
+partial with block:
+<%= render "partial_that_yields" do %>
+  yielding block
+<% end %>
+after partial with block
+
+partial with empty block:
+<%= render "partial_that_yields" do %>
+<% end %>
+after partial with empty block


### PR DESCRIPTION
This PR adds a failing test for what I *think* is a bug, but would like to confirm. The bug occurs if you do this:

```erb
# app/views/layouts/application.html.erb

<%= yield %>

<%= render partial: "whatever" %>
```

```erb
# app/views/_whatever.html.erb

hello from the partial!

<%= yield %>
```

```erb
# app/views/view.html.erb

hello from the view!
```

The output HTML will look like this:

```erb
hello from the view!

hello from the partial!

hello from the view!
```

ie. your view will get rendered twice. This seems like a bug to me. You can work around this in the layout by passing an empty block:

```erb
# app/views/layouts/application.html.erb

<%= yield %>

<%= render partial: "whatever" do %>
<% end %>
```

But that's not a very nice workaround.

I've added what I think is a fix, but want to confirm it's actually a bug too.