### PR TITLE
Properly clear the ActiveRecord::QueryLogs context

### DIFF
--- a/activerecord/lib/active_record/query_logs.rb
+++ b/activerecord/lib/active_record/query_logs.rb
@@ -96,6 +96,10 @@ module ActiveRecord
         end
       end
 
+      def clear_context # :nodoc:
+        context.clear
+      end
+
       def call(sql) # :nodoc:
         if prepend_comment
           "#{self.comment} #{sql}"

--- a/activerecord/lib/active_record/query_logs/test_helper.rb
+++ b/activerecord/lib/active_record/query_logs/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveRecord::QueryLogs::TestHelper # :nodoc:
+  def before_setup
+    ActiveRecord::QueryLogs.clear_context
+    super
+  end
+
+  def after_teardown
+    super
+    ActiveRecord::QueryLogs.clear_context
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -376,6 +376,15 @@ To keep using the current cache store, you can turn off cache versioning entirel
           if app.config.active_record.cache_query_log_tags
             ActiveRecord::QueryLogs.cache_query_log_tags = true
           end
+
+          app.reloader.before_class_unload { ActiveRecord::QueryLogs.clear_context }
+          app.executor.to_run              { ActiveRecord::QueryLogs.clear_context }
+          app.executor.to_complete         { ActiveRecord::QueryLogs.clear_context }
+
+          ActiveSupport.on_load(:active_support_test_case) do
+            require "active_record/query_logs/test_helper"
+            include ActiveRecord::QueryLogs::TestHelper
+          end
         end
       end
     end

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -2,8 +2,12 @@
 
 require "cases/helper"
 require "models/dashboard"
+require "active_record/query_logs/test_helper"
 
 class QueryLogsTest < ActiveRecord::TestCase
+  # Automatically included in Rails apps via railtie but that don't run here.
+  include ActiveRecord::QueryLogs::TestHelper
+
   fixtures :dashboards
 
   ActiveRecord::QueryLogs.taggings[:application] = -> {


### PR DESCRIPTION
It need to be cleared after each request/job, that's what `app.executor` is for.

For tests though, we have to use a test helper.

This is the same approach than `ActiveSupport::CurrentAttributes`.

cc @keeran 