### PR TITLE
Fix boolean error in form helpers guide

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -1021,7 +1021,7 @@ end
 
 ### Preventing Empty Records
 
-It is often useful to ignore sets of fields that the user has not filled in. You can control this by passing a `:reject_if` proc to `accepts_nested_attributes_for`. This proc will be called with each hash of attributes submitted by the form. If the proc returns `false` then Active Record will not build an associated object for that hash. The example below only tries to build an address if the `kind` attribute is set.
+It is often useful to ignore sets of fields that the user has not filled in. You can control this by passing a `:reject_if` proc to `accepts_nested_attributes_for`. This proc will be called with each hash of attributes submitted by the form. If the proc returns `true` then Active Record will not build an associated object for that hash. The example below only tries to build an address if the `kind` attribute is set.
 
 ```ruby
 class Person < ApplicationRecord


### PR DESCRIPTION
### Summary

The rails guides states for `accepts_nested_attributes_for :addressed`
that `reject_if:` allows prevention of empty records. It says

> "_This proc will be called 
with each hash of attributes submitted by the form. If the proc 
returns **false** then Active Record will not build an associated 
object for that hash._"

However since the option is `reject_if` the record WILL be built if
the proc returns `false`. Since it is a **reject if** the proc
actually needs to return `true` in order to prevent building a record.

So this above statement is false

So this PR corrects this statement, by replacing **false** with **true**.



