### PR TITLE
Forms: Deprecate `local:` and `remote:` options

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Deprecate `:remote` option for `form_for` and `:local` option for `form_with`
+
+    Also deprecate `config.action_view.embed_authenticity_token_in_remote_forms` and
+    `config.action_view.form_with_generates_remote_forms` configurations.
+
+    *Sean Doyle*
+
 *   Extract `current_page?`, `button_to`, and `link_to` methods to
     `ActionView::Helpers::NavigationHelper`
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -185,19 +185,6 @@ module ActionView
       #   utf8 is not output.
       # * <tt>:html</tt> - Optional HTML attributes for the form tag.
       #
-      # ==== Deprecated: Rails UJS options
-      #
-      # * <tt>:remote</tt> - If set to true, will allow the Unobtrusive
-      #   JavaScript drivers to control the submit behavior.
-      # * <tt>:authenticity_token</tt> - Authenticity token to use in the form.
-      #   Use only if you need to pass custom authenticity token string, or to
-      #   not add authenticity_token field at all (by passing <tt>false</tt>).
-      #   Remote forms may omit the embedded authenticity token by setting
-      #   <tt>config.action_view.embed_authenticity_token_in_remote_forms = false</tt>.
-      #   This is helpful when you're fragment-caching the form. Remote forms
-      #   get the authenticity token from the <tt>meta</tt> tag, so embedding is
-      #   unnecessary unless you support browsers without JavaScript.
-      #
       # Also note that +form_for+ doesn't create an exclusive scope. It's still
       # possible to use both the stand-alone FormHelper methods and methods
       # from FormTagHelper. For example:
@@ -327,29 +314,6 @@ module ActionView
       # in the options hash. If the verb is not GET or POST, which are natively
       # supported by HTML forms, the form will be set to POST and a hidden input
       # called _method will carry the intended verb for the server to interpret.
-      #
-      # === Deprecated: Unobtrusive JavaScript
-      #
-      # Specifying:
-      #
-      #    remote: true
-      #
-      # in the options hash creates a form that will allow the unobtrusive JavaScript drivers to modify its
-      # behavior. The form submission will work just like a regular submission as viewed by the receiving
-      # side (all elements available in <tt>params</tt>).
-      #
-      # Example:
-      #
-      #   <%= form_for(@article, remote: true) do |f| %>
-      #     ...
-      #   <% end %>
-      #
-      # The HTML generated for this would be:
-      #
-      #   <form action='http://www.example.com' method='post' data-remote='true'>
-      #     <input name='_method' type='hidden' value='patch' />
-      #     ...
-      #   </form>
       #
       # === Setting HTML options
       #
@@ -497,6 +461,18 @@ module ActionView
 
       mattr_accessor :form_with_generates_remote_forms, default: true
 
+      class << self
+        redefine_method :form_with_generates_remote_forms= do |value|
+          if value
+            ActionView.deprecator.warn \
+              "Setting config.action_view.form_with_generates_remote_forms is deprecated and will be removed in a future version of Rails. " \
+              "Call form_with and form_for with a `data: { remote: true }` option instead. "
+          end
+
+          @@form_with_generates_remote_forms = value
+        end
+      end
+
       mattr_accessor :form_with_generates_ids, default: false
 
       mattr_accessor :multiple_file_field_include_hidden, default: false
@@ -642,19 +618,6 @@ module ActionView
       # * <tt>:class</tt> - Optional HTML class attribute.
       # * <tt>:data</tt> - Optional HTML data attributes.
       # * <tt>:html</tt> - Other optional HTML attributes for the form tag.
-      #
-      # ==== Deprecated: Rails UJS options
-      #
-      # * <tt>:local</tt> - Whether to use standard HTTP form submission.
-      #   When set to <tt>true</tt>, the form is submitted via standard HTTP.
-      #   When set to <tt>false</tt>, the form is submitted as a "remote form", which
-      #   is handled by \Rails UJS as an XHR. When unspecified, the behavior is derived
-      #   from <tt>config.action_view.form_with_generates_remote_forms</tt> where the
-      #   config's value is actually the inverse of what <tt>local</tt>'s value would be.
-      #   As of \Rails 6.1, that configuration option defaults to <tt>false</tt>
-      #   (which has the equivalent effect of passing <tt>local: true</tt>).
-      #   In previous versions of \Rails, that configuration option defaults to
-      #   <tt>true</tt> (the equivalent of passing <tt>local: false</tt>).
       #
       # === Examples
       #

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -22,8 +22,19 @@ module ActionView
       include TextHelper
       include ContentExfiltrationPreventionHelper
 
