### PR TITLE
Add a note that index length is supported only by MySQL [skip ci]

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -778,7 +778,7 @@ module ActiveRecord
       #
       #   CREATE INDEX by_name_surname ON accounts(name(10), surname(15))
       #
-      # Note: SQLite doesn't support index length.
+      # Note: only supported by MySQL
       #
       # ====== Creating an index with a sort order (desc or asc, asc is the default)
       #


### PR DESCRIPTION
It was added way back in https://github.com/rails/rails/commit/5b95730edc33ee97f53da26a3868eb983305a771

From the comment, it seems that PostgreSQL also supports index length, but this is not true.