### PR TITLE
Extract annotations using a parser for Ruby files

### DIFF
--- a/railties/test/commands/notes_test.rb
+++ b/railties/test/commands/notes_test.rb
@@ -162,6 +162,12 @@ class Rails::Command::NotesTest < ActiveSupport::TestCase
     OUTPUT
   end
 
+  test "does not pick up notes inside string literals" do
+    app_file "app/models/profile.rb", '"# TODO: do something"'
+
+    assert_empty run_notes_command
+  end
+
   private
     def run_notes_command(args = [])
       rails "notes", args


### PR DESCRIPTION
When you're looking for annotations, it's possible (albeit extremely unlikely) for it to pick up things that aren't comments (see the added test for an example). If we instead use a parser like ripper, we can filter down to just the comments and only try to extract the annotations from the source file's comments.