### PR TITLE
Don't require role when passing shard to connected_to

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Don't require `role` when passing `shard` to `connected_to`.
+
+    `connected_to` can now be called with a `shard` only. Note that `role` is still inherited if `connected_to` calls are nested.
+
+    *Eileen M. Uchitelle*
+
 *   Add option to lazily load the schema cache on the connection.
 
     Previously, the only way to load the schema cache in Active Record was through the Railtie on boot. This option provides the ability to load the schema cache on the connection after it's been established. Loading the cache lazily on the connection can be beneficial for Rails applications that use multiple databases because it will load the cache at the time the connection is established. Currently Railties doesn't have access to the connections before boot.

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -153,10 +153,6 @@ module ActiveRecord
         raise ArgumentError, "must provide a `shard` and/or `role`."
       end
 
-      unless role
-        raise ArgumentError, "`connected_to` cannot accept a `shard` argument without a `role`."
-      end
-
       with_role_and_shard(role, shard, prevent_writes, &blk)
     end
 

--- a/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
+++ b/activerecord/test/cases/connection_adapters/connection_swapping_nested_test.rb
@@ -156,17 +156,17 @@ module ActiveRecord
             assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
 
             # Switch only primary to shard_one
-            PrimaryBase.connected_to(role: global_role, shard: :shard_one) do
+            PrimaryBase.connected_to(shard: :shard_one) do
               assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
               assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
 
               # Switch global to shard_one
-              ActiveRecord::Base.connected_to(role: global_role, shard: :shard_one) do
+              ActiveRecord::Base.connected_to(shard: :shard_one) do
                 assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
                 assert_equal "secondary_shard_one", SecondaryBase.connection_pool.db_config.name
 
                 # Switch only secondary to shard_two
-                SecondaryBase.connected_to(role: global_role, shard: :shard_two) do
+                SecondaryBase.connected_to(shard: :shard_two) do
                   assert_equal "primary_shard_one", PrimaryBase.connection_pool.db_config.name
                   assert_equal "secondary_shard_two", SecondaryBase.connection_pool.db_config.name
                 end
@@ -183,7 +183,7 @@ module ActiveRecord
               end
 
               # Switch everything to default
-              ActiveRecord::Base.connected_to(role: global_role, shard: :default) do
+              ActiveRecord::Base.connected_to(shard: :default) do
                 assert_equal "primary", PrimaryBase.connection_pool.db_config.name
                 assert_equal "secondary", SecondaryBase.connection_pool.db_config.name
               end


### PR DESCRIPTION
Originally we required `role` when switching `shard`'s because I felt it
made it less confusing. However now that we're exploring some more
multi-tenancy work I agree we need to move this condition. Otherwise if
you're using one middleware to switch roles and another to switch
shards, you may be forced to pass the role around in places you're only
concerned with shard. This also simplifies the call for applications
that don't use roles and only have writer shards.

cc/ @seejohnrun