### PR TITLE
Introduce a method to allow updating the defaults and env of an instance of ActionController::Renderer

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add an `ActionController::Renderer#update_defaults` method to allow updating the defaults on
+    the current renderer object.  This helps cases such as `view_component`, `turbo-rails`, `ActionText`
+    and others that use the default `ApplicationController` instance which creates an instance of
+    `ActionDispatch::Request` and passes the `@env` variable that is not updated by the call to
+    `ApplicationController.renderer.defaults.merge!`
+
+    *Eric Musgrove*
+
 *   `Rails.application.executor` hooks can now be called around every request in a `ActionController::TestCase`
 
     This helps to better simulate request or job local state being reset between requests and prevent state

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -59,6 +59,13 @@ module ActionController
       self.class.new controller, @env, self.defaults.merge(defaults)
     end
 
+    # Update the defaults and env for this renderer, allowing usage of
+    # the render method to work with the updated env.
+    def update_defaults(new_defaults)
+      defaults.merge!(new_defaults)
+      @env = normalize_keys defaults, @env, true
+    end
+
     # Accepts a custom Rack environment to render templates in.
     # It will be merged with the default Rack environment defined by
     # +ActionController::Renderer::DEFAULTS+.
@@ -102,13 +109,13 @@ module ActionController
     alias_method :render_to_string, :render # :nodoc:
 
     private
-      def normalize_keys(defaults, env)
+      def normalize_keys(defaults, env, refresh_keys = false)
         new_env = {}
         env.each_pair { |k, v| new_env[rack_key_for(k)] = rack_value_for(k, v) }
 
         defaults.each_pair do |k, v|
           key = rack_key_for(k)
-          new_env[key] = rack_value_for(k, v) unless new_env.key?(key)
+          new_env[key] = rack_value_for(k, v) if !new_env.key?(key) || refresh_keys
         end
 
         new_env["rack.url_scheme"] = new_env["HTTPS"] == "on" ? "https" : "http"

--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -97,6 +97,22 @@ class RendererTest < ActiveSupport::TestCase
     assert_equal "true", content
   end
 
+  test "rendering with updated defaults" do
+    renderer = ApplicationController.renderer
+
+    prior_content = renderer.render(inline: "<%= request.host %>")
+
+    new_defaults = { http_host: "example.com" }
+    renderer.update_defaults(new_defaults)
+
+    content = renderer.render(inline: "<%= request.host %>")
+
+    assert_equal ActionController::Renderer::DEFAULTS[:http_host], prior_content
+    assert_equal "example.com", content
+
+    renderer.update_defaults(ActionController::Renderer::DEFAULTS)
+  end
+
   test "same defaults from the same controller" do
     renderer_defaults = ->(controller) { controller.renderer.defaults }
 


### PR DESCRIPTION
### Summary

As noted [here](https://github.com/rails/rails/issues/41795) and [here](https://github.com/hotwired/turbo-rails/issues/155), and the various linked issues, calling the `render` method on the default instance of `ApplicationController.renderer`, even if the user has overwritten the defaults via a call to `ApplicationController.renderer.defaults.merge!`, still results in incorrect behavior because the `render` method utilizes the `@env` variable which, after initialization, does not have a way to be updated outside of creating an entirely new instance of a renderer.

These changes introduce a method, `update_defaults`, and modifies the `normalize_keys` method to accept a boolean noting if the keys are being refreshed or not (default `false)`.  This allows an instance of a renderer to update both the defaults and the `@env` values, meaning other code which calls `ApplicationController.render`, for example, will utilize the proper updated environment values (http_host, ssl, etc.) instead of having to create a new instance of a renderer or creating a patch to force upstream code to utilize a new instance of a renderer instead of the default `ApplicationController` renderer

This would theoretically allow resolution of the below issues, as well as any number of others which are expecting the call to `ApplicationController.renderer.defaults.merge!` as was introduced as an initializer to update the various defaults of their `ApplicationController.render` method calls.

* https://github.com/rails/rails/issues/41795
* https://github.com/hotwired/turbo-rails/issues/155
* https://github.com/hotwired/turbo-rails/issues/54
* https://github.com/rails/rails/issues/31979
* https://github.com/rails/rails/issues/35578