### PR TITLE
Implement `field_id` in terms of the FormBuilder's `namespace:` option

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1748,8 +1748,8 @@ module ActionView
       # <tt>aria-describedby</tt> attribute referencing the <tt><span></tt>
       # element, sharing a common <tt>id</tt> root (<tt>post_title</tt>, in this
       # case).
-      def field_id(method, *suffixes, index: @index)
-        @template.field_id(@object_name, method, *suffixes, index: index)
+      def field_id(method, *suffixes, namespace: @options[:namespace], index: @index)
+        @template.field_id(@object_name, method, *suffixes, namespace: namespace, index: index)
       end
 
       # Generate an HTML <tt>name</tt> attribute value for the given name and

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -96,7 +96,7 @@ module ActionView
       # <tt>aria-describedby</tt> attribute referencing the <tt><span></tt>
       # element, sharing a common <tt>id</tt> root (<tt>post_title</tt>, in this
       # case).
-      def field_id(object_name, method_name, *suffixes, index: nil)
+      def field_id(object_name, method_name, *suffixes, index: nil, namespace: nil)
         if object_name.respond_to?(:model_name)
           object_name = object_name.model_name.singular
         end
@@ -105,16 +105,13 @@ module ActionView
 
         sanitized_method_name = method_name.to_s.delete_suffix("?")
 
-        # a little duplication to construct fewer strings
-        if sanitized_object_name.empty?
-          sanitized_method_name
-        elsif suffixes.any?
-          [sanitized_object_name, index, sanitized_method_name, *suffixes].compact.join("_")
-        elsif index
-          "#{sanitized_object_name}_#{index}_#{sanitized_method_name}"
-        else
-          "#{sanitized_object_name}_#{sanitized_method_name}"
-        end
+        [
+          namespace,
+          sanitized_object_name.presence,
+          (index unless sanitized_object_name.empty?),
+          sanitized_method_name,
+          *suffixes,
+        ].tap(&:compact!).join("_")
       end
 
       # Generate an HTML <tt>name</tt> attribute value for the given name and

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -97,7 +97,7 @@ module ActionView
             options["name"] = options.fetch("name") { tag_name(options["multiple"], index) }
 
             if generate_ids?
-              options["id"] = options.fetch("id") { tag_id(index) }
+              options["id"] = options.fetch("id") { tag_id(index, options.delete("namespace")) }
               if namespace = options.delete("namespace")
                 options["id"] = options["id"] ? "#{namespace}_#{options['id']}" : namespace
               end
@@ -108,8 +108,8 @@ module ActionView
             @template_object.field_name(@object_name, sanitized_method_name, multiple: multiple, index: index)
           end
 
-          def tag_id(index = nil)
-            @template_object.field_id(@object_name, @method_name, index: index)
+          def tag_id(index = nil, namespace = nil)
+            @template_object.field_id(@object_name, @method_name, index: index, namespace: namespace)
           end
 
           def sanitized_method_name

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1689,6 +1689,22 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_field_id_with_namespace
+    form_for(Post.new, namespace: :special) do |form|
+      concat form.label(:title)
+      concat form.text_field(:title, aria: { describedby: form.field_id(:title, :error) })
+      concat tag.span("is blank", id: form.field_id(:title, :error))
+    end
+
+    expected = whole_form("/posts", "special_new_post", "new_post") do
+      '<label for="special_post_title">Title</label>' \
+      '<input id="special_post_title" name="post[title]" type="text" aria-describedby="special_post_title_error">' \
+      '<span id="special_post_title_error">is blank</span>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_field_name_with_blank_as_and_multiple
     form_for(Post.new, as: "") do |form|
       concat form.text_field(:title, name: form.field_name(:title, multiple: true))
@@ -1792,6 +1808,20 @@ class FormHelperTest < ActionView::TestCase
 
     expected = whole_form("/posts", "new_post", "new_post") do
       %(<input id="post_1_title" name="post[1][title][subtitle][]" type="text">)
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_field_id_with_namespace_and_index
+    form_for(Post.new, namespace: :special, index: 1) do |form|
+      concat form.text_field(:title, aria: { describedby: form.field_id(:title, :error) })
+      concat tag.span("is blank", id: form.field_id(:title, :error))
+    end
+
+    expected = whole_form("/posts", "special_new_post", "new_post") do
+      '<input id="special_post_1_title" name="post[1][title]" type="text" aria-describedby="special_post_1_title_error">' \
+      '<span id="special_post_1_title_error">is blank</span>'
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
When constructing the field's `[id]` attribute, the current
`FormBuilder#field_id` implementation (introduced in [59ca21c][]) ignores the
`namespace:` option.

This commit incorporates any namespace by prepending it to the
`@object_name`.

[59ca21c]: https://github.com/rails/rails/commit/59ca21c0119fff803e75e78d800c0c98aee7fd4c