### PR TITLE
Keep connection alive on TransactionRollbackError

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -330,9 +330,11 @@ module ActiveRecord
         ensure
           if transaction
             if error
-              # @connection still holds an open or invalid transaction, so we must not
+              # @connection still holds an open transaction, so we must not
               # put it back in the pool for reuse.
-              @connection.throw_away! unless transaction.state.rolledback?
+              unless transaction.state.rolledback? || transaction.state.invalidated?
+                @connection.throw_away!
+              end
             else
               if Thread.current.status == "aborting"
                 rollback_transaction


### PR DESCRIPTION
### Summary

Fixes #43130

Prior to this change, databases that raised a `TransactionRollbackError` (either through `ActiveRecord::Deadlock` or `ActiveRecord::SerializationFailure`) would have their connections removed from the pool and discarded.

This commit prevents the connection from being thrown away if the transaction itself was marked as invalidated. This is consistent with similar logic that keeps the connection in the pool if the transaction successfully rolled back.
