### PR TITLE
Replace ableist language

### DIFF
--- a/actionmailer/test/test_case_test.rb
+++ b/actionmailer/test/test_case_test.rb
@@ -43,7 +43,7 @@ class MailerDeliveriesClearingTest < ActionMailer::TestCase
   end
 end
 
-class CrazyNameMailerTest < ActionMailer::TestCase
+class ManuallySetNameMailerTest < ActionMailer::TestCase
   tests TestTestMailer
 
   def test_set_mailer_class_manual
@@ -51,7 +51,7 @@ class CrazyNameMailerTest < ActionMailer::TestCase
   end
 end
 
-class CrazySymbolNameMailerTest < ActionMailer::TestCase
+class ManuallySetSymbolNameMailerTest < ActionMailer::TestCase
   tests :test_test_mailer
 
   def test_set_mailer_class_manual_using_symbol
@@ -59,7 +59,7 @@ class CrazySymbolNameMailerTest < ActionMailer::TestCase
   end
 end
 
-class CrazyStringNameMailerTest < ActionMailer::TestCase
+class ManuallySetStringNameMailerTest < ActionMailer::TestCase
   tests "test_test_mailer"
 
   def test_set_mailer_class_manual_using_string

--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -1166,7 +1166,7 @@ class InferringClassNameTest < ActionController::TestCase
     end
 end
 
-class CrazyNameTest < ActionController::TestCase
+class ManuallySetNameTest < ActionController::TestCase
   tests ContentController
 
   def test_controller_class_can_be_set_manually_not_just_inferred
@@ -1174,7 +1174,7 @@ class CrazyNameTest < ActionController::TestCase
   end
 end
 
-class CrazySymbolNameTest < ActionController::TestCase
+class ManuallySetSymbolNameTest < ActionController::TestCase
   tests :content
 
   def test_set_controller_class_using_symbol
@@ -1182,7 +1182,7 @@ class CrazySymbolNameTest < ActionController::TestCase
   end
 end
 
-class CrazyStringNameTest < ActionController::TestCase
+class ManuallySetStringNameTest < ActionController::TestCase
   tests "content"
 
   def test_set_controller_class_using_string

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -908,7 +908,7 @@ class RequestFormat < BaseRequestTest
 
       assert_equal [ Mime[:html] ], request.formats
 
-      request = stub_request "HTTP_ACCEPT" => "koz-asked/something-crazy",
+      request = stub_request "HTTP_ACCEPT" => "koz-asked/something-wild",
                              "QUERY_STRING" => ""
 
       assert_equal [ Mime[:html] ], request.formats

--- a/actionview/test/template/test_test.rb
+++ b/actionview/test/template/test_test.rb
@@ -69,7 +69,7 @@ class PeopleHelperTest < ActionView::TestCase
     end
 end
 
-class CrazyHelperTest < ActionView::TestCase
+class ManuallySetHelperTest < ActionView::TestCase
   tests PeopleHelper
 
   def test_helper_class_can_be_set_manually_not_just_inferred
@@ -77,7 +77,7 @@ class CrazyHelperTest < ActionView::TestCase
   end
 end
 
-class CrazySymbolHelperTest < ActionView::TestCase
+class ManuallySetSymbolHelperTest < ActionView::TestCase
   tests :people
 
   def test_set_helper_class_using_symbol
@@ -85,7 +85,7 @@ class CrazySymbolHelperTest < ActionView::TestCase
   end
 end
 
-class CrazyStringHelperTest < ActionView::TestCase
+class ManuallySetStringHelperTest < ActionView::TestCase
   tests "people"
 
   def test_set_helper_class_using_string

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -30,7 +30,7 @@ class TextHelperTest < ActionView::TestCase
   def test_simple_format
     assert_equal "<p></p>", simple_format(nil)
 
-    assert_equal "<p>crazy\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("crazy\r\n cross\r platform linebreaks")
+    assert_equal "<p>ridiculous\n<br /> cross\n<br /> platform linebreaks</p>", simple_format("ridiculous\r\n cross\r platform linebreaks")
     assert_equal "<p>A paragraph</p>\n\n<p>and another one!</p>", simple_format("A paragraph\n\nand another one!")
     assert_equal "<p>A paragraph\n<br /> With a newline</p>", simple_format("A paragraph\n With a newline")
 

--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -74,8 +74,8 @@ module ActiveRecord
           end
         end
 
-        # Note: this does not capture all cases, for example it would be crazy to try to
-        # properly support stale-checking for nested associations.
+        # Note: this does not capture all cases, for example it would be impractical
+        # to try to properly support stale-checking for nested associations.
         def stale_state
           if through_reflection.belongs_to?
             owner[through_reflection.foreign_key] && owner[through_reflection.foreign_key].to_s

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -679,7 +679,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
     assert_queries(1) do
       posts = Post.references(:authors, :comments).
         merge(includes: [ :author, :comments ], limit: 2, offset: 10,
-          where: [ "authors.name = ? and comments.body = ?", "David", "go crazy" ]).to_a
+          where: [ "authors.name = ? and comments.body = ?", "David", "go wild" ]).to_a
       assert_equal 0, posts.size
     end
   end
