### PR TITLE
activerecord: add missing require statements

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "uri"
 require "active_record/database_configurations/database_config"
 require "active_record/database_configurations/hash_config"
 require "active_record/database_configurations/url_config"

--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "uri"
 require "active_support/core_ext/enumerable"
 
 module ActiveRecord


### PR DESCRIPTION
I have a project that users ActiveRecord without the rest of rails, and without bundler. When upgrading from 6.0 to 6.1, I started getting `unitialized constant ..::URI` errors.
