### PR TITLE
When generating form partials, use correct fields for date, time and datetime

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+*   Scaffolds now use date_field, time_field and datetime_field instead of
+    date_select, time_select and datetime_select; thus providing native date/time pickers.
+
+    *Martijn Lafeber*
+
 *   Fix a regression in which autoload paths were initialized too late.
 
     *Xavier Noria*

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -106,9 +106,9 @@ module Rails
         @field_type ||= case type
                         when :integer                  then :number_field
                         when :float, :decimal          then :text_field
-                        when :time                     then :time_select
-                        when :datetime, :timestamp     then :datetime_select
-                        when :date                     then :date_select
+                        when :time                     then :time_field
+                        when :datetime, :timestamp     then :datetime_field
+                        when :date                     then :date_field
                         when :text                     then :text_area
                         when :rich_text                then :rich_text_area
                         when :boolean                  then :check_box

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -29,16 +29,16 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
 
   def test_field_type_returns_datetime_select
     %w(datetime timestamp).each do |attribute_type|
-      assert_field_type attribute_type, :datetime_select
+      assert_field_type attribute_type, :datetime_field
     end
   end
 
   def test_field_type_returns_time_select
-    assert_field_type :time, :time_select
+    assert_field_type :time, :time_field
   end
 
   def test_field_type_returns_date_select
-    assert_field_type :date, :date_select
+    assert_field_type :date, :date_field
   end
 
   def test_field_type_returns_text_area


### PR DESCRIPTION
### Summary

This changes the scaffolding to use `date_field`, `time_field` and `datetime_field` instead of `date_select`, `time_select` and `datetime_select`

### Other Information

Native pickers have been supported by mobile browsers for quite some time. More recently, Safari (14.1) and Firefox (93) are the last of the desktop browsers to implement [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) input. The input types [date](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date) and [time](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time) have been supported by earlier versions. The usability is much nicer than multiple select boxes, especially on mobile.

This will change the scaffolding from (Chrome screenshots):

<img width="356" alt="Screenshot 2021-10-14 at 09 01 05" src="https://user-images.githubusercontent.com/37751/137268293-9dc88319-dc0e-4dce-a27c-858dea038155.png">

to:

<img width="246" alt="Screenshot 2021-10-14 at 09 01 29" src="https://user-images.githubusercontent.com/37751/137268312-c66b468e-83d2-4c9a-a444-f028a7610b3a.png">
