### PR TITLE
Improve active_job test_helper error messages

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -417,8 +417,20 @@ module ActiveJob
         end
       end
 
+      matching_class = potential_matches.select do |enqueued_job|
+        enqueued_job["job_class"] == job.to_s
+      end
+
       message = +"No enqueued job found with #{expected}"
-      message << "\n\nPotential matches: #{potential_matches.join("\n")}" if potential_matches.present?
+      if potential_matches.empty?
+        message << "\n\nNo jobs where enqueued"
+      elsif matching_class.empty?
+        message << "\n\nNo jobs of class #{expected[:job]} where enqueued, job classes enqueued: "
+        message << potential_matches.map { |job| job["job_class"] }.join(", ")
+      else
+        message << "\n\nPotential matches: #{matching_class.join("\n")}"
+      end
+
       assert matching_job, message
       instantiate_job(matching_job)
     end
@@ -507,8 +519,20 @@ module ActiveJob
         end
       end
 
+      matching_class = potential_matches.select do |enqueued_job|
+        enqueued_job["job_class"] == job.to_s
+      end
+
       message = +"No performed job found with #{expected}"
-      message << "\n\nPotential matches: #{potential_matches.join("\n")}" if potential_matches.present?
+      if potential_matches.empty?
+        message << "\n\nNo jobs where performed"
+      elsif matching_class.empty?
+        message << "\n\nNo jobs of class #{expected[:job]} where performed, job classes performed: "
+        message << potential_matches.map { |job| job["job_class"] }.join(", ")
+      else
+        message << "\n\nPotential matches: #{matching_class.join("\n")}"
+      end
+
       assert matching_job, message
 
       instantiate_job(matching_job)

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -698,8 +698,33 @@ class EnqueuedJobsTest < ActiveJob::TestCase
         HelloJob.perform_later(ricardo)
       end
     end
+
     assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
     assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
+  end
+
+  def test_show_jobs_that_are_enqueued_when_job_is_not_queued_at_all
+    ricardo = Person.new(9)
+    wilma = Person.new(11)
+
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_with(job: MultipleKwargsJob, args: [wilma]) do
+        HelloJob.perform_later(ricardo)
+      end
+    end
+
+    assert_match(/No enqueued job found with {:job=>MultipleKwargsJob, :args=>\[#{wilma.inspect}\]}/, error.message)
+    assert_match(/No jobs of class MultipleKwargsJob where enqueued, job classes enqueued: HelloJob/, error.message)
+  end
+
+  def test_shows_no_jobs_enqueued_when_there_are_no_jobs
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_enqueued_with(job: HelloJob, args: []) do
+      end
+    end
+
+    assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
+    assert_match(/No jobs where enqueued/, error.message)
   end
 
   def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
@@ -1952,6 +1977,28 @@ class PerformedJobsTest < ActiveJob::TestCase
 
     assert_match(/No performed job found with {:job=>HelloJob, :args=>\[#{wilma.inspect}\]}/, error.message)
     assert_match(/Potential matches: {.*?:job=>HelloJob, :args=>\[#<Person.* @id="9">\], :queue=>"default".*?}/, error.message)
+  end
+
+  def test_assert_performed_says_no_jobs_performed
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_with(job: HelloJob, args: [])
+    end
+
+    assert_match(/No performed job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
+    assert_match(/No jobs where performed/, error.message)
+  end
+
+  def test_assert_performed_when_not_matching_the_class_shows_alteratives
+    ricardo = Person.new(9)
+    wilma = Person.new(11)
+    HelloJob.perform_later(ricardo)
+    perform_enqueued_jobs
+    error = assert_raise ActiveSupport::TestCase::Assertion do
+      assert_performed_with(job: MultipleKwargsJob, args: [wilma])
+    end
+
+    assert_match(/No performed job found with {:job=>MultipleKwargsJob, :args=>\[#<Person.* @id=11>\]}/, error.message)
+    assert_match(/No jobs of class MultipleKwargsJob where performed, job classes performed: HelloJob/, error.message)
   end
 
   def test_assert_performed_with_does_not_change_jobs_count


### PR DESCRIPTION
Error messages from `assert_enqueued_with` and `assert_performed_with`
shows which other jobs are enqueued or performed when you get an
error.  We can improve these messages to make it clearer why the job
didn't match. This one error messages now have three different formats
based on why the job didn't match

1. Didn't match because no jobs are queued at all. This now reports,
```
No performed job found with {:job=>HelloJob, :args=>[]}

No jobs where performed
```

2. Didn't match because that job class was not queued. This now reports,
```
No performed job found with {:job=>MultipleKwargsJob, :args=>[#<Person:0x00007fe38f9f8100 @id=11>]}

No jobs of class MultipleKwargsJob where performed, job classes performed: HelloJob
```

3. Doesn't match due to arguments, queue, priority or other reason. This now reports
```
No performed job found with {:job=>HelloJob, :args=>[#<Person:0x00007fe3a89fc2c8 @id=11>]}

Potential matches: {"job_class"=>"HelloJob", "job_id"=>"f8636fd9-c7a0-4565-9198-17e175f30f0e", "provider_job_id"=>nil, "queue_name"=>"default", "priority"=>nil, "arguments"=>[{"_aj_globalid"=>"gid://aj/Person/9"}], "executions"=>0, "exception_executions"=>{}, "locale"=>"en", "timezone"=>nil, "enqueued_at"=>"2021-10-27T23:19:54Z", :job=>HelloJob, :args=>[#<Person:0x00007fe3a89dce00 @id="9">], :queue=>"default", :priority=>nil}
```

Which matches the old error message, but only reports jobs that where
queued of the same class as the job you are asserting was queued.
