### PR TITLE
Replace more ableist language

### DIFF
--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -627,7 +627,7 @@ module ActionController
         end
 
         def check_required_ivars
-          # Sanity check for required instance variables so we can give an
+          # Check for required instance variables so we can give an
           # understandable error message.
           [:@routes, :@controller, :@request, :@response].each do |iv_name|
             if !instance_variable_defined?(iv_name) || instance_variable_get(iv_name).nil?

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -160,7 +160,7 @@ class DriverTest < ActiveSupport::TestCase
   end
 
   test "does not configure browser if driver is not :selenium" do
-    # sanity check
+    # Check that it does configure browser if the driver is :selenium
     assert ActionDispatch::SystemTesting::Driver.new(:selenium).instance_variable_get(:@browser)
 
     assert_nil ActionDispatch::SystemTesting::Driver.new(:rack_test).instance_variable_get(:@browser)

--- a/actionpack/test/dispatch/test_request_test.rb
+++ b/actionpack/test/dispatch/test_request_test.rb
@@ -3,7 +3,7 @@
 require "abstract_unit"
 
 class TestRequestTest < ActiveSupport::TestCase
-  test "sane defaults" do
+  test "reasonable defaults" do
     env = ActionDispatch::TestRequest.create.env
 
     assert_equal "GET", env.delete("REQUEST_METHOD")

--- a/activemodel/test/cases/attribute_test.rb
+++ b/activemodel/test/cases/attribute_test.rb
@@ -225,7 +225,7 @@ module ActiveModel
       changed = attribute.with_value_from_user("foo")
       forgotten = changed.forgetting_assignment
 
-      assert changed.changed? # sanity check
+      assert changed.changed? # Check to avoid a false positive
       assert_not_predicate forgotten, :changed?
     end
 

--- a/activerecord/lib/active_record/associations/association.rb
+++ b/activerecord/lib/active_record/associations/association.rb
@@ -295,7 +295,7 @@ module ActiveRecord
 
         # Raises ActiveRecord::AssociationTypeMismatch unless +record+ is of
         # the kind of the class of the associated objects. Meant to be used as
-        # a sanity check when you are about to assign an associated record.
+        # a safety check when you are about to assign an associated record.
         def raise_on_type_mismatch!(record)
           unless record.is_a?(reflection.klass)
             fresh_class = reflection.class_name.safe_constantize

--- a/activerecord/test/cases/adapters/postgresql/connection_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/connection_test.rb
@@ -141,7 +141,7 @@ module ActiveRecord
     def test_reconnection_after_actual_disconnection_with_verify
       original_connection_pid = @connection.query("select pg_backend_pid()")
 
-      # Sanity check.
+      # Double check we are connected to begin with
       assert_predicate @connection, :active?
 
       secondary_connection = ActiveRecord::Base.connection_pool.checkout

--- a/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/rename_table_test.rb
@@ -14,14 +14,11 @@ class PostgresqlRenameTableTest < ActiveRecord::PostgreSQLTestCase
   end
 
   test "renaming a table also renames the primary key index" do
-    # sanity check
-    assert_equal 1, num_indices_named("before_rename_pkey")
-    assert_equal 0, num_indices_named("after_rename_pkey")
-
-    @connection.rename_table :before_rename, :after_rename
-
-    assert_equal 0, num_indices_named("before_rename_pkey")
-    assert_equal 1, num_indices_named("after_rename_pkey")
+    assert_changes(-> { num_indices_named("before_rename_pkey") }, from: 1, to: 0) do
+      assert_changes(-> { num_indices_named("after_rename_pkey") }, from: 0, to: 1) do
+        @connection.rename_table :before_rename, :after_rename
+      end
+    end
   end
 
   private

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -768,9 +768,9 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
     assert_equal firm.clients.count, firm.clients.update_all(description: "Great!")
   end
 
-  def test_belongs_to_sanity
+  def test_belongs_to_with_new_object
     c = Client.new
-    assert_nil c.firm, "belongs_to failed sanity check on new object"
+    assert_nil c.firm, "belongs_to failed on new object"
   end
 
   def test_find_ids

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1085,7 +1085,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     model = @target.select("id").last!
 
     assert_equal ["id"], model.attribute_names
-    # Sanity check, make sure other columns exist.
+    # Ensure other columns exist.
     assert_not_equal ["id"], @target.column_names
   end
 

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1290,9 +1290,9 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_automatically_save_the_associated_model
-    @pirate.ship.name = "The Vile Insanity"
+    @pirate.ship.name = "The Vile Serpent"
     @pirate.save
-    assert_equal "The Vile Insanity", @pirate.reload.ship.name
+    assert_equal "The Vile Serpent", @pirate.reload.ship.name
   end
 
   def test_changed_for_autosave_should_handle_cycles
@@ -1306,9 +1306,9 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
   end
 
   def test_should_automatically_save_bang_the_associated_model
-    @pirate.ship.name = "The Vile Insanity"
+    @pirate.ship.name = "The Vile Serpent"
     @pirate.save!
-    assert_equal "The Vile Insanity", @pirate.reload.ship.name
+    assert_equal "The Vile Serpent", @pirate.reload.ship.name
   end
 
   def test_should_automatically_validate_the_associated_model
@@ -1376,7 +1376,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
 
   def test_should_not_save_and_return_false_if_a_callback_cancelled_saving
     pirate = Pirate.new(catchphrase: "Arr")
-    ship = pirate.build_ship(name: "The Vile Insanity")
+    ship = pirate.build_ship(name: "The Vile Serpent")
     ship.cancel_save_from_callback = true
 
     assert_no_difference "Pirate.count" do
