### PR TITLE
Add missing punctuations in activerecord CHANGELOG [ci-skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -270,10 +270,10 @@
 
     The behavior now is:
 
-    `columns`: (unchanged) raises a db error if the table does not exist
-    `columns_hash`: (unchanged) raises a db error if the table does not exist
-    `primary_keys`: (unchanged) returns `nil` if the table does not exist
-    `indexes`: (changed for mysql2) returns `[]` if the table does not exist
+    `columns`: (unchanged) raises a db error if the table does not exist.
+    `columns_hash`: (unchanged) raises a db error if the table does not exist.
+    `primary_keys`: (unchanged) returns `nil` if the table does not exist.
+    `indexes`: (changed for mysql2) returns `[]` if the table does not exist.
 
     *Eileen M. Uchitelle*
 
@@ -418,7 +418,7 @@
 *   Add option to disable schema dump per-database.
 
     Dumping the schema is on by default for all databases in an application. To turn it off for a
-    specific database use the `schema_dump` option:
+    specific database, use the `schema_dump` option:
 
     ```yaml
     # config/database.yml
@@ -617,7 +617,7 @@
 
 *   Fix compatibility with `psych >= 4`.
 
-    Starting in Psych 4.0.0 `YAML.load` behaves like `YAML.safe_load`. To preserve compatibility
+    Starting in Psych 4.0.0 `YAML.load` behaves like `YAML.safe_load`. To preserve compatibility,
     Active Record's schema cache loader and `YAMLColumn` now uses `YAML.unsafe_load` if available.
 
     *Jean Boussier*
@@ -1147,8 +1147,8 @@
 
     *Eileen M. Uchitelle*, *John Crepezzi*
 
-*   Support hash config for `structure_dump_flags` and `structure_load_flags` flags
-    Now that Active Record supports multiple databases configuration
+*   Support hash config for `structure_dump_flags` and `structure_load_flags` flags.
+    Now that Active Record supports multiple databases configuration,
     we need a way to pass specific flags for dump/load databases since
     the options are not the same for different adapters.
     We can use in the original way:


### PR DESCRIPTION
Some long sentences are missing punctuations. Line breaks in markdown does not break line in actual preview so these lines looks like a single sentence.