### PR TITLE
Implement BatchEnumerator#size to efficiently calculate number of batches

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `ActiveRecord::Batches::BatchEnumerator#size` method to efficiently calculate number of batches
+    for a given batch size
+
+    ```ruby
+    Post.count # => 15
+    Post.in_batches(of: 6).size # => 3
+    ```
+
+    *Nikita Vasilevsky*
+
 *   Load STI Models in fixtures
 
     Data from Fixtures now loads based on the specific class for models with

--- a/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
+++ b/activerecord/lib/active_record/relation/batches/batch_enumerator.rb
@@ -94,6 +94,14 @@ module ActiveRecord
         return enum.each(&block) if block_given?
         enum
       end
+
+
+      # Returns the total number of batches for a given batch size
+      #
+      #   Person.in_batches(of: 3).size
+      def size
+        (@relation.count + @of - 1) / @of
+      end
     end
   end
 end

--- a/activerecord/test/cases/batches_test.rb
+++ b/activerecord/test/cases/batches_test.rb
@@ -700,4 +700,18 @@ class EachTest < ActiveRecord::TestCase
       end
     end
   end
+
+  test ".in_batches.size efficiently calculates number of batches" do
+    assert_queries(1) do
+      assert_equal(@total, Post.in_batches(of: 1).size)
+    end
+
+    Post.stub(:count, 12) do
+      assert_equal(4, Post.in_batches(of: 3).size)
+    end
+
+    Post.stub(:count, 11) do
+      assert_equal(3, Post.in_batches(of: 5).size)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Explicitly define `BatchEnumerator#size` instead of using `Enumerable#count` to avoid unnecessary queries for the calculation

### Other Information
I'm borrowing the implementation from the `job-iteration` gem - https://github.com/Shopify/job-iteration/blob/2cebca07a25af31ed52dd11ac85c3e6b621d05e1/lib/job-iteration/active_record_batch_enumerator.rb#L43

Default implementation iterates over batches to calculate the total number of batches, which looks like this:
```
(rdbg) Topic.in_batches(of: 2).count 
D, [2021-11-16T18:13:17.131261 #45603] DEBUG -- :   Topic Pluck (0.1ms)  SELECT "topics"."id" FROM "topics" ORDER BY "topics"."id" ASC LIMIT ?  [["LIMIT", 2]]
D, [2021-11-16T18:13:17.131802 #45603] DEBUG -- :   Topic Pluck (0.1ms)  SELECT "topics"."id" FROM "topics" WHERE "topics"."id" > ? ORDER BY "topics"."id" ASC LIMIT ?  [["id", 2], ["LIMIT", 2]]
D, [2021-11-16T18:13:17.132159 #45603] DEBUG -- :   Topic Pluck (0.0ms)  SELECT "topics"."id" FROM "topics" WHERE "topics"."id" > ? ORDER BY "topics"."id" ASC LIMIT ?  [["id", 4], ["LIMIT", 2]]
3
``` 

### For reviewers

- I was considering defining a new test file for the `BatchEnumerator` itself, but couldn't come up with a test case any different than the one I have in the `batches_test` I kind of want to keep the `in_batches` test to make sure that regardless of the implementation the method doesn't perform unnecessary queries but also realize that it would be better to test the behaviour in the test like `batch_enumerator_test.rb` 