### PR TITLE
Revert "Guard against subscriber exceptions in ActiveSupport::Notifications"

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -213,10 +213,9 @@ module ActiveRecord
     def test_exceptions_from_notifications_are_not_translated
       original_error = StandardError.new("This StandardError shouldn't get translated")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { raise original_error }
-      wrapped_error = assert_raises(ActiveSupport::Notifications::InstrumentationSubscriberError) do
+      actual_error = assert_raises(StandardError) do
         @connection.execute("SELECT * FROM posts")
       end
-      actual_error = wrapped_error.exceptions.first
 
       assert_equal original_error, actual_error
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -489,13 +489,11 @@ class QueryCacheTest < ActiveRecord::TestCase
       payload[:sql].downcase!
     end
 
-    error = assert_raises ActiveSupport::Notifications::InstrumentationSubscriberError do
+    assert_raises FrozenError do
       ActiveRecord::Base.cache do
         assert_queries(1) { Task.find(1); Task.find(1) }
       end
     end
-
-    assert error.exceptions.first.is_a?(FrozenError)
   ensure
     ActiveSupport::Notifications.unsubscribe subscriber
   end

--- a/activesupport/test/notifications/evented_notification_test.rb
+++ b/activesupport/test/notifications/evented_notification_test.rb
@@ -5,9 +5,6 @@ require_relative "../abstract_unit"
 module ActiveSupport
   module Notifications
     class EventedTest < ActiveSupport::TestCase
-      # we expect all exception types to be handled, so test with the most basic type
-      class BadListenerException < Exception; end
-
       class Listener
         attr_reader :events
 
@@ -27,24 +24,6 @@ module ActiveSupport
       class ListenerWithTimedSupport < Listener
         def call(name, start, finish, id, payload)
           @events << [:call, name, start, finish, id, payload]
-        end
-      end
-
-      class BadStartListener < Listener
-        def start(name, id, payload)
-          raise BadListenerException
-        end
-
-        def finish(name, id, payload)
-        end
-      end
-
-      class BadFinishListener < Listener
-        def start(name, id, payload)
-        end
-
-        def finish(name, id, payload)
-          raise BadListenerException
         end
       end
 
@@ -82,54 +61,6 @@ module ActiveSupport
         notifier.start  "world", 1, {}
         notifier.finish  "world", 1, {}
         notifier.finish  "hello", 1, {}
-
-        assert_equal 4, listener.events.length
-        assert_equal [
-          [:start,  "hello", 1, {}],
-          [:start,  "world", 1, {}],
-          [:finish,  "world", 1, {}],
-          [:finish,  "hello", 1, {}],
-        ], listener.events
-      end
-
-      def test_listen_start_exception_consistency
-        notifier = Fanout.new
-        listener = Listener.new
-        notifier.subscribe nil, BadStartListener.new
-        notifier.subscribe nil, listener
-
-        assert_raises InstrumentationSubscriberError do
-          notifier.start  "hello", 1, {}
-        end
-        assert_raises InstrumentationSubscriberError do
-          notifier.start  "world", 1, {}
-        end
-        notifier.finish  "world", 1, {}
-        notifier.finish  "hello", 1, {}
-
-        assert_equal 4, listener.events.length
-        assert_equal [
-          [:start,  "hello", 1, {}],
-          [:start,  "world", 1, {}],
-          [:finish,  "world", 1, {}],
-          [:finish,  "hello", 1, {}],
-        ], listener.events
-      end
-
-      def test_listen_finish_exception_consistency
-        notifier = Fanout.new
-        listener = Listener.new
-        notifier.subscribe nil, BadFinishListener.new
-        notifier.subscribe nil, listener
-
-        notifier.start  "hello", 1, {}
-        notifier.start  "world", 1, {}
-        assert_raises InstrumentationSubscriberError do
-          notifier.finish  "world", 1, {}
-        end
-        assert_raises InstrumentationSubscriberError do
-          notifier.finish  "hello", 1, {}
-        end
 
         assert_equal 4, listener.events.length
         assert_equal [


### PR DESCRIPTION
Reverts rails/rails#43282

@theojulienne @matthewd @rafaelfranca @jhawthorn I'm afraid this PR breaks a tons of code and more importantly breaks the legitimate use case of raising from a subscriber to interrupt an action.

Could we somehow split the `finish` in two, so that we first complete all the events, and then call all the subscribers?

Alternatively as a short term solution I suppose we can re-raise the first exception we got? It's a bit dirty, but would work as a stopgap?