### PR TITLE
ActiveSupport::Cache, fix race conditions on test/cache - part IV

### DIFF
--- a/activesupport/test/cache/behaviors/failure_raising_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_raising_behavior.rb
@@ -2,43 +2,52 @@
 
 module FailureRaisingBehavior
   def test_fetch_read_failure_raises
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.fetch("foo")
+        cache.fetch(key)
       end
     end
   end
 
   def test_fetch_with_block_read_failure_raises
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.write(key, value)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.fetch("foo") { "1" }
+        cache.fetch(key) { SecureRandom.alphanumeric }
       end
     end
 
-    assert_equal "bar", @cache.read("foo")
+    assert_equal value, @cache.read(key)
   end
 
   def test_read_failure_raises
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.read("foo")
+        cache.read(key)
       end
     end
   end
 
   def test_read_multi_failure_raises
-    @cache.write_multi("foo" => "bar", "baz" => "quux")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write_multi(
+      key => SecureRandom.alphanumeric,
+      other_key => SecureRandom.alphanumeric
+    )
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.read_multi("foo", "baz")
+        cache.read_multi(key, other_key)
       end
     end
   end
@@ -46,7 +55,7 @@ module FailureRaisingBehavior
   def test_write_failure_raises
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.write("foo", "bar")
+        cache.write(SecureRandom.uuid, SecureRandom.alphanumeric)
       end
     end
   end
@@ -54,57 +63,69 @@ module FailureRaisingBehavior
   def test_write_multi_failure_raises
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.write_multi("foo" => "bar", "baz" => "quux")
+        cache.write_multi(
+          SecureRandom.uuid => SecureRandom.alphanumeric,
+          SecureRandom.uuid => SecureRandom.alphanumeric
+        )
       end
     end
   end
 
   def test_fetch_multi_failure_raises
-    @cache.write_multi("foo" => "bar", "baz" => "quux")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write_multi(
+      key => SecureRandom.alphanumeric,
+      other_key => SecureRandom.alphanumeric
+    )
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.fetch_multi("foo", "baz") { |k| "unavailable" }
+        cache.fetch_multi(key, other_key) { |k| "unavailable" }
       end
     end
   end
 
   def test_delete_failure_raises
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.delete("foo")
+        cache.delete(key)
       end
     end
   end
 
   def test_exist_failure_raises
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.exist?("foo")
+        cache.exist?(key)
       end
     end
   end
 
   def test_increment_failure_raises
-    @cache.write("foo", 1, raw: true)
+    key = SecureRandom.uuid
+    @cache.write(key, 1, raw: true)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.increment("foo")
+        cache.increment(key)
       end
     end
   end
 
   def test_decrement_failure_raises
-    @cache.write("foo", 1, raw: true)
+    key = SecureRandom.uuid
+    @cache.write(key, 1, raw: true)
 
     assert_raise Redis::BaseError do
       emulating_unavailability do |cache|
-        cache.decrement("foo")
+        cache.decrement(key)
       end
     end
   end

--- a/activesupport/test/cache/behaviors/failure_safety_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_safety_behavior.rb
@@ -2,18 +2,21 @@
 
 module FailureSafetyBehavior
   def test_fetch_read_failure_returns_nil
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     emulating_unavailability do |cache|
-      assert_nil cache.fetch("foo")
+      assert_nil cache.fetch(key)
     end
   end
 
   def test_fetch_read_failure_does_not_attempt_to_write
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    @cache.write(key, value)
 
     emulating_unavailability do |cache|
-      val = cache.fetch("foo") { "1" }
+      val = cache.fetch(key) { "1" }
 
       ##
       # Though the `write` part of fetch fails for the same reason
@@ -21,77 +24,97 @@ module FailureSafetyBehavior
       assert_equal "1", val
     end
 
-    assert_equal "bar", @cache.read("foo")
+    assert_equal value, @cache.read(key)
   end
 
   def test_read_failure_returns_nil
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     emulating_unavailability do |cache|
-      assert_nil cache.read("foo")
+      assert_nil cache.read(key)
     end
   end
 
   def test_read_multi_failure_returns_empty_hash
