### PR TITLE
Raise an exception when using unrecognized options in change_table block

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -67,6 +67,14 @@ module ActiveRecord
           end
         end
 
+        def change_table(table_name, **options)
+          if block_given?
+            super { |t| yield compatible_table_definition(t) }
+          else
+            super
+          end
+        end
+
         module TableDefinition
           def new_column_definition(name, type, **options)
             type = PostgreSQLCompat.compatible_timestamp_type(type, @conn)
@@ -77,6 +85,10 @@ module ActiveRecord
             options[:precision] ||= nil
             super
           end
+
+          private
+            def raise_on_if_exist_options(options)
+            end
         end
 
         private

--- a/activerecord/test/cases/invertible_migration_test.rb
+++ b/activerecord/test/cases/invertible_migration_test.rb
@@ -96,7 +96,7 @@ module ActiveRecord
       def change
         change_table("horses") do |t|
           t.remove_index [:name, :color]
-          t.remove_index [:color], if_exists: true
+          t.remove_index [:color] if t.index_exists?(:color)
         end
       end
     end

--- a/activerecord/test/cases/migration/change_table_test.rb
+++ b/activerecord/test/cases/migration/change_table_test.rb
@@ -188,7 +188,7 @@ module ActiveRecord
 
       def test_index_exists
         with_change_table do |t|
-          @connection.expect :index_exists?, nil, [:delete_me, :bar, {}]
+          @connection.expect :index_exists?, nil, [:delete_me, :bar]
           t.index_exists?(:bar)
         end
       end
@@ -287,6 +287,22 @@ module ActiveRecord
         with_change_table do |t|
           @connection.expect :remove_check_constraint, nil, [:delete_me, name: "price_check"]
           t.remove_check_constraint name: "price_check"
+        end
+      end
+
+      def test_remove_column_with_if_exists_raises_error
+        assert_raises(ArgumentError) do
+          with_change_table do |t|
+            t.remove :name, if_exists: true
+          end
+        end
+      end
+
+      def test_add_column_with_if_not_exists_raises_error
+        assert_raises(ArgumentError) do
+          with_change_table do |t|
+            t.string :nickname, if_not_exists: true
+          end
         end
       end
     end

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -519,6 +519,20 @@ module ActiveRecord
         assert connection.column_exists?(:testings, :published_at, **precision_implicit_default)
       end
 
+      def test_change_table_allows_if_exists_option_on_6_1
+        migration = Class.new(ActiveRecord::Migration[6.1]) {
+          def migrate(x)
+            change_table(:testings) do |t|
+              t.remove :foo, if_exists: true
+            end
+          end
+        }.new
+
+        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+        assert_not connection.column_exists?(:testings, :foo)
+      end
+
       private
         def precision_implicit_default
           if current_adapter?(:Mysql2Adapter)


### PR DESCRIPTION
### Summary

This PR raises an exception when the yielded `Table` inside a `change_table` block receives a method with the keyword arguments `if_exists` or `if_not_exists`. This prevents unexpected behavior when a `change_table` block called with the option `bulk: true` will silently ignore the option, but when called without that option, it will be obeyed.

#### Background

In a database migration, the expressions `add_column`, `remove_index`, etc. accept as keyword options `if_exists: true`/`if_not_exists: true` which will skip that table alteration if the column or index does or does not already exist.

This might lead some to think that within a change_table block,
```ruby
change_table(:table) do |t|
	t.column :new_column, if_not_exists: true
	t.remove_index :old_column, if_exists: true
end
```
also works, but it doesn't. Or rather, it works accidentally when change_table is not called with `bulk: true`, but the option is silently ignored when it is called with `bulk: true`.

This commit raises an exception when these options are used in a change_table block. The documentation for `Table` already suggests using this syntax for conditional operations, which *does* work for both bulk and individual migrations:
```ruby
change_table(:table) do |t|
	t.column :new_column unless t.column_exists?(:new_column)
	t.remove_index :old_column if t.index_exists?(:new_column)
end
```
This suggestion is already made in the documentation to [`ActiveRecord::ConnectionAdapters::Table`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/Table.html#method-i-column_exists-3F), so it seems like a pretty safe suggestion to put in the exception message.

### Other Information

I could have solved the behavior discrepency between `bulk: true` and `bulk: false` by pulling the same checks [from `ActiveRecord::ConnectionAdapters::SchemaStatements`](https://github.com/rails/rails/blob/9f980664fc1bc1fb9845e17d2c5a9ab710156303/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L614) into [`ActiveRecord::ConnectionAdapters::Table`](https://github.com/rails/rails/blob/9f980664fc1bc1fb9845e17d2c5a9ab710156303/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L624). (And in a different branch, I did just that.) But that added two repetitions of the same checks that would need to be kept in sync.

If we really wanted to unify the behavior to always accept if_exists/if_not_exists in all contexts, we could pull that logic out of `SchemaStatements` and have it live only in `Table`. However that would end up breaking the form of migration that is called outside of a change_table block (`add_column(:table, :column_name, ..)`) because `Table` doesn't sit in between that method call and the database call, and I think I would need some guidance on how best to solve that.