### PR TITLE
Optimize Array#many? without a block

### DIFF
--- a/activesupport/lib/active_support/core_ext/array/access.rb
+++ b/activesupport/lib/active_support/core_ext/array/access.rb
@@ -49,6 +49,19 @@ class Array
   end
   alias :without :excluding
 
+  # See <tt>Enumerable#many?</tt>
+  def many?
+    if block_given?
+      cnt = 0
+      any? do |element|
+        cnt += 1 if yield element
+        cnt > 1
+      end
+    else
+      length > 1
+    end
+  end
+
   # Equal to <tt>self[1]</tt>.
   #
   #   %w( a b c d e ).second # => "b"

--- a/activesupport/test/core_ext/array/access_test.rb
+++ b/activesupport/test/core_ext/array/access_test.rb
@@ -47,4 +47,15 @@ class AccessTest < ActiveSupport::TestCase
   def test_without
     assert_equal [1, 2, 4], [1, 2, 3, 4, 5].without(3, 5)
   end
+
+  def test_many
+    assert_equal false, [].many?
+    assert_equal false, [ 1 ].many?
+    assert_equal true,  [ 1, 2 ].many?
+
+    assert_equal false, [].many? { |x| x > 1 }
+    assert_equal false, [ 2 ].many? { |x| x > 1 }
+    assert_equal false, [ 1, 2 ].many? { |x| x > 1 }
+    assert_equal true,  [ 1, 2, 2 ].many? { |x| x > 1 }
+  end
 end


### PR DESCRIPTION
We can speed up `many?` without a block by 2 times by using array length instead of Enumerable iterators.

With a block, the implementation is the same. Since this is quite a low-level method, I have decided to copy the code rather than using `super` to avoid small performance regression due to an extra method invocation.

```
Without block
Warming up --------------------------------------
              before   143.786k i/100ms
               after   271.646k i/100ms
Calculating -------------------------------------
              before      1.451M (± 0.9%) i/s -      7.333M in   5.053091s
               after      2.754M (± 0.8%) i/s -     13.854M in   5.031672s

Comparison:
               after:  2753544.5 i/s
              before:  1451328.0 i/s - 1.90x  (± 0.00) slower

With block
Warming up --------------------------------------
              before    75.521k i/100ms
               after    76.015k i/100ms
Calculating -------------------------------------
              before    755.638k (± 0.6%) i/s -      3.852M in   5.097294s
               after    760.052k (± 0.8%) i/s -      3.877M in   5.100954s

Comparison:
               after:   760051.8 i/s
              before:   755638.0 i/s - same-ish: difference falls within error
```

```ruby
require 'benchmark/ips'
require 'active_support'
require 'active_support/core_ext'

class Array
  def many_2?
    if block_given?
      cnt = 0
      any? do |element|
        cnt += 1 if yield element
        cnt > 1
      end
    else
      length > 1
    end
  end
end

arrays = [
  [],
  [1],
  [1,2],
  1.upto(100).to_a,
]

puts "Without block"
Benchmark.ips do |x|
  x.report("before"){ arrays.each{ |a| a.many? } }
  x.report("after"){ arrays.each{ |a| a.many_2? } }
  x.compare!
end

puts "With block"
Benchmark.ips do |x|
  x.report("before"){ arrays.each{ |a| a.many?(&:even?) } }
  x.report("after"){ arrays.each{ |a| a.many_2?(&:even?) } }
  x.compare!
end
```