### PR TITLE
Bump required digest version to 3.1.0.pre for Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -182,8 +182,8 @@ if RUBY_VERSION >= "3.1"
   gem "net-imap", require: false
   gem "net-pop", require: false
 
-  # digest gem, which is one of the default gems has bumped to 3.0.1.pre for ruby 3.1.0dev.
-  gem "digest", "~> 3.0.1.pre", require: false
+  # digest gem, which is one of the default gems has bumped to 3.1.0.pre for ruby 3.1.0dev.
+  gem "digest", "~> 3.1.0.pre", require: false
 
   # matrix was removed from default gems in Ruby 3.1, but is used by the `capybara` gem.
   # So we need to add it as a dependency until `capybara` is fixed: https://github.com/teamcapybara/capybara/pull/2468

--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -15,9 +15,9 @@ gemfile(true) do
     # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
     gem "net-smtp", require: false
 
-    # digest gem, which is one of the default gems has bumped to 3.0.1.pre for ruby 3.1.0dev.
+    # digest gem, which is one of the default gems has bumped to 3.1.0.pre for ruby 3.1.0dev.
     # Also `net-smtp` v0.2.2 adds dependency to digest gem which attempts to install digest 3.0.0.
-    gem "digest", "~> 3.0.1.pre", require: false
+    gem "digest", "~> 3.1.0.pre", require: false
   end
 end
 

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -14,9 +14,9 @@ gemfile(true) do
     # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
     gem "net-smtp", require: false
 
-    # digest gem, which is one of the default gems has bumped to 3.0.1.pre for ruby 3.1.0dev.
+    # digest gem, which is one of the default gems has bumped to 3.1.0.pre for ruby 3.1.0dev.
     # Also `net-smtp` v0.2.2 adds dependency to digest gem which attempts to install digest 3.0.0.
-    gem "digest", "~> 3.0.1.pre", require: false
+    gem "digest", "~> 3.1.0.pre", require: false
   end
 end
 


### PR DESCRIPTION
### Summary

This commit addresses these failures since https://github.com/ruby/ruby/commit/e94bcda02539e1695cdda9550ace45c1890e541c

- `bundle install` failure

```ruby
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Could not find gem 'digest (~> 3.0.1.pre)' in rubygems repository https://rubygems.org/ or installed locally.
The source contains the following versions of 'digest': 1.0.0, 3.0.0, 3.1.0.pre0, 3.1.0.pre1, 3.1.0.pre2, 3.1.0.pre2 java
$
```

* Action Mailbox bug report template failures

```ruby
$ cd guides/bug_report_templates
$ ruby -v
ruby 3.1.0dev (2021-10-12T11:53:18Z master 58ae1efb49) [x86_64-linux]
$ ruby action_mailbox_main.rb
Fetching gem metadata from https://rubygems.org/......
/home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/resolver.rb:278:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'digest (~> 3.0.1.pre)' in rubygems repository https://rubygems.org/ or installed locally. (Bundler::GemNotFound)
The source contains the following versions of 'digest': 1.0.0, 3.0.0, 3.1.0.pre0, 3.1.0.pre1, 3.1.0.pre2, 3.1.0.pre2 java
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/resolver.rb:253:in `each'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/resolver.rb:253:in `verify_gemfile_dependencies_are_found!'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/resolver.rb:50:in `start'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/resolver.rb:23:in `resolve'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/definition.rb:267:in `resolve'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/definition.rb:183:in `resolve_remotely!'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/installer.rb:280:in `resolve_if_needed'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/installer.rb:82:in `block in run'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/process_lock.rb:12:in `block in lock'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/process_lock.rb:9:in `open'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/process_lock.rb:9:in `lock'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/installer.rb:71:in `run'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/installer.rb:23:in `install'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/inline.rb:63:in `block (2 levels) in gemfile'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/settings.rb:131:in `temporary'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/inline.rb:62:in `block in gemfile'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/settings.rb:131:in `temporary'
  from /home/yahonda/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/bundler/inline.rb:55:in `gemfile'
  from action_mailbox_main.rb:5:in `<main>'
$
```

Refer https://github.com/ruby/ruby/commit/e94bcda02539e1695cdda9550ace45c1890e541c

