### PR TITLE
Avoid renders in equality check of rich_text content

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Fix an issue that caused the content layout to render multiple times when a
+    rich_text field was updated.
 
+    *Jacob Herrington*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actiontext/CHANGELOG.md) for previous changes.

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -104,7 +104,9 @@ module ActionText
     end
 
     def ==(other)
-      if other.is_a?(self.class)
+      if self.class == other.class
+        to_html == other.to_html
+      elsif other.is_a?(self.class)
         to_s == other.to_s
       end
     end


### PR DESCRIPTION
### Summary

Avoiding the use of `ActionText::Content#to_s`, which in turn uses `ActionText::Content#to_rendered_html_with_layout`, stops the duplicate rendering issue described in https://github.com/rails/rails/issues/43469.

### Other Information

This approach was suggested as a workaround in https://github.com/rails/rails/issues/37818 and testing it locally does seem to work as expected. Since I've seen at least two issues around this, I thought I'd propose this change.

I'd like to write some kind of test for this code, but I'm really not sure how I'd go about doing that! If anyone wants to point me in the right direction, that'd be great. 😄 

This change could introduce some weird behavior because we won't be including the layout in the equality check if it is merged. I'm not sure what sort of impact it would have on people using this code otherwise.

I'm thinking because `_content.html.erb` is somewhat trivial, it might not be that big of a deal:
https://github.com/rails/rails/blob/16c537e098b2eea86e32b2cdf7a1b54f6270517d/actiontext/app/views/layouts/action_text/contents/_content.html.erb#L1-L3