### PR TITLE
Fix invalid link to List of Free Programming Books

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -28,7 +28,7 @@ curve diving straight into Rails. There are several curated lists of online reso
 for learning Ruby:
 
 * [Official Ruby Programming Language website](https://www.ruby-lang.org/en/documentation/)
-* [List of Free Programming Books](https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books.md#ruby)
+* [List of Free Programming Books](https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#ruby)
 
 Be aware that some resources, while still excellent, cover older versions of
 Ruby, and may not include some syntax that you will see in day-to-day


### PR DESCRIPTION
This PR fixes invalid link to [List of Free Programming Books](https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#ruby) in [Getting Started](https://edgeguides.rubyonrails.org/getting_started.html#guide-assumptions).

Correct link in the [:octocat: EbookFoundation/free-programming-books](https://github.com/EbookFoundation/free-programming-books) repository is here:

```diff
- https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books.md#ruby
+ https://github.com/EbookFoundation/free-programming-books/blob/master/books/free-programming-books-langs.md#ruby
```

I assume [Getting Started](https://edgeguides.rubyonrails.org/getting_started.html) is one of the most frequently visited pages, so hope this PR helpful for those who are thinking to start learning Ruby/Rails! 💎✨  
