### PR TITLE
ActiveJob: Validate arguments for perform_later

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -3,6 +3,11 @@
 
     *Veerpal Brar*
 
+*   Raise an `ArgumentErrorError` if `perform_later` is invoked with arguments
+    not compatible with `perform`. 
+
+    *Christian Schmidt*
+
 
 ## Rails 7.0.0.alpha2 (September 15, 2021) ##
 

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -3,7 +3,7 @@
 
     *Veerpal Brar*
 
-*   Raise an `ArgumentErrorError` if `perform_later` is invoked with arguments
+*   Raise an `ArgumentError` if `perform_later` is invoked with arguments
     not compatible with `perform`. 
 
     *Christian Schmidt*

--- a/activejob/lib/active_job/core.rb
+++ b/activejob/lib/active_job/core.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/method"
+
 module ActiveJob
   # Provides general behavior that will be included into every Active Job
   # object that inherits from ActiveJob::Base.
@@ -58,7 +60,7 @@ module ActiveJob
     module ClassMethods
       # Creates a new job instance from a hash created with +serialize+
       def deserialize(job_data)
-        job = job_data["job_class"].constantize.new
+        job = job_data["job_class"].constantize.allocate
         job.deserialize(job_data)
         job
       end
@@ -89,6 +91,8 @@ module ActiveJob
     # Creates a new job instance. Takes the arguments that will be
     # passed to the perform method.
     def initialize(*arguments)
+      method(:perform).validate_parameters(*arguments)
+
       @arguments  = arguments
       @job_id     = SecureRandom.uuid
       @queue_name = self.class.queue_name

--- a/activejob/test/cases/queuing_test.rb
+++ b/activejob/test/cases/queuing_test.rb
@@ -2,6 +2,7 @@
 
 require "helper"
 require "jobs/hello_job"
+require "jobs/kwargs_job"
 require "jobs/enqueue_error_job"
 require "active_support/core_ext/numeric/time"
 
@@ -52,6 +53,18 @@ class QueuingTest < ActiveSupport::TestCase
     EnqueueErrorJob.perform_later do |job|
       assert_equal false, job.successfully_enqueued?
       assert_equal ActiveJob::EnqueueError, job.enqueue_error.class
+    end
+  end
+
+  test "perform_later validates args" do
+    assert_raises ArgumentError do
+      HelloJob.perform_later "Jamie", "extra argument"
+    end
+  end
+
+  test "perform_later validates kwargs" do
+    assert_raises ArgumentError do
+      KwargsJob.perform_later "not kwarg"
     end
   end
 end

--- a/activejob/test/jobs/abort_before_enqueue_job.rb
+++ b/activejob/test/jobs/abort_before_enqueue_job.rb
@@ -10,7 +10,7 @@ class AbortBeforeEnqueueJob < ActiveJob::Base
 
   attr_accessor :flag
 
-  def perform
+  def perform(action = :raise)
     raise "This should never be called"
   end
 

--- a/activejob/test/jobs/logging_job.rb
+++ b/activejob/test/jobs/logging_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class LoggingJob < ActiveJob::Base
-  def perform(dummy)
-    logger.info "Dummy, here is it: #{dummy}"
+  def perform(*args)
+    logger.info "Dummy, here is it: #{args.join(', ')}"
   end
 
   def job_id

--- a/activejob/test/jobs/multiple_kwargs_job.rb
+++ b/activejob/test/jobs/multiple_kwargs_job.rb
@@ -3,7 +3,7 @@
 require_relative "../support/job_buffer"
 
 class MultipleKwargsJob < ActiveJob::Base
-  def perform(argument1:, argument2:)
+  def perform(argument1:, argument2: nil)
     JobBuffer.add("Job with argument1: #{argument1}, argument2: #{argument2}")
   end
 end

--- a/activejob/test/jobs/retry_job.rb
+++ b/activejob/test/jobs/retry_job.rb
@@ -37,7 +37,7 @@ class RetryJob < ActiveJob::Base
   discard_on(CustomDiscardableError) { |job, error| JobBuffer.add("Dealt with a job that was discarded in a custom way. Message: #{error.message}") }
 
   before_enqueue do |job|
