### PR TITLE
add Pathname#existence

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add `Pathname#existence`.
+
+    ```ruby
+    Pathname.new("file").existence&.read
+    ```
+
+    *Timo Schilling*
+
 *   Remove deprecate `ActiveSupport::Multibyte::Unicode.default_normalization_form`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/core_ext/pathname.rb
+++ b/activesupport/lib/active_support/core_ext/pathname.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/pathname/existence"

--- a/activesupport/lib/active_support/core_ext/pathname/existence.rb
+++ b/activesupport/lib/active_support/core_ext/pathname/existence.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Pathname
+  # Returns the receiver if the named file exists otherwise returns +nil+.
+  # <tt>pathname.existence</tt> is equivalent to
+  #
+  #    pathname.existence? ? object : nil
+  #
+  # For example, something like
+  #
+  #   content = pathname.read if pathname.exist?
+  #
+  # becomes
+  #
+  #   content = pathname.existence&.read
+  #
+  # @return [Pathname]
+  def existence
+    self if exist?
+  end
+end

--- a/activesupport/test/core_ext/pathname/existence_test.rb
+++ b/activesupport/test/core_ext/pathname/existence_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/pathname/existence"
+
+class PathnameExistenceTest < ActiveSupport::TestCase
+  def test_presence
+    existing = Pathname.new(__FILE__)
+    not_existing = Pathname.new("not existing")
+    assert_equal existing, existing.existence
+    assert_nil not_existing.existence
+  end
+end

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -4055,3 +4055,18 @@ end
 NOTE: Defined in `active_support/core_ext/load_error.rb`.
 
 [LoadError#is_missing?]: https://api.rubyonrails.org/classes/LoadError.html#method-i-is_missing-3F
+
+Extensions to Pathname
+-------------------------
+
+### `existence`
+
+The [`existence`][Pathname#existence] method returns the receiver if the named file exists otherwise returns +nil+. It is useful for idioms like this:
+
+```ruby
+content = Pathname.new("file").existence&.read
+```
+
+NOTE: Defined in `active_support/core_ext/pathname/existence.rb`.
+
+[Pathname#existence]: https://api.rubyonrails.org/classes/Pathname.html#method-i-existence


### PR DESCRIPTION
### Summary

I would like to add `Pathname#existence`, it's like `Object#presence` but for file existence.

Often I see code like this:
```
content = Rails.root.join('file').read if Rails.root.join('file').exist?
```

With that the code can change to:
```
content = Rails.root.join('file').existence&.read
```
