### PR TITLE
Ensure Time.zone.parse handles years like Time.parse

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -435,9 +435,18 @@ module ActiveSupport
     #
     #   Time.zone.parse('Mar 2000') # => Wed, 01 Mar 2000 00:00:00 HST -10:00
     #
+    # As with +Time.parse+, a block can be provided to control how year values are handled:
+    #
+    #   Time.zone.parse("70-10-31") { |year| year + (year < 70 ? 2000 : 1900) }
+    #   # => Sat, 31 Oct 1970 00:00:00.000000000 HST -10:00
+    #
     # If the string is invalid then an +ArgumentError+ could be raised.
     def parse(str, now = now())
-      parts_to_time(Date._parse(str, false), now)
+      comp = !block_given?
+      parts = Date._parse(str, comp)
+      parts[:year] = yield(parts[:year]) if parts[:year] && !comp
+
+      parts_to_time(parts, now)
     end
 
     # Method for creating new ActiveSupport::TimeWithZone instance in time zone

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -497,6 +497,22 @@ class TimeZoneTest < ActiveSupport::TestCase
     assert_equal Time.utc(2014, 10, 25, 22, 0, 0), zone.parse("2014-10-26 01:00:00")
   end
 
+  def test_parse_with_two_digit_year
+    zone = ActiveSupport::TimeZone["UTC"]
+    time = zone.parse("13-03-10 00:00:00")
+    assert_equal Time.utc(2013, 3, 10, 0, 0, 0), time
+  end
+
+  def test_parse_with_block
+    zone = ActiveSupport::TimeZone["UTC"]
+    override = 2020
+    time = zone.parse("13-03-10 00:00:00") do |year|
+      assert_equal 13, year
+      override
+    end
+    assert_equal Time.utc(override, 3, 10, 0, 0, 0), time
+  end
+
   def test_rfc3339
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
     twz = zone.rfc3339("1999-12-31T14:00:00-10:00")


### PR DESCRIPTION
### Summary

Currently, `Time.zone.parse` handles two-digit years differently to `Time.parse`, `DateTime.parse`, and `Date.parse`:

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
end

require "active_support/all"
require "minitest/autorun"

class ParsingTest < Minitest::Test
  def test_time_zone_parsing
    zone = ActiveSupport::TimeZone["UTC"]
    value = "21-01-03"

    date = Date.parse(value)           #=> Sun, 03 Jan 2021
    time = Time.parse(value)           #=> 2021-01-03 00:00:00 +0000
    datetime = DateTime.parse(value)   #=> Sun, 03 Jan 2021 00:00:00 +0000
    time_with_zone = zone.parse(value) #=> Sun, 03 Jan 0021 00:00:00.000000000 UTC +00:00

    assert_equal date, time
    assert_equal time, datetime
    assert_equal datetime, date

    assert_equal 2021, time.year
    assert_equal 2021, time_with_zone.year #=> fails, actually equals 21
  end
end 
```

It appears this behaviour of `Time.zone.parse` was a known side-effect of 005d910624, and part of an [attempt to keep consistency](https://github.com/rails/rails/pull/12458#issuecomment-31603901). However, on the basis of the snippet above, I'd argue that there is now (years later) marked inconsistency between `Time.zone.parse` and other time-handling classes in Ruby.

In keeping with the idea that ActiveSupport's `TimeWithZone` is a more capable enhancement of Ruby's `Time`, this PR aligns the parsing behaviour of `TimeZone` with `Time` by adopting the same defaults and block-based configuration [as `Time.parse` uses](https://github.com/ruby/ruby/blob/ruby_3_0/lib/time.rb#L315-L325).

This doesn't change in any way the usual health warnings of parsing unusually-formatted date values, it should mean that there is more consistency across the ways of doing that parsing.

