### PR TITLE
Replaces the hash rocket operator in favor of the newer Ruby syntax on render

### DIFF
--- a/actionpack/lib/abstract_controller/rendering.rb
+++ b/actionpack/lib/abstract_controller/rendering.rb
@@ -70,8 +70,8 @@ module AbstractController
 
   private
     # Normalize args by converting <tt>render "foo"</tt> to
-    # <tt>render :action => "foo"</tt> and <tt>render "foo/bar"</tt> to
-    # <tt>render :file => "foo/bar"</tt>.
+    # <tt>render action: "foo"</tt> and <tt>render "foo/bar"</tt> to
+    # <tt>render file: "foo/bar"</tt>.
     def _normalize_args(action = nil, options = {}) # :doc:
       if action.respond_to?(:permitted?)
         if action.permitted?

--- a/actionpack/test/controller/new_base/render_partial_test.rb
+++ b/actionpack/test/controller/new_base/render_partial_test.rb
@@ -6,11 +6,11 @@ module RenderPartial
   class BasicController < ActionController::Base
     self.view_paths = [ActionView::FixtureResolver.new(
       "render_partial/basic/_basic.html.erb"      => "BasicPartial!",
-      "render_partial/basic/basic.html.erb"       => "<%= @test_unchanged = 'goodbye' %><%= render :partial => 'basic' %><%= @test_unchanged %>",
-      "render_partial/basic/with_json.html.erb"   => "<%= render :partial => 'with_json', :formats => [:json] %>",
-      "render_partial/basic/_with_json.json.erb"  => "<%= render :partial => 'final', :formats => [:json] %>",
+      "render_partial/basic/basic.html.erb"       => "<%= @test_unchanged = 'goodbye' %><%= render partial: 'basic' %><%= @test_unchanged %>",
+      "render_partial/basic/with_json.html.erb"   => "<%= render partial: 'with_json', formats: [:json] %>",
+      "render_partial/basic/_with_json.json.erb"  => "<%= render partial: 'final', formats: [:json] %>",
       "render_partial/basic/_final.json.erb"      => "{ final: json }",
-      "render_partial/basic/overridden.html.erb"  => "<%= @test_unchanged = 'goodbye' %><%= render :partial => 'overridden' %><%= @test_unchanged %>",
+      "render_partial/basic/overridden.html.erb"  => "<%= @test_unchanged = 'goodbye' %><%= render partial: 'overridden' %><%= @test_unchanged %>",
       "render_partial/basic/_overridden.html.erb" => "ParentPartial!",
       "render_partial/child/_overridden.html.erb" => "OverriddenPartial!"
     )]

--- a/actionpack/test/controller/new_base/render_template_test.rb
+++ b/actionpack/test/controller/new_base/render_template_test.rb
@@ -12,8 +12,8 @@ module RenderTemplate
       "with_raw.html.erb"          => "Hello <%=raw '<strong>this is raw</strong>' %>",
       "with_implicit_raw.html.erb" => "Hello <%== '<strong>this is also raw</strong>' %> in an html template",
       "with_implicit_raw.text.erb" => "Hello <%== '<strong>this is also raw</strong>' %> in a text template",
-      "test/with_json.html.erb"    => "<%= render :template => 'test/with_json', :formats => [:json] %>",
-      "test/with_json.json.erb"    => "<%= render :template => 'test/final', :formats => [:json]  %>",
+      "test/with_json.html.erb"    => "<%= render template: 'test/with_json', formats: [:json] %>",
+      "test/with_json.json.erb"    => "<%= render template: 'test/final', formats: [:json]  %>",
       "test/final.json.erb"        => "{ final: json }",
       "test/with_error.html.erb"   => "<%= raise 'i do not exist' %>"
     )]

--- a/actionpack/test/fixtures/functional_caching/html_fragment_cached_with_partial.html.erb
+++ b/actionpack/test/fixtures/functional_caching/html_fragment_cached_with_partial.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'partial' %>
+<%= render partial: 'partial' %>

