### PR TITLE
Remove child event tracking from ActiveSupport::Subscriber

### DIFF
--- a/actionview/lib/action_view/log_subscriber.rb
+++ b/actionview/lib/action_view/log_subscriber.rb
@@ -50,28 +50,58 @@ module ActionView
       end
     end
 
-    def start(name, id, payload)
-      log_rendering_start(payload, name)
+    module Utils # :nodoc:
+      def logger
+        ActionView::Base.logger
+      end
+
+    private
+      def from_rails_root(string)
+        string = string.sub(rails_root, "")
+        string.sub!(VIEWS_PATTERN, "")
+        string
+      end
+
+      def rails_root # :doc:
+        @root ||= "#{Rails.root}/"
+      end
+    end
+
+    include Utils
+
+    class Start # :nodoc:
+      include Utils
+
+      def start(name, id, payload)
+        return unless logger
+        logger.debug do
+          qualifier =
+            if name == "render_template.action_view"
+              ""
+            elsif name == "render_layout.action_view"
+              "layout "
+            end
+
+          return unless qualifier
+
+          message = +"  Rendering #{qualifier}#{from_rails_root(payload[:identifier])}"
+          message << " within #{from_rails_root(payload[:layout])}" if payload[:layout]
+          message
+        end
+      end
+
+      def finish(name, id, payload)
+      end
+    end
+
+    def self.attach_to(*)
+      ActiveSupport::Notifications.subscribe("render_template.action_view", ActionView::LogSubscriber::Start.new)
+      ActiveSupport::Notifications.subscribe("render_layout.action_view", ActionView::LogSubscriber::Start.new)
 
       super
     end
 
-    def logger
-      ActionView::Base.logger
-    end
-
   private
-    EMPTY = ""
-    def from_rails_root(string) # :doc:
-      string = string.sub(rails_root, EMPTY)
-      string.sub!(VIEWS_PATTERN, EMPTY)
-      string
-    end
-
-    def rails_root # :doc:
-      @root ||= "#{Rails.root}/"
-    end
-
     def render_count(payload) # :doc:
       if payload[:cache_hits]
         "[#{payload[:cache_hits]} / #{payload[:count]} cache hits]"
@@ -86,23 +116,6 @@ module ActionView
         "[cache hit]"
       when :miss
         "[cache miss]"
-      end
-    end
-
-    def log_rendering_start(payload, name)
-      debug do
-        qualifier =
-          if name == "render_template.action_view"
-            ""
-          elsif name == "render_layout.action_view"
-            "layout "
-          end
-
-        return unless qualifier
-
-        message = +"  Rendering #{qualifier}#{from_rails_root(payload[:identifier])}"
-        message << " within #{from_rails_root(payload[:layout])}" if payload[:layout]
-        message
       end
     end
   end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Deprecate `Notification::Event`'s `#children` and `#parent_of?`
+
 *   Change default serialization format of `MessageEncryptor` from `Marshal` to `JSON` for Rails 7.1.
 
     Existing apps are provided with an upgrade path to migrate to `JSON` as described in `guides/source/upgrading_ruby_on_rails.md`

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -107,14 +107,10 @@ module ActiveSupport
       LogSubscriber.logger
     end
 
-    def start(name, id, payload)
-      super if logger
-    end
-
-    def finish(name, id, payload)
+    def call(event)
       super if logger
     rescue => e
-      log_exception(name, e)
+      log_exception(event.name, e)
     end
 
     def publish_event(event)

--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -56,7 +56,7 @@ module ActiveSupport
     end
 
     class Event
-      attr_reader :name, :time, :end, :transaction_id, :children
+      attr_reader :name, :time, :end, :transaction_id
       attr_accessor :payload
 
       def initialize(name, start, ending, transaction_id, payload)
@@ -65,7 +65,6 @@ module ActiveSupport
         @time           = start ? start.to_f * 1_000.0 : start
         @transaction_id = transaction_id
         @end            = ending ? ending.to_f * 1_000.0 : ending
-        @children       = []
         @cpu_time_start = 0.0
         @cpu_time_finish = 0.0
         @allocation_count_start = 0
@@ -117,6 +116,23 @@ module ActiveSupport
         @allocation_count_finish - @allocation_count_start
       end
 
+      def children # :nodoc:
+        ActiveSupport::Deprecation.warn <<~EOM
+          ActiveSupport::Notifications::Event#children is deprecated and will
+          be removed in Rails 7.2.
+        EOM
+        []
+      end
+
+      def parent_of?(event) # :nodoc:
+        ActiveSupport::Deprecation.warn <<~EOM
+          ActiveSupport::Notifications::Event#parent_of? is deprecated and will
+          be removed in Rails 7.2.
+        EOM
+        start = (time - event.time) * 1000
+        start <= 0 && (start + duration >= event.duration)
+      end
+
       # Returns the difference in milliseconds between when the execution of the
       # event started and when it ended.
       #
@@ -131,14 +147,6 @@ module ActiveSupport
       #   @event.duration # => 1000.138
       def duration
         self.end - time
-      end
-
-      def <<(event)
-        @children << event
-      end
-
-      def parent_of?(event)
-        @children.include? event
       end
 
       private

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -77,7 +77,9 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
 
   def test_event_attributes
     ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    instrument "some_event.my_log_subscriber"
+    instrument "some_event.my_log_subscriber" do
+      [] # Make an allocation
+    end
     wait
     event = @log_subscriber.event
     if defined?(JRUBY_VERSION)

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -462,21 +462,6 @@ module Notifications
       assert_equal Hash[payload: :bar], event.payload
     end
 
-    def test_event_is_parent_based_on_children
-      time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-
-      parent    = event(:foo, Process.clock_gettime(Process::CLOCK_MONOTONIC), Process.clock_gettime(Process::CLOCK_MONOTONIC) + 100, random_id, {})
-      child     = event(:foo, time, time + 10, random_id, {})
-      not_child = event(:foo, time, time + 100, random_id, {})
-
-      parent.children << child
-
-      assert parent.parent_of?(child)
-      assert_not child.parent_of?(parent)
-      assert_not parent.parent_of?(not_child)
-      assert_not not_child.parent_of?(parent)
-    end
-
     def test_subscribe_raises_error_on_non_supported_arguments
       notifier = ActiveSupport::Notifications::Fanout.new
 


### PR DESCRIPTION
Previously `ActiveSupport::Subscriber` would manage its own events, keep them in a thread-local stack, and track "child" events of the same subscriber.

I don't think this was particularly useful, since it only considered notifications delivered to the same subscriber, and I can't find evidence of this being used in the wild. I think this was intended to support tracing, but any such tool would want to do this itself (a minimum in order to support multiple namespaces).

Additionally, this has caused a few users to OOM in production environments, notably when queueing many jobs from another job. Based on the limited use and significant issues, I'd like to remove this tracking.

Based on my software archaeology this was introduced to solve issues seen in the newrelic agent https://github.com/rails/rails/pull/5932. The modern agent doesn't use this as far as I can tell (instead it builds and keeps track of its own events based on start/stop). IMO this implementation wouldn't be useful for it for the reasons described above.

In the second commit I remove `children` and `parent_of?`. My thinking is that in the off chance anyone is using this it should error loudly. However if preferred I could return sensible default values and emit a deprecation warning.

Anyone who needs this functionality can (and likely wants to) re-implement it in their own start/stop based subscription.

Fixes #21036 cc @pixeltrix (there's some discussion about nested tags for logging, which this change keeps intact 🙂)

