### PR TITLE
No need to specify webdrivers version to support selenium-webdriver 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,8 +101,7 @@ gem "aws-sdk-sns", require: false
 gem "webmock"
 
 group :ujs do
-  # ">= 4.6.1" can be removed once https://github.com/titusfortner/webdrivers/pull/218 is merged and released.
-  gem "webdrivers", ">= 4.6.1"
+  gem "webdrivers"
 end
 
 # Action View

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,10 +505,10 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.6)
       rexml (~> 3.2)
-    webdrivers (4.6.1)
+    webdrivers (4.7.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
+      selenium-webdriver (> 3.141, < 5.0)
     webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -600,7 +600,7 @@ DEPENDENCIES
   tzinfo-data
   w3c_validators (~> 1.3.6)
   wdm (>= 0.1.0)
-  webdrivers (>= 4.6.1)
+  webdrivers
   webmock
   webrick
   websocket-client-simple!


### PR DESCRIPTION
### Summary

`webdrivers` 4.7.0 has been released including https://github.com/titusfortner/webdrivers/pull/218 which supports selenium-webdriver 4.0.0

Refer
https://github.com/titusfortner/webdrivers/blob/main/CHANGELOG.md#470-2021-10-14
Related to #43456
