### PR TITLE
Change session host to application default options url or fallback

### DIFF
--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -10,7 +10,7 @@ module Rails
     def app(create = false)
       @app_integration_instance = nil if create
       @app_integration_instance ||= new_session do |sess|
-        sess.host! "www.example.com"
+        sess.host! Rails.application.routes.default_url_options[:host] || "www.example.com"
       end
     end
 

--- a/railties/test/application/console_test.rb
+++ b/railties/test/application/console_test.rb
@@ -43,6 +43,23 @@ class ConsoleTest < ActiveSupport::TestCase
     assert_equal "/foo", console_session.foo_path
   end
 
+  def test_app_can_access_default_url_options_host
+    load_environment
+    Rails.application.routes.default_url_options.merge!(host: "localhost:3000")
+    console_session = irb_context.app
+
+    assert_equal "localhost:3000", console_session.host
+  end
+
+  def test_app_uses_fallback_session_host_if_default_url_options_host_is_nil
+    load_environment
+    console_session = irb_context.app
+
+    fallback_session_host = "www.example.com"
+
+    assert_equal fallback_session_host, console_session.host
+  end
+
   def test_new_session_should_return_integration_session
     load_environment
     session = irb_context.new_session


### PR DESCRIPTION
### Summary

In the rails console app `sess.host!` was equal to `"www.example.com"`. When making a request like `app.get '/'` in the console after `Rails.application.routes.default_url_options[:host]` was set a HTTP `403` response was returned. This fix makes `sess.host!` equal to `Rails.application.routes.default_url_options[:host]` if it is set or default to `www.example.com`, now the request should return a HTTP `200` status with the correct application URL.

### Other Information
See details in this issue: https://github.com/rails/rails/issues/43357

![Screenshot 2021-10-03 at 03 20 51](https://user-images.githubusercontent.com/12435007/135736209-2fa98d3d-6411-4c2d-aa38-c9291f3e828b.png)
