### PR TITLE
Refactor ActiveRecord::QueryLogs context API

### DIFF
--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -119,9 +119,9 @@ module ActionController
 
         ActiveSupport.on_load(:active_record) do
           ActiveRecord::QueryLogs.taggings.merge!(
-            controller:            ->(context) { context[:controller].controller_name },
-            action:                ->(context) { context[:controller].action_name },
-            namespaced_controller: ->(context) { context[:controller].class.name }
+            controller:            ->(context) { context[:controller]&.controller_name },
+            action:                ->(context) { context[:controller]&.action_name },
+            namespaced_controller: ->(context) { context[:controller].class.name if context[:controller] }
           )
         end
       end

--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -70,7 +70,7 @@ module ActiveJob
         end
 
         ActiveSupport.on_load(:active_record) do
-          ActiveRecord::QueryLogs.taggings[:job] = ->(context) { context[:job].class.name unless context[:job].nil? }
+          ActiveRecord::QueryLogs.taggings[:job] = ->(context) { context[:job].class.name if context[:job] }
         end
       end
     end

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -112,12 +112,12 @@ class QueryLogsTest < ActiveRecord::TestCase
 
   def test_resets_cache_on_context_update
     ActiveRecord::QueryLogs.cache_query_log_tags = true
-    ActiveRecord::QueryLogs.update_context(temporary: "value")
+    ActiveRecord::QueryLogs.set_context(temporary: "value")
     ActiveRecord::QueryLogs.tags = [ temporary_tag: ->(context) { context[:temporary] } ]
 
     assert_equal " /*temporary_tag:value*/", ActiveRecord::QueryLogs.call("")
 
-    ActiveRecord::QueryLogs.update_context(temporary: "new_value")
+    ActiveRecord::QueryLogs.set_context(temporary: "new_value")
 
     assert_nil ActiveRecord::QueryLogs.cached_comment
     assert_equal " /*temporary_tag:new_value*/", ActiveRecord::QueryLogs.call("")
@@ -128,13 +128,13 @@ class QueryLogsTest < ActiveRecord::TestCase
 
   def test_ensure_context_has_symbol_keys
     ActiveRecord::QueryLogs.tags = [ new_key: ->(context) { context[:symbol_key] } ]
-    ActiveRecord::QueryLogs.update_context("symbol_key" => "symbolized")
+    ActiveRecord::QueryLogs.set_context("symbol_key" => "symbolized")
 
     assert_sql(%r{/\*new_key:symbolized}) do
       Dashboard.first
     end
   ensure
-    ActiveRecord::QueryLogs.update_context(application_name: nil)
+    ActiveRecord::QueryLogs.set_context(application_name: nil)
   end
 
   def test_default_tag_behavior
@@ -249,14 +249,14 @@ class QueryLogsTest < ActiveRecord::TestCase
 
   def test_custom_proc_context_tags
     original_tags = ActiveRecord::QueryLogs.tags
-    ActiveRecord::QueryLogs.update_context(foo: "bar")
+    ActiveRecord::QueryLogs.set_context(foo: "bar")
     ActiveRecord::QueryLogs.tags = [ :application, { custom_context_proc: ->(context) { context[:foo] } } ]
 
     assert_sql(%r{/\*application:active_record,custom_context_proc:bar\*/$}) do
       Dashboard.first
     end
   ensure
-    ActiveRecord::QueryLogs.update_context(foo: nil)
+    ActiveRecord::QueryLogs.set_context(foo: nil)
     ActiveRecord::QueryLogs.tags = original_tags
   end
 

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -123,7 +123,7 @@ module ApplicationTests
     test "query cache is cleared between requests" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.cache_query_log_tags = true"
-      add_to_config "config.active_record.query_log_tags = [ { dynamic: ->(context) { context[:controller].dynamic_content } } ]"
+      add_to_config "config.active_record.query_log_tags = [ { dynamic: ->(context) { context[:controller]&.dynamic_content } } ]"
 
       boot_app
 
@@ -141,7 +141,7 @@ module ApplicationTests
     test "query cache is cleared between job executions" do
       add_to_config "config.active_record.query_log_tags_enabled = true"
       add_to_config "config.active_record.cache_query_log_tags = true"
-      add_to_config "config.active_record.query_log_tags = [ { dynamic: ->(context) { context[:job].dynamic_content } } ]"
+      add_to_config "config.active_record.query_log_tags = [ { dynamic: ->(context) { context[:job]&.dynamic_content } } ]"
 
       boot_app
 


### PR DESCRIPTION
This remove the null object as proposed in https://github.com/rails/rails/commit/8af78700d244c9e2e6403ce704326ef45ecbe288 (cc @rafaelfranca @jhawthorn @kaspth). 

Since it pretends to be nil but acts as thruthy in boolean context it cause more confusion than it cleans code.

Also `update_context` is removed in favor of `set_context` without a block.

Also cc @keeran 