### PR TITLE
Stop failing GSRF token generation when session is disabled

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -57,17 +57,6 @@ module ActionController # :nodoc:
   module RequestForgeryProtection
     extend ActiveSupport::Concern
 
-    class DisabledSessionError < StandardError
-      MESSAGE = <<~EOS.squish
-        Request forgery protection requires a working session store but your application has sessions disabled.
-        You need to either disable request forgery protection, or configure a working session store.
-      EOS
-
-      def initialize(message = MESSAGE)
-        super
-      end
-    end
-
     include AbstractController::Helpers
     include AbstractController::Callbacks
 
@@ -100,11 +89,6 @@ module ActionController # :nodoc:
       # Controls whether forgery protection is enabled by default.
       config_accessor :default_protect_from_forgery
       self.default_protect_from_forgery = false
-
-      # Controls whether trying to use forgery protection without a working session store
-      # issues a warning or raises an error.
-      config_accessor :silence_disabled_session_errors
-      self.silence_disabled_session_errors = true
 
       # Controls whether URL-safe CSRF tokens are generated.
       config_accessor :urlsafe_csrf_tokens, instance_writer: false
@@ -469,20 +453,7 @@ module ActionController # :nodoc:
 
       # Checks if the controller allows forgery protection.
       def protect_against_forgery? # :doc:
-        allow_forgery_protection && ensure_session_is_enabled!
-      end
-
-      def ensure_session_is_enabled!
-        if !session.respond_to?(:enabled?) || session.enabled?
-          true
-        else
-          if silence_disabled_session_errors
-            ActiveSupport::Deprecation.warn(DisabledSessionError::MESSAGE)
-            false
-          else
-            raise DisabledSessionError
-          end
-        end
+        allow_forgery_protection && (!session.respond_to?(:enabled?) || session.enabled?)
       end
 
       NULL_ORIGIN_MESSAGE = <<~MSG

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -203,10 +203,6 @@ module Rails
             action_dispatch.cookies_serializer = :json
           end
 
-          if respond_to?(:action_controller)
-            action_controller.silence_disabled_session_errors = false
-          end
-
           if respond_to?(:action_view)
             action_view.button_to_generates_button_tag = true
             action_view.apply_stylesheet_media_default = false


### PR DESCRIPTION
Ref: https://github.com/hotwired/turbo-rails/issues/243

In theory this should have warned early that the CSRF check
will fail, which would have been less puzzling for the developer.

However there are several cases where we render forms but the session
is inacessible. That's the case of turbo (https://github.com/hotwired/turbo-rails/issues/243)
as well as some others.

So unless we figure a proper way to detect these cases, we're better
to not cause this error.

Writing to a disabled session directly will still raise, this
only silence it for the specific case of CSRF.

