### PR TITLE
Fix (Inflector::Methods#underscore): small regression

### DIFF
--- a/activesupport/lib/active_support/inflector/methods.rb
+++ b/activesupport/lib/active_support/inflector/methods.rb
@@ -97,7 +97,7 @@ module ActiveSupport
       return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
       word = camel_cased_word.to_s.gsub("::", "/")
       word.gsub!(inflections.acronyms_underscore_regex) { "#{$1 && '_' }#{$2.downcase}" }
-      word.gsub!(/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }
+      word.gsub!(/([A-Z]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }
       word.tr!("-", "_")
       word.downcase!
       word

--- a/activesupport/test/inflector_test_cases.rb
+++ b/activesupport/test/inflector_test_cases.rb
@@ -121,6 +121,7 @@ module InflectorTestCases
     "ApplicationController" => "application_controller",
     "Area51Controller"      => "area51_controller",
     "AppCDir"               => "app_c_dir",
+    "Accountsv2N2Test"      => "accountsv2_n2_test",
   }
 
   UnderscoreToLowerCamel = {


### PR DESCRIPTION
### Summary

After this pull request was merged : https://github.com/rails/rails/commit/dd5b00cd6c074944d53281cc1e111ce1ff57e1c3, a tiny regression appeared on `ActiveSupport::Inflector.underscore` for some cases

Before when we were using the method `underscore` on `Accountsv2N2Test` it was returning this : `accountsv2_n2_test` but after the modifications, it was only returning this : `accountsv2n2_test`

To fix this we modified the regex from `/([A-Z\d]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/` to `/([A-Z]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/` and we added a little test case to it.

Please feel free to ask me any question about it.

Best regards,

Thornolf