### PR TITLE
Remove unused instrumentation hooks from action_controller

### DIFF
--- a/actionpack/lib/action_controller/log_subscriber.rb
+++ b/actionpack/lib/action_controller/log_subscriber.rb
@@ -62,8 +62,7 @@ module ActionController
       end
     end
 
-    %w(write_fragment read_fragment exist_fragment?
-       expire_fragment expire_page write_page).each do |method|
+    %w(write_fragment read_fragment exist_fragment? expire_fragment).each do |method|
       class_eval <<-METHOD, __FILE__, __LINE__ + 1
         def #{method}(event)
           return unless logger.info? && ActionController::Base.enable_fragment_cache_logging

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -156,30 +156,6 @@ Within the Ruby on Rails framework, there are a number of hooks provided for com
 }
 ```
 
-#### write_page.action_controller
-
-| Key     | Value             |
-| ------- | ----------------- |
-| `:path` | The complete path |
-
-```ruby
-{
-  path: '/users/1'
-}
-```
-
-#### expire_page.action_controller
-
-| Key     | Value             |
-| ------- | ----------------- |
-| `:path` | The complete path |
-
-```ruby
-{
-  path: '/users/1'
-}
-```
-
 #### start_processing.action_controller
 
 | Key           | Value                                                     |


### PR DESCRIPTION
### Summary

Instrumentation hooks for `write_page.action_controller` and `expire_page.action_controller` seem to be removed in https://github.com/rails/rails/pull/7833. So, subscribers for them are no longer necessary.

I think rails doesn't have to care about instrumentation hooks that are not provided by rails by subscribing to them in its core implementation.

### Other Information

I searched the pattern including `write_page` and `expire_page` with git-grep(1) and got the result like this:

<img width="1787" alt="Screen Shot 2021-10-03 at 21 43 44" src="https://user-images.githubusercontent.com/13130705/135754290-4746c476-71b1-4208-a10c-85e1a2238b55.png">
