### PR TITLE
Allow multiline to be passed in routes when using wildcards.

### DIFF
--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -166,7 +166,7 @@ module ActionDispatch
           super(left)
 
           # By default wildcard routes are non-greedy and must match something.
-          @regexp = /.+?/
+          @regexp = /.+?/m
         end
 
         def star?; true; end

--- a/actionpack/lib/action_dispatch/journey/nodes/node.rb
+++ b/actionpack/lib/action_dispatch/journey/nodes/node.rb
@@ -53,7 +53,7 @@ module ActionDispatch
               if formatted != false
                 # Add a constraint for wildcard route to make it non-greedy and
                 # match the optional format part of the route by default.
-                wildcard_options[node.name.to_sym] ||= /.+?/
+                wildcard_options[node.name.to_sym] ||= /.+?/m
               end
             end
 

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -91,7 +91,6 @@ module ActionDispatch
       # as requirements.
       def requirements
         @defaults.merge(path.requirements).delete_if { |_, v|
-          /.+?/ == v ||
           /.+?/m == v
         }
       end

--- a/actionpack/lib/action_dispatch/journey/route.rb
+++ b/actionpack/lib/action_dispatch/journey/route.rb
@@ -91,7 +91,8 @@ module ActionDispatch
       # as requirements.
       def requirements
         @defaults.merge(path.requirements).delete_if { |_, v|
-          /.+?/ == v
+          /.+?/ == v ||
+          /.+?/m == v
         }
       end
 

--- a/actionpack/test/controller/routing_test.rb
+++ b/actionpack/test/controller/routing_test.rb
@@ -624,6 +624,34 @@ class LegacyRouteSetTests < ActiveSupport::TestCase
         url_for(rs, controller: "content", action: "show_file", path: %w(pages boo))
   end
 
+  def test_escapes_newline_character_for_dynamic_path
+    rs.draw do
+      get "/dynamic/:dynamic_segment" => "subpath_books#show", as: :dynamic
+
+      ActiveSupport::Deprecation.silence do
+        get ":controller/:action/:id"
+      end
+    end
+
+    results = rs.recognize_path("/dynamic/a%0Anewline")
+    assert(results, "Recognition should have succeeded")
+    assert_equal("a\nnewline", results[:dynamic_segment])
+  end
+
+  def test_escapes_newline_character_for_wildcard_path
+    rs.draw do
+      get "/wildcard/*wildcard_segment" => "subpath_books#show", as: :wildcard
+
+      ActiveSupport::Deprecation.silence do
+        get ":controller/:action/:id"
+      end
+    end
+
+    results = rs.recognize_path("/wildcard/a%0Anewline")
+    assert(results, "Recognition should have succeeded")
+    assert_equal("a\nnewline", results[:wildcard_segment])
+  end
+
   def test_dynamic_recall_paths_allowed
     rs.draw do
       get "*path" => "content#show_file"

--- a/actionpack/test/dispatch/mapper_test.rb
+++ b/actionpack/test/dispatch/mapper_test.rb
@@ -92,7 +92,7 @@ module ActionDispatch
         scope = Mapper::Scope.new({})
         ast = Journey::Parser.parse "/store/:name(*rest)"
         m = Mapper::Mapping.build(scope, FakeSet.new, ast, "foo", "bar", nil, [:get], nil, {}, true, options)
-        assert_equal(/.+?/, m.requirements[:rest])
+        assert_equal(/.+?/m, m.requirements[:rest])
       end
 
       def test_via_scope
@@ -137,7 +137,7 @@ module ActionDispatch
         mapper = Mapper.new fakeset
         mapper.get "/*path", to: "pages#show"
         assert_equal "/*path(.:format)", fakeset.asts.first.to_s
-        assert_equal(/.+?/, fakeset.requirements.first[:path])
+        assert_equal(/.+?/m, fakeset.requirements.first[:path])
       end
 
       def test_map_wildcard_with_other_element
@@ -145,7 +145,7 @@ module ActionDispatch
         mapper = Mapper.new fakeset
         mapper.get "/*path/foo/:bar", to: "pages#show"
         assert_equal "/*path/foo/:bar(.:format)", fakeset.asts.first.to_s
-        assert_equal(/.+?/, fakeset.requirements.first[:path])
+        assert_equal(/.+?/m, fakeset.requirements.first[:path])
       end
 
       def test_map_wildcard_with_multiple_wildcard
@@ -153,8 +153,8 @@ module ActionDispatch
         mapper = Mapper.new fakeset
         mapper.get "/*foo/*bar", to: "pages#show"
         assert_equal "/*foo/*bar(.:format)", fakeset.asts.first.to_s
-        assert_equal(/.+?/, fakeset.requirements.first[:foo])
-        assert_equal(/.+?/, fakeset.requirements.first[:bar])
+        assert_equal(/.+?/m, fakeset.requirements.first[:foo])
+        assert_equal(/.+?/m, fakeset.requirements.first[:bar])
       end
 
       def test_map_wildcard_with_format_false

--- a/actionpack/test/dispatch/routing/route_set_test.rb
+++ b/actionpack/test/dispatch/routing/route_set_test.rb
@@ -149,6 +149,22 @@ module ActionDispatch
         assert_equal "/users/1.json", url_helpers.user_path(1, :json)
       end
 
+      test "escape new line for dynamic params" do
+        draw do
+          get "/dynamic/:dynamic_segment", to: SimpleApp.new("foo#index"), as: :dynamic
+        end
+
+        assert_equal "/dynamic/a%0Anewline", url_helpers.dynamic_path(dynamic_segment: "a\nnewline")
+      end
+
+      test "escape new line for wildcard params" do
+        draw do
+          get "/wildcard/*wildcard_segment", to: SimpleApp.new("foo#index"), as: :wildcard
+        end
+
+        assert_equal "/wildcard/a%0Anewline", url_helpers.wildcard_path(wildcard_segment: "a\nnewline")
+      end
+
       private
         def draw(&block)
           @set.draw(&block)

