### PR TITLE
allow configuration for ActionDispatch::Static to serve additional headers for fingerprinted files.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,4 @@
-*   Add `fingerprinted_pattern` and `fingerprinted_headers` options to
+*   Add `fingerprinted_patterns` and `fingerprinted_headers` options to
     `ActionDispatch::Static` to allow for additional headers to be set for
     fingerprinted files.
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `fingerprinted_pattern` and `fingerprinted_headers` options to
+    `ActionDispatch::Static` to allow for additional headers to be set for
+    fingerprinted files.
+
+    *Lachlan Sylvester*
+
 *   Remove deprecated `Rails.config.action_view.raise_on_missing_translations`.
 
     *Rafael Mendonça França*

--- a/actionpack/lib/action_dispatch/middleware/static.rb
+++ b/actionpack/lib/action_dispatch/middleware/static.rb
@@ -14,9 +14,9 @@ module ActionDispatch
   #
   # Only files in the root directory are served; path traversal is denied.
   class Static
-    def initialize(app, path, index: "index", headers: {}, fingerprinted_pattern: nil, fingerprinted_headers: {})
+    def initialize(app, path, index: "index", headers: {}, fingerprinted_patterns: [], fingerprinted_headers: {})
       @app = app
-      @file_handler = FileHandler.new(path, index: index, headers: headers, fingerprinted_pattern: fingerprinted_pattern, fingerprinted_headers: fingerprinted_headers)
+      @file_handler = FileHandler.new(path, index: index, headers: headers, fingerprinted_patterns: fingerprinted_patterns, fingerprinted_headers: fingerprinted_headers)
     end
 
     def call(env)
@@ -46,14 +46,14 @@ module ActionDispatch
       "identity" => nil
     }
 
-    def initialize(root, index: "index", headers: {}, fingerprinted_pattern: nil, fingerprinted_headers: {}, precompressed: %i[ br gzip ], compressible_content_types: /\A(?:text\/|application\/javascript)/)
+    def initialize(root, index: "index", headers: {}, fingerprinted_patterns: [], fingerprinted_headers: {}, precompressed: %i[ br gzip ], compressible_content_types: /\A(?:text\/|application\/javascript)/)
       @root = root.chomp("/").b
       @index = index
 
       @precompressed = Array(precompressed).map(&:to_s) | %w[ identity ]
       @compressible_content_types = compressible_content_types
 
-      @fingerprinted_pattern = fingerprinted_pattern
+      @fingerprinted_pattern = Regexp.union(fingerprinted_patterns)
       @fingerprinted_headers = fingerprinted_headers
 
       @file_server = ::Rack::File.new(@root, headers)
@@ -191,7 +191,7 @@ module ActionDispatch
       end
 
       def fingerprinted?(path)
-        @fingerprinted_pattern&.match?(path)
+        @fingerprinted_pattern.match?(path)
       end
   end
 end

--- a/actionpack/test/dispatch/static_test.rb
+++ b/actionpack/test/dispatch/static_test.rb
@@ -240,15 +240,15 @@ module StaticTests
   end
 
   def test_fingerprinted_headers
-    app = ActionDispatch::Static.new(DummyApp, @root, fingerprinted_pattern: /.digest./, fingerprinted_headers: {"Cache-Control" => "public, max-age=31536000, immutable"})
+    app = ActionDispatch::Static.new(DummyApp, @root, fingerprinted_patterns: [/.digest./], fingerprinted_headers: { "Cache-Control" => "public, max-age=31536000, immutable" })
 
-    with_static_file '/foo.digest.js' do
+    with_static_file "/foo.digest.js" do
       response = Rack::MockRequest.new(app).request("GET", "/foo.digest.js")
 
       assert_equal "public, max-age=31536000, immutable", response.headers["Cache-Control"]
     end
 
-    with_static_file '/foo.js' do
+    with_static_file "/foo.js" do
       response = Rack::MockRequest.new(app).request("GET", "/foo.js")
 
       assert_nil response.headers["Cache-Control"]

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -39,6 +39,7 @@ module Rails
         @public_file_server                      = ActiveSupport::OrderedOptions.new
         @public_file_server.enabled              = true
         @public_file_server.index_name           = "index"
+        @public_file_server.fingerprinted_headers = {"Cache-Control" => "public, max-age=31536000, immutable"}
         @force_ssl                               = false
         @ssl_options                             = {}
         @session_store                           = nil

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -40,6 +40,7 @@ module Rails
         @public_file_server.enabled              = true
         @public_file_server.index_name           = "index"
         @public_file_server.fingerprinted_headers = {"Cache-Control" => "public, max-age=31536000, immutable"}
+        @public_file_server.fingerprinted_patterns = []
         @force_ssl                               = false
         @ssl_options                             = {}
         @session_store                           = nil

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -24,8 +24,8 @@ module Rails
 
           if config.public_file_server.enabled
             headers = config.public_file_server.headers || {}
-
-            middleware.use ::ActionDispatch::Static, paths["public"].first, index: config.public_file_server.index_name, headers: headers
+            fingerprinted_headers = config.public_file_server.headers || {}
+            middleware.use ::ActionDispatch::Static, paths["public"].first, index: config.public_file_server.index_name, headers: headers, fingerprinted_pattern: config.public_file_server.fingerprint_pattern, fingerprinted_headers: fingerprinted_headers
           end
 
           if rack_cache = load_rack_cache

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -25,7 +25,7 @@ module Rails
           if config.public_file_server.enabled
             headers = config.public_file_server.headers || {}
             fingerprinted_headers = config.public_file_server.headers || {}
-            middleware.use ::ActionDispatch::Static, paths["public"].first, index: config.public_file_server.index_name, headers: headers, fingerprinted_pattern: config.public_file_server.fingerprint_pattern, fingerprinted_headers: fingerprinted_headers
+            middleware.use ::ActionDispatch::Static, paths["public"].first, index: config.public_file_server.index_name, headers: headers, fingerprinted_patterns: config.public_file_server.fingerprinted_patterns, fingerprinted_headers: fingerprinted_headers
           end
 
           if rack_cache = load_rack_cache


### PR DESCRIPTION
### Summary

Currently - when using the `public_file_server` to serve assets - it is recommended that you set far future expiring cache headers on the assets so that the assets are cached by the CDN and the rails application doesn't need to keep serving the same files. See https://guides.rubyonrails.org/asset_pipeline.html#cdns-and-the-cache-control-header

However - doing this would result in all files in the public directory being served with the same headers - regardless if they have been fingerprinted or not. This may cause files that are committed into the public directory (instead of being committed under assets and then compiled by Sprockets or similar) to unintentionally be cached for a very long time.

This PR adds two configuration options to ActionDispatch::Static to handle fingerprinted assets.

*  `fingerprinted_patterns` which is an array of pattern that are used to detect fingerprinted files. An array is used so that libraries can append a pattern matching the format for its digested files without having to be concerned about overwriting any existing settings.

 * `fingerprinted_headers` which are the additional headers that will get set when a file matches
the fingerprinted patterns. By default it is far future expires header.


