### PR TITLE
Typo in Active Storage: `custom_metadatata` -> `custom_metadata`

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -398,7 +398,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
       if forcibly_serve_as_binary?
         { content_type: ActiveStorage.binary_content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
       elsif !allowed_inline?
-        { content_type: content_type, disposition: :attachment, filename: filename, custom_metadatata: custom_metadata }
+        { content_type: content_type, disposition: :attachment, filename: filename, custom_metadata: custom_metadata }
       else
         { content_type: content_type, custom_metadata: custom_metadata }
       end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -295,7 +295,7 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
         content_type: "application/octet-stream",
         disposition: :attachment,
         filename: blob.filename,
-        custom_metadatata: { "test" => true }
+        custom_metadata: { "test" => true }
       }
     ]
 


### PR DESCRIPTION
Introduced in https://github.com/rails/rails/pull/43294
