### PR TITLE
Address action_mailbox bug report templates failures with Ruby3.1.0dev

### DIFF
--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -14,6 +14,10 @@ gemfile(true) do
     # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
     # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
     gem "net-smtp", require: false
+
+    # digest gem, which is one of the default gems has bumped to 3.0.1.pre for ruby 3.1.0dev.
+    # Also `net-smtp` v0.2.2 adds dependency to digest gem which attempts to install digest 3.0.0.
+    gem "digest", "~> 3.0.1.pre", require: false
   end
 end
 

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -13,6 +13,10 @@ gemfile(true) do
     # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
     # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
     gem "net-smtp", require: false
+
+    # digest gem, which is one of the default gems has bumped to 3.0.1.pre for ruby 3.1.0dev.
+    # Also `net-smtp` v0.2.2 adds dependency to digest gem which attempts to install digest 3.0.0.
+    gem "digest", "~> 3.0.1.pre", require: false
   end
 end
 


### PR DESCRIPTION
### Summary

This commit addresses CI failure since https://buildkite.com/rails/rails/builds/81642#ee889e34-4f2f-4bb6-9204-9c9bd0d27fa8

`net-smtp` gem v0.2.2 released which adds dependency to digest gem  which attempts to install digest 3.0.0.
However, Ruby 3.1.0dev requires digest gem 3.0.1, which causes this failure.

Refer
https://github.com/ruby/net-smtp/releases/tag/v0.2.2
https://github.com/ruby/net-smtp/commit/b1adc9e0be2c53a7ca23209ceedc5f7192149f6c

- Steps to reproduce
```ruby
$ cd guides/bug_report_templates
$ ruby action_mailbox_main.rb
```

- Result without this commit

```ruby
$ ruby -v
ruby 3.1.0dev (2021-10-10T15:24:09Z master 10c650628a) [x86_64-linux]
$ cd guides/bug_report_templates
$ ruby action_mailbox_main.rb
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Using rake 13.0.6
Using concurrent-ruby 1.1.9
Using minitest 5.14.4
Using builder 3.2.4
Using erubi 1.10.0
Using mini_mime 1.1.1
Using bundler 2.3.0.dev
Using rack 2.2.3
Using digest 3.0.0
Using io-wait 0.1.1
Using method_source 1.0.0
Using timeout 0.1.1
Using thor 1.1.0
Using zeitwerk 2.5.0.beta5
Using sqlite3 1.4.2
Using i18n 1.8.10
Using tzinfo 2.0.4
Using mail 2.7.1
Using marcel 1.0.2
Using rack-test 1.1.0
Using net-protocol 0.1.1
Using sprockets 4.0.2
Using activesupport 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using websocket-extensions 0.1.5
Using net-smtp 0.2.2
Using websocket-driver 0.7.5
Using crass 1.0.6
Using nio4r 2.5.8
Using racc 1.5.2
Using mini_portile2 2.6.1
Using nokogiri 1.12.5
Using loofah 2.12.0
Using rails-html-sanitizer 1.4.2
Using rails-dom-testing 2.0.3
Using globalid 0.5.2
Using actionview 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using activemodel 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using actionpack 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using activejob 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using actioncable 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using actionmailer 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using sprockets-rails 3.2.2
Using activerecord 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using railties 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using activestorage 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using actiontext 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using actionmailbox 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
Using rails 7.0.0.alpha2 from https://github.com/rails/rails.git (at /home/yahonda/src/github.com/rails/rails@5e1a039)
/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated digest 3.0.1.pre, but your Gemfile requires digest 3.0.0. Since digest is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports digest as a default gem. (Gem::LoadError)
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:25:in `block in setup'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/spec_set.rb:136:in `each'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/spec_set.rb:136:in `each'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:24:in `map'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/runtime.rb:24:in `setup'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/inline.rb:71:in `block in gemfile'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/settings.rb:131:in `temporary'
	from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/inline.rb:55:in `gemfile'
	from action_mailbox_main.rb:5:in `<main>'
$
```
