### PR TITLE
Generate credentials with SecureRandom.alphanumeric instead of SecureRandom.hex

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -698,7 +698,7 @@ module Rails
 
           return random_key if random_key.present?
 
-          random_key = SecureRandom.hex(64)
+          random_key = SecureRandom.alphanumeric(128)
           FileUtils.mkdir_p(key_file.dirname)
           File.binwrite(key_file, random_key)
           random_key

--- a/railties/lib/rails/commands/secret/secret_command.rb
+++ b/railties/lib/rails/commands/secret/secret_command.rb
@@ -6,7 +6,7 @@ module Rails
       desc "secret", "Generate a cryptographically secure secret key (this is typically used to generate a secret for cookie sessions)."
       def perform
         require "securerandom"
-        puts SecureRandom.hex(64)
+        puts SecureRandom.alphanumeric(128)
       end
     end
   end

--- a/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
+++ b/railties/lib/rails/generators/rails/credentials/credentials_generator.rb
@@ -40,7 +40,7 @@ module Rails
         end
 
         def secret_key_base
-          @secret_key_base ||= SecureRandom.hex(64)
+          @secret_key_base ||= SecureRandom.alphanumeric(128)
         end
 
         def render_template_to_encrypted_file

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -368,7 +368,7 @@ class Rails::Command::CredentialsTest < ActiveSupport::TestCase
   end
 
   private
-    DEFAULT_CREDENTIALS_PATTERN = /access_key_id: 123\n.*secret_key_base: \h{128}\n/m
+    DEFAULT_CREDENTIALS_PATTERN = /access_key_id: 123\n.*secret_key_base: [a-zA-Z0-9]{128}\n/m
 
     def run_edit_command(visual: "cat", editor: "cat", environment: nil, **options)
       switch_env("VISUAL", visual) do


### PR DESCRIPTION
This allows for more entropy within keys while retaining the same byte size
