### PR TITLE
Support dumping & loading PostgreSQL 14 schemas

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -4,6 +4,8 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       class SchemaDumper < ConnectionAdapters::SchemaDumper # :nodoc:
+        ignore_tables << "pg_stat_statements_info"
+
         private
           def extensions(stream)
             extensions = @connection.extensions


### PR DESCRIPTION
### Summary

PostgreSQL 14 introduced a `pg_stat_statements_info` view table as part of the commonly-used [`pg_stat_statements` extension](https://www.postgresql.org/docs/current/pgstatstatements.html#id-1.11.7.39.7).

Previously, when dumping a PostgreSQL v14 schema, a `create_view "pg_stat_statements_info" [...]` would get inserted into the schema file. Since PG itself creates this view, subsequently loading the schema would fail because it already exists.

This adds the view to `ignore_tables` when loading the PG schema dumper.

I wasn't sure if this is the best place for the config nor how to approach a test file, but figured I'd try out Cunningham's Law and give it a go.
