### PR TITLE
fix actioncable module field in package.json

### DIFF
--- a/actioncable/package.json
+++ b/actioncable/package.json
@@ -2,7 +2,7 @@
   "name": "@rails/actioncable",
   "version": "7.0.0-alpha2",
   "description": "WebSocket framework for Ruby on Rails.",
-  "module": "app/javascript/action_cable/index.js",
+  "module": "app/assets/javascripts/actioncable.esm.js",
   "main": "app/assets/javascripts/actioncable.js",
   "files": [
     "app/assets/javascripts/*.js",


### PR DESCRIPTION
### Summary

The current module field points to a file that isn't included in the
files field of actioncable's package.json. This leads to errors when
trying to use actioncable in bundlers that use esm modules natively
(like Vite)

### Other Information

Fixes #43239 