### PR TITLE
Updated disable_joins examples for has_one through association.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -647,7 +647,7 @@
 
     ```ruby
     class Person
-      belongs_to :dog
+      has_one :dog
       has_one :veterinarian, through: :dog, disable_joins: true
     end
     ```

--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -506,8 +506,17 @@ class Dog < AnimalsRecord
   has_many :treats, through: :humans, disable_joins: true
   has_many :humans
 
-  belongs_to :home
+  has_one :home
   has_one :yard, through: :home, disable_joins: true
+end
+
+class Home
+  belongs_to :dog
+  has_one :yard
+end
+
+class Yard
+  belongs_to :home
 end
 ```
 


### PR DESCRIPTION
### Summary

The `disable_joins` option for has_one through association got added by this pull request https://github.com/rails/rails/pull/42079.

The example shows  dog `belongs_to :home` and the generated sql query checks `homes.dog_id` which doesn't seem correct. I have added other class structure as well for better clarity on the relations here.

```sql
SELECT "home"."id" FROM "homes" WHERE "homes"."dog_id" = ? [["dog_id", 1]]
SELECT "yards".* FROM "yards" WHERE "yards"."home_id" = ? [["home_id", 1]]
```

### Other Information

The has_many through association also have the disable_joins options available by this PR https://github.com/rails/rails/pull/41937.

cc: @eileencodes 

Feel free to close the PR if the change doesn't make any sense at all. 
