### PR TITLE
Use the native `Class#descendants` if available

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -18,7 +18,7 @@ class Class
     ObjectSpace.each_object(singleton_class).reject do |k|
       k.singleton_class? || k == self
     end
-  end
+  end unless method_defined?(:descendants) # RUBY_VERSION >= "3.1"
 
   # Returns an array with the direct children of +self+.
   #


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/14394
Ref: https://github.com/ruby/ruby/pull/4974

Ruby 3.1 is very likely to ship with a native implementation of `Class#descendants` that doesn't need to iterate over ObjectSpace. So we should use it if available.

I'll wait for the Ruby PR to be merged before merging it here. We'd also need to skip most of `DescendantsTracker` as well, but I'm not quite sure how to detect that yet, I'd rather avoid a `RUBY_VERSION` check if possible.