### PR TITLE
Add `sql_type` option to `column_exists?`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `sql_type` option to `column_exists?`
+
+    Allows you to check if a column exists using its raw SQL type, rather than the type that Rails casts to.
+
+    *Alex Ghiculescu*
+
 *   Add middleware for automatic shard swapping.
 
     Provides a basic middleware to perform automatic shard swapping. Applications will provide a resolver which will determine for an individual request which shard should be used. Example:

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -126,6 +126,10 @@ module ActiveRecord
       #   # Check a column exists of a particular type
       #   column_exists?(:suppliers, :name, :string)
       #
+      #   # The third argument argument is unreliable on some databases, and is discouraged.
+      #   # The sql_type option is more accurate:
+      #   column_exists?(:suppliers, :name, sql_type: :char)
+      #
       #   # Check a column exists with a specific definition
       #   column_exists?(:suppliers, :name, :string, limit: 100)
       #   column_exists?(:suppliers, :name, :string, default: 'default')
@@ -137,6 +141,9 @@ module ActiveRecord
         checks = []
         checks << lambda { |c| c.name == column_name }
         checks << lambda { |c| c.type == type.to_sym rescue nil } if type
+        if sql_type = options.delete(:sql_type)
+          checks << lambda { |c| c.sql_type.to_sym == sql_type.to_sym rescue nil }
+        end
         column_options_keys.each do |attr|
           checks << lambda { |c| c.send(attr) == options[attr] } if options.key?(attr)
         end

--- a/activerecord/test/cases/migration/columns_test.rb
+++ b/activerecord/test/cases/migration/columns_test.rb
@@ -311,6 +311,35 @@ module ActiveRecord
         connection.drop_table(:my_table) rescue nil
       end
 
+      def test_column_exists_with_simple_sql_type
+        expected_sql_type = current_adapter?(:PostgreSQLAdapter) ? "character varying" : "varchar"
+
+        connection.create_table "my_table", force: true do |t|
+          t.string :name
+        end
+
+        assert connection.column_exists?("my_table", :name)
+        assert connection.column_exists?("my_table", :name, type: "string")
+        assert connection.column_exists?("my_table", :name, sql_type: expected_sql_type)
+      ensure
+        connection.drop_table(:my_table) rescue nil
+      end
+
+      def test_column_exists_with_complex_sql_type
+        type = current_adapter?(:PostgreSQLAdapter) ? :char : :blob
+        expected_sql_type = current_adapter?(:PostgreSQLAdapter) ? "character(1)" : "blob"
+
+        connection.create_table "my_table", force: true do |t|
+          t.column :name, type
+        end
+
+        assert connection.column_exists?("my_table", :name)
+        assert connection.column_exists?("my_table", :name, type: "string")
+        assert connection.column_exists?("my_table", :name, sql_type: expected_sql_type)
+      ensure
+        connection.drop_table(:my_table) rescue nil
+      end
+
       def test_add_column_without_column_name
         e = assert_raise ArgumentError do
           connection.create_table "my_table", force: true do |t|


### PR DESCRIPTION
Allows you to check if a column exists using its raw SQL type, rather than the type that Rails casts to.

Fixes https://github.com/rails/rails/issues/43054
