### PR TITLE
Bump Rake Pin in Railties

### DIFF
--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", version
   s.add_dependency "actionpack",    version
 
-  s.add_dependency "rake", ">= 0.13"
+  s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0"
   s.add_dependency "method_source"
   s.add_dependency "zeitwerk", "~> 2.5.0.beta5"


### PR DESCRIPTION
In Rails 6.1, `rake_command.rb` was rewritten with Rake methods only
available in Rake 12.2 and higher.
https://github.com/rails/rails/blob/c2b701e33470adb1fab15c5e68957facdb26ebb1/railties/lib/rails/commands/rake/rake_command.rb#L18
68a3f67

If there is an older version of Rake installed on a system `rails` and
`rake` commands error with a missing method error.
ruby/rake@ae4f786
