### PR TITLE
Implement `form_for` by delegating to `form_with`

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -914,7 +914,7 @@ module ActionView
             html_options["data-remote"] = true if html_options.delete("remote")
 
             if html_options["data-remote"] &&
-               !embed_authenticity_token_in_remote_forms &&
+               embed_authenticity_token_in_remote_forms == false &&
                html_options["authenticity_token"].blank?
               # The authenticity token is taken from the meta tag in this case
               html_options["authenticity_token"] = false


### PR DESCRIPTION
Improve the parity between `form_for` and `form_with` by implementing
`form_for` in terms of `form_with`.

The private [FormTagHelper#html_options_for_form][] helper covers the
same logic as [FormHelper#html_options_for_form_with][].

This commit replaces the re-implementation within `#form_with` with a
call to `#html_options_for_form`. In order to pass along the data in a
correct shape, keep the `#html_options_for_form_with` method and use it
to coerce the options. Similarly, this commit replaces `html_options` transformations 
with coercion of data into the shape it needs to be in order to delegate to `form_with`.

In the same spirit, this commit also implements `fields_for` in terms of
`fields`.

[FormTagHelper#html_options_for_form]: https://github.com/rails/rails/blob/fb1ab3460a676ce7def0819c2e92289ef2dcbe3b/actionview/lib/action_view/helpers/form_tag_helper.rb#L873-L894
[FormHelper#html_options_for_form_with]: https://github.com/rails/rails/blob/fb1ab3460a676ce7def0819c2e92289ef2dcbe3b/actionview/lib/action_view/helpers/form_helper.rb#L1552-L1579