### PR TITLE
add rexml dependency

### DIFF
--- a/activesupport/activesupport.gemspec
+++ b/activesupport/activesupport.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_dependency "tzinfo",          "~> 2.0"
   s.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.2"
   s.add_dependency "minitest",        ">= 5.1"
+  s.add_dependency "rexml",           ">= 3.2"
 end


### PR DESCRIPTION
### Summary
`rexml` gem is a bundled gem since Ruby 3.0.0. So it should be added to `activesupport.gemspec` as dependency, because  `XmlMini.backend = "REXML"` is still in use. As result `Hash.from_xml` will raise exception in environments without test & development group gems.

fixes: #43463