### PR TITLE
Rails 7.0 requires selenium-webdriver >= 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rake", ">= 11.1"
 gem "sprockets-rails", ">= 2.0.0"
 gem "propshaft", ">= 0.1.7"
 gem "capybara", ">= 3.26"
-gem "selenium-webdriver", ">= 4.0.0.alpha7"
+gem "selenium-webdriver", ">= 4.0.0"
 
 gem "rack-cache", "~> 1.2"
 gem "stimulus-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,14 +430,14 @@ GEM
     ruby-vips (2.1.2)
       ffi (~> 1.12)
     ruby2_keywords (0.0.4)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     rufus-scheduler (3.7.0)
       fugit (~> 1.1, >= 1.1.6)
     sdoc (2.2.0)
       rdoc (>= 5.0)
-    selenium-webdriver (4.0.0.beta4)
+    selenium-webdriver (4.0.3)
       childprocess (>= 0.5, < 5.0)
-      rexml (~> 3.2)
+      rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
     sequel (5.45.0)
     serverengine (2.0.7)
@@ -505,10 +505,10 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.6)
       rexml (~> 3.2)
-    webdrivers (4.7.0)
+    webdrivers (5.0.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
-      selenium-webdriver (> 3.141, < 5.0)
+      selenium-webdriver (~> 4.0)
     webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -584,7 +584,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   sdoc (>= 2.2.0)
-  selenium-webdriver (>= 4.0.0.alpha7)
+  selenium-webdriver (>= 4.0.0)
   sequel
   sidekiq
   sneakers

--- a/actionpack/lib/action_dispatch/system_testing/browser.rb
+++ b/actionpack/lib/action_dispatch/system_testing/browser.rb
@@ -33,19 +33,9 @@ module ActionDispatch
       def preload
         case type
         when :chrome
-          if ::Selenium::WebDriver::Service.respond_to? :driver_path=
-            ::Selenium::WebDriver::Chrome::Service.driver_path&.call
-          else
-            # Selenium <= v3.141.0
-            ::Selenium::WebDriver::Chrome.driver_path
-          end
+          ::Selenium::WebDriver::Chrome::Service.driver_path&.call
         when :firefox
-          if ::Selenium::WebDriver::Service.respond_to? :driver_path=
-            ::Selenium::WebDriver::Firefox::Service.driver_path&.call
-          else
-            # Selenium <= v3.141.0
-            ::Selenium::WebDriver::Firefox.driver_path
-          end
+          ::Selenium::WebDriver::Firefox::Service.driver_path&.call
         end
       end
 

--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -21,6 +21,7 @@ module ActionDispatch
         end
 
         if driver_type == :selenium
+          gem "selenium-webdriver", ">= 4.0.0"
           require "selenium/webdriver"
           @browser = Browser.new(options[:using])
           @browser.preload


### PR DESCRIPTION
New Rails 7.0 generator produces a Gemfile with "selenium-webdriver",
">= 4.0.0" to support Ruby 3.0 (#43270), and latest webdrivers 5.0.0
requires selenium-webdriver ~ 4.0.

https://rubygems.org/gems/webdrivers/versions/5.0.0

It is time to drop selenium-webdriver 3.x support for Rails 7.0.
