### PR TITLE
Prevent endless ranges from locking up Arel::Predications#in

### DIFF
--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -215,7 +215,7 @@ module Arel # :nodoc: all
     end
 
     def quoted_array(others)
-      others.map { |v| quoted_node(v) }
+      others.to_a.map { |v| quoted_node(v) }
     end
 
     private

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -730,6 +730,14 @@ module Arel
             SELECT "users"."id" FROM "users" WHERE "users"."id" IN (1, 2, 3)
           }
         end
+
+        it "raises an error if passed an endless range" do
+          attribute = Attribute.new nil, nil
+
+          assert_raises(RangeError, "cannot convert endless range to an array") do
+            attribute.in(10..)
+          end
+        end
       end
 
       describe "#in_any" do


### PR DESCRIPTION
### Summary

When an endless range is passed into `quoted_array` the call to `map`
runs endlessly. Calling `to_a` ensures this fails with an exception.

### Other Information

This is the simplest solution to the problem, and does not seem to break anything.

cc @matthewd 