### PR TITLE
Track which attributes have been set

### DIFF
--- a/activemodel/lib/active_model/attribute.rb
+++ b/activemodel/lib/active_model/attribute.rb
@@ -109,6 +109,10 @@ module ActiveModel
       defined?(@value)
     end
 
+    def assigned?
+      original_attribute.present?
+    end
+
     def ==(other)
       self.class == other.class &&
         name == other.name &&
@@ -147,7 +151,6 @@ module ActiveModel
 
     private
       attr_reader :original_attribute
-      alias :assigned? :original_attribute
 
       def initialize_dup(other)
         if defined?(@value) && @value.duplicable?

--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -89,6 +89,10 @@ module ActiveModel
       attributes.each_key.select { |name| self[name].has_been_read? }
     end
 
+    def assigned
+      attributes.each_key.select { |name| self[name].assigned? }
+    end
+
     def map(&block)
       new_attributes = attributes.transform_values(&block)
       AttributeSet.new(new_attributes)

--- a/activemodel/test/cases/attribute_set_test.rb
+++ b/activemodel/test/cases/attribute_set_test.rb
@@ -266,6 +266,17 @@ module ActiveModel
       assert_equal [:foo], attributes.accessed
     end
 
+    test "#assigned_attributes returns only attributes which have been written" do
+      builder = AttributeSet::Builder.new(foo: Type::Value.new, bar: Type::Value.new)
+      attributes = builder.build_from_database(foo: "1", bar: "2")
+
+      assert_equal [], attributes.assigned
+
+      attributes.write_from_user(:foo, 1)
+
+      assert_equal [:foo], attributes.assigned
+    end
+
     test "#map returns a new attribute set with the changes applied" do
       builder = AttributeSet::Builder.new(foo: Type::Integer.new, bar: Type::Integer.new)
       attributes = builder.build_from_database(foo: "1", bar: "2")

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Provide means to track which attributes have been set through `ActiveRecord::AttributeMethods#assigned_fields`.
+
+    *Aaron Lipman*
+
 *   Add support for setting the filename of the schema or structure dump in the database config.
 
     Applications may now set their the filename or path of the schema / structure dump file in their database configuration.

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -377,6 +377,17 @@ module ActiveRecord
       @attributes.accessed
     end
 
+    # Returns the names of all attributes which have been set,
+    # regardless of whether they have changed.
+    #
+    #   @post = Post.last
+    #   @post.assigned_fields # => []
+    #   @post.title = 'hello world'
+    #   @post.assigned_fields # => ['title']
+    def assigned_fields
+      @attributes.assigned
+    end
+
     private
       def attribute_method?(attr_name)
         # We check defined? because Syck calls respond_to? before actually calling initialize.

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -1107,6 +1107,17 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     assert_equal ["title"], model.accessed_fields
   end
 
+  test "assigned_fields" do
+    model = @target.first
+    assert_equal [], model.assigned_fields
+
+    model.title = model.title
+    assert_equal ["title"], model.assigned_fields
+
+    model.save!
+    assert_equal [], model.assigned_fields
+  end
+
   test "generated attribute methods ancestors have correct module" do
     mod = Topic.send(:generated_attribute_methods)
     assert_equal "Topic::GeneratedAttributeMethods", mod.inspect


### PR DESCRIPTION
Introduce `ActiveRecord::AttributeMethods#assigned_fields`. This provides a means to check which attributes have been assigned a value, mirroring the behavior of `#accessed_fields`.

This is particularly useful for conditional callbacks which should run depending on whether an attribute's value has been specified, regardless of whether the value has changed.

(This is a somewhat more implicit interface than the typical practice of triggering conditional callbacks through an `attr_accessor`. I feel this approach allows for cleaner code by reducing models' interfaces in favor of internal logic, but I'm curious as to others' thoughts.)