### PR TITLE
Fix joining through a polymorphic association

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -1027,7 +1027,7 @@ module ActiveRecord
       end
 
       def join_scopes(table, predicate_builder, klass = self.klass, record = nil) # :nodoc:
-        scopes = @previous_reflection.join_scopes(table, predicate_builder, record) + super
+        scopes = @previous_reflection.join_scopes(table, predicate_builder, klass, record) + super
         scopes << build_scope(table, predicate_builder, klass).instance_exec(record, &source_type_scope)
       end
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -116,7 +116,7 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :categories, :companies, :developers, :projects,
            :developers_projects, :topics, :authors, :author_addresses, :comments,
            :posts, :readers, :taggings, :cars, :tags,
-           :categorizations, :zines, :interests
+           :categorizations, :zines, :interests, :humans
 
   def setup
     Client.destroyed_client_ids.clear
@@ -2535,6 +2535,14 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
     assert_equal [image], post.images
     assert_equal post, image.imageable
+  end
+
+  def test_joining_through_a_polymorphic_association_with_a_where_clause
+    writer   = humans(:gordon)
+    category = categories(:general)
+    TypedEssay.create! category: category, writer: writer
+
+    assert_equal 1, Category.joins(:human_writers_of_typed_essays).count
   end
 
   def test_build_with_polymorphic_has_many_does_not_allow_to_override_type_and_id

--- a/activerecord/test/models/category.rb
+++ b/activerecord/test/models/category.rb
@@ -30,6 +30,9 @@ class Category < ActiveRecord::Base
   has_many :authors, through: :categorizations
   has_many :authors_with_select, -> { select "authors.*, categorizations.post_id" }, through: :categorizations, source: :author
 
+  has_many :essays, primary_key: :name
+  has_many :human_writers_of_typed_essays, -> { where(essays: { type: TypedEssay.name }) }, through: :essays, source: :writer, source_type: "Human", primary_key: :name
+
   scope :general, -> { where(name: "General") }
 
   # Should be delegated `ast` and `locked` to `arel`.

--- a/activerecord/test/models/essay.rb
+++ b/activerecord/test/models/essay.rb
@@ -6,3 +6,6 @@ class Essay < ActiveRecord::Base
   belongs_to :category, primary_key: :name
   has_one :owner, primary_key: :name
 end
+
+class TypedEssay < Essay
+end


### PR DESCRIPTION
Fixes #43362

In https://github.com/rails/rails/commit/18b0135e188f3fe38da88197b94bae77a93b0d36, the API of `ActiveRecord::Reflection#join_scopes` changed to accept 4 arguments: table, predicate_builder, klass = self.klass, record = nil. One call to this method was not updated with this new API but no error was raised because of default arguments.