### PR TITLE
Fix Selenium deprecation warnings in CI.

### DIFF
--- a/ci/qunit-selenium-runner.rb
+++ b/ci/qunit-selenium-runner.rb
@@ -4,14 +4,16 @@ require "webdrivers"
 require_relative "test_run"
 
 driver = if ARGV[1]
-  ::Selenium::WebDriver.for(:remote, url: ARGV[1], desired_capabilities: :chrome)
+  capability = ::Selenium::WebDriver::Remote::Capabilities.chrome
+  
+  ::Selenium::WebDriver.for(:remote, url: ARGV[1], capabilities: [capability])
 else
   driver_options = Selenium::WebDriver::Chrome::Options.new
   driver_options.add_argument("--headless")
   driver_options.add_argument("--disable-gpu")
   driver_options.add_argument("--no-sandbox")
 
-  ::Selenium::WebDriver.for(:chrome, options: driver_options)
+  ::Selenium::WebDriver.for(:chrome, capabilities: [driver_options])
 end
 
 driver.get(ARGV[0])


### PR DESCRIPTION
In collaboration with @gmcgibbon.

### Summary
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
This PR fixes the Selenium deprecation warnings in the CI's `test:ujs` task.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

More specifically, this PR fixes the two following deprecation warnings:

```
WARN Selenium [DEPRECATION] [:desired_capabilities] :desired_capabilities as a parameter for driver initialization is deprecated. Use :capabilities with an Array value of capabilities/options if necessary instead.
```

and

```
WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
```

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
