### PR TITLE
Add year and day translation support for date_select

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,25 @@
+*   Add year and day translation support for `date_select`
+
+    ```ruby
+    # config/locales/en.rb
+    {
+      en: {
+        date: {
+          year_format: lambda { |_key, options| "Heisei #{options[:number] - 1988}" },
+          day_format: lambda { |_key, options| ActiveSupport::Inflector.ordinalize(options[:number]) }
+        }
+      }
+    }
+    ```
+
+    ```ruby
+    date_select("article", "written_on")
+    # generates year options like <option value="2003">Heisei 15</option>\n<option value="2004">Heisei 16</option>...
+    # and day options like <option value="1">1st</option>\n<option value="2">2nd</option>...
+    ```
+
+    *Shunichi Ikegami*
+
 *   Support `fields model: [@nested, @model]` the same way as `form_with model:
     [@nested, @model]`.
 

--- a/actionview/lib/action_view/helpers/date_helper.rb
+++ b/actionview/lib/action_view/helpers/date_helper.rb
@@ -920,8 +920,12 @@ module ActionView
           elsif @options[:use_two_digit_numbers]
             "%02d" % number
           else
-            number
+            translate_day(number) || number
           end
+        end
+
+        def translate_day(number)
+          I18n.translate("date.day_format", number: number, locale: @options[:locale], default: nil)
         end
 
         # Looks up month names by number (1-based):
@@ -970,8 +974,12 @@ module ActionView
           if year_format_lambda = @options[:year_format]
             year_format_lambda.call(number)
           else
-            number
+            translate_year(number) || number
           end
+        end
+
+        def translate_year(number)
+          I18n.t("date.year_format", number: number, locale: @options[:locale], default: nil)
         end
 
         def date_order

--- a/actionview/test/template/date_helper_i18n_test.rb
+++ b/actionview/test/template/date_helper_i18n_test.rb
@@ -139,15 +139,17 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
 
   # date_or_time_select
 
+  # Note that :year_format and :day_format options are required to prevent I18n.translate from being called for year and day formatting.
+
   def test_date_or_time_select_given_an_order_options_does_not_translate_order
     assert_not_called(I18n, :translate) do
-      datetime_select("post", "updated_at", order: [:year, :month, :day], locale: "en", use_month_names: Date::MONTHNAMES)
+      datetime_select("post", "updated_at", order: [:year, :month, :day], locale: "en", use_month_names: Date::MONTHNAMES, year_format: ->(year) { year.to_s }, day_format: ->(day) { day.to_s })
     end
   end
 
   def test_date_or_time_select_given_no_order_options_translates_order
     assert_called_with(I18n, :translate, [ [:'date.order', locale: "en", default: []], [:"date.month_names", { locale: "en" }] ], returns: %w(year month day)) do
-      datetime_select("post", "updated_at", locale: "en")
+      datetime_select("post", "updated_at", locale: "en", year_format: ->(year) { year.to_s }, day_format: ->(day) { day.to_s })
     end
   end
 
@@ -161,7 +163,7 @@ class DateHelperSelectTagsI18nTests < ActiveSupport::TestCase
 
   def test_date_or_time_select_given_symbol_keys
     assert_called_with(I18n, :translate, [ [:'date.order', locale: "en", default: []], [:"date.month_names", { locale: "en" }] ], returns: [:year, :month, :day]) do
-      datetime_select("post", "updated_at", locale: "en")
+      datetime_select("post", "updated_at", locale: "en", year_format: ->(year) { year.to_s }, day_format: ->(day) { day.to_s })
     end
   end
 end

--- a/actionview/test/template/date_helper_test.rb
+++ b/actionview/test/template/date_helper_test.rb
@@ -251,7 +251,7 @@ class DateHelperTest < ActionView::TestCase
     assert_dom_equal expected, select_day(2, use_two_digit_numbers: true)
   end
 
-  def test_select_day_with_day_fomat
+  def test_select_day_with_day_format
     expected = +%(<select id="date_day" name="date[day]">\n)
     expected << %(<option value="1">1st</option>\n<option selected="selected" value="2">2nd</option>\n<option value="3">3rd</option>\n<option value="4">4th</option>\n<option value="5">5th</option>\n<option value="6">6th</option>\n<option value="7">7th</option>\n<option value="8">8th</option>\n<option value="9">9th</option>\n<option value="10">10th</option>\n<option value="11">11th</option>\n<option value="12">12th</option>\n<option value="13">13th</option>\n<option value="14">14th</option>\n<option value="15">15th</option>\n<option value="16">16th</option>\n<option value="17">17th</option>\n<option value="18">18th</option>\n<option value="19">19th</option>\n<option value="20">20th</option>\n<option value="21">21st</option>\n<option value="22">22nd</option>\n<option value="23">23rd</option>\n<option value="24">24th</option>\n<option value="25">25th</option>\n<option value="26">26th</option>\n<option value="27">27th</option>\n<option value="28">28th</option>\n<option value="29">29th</option>\n<option value="30">30th</option>\n<option value="31">31st</option>\n)
     expected << "</select>\n"
