### PR TITLE
Introduce `**options` argument in the `DestroyAssociationAsyncJob#perform` method

### DIFF
--- a/activerecord/lib/active_record/destroy_association_async_job.rb
+++ b/activerecord/lib/active_record/destroy_association_async_job.rb
@@ -15,7 +15,7 @@ module ActiveRecord
     def perform(
       owner_model_name: nil, owner_id: nil,
       association_class: nil, association_ids: nil, association_primary_key_column: nil,
-      ensuring_owner_was_method: nil
+      ensuring_owner_was_method: nil, **_options
     )
       association_model = association_class.constantize
       owner_class = owner_model_name.constantize


### PR DESCRIPTION
It allows extending the job with additional options without breaking people's
applications.

See https://github.com/rails/rails/pull/42452/files#r678742445.

[#42430]

/cc @rafaelfranca 