### PR TITLE
Fixed tiny grammatical mistakes in comments [skip ci]

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -109,7 +109,7 @@ module ActiveJob
     #     end
     #   end
     #
-    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # +:only+ and +:except+ options accept Class, Array of Class or Proc. When passed a Proc,
     # a hash containing the job's class and it's argument are passed as argument.
     #
     # Asserts the number of times a job is enqueued to a specific queue by passing +:queue+ option.
@@ -168,7 +168,7 @@ module ActiveJob
     #     end
     #   end
     #
-    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # +:only+ and +:except+ options accept Class, Array of Class or Proc. When passed a Proc,
     # a hash containing the job's class and it's argument are passed as argument.
     #
     # Asserts that no jobs are enqueued to a specific queue by passing +:queue+ option
@@ -325,7 +325,7 @@ module ActiveJob
     #     end
     #   end
     #
-    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # +:only+ and +:except+ options accept Class, Array of Class or Proc. When passed a Proc,
     # an instance of the job will be passed as argument.
     #
     # If the +:queue+ option is specified,
@@ -579,7 +579,7 @@ module ActiveJob
     #     assert_performed_jobs 1
     #   end
     #
-    # +:only+ and +:except+ options accepts Class, Array of Class or Proc. When passed a Proc,
+    # +:only+ and +:except+ options accept Class, Array of Class or Proc. When passed a Proc,
     # an instance of the job will be passed as argument.
     #
     # If the +:queue+ option is specified,


### PR DESCRIPTION
I just fixed some tiny grammatical mistakes in some comments.

':only+ and +:except+ options' is a subject of plural noun.