-      mattr_accessor :embed_authenticity_token_in_remote_forms
-      self.embed_authenticity_token_in_remote_forms = nil
+      mattr_accessor :embed_authenticity_token_in_remote_forms, default: nil
+
+      class << self
+        redefine_method :embed_authenticity_token_in_remote_forms= do |value|
+          if value
+            ActionView.deprecator.warn \
+              "Setting config.action_view.embed_authenticity_token_in_remote_forms is deprecated and will be removed in a future version of Rails. " \
+              "Call form_with and form_for with an :authenticity_token option instead."
+          end
+
+          @@embed_authenticity_token_in_remote_forms = value
+        end
+      end
 
       mattr_accessor :default_enforce_utf8, default: true
 

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -62,7 +62,7 @@ module ActionView
       #   <% end -%>
       #   # => <form action="/posts" method="post"><div><input type="submit" name="commit" value="Save" /></div></form>
       #
-      #   <%= form_tag('/posts', remote: true) %>
+      #   <%= form_tag('/posts', data: { remote: true }) %>
       #   # => <form action="/posts" method="post" data-remote="true">
       #
       #   form_tag(false, method: :get)
@@ -1021,7 +1021,14 @@ module ActionView
             end
             html_options["accept-charset"] = "UTF-8"
 
-            html_options["data-remote"] = true if html_options.delete("remote")
+            if html_options.delete("remote")
+              ActionView.deprecator.warn \
+                "Passing :local as an option is deprecated and will be removed in a future version of Rails. " \
+                "To control the [data-remote] attribute, pass that option directly. " \
+                "To control the generation of CSRF tokens, pass an :authenticity_token option directly."
+
+              html_options["data-remote"] = true
+            end
 
             if html_options["data-remote"] &&
                embed_authenticity_token_in_remote_forms == false &&

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -20,13 +20,25 @@ module ActionView
     guard_load_hooks(:action_view, :action_view_test_case)
 
     config.after_initialize do |app|
-      ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
-        app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
+      if app.config.action_view.key?(:embed_authenticity_token_in_remote_forms)
+        ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
+          app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
+
+        ActionView.deprecator.warn \
+          "Setting config.action_view.embed_authenticity_token_in_remote_forms is deprecated and will be removed in a future version of Rails. " \
+          "Call form_with and form_for with an :authenticity_token option instead."
+      end
     end
 
     config.after_initialize do |app|
-      form_with_generates_remote_forms = app.config.action_view.delete(:form_with_generates_remote_forms)
-      ActionView::Helpers::FormHelper.form_with_generates_remote_forms = form_with_generates_remote_forms
+      if app.config.action_view.key?(:form_with_generates_remote_forms)
+        form_with_generates_remote_forms = app.config.action_view.delete(:form_with_generates_remote_forms)
+        ActionView::Helpers::FormHelper.form_with_generates_remote_forms = form_with_generates_remote_forms
+
+        ActionView.deprecator.warn \
+          "Setting config.action_view.form_with_generates_remote_forms is deprecated and will be removed in a future version of Rails. " \
+          "Call form_with and form_for with a `data: { remote: true }` option instead. "
+      end
     end
 
     config.after_initialize do |app|

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -20,25 +20,13 @@ module ActionView
     guard_load_hooks(:action_view, :action_view_test_case)
 
     config.after_initialize do |app|
-      if app.config.action_view.key?(:embed_authenticity_token_in_remote_forms)
-        ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
-          app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
-
-        ActionView.deprecator.warn \
-          "Setting config.action_view.embed_authenticity_token_in_remote_forms is deprecated and will be removed in a future version of Rails. " \
-          "Call form_with and form_for with an :authenticity_token option instead."
-      end
+      ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
+        app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
     end
 
     config.after_initialize do |app|
