### PR TITLE
Fix flaky test in HasManyThroughDisableJoinsAssociationsTest

### DIFF
--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -53,13 +53,13 @@ class Author < ActiveRecord::Base
 
   has_many :ratings, through: :comments
   has_many :good_ratings,
-    -> { where("ratings.value > 5") },
+    -> { where("ratings.value > 5").order(:id) },
     through: :comments,
     source: :ratings
 
   has_many :no_joins_ratings, through: :no_joins_comments, disable_joins: :true, source: :ratings
   has_many :no_joins_good_ratings,
-    -> { where("ratings.value > 5") },
+    -> { where("ratings.value > 5").order(:id) },
     through: :comments,
     source: :ratings,
     disable_joins: true


### PR DESCRIPTION
### Summary

While working on #38957 I got the [HasManyThroughDisableJoinsAssociationsTest#test_to_a_on_disable_joins_with_multiple_scopes](https://github.com/rails/rails/blob/main/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb#L123) sometimes failing in PSQL suite, which's weird since I do not even touch AR:

```
Failure:
HasManyThroughDisableJoinsAssociationsTest#test_to_a_on_disable_joins_with_multiple_scopes [/rails/activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb:124]:
--- expected
+++ actual
@@ -1 +1 @@
-[#<Rating id: 6, comment_id: 16, value: 8>, #<Rating id: 7, comment_id: 16, value: 9>]
+[#<Rating id: 7, comment_id: 16, value: 9>, #<Rating id: 6, comment_id: 16, value: 8>]
```

PostgreSQL does not guarantee the order of records and we never specify it. I wonder if adding an explicit order is fine or it makes the spec itself wrong.