### PR TITLE
Revert "Call Executor#wrap around each test"

### DIFF
--- a/activerecord/lib/active_record/query_logs/test_helper.rb
+++ b/activerecord/lib/active_record/query_logs/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveRecord::QueryLogs::TestHelper # :nodoc:
+  def before_setup
+    ActiveRecord::QueryLogs.clear_context
+    super
+  end
+
+  def after_teardown
+    super
+    ActiveRecord::QueryLogs.clear_context
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -380,6 +380,11 @@ To keep using the current cache store, you can turn off cache versioning entirel
           app.reloader.before_class_unload { ActiveRecord::QueryLogs.clear_context }
           app.executor.to_run              { ActiveRecord::QueryLogs.clear_context }
           app.executor.to_complete         { ActiveRecord::QueryLogs.clear_context }
+
+          ActiveSupport.on_load(:active_support_test_case) do
+            require "active_record/query_logs/test_helper"
+            include ActiveRecord::QueryLogs::TestHelper
+          end
         end
       end
     end

--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -2,8 +2,12 @@
 
 require "cases/helper"
 require "models/dashboard"
+require "active_record/query_logs/test_helper"
 
 class QueryLogsTest < ActiveRecord::TestCase
+  # Automatically included in Rails apps via railtie but that don't run here.
+  include ActiveRecord::QueryLogs::TestHelper
+
   fixtures :dashboards
 
   ActiveRecord::QueryLogs.taggings[:application] = -> {
@@ -11,10 +15,6 @@ class QueryLogsTest < ActiveRecord::TestCase
   }
 
   def setup
-    # QueryLogs context is automatically reset in Rails app via an executor hooks set in railtie
-    # But not in Active Record's own test suite.
-    ActiveRecord::QueryLogs.clear_context
-
     # Enable the query tags logging
     @original_transformers = ActiveRecord.query_transformers
     @original_prepend = ActiveRecord::QueryLogs.prepend_comment
@@ -28,9 +28,6 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveRecord.query_transformers = @original_transformers
     ActiveRecord::QueryLogs.prepend_comment = @original_prepend
     ActiveRecord::QueryLogs.tags = []
-    # QueryLogs context is automatically reset in Rails app via an executor hooks set in railtie
-    # But not in Active Record's own test suite.
-    ActiveRecord::QueryLogs.clear_context
   end
 
   def test_escaping_good_comment

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,9 +1,3 @@
-*   `Rails.application.executor` hooks are now called around every tests.
-
-    This helps to better simulate request or job local state being reset.
-
-    *Jean Boussier*
-
 *   Fix the `Digest::UUID.uuid_from_hash` behavior for namespace IDs that are different from the ones defined on `Digest::UUID`.
 
     The new behavior will be enabled by setting the

--- a/activesupport/lib/active_support/current_attributes/test_helper.rb
+++ b/activesupport/lib/active_support/current_attributes/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveSupport::CurrentAttributes::TestHelper # :nodoc:
+  def before_setup
+    ActiveSupport::CurrentAttributes.reset_all
+    super
+  end
+
+  def after_teardown
+    super
+    ActiveSupport::CurrentAttributes.reset_all
+  end
+end

--- a/activesupport/lib/active_support/executor/test_helper.rb
+++ b/activesupport/lib/active_support/executor/test_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module ActiveSupport::Executor::TestHelper # :nodoc:
-  def run(...)
-    Rails.application.executor.wrap { super }
-  end
-end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -33,8 +33,8 @@ module ActiveSupport
       app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
 
       ActiveSupport.on_load(:active_support_test_case) do
-        require "active_support/executor/test_helper"
-        include ActiveSupport::Executor::TestHelper
+        require "active_support/current_attributes/test_helper"
+        include ActiveSupport::CurrentAttributes::TestHelper
       end
     end
 

--- a/activesupport/test/current_attributes_test.rb
+++ b/activesupport/test/current_attributes_test.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/current_attributes/test_helper"
 
 class CurrentAttributesTest < ActiveSupport::TestCase
-  # CurrentAttributes is automatically reset in Rails app via executor hooks set in railtie
-  # But not in Active Support's own test suite.
-  setup do
-    ActiveSupport::CurrentAttributes.reset_all
-  end
-
-  teardown do
-    ActiveSupport::CurrentAttributes.reset_all
-  end
+  # Automatically included in Rails apps via railtie but that don't run here.
+  include ActiveSupport::CurrentAttributes::TestHelper
 
   Person = Struct.new(:id, :name, :time_zone)
 


### PR DESCRIPTION
Reverts rails/rails#43546

Reverting for now because it breaks integration tests. https://github.com/rails/rails/pull/43550 should fix it, but It's causing some tests to get stuck on CI, and it might take a while before I figure it out.

So I'd rather get back on a working `main` branch for now.