### PR TITLE
ActiveSupport: Fix some race conditions on test/cache/stores

### DIFF
--- a/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_increment_decrement_behavior.rb
@@ -2,26 +2,28 @@
 
 module CacheIncrementDecrementBehavior
   def test_increment
-    @cache.write("foo", 1, raw: true)
-    assert_equal 1, @cache.read("foo", raw: true).to_i
-    assert_equal 2, @cache.increment("foo")
-    assert_equal 2, @cache.read("foo", raw: true).to_i
-    assert_equal 3, @cache.increment("foo")
-    assert_equal 3, @cache.read("foo", raw: true).to_i
+    key = SecureRandom.uuid
+    @cache.write(key, 1, raw: true)
+    assert_equal 1, @cache.read(key, raw: true).to_i
+    assert_equal 2, @cache.increment(key)
+    assert_equal 2, @cache.read(key, raw: true).to_i
+    assert_equal 3, @cache.increment(key)
+    assert_equal 3, @cache.read(key, raw: true).to_i
 
-    missing = @cache.increment("bar")
+    missing = @cache.increment(SecureRandom.alphanumeric)
     assert(missing.nil? || missing == 1)
   end
 
   def test_decrement
-    @cache.write("foo", 3, raw: true)
-    assert_equal 3, @cache.read("foo", raw: true).to_i
-    assert_equal 2, @cache.decrement("foo")
-    assert_equal 2, @cache.read("foo", raw: true).to_i
-    assert_equal 1, @cache.decrement("foo")
-    assert_equal 1, @cache.read("foo", raw: true).to_i
+    key = SecureRandom.uuid
+    @cache.write(key, 3, raw: true)
+    assert_equal 3, @cache.read(key, raw: true).to_i
+    assert_equal 2, @cache.decrement(key)
+    assert_equal 2, @cache.read(key, raw: true).to_i
+    assert_equal 1, @cache.decrement(key)
+    assert_equal 1, @cache.read(key, raw: true).to_i
 
-    missing = @cache.decrement("bar")
+    missing = @cache.decrement(SecureRandom.alphanumeric)
     assert(missing.nil? || missing == -1)
   end
 end

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -3,110 +3,128 @@
 # Tests the base functionality that should be identical across all cache stores.
 module CacheStoreBehavior
   def test_should_read_and_write_strings
-    assert @cache.write("foo", "bar")
-    assert_equal "bar", @cache.read("foo")
+    key = SecureRandom.uuid
+    assert @cache.write(key, "bar")
+    assert_equal "bar", @cache.read(key)
   end
 
   def test_should_overwrite
-    @cache.write("foo", "bar")
-    @cache.write("foo", "baz")
-    assert_equal "baz", @cache.read("foo")
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    @cache.write(key, "baz")
+    assert_equal "baz", @cache.read(key)
   end
 
   def test_fetch_without_cache_miss
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
     assert_not_called(@cache, :write) do
-      assert_equal "bar", @cache.fetch("foo") { "baz" }
+      assert_equal "bar", @cache.fetch(key) { "baz" }
     end
   end
 
   def test_fetch_with_cache_miss
-    assert_called_with(@cache, :write, ["foo", "baz", @cache.options]) do
-      assert_equal "baz", @cache.fetch("foo") { "baz" }
+    key = SecureRandom.uuid
+    assert_called_with(@cache, :write, [key, "baz", @cache.options]) do
+      assert_equal "baz", @cache.fetch(key) { "baz" }
     end
   end
 
   def test_fetch_with_cache_miss_passes_key_to_block
     cache_miss = false
-    assert_equal 3, @cache.fetch("foo") { |key| cache_miss = true; key.length }
+    key = SecureRandom.alphanumeric(10)
+    assert_equal 10, @cache.fetch(key) { |key| cache_miss = true; key.length }
     assert cache_miss
 
     cache_miss = false
-    assert_equal 3, @cache.fetch("foo") { |key| cache_miss = true; key.length }
+    assert_equal 10, @cache.fetch(key) { |fetch_key| cache_miss = true; fetch_key.length }
     assert_not cache_miss
   end
 
   def test_fetch_with_forced_cache_miss
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
     assert_not_called(@cache, :read) do
-      assert_called_with(@cache, :write, ["foo", "bar", @cache.options.merge(force: true)]) do
-        @cache.fetch("foo", force: true) { "bar" }
+      assert_called_with(@cache, :write, [key, "bar", @cache.options.merge(force: true)]) do
+        @cache.fetch(key, force: true) { "bar" }
       end
     end
   end
 
   def test_fetch_with_cached_nil
