### PR TITLE
Make ActionDispatch::Routing::RouteWrapper class private since it's o…

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -5,7 +5,7 @@ require "io/console/size"
 
 module ActionDispatch
   module Routing
-    class RouteWrapper < SimpleDelegator
+    class RouteWrapper < SimpleDelegator # :nodoc:
       def endpoint
         app.dispatcher? ? "#{controller}##{action}" : rack_app.inspect
       end


### PR DESCRIPTION
…nly used within Routing module.

### Summary

While working on [this issue](https://github.com/rails/rails/pull/43440) I noticed that the class `ActionDispatch::Routing::RouteWrapper` was only used within `Routing` module as a decorator for `route`. I made it <s>private so we don't use that module outside.</s> `no-doc` 
