### PR TITLE
Guides: Mention rake routes task

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -142,6 +142,8 @@ Creating a resourceful route will also expose a number of helpers to the control
 
 Each of these helpers has a corresponding `_url` helper (such as `photos_url`) which returns the same path prefixed with the current host, port, and path prefix.
 
+TIP: To find the route helper names for your routes, see [Listing existing routes](#listing-existing-routes) below.
+
 ### Defining Multiple Resources at the Same Time
 
 If you need to create routes for more than one resource, you can save a bit of typing by defining them all with a single call to `resources`:


### PR DESCRIPTION
[skip ci]

### Summary
The Routing guide doesn't mention the `rake routes` task, which is a very helpful tool in understanding route helper names. These can sometimes get quite long, especially including namespaces. So it would be really helpful for a developer to learn how to discover these.

I initially wanted to write a formula for guessing helper names (eg "it is a concatenation of action name, namespace(s), controller name"), but then realised this tip is more helpful as it is more direct.

### Other Information
N/A
