### PR TITLE
Wrap `ActionController::TestCase` with Rails executor

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `Rails.application.executor` hooks can now be called around every request in a `ActionController::TestCase`
+
+    This helps to better simulate request or job local state being reset between requests and prevent state
+    leaking from one request to another.
+
+    To enable this, set `config.active_support.executor_around_test_case = true` (this is the default in Rails 7).
+
+    *Alex Ghiculescu*
+
 *   Consider onion services secure for cookies.
 
     *Justin Tracey*

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -122,5 +122,11 @@ module ActionController
         end
       end
     end
+
+    initializer "action_controller.test_case" do |app|
+      ActiveSupport.on_load(:action_controller_test_case) do
+        ActionController::TestCase.executor_around_each_request = app.config.active_support.executor_around_test_case
+      end
+    end
   end
 end

--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -28,12 +28,14 @@
 
     *Sean Doyle*
 
-*   `Rails.application.executor` hooks are now called around every tests.
+*   `Rails.application.executor` hooks can now be called around every test
 
-    This helps to better simulate request or job local state being reset around tests and prevent state
-    to leak from one test to another.
+    This helps to better simulate request or job local state being reset around tests and prevents state
+    leaking from one test to another.
 
     However it requires the executor hooks executed in the test environment to be re-entrant.
+
+    To enable this, set `config.active_support.executor_around_test_case = true` (this is the default in Rails 7).
 
     *Jean Boussier*
 

--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -40,7 +40,7 @@ module ActiveSupport
     end
 
     initializer "active_support.reset_all_current_attributes_instances" do |app|
-      executor_around_test_case = app.config.active_support.delete(:executor_around_test_case)
+      executor_around_test_case = app.config.active_support.executor_around_test_case
 
       app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
       app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }

--- a/railties/test/application/action_controller_test_case_integration_test.rb
+++ b/railties/test/application/action_controller_test_case_integration_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "rack/test"
+
+class SharedSetup < ActionController::TestCase
+  class_attribute :executor_around_each_request
+
+  include ActiveSupport::Testing::Isolation
+
+  setup do
+    build_app
+
+    app_file "app/models/current.rb", <<-RUBY
+      class Current < ActiveSupport::CurrentAttributes
+        attribute :customer
+
+        resets { Time.zone = "UTC" }
+
+        def customer=(customer)
+          super
+          Time.zone = customer&.time_zone
+        end
+      end
+    RUBY
+
+    app_file "app/models/customer.rb", <<-RUBY
+      class Customer < Struct.new(:name)
+        def time_zone
+          "Copenhagen"
+        end
+      end
+    RUBY
+
+    remove_from_config '.*config\.load_defaults.*\n'
+    add_to_config "config.active_support.executor_around_test_case = #{self.class.executor_around_each_request}"
+
+    app_file "app/controllers/customers_controller.rb", <<-RUBY
+      class CustomersController < ApplicationController
+        layout false
+
+        def get_current_customer
+          render :index
+        end
+
+        def set_current_customer
+          Current.customer = Customer.new("david")
+          render :index
+        end
+      end
+    RUBY
+
+    app_file "app/views/customers/index.html.erb", <<-RUBY
+      <%= Current.customer&.name || 'noone' %>,<%= Time.zone.name %>
+    RUBY
+
+    require "#{app_path}/config/environment"
+
+    @controller = CustomersController.new
+    @routes = ActionDispatch::Routing::RouteSet.new.tap do |r|
+      r.draw do
+        get "/customers/:action", controller: :customers
+      end
+    end
+  end
+
+  teardown :teardown_app
+end
+
+class ActionControllerTestCaseWithExecutorIntegrationTest < SharedSetup
+  self.executor_around_each_request = true
+
+  test "current customer is cleared after each request" do
+    assert Rails.application.config.active_support.executor_around_test_case
+    assert ActionController::TestCase.executor_around_each_request
+
+    get :get_current_customer
+    assert_response :ok
+    assert_match(/noone,UTC/, response.body)
+
+    get :set_current_customer
+    assert_response :ok
+    assert_match(/david,Copenhagen/, response.body)
+
+    get :get_current_customer
+    assert_response :ok
+    assert_match(/noone,UTC/, response.body)
+  end
+end
+
+class ActionControllerTestCaseWithoutExecutorIntegrationTest < SharedSetup
+  self.executor_around_each_request = false
+
+  test "current customer is not cleared after each request" do
+    assert_not Rails.application.config.active_support.executor_around_test_case
+    assert_not ActionController::TestCase.executor_around_each_request
+
+    get :get_current_customer
+    assert_response :ok
+    assert_match(/noone,UTC/, response.body)
+
+    get :set_current_customer
+    assert_response :ok
+    assert_match(/david,Copenhagen/, response.body)
+
+    get :get_current_customer
+    assert_response :ok
+    assert_match(/david,Copenhagen/, response.body)
+  end
+end


### PR DESCRIPTION
Currently when you run an integration test (`ActionDispatch::IntegrationTest`), current attributes etc are reset at the end of each request, even if a test has multiple requests in it. This was refactored in https://github.com/rails/rails/pull/43550 but the functionality has been there for a long time.

The same is *not* true if you use `ActionController::TestCase`. Since https://github.com/rails/rails/pull/43550 attributes are reset at the end of a **test**, but if a test makes more than one request, current attributes will persist between requests.

This PR calls `Executor#wrap` around each request in a test if `config.active_support.executor_around_test_case` is enabled. It is by default in Rails 7, but not in older Rails.