-    if job.arguments.include?(:log_scheduled_at) && job.scheduled_at
+    if job.arguments&.include?(:log_scheduled_at) && job.scheduled_at
       JobBuffer.add("Next execution scheduled at #{job.scheduled_at}")
     end
   end

--- a/activesupport/lib/active_support/core_ext/callable/parameters.rb
+++ b/activesupport/lib/active_support/core_ext/callable/parameters.rb
@@ -49,6 +49,10 @@ module Callable
         # This will fail but call it anyway to make Ruby raise an ArgumentError
         # with an appropriate error message.
         call(...)
+
+        # If the above did not raise as expected, there is a bug in parameters_valid?.
+        # Raise an exception to alert the user that this callable was invoked unintentionally.
+        raise "parameters_valid? not in sync with call - #{self.class} has been invoked!"
       end
     end
 

--- a/activesupport/lib/active_support/core_ext/callable/parameters.rb
+++ b/activesupport/lib/active_support/core_ext/callable/parameters.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Callable
+  module Parameters
+    # Returns true if the specified parameters satisfy the callable signature,
+    # i.e. if arity and keyword parameters match.
+    #
+    # If the parameters are valid, the callable can be invoked with these parameters
+    # raising an +ArgumentError+. This does not include +ArgumentError+ raised
+    # explicitly inside the callable.
+    def parameters_valid?(*args, **kwargs)
+      summary = parameter_summary
+      count = args.count
+
+      if kwargs.any? && summary[:key].none?
+        count += 1
+        kwargs = {}
+      end
+
+      if count < summary[:min]
+        return false
+      end
+
+      if count > summary[:max] && !summary[:rest]
+        return false
+      end
+
+      keys = kwargs.keys
+
+      missing = summary[:keyreq] - keys
+      if missing.any?
+        return false
+      end
+
+      unless summary[:keyrest]
+        unknown = keys - summary[:key]
+        if unknown.any?
+          return false
+        end
+      end
+
+      true
+    end
+
+    # Raises +ArgumentError+ if the specified parameters do not satisfy the callable
+    # signature, i.e. if arity and keyword parameters do not match.
+    def validate_parameters(...)
+      unless parameters_valid?(...)
+        # This will fail but call it anyway to make Ruby raise an ArgumentError
+        # with an appropriate error message.
+        call(...)
+      end
+    end
+
+    private
+      def parameter_summary
+        @parameter_summary ||= begin
+          summary = {
+            min: 0,
+            max: 0,
+            rest: false,
+            keyrest: false,
+            key: [],
+            keyreq: [],
+          }
+
+          parameters.each_with_object(summary) do |parameter, summary|
+            type, name = parameter
+            case type
+            when :opt
+              summary[:max] += 1
+            when :req
+              summary[:min] += 1
+              summary[:max] += 1
+            when :keyreq
+              summary[:key] << name
+              summary[:keyreq] << name
+            when :key
+              summary[:key] << name
+            when :rest
+              summary[:rest] = true
+            when :keyrest
+              summary[:keyrest] = true
+            when :block
+              summary[:block] = true
+            when :nokey
+              summary[:nokey] = true
+            else
+              raise "Unknown parameter type: #{type}"
+            end
+          end
+        end.freeze
+      end
+  end
+end

--- a/activesupport/lib/active_support/core_ext/callable/parameters.rb
+++ b/activesupport/lib/active_support/core_ext/callable/parameters.rb
@@ -12,7 +12,7 @@ module Callable
       summary = parameter_summary
       count = args.count
 
-      if kwargs.any? && summary[:key].none?
+      if kwargs.any? && summary[:key].none? && !summary[:keyrest]
         count += 1
         kwargs = {}
       end

--- a/activesupport/lib/active_support/core_ext/method.rb
+++ b/activesupport/lib/active_support/core_ext/method.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/callable/parameters"
+
+class Method
+  include Callable::Parameters
+end

--- a/activesupport/lib/active_support/core_ext/proc.rb
+++ b/activesupport/lib/active_support/core_ext/proc.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/callable/parameters"
+
+class Proc
+  include Callable::Parameters
+end

--- a/activesupport/test/core_ext/callable_test.rb
+++ b/activesupport/test/core_ext/callable_test.rb
@@ -112,6 +112,17 @@ class CallableTest < ActiveSupport::TestCase
   def dummy(req, opt = nil, keyreq:, key: nil)
   end
 