-      if app.config.action_view.key?(:form_with_generates_remote_forms)
-        form_with_generates_remote_forms = app.config.action_view.delete(:form_with_generates_remote_forms)
-        ActionView::Helpers::FormHelper.form_with_generates_remote_forms = form_with_generates_remote_forms
-
-        ActionView.deprecator.warn \
-          "Setting config.action_view.form_with_generates_remote_forms is deprecated and will be removed in a future version of Rails. " \
-          "Call form_with and form_for with a `data: { remote: true }` option instead. "
-      end
+      form_with_generates_remote_forms = app.config.action_view.delete(:form_with_generates_remote_forms)
+      ActionView::Helpers::FormHelper.form_with_generates_remote_forms = form_with_generates_remote_forms
     end
 
     config.after_initialize do |app|

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -124,7 +124,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
   end
 
   def test_form_with_with_local_true
-    actual = ActionView.deprecator.silence do
+    actual = assert_deprecated ActionView.deprecator do
       form_with(local: true)
     end
 
@@ -175,7 +175,7 @@ class FormWithActsLikeFormTagTest < FormWithTest
   end
 
   def test_form_with_with_block_in_erb_and_local_true
-    @rendered = ActionView.deprecator.silence do
+    @rendered = assert_deprecated ActionView.deprecator do
       render_erb("<%= form_with(url: 'http://www.example.com', local: true) do %>Hello world!<% end %>")
     end
 
@@ -899,7 +899,9 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     assert_dom_equal expected, @rendered
   ensure
-    ActionView::Helpers::FormHelper.form_with_generates_remote_forms = old_value
+    ActionView.deprecator.silence do
+      ActionView::Helpers::FormHelper.form_with_generates_remote_forms = old_value
+    end
   end
 
   def test_form_with_skip_enforcing_utf8_true

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -124,7 +124,9 @@ class FormWithActsLikeFormTagTest < FormWithTest
   end
 
   def test_form_with_with_local_true
-    actual = form_with(local: true)
+    actual = ActionView.deprecator.silence do
+      form_with(local: true)
+    end
 
     expected = whole_form("http://www.example.com", local: true)
     assert_dom_equal expected, actual
@@ -173,7 +175,9 @@ class FormWithActsLikeFormTagTest < FormWithTest
   end
 
   def test_form_with_with_block_in_erb_and_local_true
-    @rendered = render_erb("<%= form_with(url: 'http://www.example.com', local: true) do %>Hello world!<% end %>")
+    @rendered = ActionView.deprecator.silence do
+      render_erb("<%= form_with(url: 'http://www.example.com', local: true) do %>Hello world!<% end %>")
+    end
 
     expected = whole_form("http://www.example.com", local: true) do
       "Hello world!"

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2472,7 +2472,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_remote
-    ActionView.deprecator.silence do
+    assert_deprecated ActionView.deprecator do
       form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
         concat f.text_field(:title)
         concat f.textarea(:body)
@@ -2543,7 +2543,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_remote_in_html
-    ActionView.deprecator.silence do
+    assert_deprecated ActionView.deprecator do
       form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
         concat f.text_field(:title)
         concat f.textarea(:body)
@@ -2564,7 +2564,7 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_remote_without_html
     @post.persisted = false
     @post.stub(:to_key, nil) do
-      ActionView.deprecator.silence do
+      assert_deprecated ActionView.deprecator do
         form_for(@post, remote: true) do |f|
           concat f.text_field(:title)
           concat f.textarea(:body)
