### PR TITLE
Propagate `save(validate:)` option for `:has_many` associations on au…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Propagate `save(validate:)` option for `:has_many` associations on autosave.
+
+    `save(validate:)` option is propagated to associated records during `autosave` when `autosave` option is
+    `nil`. Affects only `:has_many` associations.
+
+    Fixes #43400
+
+    *Jacopo Beschi*
+
 *   Add support for setting the filename of the schema or structure dump in the database config.
 
     Applications may now set their the filename or path of the schema / structure dump file in their database configuration.

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -409,7 +409,11 @@ module ActiveRecord
                 if autosave
                   saved = association.insert_record(record, false)
                 elsif !reflection.nested?
-                  association_saved = association.insert_record(record)
+                  association_saved = if @_save_options.key?(:validate)
+                    association.insert_record(record, @_save_options[:validate])
+                  else
+                    association.insert_record(record)
+                  end
 
                   if reflection.validate?
                     errors.add(reflection.name) unless association_saved

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1847,6 +1847,30 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     assert pirate.valid?
     assert_not pirate.valid?(:conference)
   end
+
+  test "propagates (validate: false) option to associations when autosave is nil" do
+    pirate = SpacePirate.create!
+    pirate.birds.build
+
+    assert_equal false, pirate.save
+    assert_equal true,  pirate.save(validate: false)
+  end
+
+  test "propagates (validate: false) option to associations when autosave is true" do
+    pirate = SpacePirate.create!
+    pirate.birds_with_autosave.build
+
+    assert_equal false, pirate.save
+    assert_equal true,  pirate.save(validate: false)
+  end
+
+  test "propagates (validate: false) option to associations when autosave is false" do
+    pirate = SpacePirate.create!
+    pirate.birds_without_autosave.build
+
+    assert_equal false, pirate.save
+    assert_equal true, pirate.save(validate: false)
+  end
 end
 
 class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -109,6 +109,8 @@ class SpacePirate < ActiveRecord::Base
   has_one :ship, foreign_key: :pirate_id
   has_one :ship_with_annotation, -> { annotate("that is a rocket") }, class_name: :Ship, foreign_key: :pirate_id
   has_many :birds, foreign_key: :pirate_id
+  has_many :birds_with_autosave, foreign_key: :pirate_id, autosave: true, class_name: :Bird
+  has_many :birds_without_autosave, foreign_key: :pirate_id, autosave: false, class_name: :Bird
   has_many :birds_with_annotation, -> { annotate("that are also parrots") }, class_name: :Bird, foreign_key: :pirate_id
   has_many :treasures, as: :looter
   has_many :treasure_estimates, through: :treasures, source: :price_estimates


### PR DESCRIPTION
### Summary

`save(validate:)` option is propagated to associated records during `autosave` when `autosave` option is `nil`. 
Affects only `:has_many` associations.

Fixes #43400

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
