### PR TITLE
Replace CSS references with inline basics for scaffolds

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/_form.html.erb.tt
@@ -1,6 +1,6 @@
 <%%= form_with(model: <%= model_resource_name %>) do |form| %>
   <%% if <%= singular_table_name %>.errors.any? %>
-    <div id="error_explanation">
+    <div style="color: red">
       <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>
 
       <ul>
@@ -12,26 +12,26 @@
   <%% end %>
 
 <% attributes.each do |attribute| -%>
-  <div class="field">
+  <div>
 <% if attribute.password_digest? -%>
-    <%%= form.label :password %>
+    <%%= form.label :password, style: "display: block" %>
     <%%= form.password_field :password %>
   </div>
 
-  <div class="field">
-    <%%= form.label :password_confirmation %>
+  <div>
+    <%%= form.label :password_confirmation, style: "display: block" %>
     <%%= form.password_field :password_confirmation %>
 <% elsif attribute.attachments? -%>
-    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.label :<%= attribute.column_name %>, style: "display: block" %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true %>
 <% else -%>
-    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.label :<%= attribute.column_name %>, style: "display: block" %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %> %>
 <% end -%>
   </div>
 
 <% end -%>
-  <div class="actions">
+  <div>
     <%%= form.submit %>
   </div>
 <%% end %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
@@ -1,4 +1,4 @@
-<p id="notice"><%%= notice %></p>
+<p style="color: green"><%%= notice %></p>
 
 <h1><%= human_name.pluralize %></h1>
 

--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -1,4 +1,4 @@
-<div id="<%%= dom_id <%= singular_table_name %> %>" class="scaffold_record">
+<div id="<%%= dom_id <%= singular_table_name %> %>">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
   <p>
     <strong><%= attribute.human_name %>:</strong>

--- a/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/show.html.erb.tt
@@ -1,4 +1,4 @@
-<p id="notice"><%%= notice %></p>
+<p style="color: green"><%%= notice %></p>
 
 <%%= render @<%= singular_table_name %> %>
 


### PR DESCRIPTION
We no longer add a scaffold.css, so we shouldn't depend on it.