### PR TITLE
Allow ActiveModel::Error#merge! to handle merging of an instance to itself

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -140,6 +140,8 @@ module ActiveModel
     #
     #   person.errors.merge!(other)
     def merge!(other)
+      return errors if equal?(other)
+
       other.errors.each { |error|
         import(error)
       }

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -657,6 +657,16 @@ class ErrorsTest < ActiveModel::TestCase
     assert(person.errors.added?(:name, :blank))
   end
 
+  test "merge does not import errors when merging with self" do
+    errors = ActiveModel::Errors.new(Person.new)
+    errors.add(:name, :invalid)
+    errors_before_merge = errors.dup
+
+    errors.merge!(errors)
+
+    assert(errors.errors.eql?(errors_before_merge.errors))
+  end
+
   test "errors are marshalable" do
     errors = ActiveModel::Errors.new(Person.new)
     errors.add(:name, :invalid)


### PR DESCRIPTION
### Summary

This resolves an issue where attempting to merge an `ActiveModel::Error` instance with itself results in an endless loop where `ActiveModel::NestedError`s are continuously imported on the instance until interrupted. Though the merging of identical objects is less likely to happen in practice, this method should still be able to handle such a case gracefully. This change ensures that instances attempting to merge on themselves return early rather than hanging indefinitely.

Addresses https://github.com/rails/rails/issues/43737.
