### PR TITLE
Fixed bug that occurred when scaffold generated a model with nested namespace.

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
+++ b/railties/lib/rails/generators/erb/scaffold/scaffold_generator.rb
@@ -22,7 +22,7 @@ module Erb # :nodoc:
           end
         end
 
-        template "partial.html.erb", File.join("app/views", controller_file_path, "_#{singular_table_name}.html.erb")
+        template "partial.html.erb", File.join("app/views", controller_file_path, "_#{singular_name}.html.erb")
       end
 
     private

--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -1,20 +1,20 @@
-<div id="<%%= dom_id <%= singular_table_name %> %>">
+<div id="<%%= dom_id <%= singular_name %> %>">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
   <p>
     <strong><%= attribute.human_name %>:</strong>
 <% if attribute.attachment? -%>
-    <%%= link_to <%= singular_table_name %>.<%= attribute.column_name %>.filename, <%= singular_table_name %>.<%= attribute.column_name %> if <%= singular_table_name %>.<%= attribute.column_name %>.attached? %>
+    <%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %> if <%= singular_name %>.<%= attribute.column_name %>.attached? %>
 <% elsif attribute.attachments? -%>
-    <%% <%= singular_table_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
+    <%% <%= singular_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
       <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
     <%% end %>
 <% else -%>
-    <%%= <%= singular_table_name %>.<%= attribute.column_name %> %>
+    <%%= <%= singular_name %>.<%= attribute.column_name %> %>
 <% end -%>
   </p>
 
 <% end -%>
   <p>
-    <%%= link_to "Show this <%= human_name.downcase %>", <%= singular_table_name %> %>
+    <%%= link_to "Show this <%= human_name.downcase %>", <%= singular_name %> %>
   </p>
 </div>

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -273,6 +273,12 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match(%("New role", new_admin_role_path), content)
     end
 
+    assert_file "app/views/admin/roles/_role.html.erb" do |content|
+      assert_match(%("Show this role", role), content)
+      assert_match "role", content
+      assert_no_match "admin_role", content
+    end
+
     %w(edit new show _form).each do |view|
       assert_file "app/views/admin/roles/#{view}.html.erb"
     end


### PR DESCRIPTION
### Summary

As a follow-up to #41210 , this commit adds a bug fix for generating scaffold with nested model
 incorrectly creating a partial view.

In Rails 7.0.0.alpha2, `. /bin/rails g scaffold admin/accont` will generate `app/views/admin/_admin_account`, but the correct path is `app/views/admin/_account`.

```
$ ./bin/rails generate scaffold admin/account
$ ./bin/rails db:migrate
$ ./bin/rails runner 'Admin::Account.create!'
$ open http://127.0.0.1:3000/admin/accounts
```

<img width="1020" alt="スクリーンショット 2021-10-11 14 57 44" src="https://user-images.githubusercontent.com/1688137/136741116-0818b53d-4754-4e3c-95b3-67179b026e80.png">

Assuming that the `@admin_accounts` instance variable contains an instance of the `Admin::Account` model, this will use `admin/accounts/_account.html.erb` to render it and will pass the local variable `account` into the partial. Unfortunately, rails7.0.0.alpha generated `admin/accounts/_admin_account.html.erb` and use `admin_account` as local variable in the partial.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
