### PR TITLE
Check for default function before attribute changes for partial inserts

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/dirty.rb
+++ b/activerecord/lib/active_record/attribute_methods/dirty.rb
@@ -233,7 +233,9 @@ module ActiveRecord
             changed_attribute_names_to_save
           else
             attribute_names.reject do |attr_name|
-              !attribute_changed?(attr_name) && column_for_attribute(attr_name).default_function
+              if column_for_attribute(attr_name).default_function
+                !attribute_changed?(attr_name)
+              end
             end
           end
         end


### PR DESCRIPTION
We're limiting the attributes being used for INSERTs to those without a default function and no changes. But we can first check for the presence of a default function before checking for changes.

That's because the default function will be stored in the schema cache and amounts to a hash fetch in `column_for_attribute`, while checking for changes potentially calls user code when using the Active Record
Attributes API.

### Summary

Follow-up to https://github.com/rails/rails/pull/43296. This just swaps the order of the checks because I believe there are not a lot of columns with a default function.

cc @byroot @rafaelfranca