### PR TITLE
Add ability to define connections in a yaml file

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,40 @@
+*   Add ability to define connections in a separate YAML file.
+
+    Rails will now parse a `connections.yml` file if present. This file takes precedence over `connects_to` in the models. The feature is useful for applications that are using tenant sharding or need more dynamic connection management. While the feature is more useful for sharding, it can be used for roles as well.
+
+    Simply create a `config/connections.yml` file in your application and setup your connections like you would in the model. Note that this will only work with database configurations that are defined in your `config/database.yml`.
+
+    ```yml
+    ApplicationRecord:
+      shards:
+        default:
+          writing: primary
+          reading: primary_replica
+        shard_one:
+          writing: shard_one_primary
+          reading: shard_one_replica
+    AnimalsRecord:
+      database:
+        writing: animals
+        reading: animals_replica
+    ```
+
+    ```ruby
+    class ApplicationRecord < ActiveRecord::Base
+      primary_abstract_class
+
+      connects_to_file
+    end
+
+    class AnimalsRecord < ApplicationRecord
+      self.abstract_class = true
+
+      connects_to_file
+    end
+    ```
+
+    *Eileen M. Uchitelle*, *John Crepezzi*
+
 *   Add `ActiveRecord::Base.prohibit_shard_swapping` to prevent attempts to change the shard within a block.
 
     *John Crepezzi*, *Eileen M. Uchitelle*

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -11,6 +11,7 @@ require "active_record/relation/delegation"
 require "active_record/attributes"
 require "active_record/type_caster"
 require "active_record/database_configurations"
+require "active_record/connection_configurations"
 
 module ActiveRecord # :nodoc:
   # = Active Record

--- a/activerecord/lib/active_record/connection_configurations.rb
+++ b/activerecord/lib/active_record/connection_configurations.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "active_record/connection_configurations/connection_config"
+
+module ActiveRecord
+  class ConnectionConfigurations # :nodoc:
+    include Enumerable
+
+    attr_reader :configurations
+
+    def initialize(configurations)
+      @configurations = build_configs(configurations)
+    end
+
+    def each
+      configurations.each do |class_name, configuration|
+        yield [class_name, configuration]
+      end
+    end
+
+    def configs_for(class_name:)
+      configurations[class_name]
+    end
+
+    private
+      def build_configs(configurations)
+        result = {}
+
+        configurations.each do |class_name, config|
+          result[class_name] = ConnectionConfig.new(config)
+        end
+
+        result
+      end
+  end
+end

--- a/activerecord/lib/active_record/connection_configurations/connection_config.rb
+++ b/activerecord/lib/active_record/connection_configurations/connection_config.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/hash/deep_transform_values"
+
+module ActiveRecord
+  class ConnectionConfigurations
+    class ConnectionConfig # :nodoc:
+      attr_reader :connection_config
+
+      def initialize(config_hash)
+        @connection_config = symbolize_hash_for_connects_to(config_hash)
+      end
+
+      private
+        def symbolize_hash_for_connects_to(config_hash)
+          if config_hash["database"] && config_hash["shards"]
+            raise ArgumentError, "Connection configurations can only accept a `database` or `shards` argument, but not both arguments."
+          end
+
+          config_hash.deep_symbolize_keys.deep_transform_values!(&:to_sym)
+        end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -108,6 +108,16 @@ module ActiveRecord
       connections
     end
 
+    # Establishes connections based on configurations defined in `connections.yml`.
+    def connects_with_file
+      raise ArgumentError, "must provide a connections.yml to use connects_with_file" if connection_configurations.none?
+
+      config_for_class = connection_configurations.configs_for(class_name: name)
+      raise ArgumentError, "no entry for #{name} found in connections.yml" if config_for_class.nil?
+
+      connects_to(**config_for_class.connection_config)
+    end
+
     # Connects to a role (ex writing, reading or a custom role) and/or
     # shard for the duration of the block. At the end of the block the
     # connection will be returned to the original role / shard.

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -57,6 +57,15 @@ module ActiveRecord
         @@configurations
       end
 
+      def self.connection_configurations=(config) # :nodoc:
+        @@connection_configurations = ActiveRecord::ConnectionConfigurations.new(config)
+      end
+      self.connection_configurations = {}
+
+      def self.connection_configurations
+        @@connection_configurations
+      end
+
       ##
       # :singleton-method:
       # Force enumeration of all columns in SELECT statements.

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -264,6 +264,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           self.connection_handlers = { ActiveRecord.writing_role => ActiveRecord::Base.default_connection_handler }
         end
         self.configurations = Rails.application.config.database_configuration
+        self.connection_configurations = Rails.application.config.connection_configuration
 
         establish_connection
       end

