### PR TITLE
Add custom_error to ActiveModel::Error and ActiveModel::Errors

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -227,7 +227,7 @@ module ActiveModel
     def as_json(**options)
       return to_hash if options.nil?
 
-      if options.keys.include?(:full_messages)
+      if options.key?(:full_messages)
         ActiveSupport::Deprecation.warn(
           "using the full_messages boolean positional argument is deprecated" \
           "and will be unsupported in a future version of Rails." \
@@ -488,7 +488,7 @@ module ActiveModel
     # custom_messages alongside messages. For this reason, the
     # key `message` was added to the lookup chain.
     # Even though the lookup chain handles the previous behaviour,
-    # it's prefered to use the more specific version of the chain defining
+    # it's preferred to use the more specific version of the chain defining
     # explicit a message: key and value.
     #
     # Error messages are looked up in the following order:

--- a/activemodel/lib/active_model/locale/en.yml
+++ b/activemodel/lib/active_model/locale/en.yml
@@ -6,32 +6,53 @@ en:
     # The values :model, :attribute and :value are always available for interpolation
     # The value :count is available when applicable. Can be used for pluralization.
     messages:
-      model_invalid: "Validation failed: %{errors}"
-      inclusion: "is not included in the list"
-      exclusion: "is reserved"
-      invalid: "is invalid"
-      confirmation: "doesn't match %{attribute}"
-      accepted: "must be accepted"
-      empty: "can't be empty"
-      blank: "can't be blank"
-      present: "must be blank"
+      model_invalid:
+        message: "Validation failed: %{errors}"
+      inclusion:
+        message: "is not included in the list"
+      exclusion:
+        message: "is reserved"
+      invalid:
+        message: "is invalid"
+      confirmation:
+        message: "doesn't match %{attribute}"
+      accepted:
+        message: "must be accepted"
+      empty:
+        message: "can't be empty"
+      blank:
+        message: "can't be blank"
+      present:
+        message: "must be blank"
       too_long:
-        one: "is too long (maximum is 1 character)"
-        other: "is too long (maximum is %{count} characters)"
+        message:
+          one: "is too long (maximum is 1 character)"
+          other: "is too long (maximum is %{count} characters)"
       too_short:
         one: "is too short (minimum is 1 character)"
         other: "is too short (minimum is %{count} characters)"
       wrong_length:
         one: "is the wrong length (should be 1 character)"
         other: "is the wrong length (should be %{count} characters)"
-      not_a_number: "is not a number"
-      not_an_integer: "must be an integer"
-      greater_than: "must be greater than %{count}"
-      greater_than_or_equal_to: "must be greater than or equal to %{count}"
-      equal_to: "must be equal to %{count}"
-      less_than: "must be less than %{count}"
-      less_than_or_equal_to: "must be less than or equal to %{count}"
-      other_than: "must be other than %{count}"
-      in: "must be in %{count}"
-      odd: "must be odd"
-      even: "must be even"
+      not_a_number:
+        message: "is not a number"
+      not_an_integer:
+        message: "must be an integer"
+      greater_than:
+        message: "must be greater than %{count}"
+      greater_than_or_equal_to:
+        message: "must be greater than or equal to %{count}"
+      equal_to:
+        message: "must be equal to %{count}"
+      less_than:
+        message: "must be less than %{count}"
+      less_than_or_equal_to:
+        message: "must be less than or equal to %{count}"
+      other_than:
+        message: "must be other than %{count}"
+      in:
+        message: "must be in %{count}"
+      odd:
+        message: "must be odd"
+      even:
+        message: "must be even"

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -16,10 +16,11 @@ class ErrorsTest < ActiveModel::TestCase
     def validate!
       return unless name.nil?
 
-      errors.add(:name,
-                 :blank,
-                 message: "cannot be nil",
-                 custom_message: "Whoops! You need to provide a value"
+      errors.add(
+        :name,
+        :blank,
+        message: "cannot be nil",
+        custom_message: "Whoops! You need to provide a value"
       )
     end
 


### PR DESCRIPTION

- [Summary](#summary)
- [Context](#context)
  - [Listing errors at the top of a long form](#listing-errors-at-the-top-of-a-long-form)
  - [Error per input field](#error-per-input-field)
    - [Current behaviour](#current-behaviour)
- [Implemented behaviour: custom_message](#implemented-behaviour-custom-message)
  - [Usage](#usage)
- [Notes on implementation](#notes-on-implementation)
- [Future work](#future-work)

# Summary

> Note: This PR is a new take on https://github.com/rails/rails/pull/43283 by @ollieh-m based on the comments provided by me and @rafaelfranca. Note that the description of this PR is similar but not the same as the comment I made on that PR so please read again if you already read the other one :) 

# Context

This PR adds the `custom_message` functionality to `ActiveModel::Error` and helper methods in `ActiveModel::Errors` in an effort to make feedback in form fields nicer.

## Listing errors at the top of a long form
When creating a form, specially a long one, it's usually a good idea for all errors to be at the top of the form. This makes it specially important for users of your app that use assistive technologies (more on that [here](https://www.w3.org/WAI/tutorials/forms/notifications/#listing-errors))

Each item in this list describes a) the attribute that has an error and b) the error on that attribute. Each list item can potentially have a link with an anchor to the element that needs to be corrected

![image](https://user-images.githubusercontent.com/10928518/136735039-9dbdfd95-ea5c-4557-a1ad-99639cafd041.png)

This message is currently constructed using the `full_message` method which concatenates the name of the attribute with the error message.

## Error per input field

### Current behaviour

As UX on the web has evolved, it's become commonplace to have the error message alongside the input field. This makes it a little bit redundant to have the name of the attribute be repeated. The following example showcases what an input field would look like using the `full_messages_for(:attribute)` method.

![image](https://user-images.githubusercontent.com/10928518/136736534-66a783bd-7e8c-4ce9-9aa7-71f928a1a3b5.png)

# Implemented behaviour: `custom_message`

I've added a `custom_message` method to create an alternative message in forms like these that don't need the attribute's name or might not follow the format attribute + message. In working in this PR I discovered a feature in `full_messages` that allows its format to be modified from `#{name} #{message}` to something else and also a PR https://github.com/rails/rails/pull/42708 that allows this configuration to be made per validation. 

However, neither of these accomplish the purpose of this feature to have 2 distinct ways to describe error messages: one conventionally formatted with `full_message` and one friendlier with `custom_message`.

![image](https://user-images.githubusercontent.com/10928518/136736580-4a1fb080-f3e1-42d1-be6b-61d1571cb8d2.png)

## Usage

```erb
<%= form_with(model: @person) do |form|%>
<!-- for accessibility -->
<ul>
<% form.object.errors.full_messages.each do |message| %>
  <li><%= message %></li>
</ul>
<%= form.email_field :email %>
<p class="error"><%= form.object.errors.custom_message_for(:email) %></p>
<% end %>
```

# Notes on the implementation
1. I based the implementation and tests for the `ActiveModel::Error` class on the `message` and `generate_message` already present. 
2. I decided to go with a new structure for the YAML translation file where the type of error (e.g. `blank`) is not a single key with a string value but a key with child keys: `blank: { message: "can't be blank", custom_message: "Whoops! it's blank!" } `. This required for the lookup chain for `message` to support the previous, simpler nesting: `blank: "can't be blank"`. I've commented this in the lookup chain docs in `Errors` in case we wish to deprecate this in the future.
3. I enhanced the `as_json` and `to_hash` methods to support a more explicit type of argument: `message_method`. This allows callers to ask for the type of message they want, either `message`, `custom_message` and `full_message`. I've added deprecation warnings for users to upgrade to using explicit keyword arguments for as_json

# Future work
1. The `Error` class and specially its tests are quite long. I'm personally not used to this and thought it could be good to split the rendering of `message` and `custom_message` into different classes like `MessageRenderer` and `CustomMessageRenderer` or something similar. 
2. I wonder it's necessary to deprecate the previous lookup chain values
3. @rafaelfranca made an interesting comment on `full_message` not being the right name for what it does and I agree. `formatted_message` as he suggested describes its behaviour and intention much better. I wonder if we should take this opportunity to rename it and create a deprecation warning for `full_message`

### Other Information
TODO: 
If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
