### PR TITLE
Configure Controller, Integration, Mailer, and View test HTML assertions

### DIFF
--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `:capybara` support for `config.action_mailer.dom_testing_assertions`
+
+    Setting `:capybara` integrates with `Capybara::Minitest::Assertions`
+
+    *Sean Doyle*
+
 *   Introduce `config.action_mailer.dom_testing_assertions`
 
     Adds support for `:rails_dom_testing` to support `Rails::Dom::Testing::Assertions` and `:none`.

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce `config.action_mailer.dom_testing_assertions`
+
+    Adds support for `:rails_dom_testing` to support `Rails::Dom::Testing::Assertions` and `:none`.
+    Defaults to with `:rails_dom_testing`.
+
+    *Sean Doyle*
+
 *   Add support for `config.action_mailer.raise_on_missing_callback_actions`
     when using `_deliver` callbacks with `only:` and `except:` options.
 

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -8,6 +8,7 @@ require "abstract_controller/railties/routes_helpers"
 module ActionMailer
   class Railtie < Rails::Railtie # :nodoc:
     config.action_mailer = ActiveSupport::OrderedOptions.new
+    config.action_mailer.dom_testing_assertions = :rails_dom_testing
     config.action_mailer.preview_paths = []
     config.eager_load_namespaces << ActionMailer
 
@@ -19,6 +20,21 @@ module ActionMailer
 
     initializer "action_mailer.logger" do
       ActiveSupport.on_load(:action_mailer) { self.logger ||= Rails.logger }
+    end
+
+    initializer "action_mailer.test_case" do |app|
+      dom_testing_assertions = app.config.action_mailer.delete(:dom_testing_assertions)
+
+      ActiveSupport.on_load(:action_mailer_test_case) do
+        case dom_testing_assertions
+        when :rails_dom_testing
+          include ActionView::RailsDomTestingAssertions
+        when :none
+          # do nothing
+        else
+          raise ArgumentError.new("unrecognized value #{assertions.inspect} for config.action_mailer.dom_testing_assertions")
+        end
+      end
     end
 
     initializer "action_mailer.set_configs" do |app|

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -27,6 +27,8 @@ module ActionMailer
 
       ActiveSupport.on_load(:action_mailer_test_case) do
         case dom_testing_assertions
+        when :capybara
+          include ActionView::CapybaraAssertions
         when :rails_dom_testing
           include ActionView::RailsDomTestingAssertions
         when :none

--- a/actionmailer/lib/action_mailer/test_case.rb
+++ b/actionmailer/lib/action_mailer/test_case.rb
@@ -34,14 +34,13 @@ module ActionMailer
 
       include ActiveSupport::Testing::ConstantLookup
       include TestHelper
-      include Rails::Dom::Testing::Assertions::SelectorAssertions
-      include Rails::Dom::Testing::Assertions::DomAssertions
 
       included do
         class_attribute :_decoders, default: Hash.new(->(body) { body }).merge!(
           Mime[:html] => ->(body) { Rails::Dom::Testing.html_document.parse(body) }
         ).freeze # :nodoc:
         class_attribute :_mailer_class
+        attr_accessor :html_document
         setup :initialize_test_deliveries
         setup :set_expected_mail
         teardown :restore_test_deliveries
@@ -115,7 +114,16 @@ module ActionMailer
 
         assert_not_nil part, "expected part matching #{mime_type} in #{mail.inspect}"
 
-        yield decoder.call(part.decoded) if block_given?
+        if block_given?
+          decoded = decoder.call(part.decoded)
+
+          begin
+            previous_html_document, self.html_document = self.html_document, (decoded if mime_type.html?)
+            yield decoded
+          ensure
+            self.html_document = previous_html_document
+          end
+        end
       end
 
       # Assert that a Mail instance does not have a part with a matching MIME type

--- a/actionmailer/test/abstract_unit.rb
+++ b/actionmailer/test/abstract_unit.rb
@@ -40,4 +40,8 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 end
 
