### PR TITLE
ActiveSupport: Remove warnings on test/cache/stores

### DIFF
--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -56,6 +56,8 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   end
 
   def after_teardown
+    return unless defined?(@_stores) # because skipped test
+
     stores, @_stores = @_stores, []
     stores.each do |store|
       # Eagerly closing Dalli connection avoid file descriptor exhaustion.

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -124,6 +124,7 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
   class StoreTest < ActiveSupport::TestCase
     setup do
+      @cache = nil
       skip "redis server is not up" unless REDIS_UP
       @namespace = "test-#{SecureRandom.hex}"
 


### PR DESCRIPTION
### Summary

Since the test are skipped when Redis | Memcache are not reacheable two instance variables are not initialized properly but used on teardown blocks, having warnings about undeclared variables:

- instance variable `@cache` not initialized (redis cache store)
- instance variable `@_stores` not initialized (memcache store)

### Other Information

This is what a developer without Redis, Memcache see when running the tests for Cache Stores:


![Screenshot_20211114_231255](https://user-images.githubusercontent.com/1037088/141863206-b8a35893-c477-4ac0-9b4f-c472b1317da8.png)

![Screenshot_20211114_231327](https://user-images.githubusercontent.com/1037088/141863258-3c6409a9-25ff-44d9-bbd4-27c45276cd57.png)

With this patch (if accepted), the developer will have this instead:

![Screenshot_20211115_003541](https://user-images.githubusercontent.com/1037088/141863323-72736000-ea34-407e-a6b8-39c76f7e1a5c.png)