### PR TITLE
Call yarn directly

### DIFF
--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -27,8 +27,3 @@ namespace :yarn do
     exit 1
   end
 end
-
-# Run Yarn prior to Sprockets assets precompilation, so dependencies are available for use.
-if Rake::Task.task_defined?("assets:precompile") && File.exist?(Rails.root.join("bin", "yarn"))
-  Rake::Task["assets:precompile"].enhance [ "yarn:install" ]
-end

--- a/railties/lib/rails/tasks/yarn.rake
+++ b/railties/lib/rails/tasks/yarn.rake
@@ -10,7 +10,7 @@ namespace :yarn do
     end
 
     yarn_flags =
-      if `#{RbConfig.ruby} "#{Rails.root}/bin/yarn" --version`.start_with?("1")
+      if `yarn --version`.start_with?("1")
         "--no-progress --frozen-lockfile"
       else
         "--immutable"
@@ -18,12 +18,12 @@ namespace :yarn do
 
     system(
       { "NODE_ENV" => node_env },
-      "#{RbConfig.ruby} \"#{Rails.root}/bin/yarn\" install #{yarn_flags}",
+      "yarn install #{yarn_flags}",
       exception: true
     )
   rescue Errno::ENOENT
-    $stderr.puts "bin/yarn was not found."
-    $stderr.puts "Please run `bundle exec rails app:update:bin` to create it."
+    $stderr.puts "yarn install failed to execute."
+    $stderr.puts "Ensure yarn is installed and `yarn --version` runs without errors."
     exit 1
   end
 end


### PR DESCRIPTION
### Summary

This PR changes the `yarn:install` task to use `yarn` directly from the PATH instead of looking for `bin/yarn` since the latter is no longer created in Rails 7.

It also removes `assets:precompile`'s direct dependency on `yarn:install` for the same reason. Instead, tasks for webpacker, jsbundling-rails, cssbundling-rails, etc should depend on yarn:install on their own.

Related PRs: rails/jsbundling-rails#49 and rails/cssbundling-rails#42

### Other Information

I considered continuing to call `bin/yarn` when present. However, given that there are several instances of `yarn` being called directly via the PATH (see: jsbundling-rails and cssbundling-rails), this would only serve to cause yarn to be called from two different paths. At best this is useless and at worst complicates debugging. Further, the default bin/yarn only served to pass through arguments, so it seems harmless to drop use of it completely.