--- a/actionpack/test/fixtures/functional_caching/inline_fragment_cached.html.erb
+++ b/actionpack/test/fixtures/functional_caching/inline_fragment_cached.html.erb
@@ -1,2 +1,2 @@
-<%= render :inline => 'Some inline content' %>
+<%= render inline: 'Some inline content' %>
 <%= cache do %>Some cached content<% end %>

--- a/actionpack/test/fixtures/layouts/with_html_partial.html.erb
+++ b/actionpack/test/fixtures/layouts/with_html_partial.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "partial_only_html" %><%= yield %>
+<%= render partial: "partial_only_html" %><%= yield %>

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -129,8 +129,8 @@ module ActionView
         lookup_context.formats = [format.to_sym] if format.to_sym
       end
 
-      # Normalize args by converting render "foo" to render :action => "foo" and
-      # render "foo/bar" to render :template => "foo/bar".
+      # Normalize args by converting render "foo" to render action: "foo" and
+      # render "foo/bar" to render template: "foo/bar".
       def _normalize_args(action = nil, options = {})
         options = super(action, options)
         case action

--- a/actionview/test/fixtures/actionpack/layouts/_partial_and_yield.erb
+++ b/actionview/test/fixtures/actionpack/layouts/_partial_and_yield.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'test/partial' %>
+<%= render partial: 'test/partial' %>
 <%= yield %>

--- a/actionview/test/fixtures/actionpack/layouts/with_html_partial.html.erb
+++ b/actionview/test/fixtures/actionpack/layouts/with_html_partial.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "partial_only_html" %><%= yield %>
+<%= render partial: "partial_only_html" %><%= yield %>

--- a/actionview/test/fixtures/actionpack/layouts/yield_with_render_inline_inside.erb
+++ b/actionview/test/fixtures/actionpack/layouts/yield_with_render_inline_inside.erb
@@ -1,2 +1,2 @@
-<%= render :inline => 'welcome' %>
+<%= render inline: 'welcome' %>
 <%= yield %>

--- a/actionview/test/fixtures/actionpack/layouts/yield_with_render_partial_inside.erb
+++ b/actionview/test/fixtures/actionpack/layouts/yield_with_render_partial_inside.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'test/partial' %>
+<%= render partial: 'test/partial' %>
 <%= yield %>

--- a/actionview/test/fixtures/actionpack/test/_first_json_partial.json.erb
+++ b/actionview/test/fixtures/actionpack/test/_first_json_partial.json.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "test/second_json_partial" %>
+<%= render partial: "test/second_json_partial" %>

--- a/actionview/test/fixtures/actionpack/test/change_priority.html.erb
+++ b/actionview/test/fixtures/actionpack/test/change_priority.html.erb
@@ -1,2 +1,2 @@
-<%= render :partial => "test/json_change_priority", formats: :json %>
-HTML Template, but <%= render :partial => "test/changing_priority" %> partial
+<%= render partial: "test/json_change_priority", formats: :json %>
+HTML Template, but <%= render partial: "test/changing_priority" %> partial

--- a/actionview/test/fixtures/actionpack/test/html_template.html.erb
+++ b/actionview/test/fixtures/actionpack/test/html_template.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "test/first_json_partial", formats: :json %>
+<%= render partial: "test/first_json_partial", formats: :json %>

--- a/actionview/test/fixtures/actionpack/test/list.erb
+++ b/actionview/test/fixtures/actionpack/test/list.erb
@@ -1,1 +1,1 @@
-<%= @test_unchanged = 'goodbye' %><%= render :partial => 'customer', :collection => @customers %><%= @test_unchanged %>
+<%= @test_unchanged = 'goodbye' %><%= render partial: 'customer', collection: @customers %><%= @test_unchanged %>

--- a/actionview/test/fixtures/actionpack/test/potential_conflicts.erb
+++ b/actionview/test/fixtures/actionpack/test/potential_conflicts.erb
@@ -1,4 +1,4 @@
 First: <%= @name %>
-<%= render :partial => "person", :locals => { :name => "Stephan" } -%>
+<%= render partial: "person", locals: { name: "Stephan" } -%>
 Fourth: <%= @name %>
 Fifth: <%= name %>

--- a/actionview/test/fixtures/actionpack/test/render_file_from_template.html.erb
+++ b/actionview/test/fixtures/actionpack/test/render_file_from_template.html.erb
@@ -1,1 +1,1 @@
-<%= render :file => @path %>
+<%= render file: @path %>

