### PR TITLE
Clarify try is like public_send in the guides

### DIFF
--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -220,7 +220,7 @@ NOTE: Defined in `active_support/core_ext/object/deep_dup.rb`.
 
 ### `try`
 
-When you want to call a method on an object only if it is not `nil`, the simplest way to achieve it is with conditional statements, adding unnecessary clutter. The alternative is to use [`try`][Object#try]. `try` is like `Object#send` except that it returns `nil` if sent to `nil`.
+When you want to call a method on an object only if it is not `nil`, the simplest way to achieve it is with conditional statements, adding unnecessary clutter. The alternative is to use [`try`][Object#try]. `try` is like `Object#public_send` except that it returns `nil` if sent to `nil`.
 
 Here is an example:
 


### PR DESCRIPTION
### Summary

As per the docs and the implementation, `try` isn't like `send`, it's like `public_send`. I think that's worth clarifying in the guides.

https://github.com/rails/rails/blob/2ed58965fd1072d12e68671f32e9d79a5151b43c/activesupport/lib/active_support/core_ext/object/try.rb#L44-L46