### PR TITLE
Fix eager loading models without primary keys

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix eager loading for models without primary keys.
+
+    *Anmol Chopra*, *Matt Lawrence*, and *Jonathan Hefner*
+
 *   Avoid validating a unique field if it has not changed and is backed by a unique index.
 
     Previously, when saving a record, ActiveRecord will perform an extra query to check for the uniqueness of

--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -252,35 +252,39 @@ module ActiveRecord
               next
             end
 
-            key = aliases.column_alias(node, node.primary_key)
-            id = row[key]
-            if id.nil?
+            if node.primary_key
+              key = aliases.column_alias(node, node.primary_key)
+              id = row[key]
+            else
+              key = aliases.column_alias(node, node.reflection.join_primary_key.to_s)
+              id = nil # Avoid id-based model caching.
+            end
+
+            if row[key].nil?
               nil_association = ar_parent.association(node.reflection.name)
               nil_association.loaded!
               next
             end
 
-            model = seen[ar_parent][node][id]
-
-            if model
-              construct(model, node, row, seen, model_cache, strict_loading_value)
-            else
+            unless model = seen[ar_parent][node][id]
               model = construct_model(ar_parent, node, row, model_cache, id, strict_loading_value)
-
-              seen[ar_parent][node][id] = model
-              construct(model, node, row, seen, model_cache, strict_loading_value)
+              seen[ar_parent][node][id] = model if id
             end
+
+            construct(model, node, row, seen, model_cache, strict_loading_value)
           end
         end
 
         def construct_model(record, node, row, model_cache, id, strict_loading_value)
           other = record.association(node.reflection.name)
 
-          model = model_cache[node][id] ||=
-            node.instantiate(row, aliases.column_aliases(node)) do |m|
+          unless model = model_cache[node][id]
+            model = node.instantiate(row, aliases.column_aliases(node)) do |m|
               m.strict_loading! if strict_loading_value
               other.set_inverse_instance(m)
             end
+            model_cache[node][id] = model if id
+          end
 
           if node.reflection.collection?
             other.target.push(model)

--- a/activerecord/test/cases/associations/eager_test.rb
+++ b/activerecord/test/cases/associations/eager_test.rb
@@ -30,6 +30,9 @@ require "models/categorization"
 require "models/sponsor"
 require "models/mentor"
 require "models/contract"
+require "models/pirate"
+require "models/matey"
+require "models/parrot"
 
 class EagerLoadingTooManyIdsTest < ActiveRecord::TestCase
   fixtures :citations
@@ -47,7 +50,8 @@ class EagerAssociationTest < ActiveRecord::TestCase
   fixtures :posts, :comments, :authors, :essays, :author_addresses, :categories, :categories_posts,
             :companies, :accounts, :tags, :taggings, :ratings, :people, :readers, :categorizations,
             :owners, :pets, :author_favorites, :jobs, :references, :subscribers, :subscriptions, :books,
-            :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors
+            :developers, :projects, :developers_projects, :members, :memberships, :clubs, :sponsors,
+            :pirates, :mateys
 
   def test_eager_with_has_one_through_join_model_with_conditions_on_the_through
     member = Member.all.merge!(includes: :favorite_club).find(members(:some_other_guy).id)
@@ -197,6 +201,27 @@ class EagerAssociationTest < ActiveRecord::TestCase
     authors = Author.includes(:post).references(:post).to_a
     assert authors.count > 0
     assert_no_queries { authors.map(&:post) }
+  end
+
+  def test_eager_loaded_has_one_association_without_primary_key
+    pirate = pirates(:redbeard)
+    attacker_matey = pirate.attacker_matey
+    eager_loaded = Pirate.eager_load(:attacker_matey).where(id: pirate).first
+
+    assert_no_queries do
+      assert_equal attacker_matey.attributes, eager_loaded.attacker_matey.attributes
+    end
+  end
+
+  def test_eager_loaded_has_many_association_without_primary_key
+    pirate = pirates(:blackbeard)
+    mateys = pirate.mateys.to_a
+    eager_loaded = Pirate.eager_load(:mateys).where(id: pirate).first
+
+    assert_not_empty mateys
+    assert_no_queries do
+      assert_equal mateys.map(&:attributes), eager_loaded.mateys.map(&:attributes)
+    end
   end
 
   def test_type_cast_in_where_references_association_name

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -44,6 +44,9 @@ class Pirate < ActiveRecord::Base
 
   has_one :foo_bulb, -> { where name: "foo" }, foreign_key: :car_id, class_name: "Bulb"
 
+  has_many :mateys, foreign_key: :pirate_id
+  has_one :attacker_matey, foreign_key: :target_id, class_name: "Matey"
+
   accepts_nested_attributes_for :parrots, :birds, allow_destroy: true, reject_if: proc(&:empty?)
   accepts_nested_attributes_for :ship, allow_destroy: true, reject_if: proc(&:empty?)
   accepts_nested_attributes_for :update_only_ship, update_only: true


### PR DESCRIPTION
### Summary

Eager-loading models without primary keys does not function correctly.

Fixes #29374

### Example

Consider the following and assume that the second model is backed by a DB object without a primary key (like a view):

```rb
class MyModel < ActiveRecord::Base
   has_one :model_without_primary_key, primary_key: :some_other_column
end

class ModelWithoutPrimaryKey < ActiveRecord::Base
   belongs_to :my_model, primary_key: :some_other_column
end
```
If we create a couple of records, we can see that `eager_load` produces incorrect results:

```rb
MyModel.create # => #<MyModel id: 1>
ModelWithoutPrimaryKey.create(some_other_column: 100, my_model_id: 1)

my_instance = MyModel.eager_load(:model_without_primary_key).first
my_instance.model_without_primary_key # => nil

my_instance.reload
my_instance.model_without_primary_key #=> #<ModelWithoutPrimaryKey ... >
```

This issue comes up during normal ActiveRecord use-cases when models are backed by DB views. It can also come up  with chains like:

```rb
my_instance.includes(:model_without_primary_key).order('model_without_primary_key.name')
```

### Credit

I give 95% of the credit to @chopraanmol1 and based this PR on their GH-30212, which looks to have gone stale a couple of years ago.
