### PR TITLE
Add missing space to error message

### DIFF
--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -82,7 +82,7 @@ module ActiveRecord
 
         def validate_credential(key, error_message = "is not configured")
           unless ActiveRecord::Encryption.config.public_send(key).present?
-            raise Errors::Configuration, "#{key} #{error_message}. Please configure it via credential"\
+            raise Errors::Configuration, "#{key} #{error_message}. Please configure it via credential "\
               "active_record_encryption.#{key} or by setting config.active_record.encryption.#{key}"
           end
         end


### PR DESCRIPTION
### Summary

Adds a missing space to the following error message:

```
ActiveRecord::Encryption::Errors::Configuration:
        key_derivation_salt is not configured. Please configure it via credentialactive_record_encryption.key_derivation_salt or by setting config.active_record.encryption.key_derivation_salt
```