### PR TITLE
Run `after_rollback` callbacks on `ActiveRecord::StatementInvalid` errors

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Trigger `after_rollback` callbacks on `ActiveRecord::StatementInvalid` errors
+
+    When an `ActiveRecord::StatementInvalid` error was raised, it would
+    (rightly) prevent `trigger_update_callback` from getting set to `true`.
+    But in addition to preventing update callbacks that would also prevent
+    `after_rollback` callbacks.
+
+    Fixes #43721
+
+    *Kyle Stevens*
+
 *   Load STI Models in fixtures
 
     Data from Fixtures now loads based on the specific class for models with

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1065,6 +1065,9 @@ module ActiveRecord
       return false if destroyed?
       result = new_record? ? _create_record(&block) : _update_record(&block)
       result != false
+    rescue ActiveRecord::StatementInvalid
+      @_trigger_rollback_callback = true
+      raise
     end
 
     # Updates the associated record with values matching those of the instance attributes.

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -333,6 +333,7 @@ module ActiveRecord
     ensure
       restore_transaction_record_state(force_restore_state)
       clear_transaction_record_state
+      @_trigger_rollback_callback = false
       @_trigger_update_callback = @_trigger_destroy_callback = false if force_restore_state
     end
 
@@ -359,11 +360,12 @@ module ActiveRecord
 
     def trigger_transactional_callbacks? # :nodoc:
       (@_new_record_before_last_commit || _trigger_update_callback) && persisted? ||
-        _trigger_destroy_callback && destroyed?
+        _trigger_destroy_callback && destroyed? ||
+          _trigger_rollback_callback
     end
 
     private
-      attr_reader :_committed_already_called, :_trigger_update_callback, :_trigger_destroy_callback
+      attr_reader :_committed_already_called, :_trigger_update_callback, :_trigger_destroy_callback, :_trigger_rollback_callback
 
       # Save the new record state and id of a record so it can be restored later if a transaction fails.
       def remember_transaction_record_state


### PR DESCRIPTION
### Summary

Fixes #43721

When rollbacks occurred due to database errors (`ActiveRecord::StatementInvalid`), `after_rollback` callbacks would not run.

Rollback callbacks are only performed if `record.trigger_transactional_callbacks?` returns `true`.

That method is based on a number of variables:

    def trigger_transactional_callbacks?
      (@_new_record_before_last_commit || _trigger_update_callback) && persisted? ||
        _trigger_destroy_callback && destroyed? ||
          _trigger_rollback_callback
    end

Most importantly, `_trigger_update_callback` gets set to `false` when an `ActiveRecord::StatementInvalid` error occurs which would then prevent the `after_rollback` callbacks as well.

This PR introduces `_trigger_rollback_callback` to account for database errors.

## Other Information
The change in this commit affects the following method:

https://github.com/rails/rails/blob/90357af08048ef5076730505f6e7b14a81f33d0c/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L126-L135