### PR TITLE
Remove ActiveJob.job_or_instantiate method

### DIFF
--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -26,19 +26,13 @@ module ActiveJob
       #
       # After the attempted enqueue, the job will be yielded to an optional block.
       def perform_later(...)
-        job = job_or_instantiate(...)
+        job = new(...)
         enqueue_result = job.enqueue
 
         yield job if block_given?
 
         enqueue_result
       end
-
-      private
-        def job_or_instantiate(*args) # :doc:
-          args.first.is_a?(self) ? args.first : new(*args)
-        end
-        ruby2_keywords(:job_or_instantiate)
     end
 
     # Enqueues the job to be performed by the queue adapter.

--- a/activejob/lib/active_job/execution.rb
+++ b/activejob/lib/active_job/execution.rb
@@ -15,7 +15,7 @@ module ActiveJob
       #   MyJob.perform_now("mike")
       #
       def perform_now(...)
-        job_or_instantiate(...).perform_now
+        new(...).perform_now
       end
 
       def execute(job_data) # :nodoc:


### PR DESCRIPTION
### Summary

Recently, I found a possible useless method in ActiveJob

```ruby
def job_or_instantiate(*args)
  args.first.is_a?(self) ? args.first : new(*args)
end
```

It comes from [a commit](https://github.com/rails/rails/commit/1e237b4) from 2014.

I also did some research in Rails source code but can't find any circumstance related to this `args.first.is_a?(self)`.

The circumstance of this method seems like this:

```
job = MyJob.new(word: "Hi")

MyJob.perform_later(job)
```

But I saw no one deliver job this way.

If I get nothing wrong, I guess we can delete this weird method, maybe.


