### PR TITLE
Improve check for GC.stat(:total_allocated_objects)

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -158,15 +158,13 @@ module ActiveSupport
           end
         end
 
-        begin
-          GC.stat(:total_allocated_objects)
-        rescue ArgumentError # Likely on JRuby
+        if GC.stat.key?(:total_allocated_objects)
+          def now_allocations
+            GC.stat(:total_allocated_objects)
+          end
+        else # Likely on JRuby, TruffleRuby
           def now_allocations
             0
-          end
-        else
-          def now_allocations  # rubocop:disable Lint/DuplicateMethods
-            GC.stat(:total_allocated_objects)
           end
         end
     end


### PR DESCRIPTION
### Summary

* This works whether the Ruby implementation raises or uses a Hash with
  a default of 0 to represent unknown keys (like TruffleRuby) and so
  this is more portable.
* Also avoids an extra exception on JRuby.

Related to https://github.com/rails/rails/pull/43502#discussion_r754284693, cc @casperisfine 

cc @bjfish (FYI)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
