### PR TITLE
re-add viewport meta tag to application layout

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title><%= camelized %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -182,7 +182,7 @@ module ApplicationTests
     end
 
     def test_code_statistics
-      assert_match "Code LOC: 61     Test LOC: 3     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 62     Test LOC: 3     Code to Test Ratio: 1:0.0",
         rails("stats")
     end
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -551,6 +551,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_viewport_meta_tag_is_present
+    run_generator [destination_root]
+
+    assert_file "app/views/layouts/application.html.erb" do |contents|
+      assert_match(/<meta name="viewport"/, contents)
+    end
+  end
+
   def test_javascript_is_skipped_if_required
     run_generator [destination_root, "--skip-javascript"]
 


### PR DESCRIPTION
Viewport meta tag was removed by mistake as  discussed here https://github.com/rails/rails/commit/164c2f625742da95407c44c70a381e2c80e4e118#r57539098

Cc / @dhh @hahmed 