### PR TITLE
Specify ORDER BY enumsortorder for postgres enums

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -459,7 +459,7 @@ module ActiveRecord
         query = <<~SQL
           SELECT
             type.typname AS name,
-            string_agg(enum.enumlabel, ',') AS value
+            string_agg(enum.enumlabel, ',' ORDER BY enum.enumsortorder) AS value
           FROM pg_enum AS enum
           JOIN pg_type AS type
             ON (type.oid = enum.enumtypid)


### PR DESCRIPTION
We've had CI failures on Active Record since Postgresql 14 was released related to enums not being in the right order.

This should fix the test failures in ActiveRecord (but there are still other test failures in railties and AJ)