### PR TITLE
Add .shuffle and .sample to Active Record

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -6,6 +6,7 @@ module ActiveRecord
       :find, :find_by, :find_by!, :take, :take!, :sole, :find_sole_by, :first, :first!, :last, :last!,
       :second, :second!, :third, :third!, :fourth, :fourth!, :fifth, :fifth!,
       :forty_two, :forty_two!, :third_to_last, :third_to_last!, :second_to_last, :second_to_last!,
+      :shuffle, :sample,
       :exists?, :any?, :many?, :none?, :one?,
       :first_or_create, :first_or_create!, :first_or_initialize,
       :find_or_create_by, :find_or_create_by!, :find_or_initialize_by,

--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -297,6 +297,14 @@ module ActiveRecord
       second_to_last || raise_record_not_found_exception!
     end
 
+    def shuffle
+      order("RANDOM()")
+    end
+
+    def sample(n = nil)
+      shuffle.first(n)
+    end
+
     # Returns true if a record exists in the table that matches the +id+ or
     # conditions given, or false otherwise. The argument can take six forms:
     #

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -1703,6 +1703,23 @@ class FinderTest < ActiveRecord::TestCase
     end
   end
 
+  test "#shuffle" do
+    assert_equal Topic.count, Topic.shuffle.count
+    assert_equal [topics(:first)], Topic.where(title: "The First Topic").shuffle
+    assert_equal [], Topic.where(title: "This Topic Doesn't Exist").shuffle
+  end
+
+  test "#sample" do
+    assert Topic.sample
+    assert_equal topics(:first), Topic.where(title: "The First Topic").sample
+    assert_nil Topic.where(title: "This Topic Doesn't Exist").sample
+  end
+
+  test "#sample with a number of samples" do
+    assert_equal 3, Topic.sample(3).count
+    assert_equal 3, Topic.sample(3).length
+  end
+
   private
     def table_with_custom_primary_key
       yield(Class.new(Toy) do


### PR DESCRIPTION
### Summary

I often want to do things like `User.sample` or `Post.shuffle` or `Comment.sample(10)` and would find it more readable than `User.all.sample` / `Post.all.shuffle`. I thought I might as well do this in SQL.

But I'm not sure how to have a different SQL for each database, e.g. https://www.javatpoint.com/sql-order-by-random (`RAND()` for MySQL, `RANDOM()` for PostgreSQL/SQLite, etc.)

I'm not the only one needing this, e.g.

- [Stack Overflow question with 47 upvotes and an answer with 114 upvotes](https://stackoverflow.com/questions/17372886/whats-the-rails-4-way-of-finding-some-number-of-random-records)
- [Another Stack Overflow question with much more upvotes](https://stackoverflow.com/questions/2752231/random-record-in-activerecord)

I'm sure it could be optimised later, but the public API would be there.

There could be incompatibilities because the old `shuffle` would return an array and not an `ActiveRecord::Relation`

I would also need to add a CHANGELOG entry

TODO:

- [ ] get idea approval
- [ ] support all supported databases
- [ ] optimise performance
- [ ] add docs
- [ ] add CHANGELOG entry