### PR TITLE
Add `:except_on` option for validations

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `:except_on` option for validations. Grants the ability to _skip_ validations in specified contexts.
+
+    ```ruby
+    class User < ApplicationRecord
+        #...
+        validates :birthday, presence: { except_on: :admin }
+        #...
+    end
+
+    user = User.new(attributes except birthday)
+    user.save(context: :admin)
+    ```
+
+    *Drew Bragg*
+
 ## Rails 8.0.0.beta1 (September 26, 2024) ##
 
 *   Make `ActiveModel::Serialization#read_attribute_for_serialization` public

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -69,6 +69,11 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   <tt>except_on: :custom_validation_context</tt> or
+      #   <tt>except_on: [:create, :custom_validation_context]</tt>)
       # * <tt>:allow_nil</tt> - Skip validation if attribute is +nil+.
       # * <tt>:allow_blank</tt> - Skip validation if attribute is blank.
       # * <tt>:if</tt> - Specifies a method, proc, or string to call to determine
@@ -84,7 +89,7 @@ module ActiveModel
         validates_with BlockValidator, _merge_attributes(attr_names), &block
       end
 
-      VALID_OPTIONS_FOR_VALIDATE = [:on, :if, :unless, :prepend].freeze # :nodoc:
+      VALID_OPTIONS_FOR_VALIDATE = [:on, :if, :unless, :prepend, :except_on].freeze # :nodoc:
 
       # Adds a validation method or block to the class. This is useful when
       # overriding the +validate+ instance method becomes too unwieldy and
@@ -135,7 +140,12 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
-      # * <tt>:if</tt> - Specifies a method, proc, or string to call to determine
+      # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   <tt>except_on: :custom_validation_context</tt> or
+      #   <tt>except_on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
       #   proc or string should return or evaluate to a +true+ or +false+ value.
@@ -160,6 +170,15 @@ module ActiveModel
 
         if options.key?(:on)
           options = options.merge(if: [predicate_for_validation_context(options[:on]), *options[:if]])
+        end
+
+        if options.key?(:except_on)
+          options = options.dup
+          options[:except_on] = Array(options[:except_on])
+          options[:unless] = [
+            ->(o) { (options[:except_on] & Array(o.validation_context)).any? },
+            *options[:unless]
+          ]
         end
 
         set_callback(:validate, *args, options, &block)

--- a/activemodel/lib/active_model/validations/validates.rb
+++ b/activemodel/lib/active_model/validations/validates.rb
@@ -78,7 +78,12 @@ module ActiveModel
       #   or an array of symbols. (e.g. <tt>on: :create</tt> or
       #   <tt>on: :custom_validation_context</tt> or
       #   <tt>on: [:create, :custom_validation_context]</tt>)
-      # * <tt>:if</tt> - Specifies a method, proc, or string to call to determine
+      # * <tt>:except_on</tt> - Specifies the contexts where this validation is not active.
+      #   Runs in all validation contexts by default +nil+. You can pass a symbol
+      #   or an array of symbols. (e.g. <tt>except: :create</tt> or
+      #   <tt>except_on: :custom_validation_context</tt> or
+      #   <tt>except_on: [:create, :custom_validation_context]</tt>)
+      # * <tt>:if</tt> - Specifies a method, proc or string to call to determine
       #   if the validation should occur (e.g. <tt>if: :allow_validation</tt>,
       #   or <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method,
       #   proc or string should return or evaluate to a +true+ or +false+ value.
@@ -155,7 +160,7 @@ module ActiveModel
       # When creating custom validators, it might be useful to be able to specify
       # additional default keys. This can be done by overwriting this method.
       def _validates_default_keys
-        [:if, :unless, :on, :allow_blank, :allow_nil, :strict]
+        [:if, :unless, :on, :allow_blank, :allow_nil, :strict, :except_on]
       end
 
       def _parse_validates_options(options)


### PR DESCRIPTION
### Summary

Leveraging `on` gives us the ability to run certain validations in certain contexts. This PR will give us the ability to _skip_ certain validations in certain contexts.

For example, say we have an admin dashboard where an admin can add users but may not have complete data for them.  Normally, we want a users birthday to be present but we dont want to require an admin to know it in order to add a person. Instead of needing to do something like:
```ruby
class User < ApplicationRecord
  #...
  validates :birthday, presence: { on: [:create, :update] }
  #...
end

user = User.new(attributes except birthday)
user.save(context: :admin)
```
We can instead do:
```ruby
class User < ApplicationRecord
  #...
  validates :birthday, presence: { except_on: :admin }
  #...
end

user = User.new(attributes except birthday)
user.save(context: :admin)
```

### Other Information

This would probably be useful for callbacks also but I thought I'd start here and gauge feedback before I go down that path.