### PR TITLE
Update the assets guide to remove uglifier

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -46,7 +46,7 @@ in `production.rb` - `config.assets.css_compressor` for your CSS and
 
 ```ruby
 config.assets.css_compressor = :yui
-config.assets.js_compressor = :uglifier
+config.assets.js_compressor = :terser
 ```
 
 NOTE: The `sassc-rails` gem is automatically used for CSS compression if included
@@ -1042,8 +1042,8 @@ config.assets.css_compressor = :sass
 
 ### JavaScript Compression
 
-Possible options for JavaScript compression are `:terser`, `:closure`, `:uglifier` and
-`:yui`. These require the use of the `terser`, `closure-compiler`, `uglifier` or
+Possible options for JavaScript compression are `:terser`, `:closure` and
+`:yui`. These require the use of the `terser`, `closure-compiler` or
 `yui-compressor` gems, respectively.
 
 Take the `terser` gem, for example.


### PR DESCRIPTION
### Summary

Uglifier only supports ES5 and the author recommends using Terser for ES6 support.

Fixes #43610

