### PR TITLE
 Action View: compile ERB templates with `# frozen_string_literal: true`

### DIFF
--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -48,6 +48,11 @@ module ActionView
     end
 
     config.after_initialize do |app|
+      frozen_string_literal = app.config.action_view.delete(:frozen_string_literal)
+      ActionView::Template.frozen_string_literal = frozen_string_literal
+    end
+
+    config.after_initialize do |app|
       ActionView::Helpers::AssetTagHelper.image_loading = app.config.action_view.delete(:image_loading)
       ActionView::Helpers::AssetTagHelper.image_decoding = app.config.action_view.delete(:image_decoding)
       ActionView::Helpers::AssetTagHelper.preload_links_header = app.config.action_view.delete(:preload_links_header)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -114,6 +114,9 @@ module ActionView
 
     extend Template::Handlers
 
+    singleton_class.attr_accessor :frozen_string_literal
+    @frozen_string_literal = false
+
     attr_reader :identifier, :handler
     attr_reader :variable, :format, :variant, :locals, :virtual_path
 
@@ -297,7 +300,11 @@ module ActionView
         end
 
         begin
-          mod.module_eval(source, identifier, 0)
+          if Template.frozen_string_literal
+            mod.module_eval("# frozen_string_literal: true\n#{source}", identifier, -1)
+          else
+            mod.module_eval(source, identifier, 0)
+          end
         rescue SyntaxError
           # Account for when code in the template is not syntactically valid; e.g. if we're using
           # ERB and the user writes <%= foo( %>, attempting to call a helper `foo` and interpolate

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -702,6 +702,33 @@ module RenderTestCases
       @view.render(TestRenderable.new)
     )
   end
+
+  def test_render_mutate_string_literal
+    assert_equal "foobar", @view.render(inline: "'foo' << 'bar'", type: :ruby)
+  end
+end
+
+class FrozenStringLiteralEnabledViewRenderTest < ActiveSupport::TestCase
+  include RenderTestCases
+
+  def setup
+    @previous_frozen_literal = ActionView::Template.frozen_string_literal
+    ActionView::Template.frozen_string_literal = true
+    view_paths = ActionController::Base.view_paths
+    setup_view(view_paths)
+  end
+
+  def teardown
+    super
+    ActionView::Template.frozen_string_literal = @previous_frozen_literal
+  end
+
+  def test_render_mutate_string_literal
+    error = assert_raise ActionView::Template::Error do
+      @view.render(inline: "'foo' << 'bar'", type: :ruby)
+    end
+    assert_includes(error.message, "can't modify frozen String")
+  end
 end
 
 class CachedViewRenderTest < ActiveSupport::TestCase

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1105,6 +1105,10 @@ Accepts a logger conforming to the interface of Log4r or the default Ruby Logger
 
 Gives the trim mode to be used by ERB. It defaults to `'-'`, which turns on trimming of tail spaces and newline when using `<%= -%>` or `<%= =%>`. See the [Erubis documentation](http://www.kuwata-lab.com/erubis/users-guide.06.html#topics-trimspaces) for more information.
 
+#### `config.action_view.frozen_string_literal`
+
+Compiles the ERB template with the `# frozen_string_literal: true` magic comment, making all string literals frozen and saving allocations. Set to `true` to enable it for all views.
+
 #### `config.action_view.embed_authenticity_token_in_remote_forms`
 
 Allows you to set the default behavior for `authenticity_token` in forms with


### PR DESCRIPTION
This adds `# frozen_string_literals: true` at the top of the
generated code, which can be significant in some views.

It may break backward compatibility though. So maybe we should ship this behind a flag?

@rafaelfranca thoughts?
