### PR TITLE
fix: duplicate active record objects on inverse_of

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -456,6 +456,10 @@ module ActiveRecord
 
           yield(record) if block_given?
 
+          if !index && @replaced_or_added_targets.include?(record)
+            index = @target.index(record)
+          end
+
           @replaced_or_added_targets << record if inversing || index || record.new_record?
 
           if index

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -766,6 +766,15 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
+  def test_with_hash_many_inversing_does_not_add_duplicate_associated_objects
+    with_has_many_inversing(Interest) do
+      human = Human.new
+      interest = Interest.new(human: human)
+      human.interests << interest
+      assert_equal 1, human.interests.size
+    end
+  end
+
   def test_unscope_does_not_set_inverse_when_incorrect
     interest = interests(:trainspotting)
     human = interest.human


### PR DESCRIPTION
Closes issue #43222.

### Summary

Fixes a bug that causes duplicate references to the same object to be
added to the collection association on an active_record object when
inverse_of is used.

In cases where has_many_inversing is set to true, the
set_inverse_instance function calls target= on collection_association during concat
resulting in multiple appends to target. This only occurs for new records. This
PR introduces changes that sets the index so the duplicate object
replaces the original.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