-    @cache.write("foo", nil)
+    key = SecureRandom.uuid
+    @cache.write(key, nil)
     assert_not_called(@cache, :write) do
-      assert_nil @cache.fetch("foo") { "baz" }
+      assert_nil @cache.fetch(key) { "baz" }
     end
   end
 
   def test_fetch_cache_miss_with_skip_nil
+    key = SecureRandom.uuid
     assert_not_called(@cache, :write) do
-      assert_nil @cache.fetch("foo", skip_nil: true) { nil }
+      assert_nil @cache.fetch(key, skip_nil: true) { nil }
       assert_equal false, @cache.exist?("foo")
     end
   end
 
   def test_fetch_with_forced_cache_miss_with_block
-    @cache.write("foo", "bar")
-    assert_equal "foo_bar", @cache.fetch("foo", force: true) { "foo_bar" }
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    assert_equal "foo_bar", @cache.fetch(key, force: true) { "foo_bar" }
   end
 
   def test_fetch_with_forced_cache_miss_without_block
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
     assert_raises(ArgumentError) do
-      @cache.fetch("foo", force: true)
+      @cache.fetch(key, force: true)
     end
 
-    assert_equal "bar", @cache.read("foo")
+    assert_equal "bar", @cache.read(key)
   end
 
   def test_should_read_and_write_hash
-    assert @cache.write("foo", a: "b")
-    assert_equal({ a: "b" }, @cache.read("foo"))
+    key = SecureRandom.uuid
+    assert @cache.write(key, a: "b")
+    assert_equal({ a: "b" }, @cache.read(key))
   end
 
   def test_should_read_and_write_integer
-    assert @cache.write("foo", 1)
-    assert_equal 1, @cache.read("foo")
+    key = SecureRandom.uuid
+    assert @cache.write(key, 1)
+    assert_equal 1, @cache.read(key)
   end
 
   def test_should_read_and_write_nil
-    assert @cache.write("foo", nil)
-    assert_nil @cache.read("foo")
+    key = SecureRandom.uuid
+    assert @cache.write(key, nil)
+    assert_nil @cache.read(key)
   end
 
   def test_should_read_and_write_false
-    assert @cache.write("foo", false)
-    assert_equal false, @cache.read("foo")
+    key = SecureRandom.uuid
+    assert @cache.write(key, false)
+    assert_equal false, @cache.read(key)
   end
 
   def test_read_multi
-    @cache.write("foo", "bar")
-    @cache.write("fu", "baz")
-    @cache.write("fud", "biz")
-    assert_equal({ "foo" => "bar", "fu" => "baz" }, @cache.read_multi("foo", "fu"))
+    key = SecureRandom.uuid
+    @cache.write(key, "bar")
+    other_key = SecureRandom.uuid
+    @cache.write(other_key, "baz")
+    @cache.write(SecureRandom.alphanumeric, "biz")
+    assert_equal({ key => "bar", other_key => "baz" }, @cache.read_multi(key, other_key))
   end
 
   def test_read_multi_with_expires
     time = Time.now
-    @cache.write("foo", "bar", expires_in: 10)
-    @cache.write("fu", "baz")
-    @cache.write("fud", "biz")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 10)
+    @cache.write(other_key, "baz")
+    @cache.write(SecureRandom.alphanumeric, "biz")
     Time.stub(:now, time + 11) do
-      assert_equal({ "fu" => "baz" }, @cache.read_multi("foo", "fu"))
+      assert_equal({ other_key => "baz" }, @cache.read_multi(other_key, SecureRandom.alphanumeric))
     end
   end
 
@@ -117,31 +135,39 @@ module CacheStoreBehavior
   end
 
   def test_fetch_multi
-    @cache.write("foo", "bar")
-    @cache.write("fud", "biz")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    third_key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    @cache.write(other_key, "biz")
 
-    values = @cache.fetch_multi("foo", "fu", "fud") { |value| value * 2 }
+    values = @cache.fetch_multi(key, other_key, third_key) { |value| value * 2 }
 
-    assert_equal({ "foo" => "bar", "fu" => "fufu", "fud" => "biz" }, values)
-    assert_equal("fufu", @cache.read("fu"))
+    assert_equal({ key => "bar", other_key => "biz", third_key => (third_key * 2) }, values)
+    assert_equal((third_key * 2), @cache.read(third_key))
   end
 
   def test_fetch_multi_without_expires_in
