### PR TITLE
Fix active_record_migrations guide typo

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -525,7 +525,7 @@ add_belongs_to :taggings, :taggable, polymorphic: true
 The polymorphic option will create two columns on the taggings table which can
 be used for polymorphic associations: `taggable_type` and `taggable_id`.
 
-A foreign key can be created with the the `foreign_key` option.
+A foreign key can be created with the `foreign_key` option.
 
 ```ruby
 add_reference :users, :role, foreign_key: true


### PR DESCRIPTION
A small fix in Active Record Migrations Guides.