### PR TITLE
clear secure password cache if password is set to `nil` [backport to 6-1-stable] 

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,21 @@
+*   Clear secure password cache if password is set to `nil`
+
+    Before:
+
+       user.password = 'something'
+       user.password = nil
+
+       user.password # => 'something'
+
+    Now:
+
+       user.password = 'something'
+       user.password = nil
+
+       user.password # => nil
+
+    *Markus Doits*
+
 *   Fix delegation in ActiveModel::Type::Registry#lookup and ActiveModel::Type.lookup
 
     Passing a last positional argument `{}` would be incorrectly considered as keyword argument.

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -94,6 +94,7 @@ module ActiveModel
 
         define_method("#{attribute}=") do |unencrypted_password|
           if unencrypted_password.nil?
+            instance_variable_set("@#{attribute}", nil)
             self.public_send("#{attribute}_digest=", nil)
           elsif !unencrypted_password.empty?
             instance_variable_set("@#{attribute}", unencrypted_password)

--- a/activemodel/test/cases/secure_password_test.rb
+++ b/activemodel/test/cases/secure_password_test.rb
@@ -91,6 +91,12 @@ class SecurePasswordTest < ActiveModel::TestCase
     assert_equal ["doesn't match Password"], @user.errors[:password_confirmation]
   end
 
+  test "resetting password to nil clears the password cache" do
+    @user.password = "password"
+    @user.password = nil
+    assert_nil @user.password
+  end
+
   test "update an existing user with validation and no change in password" do
     assert @existing_user.valid?(:update), "user should be valid"
   end


### PR DESCRIPTION
**Backport** of #43378 to `6-1-stable`

```rb
# before:
user.password = 'something'
user.password = nil

user.password # => 'something'

# now:
user.password = 'something'
user.password = nil

user.password # => nil
```
