### PR TITLE
Using pluck(ids) instead of map

### DIFF
--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -10,20 +10,20 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     order = [3, 4, 1]
     posts = Post.in_order_of(:id, order).limit(3)
 
-    assert_equal(order, posts.map(&:id))
+    assert_equal(order, posts.ids)
   end
 
   def test_in_order_of_expression
     order = [3, 4, 1]
     posts = Post.in_order_of(Arel.sql("id * 2"), order.map { |id| id * 2 }).limit(3)
 
-    assert_equal(order, posts.map(&:id))
+    assert_equal(order, posts.ids)
   end
 
   def test_in_order_of_after_regular_order
     order = [3, 4, 1]
     posts = Post.where(type: "Post").order(:type).in_order_of(:id, order).limit(3)
 
-    assert_equal(order, posts.map(&:id))
+    assert_equal(order, posts.ids)
   end
 end


### PR DESCRIPTION
### Summary
Using pluck (primary key - ids) instead of map(:id) for ActiveRecord_Relation.

### Other Information
These tests were added in https://github.com/rails/rails/pull/42061.