-    @cache.write("foo", "bar")
-    @cache.write("fud", "biz")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    third_key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    @cache.write(other_key, "biz")
 
-    values = @cache.fetch_multi("foo", "fu", "fud", expires_in: nil) { |value| value * 2 }
+    values = @cache.fetch_multi(key, third_key, other_key, expires_in: nil) { |value| value * 2 }
 
-    assert_equal({ "foo" => "bar", "fu" => "fufu", "fud" => "biz" }, values)
-    assert_equal("fufu", @cache.read("fu"))
+    assert_equal({ key => "bar", third_key => (third_key * 2), other_key => "biz" }, values)
+    assert_equal((third_key * 2), @cache.read(third_key))
   end
 
   def test_fetch_multi_with_objects
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
     cache_struct = Struct.new(:cache_key, :title)
-    foo = cache_struct.new("foo", "FOO!")
-    bar = cache_struct.new("bar")
+    foo = cache_struct.new(key, "FOO!")
+    bar = cache_struct.new(other_key)
 
-    @cache.write("bar", "BAM!")
+    @cache.write(other_key, "BAM!")
 
     values = @cache.fetch_multi(foo, bar) { |object| object.title }
 
@@ -149,16 +175,20 @@ module CacheStoreBehavior
   end
 
   def test_fetch_multi_returns_ordered_names
-    @cache.write("bam", "BAM")
+    key = SecureRandom.alphanumeric.downcase
+    other_key = SecureRandom.alphanumeric.downcase
+    third_key = SecureRandom.alphanumeric.downcase
+    @cache.write(key, "BAM")
 
-    values = @cache.fetch_multi("foo", "bar", "bam") { |key| key.upcase }
+    values = @cache.fetch_multi(other_key, third_key, key) { |key| key.upcase }
 
-    assert_equal(%w(foo bar bam), values.keys)
+    assert_equal([other_key, third_key, key], values.keys)
+    assert_equal([other_key.upcase, third_key.upcase, "BAM"], values.values)
   end
 
   def test_fetch_multi_without_block
     assert_raises(ArgumentError) do
-      @cache.fetch_multi("foo")
+      @cache.fetch_multi(SecureRandom.alphanumeric)
     end
   end
 
@@ -262,38 +292,54 @@ module CacheStoreBehavior
   end
 
   def test_cache_key
-    obj = Object.new
-    def obj.cache_key
-      :foo
+    key = SecureRandom.uuid
+    klass = Class.new do
+      def initialize(key)
+        @key = key
+      end
+      def cache_key
+        @key
+      end
     end
-    @cache.write(obj, "bar")
-    assert_equal "bar", @cache.read("foo")
+    @cache.write(klass.new(key), "bar")
+    assert_equal "bar", @cache.read(key)
   end
 
   def test_param_as_cache_key
-    obj = Object.new
-    def obj.to_param
-      "foo"
+    key = SecureRandom.uuid
+    klass = Class.new do
+      def initialize(key)
+        @key = key
+      end
+      def to_param
+        @key
+      end
     end
-    @cache.write(obj, "bar")
-    assert_equal "bar", @cache.read("foo")
+    @cache.write(klass.new(key), "bar")
+    assert_equal "bar", @cache.read(key)
   end
 
   def test_unversioned_cache_key
-    obj = Object.new
-    def obj.cache_key
-      "foo"
+    key = SecureRandom.uuid
+    klass = Class.new do
+      def initialize(key)
+        @key = key
+      end
+      def cache_key
+        @key
+      end
+      def cache_key_with_version
+        "#{@key}-v1"
+      end
     end
-    def obj.cache_key_with_version
-      "foo-v1"
-    end
-    @cache.write(obj, "bar")
-    assert_equal "bar", @cache.read("foo")
+    @cache.write(klass.new(key), "bar")
+    assert_equal "bar", @cache.read(key)
   end
 
   def test_array_as_cache_key
-    @cache.write([:fu, "foo"], "bar")
-    assert_equal "bar", @cache.read("fu/foo")
+    key = SecureRandom.uuid
+    @cache.write([key, "foo"], "bar")
+    assert_equal "bar", @cache.read("#{key}/foo")
   end
 
   InstanceTest = Struct.new(:name, :id) do
