### PR TITLE
Import actiontext.css when actiontext is installed

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -32,7 +32,19 @@ module ActionText
       end
 
       def create_actiontext_files
+        destination = Pathname(destination_root)
+
         template "actiontext.css", "app/assets/stylesheets/actiontext.css"
+
+        unless destination.join("app/assets/application.css").exist?
+          if (stylesheets = Dir.glob "#{destination_root}/app/assets/stylesheets/application.*.{scss,css}").length > 0
+            insert_into_file stylesheets.first.to_s, %(@import 'actiontext.css';)
+          else
+            say <<~INSTRUCTIONS, :green
+              To use the Trix editor, you must require 'app/assets/stylesheets/actiontext.css' in your base stylesheet.
+            INSTRUCTIONS
+          end
+        end
 
         gem_root = "#{__dir__}/../../../.."
 

--- a/railties/test/generators/action_text_install_generator_test.rb
+++ b/railties/test/generators/action_text_install_generator_test.rb
@@ -13,6 +13,8 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
     FileUtils.mkdir_p("#{destination_root}/app/javascript")
     FileUtils.touch("#{destination_root}/app/javascript/application.js")
 
+    FileUtils.mkdir_p("#{destination_root}/app/assets/stylesheets")
+
     FileUtils.mkdir_p("#{destination_root}/config")
     FileUtils.touch("#{destination_root}/config/importmap.rb")
   end
@@ -54,6 +56,32 @@ class ActionText::Generators::InstallGeneratorTest < Rails::Generators::TestCase
   test "creates Action Text stylesheet" do
     run_generator_instance
     assert_file "app/assets/stylesheets/actiontext.css"
+  end
+
+  test "appends @import 'actiontext.css' to base scss file" do
+    FileUtils.touch("#{destination_root}/app/assets/stylesheets/application.bootstrap.scss")
+
+    run_generator_instance
+
+    assert_file "app/assets/stylesheets/application.bootstrap.scss" do |content|
+      assert_match "@import 'actiontext.css';", content
+    end
+  end
+
+
+  test "appends @import 'actiontext.css'; to base css file" do
+    FileUtils.touch("#{destination_root}/app/assets/stylesheets/application.postcss.css")
+
+    run_generator_instance
+
+    assert_file "app/assets/stylesheets/application.postcss.css" do |content|
+      assert_match "@import 'actiontext.css';", content
+    end
+  end
+
+  test "throws a warning for missing base (s)css file" do
+    assert_match "To use the Trix editor, you must require 'app/assets/stylesheets/actiontext.css' in your base stylesheet.",
+      run_generator_instance
   end
 
   test "creates Active Storage view partial" do


### PR DESCRIPTION
### Summary

Import actiontext.css when actiontext is installed 

When a Rails app is generated with the --css option and the
action_text:install task is run, the Trix editor will not work as
expected. This occurs because using cssbundling-rails does not create an
application.css file, which would normally automatically require
actiontext.css.

Adding a step to append an import statement to the base CSS or SCSS
file, when one can be detected, solves the issue. In the case a base CSS
or SCSS file can't be detected, we output a warning to import the
necessary CSS file.

Closes: #43441