### PR TITLE
Add `ActionController::Parameters#require_slice`

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -702,6 +702,30 @@ module ActionController
       self
     end
 
+    # Returns a new <tt>ActionController::Parameters</tt> instance that includes
+    # only the given +keys+. The given +keys+ are marked as permitted, but any
+    # nested keys are not. If any of the given +keys+ don't exist, raises
+    # <tt>ActionController::ParameterMissing</tt>.
+    #
+    #   params = ActionController::Parameters.new(a: 1, b: 2, nested: { c: 3 })
+    #
+    #   sliced = params.require_slice(:a, :nested)
+    #   sliced                       # => #<ActionController::Parameters {"a"=>1, "nested"=>{"c"=>3}} permitted: true>
+    #   sliced.permitted?            # => true
+    #   sliced[:nested]              # => #<ActionController::Parameters {"c"=>3} permitted: false>
+    #   sliced[:nested].permitted?   # => false
+    #
+    #   params.require_slice(:a, :z) # => ActionController::ParameterMissing (param is missing or the value is empty: z)
+    def require_slice(*keys)
+      keys.each do |key|
+        raise ParameterMissing.new(key, @parameters.keys) unless @parameters.key?(key)
+      end
+
+      slice(*keys).tap do |sliced|
+        sliced.permitted = true
+      end
+    end
+
     # Returns a new <tt>ActionController::Parameters</tt> instance that
     # filters out the given +keys+.
     #


### PR DESCRIPTION
This method behaves like `slice`, but raises `ParameterMissing` if any of the specified keys are missing.  Additionally, the specified params are marked as permitted, but any nested params are not.  e.g. `params.require_slice(:foo, :bar).require(:foo)` is the same as `params.require(:foo)`, regardless of what the `:foo` param is.

This method is useful for permitting and requiring multiple keys.  It is also useful for permitting top-level (unscoped) params without triggering the `action_on_unpermitted_parameters` action due to incidental params like `authenticity_token` and `commit`.  For example, "change password" params implemented like:

```ruby
def password_params
  params.require(:password).permit(
    :password_challenge,
    :password,
    :password_confirmation,
  ).with_defaults(password_challenge: "")
end
```

Could instead be implemented like:

```ruby
def password_params
  params.require_slice(
    :password_challenge,
    :password,
    :password_confirmation,
  )
end
```

---

Tangential: #43688, #43689