### PR TITLE
ActiveModel and ActiveRecord pattern matching

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -101,6 +101,24 @@ module ActiveModel
       @attributes.to_hash
     end
 
+    # Returns a hash of all the attributes with their names symbolized as keys and the values of the attributes as values.
+    # It allows for pattern matching directly on an object.
+    #
+    #   class Person
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :name, :string
+    #     attribute :age, :integer
+    #   end
+    #
+    #   person = Person.new(name: 'Francesco', age: 22)
+    #   person => {name:}
+    #   name 
+    #   # => "Francesco"
+    def deconstruct_keys(_keys)
+      attributes.symbolize_keys
+    end
+
     # Returns an array of attribute names as strings
     #
     #   class Person

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -265,6 +265,21 @@ module ActiveRecord
       @attributes.to_hash
     end
 
+
+    # Returns a hash of all the attributes with their names symbolized as keys and the values of the attributes as values.
+    # It allows for pattern matching directly on an object.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   person = Person.create(name: 'Francesco', age: 22)
+    #   person => {id:, name:}
+    #   [name, id]
+    #   # => ["Francesco", 3]
+    def deconstruct_keys(_keys)
+      attributes.symbolize_keys
+    end
+
     # Returns an <tt>#inspect</tt>-like string for the value of the
     # attribute +attr_name+. String attributes are truncated up to 50
     # characters. Other attributes return the value of <tt>#inspect</tt>


### PR DESCRIPTION
### Summary

Ruby 3.0 adds a support for pattern matching. Any class that implements `deconstruct_keys` method can be directly used in pattern matching. These changes allow any of the `ActiveModel` or `ActiveRecord` classes to be directly pattern matched:
```ruby
class Person < ApplicationRecord
end

person = Person.new(name: "Jerry", age: 25)
person => {name:, age:}
name
=> "Jerry"
```

### Other Information

I am not sure how to write a test for the pattern matching because it is only supported as of 3.0.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
