### PR TITLE
Correct preloading association scope documentation

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -574,7 +574,8 @@ module ActiveRecord
       #   end
       #
       # Note: Joining, eager loading and preloading of these associations is not possible.
-      # These operations happen before instance creation and the scope will be called with a +nil+ argument.
+      # These operations happen before instance creation, and the scope will be called with a +nil+ argument
+      # only if the scope proc's argument has a default value.
       #
       # == Association callbacks
       #


### PR DESCRIPTION
### Summary

The implementation of `reflection.check_eager_loadable!` requires that
the arity of the proc be zero (or else it won't be called), so the docs
saying that the proc will be called with `nil` isn't true by itself --
the proc must also be declared with an optional argument.