### PR TITLE
Raise error when serializing an anonymous class.

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Raise an `SerializationError` in `Serializer::ModuleSerializer`
+    if the module name is not present. 
+
+    *Veerpal Brar*
+
+
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 
 *   No changes.

--- a/activejob/lib/active_job/serializers/module_serializer.rb
+++ b/activejob/lib/active_job/serializers/module_serializer.rb
@@ -4,6 +4,7 @@ module ActiveJob
   module Serializers
     class ModuleSerializer < ObjectSerializer # :nodoc:
       def serialize(constant)
+        raise SerializationError, "Serializing an anonymous class is not supported" unless constant.name
         super("value" => constant.name)
       end
 

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -50,7 +50,7 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
     end
   end
 
-  [ Object.new, Person.find("5").to_gid ].each do |arg|
+  [ Object.new, Person.find("5").to_gid, Class.new ].each do |arg|
     test "does not serialize #{arg.class}" do
       assert_raises ActiveJob::SerializationError do
         ActiveJob::Arguments.serialize [ arg ]


### PR DESCRIPTION
### Summary

The ModuleSerializer does not support serializing anonymous classes
because when we try to deserialize the anonymous class, it wouldn't
know which class to use (since class name is nil).

For this reason, ModuleSerialzier now raises an error if the class
name is nil. Previously, ModuleSerializer would raise an `undefined
method constantize for nil:NilClass` error during deserialization.
It's not clear why the deserialization failed from the error.

In this commit, we raise an explicit error when trying to serialize
an anonymous class indicating this behaviour is not supported.

Fixes https://github.com/rails/rails/issues/43306

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