--- a/actionpack/test/journey/nodes/ast_test.rb
+++ b/actionpack/test/journey/nodes/ast_test.rb
@@ -67,7 +67,7 @@ module ActionDispatch
           ast = Ast.new(tree, true)
 
           wildcard_options = ast.wildcard_options
-          assert_equal %r{.+?}, wildcard_options[:glob]
+          assert_equal %r{.+?}m, wildcard_options[:glob]
         end
 
         def test_wildcard_options_when_false
@@ -83,7 +83,7 @@ module ActionDispatch
           ast = Ast.new(tree, nil)
 
           wildcard_options = ast.wildcard_options
-          assert_equal %r{.+?}, wildcard_options[:glob]
+          assert_equal %r{.+?}m, wildcard_options[:glob]
         end
       end
     end


### PR DESCRIPTION
Fixed a bug in action_dispatch where routes with newlines weren't detected when using wildcard segments

### Summary

Original issue posted: https://github.com/rails/rails/issues/39103

`Problem:` URL generation does not escape a newline character in a wildcard segment.

### Steps to reproduce it

```ruby
  draw do
    get "/wildcard/*wildcard_segment", to: SimpleApp.new("foo#index"), as: :wildcard
    get "/dynamic/:dynamic_segment", to: SimpleApp.new("foo#index"), as: :dynamic
  end

  assert_equal "/dynamic/a%0Anewline", url_helpers.dynamic_path(dynamic_segment: "a\nnewline") # succeeds
  assert_equal "/wildcard/a%0Anewline", url_helpers.wildcard_path(wildcard_segment: "a\nnewline") # fails with the error:
  # ActionController::UrlGenerationError (No route matches {:action=>"index", :controller=>"test", :wildcard_segment=>"a\nnewline"}, possible unmatched constraints: [:wildcard_segment]):
```

<details> <summary> Code snippet with tests passing </summary>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails", github: 'ignacio-chiazzo/rails', branch: 'wildcard-routes'
end

require "rack/test"
require "action_controller/railtie"

class TestApp < Rails::Application
  config.root = __dir__
  config.hosts << "example.org"
  config.session_store :cookie_store, key: "cookie_store_key"
  secrets.secret_key_base = "secret_key_base"

  config.logger = Logger.new($stdout)
  Rails.logger  = config.logger

  routes.draw do
    get "/" => "test#index"
    get "/dynamic/:dynamic_segment" => "test#index", as: :dynamic
    get "/wildcard/*wildcard_segment" => "test#index", as: :wildcard
  end
end

class TestController < ActionController::Base
  include Rails.application.routes.url_helpers

  def index
    urls =
      dynamic_path(dynamic_segment: params[:s]) + "\n" +
      wildcard_path(wildcard_segment: params[:s]) + "\n"
    render plain: urls
  end
end

require "minitest/autorun"

class BugTest < Minitest::Test
  include Rack::Test::Methods

  def test_generates_url_with_spaces
    get "/?s=a%20space"
    assert last_response.ok?
    assert_equal <<~BODY, last_response.body
      /dynamic/a%20space
      /wildcard/a%20space
    BODY
  end

  def test_generates_url_with_newlines
    get "/?s=a%0Anewline"
    puts last_response
    assert last_response.ok?
    assert_equal <<~BODY, last_response.body
      /dynamic/a%0Anewline
      /wildcard/a%0Anewline
    BODY
  end

  private
    def app
      Rails.application
    end
end
```

</details>

Note: See the original issue for more details.

### Code issue:

TL;DR The issue is that the Regex doesn't check for `multiline`. 

If there is a route that uses a wildcard (e.g.`/wildcard/*wildcard_segment`) and the client sends a URL like this`/wildcard/a%0newline`, the [`Formatter` class](https://github.com/ignacio-chiazzo/rails/blob/b5f2b550f69a99336482739000c58e4e04e033aa/actionpack/lib/action_dispatch/journey/formatter.rb#L179) checks that the path `a\nnewline` matches against the REGEX `/\\A(?-mix:.+?)\\Z/`.

This REGEX uses the [Ruby opts:source](https://ruby-doc.org/core-2.2.0/Regexp.html#method-i-to_s) notation, but it's the same as `/\A#{/.+?/}\Z/`. Note that the regex embedded (`/.+?/`) doesn't use multiline (that's why we see `-mix`), which means that `multiline` (`m`), `extended mode` (`x`), and case sensitive (`i`) are disabled. 

To fix the issue I enabled multiline in the sub Regex when `wildcard` only. It looks like `wildcard` was disabled [on purpose](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/routing/mapper.rb#L256), I tried using git blame to see the reason behind but I couldn't find it (it's added a long time ago > 12 years)  [(latest commit I found)](https://github.com/ignacio-chiazzo/rails/commit/ca3936dbd691538d97d8dbe2bc1d64c21dc7db0e)

**Why does dynamic route work?**  dynamic paths don't have a `requirement`, so it doesn't check against a REGEX, [it just checks](https://github.com/ignacio-chiazzo/rails/blob/b5f2b550f69a99336482739000c58e4e04e033aa/actionpack/lib/action_dispatch/journey/formatter.rb#L173-L176) that the value `dynamic_segment` is not nil.

### Reviewers

- Is there any security issue I'm ignoring here?
- Is there any reason not to allow `multiline` when using `wildcard segments` that I am missing?