### PR TITLE
Use nested queries when doing DELETE and GROUP_BY and HAVINAG clauses…

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Use subquery for DELETE with GROUP_BY and HAVING clauses.
+
+    Prior to this change, deletes with GROUP_BY and HAVING were returning an error.
+
+    After this change, GROUP_BY and HAVING are valid clauses in DELETE queries, generating the following query: 
+
+    ```sql
+    DELETE FROM "posts" WHERE "posts"."id" IN (
+        SELECT "posts"."id" FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" GROUP BY "posts"."id" HAVING (count(comments.id) >= 2))
+    )  [["flagged", "t"]]
+    ```
+
+    *Ignacio Chiazzo Cardarello*
+
 *   Use subquery for UPDATE with GROUP_BY and HAVING clauses.
 
     Prior to this change, updates with GROUP_BY and HAVING were being ignored, generating a SQL like this:

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -11,7 +11,7 @@ module ActiveRecord
                             :reverse_order, :distinct, :create_with, :skip_query_cache]
 
     CLAUSE_METHODS = [:where, :having, :from]
-    INVALID_METHODS_FOR_DELETE_ALL = [:distinct, :group, :having]
+    INVALID_METHODS_FOR_DELETE_ALL = [:distinct]
 
     VALUE_METHODS = MULTI_VALUE_METHODS + SINGLE_VALUE_METHODS + CLAUSE_METHODS
 
@@ -616,7 +616,9 @@ module ActiveRecord
       arel = eager_loading? ? apply_join_dependency.arel : build_arel
       arel.source.left = table
 
-      stmt = arel.compile_delete(table[primary_key])
+      group_values_arel_columns = arel_columns(group_values.uniq)
+      having_clause_ast = having_clause.ast unless having_clause.empty?
+      stmt = arel.compile_delete(table[primary_key], having_clause_ast, group_values_arel_columns)
 
       klass.connection.delete(stmt, "#{klass} Delete All").tap { reset }
     end

--- a/activerecord/lib/arel/crud.rb
+++ b/activerecord/lib/arel/crud.rb
@@ -33,13 +33,15 @@ module Arel # :nodoc: all
       um
     end
 
-    def compile_delete(key = nil)
+    def compile_delete(key = nil, having_clause = nil, group_values_columns = [])
       dm = DeleteManager.new(source)
       dm.take(limit)
       dm.offset(offset)
       dm.order(*orders)
       dm.wheres = constraints
       dm.key = key
+      dm.group(group_values_columns) unless group_values_columns.empty?
+      dm.having(having_clause) unless having_clause.nil?
       dm
     end
   end

--- a/activerecord/lib/arel/delete_manager.rb
+++ b/activerecord/lib/arel/delete_manager.rb
@@ -12,5 +12,21 @@ module Arel # :nodoc: all
       @ast.relation = relation
       self
     end
+
+    def group(columns)
+      columns.each do |column|
+        column = Nodes::SqlLiteral.new(column) if String === column
+        column = Nodes::SqlLiteral.new(column.to_s) if Symbol === column
+
+        @ast.groups.push Nodes::Group.new column
+      end
+
+      self
+    end
+
+    def having(expr)
+      @ast.havings << expr
+      self
+    end
   end
 end


### PR DESCRIPTION
### Summary
HAVING and GROUP BY are being ignored when using `dalete_all`. 

```ruby
Post.joins(:comments).group("posts.id").having("count(comments.id) >= 2")
```

This generates the query:
```sql
SELECT "posts".* FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" GROUP BY "posts"."id" HAVING (count(comments.id) >= 2)
```

If we do `delete_all`, we expect the `GROUP BY` and `HAVING` to be used, but ActiveRecord was ignoring it.
 
**Actual**
`eval error: delete_all doesn't support group, having` 

**Expected**
```sql
DELETE FROM "posts" WHERE "posts"."id" IN (
SELECT "posts"."id" FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" GROUP BY "posts"."id" HAVING (count(comments.id) >= 2))
)  [["flagged", "t"]]
```

**Note:** MySQL doesn't accept doing `DELETE` with `GROUP BY` and `HAVING`. The solution is to use a nested query like this:

```mysql
DELETE FROM "posts" WHERE "posts"."id" IN (
SELECT "posts"."id" FROM "posts" INNER JOIN "comments" ON "comments"."post_id" = "posts"."id" GROUP BY "posts"."id" HAVING (count(comments.id) >= 2))
)  [["flagged", "t"]]
```
<details> 
<summary>Steps to reproduce the issue</summary>

```ruby

# frozen_string_literal: true

require "bundler/inline"
require "debug"
gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Activate the gem you are reporting the issue against.
  # gem "rails", github: "ignacio-chiazzo/rails", branch: "ignacio/delete_all"
  gem "rails", github: "ignacio-chiazzo/rails"
  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

# This connection will do for database-independent bug reports.
# Rails.backtrace_cleaner.remove_silencers!
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.boolean :flagged
  end

  create_table :comments, force: true do |t|
    t.integer :post_id
  end
end

class Post < ActiveRecord::Base
  has_many :comments

  scope :heavily_commented, -> {
    joins(:comments)
    .group("posts.id")
    .having("count(comments.id) >= 2")
  }

end

class Comment < ActiveRecord::Base
  belongs_to :post
end

class BugTest < Minitest::Test
  def test_flagging_commented_delete_all
    post_with_2_comments = Post.create!
    post_with_2_comments.comments << Comment.create!
    post_with_2_comments.comments << Comment.create!

    post_with_1_comment = Post.create!
    post_with_1_comment.comments << Comment.create!

    assert_equal  [post_with_2_comments], Post.heavily_commented.to_a
    
    Post.heavily_commented.delete_all
    assert_nil post_with_1_comment.reload.flagged
  end
end

```
</details>

