### PR TITLE
Accept an integer for the week start day for `Date#next_week`, `Date#beginning_of_week`, etc

### DIFF
--- a/actionview/lib/action_view/helpers/form_options_helper.rb
+++ b/actionview/lib/action_view/helpers/form_options_helper.rb
@@ -601,14 +601,16 @@ module ActionView
       #   <tt>I18n.translate("date.day_names")</tt> as the values. By default, Sunday is always 0.
       # * <tt>:day_format</tt> - The I18n key of the array to use for the weekday options.
       #   Defaults to +:day_names+, set to +:abbr_day_names+ for abbreviations.
-      # * <tt>:beginning_of_week</tt> - Defaults to Date.beginning_of_week.
+      # * <tt>:beginning_of_week</tt> - A symbol (:sunday - :saturday) or integer (0 - 6;
+      # Sunday is 0) for which day the week should start on. Defaults to Date.beginning_of_week.
       #
       # NOTE: Only the option tags are returned, you have to wrap this call in
       # a regular HTML select tag.
       def weekday_options_for_select(selected = nil, index_as_value: false, day_format: :day_names, beginning_of_week: Date.beginning_of_week)
         day_names = I18n.translate("date.#{day_format}")
         day_names = day_names.map.with_index.to_a if index_as_value
-        day_names = day_names.rotate(Date::DAYS_INTO_WEEK.fetch(beginning_of_week))
+        rotate_by = Date::DAYS_INTO_WEEK_BY_DAY.key?(beginning_of_week) ? beginning_of_week : Date::DAYS_INTO_WEEK.fetch(beginning_of_week)
+        day_names = day_names.rotate(rotate_by)
 
         options_for_select(day_names, selected)
       end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1536,6 +1536,13 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_weekday_options_for_select_with_beginning_of_week_set_to_saturday_using_int
+    assert_dom_equal(
+      "<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>",
+      weekday_options_for_select(beginning_of_week: 6)
+    )
+  end
+
   def test_weekday_options_for_select_with_beginning_of_week_set_to_saturday
     assert_dom_equal(
       "<option value=\"Saturday\">Saturday</option>\n<option value=\"Sunday\">Sunday</option>\n<option value=\"Monday\">Monday</option>\n<option value=\"Tuesday\">Tuesday</option>\n<option value=\"Wednesday\">Wednesday</option>\n<option value=\"Thursday\">Thursday</option>\n<option value=\"Friday\">Friday</option>",

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `Date#next_week`, `Date#beginning_of_week`, and related methods now accept
+    an integer as an alternative to a symbol for the week start day.
+
+    ```ruby
+    Date.today.beginning_of_week(:tuesday) == Date.today.beginning_of_week(2)
+    ```
+
+    *Alex Ghiculescu*
+    
 *   Fix `NoMethodError` on custom `ActiveSupport::Deprecation` behavior.
 
     `ActiveSupport::Deprecation.behavior=` was supposed to accept any object

--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -14,6 +14,7 @@ module DateAndTime
       friday: 5,
       saturday: 6
     }
+    DAYS_INTO_WEEK_BY_DAY = DAYS_INTO_WEEK.invert
     WEEKEND_DAYS = [ 6, 0 ]
 
     # Returns a new date/time representing yesterday.
@@ -246,7 +247,7 @@ module DateAndTime
     # Week is assumed to start on +start_day+, default is
     # +Date.beginning_of_week+ or +config.beginning_of_week+ when set.
     def days_to_week_start(start_day = Date.beginning_of_week)
-      start_day_number = DAYS_INTO_WEEK.fetch(start_day)
+      start_day_number = weekday_position(start_day)
       (wday - start_day_number) % 7
     end
 
@@ -328,7 +329,7 @@ module DateAndTime
     #   today.next_occurring(:monday)    # => Mon, 18 Dec 2017
     #   today.next_occurring(:thursday)  # => Thu, 21 Dec 2017
     def next_occurring(day_of_week)
-      from_now = DAYS_INTO_WEEK.fetch(day_of_week) - wday
+      from_now = weekday_position(day_of_week) - wday
       from_now += 7 unless from_now > 0
       advance(days: from_now)
     end
@@ -339,7 +340,7 @@ module DateAndTime
     #   today.prev_occurring(:monday)    # => Mon, 11 Dec 2017
     #   today.prev_occurring(:thursday)  # => Thu, 07 Dec 2017
     def prev_occurring(day_of_week)
-      ago = wday - DAYS_INTO_WEEK.fetch(day_of_week)
+      ago = wday - weekday_position(day_of_week)
       ago += 7 unless ago > 0
       advance(days: -ago)
     end
@@ -354,7 +355,11 @@ module DateAndTime
       end
 
       def days_span(day)
-        (DAYS_INTO_WEEK.fetch(day) - DAYS_INTO_WEEK.fetch(Date.beginning_of_week)) % 7
+        (weekday_position(day) - weekday_position(Date.beginning_of_week)) % 7
+      end
+
+      def weekday_position(day)
+        DAYS_INTO_WEEK_BY_DAY.key?(day) ? day : DAYS_INTO_WEEK.fetch(day)
       end
 
       def copy_time_to(other)

--- a/activesupport/test/core_ext/date_and_time_behavior.rb
+++ b/activesupport/test/core_ext/date_and_time_behavior.rb
@@ -104,16 +104,22 @@ module DateAndTimeBehavior
     # 23/10 |      |   |   |   |   |   #       |   |  1/11 |   |     |   |   # wednesday in next week `next_week(:wednesday)`
     assert_equal date_time_init(2005, 2, 28, 0, 0, 0),  date_time_init(2005, 2, 22, 15, 15, 10).next_week
     assert_equal date_time_init(2005, 3, 4, 0, 0, 0),   date_time_init(2005, 2, 22, 15, 15, 10).next_week(:friday)
