### PR TITLE
Switch trailing commas in structure.sql to leading

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Change format of generated `INSERT INTO 'schema_migrations'` statement in `db:structure:dump`
+
+    Values are now separated by leading commas instead of trailing ones, and the final semicolon is on its own line.
+
+    This ensures multiple new migrations being added do not cause merge conflicts.
+
+    *Matt Larraz*
+
 *   Don't require `role` when passing `shard` to `connected_to`.
 
     `connected_to` can now be called with a `shard` only. Note that `role` is still inherited if `connected_to` calls are nested.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1664,8 +1664,8 @@ module ActiveRecord
 
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
-            sql << versions.map { |v| "(#{quote(v)})" }.join(",\n")
-            sql << ";\n\n"
+            sql << versions.map { |v| "(#{quote(v)})" }.join("\n,")
+            sql << "\n;\n\n"
             sql
           else
             "INSERT INTO #{sm_table} (version) VALUES (#{quote(versions)});"


### PR DESCRIPTION
### Summary

Changes the formatting of the migration versions to reduce merge conflicts.

Today every new migration added adds a new line here, but also requires moving the semicolon from what was previously the most recent line:
```sql
INSERT INTO "schema_migrations" (version) VALUES
('20210924183850'),
('20211008165610'),
('20211108235701');
```

```diff
INSERT INTO "schema_migrations" (version) VALUES
('20190924183850'),
('20191008165610'),
+('20191108235701'),
-('20191108235701');
+('20191118181905');
```

This leads to merge conflicts if lots of migrations are being added at the same. By changing the formatting slightly, this is no longer an issue:

```sql
INSERT INTO "schema_migrations" (version) VALUES
('20210924183850')
,('20211008165610')
,('20211108235701')
;
```

```diff
INSERT INTO "schema_migrations" (version) VALUES
('20190924183850')
,('20191008165610')
,('20191108235701')
+,('20191118181905')
;
```

In both cases this is valid SQL with no functional difference.