### PR TITLE
Allow `ActiveJob::Base.set` to configure jobs when using `.perform_now`

### DIFF
--- a/activejob/lib/active_job/configured_job.rb
+++ b/activejob/lib/active_job/configured_job.rb
@@ -8,7 +8,7 @@ module ActiveJob
     end
 
     def perform_now(...)
-      @job_class.new(...).perform_now
+      @job_class.new(...).set(@options).perform_now
     end
 
     def perform_later(...)

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -156,6 +156,16 @@ module ActiveJob
       self.enqueued_at          = job_data["enqueued_at"]
     end
 
+    # Configures the job with the given options.
+    def set(options = {}) # :nodoc:
+      self.scheduled_at = options[:wait].seconds.from_now.to_f if options[:wait]
+      self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
+      self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
+      self.priority     = options[:priority].to_i if options[:priority]
+
+      self
+    end
+
     private
       def serialize_arguments_if_needed(arguments)
         if arguments_serialized?

--- a/activejob/lib/active_job/enqueuing.rb
+++ b/activejob/lib/active_job/enqueuing.rb
@@ -57,10 +57,7 @@ module ActiveJob
     #    my_job_instance.enqueue wait_until: Date.tomorrow.midnight
     #    my_job_instance.enqueue priority: 10
     def enqueue(options = {})
-      self.scheduled_at = options[:wait].seconds.from_now.to_f if options[:wait]
-      self.scheduled_at = options[:wait_until].to_f if options[:wait_until]
-      self.queue_name   = self.class.queue_name_from_part(options[:queue]) if options[:queue]
-      self.priority     = options[:priority].to_i if options[:priority]
+      set(options)
       self.successfully_enqueued = false
 
       run_callbacks :enqueue do

--- a/activejob/test/cases/queue_priority_test.rb
+++ b/activejob/test/cases/queue_priority_test.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 require "helper"
+require "jobs/configuration_job"
 require "jobs/hello_job"
 
 class QueuePriorityTest < ActiveSupport::TestCase
+  setup do
+    JobBuffer.clear
+  end
+
   test "priority unset by default" do
     assert_nil HelloJob.priority
   end
@@ -42,8 +47,15 @@ class QueuePriorityTest < ActiveSupport::TestCase
     end
   end
 
-  test "uses priority passed to #set" do
-    job = HelloJob.set(priority: 123).perform_later
+  test "is assigned when perform_now" do
+    ConfigurationJob.set(priority: 123).perform_now
+    job = JobBuffer.last_value
+    assert_equal 123, job.priority
+  end
+
+  test "is assigned when perform_later" do
+    ConfigurationJob.set(priority: 123).perform_later
+    job = JobBuffer.last_value
     assert_equal 123, job.priority
   end
 end

--- a/activejob/test/jobs/configuration_job.rb
+++ b/activejob/test/jobs/configuration_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../support/job_buffer"
+
+class ConfigurationJob < ActiveJob::Base
+  def perform
+    JobBuffer.add(self)
+  end
+end


### PR DESCRIPTION
### Summary

Closes #43376, to allow `ActiveJob::Base.set` to configure jobs using `perform_now`.

Extracts an instance method, `#set` (symmetrically named to the class method `.set`) that extracts the configuration assignment options embedded in `#enqueue`.

As discussed in #43376, this behavior is necessary because:

- Existing enqueue options may be relevant to a `.perform_now` job that has a `retry_on` handler.
- ActiveJob extensions may add additional configuration options that should be accessible to `.perform_now`.