+    assert_equal date_time_init(2005, 3, 4, 0, 0, 0),   date_time_init(2005, 2, 22, 15, 15, 10).next_week(5)
     assert_equal date_time_init(2006, 10, 30, 0, 0, 0), date_time_init(2006, 10, 23, 0, 0, 0).next_week
     assert_equal date_time_init(2006, 11, 1, 0, 0, 0),  date_time_init(2006, 10, 23, 0, 0, 0).next_week(:wednesday)
+    assert_equal date_time_init(2006, 11, 1, 0, 0, 0),  date_time_init(2006, 10, 23, 0, 0, 0).next_week(3)
   end
 
   def test_next_week_with_default_beginning_of_week_set
     with_bw_default(:tuesday) do
       assert_equal Time.local(2012, 3, 28), Time.local(2012, 3, 21).next_week(:wednesday)
+      assert_equal Time.local(2012, 3, 28), Time.local(2012, 3, 21).next_week(3)
       assert_equal Time.local(2012, 3, 31), Time.local(2012, 3, 21).next_week(:saturday)
+      assert_equal Time.local(2012, 3, 31), Time.local(2012, 3, 21).next_week(6)
       assert_equal Time.local(2012, 3, 27), Time.local(2012, 3, 21).next_week(:tuesday)
+      assert_equal Time.local(2012, 3, 27), Time.local(2012, 3, 21).next_week(2)
       assert_equal Time.local(2012, 4, 02), Time.local(2012, 3, 21).next_week(:monday)
+      assert_equal Time.local(2012, 4, 02), Time.local(2012, 3, 21).next_week(1)
     end
   end
 
@@ -152,18 +158,33 @@ module DateAndTimeBehavior
   def test_prev_week
     assert_equal date_time_init(2005, 2, 21, 0, 0, 0),  date_time_init(2005, 3, 1, 15, 15, 10).prev_week
     assert_equal date_time_init(2005, 2, 22, 0, 0, 0),  date_time_init(2005, 3, 1, 15, 15, 10).prev_week(:tuesday)
+    assert_equal date_time_init(2005, 2, 22, 0, 0, 0),  date_time_init(2005, 3, 1, 15, 15, 10).prev_week(2)
     assert_equal date_time_init(2005, 2, 25, 0, 0, 0),  date_time_init(2005, 3, 1, 15, 15, 10).prev_week(:friday)
+    assert_equal date_time_init(2005, 2, 25, 0, 0, 0),  date_time_init(2005, 3, 1, 15, 15, 10).prev_week(5)
     assert_equal date_time_init(2006, 10, 30, 0, 0, 0), date_time_init(2006, 11, 6, 0, 0, 0).prev_week
     assert_equal date_time_init(2006, 11, 15, 0, 0, 0), date_time_init(2006, 11, 23, 0, 0, 0).prev_week(:wednesday)
+    assert_equal date_time_init(2006, 11, 15, 0, 0, 0), date_time_init(2006, 11, 23, 0, 0, 0).prev_week(3)
   end
 
   def test_prev_week_with_default_beginning_of_week
     with_bw_default(:tuesday) do
       assert_equal Time.local(2012, 3, 14), Time.local(2012, 3, 21).prev_week(:wednesday)
+      assert_equal Time.local(2012, 3, 14), Time.local(2012, 3, 21).prev_week(3)
       assert_equal Time.local(2012, 3, 17), Time.local(2012, 3, 21).prev_week(:saturday)
+      assert_equal Time.local(2012, 3, 17), Time.local(2012, 3, 21).prev_week(6)
       assert_equal Time.local(2012, 3, 13), Time.local(2012, 3, 21).prev_week(:tuesday)
+      assert_equal Time.local(2012, 3, 13), Time.local(2012, 3, 21).prev_week(2)
       assert_equal Time.local(2012, 3, 19), Time.local(2012, 3, 21).prev_week(:monday)
+      assert_equal Time.local(2012, 3, 19), Time.local(2012, 3, 21).prev_week(1)
     end
+  end
+
+  def test_symbol_and_int_args_are_equivalent
+    assert_equal Date.today.beginning_of_week(:tuesday), Date.today.beginning_of_week(2)
+  end
+
+  def test_raises_if_invalid_wday_index
+    assert_raise(KeyError) { Date.today.beginning_of_week(7) }
   end
 
   def test_prev_week_at_same_time


### PR DESCRIPTION
Currently this works:

```ruby
Date.today.beginning_of_week(:tuesday) # returns a Tuesday
```

If you are using this functionality, you may also let users configure their week start day, and store this configuration in a database. To avoid i18n issues, the database column is most likely an integer (values 0-6) and then you display the corresponding day name in the UI.

This makes the code that provides the argument to `beginning_of_week` messy. You end up using this sort of pattern a lot:

```ruby
dayname = Date::DAYNAMES[week_start_day_from_settings].downcase.to_sym
start_of_week = date.beginning_of_week(dayname)
```

This works, but it'd be nicer if Rails could do it for you. This PR lets you pass an integer to `beginning_of_week` and related methods, so you can do this:

```ruby
Date.today.beginning_of_week(2) # returns a Tuesday
Date.today.beginning_of_week(week_start_day_from_settings) # returns a Tuesday
```
