### PR TITLE
Do not consolidate persisted in-memory records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Ignore persisted in-memory records when merging target lists.
+
+    *Kevin Sjöberg*
+
 *   Add nested_attributes_for support for `delegated_type`
 
     ```ruby

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -335,7 +335,7 @@ module ActiveRecord
             end
           end
 
-          persisted + memory
+          persisted + memory.reject(&:persisted?)
         end
 
         def _create_record(attributes, raise = false, &block)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -289,6 +289,16 @@ class AssociationProxyTest < ActiveRecord::TestCase
     assert_not_predicate david.posts, :loaded?
     assert_not_predicate david.posts, :loaded
   end
+
+  def test_target_merging_ignores_persisted_in_memory_records
+    david = authors(:david)
+    assert david.thinking_posts.include?(posts(:thinking))
+
+    david.thinking_posts.create!(title: "Something else entirely", body: "Does not matter.")
+
+    assert_equal 1, david.thinking_posts.size
+    assert_equal 1, david.thinking_posts.to_a.size
+  end
 end
 
 class OverridingAssociationsTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

`merge_target_lists` is called with two arguments. A collection of
persisted records and a collection of in-memory records. If the
in-memory collection contains any persisted records we can safely
reject them as the `persisted` collection is already up-to-date.

Fixes #43516.