+class ActionMailer::TestCase
+  include ActionView::RailsDomTestingAssertions
+end
+
 require_relative "../../tools/test_common"

--- a/actionmailer/test/capybara_assertions_test.rb
+++ b/actionmailer/test/capybara_assertions_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class ActionMailer::CapybaraAssertionsTest < ActionMailer::TestCase
+  class TestMailer < ActionMailer::Base
+    def test(options)
+      text, html = options.values_at(:text, :html)
+
+      mail subject: "Test e-mail", from: "test@test.host", to: "test <test@test.host>" do |format|
+        if text.present?
+          format.text { render plain: text }
+        end
+        if html.present?
+          format.html { render plain: html }
+        end
+      end
+    end
+  end
+
+  include ActionView::CapybaraAssertions
+
+  tests TestMailer
+
+  test "assertions from last HTML delivery" do
+    TestMailer.test(html: "<div><p>foo</p><p>bar</p></div>").deliver_now
+
+    assert_part :html do
+      assert_css "div" do |div|
+        assert_css div, "p", text: "foo"
+        assert_css div, "p", text: "bar"
+      end
+    end
+  end
+
+  test "assertions from HTML instance" do
+    mail = TestMailer.test(html: "<div><p>foo</p><p>bar</p></div>", text: "ignored")
+
+    assert_part :html, mail do
+      assert_css "div" do |div|
+        assert_css div, "p", text: "foo"
+        assert_css div, "p", text: "bar"
+      end
+    end
+  end
+
+  test "assertions from last multi-part delivery" do
+    TestMailer.test(html: "<div><p>foo</p><p>bar</p></div>", text: "ignored").deliver_now
+
+    assert_part :html do
+      assert_css "div" do |div|
+        assert_css div, "p", text: "foo"
+        assert_css div, "p", text: "bar"
+      end
+    end
+  end
+
+  test "assertions from multi-part instance" do
+    mail = TestMailer.test(html: "<div><p>foo</p><p>bar</p></div>")
+
+    assert_part :html, mail do
+      assert_css "div" do |div|
+        assert_css div, "p", text: "foo"
+        assert_css div, "p", text: "bar"
+      end
+    end
+  end
+
+  test "fails when no HTML part" do
+    mail = TestMailer.test(text: "ignored")
+
+    assert_raises Minitest::Assertion, match: "expected part matching text/html in #{mail.inspect}" do
+      assert_part :html, mail do
+      end
+    end
+  end
+end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce `config.action_controller.dom_testing_assertions` and `config.action_dispatch.dom_testing_assertions`
+
+    Adds support for `:rails_dom_testing` to support `Rails::Dom::Testing::Assertions` and `:none`.
+    Defaults to with `:rails_dom_testing`.
+
+    *Sean Doyle*
+
 *   Allow HTTP token authentication to require specific authentication schemes.
 
     Pass `scheme:` to `authenticate_or_request_with_http_token` (and the other

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `:capybara` support for `config.action_controller.dom_testing_assertions` and `config.action_dispatch.dom_testing_assertions`
+
+    Setting `:capybara` integrates with `Capybara::Minitest::Assertions`
+
+    *Sean Doyle*
+
 *   Introduce `config.action_controller.dom_testing_assertions` and `config.action_dispatch.dom_testing_assertions`
 
     Adds support for `:rails_dom_testing` to support `Rails::Dom::Testing::Assertions` and `:none`.

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -158,6 +158,8 @@ module ActionController
         ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
 
         case dom_testing_assertions
+        when :capybara
+          include ActionView::CapybaraAssertions
         when :rails_dom_testing
           include ActionView::RailsDomTestingAssertions
         when :none

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -17,6 +17,7 @@ module ActionController
     config.action_controller.log_query_tags_around_actions = true
     config.action_controller.wrap_parameters_by_default = false
     config.action_controller.allowed_redirect_hosts = []
+    config.action_controller.dom_testing_assertions = :rails_dom_testing
 
     config.eager_load_namespaces << AbstractController
     config.eager_load_namespaces << ActionController
@@ -85,6 +86,7 @@ module ActionController
 
         # Configs used in other initializers
         filtered_options = options.except(
+          :dom_testing_assertions,
           :default_protect_from_forgery,
           :log_query_tags_around_actions,
           :permit_all_parameters,
@@ -150,8 +152,19 @@ module ActionController
     end
 
     initializer "action_controller.test_case" do |app|
+      dom_testing_assertions = app.config.action_controller.delete(:dom_testing_assertions)
+
       ActiveSupport.on_load(:action_controller_test_case) do
         ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
+
+        case dom_testing_assertions
+        when :rails_dom_testing
+          include ActionView::RailsDomTestingAssertions
+        when :none
+          # do nothing
+        else
+          raise ArgumentError.new("unrecognized value #{assertions.inspect} for config.action_controller.dom_testing_assertions")
+        end
       end
     end
 

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -371,7 +371,6 @@ module ActionController
       extend ActiveSupport::Concern
       include ActionDispatch::TestProcess
       include ActiveSupport::Testing::ConstantLookup
-      include Rails::Dom::Testing::Assertions
 
       attr_reader :response, :request
 
@@ -683,10 +682,6 @@ module ActionController
           env.delete "CONTENT_LENGTH"
           env.delete "RAW_POST_DATA"
           env
-        end
-
-        def document_root_element
-          html_document.root
         end
 
         def check_required_ivars

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -36,6 +36,7 @@ module ActionDispatch
     config.action_dispatch.debug_exception_log_level = :fatal
     config.action_dispatch.strict_freshness = false
 
+    config.action_dispatch.dom_testing_assertions = :rails_dom_testing
     config.action_dispatch.ignore_leading_brackets = nil
     config.action_dispatch.strict_query_string_separator = nil
     config.action_dispatch.verbose_redirect_logs = false
@@ -102,6 +103,21 @@ module ActionDispatch
 
       ActionDispatch::Http::Cache::Request.strict_freshness = app.config.action_dispatch.strict_freshness
       ActionDispatch.test_app = app
+    end
+
+    initializer "action_dispatch.integration_test" do |app|
+      dom_testing_assertions = app.config.action_dispatch.delete(:dom_testing_assertions)
+
+      ActiveSupport.on_load(:action_dispatch_integration_test) do
+        case dom_testing_assertions
+        when :rails_dom_testing
+          include ActionView::RailsDomTestingAssertions
+        when :none
+          # do nothing
+        else
+          raise ArgumentError.new("unrecognized value #{assertions.inspect} for config.action_dispatch.dom_testing_assertions")
+        end
+      end
     end
   end
 end

--- a/actionpack/lib/action_dispatch/testing/assertions.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions.rb
@@ -12,7 +12,6 @@ module ActionDispatch
 
     include ResponseAssertions
     include RoutingAssertions
-    include Rails::Dom::Testing::Assertions
 
     def html_document
       @html_document ||= if @response.media_type&.end_with?("xml")

--- a/actionpack/test/abstract_unit.rb
+++ b/actionpack/test/abstract_unit.rb
@@ -116,7 +116,13 @@ class RoutedRackApp
   end
 end
 
+ActiveSupport.on_load :action_controller_test_case do
+  include ActionView::RailsDomTestingAssertions
+end
+
 class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
+  include ActionView::RailsDomTestingAssertions
+
   def self.build_app(routes = nil)
     RoutedRackApp.new(routes || ActionDispatch::Routing::RouteSet.new) do |middleware|
       middleware.use ActionDispatch::ShowExceptions, ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public")

--- a/actionpack/test/dispatch/capybara_assertions_test.rb
+++ b/actionpack/test/dispatch/capybara_assertions_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class RendersController < ActionController::Base
+  def create
+    render inline: params[:template]
+  end
+end
+
+class ControllerCapybaraAssertionsTest < ActionController::TestCase
+  include ActionView::CapybaraAssertions
+
+  setup do
+    @controller = RendersController.new
+  end
+
+  test "assert with Capybara selectors" do
+    post :create, params: { template: <<~HTML }
+      <html>
+        <head>
+          <title>Hello, world</title>
+        </head>
+        <body>
+          <header>Header</header>
+          <main>Main</main>
+        </body>
+      </html>
+    HTML
+
+    assert_title "Hello, world"
+    assert_selector "header", text: "Header"
+    assert_selector "main", text: "Main"
+  end
+
+  test "assert scoped within an element" do
+    post :create, params: { template: <<~HTML }
+      <header><h1>Header</h1></header>
+      <main><h1>Main</h1></main>
+    HTML
+
+    assert_selector "header" do |header|
+      assert_selector header, "h1", text: "Header"
+      assert_no_selector header, "h1", text: "Main"
+    end
+
+    assert_selector "main" do |main|
+      assert_no_selector main, "h1", text: "Header"
+      assert_selector main, "h1", text: "Main"
+    end
+  end
+
+  test "assert_select with Capybara instead of rails-dom-testing" do
+    post :create, params: { template: <<~HTML }
+      <label for="name">Name</label>
+      <select id="name"><option>First</option></select>
+    HTML
+
+    assert_select "Name", options: ["First"]
+  end
+
+  test "page isn't shared across requests" do
+    post :create, params: { template: <<~HTML }
+      <h1>First</h1>
+    HTML
+
+    assert_selector "h1", text: "First"
+
+    post :create, params: { template: <<~HTML }
+      <h1>Second</h1>
+    HTML
+
+    assert_selector "h1", text: "Second"
+  end
+end
+
+class IntegrationCapybaraAssertionsTest < ActionDispatch::IntegrationTest
+  include ActionView::CapybaraAssertions
+
+  APP = build_app(ActionDispatch::Routing::RouteSet.new.tap { |routes|
+    routes.draw { post "/", to: "renders#create" }
+  })
+
+  def app
+    APP
+  end
+
+  test "assert with Capybara selectors" do
+    post "/", params: { template: <<~HTML }
+      <html>
+        <head>
+          <title>Hello, world</title>
+        </head>
+        <body>
+          <header>Header</header>
+          <main>Main</main>
+        </body>
+      </html>
+    HTML
+
+    assert_title "Hello, world"
+    assert_selector "header", text: "Header"
+    assert_selector "main", text: "Main"
+  end
+
+
+  test "assert scoped within an element" do
+    post "/", params: { template: <<~HTML }
+      <header><h1>Header</h1></header>
+      <main><h1>Main</h1></main>
+    HTML
+
+    assert_selector "header" do |header|
+      assert_selector header, "h1", text: "Header"
+      assert_no_selector header, "h1", text: "Main"
+    end
+
+    assert_selector "main" do |main|
+      assert_no_selector main, "h1", text: "Header"
+      assert_selector main, "h1", text: "Main"
+    end
+  end
+
+  test "assert_select with Capybara instead of rails-dom-testing" do
+    post "/", params: { template: <<~HTML }
+      <label for="name">Name</label>
+      <select id="name"><option>First</option></select>
+    HTML
+
+    assert_select "Name", options: ["First"]
+  end
+
+  test "page isn't shared across requests" do
+    post "/", params: { template: <<~HTML }
+      <h1>First</h1>
+    HTML
+
+    assert_selector "h1", text: "First"
+
+    post "/", params: { template: <<~HTML }
+      <h1>Second</h1>
+    HTML
+
+    assert_selector "h1", text: "Second"
+  end
+end

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `:capybara` support for `config.action_view.dom_testing_assertions`
+
+    Setting `:capybara` integrates with `Capybara::Minitest::Assertions`
+
+    *Sean Doyle*
+
 *   Introduce `config.action_view.dom_testing_assertions`
 
     Adds support for `:rails_dom_testing` to support `Rails::Dom::Testing::Assertions` and `:none`.

--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Introduce `config.action_view.dom_testing_assertions`
+
+    Adds support for `:rails_dom_testing` to support `Rails::Dom::Testing::Assertions` and `:none`.
+    Defaults to with `:rails_dom_testing`.
+
+    *Sean Doyle*
+
 *   Deprecate registering dependency trackers after application initialization.
 
     Calling `ActionView::DependencyTracker.register_tracker` after application initialization will

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -64,6 +64,7 @@ module ActionView
     end
 
     autoload_under "testing" do
+      autoload :CapybaraAssertions
       autoload :RailsDomTestingAssertions
     end
 

--- a/actionview/lib/action_view.rb
+++ b/actionview/lib/action_view.rb
@@ -63,6 +63,10 @@ module ActionView
       autoload :StreamingTemplateRenderer
     end
 
+    autoload_under "testing" do
+      autoload :RailsDomTestingAssertions
+    end
+
     autoload_at "action_view/template/resolver" do
       autoload :Resolver
       autoload :FileSystemResolver

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -14,6 +14,7 @@ module ActionView
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
     config.action_view.prepend_content_exfiltration_prevention = false
+    config.action_view.dom_testing_assertions = :rails_dom_testing
 
     config.eager_load_namespaces << ActionView
 
@@ -116,6 +117,21 @@ module ActionView
 
     initializer "action_view.collection_caching", after: "action_controller.set_configs" do |app|
       PartialRenderer.collection_cache = app.config.action_controller.cache_store
+    end
+
+    initializer "action_view.test_case" do |app|
+      dom_testing_assertions = app.config.action_view.delete(:dom_testing_assertions)
+
+      ActiveSupport.on_load(:action_view_test_case) do
+        case dom_testing_assertions
+        when :rails_dom_testing
+          include ActionView::RailsDomTestingAssertions
+        when :none
+          # do nothing
+        else
+          raise ArgumentError.new("unrecognized value #{assertions.inspect} for config.action_view.dom_testing_assertions")
+        end
+      end
     end
 
     config.after_initialize do |app|

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -124,6 +124,8 @@ module ActionView
 
       ActiveSupport.on_load(:action_view_test_case) do
         case dom_testing_assertions
+        when :capybara
+          include ActionView::CapybaraAssertions
         when :rails_dom_testing
           include ActionView::RailsDomTestingAssertions
         when :none

--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -46,7 +46,6 @@ module ActionView
       extend ActiveSupport::Concern
 
       include ActionDispatch::Assertions, ActionDispatch::TestProcess
-      include Rails::Dom::Testing::Assertions
       include ActionController::TemplateAssertions
       include ActionView::Context
 
@@ -336,8 +335,8 @@ module ActionView
 
     private
       # Need to experiment if this priority is the best one: rendered => output_buffer
-      def document_root_element
-        Rails::Dom::Testing.html_document.parse(@rendered.blank? ? @output_buffer.to_str : @rendered).root
+      def html_document
+        Rails::Dom::Testing.html_document.parse(@rendered.blank? ? @output_buffer.to_str : @rendered)
       end
 
       module Locals

--- a/actionview/lib/action_view/testing/capybara_assertions.rb
+++ b/actionview/lib/action_view/testing/capybara_assertions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActionView
+  module CapybaraAssertions # :nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      gem "capybara"
+      require "capybara/minitest"
+
+      include Capybara::Minitest::Assertions
+
+      def page
+        Capybara.string(html_document)
+      end
+    end
+  end
+end

--- a/actionview/lib/action_view/testing/rails_dom_testing_assertions.rb
+++ b/actionview/lib/action_view/testing/rails_dom_testing_assertions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# :markup: markdown
+
+module ActionView
+  module RailsDomTestingAssertions # :nodoc:
+    extend ActiveSupport::Concern
+
+    included do
+      include Rails::Dom::Testing::Assertions
+
+      def document_root_element
+        html_document.root
+      end
+    end
+  end
+end

--- a/actionview/test/abstract_unit.rb
+++ b/actionview/test/abstract_unit.rb
@@ -90,7 +90,13 @@ class BasicController
   end
 end
 
+ActiveSupport.on_load :action_view_test_case do
+  include ActionView::RailsDomTestingAssertions
+end
+
 class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
+  include ActionView::RailsDomTestingAssertions
+
   self.app = ActionDispatch::MiddlewareStack.new do |middleware|
     middleware.use ActionDispatch::ShowExceptions, ActionDispatch::PublicExceptions.new("#{FIXTURE_LOAD_PATH}/public")
     middleware.use ActionDispatch::DebugExceptions
@@ -117,6 +123,7 @@ module ActionController
 
   class TestCase
     include ActionDispatch::TestProcess
+    include ActionView::RailsDomTestingAssertions
 
     def self.with_routes(&block)
       setup do

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -374,11 +374,7 @@ module ActionView
   end
 
   class CapybaraHTMLEncoderTest < ActionView::TestCase
-    include ::Capybara::Minitest::Assertions
-
-    def page
-      Capybara.string(rendered)
-    end
+    include ActionView::CapybaraAssertions
 
     test "document_root_element can be configured to utilize Capybara" do
       developer = DeveloperStruct.new("Eloy")

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1993,7 +1993,7 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.action_controller.dom_testing_assertions`
 
-Specifies which assertions are available in `ActionController::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
+Specifies which assertions are available in `ActionController::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:capybara` to include assertions provided by the [capybara](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
 
 #### `config.action_controller.asset_host`
 
@@ -2277,7 +2277,7 @@ The default value depends on the `config.load_defaults` target version:
 
 #### `config.action_dispatch.dom_testing_assertions`
 
-Specifies which assertions are available in `ActionDispatch::IntegrationTest` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
+Specifies which assertions are available in `ActionDispatch::IntegrationTest` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:capybara` to include assertions provided by the [capybara](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
 
 #### `config.action_dispatch.cookies_serializer`
 
@@ -2624,7 +2624,7 @@ Takes a block of code to run after the request.
 
 #### `config.action_view.dom_testing_assertions`
 
-Specifies which assertions are available in `ActionView::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
+Specifies which assertions are available in `ActionView::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:capybara` to include assertions provided by the [capybara](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
 
 #### `config.action_view.cache_template_loading`
 
@@ -2876,7 +2876,7 @@ Sets the host for the assets. Useful when CDNs are used for hosting assets rathe
 
 #### `config.action_mailer.dom_testing_assertions`
 
-Specifies which assertions are available in `ActionMailer::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
+Specifies which assertions are available in `ActionMailer::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:capybara` to include assertions provided by the [capybara](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
 
 #### `config.action_mailer.logger`
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1991,6 +1991,10 @@ The default value depends on the `config.load_defaults` target version:
 
 `config.action_controller` includes a number of configuration settings:
 
+#### `config.action_controller.dom_testing_assertions`
+
+Specifies which assertions are available in `ActionController::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
+
 #### `config.action_controller.asset_host`
 
 Sets the host for the assets. Useful when CDNs are used for hosting assets rather than the application server itself. You should only use this if you have a different configuration for Action Mailer, otherwise use `config.asset_host`.
@@ -2270,6 +2274,10 @@ The default value depends on the `config.load_defaults` target version:
 | 8.2                   | `:array`             |
 
 ### Configuring Action Dispatch
+
+#### `config.action_dispatch.dom_testing_assertions`
+
+Specifies which assertions are available in `ActionDispatch::IntegrationTest` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
 
 #### `config.action_dispatch.cookies_serializer`
 
@@ -2614,6 +2622,10 @@ Takes a block of code to run after the request.
 
 `config.action_view` includes a small number of configuration settings:
 
+#### `config.action_view.dom_testing_assertions`
+
+Specifies which assertions are available in `ActionView::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
+
 #### `config.action_view.cache_template_loading`
 
 Controls whether or not templates should be reloaded on each request. Defaults to `!config.enable_reloading`.
@@ -2861,6 +2873,10 @@ There are a number of settings available on `config.action_mailer`:
 #### `config.action_mailer.asset_host`
 
 Sets the host for the assets. Useful when CDNs are used for hosting assets rather than the application server itself. You should only use this if you have a different configuration for Action Controller, otherwise use `config.asset_host`.
+
+#### `config.action_mailer.dom_testing_assertions`
+
+Specifies which assertions are available in `ActionMailer::TestCase` tests. Set to `:rails_dom_testing` to include assertions provided by the [rails-dom-testing](https://github.com/rails/rails-dom-testing) gem. Set to `:none` to omit built-in assertions. Defaults to `:rails_dom_testing`.
 
 #### `config.action_mailer.logger`
 

--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1005,6 +1005,52 @@ to add authorization to every request header to get all the tests passing:
 post articles_url, params: { article: { body: "Rails is awesome!", title: "Hello Rails" } }, headers: { Authorization: ActionController::HttpAuthentication::Basic.encode_credentials("dhh", "secret") }
 ```
 
+#### Asserting with Capybara
+
+By default, `ActionDispatch::IntegrationTest` cases use [rails-dom-testing][] assertions. To add support for [Capybara::Minitest::Assertions][] assertions, set `config.action_controller.dom_testing_assertions` when configuring your application:
+
+```ruby
+# config/application.rb
+module MyApp
+  class Application < Rails::Application
+    config.action_dispatch.dom_testing_assertions = :capybara
+
+    # …
+  end
+end
+
+# test/integration/blog_flow_test.rb
+require "test_helper"
+
+class BlogFlowTest < ActionDispatch::IntegrationTest
+  test "can see the welcome page" do
+    get "/"
+
+    assert_css "h1", text: "Welcome#index"
+  end
+end
+```
+
+In addition to CSS selector assertions, Capybara provides a wide range of [selectors][Capybara::Selector]:
+
+```ruby
+require "test_helper"
+
+class BlogFlowTest < ActionDispatch::IntegrationTest
+  test "can see the welcome page" do
+    get "/"
+
+    assert_selector :element, "h1", text: "Welcome#index"
+    asssert_link "About us", href: "/about"
+  end
+end
+```
+
+[rails-dom-testing]: https://github.com/rails/rails-dom-testing
+[Capybara::Minitest::Assertions]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions
+[Capybara::Selector]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Selector
+
+
 ### HTTP Request Types for Functional Tests
 
 If you're familiar with the HTTP protocol, you'll know that `get` is a type of
@@ -1980,6 +2026,34 @@ end
 
 More information about the assertions included by Capybara can be found in the
 [Capybara Assertions](#capybara-assertions) section.
+
+To configure **all** `ActionView::TestCase` tests to use Capybara assertions, set `config.action_view.dom_testing_assertions = :capybara`:
+
+```ruby
+# config/application.rb
+
+module MyApp
+  class Application < Rails::Application
+    config.action_view.dom_testing_assertions = :capybara
+
+    # …
+  end
+end
+
+# test/views/article_partial_test.rb
+
+require "test_helper"
+
+class ArticlePartialTest < ActionView::TestCase
+  test "renders a link to itself" do
+    article = Article.create! title: "Hello, world"
+
+    render "articles/article", article: article
+
+    assert_link article.title, href: article_url(article)
+  end
+end
+```
 
 ### Parsing View Content
 

--- a/railties/test/abstract_unit.rb
+++ b/railties/test/abstract_unit.rb
@@ -22,4 +22,12 @@ class ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
 end
 
+ActiveSupport.on_load(:action_controller_test_case) do
+  include ActionView::RailsDomTestingAssertions
+end
+
+ActiveSupport.on_load(:action_mailer_test_case) do
+  include ActionView::RailsDomTestingAssertions
+end
+
 require_relative "../../tools/test_common"


### PR DESCRIPTION
Related to https://github.com/rails/rails/pull/55743
This is a re-submission of https://github.com/rails/rails/pull/41291.

The problem
===

Framework test cases that render HTML also include a module of
assertions provided by the [rails-dom-testing][] gem. These test cases
include:

* [ActionController::TestCase][] (through [ActionController::TestCase::Behavior][])
* [ActionDispatch::IntegrationTest][] (through [ActionDispatch::Assertions][])
* [ActionMailer::TestCase][] (through [ActionMailer::TestCase::Behavior][])
* [ActionView::TestCase][] (through [ActionView::TestCase::Behavior][])

Once included, additional user-provided test assertions can collide with
the `Rails::Dom::Testing::Assertions` methods.

For example, the `assert_select` method from
`Rails::Dom::Testing::Assertions` (asserts using a CSS selector)
directly conflicts with the [assert_select][] method from
`Capybara::Minitest::Assertions` (asserts the presence of a `<select>`
HTML element), which could be included by a user into one of the test
case classes mentioned above.

While these collisions can be handled on a case-by-case basis, it isn't
possible to opt-out of `Rails::Dom::Testing::Assertions` support at the
application level.

The proposal
===

This commit introduces framework-specific configuration values:

* `config.action_controller.dom_testing_assertions` to configure [ActionController::TestCase][]
* `config.action_dispatch.dom_testing_assertions` to configure [ActionDispatch::IntegrationTest][]
* `config.action_mailer.dom_testing_assertions` to configure [ActionMailer::TestCase][]
* `config.action_view.dom_testing_assertions` to configure [ActionView::TestCase][]

When set to `:rails_dom_testing`, those tests include a new
framework-private `ActionView::RailsDomTestingAssertions` module to
preserve the existing behavior:

```ruby
# config/application.rb
config.action_view.dom_testing_assertions = :rails_dom_testing

class RailsDomTestingViewTest < ActionView::TestCase
  test "can use rails-dom-testing assertions" do
    render html: <<~HTML
      <label for="textbox">A textbox</label>
      <input id="textbox">
    HTML

    assert_select "#textbox"    # assert with a CSS id selector
    assert_select "input"       # assert with a CSS class selector
  end
end
```

**Each framework defaults to `:rails_dom_testing`**.

When set to `:none`, no assertions are included, providing applications
with an opportunity to include whichever methods they need to, or
customize on per-test basis.

```ruby
# config/application.rb
config.action_view.dom_testing_assertions = :none

class CustomViewTest < ActionView::TestCase
  include Capybara::Minitest::Assertions

  test "can use custom assertions" do
    render html: <<~HTML
      <label>
        A select
        <select></select>
      </label>
    HTML

    assert_select "A select"    # assert with <label> text
  end

  def page
    Capybara.string(rendered)
  end
end
```

[rails-dom-testing]: https://github.com/rails/rails-dom-testing
[ActionController::TestCase]: https://edgeapi.rubyonrails.org/classes/ActionController/TestCase.html
[ActionController::TestCase::Behavior]: https://edgeapi.rubyonrails.org/classes/ActionController/TestCase/Behavior.html
[ActionDispatch::IntegrationTest]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/IntegrationTest.html
[ActionDispatch::Assertions]: https://edgeapi.rubyonrails.org/classes/ActionDispatch/Assertions.html
[ActionMailer::TestCase]: https://edgeapi.rubyonrails.org/classes/ActionMailer/TestCase.html
[ActionMailer::TestCase::Behavior]: https://edgeapi.rubyonrails.org/classes/ActionMailer/TestCase/Behavior.html
[ActionView::TestCase]: https://edgeapi.rubyonrails.org/classes/ActionView/TestCase.html
[ActionView::TestCase::Behavior]: https://edgeapi.rubyonrails.org/classes/ActionView/TestCase/Behavior.html
[assert_select]: https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Minitest/Assertions:assert_select