### PR TITLE
Validate encrypted message format in Active Record Encryption

### DIFF
--- a/activerecord/lib/active_record/encryption/message_serializer.rb
+++ b/activerecord/lib/active_record/encryption/message_serializer.rb
@@ -33,8 +33,18 @@ module ActiveRecord
 
       private
         def parse_message(data, level)
-          raise ActiveRecord::Encryption::Errors::Decryption, "More than one level of hash nesting in headers is not supported" if level > 2
+          validate_message_data_format(data, level)
           ActiveRecord::Encryption::Message.new(payload: decode_if_needed(data["p"]), headers: parse_properties(data["h"], level))
+        end
+
+        def validate_message_data_format(data, level)
+          if level > 2
+            raise ActiveRecord::Encryption::Errors::Decryption, "More than one level of hash nesting in headers is not supported"
+          end
+
+          unless data.is_a?(Hash) && data.has_key?("p")
+            raise ActiveRecord::Encryption::Errors::Decryption, "Invalid data format: hash without payload"
+          end
         end
 
         def parse_properties(headers, level)

--- a/activerecord/test/cases/encryption/message_serializer_test.rb
+++ b/activerecord/test/cases/encryption/message_serializer_test.rb
@@ -22,10 +22,28 @@ class ActiveRecord::Encryption::MessageSerializerTest < ActiveRecord::Encryption
   end
 
   test "won't load classes from JSON" do
-    class_loading_payload = '{"json_class": "MessageSerializerTest::SomeClassThatWillNeverExist"}'
+    class_loading_payload = JSON.dump({ p: ::Base64.strict_encode64("Some payload"), json_class: "MessageSerializerTest::SomeClassThatWillNeverExist" })
 
     assert_raises(ArgumentError) { JSON.load(class_loading_payload) }
     assert_nothing_raised { @serializer.load(class_loading_payload) }
+  end
+
+  test "detects random JSON data and raises an invalid dencryption error" do
+    assert_raises ActiveRecord::Encryption::Errors::Decryption do
+      @serializer.load JSON.dump("hey there")
+    end
+  end
+
+  test "detects random JSON hashes and raises an invalid decryption error" do
+    assert_raises ActiveRecord::Encryption::Errors::Decryption do
+      @serializer.load JSON.dump({ some: "other data" })
+    end
+  end
+
+  test "detects JSON hashes with a 'p' key that is not encoded in base64" do
+    assert_raises ActiveRecord::Encryption::Errors::Encoding do
+      @serializer.load JSON.dump({ p: "some data not encoded" })
+    end
   end
 
   test "raises ForbiddenClass when trying to serialize other data types" do


### PR DESCRIPTION
This change will make AR encryption validate the serialized format of encrypted payloads in order to consider them "encrypted".

ActiveRecord's default message serializer is based on JSON. Before this patch, it could happen that it would consider random data as "encrypted" because it could be parsed as JSON. For example: the string `"\"hello\""` that parses a a JSON string, or the JSON hash `"{\"some\":\"data\"}"`. This would result in an error at encryption time.
