### PR TITLE
ActiveSupport, fix more race conditions on test/cache - part II

### DIFF
--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -655,21 +655,24 @@ module CacheStoreBehavior
     end
 
     def assert_compression(should_compress, value, **options)
+      actual = "actual" + SecureRandom.uuid
+      uncompressed = "uncompressed" + SecureRandom.uuid
+
       freeze_time do
-        @cache.write("actual", value, options)
-        @cache.write("uncompressed", value, options.merge(compress: false))
+        @cache.write(actual, value, options)
+        @cache.write(uncompressed, value, options.merge(compress: false))
       end
 
       if value.nil?
-        assert_nil @cache.read("actual")
-        assert_nil @cache.read("uncompressed")
+        assert_nil @cache.read(actual)
+        assert_nil @cache.read(uncompressed)
       else
-        assert_equal value, @cache.read("actual")
-        assert_equal value, @cache.read("uncompressed")
+        assert_equal value, @cache.read(actual)
+        assert_equal value, @cache.read(uncompressed)
       end
 
-      actual_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "actual", {}), **{})
-      uncompressed_entry = @cache.send(:read_entry, @cache.send(:normalize_key, "uncompressed", {}), **{})
+      actual_entry = @cache.send(:read_entry, @cache.send(:normalize_key, actual, {}), **{})
+      uncompressed_entry = @cache.send(:read_entry, @cache.send(:normalize_key, uncompressed, {}), **{})
 
       actual_payload = @cache.send(:serialize_entry, actual_entry, **@cache.send(:merged_options, options))
       uncompressed_payload = @cache.send(:serialize_entry, uncompressed_entry, compress: false)

--- a/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_version_behavior.rb
@@ -4,85 +4,122 @@ module CacheStoreVersionBehavior
   ModelWithKeyAndVersion = Struct.new(:cache_key, :cache_version)
 
   def test_fetch_with_right_version_should_hit
-    @cache.fetch("foo", version: 1) { "bar" }
-    assert_equal "bar", @cache.read("foo", version: 1)
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.fetch(key, version: 1) { value }
+    assert_equal value, @cache.read(key, version: 1)
   end
 
   def test_fetch_with_wrong_version_should_miss
-    @cache.fetch("foo", version: 1) { "bar" }
-    assert_nil @cache.read("foo", version: 2)
+    key = SecureRandom.uuid
+
+    @cache.fetch(key, version: 1) { SecureRandom.alphanumeric }
+    assert_nil @cache.read(key, version: 2)
   end
 
   def test_read_with_right_version_should_hit
-    @cache.write("foo", "bar", version: 1)
-    assert_equal "bar", @cache.read("foo", version: 1)
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.write(key, value, version: 1)
+    assert_equal value, @cache.read(key, version: 1)
   end
 
   def test_read_with_wrong_version_should_miss
-    @cache.write("foo", "bar", version: 1)
-    assert_nil @cache.read("foo", version: 2)
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.write(key, value, version: 1)
+    assert_nil @cache.read(key, version: 2)
   end
 
   def test_exist_with_right_version_should_be_true
-    @cache.write("foo", "bar", version: 1)
-    assert @cache.exist?("foo", version: 1)
+    key = SecureRandom.uuid
+
+    @cache.write(key, SecureRandom.alphanumeric, version: 1)
+    assert @cache.exist?(key, version: 1)
   end
 
   def test_exist_with_wrong_version_should_be_false
-    @cache.write("foo", "bar", version: 1)
-    assert_not @cache.exist?("foo", version: 2)
+    key = SecureRandom.uuid
+
+    @cache.write(key, SecureRandom.alphanumeric, version: 1)
+    assert_not @cache.exist?(key, version: 2)
   end
 
   def test_reading_and_writing_with_model_supporting_cache_version
-    m1v1 = ModelWithKeyAndVersion.new("model/1", 1)
-    m1v2 = ModelWithKeyAndVersion.new("model/1", 2)
+    model_name = SecureRandom.alphanumeric
 
-    @cache.write(m1v1, "bar")
-    assert_equal "bar", @cache.read(m1v1)
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+
+    @cache.write(m1v1, value)
+    assert_equal value, @cache.read(m1v1)
     assert_nil @cache.read(m1v2)
   end
 
   def test_reading_and_writing_with_model_supporting_cache_version_using_nested_key
