### PR TITLE
docs/guides: true/false typo

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1728,7 +1728,7 @@ irb> Book.all
 SELECT books.* FROM books WHERE (year_published >= 1969)
 
 irb> Book.in_print
-SELECT books.* FROM books WHERE (year_published >= 1969) AND books.out_of_print = true
+SELECT books.* FROM books WHERE (year_published >= 1969) AND books.out_of_print = false
 
 irb> Book.where('price > 50')
 SELECT books.* FROM books WHERE (year_published >= 1969) AND (price > 50)


### PR DESCRIPTION
### Summary
In [Active Record Querying Guide](https://guides.rubyonrails.org/active_record_querying.html#merging-of-scopes): 
Scope `Book.in_print` should return `books.out_of_print = false`
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
