### PR TITLE
Update remove_column docs for how indexes are changed/removed

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -656,7 +656,8 @@ module ActiveRecord
       # The +type+ and +options+ parameters will be ignored if present. It can be helpful
       # to provide these in a migration's +change+ method so it can be reverted.
       # In that case, +type+ and +options+ will be used by #add_column.
-      # Indexes on the column are automatically removed.
+      # Depending on the database you're using, indexes using this column may be 
+      # automatically removed or modified to remove this column from the index.
       #
       # If the options provided include an +if_exists+ key, it will be used to check if the
       # column does not exist. This will silently ignore the migration rather than raising


### PR DESCRIPTION
### Summary

This is a minor change to the documentation of `remove_column` and how it affects indexes using that column. How this works for composite indexes actually depends on the database used.

For example, [MySQL will simply remove the column from the composite index](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html#alter-table-add-drop-column). 

> If columns are dropped from a table, the columns are also removed from any index of which they are a part. If all columns that make up an index are dropped, the index is dropped as well.

On the other end, [Postgresql will remove all indexes where that column is used](https://www.postgresql.org/docs/9.1/sql-altertable.html).

>  _DROP COLUMN [ IF EXISTS ]_
>  This form drops a column from a table. Indexes and table constraints involving the column will be automatically dropped as well.

This is pretty minor, but if you're expecting the index to be completely removed, you could end up instead with an index that is a duplicate of another index or is generally not used, which could affect write performance to that table.

### Other Information

I wasn't too sure how to word this, open to changing that.