--- a/actionview/test/fixtures/actionpack/test/render_two_partials.html.erb
+++ b/actionview/test/fixtures/actionpack/test/render_two_partials.html.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'partial', :locals => {'first' => '1'} %>
-<%= render :partial => 'partial', :locals => {'second' => '2'} %>
+<%= render partial: 'partial', locals: {'first' => '1'} %>
+<%= render partial: 'partial', locals: {'second' => '2'} %>

--- a/actionview/test/fixtures/actionpack/test/with_html_partial.html.erb
+++ b/actionview/test/fixtures/actionpack/test/with_html_partial.html.erb
@@ -1,1 +1,1 @@
-<strong><%= render :partial => "partial_only_html" %></strong>
+<strong><%= render partial: "partial_only_html" %></strong>

--- a/actionview/test/fixtures/actionpack/test/with_partial.html.erb
+++ b/actionview/test/fixtures/actionpack/test/with_partial.html.erb
@@ -1,1 +1,1 @@
-<strong><%= render :partial => "partial_only" %></strong>
+<strong><%= render partial: "partial_only" %></strong>

--- a/actionview/test/fixtures/actionpack/test/with_partial.text.erb
+++ b/actionview/test/fixtures/actionpack/test/with_partial.text.erb
@@ -1,1 +1,1 @@
-**<%= render :partial => "partial_only" %>**
+**<%= render partial: "partial_only" %>**

--- a/actionview/test/fixtures/actionpack/test/with_xml_template.html.erb
+++ b/actionview/test/fixtures/actionpack/test/with_xml_template.html.erb
@@ -1,1 +1,1 @@
-<%= render :template => "test/greeting", :formats => :xml %>
+<%= render template: "test/greeting", formats: :xml %>

--- a/actionview/test/fixtures/layouts/_partial_and_yield.erb
+++ b/actionview/test/fixtures/layouts/_partial_and_yield.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'test/partial' %>
+<%= render partial: 'test/partial' %>
 <%= yield %>

--- a/actionview/test/fixtures/layouts/render_partial_html.erb
+++ b/actionview/test/fixtures/layouts/render_partial_html.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'test/partialhtml' %>
+<%= render partial: 'test/partialhtml' %>
 <%= yield %>

--- a/actionview/test/fixtures/layouts/yield_with_render_inline_inside.erb
+++ b/actionview/test/fixtures/layouts/yield_with_render_inline_inside.erb
@@ -1,2 +1,2 @@
-<%= render :inline => 'welcome' %>
+<%= render inline: 'welcome' %>
 <%= yield %>

--- a/actionview/test/fixtures/layouts/yield_with_render_partial_inside.erb
+++ b/actionview/test/fixtures/layouts/yield_with_render_partial_inside.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'test/partial' %>
+<%= render partial: 'test/partial' %>
 <%= yield %>

--- a/actionview/test/fixtures/test/_first_json_partial.json.erb
+++ b/actionview/test/fixtures/test/_first_json_partial.json.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "test/second_json_partial" %>
+<%= render partial: "test/second_json_partial" %>

--- a/actionview/test/fixtures/test/_layout_with_partial_and_yield.html.erb
+++ b/actionview/test/fixtures/test/_layout_with_partial_and_yield.html.erb
@@ -1,4 +1,4 @@
 Before
-<%= render :partial => "test/partial" %>
+<%= render partial: "test/partial" %>
 <%= yield %>
 After

--- a/actionview/test/fixtures/test/_one.html.erb
+++ b/actionview/test/fixtures/test/_one.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "two" %> world
+<%= render partial: "two" %> world

--- a/actionview/test/fixtures/test/_partial_with_layout.erb
+++ b/actionview/test/fixtures/test/_partial_with_layout.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'test/partial', :layout => 'test/layout_for_partial', :locals => { :name => 'Bar!' } %>
+<%= render partial: 'test/partial', layout: 'test/layout_for_partial', locals: { name: 'Bar!' } %>
 partial with layout

