### PR TITLE
remove removed seamless attribute

### DIFF
--- a/railties/lib/rails/templates/rails/mailers/email.html.erb
+++ b/railties/lib/rails/templates/rails/mailers/email.html.erb
@@ -124,7 +124,7 @@
 </header>
 
 <% if @part && @part.mime_type %>
-  <iframe seamless name="messageBody" src="?<%= part_query(@part.mime_type) %>"></iframe>
+  <iframe name="messageBody" src="?<%= part_query(@part.mime_type) %>"></iframe>
 <% else %>
   <p>
     You are trying to preview an email that does not have any content.

--- a/railties/test/application/mailer_previews_test.rb
+++ b/railties/test/application/mailer_previews_test.rb
@@ -585,7 +585,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo.txt"
       assert_equal 200, last_response.status
-      assert_match '<iframe seamless name="messageBody" src="?part=text%2Fplain">', last_response.body
+      assert_match '<iframe name="messageBody" src="?part=text%2Fplain">', last_response.body
       assert_match '<option selected value="part=text%2Fplain">', last_response.body
       assert_match '<option  value="part=text%2Fhtml">', last_response.body
 
@@ -595,7 +595,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo.html?name=Ruby"
       assert_equal 200, last_response.status
-      assert_match '<iframe seamless name="messageBody" src="?name=Ruby&amp;part=text%2Fhtml">', last_response.body
+      assert_match '<iframe name="messageBody" src="?name=Ruby&amp;part=text%2Fhtml">', last_response.body
       assert_match '<option selected value="name=Ruby&amp;part=text%2Fhtml">', last_response.body
       assert_match '<option  value="name=Ruby&amp;part=text%2Fplain">', last_response.body
 
@@ -634,7 +634,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe seamless name="messageBody"], last_response.body
+      assert_match %r[<iframe name="messageBody"], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
@@ -675,7 +675,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe seamless name="messageBody"], last_response.body
+      assert_match %r[<iframe name="messageBody"], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
@@ -721,7 +721,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe seamless name="messageBody"], last_response.body
+      assert_match %r[<iframe name="messageBody"], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status
@@ -779,7 +779,7 @@ module ApplicationTests
 
       get "/rails/mailers/notifier/foo"
       assert_equal 200, last_response.status
-      assert_match %r[<iframe seamless name="messageBody"], last_response.body
+      assert_match %r[<iframe name="messageBody"], last_response.body
 
       get "/rails/mailers/notifier/foo?part=text/plain"
       assert_equal 200, last_response.status


### PR DESCRIPTION
https://caniuse.com/?search=seamless

Chrome 20-26 had partial support behind a flag, though this was later removed.

### Summary

I was looking at some preview's source code when I saw the `seamless` attribute, was curious about it but it seems like it's been removed and it's not supported by any browser.