@@ -307,8 +353,10 @@ module CacheStoreBehavior
   end
 
   def test_array_with_single_instance_as_cache_key_uses_cache_key_method
-    test_instance_one = InstanceTest.new("test", 1)
-    test_instance_two = InstanceTest.new("test", 2)
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
+    test_instance_two = InstanceTest.new(other_key, 2)
 
     @cache.write([test_instance_one], "one")
     @cache.write([test_instance_two], "two")
@@ -318,9 +366,12 @@ module CacheStoreBehavior
   end
 
   def test_array_with_multiple_instances_as_cache_key_uses_cache_key_method
-    test_instance_one = InstanceTest.new("test", 1)
-    test_instance_two = InstanceTest.new("test", 2)
-    test_instance_three = InstanceTest.new("test", 3)
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    third_key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
+    test_instance_two = InstanceTest.new(other_key, 2)
+    test_instance_three = InstanceTest.new(third_key, 3)
 
     @cache.write([test_instance_one, test_instance_three], "one")
     @cache.write([test_instance_two, test_instance_three], "two")
@@ -330,7 +381,8 @@ module CacheStoreBehavior
   end
 
   def test_format_of_expanded_key_for_single_instance
-    test_instance_one = InstanceTest.new("test", 1)
+    key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
 
     expanded_key = @cache.send(:expanded_key, test_instance_one)
 
@@ -338,7 +390,8 @@ module CacheStoreBehavior
   end
 
   def test_format_of_expanded_key_for_single_instance_in_array
-    test_instance_one = InstanceTest.new("test", 1)
+    key = SecureRandom.alphanumeric
+    test_instance_one = InstanceTest.new(key, 1)
 
     expanded_key = @cache.send(:expanded_key, [test_instance_one])
 
@@ -346,133 +399,149 @@ module CacheStoreBehavior
   end
 
   def test_hash_as_cache_key
-    @cache.write({ foo: 1, fu: 2 }, "bar")
-    assert_equal "bar", @cache.read("foo=1/fu=2")
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+    @cache.write({ key => 1, other_key => 2 }, "bar")
+    assert_equal "bar", @cache.read({ key => 1, other_key => 2 })
   end
 
   def test_keys_are_case_sensitive
-    @cache.write("foo", "bar")
-    assert_nil @cache.read("FOO")
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert_nil @cache.read(key.upcase)
   end
 
   def test_exist
-    @cache.write("foo", "bar")
-    assert_equal true, @cache.exist?("foo")
-    assert_equal false, @cache.exist?("bar")
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert_equal true, @cache.exist?(key)
+    assert_equal false, @cache.exist?(SecureRandom.uuid)
   end
 
   def test_nil_exist
-    @cache.write("foo", nil)
-    assert @cache.exist?("foo")
+    key = SecureRandom.alphanumeric
+    @cache.write(key, nil)
+    assert @cache.exist?(key)
   end
 
   def test_delete
-    @cache.write("foo", "bar")
-    assert @cache.exist?("foo")
-    assert @cache.delete("foo")
-    assert_not @cache.exist?("foo")
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert @cache.exist?(key)
+    assert @cache.delete(key)
+    assert_not @cache.exist?(key)
   end
 
   def test_delete_multi
-    @cache.write("foo", "bar")
-    assert @cache.exist?("foo")
-    @cache.write("hello", "world")
-    assert @cache.exist?("hello")
-    assert_equal 2, @cache.delete_multi(["foo", "does_not_exist", "hello"])
-    assert_not @cache.exist?("foo")
-    assert_not @cache.exist?("hello")
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    assert @cache.exist?(key)
+    other_key = SecureRandom.alphanumeric
+    @cache.write(other_key, "world")
+    assert @cache.exist?(other_key)
+    assert_equal 2, @cache.delete_multi([key, SecureRandom.uuid, other_key])
+    assert_not @cache.exist?(key)
+    assert_not @cache.exist?(other_key)
   end
 
   def test_original_store_objects_should_not_be_immutable
     bar = +"bar"
-    @cache.write("foo", bar)
+    key = SecureRandom.alphanumeric
+    @cache.write(key, bar)
     assert_nothing_raised { bar.gsub!(/.*/, "baz") }
   end
 
   def test_expires_in
     time = Time.local(2008, 4, 24)
 
+    key = SecureRandom.alphanumeric
+    other_key = SecureRandom.alphanumeric
+
     Time.stub(:now, time) do
