### PR TITLE
Fix JavaScript syntax error on Action Cable Overview

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -585,7 +585,7 @@ consumer.subscriptions.create("AppearanceChannel", {
   },
 
   get documentIsActive() {
-    return document.visibilityState == "visible" && document.hasFocus()
+    return document.visibilityState === "visible" && document.hasFocus()
   },
 
   get appearingOn() {
@@ -653,7 +653,7 @@ import consumer from "./consumer"
 
 consumer.subscriptions.create("WebNotificationsChannel", {
   received(data) {
-    new Notification(data["title"], body: data["body"])
+    new Notification(data["title"], { body: data["body"] })
   }
 })
 ```


### PR DESCRIPTION
### Summary

Change two JavaScript examples in the Action Cable Overview guide to fix a couple of issues that seem to come from employing some ruby-isms:

- a syntax error caused by using keyword arguments instead of a plain object
- using `==` instead of `===` — this form usually introduces unexpected behavior, and we should try to avoid normalizing it by including it in documentation