+  def test_incompatibility_warning
+    callable = ->() { }
+    callable.stub(:call, 1) do
+      exception = assert_raises RuntimeError do
+        callable.validate_parameters(1)
+      end
+
+      assert_equal "parameters_valid? not in sync with call - Proc has been invoked!", exception.message
+    end
+  end
+
   if RUBY_VERSION < "3"
 
     def assert_parameters_valid(callable, *args)

--- a/activesupport/test/core_ext/callable_test.rb
+++ b/activesupport/test/core_ext/callable_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require_relative "../abstract_unit"
+require "active_support/core_ext/proc"
+require "active_support/core_ext/method"
+
+class CallableTest < ActiveSupport::TestCase
+  def test_none
+    callable = ->() { }
+
+    assert_parameters_valid(callable)
+    assert_parameters_not_valid(callable, 1)
+    assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_req
+    callable = ->(req) { }
+
+    assert_parameters_valid(callable, 1)
+    assert_parameters_valid(callable, foo: 1)
+    assert_parameters_not_valid(callable)
+    assert_parameters_not_valid(callable, 1, 2)
+  end
+
+  def test_req_req
+    callable = ->(req1, req2) { }
+
+    assert_parameters_valid(callable, 1, 2)
+    assert_parameters_valid(callable, 1, foo: 1)
+    assert_parameters_not_valid(callable, 1)
+    assert_parameters_not_valid(callable, 1, 2, 3)
+  end
+
+  def test_opt
+    callable = ->(req, opt = nil) { }
+
+    assert_parameters_valid(callable, 1)
+    assert_parameters_valid(callable, 1, 2)
+    assert_parameters_valid(callable, foo: 1)
+    assert_parameters_valid(callable, 1, foo: 2)
+    assert_parameters_not_valid(callable)
+    assert_parameters_not_valid(callable, 1, 2, foo: 3)
+    assert_parameters_not_valid(callable, 1, 2, 3)
+  end
+
+  def test_req_rest
+    callable = ->(req, *rest) { }
+
+    assert_parameters_valid(callable, 1)
+    assert_parameters_valid(callable, 1, 2)
+    assert_parameters_valid(callable, 1, 2, 3)
+    assert_parameters_valid(callable, foo: 1)
+    assert_parameters_valid(callable, 1, foo: 2)
+    assert_parameters_not_valid(callable)
+  end
+
+  def test_key
+    callable = ->(key: nil) { }
+
+    assert_parameters_valid(callable)
+    assert_parameters_valid(callable, key: 1)
+    assert_parameters_not_valid(callable, 1)
+    assert_parameters_not_valid(callable, 1, key: 2)
+    assert_parameters_not_valid(callable, key: 1, foo: 2)
+    assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_keyreq
+    callable = ->(keyreq:) { }
+
+    assert_parameters_valid(callable, keyreq: 1)
+    assert_parameters_not_valid(callable)
+    assert_parameters_not_valid(callable, 1)
+    assert_parameters_not_valid(callable, 1, keyreq: 1)
+    assert_parameters_not_valid(callable, keyreq: 1, foo: 2)
+    assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_keyreq_keyrest
+    callable = ->(keyreq:, **keyrest) { }
+
+    assert_parameters_valid(callable, keyreq: 1)
+    assert_parameters_valid(callable, keyreq: 1, foo: 2)
+    assert_parameters_not_valid(callable)
+    assert_parameters_not_valid(callable, 1)
+    assert_parameters_not_valid(callable, 1, keyreq: 1)
+    assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_nokey
+    callable = ->(**nil) { }
+
+    assert_parameters_valid(callable)
+    assert_parameters_not_valid(callable, 1)
+    assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_method_proc
+    method = method(:dummy)
+    [method, method.to_proc].each do |callable|
+      assert_parameters_valid(callable, 1, keyreq: 2)
+      assert_parameters_valid(callable, 1, 2, keyreq: 3, key: 4)
+      assert_parameters_not_valid(callable)
+      assert_parameters_not_valid(callable, keyreq: 1)
+      assert_parameters_not_valid(callable, 1, 2, 3, keyreq: 1)
+      assert_parameters_not_valid(callable, keyreq: 1)
+      assert_parameters_not_valid(callable, 1, 2, key: 3)
+      assert_parameters_not_valid(callable, 1, 2, keyreq: 3, key: 4, foo: 5)
+    end
+  end
+
+  def dummy(req, opt = nil, keyreq:, key: nil)
+  end
+
+  if RUBY_VERSION < "3"
+
+    def assert_parameters_valid(callable, *args)
+      assert callable.parameters_valid?(*args), "parameters_valid? to be true"
+      assert_nothing_raised do
+        callable.call(*args)
+        callable.validate_parameters(*args)
+      end
+    end
+
+    def assert_parameters_not_valid(callable, *args)
+      assert_not callable.parameters_valid?(*args), "parameters_valid? to be false"
+      assert_raises ArgumentError do
+        callable.call(*args)
+      end
+      assert_raises ArgumentError do
+        callable.validate_parameters(*args)
+      end
+    end
+
+  else
+
+    def assert_parameters_valid(callable, *args, **kw_args)
+      assert callable.parameters_valid?(*args, **kw_args), "parameters_valid? to be true"
+      assert_nothing_raised do
+        callable.call(*args, **kw_args)
+        callable.validate_parameters(*args, **kw_args)
+      end
+    end
+
+    def assert_parameters_not_valid(callable, *args, **kw_args)
+      assert_not callable.parameters_valid?(*args, **kw_args), "parameters_valid? to be false"
+      assert_raises ArgumentError do
+        callable.call(*args, **kw_args)
+      end
+      assert_raises ArgumentError do
+        callable.validate_parameters(*args, **kw_args)
+      end
+    end
+
+  end
+end

