### PR TITLE
Address `Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated.`

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -52,7 +52,7 @@ module ActionDispatch
         end
 
         def browser_options
-          @options.merge(options: @browser.options).compact
+          @options.merge(capabilities: @browser.options).compact
         end
 
         def register_selenium(app)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -79,7 +79,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "chrome"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "define extra capabilities using headless_chrome" do
@@ -99,7 +99,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "chrome"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "define extra capabilities using firefox" do
@@ -117,7 +117,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "firefox"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "define extra capabilities using headless_firefox" do
@@ -135,7 +135,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "firefox"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "does not define extra capabilities" do


### PR DESCRIPTION
### Summary

This commit addresses the deprecation warning since https://github.com/SeleniumHQ/selenium/pull/7832 is available as `selenium-webdriver` 4.0.0.

- Deprecation warning addressed

```ruby
WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
```

- Steps to reproduce (if you have sample app with system tests, you can use it)

```ruby
git clone https://github.com/yahonda/rep43493
cd rep43493
bundle install
bin/rails test:system
```

Please ignore `4 runs, 1 assertions, 0 failures, 3 errors, 0 skips` since I have not implemented any tests.
Just wanted to see if the deprecation is removed or not.

- Without this commit

```ruby
% bin/rails test:system
Run options: --seed 61164

# Running:

DEBUGGER: Detaching after fork from parent process 96379
DEBUGGER: Attaching after process 96379 fork to child process 96398
2021-10-20 12:14:40 WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
Capybara starting Puma...
* Version 5.5.2 , codename: Zawgyi
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:55905
...
```

- With this commit

```ruby
% bin/rails test:system
Run options: --seed 30906

# Running:

DEBUGGER: Detaching after fork from parent process 96604
DEBUGGER: Attaching after process 96604 fork to child process 96622
Capybara starting Puma...
* Version 5.5.2 , codename: Zawgyi
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:56015
[Screenshot Image]: /Users/yahonda/rep43493/tmp/screenshots/failures_test_should_create_User.png
```

Fix #43493
