### PR TITLE
Proof of concept: ActiveSupport::ExecutionContext

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -26,6 +26,7 @@
 require "securerandom"
 require "active_support/dependencies/autoload"
 require "active_support/version"
+require "active_support/execution_context"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
@@ -111,10 +112,6 @@ module ActiveSupport
 
   def self.utc_to_local_returns_utc_offset_times=(value)
     DateAndTime::Compatibility.utc_to_local_returns_utc_offset_times = value
-  end
-
-  def self.current_attributes_use_thread_variables=(value)
-    CurrentAttributes._use_thread_variables = value
   end
 end
 

--- a/activesupport/lib/active_support/current_attributes.rb
+++ b/activesupport/lib/active_support/current_attributes.rb
@@ -90,6 +90,8 @@ module ActiveSupport
     include ActiveSupport::Callbacks
     define_callbacks :reset
 
+    ExecutionContext.define_accessor(:current_attribute_instances)
+
     class << self
       # Returns singleton instance for this class in this thread. If none exists, one is created.
       def instance
@@ -143,24 +145,13 @@ module ActiveSupport
         current_instances.clear
       end
 
-      def _use_thread_variables=(value) # :nodoc:
-        clear_all
-        @@use_thread_variables = value
-      end
-      @@use_thread_variables = false
-
       private
         def generated_attribute_methods
           @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
         end
 
         def current_instances
-          if @@use_thread_variables
-            Thread.current.thread_variable_get(:current_attributes_instances) ||
-              Thread.current.thread_variable_set(:current_attributes_instances, {})
-          else
-            Thread.current[:current_attributes_instances] ||= {}
-          end
+          ExecutionContext.current.current_attribute_instances ||= {}
         end
 
         def current_instances_key

--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "concurrent/hash"
+
+module ActiveSupport
+  class ExecutionContext  # :nodoc:
+    module FiberLocal
+      def self.extended(base)
+        base.instance_variable_set(:@registry, Concurrent::Hash.new.compare_by_identity)
+      end
+
+      def current
+        @registry[Fiber.current] ||= new
+      end
+
+      def clear
+        @registry[Fiber.current] = nil
+      end
+
+      def clear_all
+        @registry.clear
+      end
+    end
+
+    module ThreadLocal
+      def self.extended(base)
+        base.instance_variable_set(:@registry, Concurrent::Hash.new.compare_by_identity)
+      end
+
+      def current
+        @registry[Thread.current] ||= new
+      end
+
+      def clear
+        @registry[Thread.current] = nil
+      end
+
+      def clear_all
+        @registry.clear
+      end
+    end
+
+    module ProcessLocal
+      def self.extended(base)
+        base.instance_variable_set(:@registry, nil)
+      end
+
+      def current
+        @registry ||= new
+      end
+
+      def clear
+        @registry = nil
+      end
+
+      def clear_all
+        @registry = nil
+      end
+    end
+
+    ISOLATION_LEVELS = {
+      fiber: FiberLocal,
+      thread: ThreadLocal,
+      process: ProcessLocal,
+    }.freeze
+
+    class << self
+      attr_reader :isolation_level
+
+      def isolation_level=(level)
+        mod = ISOLATION_LEVELS.fetch(level)
+        singleton_class.define_method(:current, mod.instance_method(:current))
+        singleton_class.define_method(:clear, mod.instance_method(:clear))
+        singleton_class.define_method(:clear_all, mod.instance_method(:clear_all))
+        mod.extended(self)
+        @isolation_level = level
+      end
+
+      def define_accessor(name)
+        attr_accessor(name)
+      end
+    end
+
+    self.isolation_level = :fiber
+  end
+end

--- a/activesupport/lib/active_support/execution_context.rb
+++ b/activesupport/lib/active_support/execution_context.rb
@@ -10,11 +10,12 @@ module ActiveSupport
       end
 
       def current
-        @registry[Fiber.current] ||= new
+        @registry[Fiber.current.object_id] ||= new
       end
 
       def clear
-        @registry[Fiber.current] = nil
+        @registry.delete(Fiber.current.object_id)
+        nil
       end
 
       def clear_all
@@ -28,11 +29,12 @@ module ActiveSupport
       end
 
       def current
-        @registry[Thread.current] ||= new
+        @registry[Thread.current.object_id] ||= new
       end
 
       def clear
-        @registry[Thread.current] = nil
+        @registry.delete(Thread.current.object_id)
+        nil
       end
 
       def clear_all

--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -17,9 +17,9 @@ module ActiveSupport
       EOT
     end
 
+    ExecutionContext.define_accessor(:logger_level)
     def local_level
-      # Note: Thread#[] is fiber-local
-      Thread.current[:logger_thread_safe_level]
+      ExecutionContext.current.logger_level
     end
 
     def local_level=(level)
@@ -31,7 +31,7 @@ module ActiveSupport
       else
         raise ArgumentError, "Invalid log level: #{level.inspect}"
       end
-      Thread.current[:logger_thread_safe_level] = level
+      ExecutionContext.current.logger_level = level
     end
 
     def level

--- a/activesupport/lib/active_support/tagged_logging.rb
+++ b/activesupport/lib/active_support/tagged_logging.rb
@@ -54,10 +54,10 @@ module ActiveSupport
         current_tags.clear
       end
 
+      ExecutionContext.define_accessor(:tagged_logging_tags)
       def current_tags
-        # We use our object ID here to avoid conflicting with other instances
-        thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}"
-        Thread.current[thread_key] ||= []
+        registry = ExecutionContext.current.tagged_logging_tags ||= {}
+        registry[object_id] ||= []
       end
 
       def tags_text

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -190,13 +190,15 @@ class CurrentAttributesTest < ActiveSupport::TestCase
   end
 
   test "CurrentAttributes can use thread-local variables" do
-    ActiveSupport::CurrentAttributes._use_thread_variables = true
+    previous_level = ActiveSupport::ExecutionContext.isolation_level
+    ActiveSupport::ExecutionContext.isolation_level = :thread
+
     Session.current = 42
     enumerator = Enumerator.new do |yielder|
       yielder.yield Session.current
     end
     assert_equal 42, enumerator.next
   ensure
-    ActiveSupport::CurrentAttributes._use_thread_variables = false
+    ActiveSupport::ExecutionContext.isolation_level = previous_level
   end
 end


### PR DESCRIPTION
This is somewhat related to https://github.com/rails/rails/pull/43526 / https://github.com/rails/rails/issues/43472, as there would be need for storing various metadata about the current unit of work

### Context

Many places in Active Support and Rails in general use `Thread.current#[]`
to store "request (or job) local data". This often cause problems with
`Enumerator` because it runs in a different fiber.

Ref: https://github.com/rails/rails/pull/38905
Ref: https://github.com/rails/rails/pull/39428
Ref: https://github.com/rails/rails/pull/34495
(and possibly many others)

But the required locality depends on how the application is deployed.
If you use `falcon`, then you want fiber-locals, if you use `puma/sidekiq`
you want thread-locals, and if you use `unicorn/resque`, you can do with
thread-locals, but could also just as well do with process globals.

### Proposal

Since we keep having to deal this thread vs fiber local problem in various
places, I think it suggest we have the need for a proper API to store
some state in the current unit of work scope.

Then it would be up to the application owner to set the proper isolation
level based on how they deploy their Rails app.

For backward compatibility it could ship with `:fiber` isolation as a default
but longer term `:thread` would make more sense as it would work fine for
all deployment targets except `falcon`.
