### PR TITLE
`--skip-javascript` and `--javascript` to `--skip-js` and `--js`

### DIFF
--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -33,7 +33,7 @@ module Rails
       rails: {
         actions: "-a",
         orm: "-o",
-        javascripts: "-j",
+        js: "-j",
         resource_controller: "-c",
         scaffold_controller: "-c",
         stylesheets: "-y",

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -63,7 +63,7 @@ module Rails
         class_option :asset_pipeline,      type: :string, aliases: "-a", default: "sprockets",
                                            desc: "Choose your asset pipeline [options: sprockets (default), propshaft]"
 
-        class_option :skip_javascript,     type: :boolean, aliases: "-J", default: name == "plugin",
+        class_option :skip_js,             type: :boolean, aliases: "-J", default: name == "plugin",
                                            desc: "Skip JavaScript files"
 
         class_option :skip_hotwire,        type: :boolean, default: false,
@@ -111,7 +111,7 @@ module Rails
          asset_pipeline_gemfile_entry,
          database_gemfile_entry,
          web_server_gemfile_entry,
-         javascript_gemfile_entry,
+         js_gemfile_entry,
          hotwire_gemfile_entry,
          css_gemfile_entry,
          jbuilder_gemfile_entry,
@@ -310,10 +310,10 @@ module Rails
         GemfileEntry.new "jbuilder", "~> 2.7", comment, {}, options[:api]
       end
 
-      def javascript_gemfile_entry
-        return [] if options[:skip_javascript]
+      def js_gemfile_entry
+        return [] if options[:skip_js]
 
-        if options[:javascript] == "importmap"
+        if options[:js] == "importmap"
           GemfileEntry.version("importmap-rails", ">= 0.3.4", "Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]")
         else
           GemfileEntry.version "jsbundling-rails", "~> 0.1.0", "Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]"
@@ -321,7 +321,7 @@ module Rails
       end
 
       def hotwire_gemfile_entry
-        return [] if options[:skip_javascript] || options[:skip_hotwire]
+        return [] if options[:skip_js] || options[:skip_hotwire]
 
         turbo_rails_entry =
           GemfileEntry.version("turbo-rails", ">= 0.7.11", "Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]")
@@ -333,7 +333,7 @@ module Rails
       end
 
       def using_node?
-        options[:javascript] && options[:javascript] != "importmap"
+        options[:js] && options[:js] != "importmap"
       end
 
       def css_gemfile_entry
@@ -404,17 +404,17 @@ module Rails
         bundle_command("install", "BUNDLE_IGNORE_MESSAGES" => "1") if bundle_install?
       end
 
-      def run_javascript
-        return if options[:skip_javascript] || !bundle_install?
+      def run_js
+        return if options[:skip_js] || !bundle_install?
 
-        case options[:javascript]
+        case options[:js]
         when "importmap"                    then rails_command "importmap:install"
-        when "webpack", "esbuild", "rollup" then rails_command "javascript:install:#{options[:javascript]}"
+        when "webpack", "esbuild", "rollup" then rails_command "javascript:install:#{options[:js]}"
         end
       end
 
       def run_hotwire
-        return if options[:skip_javascript] || options[:skip_hotwire] || !bundle_install?
+        return if options[:skip_js] || options[:skip_hotwire] || !bundle_install?
 
         rails_command "turbo:install stimulus:install"
       end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -265,7 +265,7 @@ module Rails
       class_option :version, type: :boolean, aliases: "-v", group: :rails, desc: "Show Rails version number and quit"
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
-      class_option :javascript, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
+      class_option :js, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
       class_option :css, type: :string, desc: "Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass... check https://github.com/rails/cssbundling-rails]"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
 
@@ -279,7 +279,7 @@ module Rails
         # Force sprockets and JavaScript to be skipped when generating API only apps.
         # Can't modify options hash as it's frozen by default.
         if options[:api]
-          self.options = options.merge(skip_asset_pipeline: true, skip_javascript: true).freeze
+          self.options = options.merge(skip_asset_pipeline: true, skip_js: true).freeze
         end
 
         if options[:minimal]
@@ -292,7 +292,7 @@ module Rails
             skip_active_storage: true,
             skip_bootsnap: true,
             skip_dev_gems: true,
-            skip_javascript: true,
+            skip_js: true,
             skip_jbuilder: true,
             skip_system_test: true,
             skip_hotwire: true).freeze
