### PR TITLE
Explicitly order Railties by load order

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -146,7 +146,7 @@ module Rails
       delegate :config, to: :instance
 
       def subclasses
-        super.reject(&:abstract_railtie?)
+        super.reject(&:abstract_railtie?).sort
       end
 
       def rake_tasks(&blk)
@@ -190,6 +190,23 @@ module Rails
       def configure(&block)
         instance.configure(&block)
       end
+
+      def <=>(other) # :nodoc:
+        load_index <=> other.load_index
+      end
+
+      def inherited(subclass)
+        subclass.increment_load_index
+        super
+      end
+
+      protected
+        attr_reader :load_index
+
+        def increment_load_index
+          @@load_counter ||= 0
+          @load_index = (@@load_counter += 1)
+        end
 
       private
         def generate_railtie_name(string)

--- a/railties/test/railties/engine_test.rb
+++ b/railties/test/railties/engine_test.rb
@@ -1312,9 +1312,28 @@ en:
       get("/assets/bar.js")
       assert_match "// App's bar js", last_response.body.strip
 
-      # ensure that railties are not added twice
-      railties = Rails.application.send(:ordered_railties).map(&:class)
-      assert_equal railties, railties.uniq
+      assert_equal <<~EXPECTED, Rails.application.send(:ordered_railties).flatten.map(&:class).map(&:name).join("\n") << "\n"
+        I18n::Railtie
+        ActiveSupport::Railtie
+        ActionDispatch::Railtie
+        ActiveModel::Railtie
+        ActionController::Railtie
+        ActiveRecord::Railtie
+        GlobalID::Railtie
+        ActiveJob::Railtie
+        ActionMailer::Railtie
+        Rails::TestUnitRailtie
+        Sprockets::Railtie
+        ActionView::Railtie
+        ActiveStorage::Engine
+        ActionCable::Engine
+        ActionMailbox::Engine
+        ActionText::Engine
+        Bukkits::Engine
+        Importmap::Engine
+        AppTemplate::Application
+        Blog::Engine
+      EXPECTED
     end
 
     test "railties_order adds :all with lowest priority if not given" do


### PR DESCRIPTION
This should fix all the routes tests reported in https://github.com/rails/rails/issues/43714 cc @yahonda 

Until now they were implicitly ordered by load order because of `DescendantTracker#descendants` register them through the `inherited` callback.

But now that on Ruby 3.1 we use the native `Class#descendants`, the ordering is rather random, or at least can't be relied on.

So we add a counter and assign an index on every Railtie subclass to be able to sort them explicitly later.
