### PR TITLE
Allow a fallback value to be returned from Rails.error.handle

### DIFF
--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -58,6 +58,30 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal [], @subscriber.events
   end
 
+  test "#handle passes through the return value" do
+    result = @reporter.handle do
+      2 + 2
+    end
+    assert_equal 4, result
+  end
+
+  test "#handle returns nil on handled raise" do
+    result = @reporter.handle do
+      raise StandardError
+      2 + 2
+    end
+    assert_nil result
+  end
+
+  test "#handle returns a fallback value on handled raise" do
+    expected = "four"
+    result = @reporter.handle(fallback: expected) do
+      raise StandardError
+      2 + 2
+    end
+    assert_equal expected, result
+  end
+
   test "#record report any unhandled error and re-raise them" do
     error = ArgumentError.new("Oops")
     assert_raises ArgumentError do
@@ -75,6 +99,13 @@ class ErrorReporterTest < ActiveSupport::TestCase
       end
     end
     assert_equal [], @subscriber.events
+  end
+
+  test "#record passes through the return value" do
+    result = @reporter.record do
+      2 + 2
+    end
+    assert_equal 4, result
   end
 
   test "can have multiple subscribers" do


### PR DESCRIPTION
## Summary

Related to #43472 and follow up to #43625.

### Problem

Both the `Rails.error.handle` and `Rails.error.record` methods pass through the return value from the wrapped block. This allows for uses like:

```ruby
result = Rails.error.record { Finder.maybe_error }
```

This works as expected when nothing is raised. In the case of `record` it will also always work as expected as the re-raise will take over control flow and we do not encounter the return value.

The case for `handle` is less intuitive. Consider:

```ruby
item = Rails.error.handle { Item.find_or_initialize }
```
or
```ruby
product = Rails.error.handle { ProductService.search(params) }
```

Both cases, if the block raises, it will return `nil`. Expected behaviour in the first case is that it should _always_ return a value, and in the second case `nil` implies nothing matches the search. Meaning, the `nil` returned from the rescue and the `nil` returned from the block are ambiguous.

### Solution

Allow an optional `fallback:` parameter to be passed to `handle` that is returned when a raise is handled. This could be a null object, a default value, or some kind of flag differentiating from a `nil` return.

```ruby
user = Rails.error.handle(fallback: User.anonymous) do
  User.find_by(params)
end
```
