### PR TITLE
Remove glob pattern from app/channels load path

### DIFF
--- a/railties/lib/rails/engine/configuration.rb
+++ b/railties/lib/rails/engine/configuration.rb
@@ -44,7 +44,7 @@ module Rails
                                            exclude: ["assets", javascript_path]
           paths.add "app/assets",          glob: "*"
           paths.add "app/controllers",     eager_load: true
-          paths.add "app/channels",        eager_load: true, glob: "**/*_channel.rb"
+          paths.add "app/channels",        eager_load: true
           paths.add "app/helpers",         eager_load: true
           paths.add "app/models",          eager_load: true
           paths.add "app/mailers",         eager_load: true


### PR DESCRIPTION
### Summary

For some reason, the Rails Engine configuration adds a glob pattern to the load path for `app/channels`. This causes channel classes themselves to be included on the load path, as opposed to just the directory:

```
$> ActiveSupport::Dependencies.autoload_paths.grep(/channels/)
=> ["/my_rails_app/app/channels", "/my_rails_app/app/channels/test_channel.rb"]
```

It was my understanding that load paths should represent _paths_, not files, so this seems a bit odd. 

### Other Information

The presence of this glob pattern has necessitated at least one change in Zeitwerk (https://github.com/rails/rails/issues/36461), which fixed it by working around the fact that files were present in a list of directories.

This also causes issues with users of [packwerk](https://github.com/Shopify/packwerk). Packwerk maintains a list of the application's load paths in its config file, and the fact that channel files appear in the load path means the files themselves need to be added to the list.  

I'm unsure if there's a reason for this glob pattern, but I could be missing something. In case it helps trip someone's memory, it was added during [this refactor](​​https://github.com/rails/rails/pull/23505): https://github.com/rails/rails/pull/23505.