### PR TITLE
Add validation for ActiveRecord.default_timezone

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -185,12 +185,19 @@ module ActiveRecord
   singleton_class.attr_accessor :legacy_connection_handling
   self.legacy_connection_handling = true
 
-  ##
-  # :singleton-method:
   # Determines whether to use Time.utc (using :utc) or Time.local (using :local) when pulling
   # dates and times from the database. This is set to :utc by default.
-  singleton_class.attr_accessor :default_timezone
-  self.default_timezone = :utc
+  def self.default_timezone=(default_timezone)
+    unless %i[local utc].include?(default_timezone)
+      raise ArgumentError, 'default_timezone must be either :utc (default) or :local'
+    end
+
+    @default_timezone = default_timezone
+  end
+
+  def self.default_timezone
+    @default_timezone ||= :utc
+  end
 
   singleton_class.attr_accessor :writing_role
   self.writing_role = :writing

--- a/activerecord/test/cases/date_time_test.rb
+++ b/activerecord/test/cases/date_time_test.rb
@@ -7,6 +7,16 @@ require "models/task"
 class DateTimeTest < ActiveRecord::TestCase
   include InTimeZone
 
+  def test_default_timezone_validation
+    assert_raises ArgumentError do
+      ActiveRecord.default_timezone = 'UTC'
+    end
+
+    # These values should not raise errors
+    ActiveRecord.default_timezone = :local
+    ActiveRecord.default_timezone = :utc
+  end
+
   def test_saves_both_date_and_time
     with_env_tz "America/New_York" do
       with_timezone_config default: :utc do


### PR DESCRIPTION
### Summary

`ActiveRecord.default_timezone` has a very limited set of valid values (`:local` or `:utc`). However, the name can mislead you into assigning it some timezone name.

Pretty much all code that deals with this configuration option later on will check equality with `:utc`. So there would never be an exception or any other error state caused by the misconfiguration.

We had a bug where we set it to `'UTC'` (the string). In this case, the configuration actually does _the opposite of what it appears to do_:

```ruby
# Don't do this! Example of BROKEN configuration
config.active_record.default_timezone = 'UTC'
```

Here is an issue caused by the same misunderstanding: https://github.com/rails/rails/issues/39938

To mitigate this, I've added a validation of the option that only allows `:local` or `:utc`:

```
in `default_timezone=': default_timezone must be either :utc (default) or :local (ArgumentError)
```

### Other information

I'm not sure where should I put the test, so please advise.