### PR TITLE
fix typo of using where instead of were

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -423,9 +423,9 @@ module ActiveJob
 
       message = +"No enqueued job found with #{expected}"
       if potential_matches.empty?
-        message << "\n\nNo jobs where enqueued"
+        message << "\n\nNo jobs were enqueued"
       elsif matching_class.empty?
-        message << "\n\nNo jobs of class #{expected[:job]} where enqueued, job classes enqueued: "
+        message << "\n\nNo jobs of class #{expected[:job]} were enqueued, job classes enqueued: "
         message << potential_matches.map { |job| job["job_class"] }.join(", ")
       else
         message << "\n\nPotential matches: #{matching_class.join("\n")}"
@@ -525,9 +525,9 @@ module ActiveJob
 
       message = +"No performed job found with #{expected}"
       if potential_matches.empty?
-        message << "\n\nNo jobs where performed"
+        message << "\n\nNo jobs were performed"
       elsif matching_class.empty?
-        message << "\n\nNo jobs of class #{expected[:job]} where performed, job classes performed: "
+        message << "\n\nNo jobs of class #{expected[:job]} were performed, job classes performed: "
         message << potential_matches.map { |job| job["job_class"] }.join(", ")
       else
         message << "\n\nPotential matches: #{matching_class.join("\n")}"

--- a/activejob/test/cases/test_helper_test.rb
+++ b/activejob/test/cases/test_helper_test.rb
@@ -714,7 +714,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/No enqueued job found with {:job=>MultipleKwargsJob, :args=>\[#{wilma.inspect}\]}/, error.message)
-    assert_match(/No jobs of class MultipleKwargsJob where enqueued, job classes enqueued: HelloJob/, error.message)
+    assert_match(/No jobs of class MultipleKwargsJob were enqueued, job classes enqueued: HelloJob/, error.message)
   end
 
   def test_shows_no_jobs_enqueued_when_there_are_no_jobs
@@ -724,7 +724,7 @@ class EnqueuedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/No enqueued job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
-    assert_match(/No jobs where enqueued/, error.message)
+    assert_match(/No jobs were enqueued/, error.message)
   end
 
   def test_assert_enqueued_with_failure_with_no_block_with_global_id_args
@@ -1985,7 +1985,7 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/No performed job found with {:job=>HelloJob, :args=>\[\]}/, error.message)
-    assert_match(/No jobs where performed/, error.message)
+    assert_match(/No jobs were performed/, error.message)
   end
 
   def test_assert_performed_when_not_matching_the_class_shows_alteratives
@@ -1998,7 +1998,7 @@ class PerformedJobsTest < ActiveJob::TestCase
     end
 
     assert_match(/No performed job found with {:job=>MultipleKwargsJob, :args=>\[#<Person.* @id=11>\]}/, error.message)
-    assert_match(/No jobs of class MultipleKwargsJob where performed, job classes performed: HelloJob/, error.message)
+    assert_match(/No jobs of class MultipleKwargsJob were performed, job classes performed: HelloJob/, error.message)
   end
 
   def test_assert_performed_with_does_not_change_jobs_count


### PR DESCRIPTION
### Summary

I was reading the great Rails this week email and ended up on this pull request https://github.com/rails/rails/pull/43554 that improves some test helpers.

> Were is the past tense of be when used as a verb.

> Where means in a specific place when used as an adverb or conjunction.

https://prowritingaid.com/grammar/1000172/Were-vs-where%E2%80%94what-is-the-difference
