### PR TITLE
Propagate `save(validate:)` option for `:has_one` associations on autosave

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Propagate `save(validate:)` option for `:has_one` associations on autosave.
+
+    `save(validate:)` option is propagated to associated records during `autosave` when `autosave` option is
+    `nil`. Affects only `:has_one` associations.
+
+    *Jacopo Beschi*
+
 *   Propagate `save(validate:)` option for `:has_many` associations on autosave.
 
     `save(validate:)` option is propagated to associated records during `autosave` when `autosave` option is

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Propagate `save(validate:)` option for `:has_many` associations on autosave.
+
+    `save(validate:)` option is propagated to associated records during `autosave` when `autosave` option is
+    `nil`. Affects only `:has_many` associations.
+
+    Fixes #43400
+
+    *Jacopo Beschi*
+
 *   Add support for setting the filename of the schema or structure dump in the database config.
 
     Applications may now set their the filename or path of the schema / structure dump file in their database configuration.

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -456,7 +456,7 @@ module ActiveRecord
                 association.set_inverse_instance(record)
               end
 
-              saved = record.save(validate: !autosave)
+              saved = record.save(validate: @_save_options.fetch(:validate, !autosave))
               raise ActiveRecord::Rollback if !saved && autosave
               saved
             end

--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -409,7 +409,11 @@ module ActiveRecord
                 if autosave
                   saved = association.insert_record(record, false)
                 elsif !reflection.nested?
-                  association_saved = association.insert_record(record)
+                  association_saved = if @_save_options.key?(:validate)
+                    association.insert_record(record, @_save_options[:validate])
+                  else
+                    association.insert_record(record)
+                  end
 
                   if reflection.validate?
                     errors.add(reflection.name) unless association_saved

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1894,6 +1894,27 @@ class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::Tes
     @pirate.non_validated_ship.name = ""
     assert_predicate @pirate, :valid?
   end
+
+  test "propagates (validate: false) option to associations when autosave is nil" do
+    @pirate.build_ship
+
+    assert_equal false, @pirate.save
+    assert_equal true,  @pirate.save(validate: false)
+  end
+
+  test "propagates (validate: false) option to associations when autosave is true" do
+    @pirate.build_ship_with_autosave
+
+    assert_equal false, @pirate.save
+    assert_equal true,  @pirate.save(validate: false)
+  end
+
+  test "propagates (validate: false) option to associations when autosave is false" do
+    @pirate.build_ship_without_autosave
+
+    assert_equal true, @pirate.save
+    assert_equal true, @pirate.save(validate: false)
+  end
 end
 
 class TestAutosaveAssociationValidationsOnABelongsToAssociation < ActiveRecord::TestCase

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -1847,6 +1847,30 @@ class TestAutosaveAssociationValidationsOnAHasManyAssociation < ActiveRecord::Te
     assert pirate.valid?
     assert_not pirate.valid?(:conference)
   end
+
+  test "propagates (validate: false) option to associations when autosave is nil" do
+    pirate = SpacePirate.create!
+    pirate.birds.build
+
+    assert_equal false, pirate.save
+    assert_equal true,  pirate.save(validate: false)
+  end
+
+  test "propagates (validate: false) option to associations when autosave is true" do
+    pirate = SpacePirate.create!
+    pirate.birds_with_autosave.build
+
+    assert_equal false, pirate.save
+    assert_equal true,  pirate.save(validate: false)
+  end
+
+  test "propagates (validate: false) option to associations when autosave is false" do
+    pirate = SpacePirate.create!
+    pirate.birds_without_autosave.build
+
+    assert_equal false, pirate.save
+    assert_equal true, pirate.save(validate: false)
+  end
 end
 
 class TestAutosaveAssociationValidationsOnAHasOneAssociation < ActiveRecord::TestCase

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -109,6 +109,8 @@ class SpacePirate < ActiveRecord::Base
   has_one :ship, foreign_key: :pirate_id
   has_one :ship_with_annotation, -> { annotate("that is a rocket") }, class_name: :Ship, foreign_key: :pirate_id
   has_many :birds, foreign_key: :pirate_id
+  has_many :birds_with_autosave, foreign_key: :pirate_id, autosave: true, class_name: :Bird
+  has_many :birds_without_autosave, foreign_key: :pirate_id, autosave: false, class_name: :Bird
   has_many :birds_with_annotation, -> { annotate("that are also parrots") }, class_name: :Bird, foreign_key: :pirate_id
   has_many :treasures, as: :looter
   has_many :treasure_estimates, through: :treasures, source: :price_estimates

--- a/activerecord/test/models/pirate.rb
+++ b/activerecord/test/models/pirate.rb
@@ -27,6 +27,8 @@ class Pirate < ActiveRecord::Base
   has_many :treasure_estimates, through: :treasures, source: :price_estimates
 
   has_one :ship
+  has_one :ship_with_autosave, class_name: "Ship", autosave: true
+  has_one :ship_without_autosave, class_name: "Ship", autosave: false
   has_one :update_only_ship, class_name: "Ship"
   has_one :non_validated_ship, class_name: "Ship"
   has_many :birds, -> { order("birds.id ASC") }


### PR DESCRIPTION
### Summary

Propagate `save(validate:)` option for `:has_one` associations on autosave.

`save(validate:)` option is propagated to associated records during `autosave` when `autosave` option is `nil`. Affects only `:has_one` associations.

*This is a follow up of https://github.com/rails/rails/pull/43525 for `has_one` associations.
Since https://github.com/rails/rails/pull/43525 has not been merged yet it also encompasses the changes done in https://github.com/rails/rails/pull/43525.*
<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
