### PR TITLE
ActionView: escape key attributes

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -137,6 +137,7 @@ module ActionView
             value = escape ? ERB::Util.unwrapped_html_escape(value) : value.to_s
           end
           value = value.gsub('"', "&quot;") if value.include?('"')
+          key = escape ? ERB::Util.unwrapped_html_escape(key) : key.to_s
           %(#{key}="#{value}")
         end
 

--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -404,9 +404,29 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_attributes_escapes_values
-    assert_not_includes "<script>alert()</script>", render_erb(<<~HTML.strip)
-      <input type="text" <%= tag.attributes xss: '"><script>alert()</script>' %>>
+    rendered = render_erb(<<~HTML.strip)
+      <input type="text" <%= tag.attributes xss: '"><script>evil_js</script>' %>>
     HTML
+
+    assert_not rendered.include?("<script>evil_js</script>")
+  end
+
+  def test_tag_attributes_escapes_keys
+    rendered = render_erb(<<~HTML.strip)
+      <input type="text" <%= tag.attributes '"><script>evil_js</script>': :xss %>>
+    HTML
+    assert_not rendered.include?("<script>evil_js</script>")
+  end
+
+  def test_content_tag_escapes_values
+    rendered = render_erb(content_tag(:div, "", xss: '"><script>evil_js</script>'))
+
+    assert_not rendered.include?("<script>evil_js</script>")
+  end
+
+  def test_content_tag_escapes_keys
+    rendered = render_erb(content_tag(:div, "", '"><script>evil_js</script>': :xss))
+    assert_not rendered.include?("<script>evil_js</script>")
   end
 
   def test_tag_attributes_nil


### PR DESCRIPTION
### Summary

When using the method `content_tag`, or any public methods that used `tag_option`, with the parameters `escape: true` only the value is sanitized not the key.

- This is not specified in the documentation
- I see no reason to not escape the key

Reason to also escape HTML attribute keys :
- It's not a fixed list, for example with `data-` attributes we can set whatever we want has a key

### Other Information

Example of wrong case (see spec for more):
```ruby
> result = content_tag(:div, "", { '"><script>evil_js</script>': :xss }, true)
=> "<div \"><script>evil_js</script>=\"xss\"></div>"
> result.class
=> ActiveSupport::SafeBuffer
```

We could also have a discussion about the `tag` method

```ruby
> tag('<script>evil_js</script>', {key: 'value'}, true)
=> "<<script>evil_js</script> key=\"value\">"
```