### PR TITLE
Add document `config.active_record.verbose_query_logs` into `Configuring Rails Applications` [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -760,6 +760,10 @@ Define the list of table that should be ignored when generating the schema
 cache. It accepts an `Array` of strings, representing the table names, or
 regular expressions.
 
+#### `config.active_record.verbose_query_logs`
+
+Specifies if source locations of methods that call database queries should be logged below relevant queries. By default, the flag is `true` in development and `false` in all other environments.
+
 #### `ActiveRecord::ConnectionAdapters::Mysql2Adapter.emulate_booleans`
 
 Controls whether the Active Record MySQL adapter will consider all `tinyint(1)` columns as booleans. Defaults to `true`.


### PR DESCRIPTION
### Summary

I added the description of `config.active_record.verbose_query_logs` in the `Configuring Rails Applications` item of the documentation because it didn't exist.

https://edgeguides.rubyonrails.org/configuring.html#configuring-active-record

The default value is `true` in the development environment and `false` in other environments.

https://github.com/rails/rails/blob/10c0b5939f8d7f3959990dd4eeb59f0b864147df/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt#L63-L64