-      @cache.write("foo", "bar", expires_in: 1.minute)
-      @cache.write("egg", "spam", expires_in: 2.minute)
-      assert_equal "bar", @cache.read("foo")
-      assert_equal "spam", @cache.read("egg")
+      @cache.write(key, "bar", expires_in: 1.minute)
+      @cache.write(other_key, "spam", expires_in: 2.minute)
+      assert_equal "bar", @cache.read(key)
+      assert_equal "spam", @cache.read(other_key)
     end
 
     Time.stub(:now, time + 30) do
-      assert_equal "bar", @cache.read("foo")
-      assert_equal "spam", @cache.read("egg")
+      assert_equal "bar", @cache.read(key)
+      assert_equal "spam", @cache.read(other_key)
     end
 
-    Time.stub(:now, time + 61) do
-      assert_nil @cache.read("foo")
-      assert_equal "spam", @cache.read("egg")
+    Time.stub(:now, time + 1.minute + 1.second) do
+      assert_nil @cache.read(key)
+      assert_equal "spam", @cache.read(other_key)
     end
 
-    Time.stub(:now, time + 121) do
-      assert_nil @cache.read("foo")
-      assert_nil @cache.read("egg")
+    Time.stub(:now, time + 2.minute + 1.second) do
+      assert_nil @cache.read(key)
+      assert_nil @cache.read(other_key)
     end
   end
 
   def test_expires_at
     time = Time.local(2008, 4, 24)
 
+    key = SecureRandom.alphanumeric
     Time.stub(:now, time) do
-      @cache.write("foo", "bar", expires_at: time + 15.seconds)
-      assert_equal "bar", @cache.read("foo")
+      @cache.write(key, "bar", expires_at: time + 15.seconds)
+      assert_equal "bar", @cache.read(key)
     end
 
     Time.stub(:now, time + 10) do
-      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.read(key)
     end
 
     Time.stub(:now, time + 30) do
-      assert_nil @cache.read("foo")
+      assert_nil @cache.read(key)
     end
   end
 
   def test_expire_in_is_alias_for_expires_in
     time = Time.local(2008, 4, 24)
 
+    key = SecureRandom.alphanumeric
     Time.stub(:now, time) do
-      @cache.write("foo", "bar", expire_in: 20)
-      assert_equal "bar", @cache.read("foo")
+      @cache.write(key, "bar", expire_in: 20)
+      assert_equal "bar", @cache.read(key)
     end
 
     Time.stub(:now, time + 10) do
-      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.read(key)
     end
 
     Time.stub(:now, time + 21) do
-      assert_nil @cache.read("foo")
+      assert_nil @cache.read(key)
     end
   end
 
   def test_expired_in_is_alias_for_expires_in
     time = Time.local(2008, 4, 24)
 
+    key = SecureRandom.alphanumeric
     Time.stub(:now, time) do
-      @cache.write("foo", "bar", expired_in: 20)
-      assert_equal "bar", @cache.read("foo")
+      @cache.write(key, "bar", expired_in: 20)
+      assert_equal "bar", @cache.read(key)
     end
 
     Time.stub(:now, time + 10) do
-      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.read(key)
     end
 
     Time.stub(:now, time + 21) do
-      assert_nil @cache.read("foo")
+      assert_nil @cache.read(key)
     end
   end
 
   def test_race_condition_protection_skipped_if_not_defined
-    @cache.write("foo", "bar")
-    time = @cache.send(:read_entry, @cache.send(:normalize_key, "foo", {}), **{}).expires_at
+    key = SecureRandom.alphanumeric
+    @cache.write(key, "bar")
+    time = @cache.send(:read_entry, @cache.send(:normalize_key, key, {}), **{}).expires_at
 
     Time.stub(:now, Time.at(time)) do
-      result = @cache.fetch("foo") do
-        assert_nil @cache.read("foo")
+      result = @cache.fetch(key) do
+        assert_nil @cache.read(key)
         "baz"
       end
       assert_equal "baz", result
@@ -481,10 +550,11 @@ module CacheStoreBehavior
 
   def test_race_condition_protection_is_limited
     time = Time.now
-    @cache.write("foo", "bar", expires_in: 60)
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 60)
     Time.stub(:now, time + 71) do
-      result = @cache.fetch("foo", race_condition_ttl: 10) do
-        assert_nil @cache.read("foo")
+      result = @cache.fetch(key, race_condition_ttl: 10) do
+        assert_nil @cache.read(key)
         "baz"
       end
       assert_equal "baz", result
