### PR TITLE
Eliminate internal uses of `PerThreadRegistry` and deprecate it

### DIFF
--- a/actionview/lib/action_view/helpers/cache_helper.rb
+++ b/actionview/lib/action_view/helpers/cache_helper.rb
@@ -292,19 +292,20 @@ module ActionView
         controller.write_fragment(name, fragment, options)
       end
 
-      class CachingRegistry
-        extend ActiveSupport::PerThreadRegistry
+      module CachingRegistry # :nodoc:
+        extend self
 
-        attr_accessor :caching
-        alias caching? caching
+        def caching?
+          ActiveSupport::IsolatedExecutionState[:action_view_caching] ||= false
+        end
 
-        def self.track_caching
-          caching_was = self.caching
-          self.caching = true
+        def track_caching
+          caching_was = ActiveSupport::IsolatedExecutionState[:action_view_caching]
+          ActiveSupport::IsolatedExecutionState[:action_view_caching] = true
 
           yield
         ensure
-          self.caching = caching_was
+          ActiveSupport::IsolatedExecutionState[:action_view_caching] = caching_was
         end
       end
     end

--- a/activerecord/lib/active_record/relation/record_fetch_warning.rb
+++ b/activerecord/lib/active_record/relation/record_fetch_warning.rb
@@ -31,17 +31,15 @@ module ActiveRecord
       end
       # :startdoc:
 
-      class QueryRegistry # :nodoc:
-        extend ActiveSupport::PerThreadRegistry
+      module QueryRegistry # :nodoc:
+        extend self
 
-        attr_reader :queries
-
-        def initialize
-          @queries = []
+        def queries
+          ActiveSupport::IsolatedExecutionState[:active_record_query_registry] ||= []
         end
 
         def reset
-          @queries.clear
+          queries.clear
         end
       end
     end

--- a/activerecord/lib/active_record/runtime_registry.rb
+++ b/activerecord/lib/active_record/runtime_registry.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
-require "active_support/per_thread_registry"
-
 module ActiveRecord
   # This is a thread locals registry for Active Record. For example:
   #
-  #   ActiveRecord::RuntimeRegistry.connection_handler
+  #   ActiveRecord::RuntimeRegistry.sql_runtime
   #
-  # returns the connection handler local to the current thread.
-  #
-  # See the documentation of ActiveSupport::PerThreadRegistry
-  # for further details.
-  class RuntimeRegistry # :nodoc:
-    extend ActiveSupport::PerThreadRegistry
+  # returns the connection handler local to the current unit of execution (either thread of fiber).
+  module RuntimeRegistry # :nodoc:
+    extend self
 
-    attr_accessor :sql_runtime
+    def sql_runtime
+      ActiveSupport::IsolatedExecutionState[:active_record_sql_runtime]
+    end
 
-    def self.sql_runtime; instance.sql_runtime; end
-    def self.sql_runtime=(x); instance.sql_runtime = x; end
+    def sql_runtime=(runtime)
+      ActiveSupport::IsolatedExecutionState[:active_record_sql_runtime] = runtime
+    end
   end
 end

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -51,6 +51,7 @@ module ActiveSupport
   autoload :IsolatedExecutionState
   autoload :Notifications
   autoload :Reloader
+  autoload :PerThreadRegistry
   autoload :SecureCompareRotator
 
   eager_autoload do

--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/string/inflections"
-require "active_support/per_thread_registry"
 
 module ActiveSupport
   module Cache
@@ -13,23 +12,18 @@ module ActiveSupport
         autoload :Middleware, "active_support/cache/strategy/local_cache_middleware"
 
         # Class for storing and registering the local caches.
-        class LocalCacheRegistry # :nodoc:
-          extend ActiveSupport::PerThreadRegistry
-
-          def initialize
-            @registry = {}
-          end
+        module LocalCacheRegistry # :nodoc:
+          extend self
 
           def cache_for(local_cache_key)
-            @registry[local_cache_key]
+            registry = ActiveSupport::IsolatedExecutionState[:active_support_local_cache_registry] ||= {}
+            registry[local_cache_key]
           end
 
           def set_cache_for(local_cache_key, value)
-            @registry[local_cache_key] = value
+            registry = ActiveSupport::IsolatedExecutionState[:active_support_local_cache_registry] ||= {}
+            registry[local_cache_key] = value
           end
-
-          def self.set_cache_for(l, v); instance.set_cache_for l, v; end
-          def self.cache_for(l); instance.cache_for l; end
         end
 
         # Simple memory backed cache. This cache is not thread safe and is intended only

--- a/activesupport/lib/active_support/per_thread_registry.rb
+++ b/activesupport/lib/active_support/per_thread_registry.rb
@@ -40,6 +40,10 @@ module ActiveSupport
   # If the class has an initializer, it must accept no arguments.
   module PerThreadRegistry
     def self.extended(object)
+      ActiveSupport::Deprecation.warn(<<~MSG)
+        ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1.
+        Use `Module#thread_mattr_accessor` instead.
+      MSG
       object.instance_variable_set :@per_thread_registry_key, object.name.freeze
     end
 

--- a/activesupport/lib/active_support/subscriber.rb
+++ b/activesupport/lib/active_support/subscriber.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/per_thread_registry"
 require "active_support/notifications"
 
 module ActiveSupport
@@ -157,23 +156,8 @@ module ActiveSupport
 
     private
       def event_stack
-        SubscriberQueueRegistry.instance.get_queue(@queue_key)
+        registry = ActiveSupport::IsolatedExecutionState[:active_support_subscriber_queue_registry] ||= {}
+        registry[@queue_key] ||= []
       end
-  end
-
-  # This is a registry for all the event stacks kept for subscribers.
-  #
-  # See the documentation of <tt>ActiveSupport::PerThreadRegistry</tt>
-  # for further details.
-  class SubscriberQueueRegistry # :nodoc:
-    extend PerThreadRegistry
-
-    def initialize
-      @registry = {}
-    end
-
-    def get_queue(queue_key)
-      @registry[queue_key] ||= []
-    end
   end
 end

--- a/activesupport/test/per_thread_registry_test.rb
+++ b/activesupport/test/per_thread_registry_test.rb
@@ -4,7 +4,9 @@ require_relative "abstract_unit"
 
 class PerThreadRegistryTest < ActiveSupport::TestCase
   class TestRegistry
-    extend ActiveSupport::PerThreadRegistry
+    ActiveSupport::Deprecation.silence do
+      extend ActiveSupport::PerThreadRegistry
+    end
 
     def foo(x:); x; end
   end


### PR DESCRIPTION
This module has been soft deprecated for a long time, but since
it was used internally it wasn't throwing deprecation warnings.

Now we can throw a deprecation warning.

cc @rafaelfranca @matthewd 