### PR TITLE
Treat html suffix in controller translation 

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Treat html suffix in controller translation.
+
+    *Rui Onodera*, *Gavin Miller*
+
 *   Allow permitting numeric params.
 
     Previously it was impossible to permit different fields on numeric parameters.

--- a/actionpack/lib/abstract_controller/translation.rb
+++ b/actionpack/lib/abstract_controller/translation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/html_safe_translation"
+
 module AbstractController
   module Translation
     mattr_accessor :raise_on_missing_translations, default: false
@@ -23,19 +25,7 @@ module AbstractController
 
       i18n_raise = options.fetch(:raise, self.raise_on_missing_translations)
 
-      if html_safe_translation_key?(key)
-        html_safe_options = options.dup
-        options.except(*I18n::RESERVED_KEYS).each do |name, value|
-          unless name == :count && value.is_a?(Numeric)
-            html_safe_options[name] = ERB::Util.html_escape(value.to_s)
-          end
-        end
-        translation = I18n.translate(key, **html_safe_options, raise: i18n_raise)
-
-        translation.respond_to?(:html_safe) ? translation.html_safe : translation
-      else
-        I18n.translate(key, **options, raise: i18n_raise)
-      end
+      ActiveSupport::HtmlSafeTranslation.translate(key, **options, raise: i18n_raise)
     end
     alias :t :translate
 
@@ -44,10 +34,5 @@ module AbstractController
       I18n.localize(object, **options)
     end
     alias :l :localize
-
-    private
-      def html_safe_translation_key?(key)
-        /(\b|_|\.)html$/.match?(key.to_s)
-      end
   end
 end

--- a/actionview/lib/action_view/helpers/translation_helper.rb
+++ b/actionview/lib/action_view/helpers/translation_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_view/helpers/tag_helper"
+require "active_support/html_safe_translation"
 
 module ActionView
   # = Action View Translation Helpers
@@ -84,14 +85,9 @@ module ActionView
 
           key = scope_key_by_partial(key)
 
-          if html_safe_translation_key?(key)
-            html_safe_options ||= html_escape_translation_options(options)
-            translated = I18n.translate(key, **html_safe_options, default: default)
-            break html_safe_translation(translated) unless translated.equal?(MISSING_TRANSLATION)
-          else
-            translated = I18n.translate(key, **options, default: default)
-            break translated unless translated.equal?(MISSING_TRANSLATION)
-          end
+          translated = ActiveSupport::HtmlSafeTranslation.translate(key, **options, default: default)
+
+          break translated unless translated.equal?(MISSING_TRANSLATION)
 
           if alternatives.present? && !alternatives.first.is_a?(Symbol)
             break alternatives.first && I18n.translate(**options, default: alternatives)
@@ -126,10 +122,6 @@ module ActionView
         NO_DEFAULT = [].freeze
         private_constant :NO_DEFAULT
 
-        def self.i18n_option?(name)
-          (@i18n_option_names ||= I18n::RESERVED_KEYS.to_set).include?(name)
-        end
-
         def scope_key_by_partial(key)
           if key&.start_with?(".")
             if @virtual_path
@@ -141,31 +133,6 @@ module ActionView
             end
           else
             key
-          end
-        end
-
-        def html_escape_translation_options(options)
-          return options if options.empty?
-          html_safe_options = options.dup
-
-          options.each do |name, value|
-            unless TranslationHelper.i18n_option?(name) || (name == :count && value.is_a?(Numeric))
-              html_safe_options[name] = ERB::Util.html_escape(value.to_s)
-            end
-          end
-
-          html_safe_options
-        end
-
-        def html_safe_translation_key?(key)
-          /(?:_|\b)html\z/.match?(key)
-        end
-
-        def html_safe_translation(translation)
-          if translation.respond_to?(:map)
-            translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
-          else
-            translation.respond_to?(:html_safe) ? translation.html_safe : translation
           end
         end
 

--- a/activesupport/lib/active_support/html_safe_translation.rb
+++ b/activesupport/lib/active_support/html_safe_translation.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  module HtmlSafeTranslation # :nodoc:
+    extend self
+
+    def translate(key, **options)
+      if html_safe_translation_key?(key)
+        html_safe_options = html_escape_translation_options(options)
+        translation = I18n.translate(key, **html_safe_options)
+        html_safe_translation(translation)
+      else
+        I18n.translate(key, **options)
+      end
+    end
+
+    private
+      def html_safe_translation_key?(key)
+        /(?:_|\b)html\z/.match?(key)
+      end
+
+      def html_escape_translation_options(options)
+        options.each do |name, value|
+          unless i18n_option?(name) || (name == :count && value.is_a?(Numeric))
+            options[name] = ERB::Util.html_escape(value.to_s)
+          end
+        end
+      end
+
+      def i18n_option?(name)
+        (@i18n_option_names ||= I18n::RESERVED_KEYS.to_set).include?(name)
+      end
+
+
+      def html_safe_translation(translation)
+        if translation.respond_to?(:map)
+          translation.map { |element| element.respond_to?(:html_safe) ? element.html_safe : element }
+        else
+          translation.respond_to?(:html_safe) ? translation.html_safe : translation
+        end
+      end
+  end
+end


### PR DESCRIPTION
This is a redo of https://github.com/rails/rails/pull/27872.

I added an extra commit to extract the common behavior of HTML safe translations to a private module in Active Support so we don't forget to match the behavior in both Action View and Action Pack.

This undo some of the memory savings we got in https://github.com/rails/rails/pull/39989 since the Action View implementation will build the html_safe options for each possible key we need to check. As I could not find an easy way to memoize that object allocation inside only the Action View loop, I though that would be an acceptable compromise. Open to ideas on how  to save that memory though.
