### PR TITLE
Remove deprecation warning of `merge` with `where.not(field_id: nil)`…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove deprecation warning of `merge` with `where.not(field_id: nil)` conditions
+
+    Merging a `where.not(field_id: nil)` doesn't print a deprecation warning.
+
+    *Jacopo Beschi*
+
 *   Add option to lazily load the schema cache on the connection.
 
     Previously, the only way to load the schema cache in Active Record was through the Railtie on boot. This option provides the ability to load the schema cache on the connection after it's been established. Loading the cache lazily on the connection can be beneficial for Rails applications that use multiple databases because it will load the cache at the time the connection is established. Currently Railties doesn't have access to the connections before boot.

--- a/activerecord/lib/active_record/relation/where_clause.rb
+++ b/activerecord/lib/active_record/relation/where_clause.rb
@@ -168,6 +168,9 @@ module ActiveRecord
             ref = referenced_columns[attr]
             next false unless ref
 
+            next true if where_not_nil?(node) && !where_nil?(ref)
+            next false if where_not_nil?(ref) && !where_nil?(node)
+
             if equality_node?(node) && equality_node?(ref) || node == ref
               true
             else
@@ -179,6 +182,14 @@ module ActiveRecord
               false
             end
           end
+        end
+
+        def where_not_nil?(node)
+          node.is_a?(Arel::Nodes::NotEqual) && node.right.value.nil?
+        end
+
+        def where_nil?(node)
+          equality_node?(node) && node.right.value.nil?
         end
 
         def equality_node?(node)

--- a/activerecord/test/cases/relation/merging_test.rb
+++ b/activerecord/test/cases/relation/merging_test.rb
@@ -157,6 +157,23 @@ class RelationMergingTest < ActiveRecord::TestCase
     assert_equal authors, david_and_mary.or(david_and_bob)
   end
 
+  def test_merge_not_nil
+    david, mary, _bob = authors(:david, :mary, :bob)
+    not_nil = Author.where.not(id: nil)
+    only_david = Author.where(id: david)
+
+    assert_not_deprecated do
+      assert_equal [david], not_nil.merge(only_david)
+      assert_equal [david], only_david.merge(not_nil)
+    end
+
+    david_and_mary = Author.where(id: david).or(Author.where(id: mary)).order(:id)
+    assert_not_deprecated do
+      assert_equal [david, mary], david_and_mary.merge(not_nil)
+      assert_equal [david, mary], not_nil.merge(david_and_mary)
+    end
+  end
+
   def test_merge_not_in_clause
     david, mary, bob = authors(:david, :mary, :bob)
 


### PR DESCRIPTION
### Summary

Merging a `where.not(field_id: nil)` doesn't print a deprecation warning.

Fixes #42759
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
