### PR TITLE
Enable eager loading by default on CI systems

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -11,9 +11,9 @@ Rails.application.configure do
   # Turn false under Spring and add config.action_view.cache_template_loading = true
   config.cache_classes = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -14,7 +14,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
This is a pattern we've been using for ages at Shopify.

When you are running test locally, most of the time you run only a subset, so it's better to load as little code as possible to have a faster time to first test result.

But when you are on CI, it's usually much preferable to eager load the whole application because you will likely need all the code anyway, and even if the test suite is split across runners, it's preferable to load all the code to ensure any codefile that may have side effects is loaded.

This also ensure that if some autoloaded constants are not properly tested on CI, at least they'll be loaded and obvious errors (e.g. SyntaxError) will be caught on CI rather than during deploy.

cc @fxn 