### PR TITLE
Fix a regression in association preloader

### DIFF
--- a/activerecord/lib/active_record/associations/preloader/batch.rb
+++ b/activerecord/lib/active_record/associations/preloader/batch.rb
@@ -6,7 +6,7 @@ module ActiveRecord
       class Batch # :nodoc:
         def initialize(preloaders, available_records:)
           @preloaders = preloaders.reject(&:empty?)
-          @available_records = available_records.flatten
+          @available_records = available_records.flatten.group_by { |r| r.class.base_class }
         end
 
         def call
@@ -14,7 +14,7 @@ module ActiveRecord
           until branches.empty?
             loaders = branches.flat_map(&:runnable_loaders)
 
-            loaders.each { |loader| loader.associate_records_from_unscoped(@available_records) }
+            loaders.each { |loader| loader.associate_records_from_unscoped(@available_records[loader.klass.base_class]) }
 
             if loaders.any?
               future_tables = branches.flat_map do |branch|

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -967,6 +967,23 @@ class PreloaderTest < ActiveRecord::TestCase
       assert_nil new_post_without_author.author
     end
   end
+
+  def test_preload_wont_set_the_wrong_target
+    post = posts(:welcome)
+    post.update!(author_id: 54321)
+    some_other_record = categories(:general)
+    some_other_record.update!(id: 54321)
+
+    assert_raises do
+      some_other_record.association(:author)
+    end
+
+    assert_nothing_raised do
+      ActiveRecord::Associations::Preloader.new(records: [post], associations: :author, available_records: [[some_other_record]]).call
+      assert post.association(:author).loaded?
+      assert_not_equal some_other_record, post.author
+    end
+  end
 end
 
 class GeneratedMethodsTest < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

2d988d0 changed Associations::Preloader::Batch to no longer group records by class in order to work with records of differing STI classes. This introduced a problem where the preloader may attempt to load an association on a record that doesn't have it, if two records of differing classes shared the same `id`.

This commit restores grouping to fix the regression, but groups by base class rather than class, so that it will work with records using STI like 2d988d0 intended.

### Other Information

In the test, the reason that I'm asserting that `some_other_record.association(:author)` raises an exception is because that is the expression that would cause an error when the preloader attempts to set inverse associations on the wrong model class.