### PR TITLE
Mention yarn linking in contributing guide to run local npm packages

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -236,6 +236,15 @@ $ bundle exec rails new ~/my-test-app --dev
 The application generated in `~/my-test-app` runs against your local branch
 and, in particular, sees any modifications upon server reboot.
 
+For JavaScript packages, you can use [`yarn link`](https://yarnpkg.com/cli/link) to source your local branch in a generated application:
+
+```bash
+$ cd rails/activestorage
+$ yarn link
+$ cd ~/my-test-app
+$ yarn link "@rails/activestorage"
+```
+
 ### Write Your Code
 
 Now get busy and add/edit code. You're on your branch now, so you can write whatever you want (make sure you're on the right branch with `git branch -a`). But if you're planning to submit your change back for inclusion in Rails, keep a few things in mind:


### PR DESCRIPTION
### Summary

In https://github.com/rails/rails/issues/43667, there was some confusion about how to use unreleased changes to npm packages. I think this should be documented because it isn't straightforward. Unlike Ruby gems, Node packages can use multiple versions of the same package. Linking is needed to tell Node to use the same local package for all instances of a dependency. 
