### PR TITLE
Don't `SELECT * FROM information_schema.tables`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -206,7 +206,7 @@ module ActiveRecord
           def data_source_sql(name = nil, type: nil)
             scope = quoted_scope(name, type: type)
 
-            sql = +"SELECT table_name FROM (SELECT * FROM information_schema.tables "
+            sql = +"SELECT table_name FROM (SELECT table_name, table_type FROM information_schema.tables "
             sql << " WHERE table_schema = #{scope[:schema]}) _subquery"
             if scope[:type] || scope[:name]
               conditions = []


### PR DESCRIPTION
### Summary

Depending on MySQL version and configuration, this is more than two
orders of magnitude slower than selecting only the two columns we need
for this query, which don't require reading any of the data files or
recalculating innodb stats.

https://dev.mysql.com/doc/refman/5.6/en/information-schema-optimization.html

Performance regression was introduced in #39712, before then the query
took around 40-50ms on my test environment, after it took 4-8s. With
this change it's back to 40-50ms.

### Other Information

I ran into this issue updating an app from Rails 6.0 to 6.1. We use the `okcomputer` gem as a heath check endpoint in the app and it uses `ActiveRecord::Migrator.current_version` automatically when it detects ActiveRecord. The query it runs hasn't changed and is still fast, but the method call also triggers a `table_exists?` query which is what slowed down in the upgrade. Since we use that check as a liveness probe in Kubernetes, and the health check slowed down so significantly, we were unable to even deploy the upgrade to a test environment because the health check timed out and Kubernetes killed the pod over and over.

Since this is a bug fix to a performance regressions introduced in 6.1, it would be nice to be able to backport it.

FYI @arthurschreiber