### PR TITLE
Add :layout and :cache_hit to render_partial.action_view

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -287,13 +287,17 @@ INFO. Additional keys may be added by the caller.
 
 #### render_partial.action_view
 
-| Key           | Value                 |
-| ------------- | --------------------- |
-| `:identifier` | Full path to template |
+| Key           | Value                                                             |
+| ------------- | ----------------------------------------------------------------- |
+| `:identifier` | Full path to template                                             |
+| `:layout`     | Applicable layout                                                 |
+| `:cache_hit`  | `:hit` or `:miss` is added when the view is rendered with `cache` |
 
 ```ruby
 {
-  identifier: "/Users/adam/projects/notifications/app/views/posts/_form.html.erb"
+  identifier: "/Users/adam/projects/notifications/app/views/posts/_post.html.erb",
+  layout: nil,
+  cache_hit: :hit
 }
 ```
 


### PR DESCRIPTION
### Summary

`:layout` and `:cache_hit` are already included in the payload of `render_partial.action_view`.
So, I added the two keys to `render_partial.action_view` in Active Support Instrumentation.

### Other Information

`:layout` is introduced in this PR: https://github.com/rails/rails/pull/38999

`:cache_hit` seems to be added first in this commit: https://github.com/rails/rails/commit/07da5aebb165f824d540fac620d2374b7a3799bb

And then, the value of `:cache_hit` has been changed from `true`/`false` to `:hit`/`:miss` with the commit: https://github.com/rails/rails/commit/8240636beda7b2b487217be1d945eb0d36145c4d
