### PR TITLE
Use safer 'destroy!' in controller scaffolds

### DIFF
--- a/railties/lib/rails/generators/active_model.rb
+++ b/railties/lib/rails/generators/active_model.rb
@@ -73,7 +73,7 @@ module Rails
 
       # DELETE destroy
       def destroy
-        "#{name}.destroy"
+        "#{name}.destroy!"
       end
     end
   end

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -51,7 +51,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@product_line\.destroy/, m)
+        assert_match(/@product_line\.destroy!/, m)
       end
 
       assert_instance_method :set_product_line, content do |m|
@@ -137,7 +137,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@product_line\.destroy/, m)
+        assert_match(/@product_line\.destroy!/, m)
       end
     end
 
@@ -254,7 +254,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       end
 
       assert_instance_method :destroy, content do |m|
-        assert_match(/@admin_role\.destroy/, m)
+        assert_match(/@admin_role\.destroy!/, m)
       end
 
       assert_instance_method :set_admin_role, content do |m|


### PR DESCRIPTION
The old code does

    @foo.destroy
    redirect_to foo_url, notice: "Foo was successfully destroyed."

which would incorrectly state the record was destroyed even if prevented by a `before_destroy` callback.

The new version would raise.

Another option would be to have an if/else, but undestroyable records are perhaps uncommon enough that this is a more sensible default? Especially since most of the time you'd probably disable/remove the "delete" action from the UI when undestroyable.