### PR TITLE
Extract AbstractAdapter#schema_version

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -641,6 +641,14 @@ module ActiveRecord
       def check_version # :nodoc:
       end
 
+      # Returns the version identifier of the schema currently available in
+      # the database. This is generally equal to the number of the highest-
+      # numbered migration that has been executed, or 0 if no schema
+      # information is present / the database is empty.
+      def schema_version
+        migration_context.current_version
+      end
+
       def field_ordered_value(column, values) # :nodoc:
         node = Arel::Nodes::Case.new(column)
         values.each.with_index(1) do |value, order|

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -208,7 +208,7 @@ module ActiveRecord
         end
 
         def reset_version!
-          @version = connection.migration_context.current_version
+          @version = connection.schema_version
         end
 
         def derive_columns_hash_and_deduplicate_values

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -332,7 +332,7 @@ db_namespace = namespace :db do
 
   desc "Retrieves the current schema version number"
   task version: :load_config do
-    puts "Current version: #{ActiveRecord::Base.connection.migration_context.current_version}"
+    puts "Current version: #{ActiveRecord::Base.connection.schema_version}"
   end
 
   # desc "Raises an error if there are pending migrations"

--- a/activerecord/test/cases/ar_schema_test.rb
+++ b/activerecord/test/cases/ar_schema_test.rb
@@ -49,7 +49,7 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
 
     assert_nothing_raised { @connection.select_all "SELECT * FROM fruits" }
     assert_nothing_raised { @connection.select_all "SELECT * FROM schema_migrations" }
-    assert_equal 7, @connection.migration_context.current_version
+    assert_equal 7, @connection.schema_version
   end
 
   def test_schema_define_with_table_name_prefix


### PR DESCRIPTION
We don't want migration_context in general to be public API, but this is a reasonable question for a user to ask.

Similarly, schema cache shouldn't need to reach into private details of the migrations API, and this way it doesn't have to.
