### PR TITLE
Fix Rails 7 Regression - ActiveStorage Content Disposition

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -17,7 +17,7 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
         response.headers["Accept-Ranges"] = "bytes"
         response.headers["Content-Length"] = @blob.byte_size.to_s
 
-        send_blob_stream @blob
+        send_blob_stream @blob, disposition: params[:disposition]
       end
     end
   end

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -9,7 +9,7 @@
 class ActiveStorage::Representations::ProxyController < ActiveStorage::Representations::BaseController
   def show
     http_cache_forever public: true do
-      send_blob_stream @representation.image
+      send_blob_stream @representation.image, disposition: params[:disposition]
     end
   end
 end

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -21,8 +21,14 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
     assert_equal "application/octet-stream", response.headers["Content-Type"]
   end
 
-  test "forcing Content-Disposition to attachment" do
+  test "forcing Content-Disposition to attachment based on type" do
     get rails_storage_proxy_url(create_blob(content_type: "application/zip"))
+    assert_match(/^attachment; /, response.headers["Content-Disposition"])
+  end
+
+  test "caller can change disposition to attachment" do
+    url = rails_storage_proxy_url(create_blob(content_type: "image/jpeg"), disposition: :attachment)
+    get url
     assert_match(/^attachment; /, response.headers["Content-Disposition"])
   end
 

--- a/activestorage/test/controllers/representations/proxy_controller_test.rb
+++ b/activestorage/test/controllers/representations/proxy_controller_test.rb
@@ -8,6 +8,22 @@ class ActiveStorage::Representations::ProxyControllerWithVariantsTest < ActionDi
     @blob = create_file_blob filename: "racecar.jpg"
   end
 
+  test "showing variant attachment" do
+    get rails_blob_representation_proxy_url(
+      disposition: :attachment,
+      filename: @blob.filename,
+      signed_blob_id: @blob.signed_id,
+      variation_key: ActiveStorage::Variation.encode(resize_to_limit: [100, 100]))
+
+    assert_response :ok
+    assert_match(/^attachment/, response.headers["Content-Disposition"])
+
+    image = read_image(@blob.variant(resize_to_limit: [100, 100]))
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  end
+
+
   test "showing variant inline" do
     get rails_blob_representation_proxy_url(
       filename: @blob.filename,


### PR DESCRIPTION
### Summary

When upgrading our app from 6.1.4.1 to 7, we noticed that the following code no longer functioned: 

```ruby
class Settings::My::StaffUploadsController < Settings::MyController

  # GET /1/settings/my/downloads/staff_uploads/1
  def show
    @staff_upload = Current.user.staff_uploads.active.find(params[:id])

    redirect_to rails_blob_path(@staff_upload.file, disposition: :attachment)
  end
end

```

Originally, this worked as expected, redirecting the file and triggering the browser to download it as an attachment. After the upgrade, it redirected to the attachment, but the disposition was always `inline`. 

### Root Cause 

After a brief investigation, I determined that this regression was introduced in [ab8e3d22](https://github.com/rails/rails/commit/ab8e3d22cbac85f1e5742dd13320cda6bd54e191) where @dhh refactored/simplifed the `ActiveStorage` `ProxyController` code, but forgot to pass the `disposition` parameter into the callers of his newly created method ( [`send_blob_stream`](https://github.com/rails/rails/commit/ab8e3d22cbac85f1e5742dd13320cda6bd54e191#diff-95204687c595476382b891cf0c82e7b9107d78875089db513c4930c58e8d5bfbR11)). 

### Resolution 

This PR passes the missing option to the `Blob:ProxyController` and the `Representations:ProxyController`'s `send_blob_stream` call, and added tests to ensure these do not regress in the future. 

We are using this solution locally in our Rails 7 Upgrade to great effect. 
