### PR TITLE
Remove non-existing encoding task dependency

### DIFF
--- a/guides/Rakefile
+++ b/guides/Rakefile
@@ -26,7 +26,7 @@ namespace :guides do
 
   # Validate guides -------------------------------------------------------------------------
   desc 'Validate guides, use ONLY=foo to process just "foo.html"'
-  task validate: :encoding do
+  task :validate do
     ruby "w3c_validator.rb"
   end
 


### PR DESCRIPTION
### Summary

The `encoding` task has been removed a few years ago in https://github.com/rails/rails/commit/510db97991719aa2b4a7af181886a6e657a3c368

And currently it breaks the `validate` task:

```
$ rake guides:validate
rake aborted!
Don't know how to build task 'encoding' (See the list of available tasks with `rake --tasks`)
/Users/st0012/.rbenv/versions/2.7.4/bin/bundle:23:in `load'
/Users/st0012/.rbenv/versions/2.7.4/bin/bundle:23:in `<main>'
Tasks: TOP => guides:validate
(See full trace by running task with --trace)
```

Removing it fixes the issue:

```
$ rake guides:validate
/Users/st0012/.rbenv/versions/2.7.4/bin/ruby w3c_validator.rb
..................................................................
```
