### PR TITLE
Granular symbol Callback deduplication.

### DIFF
--- a/activesupport/test/callback_composition_test.rb
+++ b/activesupport/test/callback_composition_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+
+module CallbackCompositionTestFixtures
+  class GreatAncientOne
+    include ActiveSupport::Callbacks
+
+    attr_reader :log, :action_name
+    def initialize(action_name)
+      @action_name, @log = action_name, []
+    end
+
+    define_callbacks :dispatch
+
+    def dispatch
+      run_callbacks :dispatch do
+        @log << action_name
+      end
+      self
+    end
+  end
+
+  module IndexLogging
+    def self.included(base)
+      base.set_callback :dispatch, :before, :log_action, if: proc { |c| c.action_name == "index" }
+    end
+
+    def log_action
+      @log << "IndexLogging"
+    end
+  end
+
+  module ShowLogging
+    def self.included(base)
+      base.set_callback :dispatch, :before, :log_action, if: proc { |c| c.action_name == "show" }
+    end
+
+    def log_action
+      @log << "ShowLogging"
+    end
+  end
+end
+
+class BasicCallbacksTest < ActiveSupport::TestCase
+  include CallbackCompositionTestFixtures
+
+  class Parent < GreatAncientOne; end
+
+  def setup
+    @index = Parent.new("index").dispatch
+  end
+
+  def test_logging_works
+    assert_equal ["index"], @index.log
+  end
+end
+
+class ParentIncludesWithoutChildTest < ActiveSupport::TestCase
+  include CallbackCompositionTestFixtures
+
+  class Parent < GreatAncientOne; end
+
+  def setup
+    Parent.include(IndexLogging)
+    @index = Parent.new("index").dispatch
+  end
+
+  def test_logging
+    assert_equal %w(IndexLogging index), @index.log
+  end
+end
+
+class ParentIncludesCallbackAfterChildTest < ActiveSupport::TestCase
+  include CallbackCompositionTestFixtures
+
+  class Parent < GreatAncientOne; end
+  class Child < Parent
+    include CallbackCompositionTestFixtures::ShowLogging
+  end
+
+  def setup
+    Parent.include(IndexLogging)
+
+    @parent_index = Parent.new("index").dispatch
+    @parent_show = Parent.new("show").dispatch
+    @child_index = Child.new("index").dispatch
+    @child_show = Child.new("show").dispatch
+  end
+
+  def test_basic_parent_logging_works
+    assert_equal %w(IndexLogging index), @parent_index.log
+    assert_equal %w(show), @parent_show.log
+  end
+
+  def test_child_index_includes_show_logging
+    assert_equal %w(ShowLogging index), @child_index.log
+  end
+
+  def test_child_show_action_not_overrode_by_parent_include
+    assert_equal %w(ShowLogging show), @child_show.log
+  end
+end
+
+class ParentIncludesCallbackAfterChildWithSkippingAllTest < ActiveSupport::TestCase
+  include CallbackCompositionTestFixtures
+
+  class Parent < GreatAncientOne; end
+  class Child < Parent
+    include CallbackCompositionTestFixtures::ShowLogging
+
+    skip_callback :dispatch, :log_action
+  end
+
+  def setup
+    Parent.include(IndexLogging)
+
+    @child_index = Child.new("index").dispatch
+  end
+
+  def test_skip_callback_called_before_include_misses_removal_of_callback_from_parent
+    # ShowLogging because it is calling log_action included from IndexLogging
+    # but the included method from ShowLogging
+    assert_equal %w(ShowLogging index), @child_index.log
+  end
+end
+
+class SkipRemovesAllCallbacksWhenCalledAfterIncludes < ActiveSupport::TestCase
+  include CallbackCompositionTestFixtures
+
+  class Parent < GreatAncientOne
+    include CallbackCompositionTestFixtures::IndexLogging
+  end
+  class Child < Parent
+    include CallbackCompositionTestFixtures::ShowLogging
+
+    skip_callback :dispatch, :log_action
+  end
+
+  def setup
+    @child_index = Child.new("index").dispatch
+  end
+
+  def test_child_skip_callbacks_removes_all_log_action_callbacks
+    assert_equal %w(index), @child_index.log
+  end
+end


