### PR TITLE
Add warning about `type` arg in `column_exists?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -124,6 +124,9 @@ module ActiveRecord
       #   column_exists?(:suppliers, :name)
       #
       #   # Check a column exists of a particular type
+      #   #
+      #   # This works for standard non-casted types (eg. string) but is unreliable
+      #   # for types that may get chasted (eg. char).
       #   column_exists?(:suppliers, :name, :string)
       #
       #   # Check a column exists with a specific definition


### PR DESCRIPTION
Resolves https://github.com/rails/rails/issues/43054 with a warning in the docs.