@@ -1390,7 +1390,7 @@ class TestAutosaveAssociationOnAHasOneAssociation < ActiveRecord::TestCase
     before = [@pirate.catchphrase, @pirate.ship.name]
 
     @pirate.catchphrase = "Arr"
-    @pirate.ship.name = "The Vile Insanity"
+    @pirate.ship.name = "The Vile Serpent"
 
     # Stub the save method of the @pirate.ship instance to raise an exception
     class << @pirate.ship
@@ -1472,9 +1472,9 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
 
   def test_should_still_work_without_an_associated_model
     @pirate.destroy
-    @ship.reload.name = "The Vile Insanity"
+    @ship.reload.name = "The Vile Serpent"
     @ship.save
-    assert_equal "The Vile Insanity", @ship.reload.name
+    assert_equal "The Vile Serpent", @ship.reload.name
   end
 
   def test_should_automatically_save_the_associated_model
@@ -1523,7 +1523,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_save_and_return_false_if_a_callback_cancelled_saving
-    ship = Ship.new(name: "The Vile Insanity")
+    ship = Ship.new(name: "The Vile Serpent")
     pirate = ship.build_pirate(catchphrase: "Arr")
     pirate.cancel_save_from_callback = true
 
@@ -1538,7 +1538,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
     before = [@ship.pirate.catchphrase, @ship.name]
 
     @ship.pirate.catchphrase = "Arr"
-    @ship.name = "The Vile Insanity"
+    @ship.name = "The Vile Serpent"
 
     # Stub the save method of the @ship.pirate instance to raise an exception
     class << @ship.pirate
@@ -1553,7 +1553,7 @@ class TestAutosaveAssociationOnABelongsToAssociation < ActiveRecord::TestCase
   end
 
   def test_should_not_load_the_associated_model
-    assert_queries(1) { @ship.name = "The Vile Insanity"; @ship.save! }
+    assert_queries(1) { @ship.name = "The Vile Serpent"; @ship.save! }
   end
 
   def test_should_save_with_non_nullable_foreign_keys

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -473,7 +473,7 @@ class FixturesTest < ActiveRecord::TestCase
   def test_nonexistent_fixture_file
     nonexistent_fixture_path = FIXTURES_ROOT + "/imnothere"
 
-    # sanity check to make sure that this file never exists
+    # Ensure that this file never exists
     assert_empty Dir[nonexistent_fixture_path + "*"]
 
     assert_raise(Errno::ENOENT) do

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -673,7 +673,7 @@ unless in_memory_db?
     end
 
     # Test typical find.
-    def test_sane_find_with_lock
+    def test_typical_find_with_lock
       assert_nothing_raised do
         Person.transaction do
           Person.lock.find(1)

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -621,7 +621,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_query_cache_does_not_establish_connection_if_unconnected
     ActiveRecord::Base.clear_active_connections!
-    assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
+    assert_not ActiveRecord::Base.connection_handler.active_connections? # Double check they are cleared
 
     middleware {
       assert_not ActiveRecord::Base.connection_handler.active_connections?, "QueryCache forced ActiveRecord::Base to establish a connection in setup"
@@ -632,7 +632,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_query_cache_is_enabled_on_connections_established_after_middleware_runs
     ActiveRecord::Base.clear_active_connections!
-    assert_not ActiveRecord::Base.connection_handler.active_connections? # sanity check
+    assert_not ActiveRecord::Base.connection_handler.active_connections? # Double check they are cleared
 
     middleware {
       assert_predicate ActiveRecord::Base.connection, :query_cache_enabled

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -61,7 +61,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_new_records_remain_new_after_round_trip
     topic = Topic.new
 
-    assert topic.new_record?, "Sanity check that new records are new"
+    assert topic.new_record?, "New record should be new"
     assert yaml_load(YAML.dump(topic)).new_record?, "Record should be new after deserialization"
 
     topic.save!

--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -587,7 +587,7 @@ Debug mode can also be enabled in Rails helper methods:
 
 The `:debug` option is redundant if debug mode is already on.
 
-You can also enable compression in development mode as a sanity check, and
+You can also enable compression in development mode, and
 disable it on-demand as required for debugging.
 
 In Production

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -181,7 +181,7 @@ module ApplicationTests
       assert_equal "Answer: 42\n", output
     end
 
-    def test_code_statistics_sanity
+    def test_code_statistics
       assert_match "Code LOC: 61     Test LOC: 3     Code to Test Ratio: 1:0.0",
         rails("stats")
     end

--- a/railties/test/generators/migration_generator_test.rb
+++ b/railties/test/generators/migration_generator_test.rb
@@ -127,7 +127,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/remove_reference :books, :author,.*\sforeign_key: true/, change)
-        assert_match(/remove_reference :books, :distributor/, change) # sanity check
+        assert_match(/remove_reference :books, :distributor/, change) # Ensure the line isn't gone completely
         assert_no_match(/remove_reference :books, :distributor,.*\sforeign_key: true/, change)
       end
     end
@@ -237,7 +237,7 @@ class MigrationGeneratorTest < Rails::Generators::TestCase
     assert_migration "db/migrate/#{migration}.rb" do |content|
       assert_method :change, content do |change|
         assert_match(/add_reference :books, :author,.*\sforeign_key: true/, change)
-        assert_match(/add_reference :books, :distributor/, change) # sanity check
+        assert_match(/add_reference :books, :distributor/, change) # Ensure the line isn't gone completely
         assert_no_match(/add_reference :books, :distributor,.*\sforeign_key: true/, change)
       end
     end


### PR DESCRIPTION
Along the same lines as ccb3cb573b, this commit removes unnecessary
references to mental health.

As in that commit, I think many of these are more descriptive than what
we had before.

The commit changes only tests and documentation.