@@ -493,28 +563,30 @@ module CacheStoreBehavior
 
   def test_race_condition_protection_is_safe
     time = Time.now
-    @cache.write("foo", "bar", expires_in: 60)
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 60)
     Time.stub(:now, time + 61) do
       begin
-        @cache.fetch("foo", race_condition_ttl: 10) do
-          assert_equal "bar", @cache.read("foo")
+        @cache.fetch(key, race_condition_ttl: 10) do
+          assert_equal "bar", @cache.read(key)
           raise ArgumentError.new
         end
       rescue ArgumentError
       end
-      assert_equal "bar", @cache.read("foo")
+      assert_equal "bar", @cache.read(key)
     end
     Time.stub(:now, time + 91) do
-      assert_nil @cache.read("foo")
+      assert_nil @cache.read(key)
     end
   end
 
   def test_race_condition_protection
     time = Time.now
-    @cache.write("foo", "bar", expires_in: 60)
+    key = SecureRandom.uuid
+    @cache.write(key, "bar", expires_in: 60)
     Time.stub(:now, time + 61) do
-      result = @cache.fetch("foo", race_condition_ttl: 10) do
-        assert_equal "bar", @cache.read("foo")
+      result = @cache.fetch(key, race_condition_ttl: 10) do
+        assert_equal "bar", @cache.read(key)
         "baz"
       end
       assert_equal "baz", result
@@ -533,13 +605,12 @@ module CacheStoreBehavior
   end
 
   def test_really_long_keys
-    key = "x" * 2048
+    key = SecureRandom.alphanumeric * 2048
     assert @cache.write(key, "bar")
     assert_equal "bar", @cache.read(key)
     assert_equal "bar", @cache.fetch(key)
     assert_nil @cache.read("#{key}x")
     assert_equal({ key => "bar" }, @cache.read_multi(key))
-    assert @cache.delete(key)
   end
 
   def test_cache_hit_instrumentation
@@ -563,7 +634,7 @@ module CacheStoreBehavior
     ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) do |*args|
       @events << ActiveSupport::Notifications::Event.new(*args)
     end
-    assert_not @cache.fetch("bad_key") { }
+    assert_not @cache.fetch(SecureRandom.uuid) { }
     assert_equal 3, @events.length
     assert_equal "cache_read.active_support", @events[0].name
     assert_equal "cache_generate.active_support", @events[1].name


### PR DESCRIPTION
### Summary

I've notice some test scenarios failing randomly when running the tests for `ActiveSupport` cache stores in isolation. The failing scenarios are currently frequent when using a computer with multiple cores.

This is the first attempt to fix most of them, and it's pretty stable by now. I'm not covering all of them because it will mean even more changes the maintainers need to carefully review.

The main problem seems to occur when multiple _shared_ specs are being executed in parallel and reusing the `{ "foo" =>  "bar" }` key/value and assume the store is already empty when they isn't. The test scenarios are _namespaced_ but the shared test are still sharing the same store with the same namespace, having as a result keys with not expected values or even empty if the other test did that a millisecond before them.

My proposed solution is to not use `foo` as the key for those shared scenarios., but any random key we hold and use for the multiple cases.

### Other Information

The test suite is launching 6 processes and using my 12 cores to run the test, there's only 5120 assertions and the chances to get the failing test increase with that.

As mentioned the case scenarios are randomly happening, these are some of them:

![Screenshot_20211118_094636](https://user-images.githubusercontent.com/1037088/142472769-ef1e925f-4cd8-4ba9-ad13-c3145c893c6f.png)

![Screenshot_20211118_095152](https://user-images.githubusercontent.com/1037088/142472847-0a415226-60ba-4caa-beb0-1d2fd86941ef.png)

![Screenshot_20211118_095456](https://user-images.githubusercontent.com/1037088/142472890-04b508fc-a208-4aa4-a59f-feb9dc4ba8fd.png)

![image](https://user-images.githubusercontent.com/1037088/142473148-d6ff597a-8993-4679-93c6-42792250c670.png)

![image](https://user-images.githubusercontent.com/1037088/142474244-4febc15a-5077-43e3-894a-a9f82341b01f.png)

![image](https://user-images.githubusercontent.com/1037088/142475810-eb20a666-8556-4f8b-b636-1119c4fb68a2.png)
