### PR TITLE
ActiveRecord::Migration next_migration_number should use numeric version comparison.

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1001,7 +1001,7 @@ module ActiveRecord
     # Determines the version number of the next migration.
     def next_migration_number(number)
       if ActiveRecord.timestamped_migrations
-        [Time.now.utc.strftime("%Y%m%d%H%M%S"), "%.14d" % number].max
+        [Time.now.utc.strftime("%Y%m%d%H%M%S").to_i, ("%.14d" % number).to_i].max
       else
         SchemaMigration.normalize_migration_number(number)
       end

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -148,6 +148,17 @@ class MigrationTest < ActiveRecord::TestCase
     assert_equal 20131219224947, migrator.current_version
   end
 
+  def test_migration_next_migration_number_consistent_across_year_boundary
+    last_year = Time.now.year - 1
+    this_year = Time.now.year
+    not_a_month = 14
+    day_of_month = Time.now.day
+    time = Time.now.utc.strftime("%H%M%S")
+    last_year_number = "#{last_year}#{not_a_month}#{day_of_month}#{time}01"
+    this_year_number = "#{this_year}#{not_a_month}#{day_of_month}#{time}01"
+    assert_equal ActiveRecord::Migration.new.next_migration_number(last_year_number).to_s, last_year_number
+  end
+
   def test_create_table_raises_if_already_exists
     connection = Person.connection
     connection.create_table :testings, force: true do |t|


### PR DESCRIPTION
Changed ActiveRecord::Migration next_migration_number to use integers for determining the next version number via call to max

### Summary
Fixes #31722 issue with ActiveRecord::Migration instance next_migration_number method reverting to timestamps across years by changing the comparison to integers rather than strings (string comparison is wacky)