### PR TITLE
Action View: Support `fields model: [...]`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Support `fields model: [@nested, @model]` the same way as `form_with model:
+    [@nested, @model]`.
+
+    *Sean Doyle*
+
 *   Add `:day_format` option to `date_select`
 
         date_select("article", "written_on", day_format: ->(day) { day.ordinalize })

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1059,6 +1059,7 @@ module ActionView
         options[:skip_default_ids] = !form_with_generates_ids
 
         if model
+          model   = model.last if model.is_a?(Array)
           scope ||= model_name_from_record_or_class(model).param_key
         end
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2033,6 +2033,16 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, output_buffer
   end
 
+  def test_fields_with_only_object_array
+    output_buffer = fields(model: [@post, @comment]) do |f|
+      concat f.text_field(:name)
+    end
+
+    expected = %(<input type="text" value="new comment" name="comment[name]" id="comment_name" />)
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_fields_object_with_bracketed_name
     output_buffer = fields("author[post]", model: @post) do |f|
       concat f.label(:title)


### PR DESCRIPTION
Support `fields model: [@nested, @model]` the same way as `form_with
model: [@nested, @model]`.

After this change, the `fields` helper matches the precedent established
by [fields_for][], [form_for][], and [form_with][].

[fields_for]: https://github.com/rails/rails/blob/5e1a039a1dd63ab70300a1340226eab690444cea/actionview/lib/action_view/helpers/form_helper.rb#L2235
[form_with]: https://github.com/rails/rails/blob/5e1a039a1dd63ab70300a1340226eab690444cea/actionview/lib/action_view/helpers/form_helper.rb#L749
[form_for]: https://github.com/rails/rails/blob/5e1a039a1dd63ab70300a1340226eab690444cea/actionview/lib/action_view/helpers/form_helper.rb#L436