### PR TITLE
Simplify ActiveSupport::Notification matching

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -108,23 +108,20 @@ module ActiveSupport
             end
           end
 
-          wrap_all pattern, subscriber_class.new(pattern, listener)
-        end
-
-        def self.wrap_all(pattern, subscriber)
-          unless pattern
-            AllMessages.new(subscriber)
-          else
-            subscriber
-          end
+          subscriber_class.new(pattern, listener)
         end
 
         class Matcher # :nodoc:
           attr_reader :pattern, :exclusions
 
           def self.wrap(pattern)
-            return pattern if String === pattern
-            new(pattern)
+            if String === pattern
+              pattern
+            elsif pattern.nil?
+              AllMessages.new
+            else
+              new(pattern)
+            end
           end
 
           def initialize(pattern)
@@ -138,6 +135,16 @@ module ActiveSupport
 
           def ===(name)
             pattern === name && !exclusions.include?(name)
+          end
+
+          class AllMessages
+            def ===(name)
+              true
+            end
+
+            def unsubscribe!(*)
+              false
+            end
           end
         end
 
@@ -240,32 +247,6 @@ module ActiveSupport
             def build_event(name, id, payload)
               ActiveSupport::Notifications::Event.new name, nil, nil, id, payload
             end
-        end
-
-        class AllMessages # :nodoc:
-          def initialize(delegate)
-            @delegate = delegate
-          end
-
-          def start(name, id, payload)
-            @delegate.start name, id, payload
-          end
-
-          def finish(name, id, payload)
-            @delegate.finish name, id, payload
-          end
-
-          def publish(name, *args)
-            @delegate.publish name, *args
-          end
-
-          def subscribed_to?(name)
-            true
-          end
-
-          def unsubscribe!(*)
-            false
-          end
         end
       end
     end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -177,10 +177,6 @@ module ActiveSupport
             pattern === name
           end
 
-          def matches?(name)
-            pattern && pattern === name
-          end
-
           def unsubscribe!(name)
             pattern.unsubscribe!(name)
           end
@@ -270,8 +266,6 @@ module ActiveSupport
           def unsubscribe!(*)
             false
           end
-
-          alias :matches? :===
         end
       end
     end


### PR DESCRIPTION
Previously `AllMessages` was a type of notification "subscriber", which meant it had to delegate all the notification methods (including new ones proposed in #43241). This changes it to a class which is only concerned with the subscribed topic's name.

These are all internal `:nodoc:` APIs and should not change user facing behaviour.