### PR TITLE
Properly handle impossible cases in (not_)between

### DIFF
--- a/activerecord/lib/arel/predications.rb
+++ b/activerecord/lib/arel/predications.rb
@@ -39,7 +39,11 @@ module Arel # :nodoc: all
         self.in([])
       elsif open_ended?(other.begin)
         if open_ended?(other.end)
-          not_in([])
+          if infinity?(other.begin) == 1 || infinity?(other.end) == -1
+            self.in([])
+          else
+            not_in([])
+          end
         elsif other.exclude_end?
           lt(other.end)
         else
@@ -80,7 +84,11 @@ module Arel # :nodoc: all
         not_in([])
       elsif open_ended?(other.begin)
         if open_ended?(other.end)
-          self.in([])
+          if infinity?(other.begin) == 1 || infinity?(other.end) == -1
+            not_in([])
+          else
+            self.in([])
+          end
         elsif other.exclude_end?
           gteq(other.end)
         else

--- a/activerecord/test/cases/arel/attributes/attribute_test.rb
+++ b/activerecord/test/cases/arel/attributes/attribute_test.rb
@@ -668,6 +668,20 @@ module Arel
           )
         end
 
+        it "can be constructed with an endless range starting from Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(::Float::INFINITY..)
+
+          _(node).must_equal Nodes::In.new(attribute, [])
+        end
+
+        it "can be constructed with a beginless range ending in -Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.between(..-::Float::INFINITY)
+
+          _(node).must_equal Nodes::In.new(attribute, [])
+        end
+
         it "can be constructed with an exclusive range" do
           attribute = Attribute.new nil, nil
           node = attribute.between(0...3)
@@ -875,6 +889,20 @@ module Arel
             attribute,
             Nodes::Quoted.new(0)
           )
+        end
+
+        it "can be constructed with an endless range starting from Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(::Float::INFINITY..)
+
+          _(node).must_equal Nodes::NotIn.new(attribute, [])
+        end
+
+        it "can be constructed with a beginless range ending in -Infinity" do
+          attribute = Attribute.new nil, nil
+          node = attribute.not_between(..-::Float::INFINITY)
+
+          _(node).must_equal Nodes::NotIn.new(attribute, [])
         end
 
         it "can be constructed with an exclusive range" do


### PR DESCRIPTION
### Summary
Fixes #43521

Some impossible ranges returned all records before. Now, these impossible ranges return no records instead, eg:

```ruby
user = User.create!(age: 20)

assert_equal User.where(age: 15..).to_a, [user]
assert_equal User.where(age: 25..).to_a, []
assert_equal User.where(age: Float::INFINITY..).to_a, []
```

The last query would return all records from database before this change, now it correctly returns no records.