@@ -687,7 +687,7 @@ class EagerAssociationTest < ActiveRecord::TestCase
   def test_eager_with_has_many_and_limit_and_high_offset_and_multiple_hash_conditions
     assert_queries(1) do
       posts = Post.all.merge!(includes: [ :author, :comments ], limit: 2, offset: 10,
-        where: { "authors.name" => "David", "comments.body" => "go crazy" }).to_a
+        where: { "authors.name" => "David", "comments.body" => "go wild" }).to_a
       assert_equal 0, posts.size
     end
   end

--- a/activerecord/test/cases/associations/has_one_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_associations_test.rb
@@ -210,13 +210,13 @@ class HasOneThroughAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_has_one_through_nonpreload_eager_loading_through_polymorphic_with_more_than_one_through_record
-    Sponsor.new(sponsor_club: clubs(:crazy_club), sponsorable: members(:groucho)).save!
+    Sponsor.new(sponsor_club: clubs(:outrageous_club), sponsorable: members(:groucho)).save!
     members = assert_queries(1) do
       Member.all.merge!(includes: :sponsor_club, where: ["members.name = ?", "Groucho Marx"], order: "clubs.name DESC").to_a # force fallback
     end
     assert_equal 1, members.size
     assert_not_nil assert_no_queries { members[0].sponsor_club }
-    assert_equal clubs(:crazy_club), members[0].sponsor_club
+    assert_equal clubs(:outrageous_club), members[0].sponsor_club
   end
 
   def test_uninitialized_has_one_through_should_return_nil_for_unsaved_record

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -688,15 +688,15 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert @topic
 
       ActiveRecord::Base.connected_to(role: :writing) do
-        @topic.title = "It doesn't have to be crazy at work"
+        @topic.title = "Topic title"
         @topic.save!
       end
 
-      assert_equal "It doesn't have to be crazy at work", @topic.title
+      assert_equal "Topic title", @topic.title
 
       ActiveRecord::Base.connected_to(role: :reading) do
         @topic = Topic.first
-        assert_equal "It doesn't have to be crazy at work", @topic.title
+        assert_equal "Topic title", @topic.title
       end
     }
 
@@ -724,15 +724,15 @@ class QueryCacheTest < ActiveRecord::TestCase
       assert @topic
 
       ActiveRecord::Base.connected_to(role: :writing) do
-        @topic.title = "It doesn't have to be crazy at work"
+        @topic.title = "Topic title"
         @topic.save!
       end
 
-      assert_equal "It doesn't have to be crazy at work", @topic.title
+      assert_equal "Topic title", @topic.title
 
       ActiveRecord::Base.connected_to(role: :reading) do
         @topic = Topic.first
-        assert_equal "It doesn't have to be crazy at work", @topic.title
+        assert_equal "Topic title", @topic.title
       end
     }
 

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -60,7 +60,7 @@ module ActiveRecord
         end
       end
 
-      def test_quoted_timestamp_crazy
+      def test_quoted_timestamp_nonsense
         with_timezone_config default: :asdfasdf do
           t = Time.now.change(usec: 0)
           assert_equal t.getlocal.to_s(:db), @quoter.quoted_date(t)
@@ -115,7 +115,7 @@ module ActiveRecord
         end
       end
 
-      def test_quoted_time_crazy
+      def test_quoted_time_nonsense
         with_timezone_config default: :asdfasdf do
           t = Time.now.change(usec: 0)
 
@@ -185,10 +185,10 @@ module ActiveRecord
         assert_equal "'Object'", @quoter.quote(Object)
       end
 
-      def test_crazy_object
-        crazy = Object.new
+      def test_quote_object_instance
+        object = Object.new
         e = assert_raises(TypeError) do
-          @quoter.quote(crazy)
+          @quoter.quote(object)
         end
         assert_equal "can't quote Object", e.message
       end

--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -594,7 +594,7 @@ class NamedScopingTest < ActiveRecord::TestCase
   end
 
   def test_subclass_merges_scopes_properly
-    assert_equal 1, SpecialComment.where(body: "go crazy").created.count
+    assert_equal 1, SpecialComment.where(body: "go wild").created.count
   end
 
   def test_model_class_should_respond_to_extending

--- a/activerecord/test/cases/validations/uniqueness_validation_test.rb
+++ b/activerecord/test/cases/validations/uniqueness_validation_test.rb
@@ -249,10 +249,10 @@ class UniquenessValidationTest < ActiveRecord::TestCase
 
     t = Topic.create("title" => "The earth is actually flat!")
 
-    r1 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're crazy!", "content" => "Crazy reply"
+    r1 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're joking!", "content" => "Silly reply"
     assert r1.valid?, "Saving r1"
 
