### PR TITLE
Create directory when dumping schema cache

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -239,6 +239,8 @@ module ActiveRecord
         end
 
         def open(filename)
+          FileUtils.mkdir_p(File.dirname(filename))
+
           File.atomic_write(filename) do |file|
             if File.extname(filename) == ".gz"
               zipper = Zlib::GzipWriter.new file

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -39,6 +39,14 @@ module ActiveRecord
         tempfile.unlink
       end
 
+      def test_cache_path_can_be_in_directory
+        cache = SchemaCache.new @connection
+        filename = "some_dir/schema.json"
+        assert cache.dump_to(filename)
+      ensure
+        File.delete(filename)
+      end
+
       def test_yaml_dump_and_load_with_gzip
         # Create an empty cache.
         cache = SchemaCache.new @connection


### PR DESCRIPTION
Since we have the schema cache path option an application author may
want to put the cache in a directory (like `db/schema_caches`) but our
current code would fail if we don't create the directory. We should
always create the directory when dumping the cache.