@@ -4257,7 +4257,7 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_data_attributes
-    ActionView.deprecator.silence do
+    assert_deprecated ActionView.deprecator do
       form_for(@post, data: { behavior: "stuff" }, remote: true) { }
     end
     assert_match %r|data-behavior="stuff"|, @rendered

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2472,10 +2472,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_remote
-    form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
-      concat f.text_field(:title)
-      concat f.textarea(:body)
-      concat f.checkbox(:secret)
+    ActionView.deprecator.silence do
+      form_for(@post, url: "/", remote: true, html: { id: "create-post", method: :patch }) do |f|
+        concat f.text_field(:title)
+        concat f.textarea(:body)
+        concat f.checkbox(:secret)
+      end
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
@@ -2541,10 +2543,12 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_remote_in_html
-    form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
-      concat f.text_field(:title)
-      concat f.textarea(:body)
-      concat f.checkbox(:secret)
+    ActionView.deprecator.silence do
+      form_for(@post, url: "/", html: { remote: true, id: "create-post", method: :patch }) do |f|
+        concat f.text_field(:title)
+        concat f.textarea(:body)
+        concat f.checkbox(:secret)
+      end
     end
 
     expected = whole_form("/", "create-post", "edit_post", method: "patch", remote: true) do
@@ -2560,10 +2564,12 @@ class FormHelperTest < ActionView::TestCase
   def test_form_for_with_remote_without_html
     @post.persisted = false
     @post.stub(:to_key, nil) do
-      form_for(@post, remote: true) do |f|
-        concat f.text_field(:title)
-        concat f.textarea(:body)
-        concat f.checkbox(:secret)
+      ActionView.deprecator.silence do
+        form_for(@post, remote: true) do |f|
+          concat f.text_field(:title)
+          concat f.textarea(:body)
+          concat f.checkbox(:secret)
+        end
       end
 
       expected = whole_form("/posts", "new_post", "new_post", remote: true) do
@@ -4251,7 +4257,9 @@ class FormHelperTest < ActionView::TestCase
   end
 
   def test_form_for_with_data_attributes
-    form_for(@post, data: { behavior: "stuff" }, remote: true) { }
+    ActionView.deprecator.silence do
+      form_for(@post, data: { behavior: "stuff" }, remote: true) { }
+    end
     assert_match %r|data-behavior="stuff"|, @rendered
     assert_match %r|data-remote="true"|, @rendered
   end

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -165,7 +165,9 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_with_remote
-    actual = form_tag({}, { remote: true })
+    actual = ActionView.deprecator.silence do
+      form_tag({}, { remote: true })
+    end
 
     expected = whole_form("http://www.example.com", remote: true)
     assert_dom_equal expected, actual

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -165,7 +165,7 @@ class FormTagHelperTest < ActionView::TestCase
   end
 
   def test_form_tag_with_remote
-    actual = ActionView.deprecator.silence do
+    actual = assert_deprecated ActionView.deprecator do
       form_tag({}, { remote: true })
     end
 

--- a/guides/source/8_2_release_notes.md
+++ b/guides/source/8_2_release_notes.md
@@ -94,6 +94,8 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 ### Deprecations
 
+*  Deprecate `:remote` option for `form_for` and `:local` option for `form_with`
+
 ### Notable changes
 
 *   Add ability to pass a block when rendering a collection. The block is executed


### PR DESCRIPTION
### Motivation / Background

There are two two parts to interpreting the `form_for` helper's `remote:` option, and the `form_with` helper's `local:` option:

1. The `[data-remote]` attribute:

   When `remote: true` or `local: false`, Action View generates `<form>`
   elements with `[data-remote="true"]`. When passed `remote: false` or
   `local: true`, the `[data-remote]` attribute is omitted.

   Omitting the options is equivalent to `remote: true` and `local:
   false`.

2. CSRF tokens

   When `remote: true` or `local: false`, Action view generates `<form>`
   elements without any CSRF tokens encoded as `<input type="hidden">`
   elements.

   When `remote: false` or `local: true`, Action view generates `<form>`
   elements with an embedded CSRF token either generated on the fly, or
   forwarded along from the form helper method's `authenticity_token:`
   option.

   When omitted, their default values are handled by two similar
   configuration values:

   * `config.action_view.embed_authenticity_token_in_remote_forms` for
     `form_for` and its `remote:` option

   * `config.action_view.form_with_generates_remote_forms` for
     `form_with` and its `local:` option

### Detail

This commit renders deprecation warnings when `local:` or `remote:`
options are passed to `form_with` and `form_for`, respectively. Also
deprecate `config.action_view.embed_authenticity_token_in_remote_forms`
and `config.action_view.form_with_generates_remote_forms`
configurations.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.