### PR TITLE
Update `cache_key_with_version` with custom timestamp column parameter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Update `ActiveRecord::Relation#cache_key_with_version` with custom timestamp column parameter like `cache_key` and `cache_version`.
+
+    *Austen Madden*
+
 *   Add `ActiveRecord::Base.prohibit_shard_swapping` to prevent attempts to change the shard within a block.
 
     *John Crepezzi*, *Eileen M. Uchitelle*

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -323,7 +323,7 @@ module ActiveRecord
     # last updated record.
     #
     #   Product.where("name like ?", "%Game%").cache_key(:last_reviewed_at)
-    def cache_key(timestamp_column = "updated_at")
+    def cache_key(timestamp_column = :updated_at)
       @cache_keys ||= {}
       @cache_keys[timestamp_column] ||= klass.collection_cache_key(self, timestamp_column)
     end
@@ -402,11 +402,14 @@ module ActiveRecord
     private :compute_cache_version
 
     # Returns a cache key along with the version.
-    def cache_key_with_version
-      if version = cache_version
+    #
+    #  Accepts a custom timestamp column to use in calculating the key and
+    #  version if provided.
+    def cache_key_with_version(timestamp_column = :updated_at)
+      if version = cache_version(timestamp_column)
         "#{cache_key}-#{version}"
       else
-        cache_key
+        cache_key(timestamp_column)
       end
     end
 

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -264,6 +264,20 @@ module ActiveRecord
       end
     end
 
+    test "cache_key_with_version contains key and version calculated with custom timestamp" do
+      last_topic_timestamp = topics(:fifth).written_on.utc.to_s(:usec)
+
+      with_collection_cache_versioning(false) do
+        key_with_version_false = Topic.all.cache_key_with_version(:written_on)
+        assert_match(last_topic_timestamp, key_with_version_false)
+      end
+
+      with_collection_cache_versioning do
+        key_with_version_true = Topic.all.cache_key_with_version(:written_on)
+        assert_match(last_topic_timestamp, key_with_version_true)
+      end
+    end
+
     def with_collection_cache_versioning(value = true)
       @old_collection_cache_versioning = ActiveRecord::Base.collection_cache_versioning
       ActiveRecord::Base.collection_cache_versioning = value


### PR DESCRIPTION
### Summary

[Currently, `ActiveRecord::Relation#cache_with_version` does not accept a custom timestamp column to use in it's cache calculations.](https://edgeapi.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-cache_key_with_version) This is unlike the methods it delegates to `cache_key` and `cache_version`. It'd be ideal if they could share a uniform interface/parameters.

### Other Information

I wanted to visually demonstrate some of the nuances to the behaviors here with and without `collection_cache_versioning`.

```ruby
test "cache_key_with_version proposed behavior test" do
  [false, true].each do |versioning|
    with_collection_cache_versioning(versioning) do
      puts <<~DEMO
        versioning(#{versioning})
        #cache_key:                                #{Topic.all.cache_key}
        #cache_version:                            #{Topic.all.cache_version}
        #cache_key_with_version:                   #{Topic.all.cache_key_with_version}
        #cache_key(custom_timestamp):              #{Topic.all.cache_key(:written_on)}
        #cache_version(custom_timestamp):          #{Topic.all.cache_version(:written_on)}
        #cache_key_with_version(custom_timestamp): #{Topic.all.cache_key_with_version(:written_on)}
      DEMO
    end
  end
end
```

Results in the following:
```
versioning(false)
#cache_key:                                topics/query-ba282520dbc4bdbe141a2e77358b2e7a-5-20211024012012102418
#cache_version:
#cache_key_with_version:                   topics/query-ba282520dbc4bdbe141a2e77358b2e7a-5-20211024012012102418
#cache_key(custom_timestamp):              topics/query-ba282520dbc4bdbe141a2e77358b2e7a-5-20130713111100009900
#cache_version(custom_timestamp):
#cache_key_with_version(custom_timestamp): topics/query-ba282520dbc4bdbe141a2e77358b2e7a-5-20130713111100009900

versioning(true)
#cache_key:                                topics/query-ba282520dbc4bdbe141a2e77358b2e7a
#cache_version:                            5-20211024012012102418
#cache_key_with_version:                   topics/query-ba282520dbc4bdbe141a2e77358b2e7a-5-20211024012012102418
#cache_key(custom_timestamp):              topics/query-ba282520dbc4bdbe141a2e77358b2e7a
#cache_version(custom_timestamp):          5-20130713111100009900
#cache_key_with_version(custom_timestamp): topics/query-ba282520dbc4bdbe141a2e77358b2e7a-5-20130713111100009900
```
