### PR TITLE
Configure the list of columns to update in upsert_all

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Add a new option `:update_only` to `upsert_all` to configure the list of columns to update in case of conflict.
+
+    Before, you could only customize the update SQL sentence via `:on_duplicate`. There is now a new option `:update_only` that lets you provide a list of columns to update in case of conflict:
+
+    ```ruby
+    Commodity.upsert_all(
+      [
+        { id: 2, name: "Copper", price: 4.84 },
+        { id: 4, name: "Gold", price: 1380.87 },
+        { id: 6, name: "Aluminium", price: 0.35 }
+      ],
+      update_only: [:price] # Only prices will be updated
+    )
+    ```
+
+    *Jorge Manrubia*
+
 *   Remove deprecated `ActiveRecord::Result#map!` and `ActiveRecord::Result#collect!`.
 
     *Rafael Mendonça França*


### PR DESCRIPTION
#41933 added a new `on_duplicate:` option to `upsert_all`, to allow providing custom SQL update code. This PR makes `on_duplicate` admit an array of columns too, so that `upsert_all` only updates those columns when a conflict happens.

Main motivation is limiting the list of updated columns in a database-agnostic way.

Pending:

- [x] Changelog update

CC @palkan @rafaelfranca 

