### PR TITLE
Fix a NoMethodError in associate_records_from_unscoped

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -205,7 +205,7 @@ module ActiveRecord
           return if preload_scope && !preload_scope.empty_scope?
           return if reflection.collection?
 
-          unscoped_records.select { |r| r[association_key_name].present? }.each do |record|
+          unscoped_records.select { |r| r && r[association_key_name].present? }.each do |record|
             owners = owners_by_key[convert_key(record[association_key_name])]
             owners&.each_with_index do |owner, i|
               association = owner.association(reflection.name)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -816,6 +816,15 @@ class PreloaderTest < ActiveRecord::TestCase
     end
   end
 
+  def test_preload_with_available_records_ignores_nils
+    post = posts(:welcome)
+
+    assert_nothing_raised do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :author, available_records: [[nil]]).call
+      assert_predicate post.association(:author), :loaded?
+    end
+  end
+
   def test_preload_with_available_records_sti
     book = Book.create!
     essay_special = EssaySpecial.create!


### PR DESCRIPTION
### Summary

Prior to 2d988d03fcd5a3952e4fefeed9a8f760e71c37cb, the method `associate_records_from_unscoped` would silently ignore nil values that were passed in as records. With that change, it raises a new exception when the `[]` method is called on each of the records. This commit restores the behavior to silently drop nils.
