### PR TITLE
Document `tag.attributes` helper [ci-skip]

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -235,6 +235,20 @@ module ActionView
       #   # A void element:
       #   tag.br  # => <br>
       #
+      # === Building HTML attributes
+      #
+      # Transforms a Hash into HTML attributes, ready to be interpolated into
+      # ERB. Includes or omits boolean attributes based on their truthiness.
+      # Transforms keys nested within
+      # <tt>aria:</tt> or <tt>data:</tt> objects into `aria-` and `data-`
+      # prefixed attributes:
+      #
+      #   <input <%= tag.attributes(type: :text, aria: { label: "Search" }) %>>
+      #   # => <input type="text" aria-label="Search">
+      #
+      #   <button <%= tag.attributes id: "call-to-action", disabled: false, aria: { expanded: false } %> class="primary">Get Started!</button>
+      #   => <button id="call-to-action" aria-expanded="false" class="primary">Get Started!</button>
+      #
       # === Legacy syntax
       #
       # The following format is for legacy syntax support. It will be deprecated in future versions of Rails.


### PR DESCRIPTION
The `tag.attributes` helper introduced in [#40657][] is implemented on a
`:nodoc:`-private `TagBuilder` class, so the documentation for the
method is omitted when generating the API Guides HTML pages.

This commit extends the `ActionView::Helpers::TagHelper` module
documentation comment to mention the new attribute building
capabilities, along with some examples.

[#40657]: https://github.com/rails/rails/pull/40657

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
