### PR TITLE
`Rails.cache.write(key, expires_in: 0)` now writes entries that will never expire.

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   `Rails.cache.write(key, expires_in: 0)` now writes entries that will never expire.
+
+    Previously it wrote an entry that would expire immediately.
+
+    *Alex Ghiculescu*
+
 *   Remove deprecate `ActiveSupport::Multibyte::Unicode.default_normalization_form`.
 
     *Rafael Mendonça França*

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -270,10 +270,12 @@ module ActiveSupport
       # (in which case all entries will be affected), or it can be supplied to
       # the +fetch+ or +write+ method to affect just one entry.
       # <tt>:expire_in</tt> and <tt>:expired_in</tt> are aliases for
-      # <tt>:expires_in</tt>.
+      # <tt>:expires_in</tt>. If <tt>:expires_in</tt> is zero or negative,
+      # it will be ignored and the entry won't expire.
       #
       #   cache = ActiveSupport::Cache::MemoryStore.new(expires_in: 5.minutes)
       #   cache.write(key, value, expires_in: 1.minute) # Set a lower value for one entry
+      #   cache.write(key, value, expires_in: 0) # `expires_in: 0` will not expire.
       #
       # Setting <tt>:expires_at</tt> will set an absolute expiration time on the cache.
       # All caches support auto-expiring content after a specified number of
@@ -920,7 +922,7 @@ module ActiveSupport
         @value      = value
         @version    = version
         @created_at = 0.0
-        @expires_in = expires_at&.to_f || expires_in && (expires_in.to_f + Time.now.to_f)
+        @expires_in = expires_at&.to_f || expires_in && expires_in > 0 && (expires_in.to_f + Time.now.to_f)
         @compressed = true if compressed
       end
 

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -480,6 +480,27 @@ module CacheStoreBehavior
     end
   end
 
+  def test_expires_in_zero_means_infinite_expiry
+    time = Time.local(2008, 4, 24)
+
+    Time.stub(:now, time) do
+      @cache.write("foo", "bar", expires_in: 0)
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 30) do
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 61) do
+      assert_equal "bar", @cache.read("foo")
+    end
+
+    Time.stub(:now, time + 121) do
+      assert_equal "bar", @cache.read("foo")
+    end
+  end
+
   def test_expires_at
     time = Time.local(2008, 4, 24)
 


### PR DESCRIPTION
Previously it wrote an entry that would expire immediately.

This PR just changes the behaviour (as I think it's a bug), but I'm open to add a config toggle if we need to make this backward compatible.

Fixes https://github.com/rails/rails/issues/43619
