### PR TITLE
`ActionController::TestCase`: reset instance variables after each request

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Instance variables set in requests in a `ActionController::TestCase` are now cleared before the next request
 
+    This means if you make multiple requests in the same test, instance variables set in the first request will
+    not persist into the second one. (It's not recommended to make multiple requests in the same test.)
+
+    *Alex Ghiculescu*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/metal/testing.rb
+++ b/actionpack/lib/action_controller/metal/testing.rb
@@ -4,6 +4,15 @@ module ActionController
   module Testing
     # Behavior specific to functional tests
     module Functional # :nodoc:
+      def clear_instance_variables_between_requests
+        if @_ivars
+          new_ivars = instance_variables - @_ivars
+          new_ivars.each { |ivar| remove_instance_variable(ivar) }
+        end
+
+        @_ivars = instance_variables
+      end
+
       def recycle!
         @_url_options = nil
         self.formats = nil

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -465,9 +465,15 @@ module ActionController
       # prefer using #get, #post, #patch, #put, #delete and #head methods
       # respectively which will make tests more expressive.
       #
+      # It's not recommended to make more than one request in the same test. Instance
+      # variables that are set in one request will not persist to the next request,
+      # but it's not guaranteed that all Rails internal state will be reset. Prefer
+      # ActionDispatch::IntegrationTest for making multiple requests in the same test.
+      #
       # Note that the request method is not verified.
       def process(action, method: "GET", params: nil, session: nil, body: nil, flash: {}, format: nil, xhr: false, as: nil)
         check_required_ivars
+        @controller.clear_instance_variables_between_requests
 
         action = +action.to_s
         http_method = method.to_s.upcase


### PR DESCRIPTION
`ActionController::TestCase` keeps a `@controller` instance variable, which represents the controller being tested. At the end of each request inside a test, its [params and format](https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/testing.rb) are reset. But any other instance variables set in the test aren't reset. This creates a problem if you do something like this:

```ruby
class UserController
  def show
    @user ||= User.find(params[:id])
    render plain: @user.name
  end
end
```

```ruby
# ActionController::TestCase subclass

test "gets the user" do
  get :show, params: { id: users(:one).id }
  assert "one", response.body

  get :show, params: { id: users(:two).id }
  assert "two", response.body # fails; response.body is "one"
end
```

The second assertion will fail, because `@user` won't be re-assigned in the second test (due to `||=`). This example is a bit contrived, but it shows how instance variables persisting between requests can lead to surprising outcomes.

This PR fixes this by clearing all instance variables that were created on the controller while a request was processed. This now matches the behaviour of `ActionDispatch::IntegrationTest`.

### Questions

- Is this behaviour intended? I don't know why it would be, but if it is I can update https://api.rubyonrails.org/classes/ActionController/TestCase.html instead of this change.
- Does this need a config switch? To me it's just a bug, and the caveat below should mean it won't break most legitimate uses of this. But if we want a Rails update to never break any existing tests then it needs to be something you can opt out of. I think this should be enabled by default.

### Caveats

It explicitly excludes instance variables that were created *before* any requests were run. And it leaves the instance variable around until the *next* request in the test. This means that you can still do this:

```ruby
# ActionController::TestCase subclass

test "gets the user" do
  @controller.user = users(:one) # assuming `Controller#user` users an ivar internally, you can set the ivar here...

  get :show_current
  assert "one", response.body

  assert_equal users(:one), @controller.user # and you can read the ivar here
end
```