### PR TITLE
Action Cable: use non-deprecated entrypoint for JS package

### DIFF
--- a/actioncable/package.json
+++ b/actioncable/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0-alpha2",
   "description": "WebSocket framework for Ruby on Rails.",
   "module": "app/javascript/action_cable/index.js",
-  "main": "app/assets/javascripts/action_cable.js",
+  "main": "app/assets/javascripts/actioncable.js",
   "files": [
     "app/assets/javascripts/*.js",
     "src/*.js"


### PR DESCRIPTION
#42856 deprecated `action_cable.js` in favor of `actioncable.js`, but the former is still the NPM package’s entrypoint. As a result, transpiled JS that imports from `@rails/actioncable` prints a deprecation warning to the console (as of the 7.0 alphas).