-    @cache.write_multi("foo" => "bar", "baz" => "quux")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write_multi(
+      key => SecureRandom.alphanumeric,
+      other_key => SecureRandom.alphanumeric
+    )
 
     emulating_unavailability do |cache|
-      assert_equal Hash.new, cache.read_multi("foo", "baz")
+      assert_equal Hash.new, cache.read_multi(key, other_key)
     end
   end
 
   def test_write_failure_returns_false
+    key = SecureRandom.uuid
     emulating_unavailability do |cache|
-      assert_equal false, cache.write("foo", "bar")
+      assert_equal false, cache.write(key, SecureRandom.alphanumeric)
     end
   end
 
   def test_write_multi_failure_not_raises
     emulating_unavailability do |cache|
       assert_nothing_raised do
-        cache.write_multi("foo" => "bar", "baz" => "quux")
+        cache.write_multi(
+          SecureRandom.uuid => SecureRandom.alphanumeric,
+          SecureRandom.uuid => SecureRandom.alphanumeric
+        )
       end
     end
   end
 
   def test_fetch_multi_failure_returns_fallback_results
-    @cache.write_multi("foo" => "bar", "baz" => "quux")
+    key = SecureRandom.uuid
+    other_key = SecureRandom.uuid
+    @cache.write_multi(
+      key => SecureRandom.alphanumeric,
+      other_key => SecureRandom.alphanumeric
+    )
+
 
     emulating_unavailability do |cache|
-      fetched = cache.fetch_multi("foo", "baz") { |k| "unavailable" }
-      assert_equal Hash["foo" => "unavailable", "baz" => "unavailable"], fetched
+      fetched = cache.fetch_multi(key, other_key) { |k| "unavailable" }
+      assert_equal Hash[key => "unavailable", other_key => "unavailable"], fetched
     end
   end
 
   def test_delete_failure_returns_false
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     emulating_unavailability do |cache|
-      assert_equal false, cache.delete("foo")
+      assert_equal false, cache.delete(key)
     end
   end
 
   def test_exist_failure_returns_false
-    @cache.write("foo", "bar")
+    key = SecureRandom.uuid
+    @cache.write(key, SecureRandom.alphanumeric)
 
     emulating_unavailability do |cache|
-      assert_not cache.exist?("foo")
+      assert_not cache.exist?(key)
     end
   end
 
   def test_increment_failure_returns_nil
-    @cache.write("foo", 1, raw: true)
+    key = SecureRandom.uuid
+    @cache.write(key, 1, raw: true)
 
     emulating_unavailability do |cache|
-      assert_nil cache.increment("foo")
+      assert_nil cache.increment(key)
     end
   end
 
   def test_decrement_failure_returns_nil
-    @cache.write("foo", 1, raw: true)
+    key = SecureRandom.uuid
+    @cache.write(key, 1, raw: true)
 
     emulating_unavailability do |cache|
-      assert_nil cache.decrement("foo")
+      assert_nil cache.decrement(key)
     end
   end
 


### PR DESCRIPTION
### Summary

I've notice some test scenarios failing randomly when running the tests for `ActiveSupport` cache stores in isolation. The failing scenarios are currently frequent when using a computer with multiple cores.

This is the fourth set of fixes. I'm not covering all of them on a single Pull Request because it will mean too many changes the maintainers need to carefully review.

### Other information

The main problem seems to occur when multiple shared specs are being executed in parallel and reusing the `foo` key and assume the store is already empty when they isn't. The test scenarios are _namespaced_ but the shared test are still sharing the same store within the namespace, having as a result keys with not expected values or even empty if the other test delete, write or replace the key or value millisecond before them.

My proposed solution is to not use `foo` as the key for those shared scenarios, but any random key we hold and use for the multiple cases.

ref. #43670 
ref. #43675
ref. #43693