### PR TITLE
Fix schema dumping for generated columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -647,8 +647,8 @@ module ActiveRecord
           default if has_default_function?(default_value, default)
         end
 
-        def has_default_function?(default_value, default)
-          !default_value && %r{\w+\(.*\)|\(.*\)::\w+|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
+        def has_default_function?(default_value, _default)
+          !default_value
         end
 
         # See https://www.postgresql.org/docs/current/static/errcodes-appendix.html

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -423,7 +423,7 @@ module ActiveRecord
           end
           column = number_klass.columns_hash["number"]
           assert_nil column.default
-          assert_nil column.default_function
+          assert_equal "(((4 + 4) * 2) / 4)", column.default_function
 
           first_number = number_klass.new
           assert_nil first_number.number

--- a/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
@@ -19,6 +19,8 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
         t.virtual :upper_name,  type: :string,  as: "UPPER(name)", stored: true
         t.virtual :name_length, type: :integer, as: "LENGTH(name)", stored: true
         t.virtual :name_octet_length, type: :integer, as: "OCTET_LENGTH(name)", stored: true
+        t.jsonb :extra
+        t.virtual :hobby, type: :string, as: "extra->>'hobby'", stored: true
       end
       VirtualColumn.create(name: "Rails")
     end
@@ -78,6 +80,8 @@ if ActiveRecord::Base.connection.supports_virtual_columns?
       assert_match(/t\.virtual\s+"upper_name",\s+type: :string,\s+as: "upper\(\(name\)::text\)", stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_length",\s+type: :integer,\s+as: "length\(\(name\)::text\)", stored: true$/i, output)
       assert_match(/t\.virtual\s+"name_octet_length",\s+type: :integer,\s+as: "octet_length\(\(name\)::text\)", stored: true$/i, output)
+      assert_match(/as:.*extra.*hobby/, output)
+      assert_no_match(/as: nil/, output)
     end
 
     def test_build_fixture_sql


### PR DESCRIPTION
This is an attempt to fix #43590, a problem when generated column with the expression like `payload->'data'` is not dumped correctly.

I don't know if the change is going to work because what I did here seems a bit too radical. But let's see what will fail, as @ghiculescu suggested in https://github.com/rails/rails/issues/43590#issuecomment-961403429.

For more details, see #43590. I do not want to merge the PR at this point. I just want to run the tests and see what fails.
