### PR TITLE
Add `ActiveRecord::Base.prohibit_shard_swapping`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `ActiveRecord::Base.prohibit_shard_swapping` to prevent attempts to change the shard within a block.
+
+    *John Crepezzi*, *Eileen M. Uchitelle*
+
 *   Filter unchanged attributes with default function from insert query when `partial_inserts` is disabled.
 
     *Akshay Birajdar*, *Jacopo Beschi*

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -182,7 +182,7 @@ module ActiveRecord
 
       prevent_writes = true if role == ActiveRecord.reading_role
 
-      connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes }
+      append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: classes)
       yield
     ensure
       connected_to_stack.pop
@@ -202,7 +202,25 @@ module ActiveRecord
 
       prevent_writes = true if role == ActiveRecord.reading_role
 
-      self.connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self] }
+      append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
+    end
+
+    # Prohibit swapping shards while inside of the passed block.
+    #
+    # In some cases you may want to be able to swap shards but not allow a
+    # nested call to connected_to or connected_to_many to swap again. This
+    # is useful in cases you're using sharding to provide per-request
+    # database isolation.
+    def prohibit_shard_swapping
+      Thread.current.thread_variable_set(:prohibit_shard_swapping, true)
+      yield
+    ensure
+      Thread.current.thread_variable_set(:prohibit_shard_swapping, false)
+    end
+
+    # Determine whether or not shard swapping is currently prohibited
+    def shard_swapping_prohibited?
+      Thread.current.thread_variable_get(:prohibit_shard_swapping)
     end
 
     # Prevent writing to the database regardless of role.
@@ -357,18 +375,26 @@ module ActiveRecord
         if ActiveRecord.legacy_connection_handling
           with_handler(role.to_sym) do
             connection_handler.while_preventing_writes(prevent_writes) do
-              self.connected_to_stack << { shard: shard, klasses: [self] }
+              append_to_connected_to_stack(shard: shard, klasses: [self])
               yield
             end
           end
         else
-          self.connected_to_stack << { role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self] }
+          append_to_connected_to_stack(role: role, shard: shard, prevent_writes: prevent_writes, klasses: [self])
           return_value = yield
           return_value.load if return_value.is_a? ActiveRecord::Relation
           return_value
         end
       ensure
         self.connected_to_stack.pop
+      end
+
+      def append_to_connected_to_stack(entry)
+        if shard_swapping_prohibited? && entry[:shard].present?
+          raise ArgumentError, "cannot swap `shard` while shard swapping is prohibited."
+        end
+
+        connected_to_stack << entry
       end
 
       def swap_connection_handler(handler, &blk) # :nodoc:


### PR DESCRIPTION
### Summary

When using sharded databases for the lifecycle of an entire request,
it's often desirable to ensure that the databases shard is not
unintentionally changed.

This commit introduces `ActiveRecord::Base.prohibit_shard_swapping`
which takes a block and prevents swapping of shards for its duration.

cc / @eileencodes 