### PR TITLE
Document alternative smtp_settings options

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1228,6 +1228,8 @@ Allows detailed configuration for the `:smtp` delivery method. It accepts a hash
 * `:open_timeout` - Number of seconds to wait while attempting to open a connection.
 * `:read_timeout` - Number of seconds to wait until timing-out a read(2) call.
 
+Additionally, it is possible to pass any [configuration option `Mail::SMTP` respects](https://github.com/mikel/mail/blob/master/lib/mail/network/delivery_methods/smtp.rb).
+
 #### `config.action_mailer.smtp_timeout`
 
 Allows to configure both the `:open_timeout` and `:read_timeout`


### PR DESCRIPTION
### Summary
[Mail supports this option](https://github.com/mikel/mail/blob/4f56234f04eb041810641ee0dfd717034a59b9dc/lib/mail/network/delivery_methods/smtp.rb#L86), so it could make sense to allow developers to configure this option inside of Rails.

I'm not very knowledgeable about this part of Rails, but this seemed really simple. I'm open to any feedback!

Closes: https://github.com/rails/rails/issues/43339
