### PR TITLE
Replaces the "hash rocket" operator in favor of the newer Ruby syntax on guides

### DIFF
--- a/guides/rails_guides/kindle.rb
+++ b/guides/rails_guides/kindle.rb
@@ -16,7 +16,7 @@ module Kindle
       puts "=> Using output dir: #{output_dir}"
       puts "=> Arranging html pages in document order"
       toc = File.read("toc.ncx")
-      doc = Nokogiri::XML(toc).xpath("//ncx:content", "ncx" => "http://www.daisy.org/z3986/2005/ncx/")
+      doc = Nokogiri::XML(toc).xpath("//ncx:content", "ncx": "http://www.daisy.org/z3986/2005/ncx/")
       html_pages = doc.filter_map { |c| c[:src] }.uniq
 
       generate_front_matter(html_pages)
@@ -87,15 +87,15 @@ module Kindle
     cover_gif = cover_jpg.sub(/jpg$/, "gif")
     puts `convert #{cover_jpg} #{cover_gif}`
     document = {
-      "doc_uuid" => x.at("package")["unique-identifier"],
-      "title" => x.at("title").inner_text.gsub(/\(.*$/, " v2"),
-      "publisher" => x.at("publisher").inner_text,
-      "author" => x.at("creator").inner_text,
-      "subject" => x.at("subject").inner_text,
-      "date" => x.at("date").inner_text,
-      "cover" => cover_gif,
-      "masthead" => nil,
-      "mobi_outfile" => mobi_outfile
+      "doc_uuid": x.at("package")["unique-identifier"],
+      "title": x.at("title").inner_text.gsub(/\(.*$/, " v2"),
+      "publisher": x.at("publisher").inner_text,
+      "author": x.at("creator").inner_text,
+      "subject": x.at("subject").inner_text,
+      "date": x.at("date").inner_text,
+      "cover": cover_gif,
+      "masthead": nil,
+      "mobi_outfile": mobi_outfile
     }
     puts document.to_yaml
     File.open("_document.yml", "w") { |f| f.puts document.to_yaml }

--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -90,8 +90,8 @@ Here are some basic examples:
 ```ruby
 xml.em("emphasized")
 xml.em { xml.b("emph & bold") }
-xml.a("A Link", "href" => "https://rubyonrails.org")
-xml.target("name" => "compile", "option" => "fast")
+xml.a("A Link", "href": "https://rubyonrails.org")
+xml.target("name": "compile", "option": "fast")
 ```
 
 which would produce:
@@ -124,7 +124,7 @@ would produce something like:
 Below is a full-length RSS example actually used on Basecamp:
 
 ```ruby
-xml.rss("version" => "2.0", "xmlns:dc" => "http://purl.org/dc/elements/1.1/") do
+xml.rss("version": "2.0", "xmlns:dc": "http://purl.org/dc/elements/1.1/") do
   xml.channel do
     xml.title(@feed_title)
     xml.link(@url)

--- a/guides/source/active_model_basics.md
+++ b/guides/source/active_model_basics.md
@@ -354,7 +354,7 @@ class Person
   attr_accessor :name
 
   def attributes
-    {'name' => nil}
+    {'name': nil}
   end
 end
 ```
@@ -388,7 +388,7 @@ class Person
   attr_accessor :name
 
   def attributes
-    {'name' => nil}
+    {'name': nil}
   end
 end
 ```
@@ -421,7 +421,7 @@ class Person
   end
 
   def attributes
-    {'name' => nil}
+    {'name': nil}
   end
 end
 ```


### PR DESCRIPTION
### Summary

Updates the guides replacing the "hash rocket" operator in favor of the new syntax introduced in [Ruby 1.9.1](https://svn.ruby-lang.org/repos/ruby/tags/v1_9_1_0/NEWS) and [Ruby 2.2](https://svn.ruby-lang.org/repos/ruby/tags/v2_2_0/NEWS) for code and style consistency.

### Other Information

There are also other files using the previous syntax for hashes, but I thought it would be better to limit this PR to the guides files to validate this type of changes first.