### PR TITLE
Add negative scopes to delegated types

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add support for negative scopes on delegated types
+
+    *Nick Pezza*
+
 *   Allow to configure `strict_loading_mode` globally or within a model.
 
     Defaults to `:all`, can be changed to `:n_plus_one_only`.

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -184,10 +184,12 @@ module ActiveRecord
     #   Entry#entryable_class # => +Message+ or +Comment+
     #   Entry#entryable_name  # => "message" or "comment"
     #   Entry.messages        # => Entry.where(entryable_type: "Message")
+    #   Entry.not_messages    # => Entry.where.not(entryable_type: "Message")
     #   Entry#message?        # => true when entryable_type == "Message"
     #   Entry#message         # => returns the message record, when entryable_type == "Message", otherwise nil
     #   Entry#message_id      # => returns entryable_id, when entryable_type == "Message", otherwise nil
     #   Entry.comments        # => Entry.where(entryable_type: "Comment")
+    #   Entry.not_comments    # => Entry.where.not(entryable_type: "Comment")
     #   Entry#comment?        # => true when entryable_type == "Comment"
     #   Entry#comment         # => returns the comment record, when entryable_type == "Comment", otherwise nil
     #   Entry#comment_id      # => returns entryable_id, when entryable_type == "Comment", otherwise nil
@@ -261,6 +263,7 @@ module ActiveRecord
           query      = "#{singular}?"
 
           scope scope_name, -> { where(role_type => type) }
+          scope "not_#{scope_name}", -> { where.not(role_type => type) }
 
           define_method query do
             public_send(role_type) == type

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -70,6 +70,11 @@ class DelegatedTypeTest < ActiveRecord::TestCase
     assert_predicate Entry.posts.first, :post?
   end
 
+  test "negative scope" do
+    assert Entry.not_messages.first.comment?
+    assert Entry.not_comments.first.message?
+  end
+
   test "accessor" do
     assert @entry_with_message.message.is_a?(Message)
     assert_nil @entry_with_message.comment


### PR DESCRIPTION
### Summary

Similar to negative scopes on enums this adds negative scopes on delegated types.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
