### PR TITLE
Enable Lint/DuplicateMethods rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -208,6 +208,9 @@ Lint/AmbiguousRegexpLiteral:
 Lint/DuplicateRequire:
   Enabled: true
 
+Lint/DuplicateMethods:
+  Enabled: true
+
 Lint/ErbNewArguments:
   Enabled: true
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -1917,8 +1917,6 @@ class RouteSetTest < ActiveSupport::TestCase
 
   include ActionDispatch::RoutingVerbs
 
-  alias :routes :set
-
   def test_generate_with_optional_params_recalls_last_request
     @set = make_set false
 

--- a/activesupport/lib/active_support/core_ext/time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/time/calculations.rb
@@ -305,7 +305,7 @@ class Time
     other.is_a?(DateTime) ? to_f - other.to_f : minus_without_coercion(other)
   end
   alias_method :minus_without_coercion, :-
-  alias_method :-, :minus_with_coercion
+  alias_method :-, :minus_with_coercion # rubocop:disable Lint/DuplicateMethods
 
   # Layers additional behavior on Time#<=> so that DateTime and ActiveSupport::TimeWithZone instances
   # can be chronologically compared with a Time

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -153,7 +153,7 @@ module ActiveSupport
             Process.clock_gettime(Process::CLOCK_THREAD_CPUTIME_ID, :float_millisecond)
           end
         rescue
-          def now_cpu
+          def now_cpu # rubocop:disable Lint/DuplicateMethods
             0.0
           end
         end
@@ -165,7 +165,7 @@ module ActiveSupport
             0
           end
         else
-          def now_allocations
+          def now_allocations  # rubocop:disable Lint/DuplicateMethods
             GC.stat(:total_allocated_objects)
           end
         end

--- a/activesupport/test/array_inquirer_test.rb
+++ b/activesupport/test/array_inquirer_test.rb
@@ -55,7 +55,7 @@ class ArrayInquirerTest < ActiveSupport::TestCase
   ensure
     Array.class_eval do
       undef_method :respond_to_missing?
-      def respond_to_missing?(name, include_private = false)
+      def respond_to_missing?(name, include_private = false) # rubocop:disable Lint/DuplicateMethods
         super
       end
     end

--- a/activesupport/test/string_inquirer_test.rb
+++ b/activesupport/test/string_inquirer_test.rb
@@ -38,7 +38,7 @@ class StringInquirerTest < ActiveSupport::TestCase
   ensure
     String.class_eval do
       undef_method :respond_to_missing?
-      def respond_to_missing?(name, include_private = false)
+      def respond_to_missing?(name, include_private = false) # rubocop:disable Lint/DuplicateMethods
         super
       end
     end

--- a/activesupport/test/subscriber_test.rb
+++ b/activesupport/test/subscriber_test.rb
@@ -34,7 +34,7 @@ end
 # Monkey patch subscriber to test that only one subscriber per method is added.
 class TestSubscriber
   remove_method :open_party
-  def open_party(event)
+  def open_party(event) # rubocop:disable Lint/DuplicateMethods
     events << event
   end
 end


### PR DESCRIPTION
### Summary

Recently I made a mistake by defining two tests with the same name - https://github.com/rails/rails/pull/43299

I would like to prevent this from happening in the future and the most obvious solution that comes to mind is rubocop.

However please feel free to suggest any other solutions or raise a concern if doesn't make sense to prevent similar errors at all
Thanks! 


### Solution
I had to disable rubocop for several legitimate cases and removed one actual duplication
