### PR TITLE
ActiveSupport::Cache - fix more race conditions on test/cache - part III

### DIFF
--- a/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_instrumentation_behavior.rb
@@ -10,7 +10,11 @@ module CacheInstrumentationBehavior
   end
 
   def test_write_multi_instrumentation
-    writes = { "a" => "aa", "b" => "bb" }
+    key_1 = SecureRandom.uuid
+    key_2 = SecureRandom.uuid
+    value_1 = SecureRandom.alphanumeric
+    value_2 = SecureRandom.alphanumeric
+    writes = { key_1 => value_1, key_2 => value_2 }
 
     events = with_instrumentation "write_multi" do
       @cache.write_multi(writes)
@@ -18,20 +22,23 @@ module CacheInstrumentationBehavior
 
     assert_equal %w[ cache_write_multi.active_support ], events.map(&:name)
     assert_nil events[0].payload[:super_operation]
-    assert_equal({ "a" => "aa", "b" => "bb" }, events[0].payload[:key])
+    assert_equal({ key_1 => value_1, key_2 => value_2 }, events[0].payload[:key])
   end
 
   def test_instrumentation_with_fetch_multi_as_super_operation
-    @cache.write("b", "bb")
+    key_1 = SecureRandom.uuid
+    @cache.write(key_1, SecureRandom.alphanumeric)
+
+    key_2 = SecureRandom.uuid
 
     events = with_instrumentation "read_multi" do
-      @cache.fetch_multi("a", "b") { |key| key * 2 }
+      @cache.fetch_multi(key_2, key_1) { |key| key * 2 }
     end
 
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
     assert_equal :fetch_multi, events[0].payload[:super_operation]
-    assert_equal ["a", "b"], events[0].payload[:key]
-    assert_equal ["b"], events[0].payload[:hits]
+    assert_equal [key_2, key_1], events[0].payload[:key]
+    assert_equal [key_1], events[0].payload[:hits]
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 
@@ -48,15 +55,18 @@ module CacheInstrumentationBehavior
   end
 
   def test_read_multi_instrumentation
-    @cache.write("b", "bb")
+    key_1 = SecureRandom.uuid
+    @cache.write(key_1, SecureRandom.alphanumeric)
+
+    key_2 = SecureRandom.uuid
 
     events = with_instrumentation "read_multi" do
-      @cache.read_multi("a", "b")
+      @cache.read_multi(key_2, key_1)
     end
 
     assert_equal %w[ cache_read_multi.active_support ], events.map(&:name)
-    assert_equal ["a", "b"], events[0].payload[:key]
-    assert_equal ["b"], events[0].payload[:hits]
+    assert_equal [key_2, key_1], events[0].payload[:key]
+    assert_equal [key_1], events[0].payload[:hits]
     assert_equal @cache.class.name, events[0].payload[:store]
   end
 

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -238,8 +238,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @old_store = lookup_store
       ActiveSupport::Cache.format_version = previous_format
 
-      @old_store.write("foo", "bar")
-      assert_equal "bar", @cache.read("foo")
+      key = SecureRandom.uuid
+      value = SecureRandom.alphanumeric
+      @old_store.write(key, value)
+      assert_equal value, @cache.read(key)
     end
 
     def test_backward_compatibility
@@ -248,8 +250,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
       @old_store = lookup_store
       ActiveSupport::Cache.format_version = previous_format
 
-      @cache.write("foo", "bar")
-      assert_equal "bar", @old_store.read("foo")
+      key = SecureRandom.uuid
+      value = SecureRandom.alphanumeric
+      @cache.write(key, value)
+      assert_equal value, @old_store.read(key)
     end
 
     def after_teardown
@@ -363,11 +367,15 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
   class DeleteMatchedTest < StoreTest
     test "deletes keys matching glob" do
-      @cache.write("foo", "bar")
-      @cache.write("fu", "baz")
-      @cache.delete_matched("foo*")
-      assert_not @cache.exist?("foo")
-      assert @cache.exist?("fu")
+      prefix = SecureRandom.alphanumeric
+      key = "#{prefix}#{SecureRandom.uuid}"
+      @cache.write(key, "bar")
+
+      other_key = SecureRandom.uuid
+      @cache.write(other_key, SecureRandom.alphanumeric)
+      @cache.delete_matched("#{prefix}*")
+      assert_not @cache.exist?(key)
+      assert @cache.exist?(other_key)
     end
 
     test "fails with regexp matchers" do
@@ -379,19 +387,26 @@ module ActiveSupport::Cache::RedisCacheStoreTests
 
   class ClearTest < StoreTest
     test "clear all cache key" do
-      @cache.write("foo", "bar")
-      @cache.write("fu", "baz")
+      key = SecureRandom.uuid
+      other_key = SecureRandom.uuid
+      @cache.write(key, SecureRandom.uuid)
+      @cache.write(other_key, SecureRandom.uuid)
       @cache.clear
-      assert_not @cache.exist?("foo")
-      assert_not @cache.exist?("fu")
+      assert_not @cache.exist?(key)
+      assert_not @cache.exist?(other_key)
     end
 
     test "only clear namespace cache key" do
-      @cache.write("foo", "bar")
-      @cache.redis.set("fu", "baz")
+      key = SecureRandom.uuid
+      other_key = SecureRandom.uuid
+
+      @cache.write(key, SecureRandom.alphanumeric)
+      @cache.redis.set(other_key, SecureRandom.alphanumeric)
       @cache.clear
-      assert_not @cache.exist?("foo")
-      assert @cache.redis.exists?("fu")
+
+      assert_not @cache.exist?(key)
+      assert @cache.redis.exists?(other_key)
+      @cache.redis.del(other_key)
     end
 
     test "clear all cache key with Redis::Distributed" do


### PR DESCRIPTION
### Summary

I've notice some test scenarios failing randomly when running the tests for `ActiveSupport` cache stores in isolation. The failing scenarios are currently frequent when using a computer with multiple cores.

This is the third set of fixes. I'm not covering all of them because it will mean even more changes the maintainers need to carefully review.

### Other information

The main problem seems to occur when multiple shared specs are being executed in parallel and reusing the `foo` key and assume the store is already empty when they isn't. The test scenarios are _namespaced_ but the shared test are still sharing the same store within the namespace, having as a result keys with not expected values or even empty if the other test did that a millisecond before them.

My proposed solution is to not use foo as the key for those shared scenarios, but any random key we hold and use for the multiple cases.

ref. #43670 
ref. #43675