### PR TITLE
Use webdriver 4.6.1 or higher to support selenium-webdriver 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,8 @@ gem "aws-sdk-sns", require: false
 gem "webmock"
 
 group :ujs do
-  gem "webdrivers"
+  # ">= 4.6.1" can be removed once https://github.com/titusfortner/webdrivers/pull/218 is merged and released.
+  gem "webdrivers", ">= 4.6.1"
 end
 
 # Action View

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,7 +505,7 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.6)
       rexml (~> 3.2)
-    webdrivers (4.6.0)
+    webdrivers (4.6.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -600,7 +600,7 @@ DEPENDENCIES
   tzinfo-data
   w3c_validators (~> 1.3.6)
   wdm (>= 0.1.0)
-  webdrivers
+  webdrivers (>= 4.6.1)
   webmock
   webrick
   websocket-client-simple!


### PR DESCRIPTION
### Summary

This pull request forces bundler to use webdriver 4.6.1 or higher to workaround #43455 until titusfortner/webdrivers#218 is merged and released.

Fix #43455
Related to https://github.com/titusfortner/webdrivers/pull/218