### PR TITLE
Link to Host Authorization guides on `blocked_host` page

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.html.erb
@@ -4,4 +4,5 @@
 <main role="main" id="container">
   <h2>To allow requests to <%= @host %> make sure it is a valid hostname (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:</h2>
   <pre>config.hosts &lt;&lt; "<%= @host %>"</pre>
+  <p>For more details view: <a href="https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization">the Host Authorization guide</a></p>
 </main>

--- a/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.text.erb
+++ b/actionpack/lib/action_dispatch/middleware/templates/rescues/blocked_host.text.erb
@@ -3,3 +3,5 @@ Blocked host: <%= @host %>
 To allow requests to <%= @host %> make sure it is a valid hostname (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:
 
   config.hosts << "<%= @host %>"
+
+For more details on host authorization view: https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization


### PR DESCRIPTION
Provide additional configuration options on hosts, namely `RAILS_DEVELOPMENT_HOSTS` environment variable introduced in https://github.com/rails/rails/pull/41560

### Summary

https://github.com/rails/rails/pull/41560 introduced an alternate way to authorize hosts via an environment variable: `RAILS_DEVELOPMENT_HOSTS`.
This PR adds a link to https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization to the `blocked_host` page so that users can discover this feature when they are faced with a blocked host.

### Other Information

Note: https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization does not link to the correct information because there is no `#actiondispatch-hostauthorization` heading to link to (yet).
This heading will be present when the new guide https://edgeguides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization is used in place of the current guides.
