### PR TITLE
Remove window/document dependencies

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -453,11 +453,7 @@
       url = url();
     }
     if (url && !/^wss?:/i.test(url)) {
-      const a = document.createElement("a");
-      a.href = url;
-      a.href = a.href;
-      a.protocol = a.protocol.replace("http", "ws");
-      return a.href;
+      return url.replace(/^http:/, "ws:").replace(/^https:/, "wss:");
     } else {
       return url;
     }

--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -28,7 +28,9 @@
         this.startedAt = now();
         delete this.stoppedAt;
         this.startPolling();
-        addEventListener("visibilitychange", this.visibilityDidChange);
+        if (typeof addEventListener !== "undefined") {
+          addEventListener("visibilitychange", this.visibilityDidChange);
+        }
         logger.log(`ConnectionMonitor started. stale threshold = ${this.constructor.staleThreshold} s`);
       }
     }
@@ -36,7 +38,9 @@
       if (this.isRunning()) {
         this.stoppedAt = now();
         this.stopPolling();
-        removeEventListener("visibilitychange", this.visibilityDidChange);
+        if (typeof removeEventListener !== "undefined") {
+          removeEventListener("visibilitychange", this.visibilityDidChange);
+        }
         logger.log("ConnectionMonitor stopped");
       }
     }

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -27,7 +27,9 @@ class ConnectionMonitor {
       this.startedAt = now();
       delete this.stoppedAt;
       this.startPolling();
-      addEventListener("visibilitychange", this.visibilityDidChange);
+      if (typeof addEventListener !== "undefined") {
+        addEventListener("visibilitychange", this.visibilityDidChange);
+      }
       logger.log(`ConnectionMonitor started. stale threshold = ${this.constructor.staleThreshold} s`);
     }
   }
@@ -35,7 +37,9 @@ class ConnectionMonitor {
     if (this.isRunning()) {
       this.stoppedAt = now();
       this.stopPolling();
-      removeEventListener("visibilitychange", this.visibilityDidChange);
+      if (typeof removeEventListener !== "undefined") {
+        removeEventListener("visibilitychange", this.visibilityDidChange);
+      }
       logger.log("ConnectionMonitor stopped");
     }
   }

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -467,11 +467,7 @@ function createWebSocketURL(url) {
     url = url();
   }
   if (url && !/^wss?:/i.test(url)) {
-    const a = document.createElement("a");
-    a.href = url;
-    a.href = a.href;
-    a.protocol = a.protocol.replace("http", "ws");
-    return a.href;
+    return url.replace(/^http:/, "ws:").replace(/^https:/, "wss:");
   } else {
     return url;
   }

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -453,11 +453,7 @@
       url = url();
     }
     if (url && !/^wss?:/i.test(url)) {
-      const a = document.createElement("a");
-      a.href = url;
-      a.href = a.href;
-      a.protocol = a.protocol.replace("http", "ws");
-      return a.href;
+      return url.replace(/^http:/, "ws:").replace(/^https:/, "wss:");
     } else {
       return url;
     }

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -28,7 +28,9 @@
         this.startedAt = now();
         delete this.stoppedAt;
         this.startPolling();
-        addEventListener("visibilitychange", this.visibilityDidChange);
+        if (typeof addEventListener !== "undefined") {
+          addEventListener("visibilitychange", this.visibilityDidChange);
+        }
         logger.log(`ConnectionMonitor started. stale threshold = ${this.constructor.staleThreshold} s`);
       }
     }
@@ -36,7 +38,9 @@
       if (this.isRunning()) {
         this.stoppedAt = now();
         this.stopPolling();
-        removeEventListener("visibilitychange", this.visibilityDidChange);
+        if (typeof removeEventListener !== "undefined") {
+          removeEventListener("visibilitychange", this.visibilityDidChange);
+        }
         logger.log("ConnectionMonitor stopped");
       }
     }

--- a/actioncable/app/javascript/action_cable/connection_monitor.js
+++ b/actioncable/app/javascript/action_cable/connection_monitor.js
@@ -19,7 +19,9 @@ class ConnectionMonitor {
       this.startedAt = now()
       delete this.stoppedAt
       this.startPolling()
-      addEventListener("visibilitychange", this.visibilityDidChange)
+      if (typeof (addEventListener) !== "undefined") {
+        addEventListener("visibilitychange", this.visibilityDidChange)
+      }
       logger.log(`ConnectionMonitor started. stale threshold = ${this.constructor.staleThreshold} s`)
     }
   }
@@ -28,7 +30,9 @@ class ConnectionMonitor {
     if (this.isRunning()) {
       this.stoppedAt = now()
       this.stopPolling()
-      removeEventListener("visibilitychange", this.visibilityDidChange)
+      if (typeof (removeEventListener) !== "undefined") {
+        removeEventListener("visibilitychange", this.visibilityDidChange)
+      }
       logger.log("ConnectionMonitor stopped")
     }
   }

--- a/actioncable/app/javascript/action_cable/consumer.js
+++ b/actioncable/app/javascript/action_cable/consumer.js
@@ -63,12 +63,9 @@ export function createWebSocketURL(url) {
   }
 
   if (url && !/^wss?:/i.test(url)) {
-    const a = document.createElement("a")
-    a.href = url
-    // Fix populating Location properties in IE. Otherwise, protocol will be blank.
-    a.href = a.href
-    a.protocol = a.protocol.replace("http", "ws")
-    return a.href
+    return url
+      .replace(/^http:/, "ws:")
+      .replace(/^https:/, "wss:")
   } else {
     return url
   }

--- a/actioncable/test/javascript/src/unit/consumer_test.js
+++ b/actioncable/test/javascript/src/unit/consumer_test.js
@@ -16,4 +16,14 @@ module("ActionCable.Consumer", () => {
     client.addEventListener("close", done)
     consumer.disconnect()
   })
+
+  consumerTest("createWebSocketURL", {connect: false, url: "http://example.com:3000/cable?token=token"}, ({consumer, assert, done}) => {
+    assert.equal(consumer.url, "ws://example.com:3000/cable?token=token")
+    done()
+  })
+
+  consumerTest("createWebSocketURL", {connect: false, url: "https://example.com:3000/cable?token=token"}, ({consumer, assert, done}) => {
+    assert.equal(consumer.url, "wss://example.com:3000/cable?token=token")
+    done()
+  })
 })


### PR DESCRIPTION
### Summary

Allow ActionCable's JS client to work in JS run times that don't have a global window or document object. (e.g. react-native)