--- a/activesupport/test/core_ext/callable_test.rb
+++ b/activesupport/test/core_ext/callable_test.rb
@@ -54,6 +54,16 @@ class CallableTest < ActiveSupport::TestCase
     assert_parameters_not_valid(callable)
   end
 
+  def test_req_keyrest
+    callable = ->(req, **keyrest) { }
+
+    assert_parameters_valid(callable, 1)
+    assert_parameters_valid(callable, 1, foo: 1)
+    assert_parameters_not_valid(callable)
+    assert_parameters_not_valid(callable, foo: 1)
+    assert_parameters_not_valid(callable, 1, 2)
+  end
+
   def test_key
     callable = ->(key: nil) { }
 
@@ -85,6 +95,25 @@ class CallableTest < ActiveSupport::TestCase
     assert_parameters_not_valid(callable, 1)
     assert_parameters_not_valid(callable, 1, keyreq: 1)
     assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_rest_key
+    callable = ->(*rest, key: nil) { }
+
+    assert_parameters_valid(callable)
+    assert_parameters_valid(callable, 1)
+    assert_parameters_valid(callable, key: 1)
+    assert_parameters_valid(callable, 1, key: 2)
+    assert_parameters_not_valid(callable, foo: 1)
+  end
+
+  def test_rest_keyrest
+    callable = ->(*rest, **keyrest) { }
+
+    assert_parameters_valid(callable)
+    assert_parameters_valid(callable, 1)
+    assert_parameters_valid(callable, key: 1)
+    assert_parameters_valid(callable, 1, key: 2)
   end
 
   def test_nokey


### PR DESCRIPTION
### Summary

`MyJob.perform_later` must be called with arguments compatible with `MyJob#perform`, but this is not validated at call time.

If bad arguments are used, an `ArgumentError` will be raised, when the job is eventually performed. This usually happens later on a different thread, making it difficult to debug.

This PR will validate the arguments at call time, making any errors easier to find.

### Other Information

The code for validating arguments is very generic, so I added this to ActiveSupport as a core-ext to `Method` and `Proc`.

The validation attempts to mimic Ruby's handling of positional and keyword arguments. This is a minefield, but I hope I have covered all cases. Feel free to prove me wrong :-) The test cases are inspired by https://github.com/ruby/ruby/blob/master/test/ruby/test_method.rb#L537-L710.

Ruby seems to use the terms “parameter” and “argument” interchangeably, unless there is some distinction I have missed. For consistency with `Method#parameters` I chose the method names `Method#validateparameters`and `Method#parameters_valid?`, even though elsewhere in Ruby and Rails, the term “argument” seems prevalent (e.g. in `ArgumentError`).

This new validation revealed some bugs in the test suite for ActiveJob. These are fixed in this PR.
