### PR TITLE
Backport #43496 – Selenium deprecation warnings in system tests – to `6-1-stable`

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/driver.rb
+++ b/actionpack/lib/action_dispatch/system_testing/driver.rb
@@ -40,7 +40,7 @@ module ActionDispatch
         end
 
         def browser_options
-          @options.merge(options: @browser.options).compact
+          @options.merge(capabilities: @browser.options).compact
         end
 
         def register_selenium(app)

--- a/actionpack/test/dispatch/system_testing/driver_test.rb
+++ b/actionpack/test/dispatch/system_testing/driver_test.rb
@@ -72,7 +72,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "chrome"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "define extra capabilities using headless_chrome" do
@@ -92,7 +92,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "chrome"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "define extra capabilities using firefox" do
@@ -110,7 +110,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "firefox"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "define extra capabilities using headless_firefox" do
@@ -128,7 +128,7 @@ class DriverTest < ActiveSupport::TestCase
       },
       "browserName" => "firefox"
     }
-    assert_equal expected, browser_options[:options].as_json
+    assert_equal expected, browser_options[:capabilities].as_json
   end
 
   test "does not define extra capabilities" do


### PR DESCRIPTION
Backporting since I believe all users of Rails 6.1 are also affected by this. I know we are at work and would like to update to selenium 4 before Rails 7 is released.