-    m1v1 = ModelWithKeyAndVersion.new("model/1", 1)
-    m1v2 = ModelWithKeyAndVersion.new("model/1", 2)
+    model_name = SecureRandom.alphanumeric
 
-    @cache.write([ "something", m1v1 ], "bar")
-    assert_equal "bar", @cache.read([ "something", m1v1 ])
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+
+    @cache.write([ "something", m1v1 ], value)
+    assert_equal value, @cache.read([ "something", m1v1 ])
     assert_nil @cache.read([ "something", m1v2 ])
   end
 
   def test_fetching_with_model_supporting_cache_version
-    m1v1 = ModelWithKeyAndVersion.new("model/1", 1)
-    m1v2 = ModelWithKeyAndVersion.new("model/1", 2)
+    model_name = SecureRandom.alphanumeric
 
-    @cache.fetch(m1v1) { "bar" }
-    assert_equal "bar", @cache.fetch(m1v1) { "bu" }
-    assert_equal "bu", @cache.fetch(m1v2) { "bu" }
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+    other_value = SecureRandom.alphanumeric
+
+    @cache.fetch(m1v1) { value }
+    assert_equal value, @cache.fetch(m1v1) { other_value }
+    assert_equal other_value, @cache.fetch(m1v2) { other_value }
   end
 
   def test_exist_with_model_supporting_cache_version
-    m1v1 = ModelWithKeyAndVersion.new("model/1", 1)
-    m1v2 = ModelWithKeyAndVersion.new("model/1", 2)
+    model_name = SecureRandom.alphanumeric
 
-    @cache.write(m1v1, "bar")
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m1v2 = ModelWithKeyAndVersion.new("#{model_name}/1", 2)
+
+    value = SecureRandom.alphanumeric
+
+    @cache.write(m1v1, value)
     assert @cache.exist?(m1v1)
     assert_not @cache.fetch(m1v2)
   end
 
   def test_fetch_multi_with_model_supporting_cache_version
-    m1v1 = ModelWithKeyAndVersion.new("model/1", 1)
-    m2v1 = ModelWithKeyAndVersion.new("model/2", 1)
-    m2v2 = ModelWithKeyAndVersion.new("model/2", 2)
+    model_name = SecureRandom.alphanumeric
+
+    m1v1 = ModelWithKeyAndVersion.new("#{model_name}/1", 1)
+    m2v1 = ModelWithKeyAndVersion.new("#{model_name}/2", 1)
+    m2v2 = ModelWithKeyAndVersion.new("#{model_name}/2", 2)
 
     first_fetch_values  = @cache.fetch_multi(m1v1, m2v1) { |m| m.cache_key }
     second_fetch_values = @cache.fetch_multi(m1v1, m2v2) { |m| m.cache_key + " 2nd" }
 
-    assert_equal({ m1v1 => "model/1", m2v1 => "model/2" }, first_fetch_values)
-    assert_equal({ m1v1 => "model/1", m2v2 => "model/2 2nd" }, second_fetch_values)
+    assert_equal({ m1v1 => "#{model_name}/1", m2v1 => "#{model_name}/2" }, first_fetch_values)
+    assert_equal({ m1v1 => "#{model_name}/1", m2v2 => "#{model_name}/2 2nd" }, second_fetch_values)
   end
 
   def test_version_is_normalized
-    @cache.write("foo", "bar", version: 1)
-    assert_equal "bar", @cache.read("foo", version: "1")
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @cache.write(key, value, version: 1)
+    assert_equal value, @cache.read(key, version: "1")
   end
 end


### PR DESCRIPTION
### Summary

I've notice some test scenarios failing randomly when running the tests for `ActiveSupport` cache stores in isolation. The failing scenarios are currently frequent when using a computer with multiple cores.

This is the second set of fixes. I'm not covering all of them because it will mean even more changes the maintainers need to carefully review.

### Other information

The main problem seems to occur when multiple shared specs are being executed in parallel and reusing the `foo` key and assume the store is already empty when they isn't. The test scenarios are _namespaced_ but the shared test are still sharing the same store within the namespace, having as a result keys with not expected values or even empty if the other test did that a millisecond before them.

My proposed solution is to not use foo as the key for those shared scenarios, but any random key we hold and use for the multiple cases.

ref. #43670 

As mentioned the case scenarios are randomly happening, these is one of them:

![image](https://user-images.githubusercontent.com/1037088/142702244-c1987595-d55b-48a5-b6bd-2e83e71c7a8e.png)