-    r2 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're crazy!", "content" => "Crazy reply again..."
+    r2 = t.replies.create "author_name" => "jeremy", "author_email_address" => "jeremy@rubyonrails.com", "title" => "You're joking!", "content" => "Silly reply again..."
     assert_not r2.valid?, "Saving r2. Double reply by same author."
 
     r2.author_email_address = "jeremy_alt_email@rubyonrails.com"

--- a/activerecord/test/fixtures/clubs.yml
+++ b/activerecord/test/fixtures/clubs.yml
@@ -3,6 +3,6 @@ boring_club:
   category_id: 1
 moustache_club:
   name: Moustache and Eyebrow Fancier Club
-crazy_club:
+outrageous_club:
   name: Skull and bones
   category_id: 2

--- a/activerecord/test/fixtures/comments.yml
+++ b/activerecord/test/fixtures/comments.yml
@@ -55,7 +55,7 @@ check_eager_sti_on_associations2:
 eager_other_comment1:
   id: 11
   post_id: 7
-  body: go crazy
+  body: go wild
   type: SpecialComment
 
 sub_special_comment:

--- a/activerecord/test/fixtures/memberships.yml
+++ b/activerecord/test/fixtures/memberships.yml
@@ -19,9 +19,9 @@ other_guys_membership:
   favorite: false
   type: CurrentMembership
 
-blarpy_winkup_crazy_club:
+blarpy_winkup_outrageous_club:
   joined_on: <%= 4.weeks.ago.to_s(:db) %>
-  club: crazy_club
+  club: outrageous_club
   member_id: 3
   favorite: false
   type: CurrentMembership

--- a/activerecord/test/fixtures/sponsors.yml
+++ b/activerecord/test/fixtures/sponsors.yml
@@ -6,8 +6,8 @@ boring_club_sponsor_for_groucho:
   sponsor_club: boring_club
   sponsorable_id: 2
   sponsorable_type: Member
-crazy_club_sponsor_for_groucho:
-  sponsor_club: crazy_club
+outrageous_club_sponsor_for_groucho:
+  sponsor_club: outrageous_club
   sponsorable_id: 3
   sponsorable_type: Member
 sponsor_for_author_david:

--- a/activesupport/lib/active_support/testing/isolation.rb
+++ b/activesupport/lib/active_support/testing/isolation.rb
@@ -63,7 +63,7 @@ module ActiveSupport
       module Subprocess
         ORIG_ARGV = ARGV.dup unless defined?(ORIG_ARGV)
 
-        # Crazy H4X to get this working in windows / jruby with
+        # Complicated H4X to get this working in windows / jruby with
         # no forking.
         def run_in_isolation(&blk)
           require "tempfile"

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -521,15 +521,15 @@ module CacheStoreBehavior
     end
   end
 
-  def test_crazy_key_characters
-    crazy_key = "#/:*(<+=> )&$%@?;'\"\'`~-"
-    assert @cache.write(crazy_key, "1", raw: true)
-    assert_equal "1", @cache.read(crazy_key, raw: true)
-    assert_equal "1", @cache.fetch(crazy_key, raw: true)
-    assert @cache.delete(crazy_key)
-    assert_equal "2", @cache.fetch(crazy_key, raw: true) { "2" }
-    assert_equal 3, @cache.increment(crazy_key)
-    assert_equal 2, @cache.decrement(crazy_key)
+  def test_absurd_key_characters
+    absurd_key = "#/:*(<+=> )&$%@?;'\"\'`~-"
+    assert @cache.write(absurd_key, "1", raw: true)
+    assert_equal "1", @cache.read(absurd_key, raw: true)
+    assert_equal "1", @cache.fetch(absurd_key, raw: true)
+    assert @cache.delete(absurd_key)
+    assert_equal "2", @cache.fetch(absurd_key, raw: true) { "2" }
+    assert_equal 3, @cache.increment(absurd_key)
+    assert_equal 2, @cache.decrement(absurd_key)
   end
 
   def test_really_long_keys

--- a/activesupport/test/callback_inheritance_test.rb
+++ b/activesupport/test/callback_inheritance_test.rb
@@ -160,11 +160,11 @@ class InheritedCallbacksTest2 < ActiveSupport::TestCase
     @update2 = Child.new("update", :closed).dispatch
   end
 
-  def test_crazy_mix_on
+  def test_complex_mix_on
     assert_equal %w(before1 update after2 after1), @update1.log
   end
 
-  def test_crazy_mix_off
+  def test_complex_mix_off
     assert_equal %w(before1 before2 update after2 after1), @update2.log
   end
 end


### PR DESCRIPTION
The word "crazy" has long been associated with mental illness. While
there may be other dictionary definitions, it's difficult for some of us
to separate the word from the stigmatization, gaslighting, and bullying
that often comes along with it.

This commit replaces instances of the word with various alternatives. I
find most of these more focused and descriptive than what we had before.

This commit involves only test and documentation changes, so should be low risk.