### PR TITLE
Improve compatibility with `date` versions `3.2.1`, `3.1.2`, `3.0.2` and `2.0.1`

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -385,6 +385,11 @@ module ActiveSupport
     # If the string is invalid then an +ArgumentError+ will be raised unlike +parse+
     # which usually returns +nil+ when given an invalid date string.
     def iso8601(str)
+      # Historically `Date._iso8601(nil)` returns `{}`, but in the `date` gem versions `3.2.1`, `3.1.2`, `3.0.2`,
+      # and `2.0.1`, `Date._iso8601(nil)` raises `TypeError` https://github.com/ruby/date/issues/39
+      # Future `date` releases are expected to revert back to the original behavior.
+      raise ArgumentError, "invalid date" if str.nil?
+
       parts = Date._iso8601(str)
 
       year = parts.fetch(:year)

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -306,6 +306,16 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal "invalid date", exception.message
   end
 
+  def test_iso8601_with_nil
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    exception = assert_raises(ArgumentError) do
+      zone.iso8601(nil)
+    end
+
+    assert_equal "invalid date", exception.message
+  end
+
   def test_iso8601_with_missing_time_components
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     twz = zone.iso8601("1999-12-31")


### PR DESCRIPTION
Ref: https://github.com/ruby/date/issues/39

Historically `Date._iso8601(nil)` returns `{}`.

But in these versions it raises a `TypeError` changing the exception type
of `ActiveSupport::TimeZone#iso8601(nil)`, which may break some applications.

This should be backported to `6-1-stable`.