--- a/actionview/test/fixtures/test/_partial_with_layout_block_content.erb
+++ b/actionview/test/fixtures/test/_partial_with_layout_block_content.erb
@@ -1,4 +1,4 @@
-<%= render :layout => 'test/layout_for_partial', :locals => { :name => 'Bar!' } do %>
+<%= render layout: 'test/layout_for_partial', locals: { name: 'Bar!' } do %>
   Content from inside layout!
 <% end %>
 partial with layout

--- a/actionview/test/fixtures/test/_partial_with_layout_block_partial.erb
+++ b/actionview/test/fixtures/test/_partial_with_layout_block_partial.erb
@@ -1,4 +1,4 @@
-<%= render :layout => 'test/layout_for_partial', :locals => { :name => 'Bar!' } do %>
+<%= render layout: 'test/layout_for_partial', locals: { name: 'Bar!' } do %>
   <%= render 'test/partial' %>
 <% end %>
 partial with layout

--- a/actionview/test/fixtures/test/change_priority.html.erb
+++ b/actionview/test/fixtures/test/change_priority.html.erb
@@ -1,2 +1,2 @@
-<%= render :partial => "test/json_change_priority", formats: :json %>
-HTML Template, but <%= render :partial => "test/changing_priority" %> partial
+<%= render partial: "test/json_change_priority", formats: :json %>
+HTML Template, but <%= render partial: "test/changing_priority" %> partial

--- a/actionview/test/fixtures/test/html_template.html.erb
+++ b/actionview/test/fixtures/test/html_template.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "test/first_json_partial", formats: :json %>
+<%= render partial: "test/first_json_partial", formats: :json %>

--- a/actionview/test/fixtures/test/layout_render_object.erb
+++ b/actionview/test/fixtures/test/layout_render_object.erb
@@ -1,1 +1,1 @@
-<%= render :layout => "layouts/customers" do |customer| %><%= customer.name %><% end %>
+<%= render layout: "layouts/customers" do |customer| %><%= customer.name %><% end %>

--- a/actionview/test/fixtures/test/list.erb
+++ b/actionview/test/fixtures/test/list.erb
@@ -1,1 +1,1 @@
-<%= @test_unchanged = 'goodbye' %><%= render :partial => 'customer', :collection => @customers %><%= @test_unchanged %>
+<%= @test_unchanged = 'goodbye' %><%= render partial: 'customer', collection: @customers %><%= @test_unchanged %>

--- a/actionview/test/fixtures/test/nested_layout.erb
+++ b/actionview/test/fixtures/test/nested_layout.erb
@@ -1,3 +1,3 @@
 <% content_for :title, "title" -%>
 <% content_for :column do -%>column<% end -%>
-<%= render :layout => 'layouts/column' do -%>content<% end -%>
+<%= render layout: 'layouts/column' do -%>content<% end -%>

--- a/actionview/test/fixtures/test/nested_streaming.erb
+++ b/actionview/test/fixtures/test/nested_streaming.erb
@@ -1,3 +1,3 @@
 <%- content_for :header do -%>?<%- end -%>
-<%= render :template => "test/streaming" %>
+<%= render template: "test/streaming" %>
 ?

--- a/actionview/test/fixtures/test/one.html.erb
+++ b/actionview/test/fixtures/test/one.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "test/two" %> world
+<%= render partial: "test/two" %> world

--- a/actionview/test/fixtures/test/render_two_partials.html.erb
+++ b/actionview/test/fixtures/test/render_two_partials.html.erb
@@ -1,2 +1,2 @@
-<%= render :partial => 'partial', :locals => {'first' => '1'} %>
-<%= render :partial => 'partial', :locals => {'second' => '2'} %>
+<%= render partial: 'partial', locals: {'first' => '1'} %>
+<%= render partial: 'partial', locals: {'second' => '2'} %>

--- a/actionview/test/fixtures/test/sub_template_raise.html.erb
+++ b/actionview/test/fixtures/test/sub_template_raise.html.erb
@@ -1,1 +1,1 @@
-<%= render :partial => "test/raise" %>
+<%= render partial: "test/raise" %>

