### PR TITLE
ActiveSupport::Cache, fix race conditions on test/cache - part VI

### DIFF
--- a/activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_delete_matched_behavior.rb
@@ -2,14 +2,23 @@
 
 module CacheDeleteMatchedBehavior
   def test_delete_matched
-    @cache.write("foo", "bar")
-    @cache.write("fu", "baz")
-    @cache.write("foo/bar", "baz")
-    @cache.write("fu/baz", "bar")
-    @cache.delete_matched(/oo/)
-    assert_not @cache.exist?("foo")
-    assert @cache.exist?("fu")
-    assert_not @cache.exist?("foo/bar")
-    assert @cache.exist?("fu/baz")
+    prefix = SecureRandom.alphanumeric # foo
+    @cache.write(prefix, SecureRandom.alphanumeric)
+
+    second_prefix = SecureRandom.alphanumeric # fu
+    @cache.write(second_prefix, SecureRandom.alphanumeric)
+
+    key = "#{prefix}/#{SecureRandom.uuid}"  # foo/bar
+    @cache.write(key, SecureRandom.alphanumeric)
+
+    other_key = "#{second_prefix}/#{SecureRandom.uuid}" # fu/baz
+    @cache.write(other_key, SecureRandom.alphanumeric)
+
+    @cache.delete_matched(/#{prefix}/) # foo
+
+    assert_not @cache.exist?(prefix)
+    assert @cache.exist?(second_prefix)
+    assert_not @cache.exist?(key)
+    assert @cache.exist?(other_key)
   end
 end

--- a/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_coder_behavior.rb
@@ -24,57 +24,74 @@ module CacheStoreCoderBehavior
   def test_coder_receive_the_entry_on_write
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
-    @store.write("foo", "bar")
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @store.write(key, value)
     assert_equal 1, coder.dumped_entries.size
     entry = coder.dumped_entries.first
     assert_instance_of ActiveSupport::Cache::Entry, entry
-    assert_equal "bar", entry.value
+    assert_equal value, entry.value
   end
 
   def test_coder_receive_the_entry_on_read
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
-    @store.write("foo", "bar")
-    @store.read("foo")
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+
+    @store.write(key, value)
+    @store.read(key)
     assert_equal 1, coder.loaded_entries.size
     entry = coder.loaded_entries.first
     assert_instance_of ActiveSupport::Cache::Entry, entry
-    assert_equal "bar", entry.value
+    assert_equal value, entry.value
   end
 
   def test_coder_receive_the_entry_on_read_multi
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
-    @store.write_multi({ "foo" => "bar", "egg" => "spam" })
-    @store.read_multi("foo", "egg")
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    other_key = SecureRandom.uuid
+    other_value = SecureRandom.alphanumeric
+
+    @store.write_multi({ key => value, other_key => other_value })
+    @store.read_multi(key, other_key)
     assert_equal 2, coder.loaded_entries.size
     entry = coder.loaded_entries.first
     assert_instance_of ActiveSupport::Cache::Entry, entry
-    assert_equal "bar", entry.value
+    assert_equal value, entry.value
 
     entry = coder.loaded_entries[1]
     assert_instance_of ActiveSupport::Cache::Entry, entry
-    assert_equal "spam", entry.value
+    assert_equal other_value, entry.value
   end
 
   def test_coder_receive_the_entry_on_write_multi
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
-    @store.write_multi({ "foo" => "bar", "egg" => "spam" })
+    key = SecureRandom.uuid
+    value = SecureRandom.alphanumeric
+    other_key = SecureRandom.uuid
+    other_value = SecureRandom.alphanumeric
+
+    @store.write_multi({ key => value, other_key => other_value })
     assert_equal 2, coder.dumped_entries.size
     entry = coder.dumped_entries.first
     assert_instance_of ActiveSupport::Cache::Entry, entry
-    assert_equal "bar", entry.value
+    assert_equal value, entry.value
 
     entry = coder.dumped_entries[1]
     assert_instance_of ActiveSupport::Cache::Entry, entry
-    assert_equal "spam", entry.value
+    assert_equal other_value, entry.value
   end
 
   def test_coder_does_not_receive_the_entry_on_read_miss
     coder = SpyCoder.new
     @store = lookup_store(coder: coder)
-    @store.read("foo")
+
+    @store.read(SecureRandom.uuid)
     assert_equal 0, coder.loaded_entries.size
   end
 end


### PR DESCRIPTION
### Summary

I've notice some test scenarios failing randomly when running the tests for `ActiveSupport::Cache`  stores in isolation. The failing scenarios are currently frequent when using a computer with multiple cores.

This is the 6th set of fixes. I'm not covering all of them on a single Pull Request because it will mean too many changes the maintainers need to carefully review.

### Other information

The main problem seems to occur when multiple shared specs are being executed in parallel and reusing the `foo` key and assume the store is already empty when they isn't. The test scenarios are _namespaced_ but the shared test are still sharing the same store within the namespace, having as a result keys with not expected values or even empty if the other test delete, write or replace the key or value millisecond before them.

My proposed solution is to not use `foo` as the key for those shared scenarios, but any random key we hold and use for the multiple cases.

ref. #43670 
ref. #43675
ref. #43693
ref. #43704
ref. #43718