### PR TITLE
Add support for setting the schema/structure dump filepath in the config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Add support for setting the filename of the schema or structure dump in the database config.
+
+    Applications may now set their the filename or path of the schema / structure dump file in their database configuration.
+
+
+    ```yaml
+    production:
+      primary:
+        database: my_db
+        schema_dump: my_schema_dump_filename.rb
+      animals:
+        database: animals_db
+        schema_dump: false
+    ```
+
+    The filename set in `schema_dump` will be used by the application. If set to `false` the schema will not be dumped. The database tasks are responsible for adding the database directory to the filename. If a full path is provided, the Rails tasks will use that instead of `ActiveRecord::DatabaseTasks.db_dir`.
+
+    *Eileen M. Uchitelle*, *Ryan Kerr*
+
 *   Add `ActiveRecord::Base.prohibit_shard_swapping` to prevent attempts to change the shard within a block.
 
     *John Crepezzi*, *Eileen M. Uchitelle*

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -121,14 +121,39 @@ module ActiveRecord
         Base.configurations.primary?(name)
       end
 
-      # Determines whether to dump the schema for a database.
-      def schema_dump
-        configuration_hash.fetch(:schema_dump, true)
+      # Determines whether to dump the schema/structure files and the
+      # filename that should be used.
+      #
+      # If +configuration_hash[:schema_dump]+ is set to +false+ or +nil+
+      # the schema will not be dumped.
+      #
+      # If the config option is set that will be used. Otherwise Rails
+      # will generate the filename from the database config name.
+      def schema_dump(format = ActiveRecord.schema_format)
+        if configuration_hash.key?(:schema_dump)
+          if config = configuration_hash[:schema_dump]
+            config
+          end
+        elsif primary?
+          schema_file_type(format)
+        else
+          "#{name}_#{schema_file_type(format)}"
+        end
       end
 
       def database_tasks? # :nodoc:
         !replica? && !!configuration_hash.fetch(:database_tasks, true)
       end
+
+      private
+        def schema_file_type(format)
+          case format
+          when :ruby
+            "schema.rb"
+          when :sql
+            "structure.sql"
+          end
+        end
     end
   end
 end

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -105,12 +105,12 @@ module ActiveRecord
 
       def test_default_schema_dump_value
         config = HashConfig.new("default_env", "primary", {})
-        assert_equal true, config.schema_dump
+        assert_equal "schema.rb", config.schema_dump
       end
 
-      def test_schema_dump_value_set_to_true
-        config = HashConfig.new("default_env", "primary", { schema_dump: true })
-        assert_equal true, config.schema_dump
+      def test_schema_dump_value_set_to_filename
+        config = HashConfig.new("default_env", "primary", { schema_dump: "my_schema.rb" })
+        assert_equal "my_schema.rb", config.schema_dump
       end
 
       def test_schema_dump_value_set_to_nil
@@ -120,7 +120,7 @@ module ActiveRecord
 
       def test_schema_dump_value_set_to_false
         config = HashConfig.new("default_env", "primary", { schema_dump: false })
-        assert_equal false, config.schema_dump
+        assert_nil config.schema_dump
       end
 
       def test_database_tasks_defaults_to_true

--- a/railties/test/application/rake/migrations_test.rb
+++ b/railties/test/application/rake/migrations_test.rb
@@ -425,21 +425,21 @@ module ApplicationTests
         assert_match(/up\s+002\s+Two migration/, output)
       end
 
-      test "schema generation when dump_schema_after_migration and schema_dump are true" do
+      test "schema generation when dump_schema_after_migration and schema_dump are set" do
         add_to_config("config.active_record.dump_schema_after_migration = true")
 
         app_file "config/database.yml", <<~EOS
           development:
             adapter: sqlite3
             database: 'dev_db'
-            schema_dump: true
+            schema_dump: "schema_file.rb"
         EOS
 
         Dir.chdir(app_path) do
           rails "generate", "model", "book", "title:string"
           rails "db:migrate"
 
-          assert File.exist?("db/schema.rb"), "should dump schema when configured to"
+          assert File.exist?("db/schema_file.rb"), "should dump schema when configured to"
         end
       end
 


### PR DESCRIPTION
Previously Rails would generate your schema/structure dump based on the
database config name. As noted on the forum in
https://discuss.rubyonrails.org/t/horizontal-sharding-schema-management/78621/6
this is problematic if you want to your shards to share the same schema
dump file.

This is also useful for applications that might have already written a
custom solution for setting the schema dump filename and want to use
something upstream. We allow setting the path for the schema cache, why
not the schema dump too?

To do this I deprecated the old schema_file database task in favor for a
new one that passes the `db_config`. The code to derive the filename
from the db_config has been duplicated there and will be the correct way
to determine filename in the future. Since these values are set on the
config they should be accessible in the config as well.

I did not need to deprecate the behavior of schema_dump because it has
not been included in any release yet (other than the alpha). However the
behavior is the same for false/nil.

Closes rails#43173
Supercedes rails#43240

Co-authored-by: Ryan Kerr <leboshi@gmail.com>
