### PR TITLE
Report Memcached and Redis cache errors to Rails.error

### DIFF
--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -94,6 +94,8 @@ module ActiveSupport
   cattr_accessor :test_order # :nodoc:
   cattr_accessor :test_parallelization_threshold, default: 50 # :nodoc:
 
+  singleton_class.attr_accessor :error_reporter # :nodoc:
+
   def self.cache_format_version
     Cache.format_version
   end

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -298,8 +298,9 @@ module ActiveSupport
 
         def rescue_error_with(fallback)
           yield
-        rescue Dalli::DalliError => e
-          logger.error("DalliError (#{e}): #{e.message}") if logger
+        rescue Dalli::DalliError => error
+          ActiveSupport.error_reporter&.report(error, handled: true, severity: :warning)
+          logger.error("DalliError (#{error}): #{error.message}") if logger
           fallback
         end
     end

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -458,15 +458,10 @@ module ActiveSupport
 
         def failsafe(method, returning: nil)
           yield
-        rescue ::Redis::BaseError => e
-          handle_exception exception: e, method: method, returning: returning
+        rescue ::Redis::BaseError => error
+          ActiveSupport.error_reporter&.report(error, handled: true, severity: :warning)
+          @error_handler&.call(method: method, exception: error, returning: returning)
           returning
-        end
-
-        def handle_exception(exception:, method:, returning:)
-          if @error_handler
-            @error_handler.(method: method, exception: exception, returning: returning)
-          end
         end
     end
   end

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -112,6 +112,10 @@ module ActiveSupport
       end
     end
 
+    initializer "active_support.set_error_reporter" do |app|
+      ActiveSupport.error_reporter = app.executor.error_reporter
+    end
+
     initializer "active_support.set_configs" do |app|
       app.config.active_support.each do |k, v|
         k = "#{k}="


### PR DESCRIPTION
Ref: https://github.com/rails/rails/issues/43472

We swallow these exceptions because it makes sense for a cache to
fallback to a cache miss in case of transcient failures.

However there's value in reporting these to the application
owners so that they can be alerted that something undesirable happened.

cc @rafaelfranca 