### PR TITLE
Improve compatibility with date versions 3.2.1, 3.1.2, 3.0.2 and `2.0.1`

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -381,6 +381,8 @@ module ActiveSupport
     # If the string is invalid then an +ArgumentError+ will be raised unlike +parse+
     # which usually returns +nil+ when given an invalid date string.
     def iso8601(str)
+      raise ArgumentError, "invalid date" if str.nil?
+
       parts = Date._iso8601(str)
 
       raise ArgumentError, "invalid date" if parts.empty?

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -274,6 +274,16 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal zone, twz.time_zone
   end
 
+  def test_iso8601_with_nil
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+
+    exception = assert_raises(ArgumentError) do
+      zone.iso8601(nil)
+    end
+
+    assert_equal "invalid date", exception.message
+  end
+
   def test_iso8601_with_invalid_string
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
 


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43643

Historically `Date._iso8601(nil)` returns `{}`.

But in these versions it raises a `TypeError` changing the exception type
of `ActiveSupport::TimeZone#iso8601(nil)`, which may break some applications.