@@ -505,7 +505,7 @@ module Rails
 
       public_task :apply_rails_template, :run_bundle
       public_task :generate_bundler_binstub
-      public_task :run_javascript
+      public_task :run_js
       public_task :run_hotwire
       public_task :run_css
 

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -6,7 +6,7 @@
     <%%= csrf_meta_tags %>
     <%%= csp_meta_tag %>
 
-    <%- if options[:skip_hotwire] || options[:skip_javascript] -%>
+    <%- if options[:skip_hotwire] || options[:skip_js] -%>
     <%%= stylesheet_link_tag "application" %>
     <%- else -%>
     <%%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/dummy_manifest.js.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/dummy_manifest.js.tt
@@ -1,7 +1,7 @@
 <% unless api? -%>
 //= link_tree ../images
 <% end -%>
-<% unless options.skip_javascript -%>
+<% unless options.skip_js -%>
 //= link_directory ../javascripts .js
 <% end -%>
 //= link_directory ../stylesheets .css

--- a/railties/lib/rails/generators/rails/plugin/templates/rails/engine_manifest.js.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/rails/engine_manifest.js.tt
@@ -1,5 +1,5 @@
 <% if mountable? -%>
-<% if !options.skip_javascript -%>
+<% if !options.skip_js -%>
 //= link_directory ../javascripts/<%= namespaced_name %> .js
 <% end -%>
 //= link_directory ../stylesheets/<%= namespaced_name %> .css

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -559,8 +559,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_javascript_is_skipped_if_required
-    run_generator [destination_root, "--skip-javascript"]
+  def test_js_is_skipped_if_required
+    run_generator [destination_root, "--skip-js"]
 
     assert_no_file "app/javascript"
 
@@ -742,8 +742,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_skip_javascript_option
-    generator([destination_root], skip_javascript: true)
+  def test_skip_js_option
+    generator([destination_root], skip_js: true)
 
     command_check = -> command, *_ do
       if command == "importmap:install"
@@ -767,7 +767,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_webpack_option
-    generator([destination_root], javascript: "webpack")
+    generator([destination_root], js: "webpack")
 
     webpacker_called = 0
     command_check = -> command, *_ do

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -174,7 +174,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "bin/rails", /APP_PATH/
   end
 
-  def test_generating_adds_dummy_app_without_javascript_and_assets_deps
+  def test_generating_adds_dummy_app_without_js_and_assets_deps
     run_generator
 
     assert_file "test/dummy/app/assets/stylesheets/application.css"
@@ -276,8 +276,8 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_no_file "#{destination_root}/Gemfile.lock"
   end
 
-  def test_skip_javascript
-    run_generator [destination_root, "--skip-javascript", "--mountable"]
+  def test_skip_js
+    run_generator [destination_root, "--skip-js", "--mountable"]
     assert_file "app/views/layouts/bukkits/application.html.erb" do |content|
       assert_no_match "javascript_pack_tag", content
     end


### PR DESCRIPTION
### Summary

I created an app and thought it was going to be `rails new --js esbuild` but it wasn't. So I thought it was misnamed and should be named `--js` and `--skip-js` like `--css`.

I think the name is closer to actual usage.

I will also make a pull request on `jsbundling-rails` to have generators be `js:install:esbuild` etc.

### Other Information

railties tests are very slow locally so I didn't run them all

TODO

- [ ] get general approval
- [ ] tests pass
- [ ] add CHANGELOG entry