--- a/actionview/test/fixtures/test/utf8.html.erb
+++ b/actionview/test/fixtures/test/utf8.html.erb
@@ -1,4 +1,4 @@
-Русский <%= render :partial => 'test/utf8_partial' %>
+Русский <%= render partial: 'test/utf8_partial' %>
 <%= "日".encoding %>
 <%= @output_buffer.encoding %>
 <%= __ENCODING__ %>

--- a/actionview/test/fixtures/test/utf8_magic.html.erb
+++ b/actionview/test/fixtures/test/utf8_magic.html.erb
@@ -1,5 +1,5 @@
 <%# encoding: utf-8 -%>
-Русский <%= render :partial => 'test/utf8_partial_magic' %>
+Русский <%= render partial: 'test/utf8_partial_magic' %>
 <%= "日".encoding %>
 <%= @output_buffer.encoding %>
 <%= __ENCODING__ %>

--- a/actionview/test/fixtures/test/utf8_magic_with_bare_partial.html.erb
+++ b/actionview/test/fixtures/test/utf8_magic_with_bare_partial.html.erb
@@ -1,5 +1,5 @@
 <%# encoding: utf-8 -%>
-Русский <%= render :partial => 'test/utf8_partial' %>
+Русский <%= render partial: 'test/utf8_partial' %>
 <%= "日".encoding %>
 <%= @output_buffer.encoding %>
 <%= __ENCODING__ %>

--- a/actionview/test/fixtures/with_format.json.erb
+++ b/actionview/test/fixtures/with_format.json.erb
@@ -1,1 +1,1 @@
-<%= render :partial => 'missing', :formats => [:json] %>
+<%= render partial: 'missing', formats: [:json] %>

--- a/actionview/test/template/dependency_tracker_test.rb
+++ b/actionview/test/template/dependency_tracker_test.rb
@@ -115,8 +115,8 @@ module SharedTrackerTests
 
   def test_finds_dependency_on_multiline_render_calls
     template = FakeTemplate.new("<%=
-      render :object => @all_posts,
-             :partial => 'posts' %>", :erb)
+      render object: @all_posts,
+             partial: 'posts' %>", :erb)
 
     tracker = make_tracker("some/_little_posts", template)
 

--- a/railties/test/application/initializers/frameworks_test.rb
+++ b/railties/test/application/initializers/frameworks_test.rb
@@ -82,11 +82,11 @@ module ApplicationTests
       app_file "app/controllers/foo_controller.rb", <<-RUBY
         class FooController < ApplicationController
           def included_helpers
-            render :inline => "<%= from_app_helper -%> <%= from_foo_helper %>"
+            render inline: "<%= from_app_helper -%> <%= from_foo_helper %>"
           end
 
           def not_included_helper
-            render :inline => "<%= respond_to?(:from_bar_helper) -%>"
+            render inline: "<%= respond_to?(:from_bar_helper) -%>"
           end
         end
       RUBY

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1227,11 +1227,11 @@ en:
       controller "main", <<-RUBY
         class MainController < ActionController::Base
           def foo
-            render inline: '<%= render :partial => "shared/foo" %>'
+            render inline: '<%= render partial: "shared/foo" %>'
           end
 
           def bar
-            render inline: '<%= render :partial => "shared/bar" %>'
+            render inline: '<%= render partial: "shared/bar" %>'
           end
         end
       RUBY
@@ -1308,7 +1308,7 @@ en:
       controller "main", <<-RUBY
         class MainController < ActionController::Base
           def foo
-            render inline: '<%= render :partial => "shared/foo" %>'
+            render inline: '<%= render partial: "shared/foo" %>'
           end
         end
       RUBY


### PR DESCRIPTION
### Summary

Updates the calls to `render` replacing the hash rocket operator in favor of the new syntax introduced in [Ruby 1.9.1](https://svn.ruby-lang.org/repos/ruby/tags/v1_9_1_0/NEWS) and [Ruby 2.2](https://svn.ruby-lang.org/repos/ruby/tags/v2_2_0/NEWS) for code and style consistency.

### Other Information

This is a follow up of #43367, trying to update some code that was still using the hash rocket syntax while the majority of the code wasn't.

What I did here was replacing `render :([a-z0-9_]+) =>` by `render $1:`, while double checking for calls that had more than one param which had to be replaced by hand.
