### PR TITLE
Set the execution context from AC::Metal rather than AbstractController

### DIFF
--- a/actionmailer/test/base_test.rb
+++ b/actionmailer/test/base_test.rb
@@ -70,6 +70,13 @@ class BaseTest < ActiveSupport::TestCase
     assert_equal("Welcome", email.body.encoded)
   end
 
+  test "mail() doesn't set the mailer as a controller in the execution context" do
+    ActiveSupport::ExecutionContext.clear
+    assert_nil ActiveSupport::ExecutionContext.to_h[:controller]
+    BaseMailer.welcome(from: "someone@example.com", to: "another@example.org").to
+    assert_nil ActiveSupport::ExecutionContext.to_h[:controller]
+  end
+
   test "can pass in :body to the mail method hash" do
     email = BaseMailer.welcome(body: "Hello there")
     assert_equal("text/plain", email.mime_type)

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -148,7 +148,6 @@ module AbstractController
 
       @_response_body = nil
 
-      ActiveSupport::ExecutionContext[:controller] = self
       process_action(action_name, *args)
     end
 

--- a/actionpack/lib/action_controller/metal/instrumentation.rb
+++ b/actionpack/lib/action_controller/metal/instrumentation.rb
@@ -48,6 +48,8 @@ module ActionController
 
     private
       def process_action(*)
+        ActiveSupport::ExecutionContext[:controller] = self
+
         raw_payload = {
           controller: self.class.name,
           action: action_name,


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/43598

The later is used by totally different codepaths such as mailers, so it's undesirable.

