### PR TITLE
Add missing `require` for `active_support/json` to `activesupport/lib/active_support/core_ext/object/json.rb`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -6,6 +6,7 @@ require "bigdecimal"
 require "ipaddr"
 require "uri/generic"
 require "pathname"
+require "active_support/json"
 require "active_support/core_ext/big_decimal/conversions" # for #to_s
 require "active_support/core_ext/hash/except"
 require "active_support/core_ext/hash/slice"


### PR DESCRIPTION
### Summary

This fixes a bug of missing `require` around ActiveSupport and JSON.

To reproduce:

```ruby
irb(main):3.0.2:001:0> require 'active_support/core_ext/object/json'
true
irb(main):3.0.2:002:0> {}.to_json
/Users/okuramasafumi/.gem/ruby/3.0.2/gems/activesupport-6.1.4.1/lib/active_support/core_ext/object/json.rb:43:in `to_json': uninitialized constant ActiveSupport::JSON (NameError)
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->