### PR TITLE
Only wrap subscriber exceptions if there is more than one

### DIFF
--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -213,11 +213,9 @@ module ActiveRecord
     def test_exceptions_from_notifications_are_not_translated
       original_error = StandardError.new("This StandardError shouldn't get translated")
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { raise original_error }
-      wrapped_error = assert_raises(ActiveSupport::Notifications::InstrumentationSubscriberError) do
+      actual_error = assert_raises(StandardError) do
         @connection.execute("SELECT * FROM posts")
       end
-      actual_error = wrapped_error.exceptions.first
-
       assert_equal original_error, actual_error
 
     ensure

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -489,13 +489,11 @@ class QueryCacheTest < ActiveRecord::TestCase
       payload[:sql].downcase!
     end
 
-    error = assert_raises ActiveSupport::Notifications::InstrumentationSubscriberError do
+    assert_raises FrozenError do
       ActiveRecord::Base.cache do
         assert_queries(1) { Task.find(1); Task.find(1) }
       end
     end
-
-    assert error.exceptions.first.is_a?(FrozenError)
   ensure
     ActiveSupport::Notifications.unsubscribe subscriber
   end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -93,8 +93,16 @@ module ActiveSupport
           exceptions ||= []
           exceptions << e
         end
-      ensure
-        raise InstrumentationSubscriberError.new(exceptions) unless exceptions.nil?
+
+        if exceptions
+          if exceptions.size == 1
+            raise exceptions.first
+          else
+            raise InstrumentationSubscriberError.new(exceptions), cause: exceptions.first
+          end
+        end
+
+        listeners
       end
 
       def listeners_for(name)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43282
Ref: https://github.com/rails/rails/pull/43561

It can be legitimate for subscriber to want to bubble up some exception to the caller, so wrapping it change the exception class which might break the calling code expecting a specific error.

We can minimize this by only using InstrumentationSubscriberError when more than one subscriber raised.