### PR DESCRIPTION
Addresses #43332

### Summary

This PR suggests an approach to address a load order issue in callbacks related to #43332.  My core concern with that issue is that it demonstrates the potential for a Parent callback to overwrite Child callback's constraints for running (if/only, etc).

Specific Changes
 - Add a `@target` instance variable to Callbacks that holds a reference to the class it is defined on
 - During callback deduplication, use `@target` in conjunction with `kind` and `filter` to ensure deduplication is local to the class that defines it [intent inferred from original dedupe commit in 2012](https://github.com/rails/rails/commit/4a9644a0d94a88896e1ebd3329b8f796fbd053d1)
 - During skip_action processing, removes all callbacks matching `kind` and `filter`.  This methods intent is to skip *any* callbacks, not just the ones on the defining class
 
#### Details

When [adding a callback, there is a step to remove duplicates](https://github.com/rails/rails/blob/18707ab17fa492eb25ad2e8f9818a320dc20b823/activesupport/lib/active_support/callbacks.rb#L573) which seems [to have been added in 2012](https://github.com/rails/rails/commit/4a9644a0d94a88896e1ebd3329b8f796fbd053d1) in order to prevent multiple callbacks being defined on a single class.

When removing duplicates, we follow these rules
 - If we have a symbol, look for any callbacks that match the same `kind` + `filter`.  Where `kind` is one of [before, after, or around] and `filter` is the method you are calling.
 - Callbacks defined in any other way (Classes, etc) are not deduped.

When deduping for symbols, we assume that the load order of defining callbacks will be Parent then Children.  This is a good assumption because the vast majority of cases will follow that pattern.  It also aligns with the concept that the symbols will be evaluated in the context of the running class instance so removing any duplicates will normally have no impact on the method lookup due to it it will normally ancestor dispatch of methods from Children up to Parent.

However, this assumption causes an interesting state when we have with a scenario where we include a module on a Parent that defines callbacks after all class initiation completes AND that new callback has the same `filter` and `kind` as a Child's callback.

When this happen the Child's callback will be detected as a duplicate and deleted, then replaced with the Parent's callback.  Adding callbacks at runtime like this is an unusual scenario and we have to ask if this is something we care about.  But it would cause unexpected logic flow for me for proc and if/unless constraints that are defined in the Child due to the Parent overriding them.  Imagine a scenario where the Parent declares `only: :index` but the Child constrains `only: :show`.  In this scenario, the Parent would override the Child's conditions to run the callback.  The load order issue is similar with skip_callback.

Based on the above, this change aligns Class based and symbol callback deduplication.  It prevents duplicate callbacks in Parents from overriding Children by introducing a target instance variable that is used to scope the deduplication to the class that is defining it.  Finally, we handle cases for skip_callback whenever we end up in a situation with mulitple callbacks.

#### Alternatives

I think we could approach callbacks in a different way here to ensure that load order does not impact the call order of these.  I am happy to investigate this further if it is something that has not been explored before.  That change would essentially look like this and would be a relatively big refactor.

For all callback actions [instead of mutating children and parents at runtime](https://github.com/rails/rails/blob/18707ab17fa492eb25ad2e8f9818a320dc20b823/activesupport/lib/active_support/callbacks.rb#L611) and then create a Compilation of callbacks, we take this approach.

Keep in mind this is psuedocode based on my current understanding of Callbacks, I may be missing something here, please call that out if you see something.
- for skip_action and set_callback, when these are called save the callback and context in an instance variable on the class
- on a request that would run callbacks, look up the ancestor chain until you find the base class that defines the "root" callback (for instance ActionController::Base for :process_action), push each class until you find that into an array
- loop through the ancestors in Parent -> Child order and run the callbacks/skip_actions, collect skip_actions into a local variable so that we skip Child callbacks properly

This could have runtime impact (positive or negative) but is worth exploring, it would potentially eliminate load order issues for callbacks.