--- a/activerecord/test/cases/connection_configurations_test.rb
+++ b/activerecord/test/cases/connection_configurations_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class ConnectionConfigurationsTest < ActiveRecord::TestCase
+  def test_shards_connection_configurations
+    config_hash = {
+      "ApplicationRecord" => {
+        "shards" => {
+          "default" => {
+            "writing" => "arunit",
+            "reading" => "arunit"
+          }
+        }
+      }
+    }
+
+    connection_configurations = ActiveRecord::ConnectionConfigurations.new(config_hash)
+
+    assert_equal 1, connection_configurations.count
+    connection_configuration = connection_configurations.configs_for(class_name: "ApplicationRecord")
+    assert_equal 1, connection_configuration.connection_config[:shards].count
+    assert_equal({ default: { writing: :arunit, reading: :arunit } }, connection_configuration.connection_config[:shards])
+  end
+
+  def test_database_connection_configurations
+    config_hash = {
+      "ApplicationRecord" => {
+        "database" => {
+          "writing" => "arunit",
+          "reading" => "arunit"
+        }
+      }
+    }
+
+    connection_configurations = ActiveRecord::ConnectionConfigurations.new(config_hash)
+
+    assert_equal 1, connection_configurations.count
+    connection_configuration = connection_configurations.configs_for(class_name: "ApplicationRecord")
+    assert_equal 2, connection_configuration.connection_config[:database].count
+    assert_equal({ writing: :arunit, reading: :arunit }, connection_configuration.connection_config[:database])
+  end
+
+  def test_shards_and_database_cant_both_be_set
+    config_hash = {
+      "ApplicationRecord" => {
+        "shards" => {
+          "default" => {
+            "writing" => "arunit",
+            "reading" => "arunit"
+          }
+        },
+        "database" => {
+          "writing" => "arunit",
+          "reading" => "arunit"
+        }
+      }
+    }
+
+    error = assert_raises ArgumentError do
+      ActiveRecord::ConnectionConfigurations.new(config_hash)
+    end
+
+    assert_equal "Connection configurations can only accept a `database` or `shards` argument, but not both arguments.", error.message
+  end
+end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -270,6 +270,7 @@ module Rails
         @paths ||= begin
           paths = super
           paths.add "config/database",    with: "config/database.yml"
+          paths.add "config/connections",      with: "config/connections.yml"
           paths.add "config/secrets",     with: "config", glob: "secrets.yml{,.enc}"
           paths.add "config/environment", with: "config/environment.rb"
           paths.add "lib/templates"
@@ -303,6 +304,19 @@ module Rails
         else
           {}
         end
+      end
+
+      def connection_configuration
+        path = paths["config/connections"].existent.first
+        yaml = Pathname.new(path) if path
+
+        if yaml&.exist?
+          ActiveSupport::ConfigurationFile.parse(yaml)
+        else
+          {}
+        end
+      rescue => e
+        raise e, "Cannot load connection configuration:\n#{e.message}", e.backtrace
       end
 
       # Loads and returns the entire raw configuration of database from

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1788,6 +1788,22 @@ module ApplicationTests
       assert Rails.configuration.ran_block
     end
 
+    test "loading the first existing connection configuration available" do
+      config = {
+        "ApplicationRecord" => { "shards" => { "default" => { "writing" => "primary", "reading" => "primary" } } },
+        "OtherRecord" => { "shards" => { "default" => { "writing" => "primary", "reading" => "primary" } } }
+      }
+
+      app_file "config/connections.yml", YAML.dump(config)
+
+      app "development"
+
+      assert_equal false,  Rails.application.config.rake_eager_load
+      assert_equal config, Rails.application.config.connection_configuration
+
+      assert_equal 1, ActiveRecord::Base.connection_handler.connection_pool_list.count
+    end
+
     test "loading the first existing database configuration available" do
       app_file "config/environments/development.rb", <<-RUBY
 


### PR DESCRIPTION
For some applications, mainly ones using a tenant sharding strategy, may
want to be able to define the connections outside of the model. A good
example of this is when your database is sharded by customer and each
customer gets their own "tenant" but the application is deployed to a
server where 100 customers are using. In those cases we can't define the
connections in a model because it will be different for each server.

This PR aims to solve that problem by providing a mechanism for reading
a file (`config/connections.yml`) that defines the connections for each
"tenant" as a shard. The file can be checked into the application or can
be generated on deploy providing a way to have a more dynamic set of
connections for an application.

To use this functionality applications can create a
`config/connections.yml` that defines shards that correspond to each
tenant.

Applications first create a database.yml:

```yaml

production:
  primary:
    database: tenant_router_db
  primary_replica:
    database: tenant_router_db
    replica: true
  database_one:
    database: my_db_one
  database_one_replica:
    database: my_db_one
    replica: true
  database_two:
    database: my_db_two
  database_two_replica:
    database: my_db_two
    replica: true
```

Then they create a connections.yml:

```yaml
ApplicationRecord:
  shards:
    default:
      writing: primary
      reading: primary
    customer_one:
      writing: database_one
      reading: database_one_replica
    customer_two:
      writing: database_two
      reading: database_two_replica
```

Lastly, in `ApplicationRecord` we add the following:

```
class ApplicationRecord < ActiveRecord::Base
  primary_abstract_class

  connects_to_file
end
```

The call to `connects_to_file` allows for an elegant way for different deploy
targets to have unique connections defined without polluting the models. This
can also be used for applications that have many shards and they don't
want to define `connects_to` in the model.

The functionality is pretty simple. If a `connections.yml` file exists
Rails will parse the file and create `ConnectionConfig` objects. When
`connects_to_file` is called then Active Record finds the
`ConnectionConfig` for the class and passes the required arguments to
`connects_to`.

Co-authored-by: John Crepezzi <john.crepezzi@gmail.com>

cc/ @seejohnrun @mtodd @matthewd 

cc/ @rafaelfranca @tenderlove @byroot - not sure if this will be useful for you in the future, I think there was a similarish proposal once to add onto the database.yml or make a new one. We need this for some work we're doing over at GH and this was the proposal we came up with. 