@@ -259,6 +259,22 @@ class DateHelperTest < ActionView::TestCase
     day_format = ->(day) { ActiveSupport::Inflector.ordinalize(day) }
     assert_dom_equal expected, select_day(Time.mktime(2011, 8, 2), day_format: day_format)
     assert_dom_equal expected, select_day(2, day_format: day_format)
+  end
+
+  def test_select_day_with_day_format_translation
+    I18n.backend.store_translations(:en, {
+      date: {
+        day_format: lambda { |_key, options| ActiveSupport::Inflector.ordinalize(options[:number]) }
+      }
+    })
+    expected = +%(<select id="date_day" name="date[day]">\n)
+    expected << %(<option value="1">1st</option>\n<option selected="selected" value="2">2nd</option>\n<option value="3">3rd</option>\n<option value="4">4th</option>\n<option value="5">5th</option>\n<option value="6">6th</option>\n<option value="7">7th</option>\n<option value="8">8th</option>\n<option value="9">9th</option>\n<option value="10">10th</option>\n<option value="11">11th</option>\n<option value="12">12th</option>\n<option value="13">13th</option>\n<option value="14">14th</option>\n<option value="15">15th</option>\n<option value="16">16th</option>\n<option value="17">17th</option>\n<option value="18">18th</option>\n<option value="19">19th</option>\n<option value="20">20th</option>\n<option value="21">21st</option>\n<option value="22">22nd</option>\n<option value="23">23rd</option>\n<option value="24">24th</option>\n<option value="25">25th</option>\n<option value="26">26th</option>\n<option value="27">27th</option>\n<option value="28">28th</option>\n<option value="29">29th</option>\n<option value="30">30th</option>\n<option value="31">31st</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_day(Time.mktime(2011, 8, 2))
+    assert_dom_equal expected, select_day(2)
+  ensure
+    I18n.backend.reload!
   end
 
   def test_select_day_with_html_options
@@ -600,6 +616,21 @@ class DateHelperTest < ActionView::TestCase
     expected << "</select>\n"
 
     assert_dom_equal expected, select_year(nil, start_year: 2003, end_year: 2005, year_format: year_format_lambda)
+  end
+
+  def test_select_year_with_year_format_translation
+    I18n.backend.store_translations(:en, {
+      date: {
+        year_format: lambda { |_key, options| "Heisei #{ options[:number] - 1988 }" }
+      }
+    })
+    expected = %(<select id="date_year" name="date[year]">\n).dup
+    expected << %(<option value="2003">Heisei 15</option>\n<option value="2004">Heisei 16</option>\n<option value="2005">Heisei 17</option>\n)
+    expected << "</select>\n"
+
+    assert_dom_equal expected, select_year(nil, start_year: 2003, end_year: 2005)
+  ensure
+    I18n.backend.reload!
   end
 
   def test_select_hour


### PR DESCRIPTION
### Summary
I added `:day_format` option to `date_select` in https://github.com/rails/rails/pull/43567

But in most cases, the same `:year_format` and `:day_format` options for each locale are used in a whole application.
It would be great if there were global year_format and day_format options for each locale.
So I added year_format and day_format to i18n.

Although lambdas in i18n may look a little strange, rails already has lambdas in i18n.
https://github.com/rails/rails/blob/main/activesupport/lib/active_support/locale/en.rb

### An example
 ```ruby
 # config/locales/en.rb
 {
   en: {
     date: {
       year_format: lambda { |_key, options| "Heisei #{options[:number] - 1988}" },
       day_format: lambda { |_key, options| ActiveSupport::Inflector.ordinalize(options[:number]) }
     }
   }
 }
 ```
 
 ```ruby
 date_select("article", "written_on")
 # generates year options like <option value="2003">Heisei 15</option>\n<option value="2004">Heisei 16</option>...
 # and day options like <option value="1">1st</option>\n<option value="2">2nd</option>...
 ```
