### PR TITLE
Add Enum translation methods.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,9 +1,31 @@
+*   Add Enum translation methods.
+
+        class Report < ActiveRecord::Base
+          enum :status, [ :confidential, :publicly_available ]
+        end
+
+        report = Report.new(status: "publicly_available")
+        report.human_enum_name(:status) # => "Publicly available"
+        Report.human_enum_name(:status, :confidential) # => "Confidential"
+        Report.human_enum_names_hash(:status)
+        # => { "confidential" => "Confidential", "publicly_available" => "Publicly available" }
+
+    I18n YAML can also be used to define translations.
+
+        en:
+          activerecord:
+            enums:
+              report:
+                status:
+                  confidential: "Restricted to the organization members"
+                  publicly_available: "Published for everyone in the world"
+
+    *Shunichi Ikegami*
+
 *   Add `:day_format` option to `date_select`
 
         date_select("article", "written_on", day_format: ->(day) { day.ordinalize })
         # generates day options like <option value="1">1st</option>\n<option value="2">2nd</option>...
-
-    *Shunichi Ikegami*
 
 *   Allow `link_to` helper to infer link name from `Model#to_s` when it
     is used with a single argument:

--- a/activerecord/test/cases/enum_i18n_test.rb
+++ b/activerecord/test/cases/enum_i18n_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/book"
+
+class EnumI18nTests < ActiveRecord::TestCase
+  fixtures :books
+
+  def setup
+    I18n.backend = I18n::Backend::Simple.new
+    @book = books(:awdr)
+  end
+
+  def test_translated_enum
+    I18n.backend.store_translations "en", activerecord: { enums: { book: { status: { published: "Already published" } } } }
+    assert_equal "Already published", @book.human_enum_name("status")
+  end
+
+  def test_translated_enum_with_symbol
+    I18n.backend.store_translations "en", activerecord: { enums: { book: { status: { published: "Already published" } } } }
+    assert_equal "Already published", @book.human_enum_name(:status)
+  end
+
+  def test_translated_enum_default
+    assert_equal "Published", @book.human_enum_name("status")
+    assert_equal "English", @book.human_enum_name("language")
+    assert_equal "Visible", @book.human_enum_name("author_visibility")
+    assert_equal "Medium", @book.human_enum_name("difficulty")
+    assert_equal "Soft", @book.human_enum_name("cover")
+  end
+
+  def test_translated_specfied_enum_value
+    I18n.backend.store_translations "en", activerecord: { enums: { book: { status: { published: "Already published" } } } }
+    assert_equal "Already published", Book.human_enum_name("status", "published")
+  end
+
+  def test_translated_specfied_enum_value_with_symbols
+    I18n.backend.store_translations "en", activerecord: { enums: { book: { status: { published: "Already published" } } } }
+    assert_equal "Already published", Book.human_enum_name(:status, :published)
+  end
+
+  def test_translated_specfied_enum_value_defalut
+    assert_equal "Proposed", Book.human_enum_name("status", "proposed")
+    assert_equal "Written", Book.human_enum_name("status", "written")
+    assert_equal "Published", Book.human_enum_name("status", "published")
+  end
+
+  def test_translated_enum_names
+    I18n.backend.store_translations "en", activerecord: { enums: { book: { status: { published: "Already published" } } } }
+    assert_equal({ "proposed" => "Proposed", "written" => "Written", "published" => "Already published" }, Book.human_enum_names_hash("status"))
+  end
+end


### PR DESCRIPTION
### Summary
It would be great if `ActiveRecord::Enum` had translation methods like `Model.human_attribute_name`.

```ruby
class Report < ActiveRecord::Base
  enum :status, [ :confidential, :publicly_available ]
end

report = Report.new(status: "publicly_available")
report.human_enum_name(:status) # => "Publicly available"
Report.human_enum_name(:status, :confidential) # => "Confidential"
Report.human_enum_names_hash(:status)
# => { "confidential" => "Confidential", "publicly_available" => "Publicly available" }
```

I18n YAML can also be used to define translations.

```yaml
en:
  activerecord:
    enums:
      report:
        status:
          confidential: "Restricted to the organization members"
          publicly_available: "Published for everyone in the world"
```

It is easy to generate select tag options for an enum.

``` ruby
form.select :status, Report.human_enum_name_hash(:status).invert
# produces
#   <select name="report[status]" id="report_status"><option value="confidential">Confidential</option>
#   <option value="publicly_available">Publicly available</option></select>
```

### Other Information

Although `invert` in the select example is a little strange, I'm not sure Enum should have a dedicated method for select tag options.

```ruby
form.select :status, Report.enum_options_for_select(:status)
```

Or Should ActionView have enum options method?

```ruby
enum_options_for_select(Report, :status, selected)
```
