### PR TITLE
add `--js` alias to `--javascript` and `--skip-js` alias to `--skip-javscript`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `--js` and `--skip-javascript` options to `rails new`
+
+    `--js` alias to `rails new --javascript ...`
+
+    Same as `-j`, e.g. `rails new --js esbuild ...`
+
+    `--skip-js` alias to `rails new --skip-javascript ...`
+
+    Same as `-J`, e.g. `rails new --skip-js ...`
+
+    *Dorian Marié*
+
 *   Allow relative paths with leading dot slash to be passed to `rails test`.
 
     Fix `rails test ./test/model/post_test.rb` to run a single test file.

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -33,7 +33,7 @@ module Rails
       rails: {
         actions: "-a",
         orm: "-o",
-        javascripts: "-j",
+        javascripts: ["-j", "--js"],
         resource_controller: "-c",
         scaffold_controller: "-c",
         stylesheets: "-y",

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -66,7 +66,7 @@ module Rails
         class_option :asset_pipeline,      type: :string, aliases: "-a", default: "sprockets",
                                            desc: "Choose your asset pipeline [options: sprockets (default), propshaft]"
 
-        class_option :skip_javascript,     type: :boolean, aliases: "-J", default: name == "plugin",
+        class_option :skip_javascript,     type: :boolean, aliases: ["-J", "--skip-js"], default: name == "plugin",
                                            desc: "Skip JavaScript files"
 
         class_option :skip_hotwire,        type: :boolean, default: false,

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -257,7 +257,7 @@ module Rails
       class_option :version, type: :boolean, aliases: "-v", group: :rails, desc: "Show Rails version number and quit"
       class_option :api, type: :boolean, desc: "Preconfigure smaller stack for API only apps"
       class_option :minimal, type: :boolean, desc: "Preconfigure a minimal rails app"
-      class_option :javascript, type: :string, aliases: "-j", default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
+      class_option :javascript, type: :string, aliases: ["-j", "--js"], default: "importmap", desc: "Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]"
       class_option :css, type: :string, aliases: "-c", desc: "Choose CSS processor [options: tailwind, bootstrap, bulma, postcss, sass... check https://github.com/rails/cssbundling-rails]"
       class_option :skip_bundle, type: :boolean, aliases: "-B", default: false, desc: "Don't run bundle install"
 

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -756,6 +756,68 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_gem "jsbundling-rails"
   end
 
+  def test_esbuild_option
+    generator([destination_root], javascript: "esbuild")
+
+    esbuild_called = 0
+    command_check = -> command, *_ do
+      case command
+      when "javascript:install:esbuild"
+        esbuild_called += 1
+      end
+    end
+
+    generator.stub(:rails_command, command_check) do
+      run_generator_instance
+    end
+
+    assert_equal 1, esbuild_called, "`javascript:install:esbuild` expected to be called once, but was called #{esbuild_called} times."
+    assert_gem "jsbundling-rails"
+  end
+
+  def test_esbuild_option_with_javacript_argument
+    run_generator [destination_root, "--javascript", "esbuild"]
+    assert_gem "jsbundling-rails"
+  end
+
+  def test_esbuild_option_with_j_argument
+    run_generator [destination_root, "-j", "esbuild"]
+    assert_gem "jsbundling-rails"
+  end
+
+  def test_esbuild_option_with_js_argument
+    run_generator [destination_root, "--js", "esbuild"]
+    assert_gem "jsbundling-rails"
+  end
+
+  def test_skip_javascript_option_with_skip_javascript_argument
+    run_generator [destination_root, "--skip-javascript"]
+    assert_no_gem "stimulus-rails"
+    assert_no_gem "turbo-rails"
+    assert_no_gem "importmap-rails"
+  end
+
+  def test_skip_javascript_option_with_J_argument
+    run_generator [destination_root, "-J"]
+    assert_no_gem "stimulus-rails"
+    assert_no_gem "turbo-rails"
+    assert_no_gem "importmap-rails"
+  end
+
+  def test_skip_javascript_option_with_skip_js_argument
+    run_generator [destination_root, "--skip-js"]
+    assert_no_gem "stimulus-rails"
+    assert_no_gem "turbo-rails"
+    assert_no_gem "importmap-rails"
+  end
+
+  def test_no_skip_javascript_option_with_no_skip_javascript_argument
+    run_generator [destination_root, "--no-skip-javascript"]
+    assert_gem "stimulus-rails"
+    assert_gem "turbo-rails"
+    assert_gem "importmap-rails"
+  end
+
   def test_hotwire
     run_generator [destination_root, "--no-skip-bundle"]
     assert_gem "turbo-rails"


### PR DESCRIPTION
### Summary

I was creating a new app and did `rails new --js esbuild` thinking it would work, but it didn't and was surprised, so here I add the `--js` alias so that `rails new --javascript ...` has two aliases: `-j` and `--js`

### Other Information

I'm not too familiar with thor so not sure 100% especially about the change in `lib/rails/generators.rb`, not sure if it has any effect at all, doesn't seem to break tests though

Because it's using thor, the `rails new --help` is updated automatically:

```
  -j, --js, [--javascript=JAVASCRIPT]                            # Choose JavaScript approach [options: importmap (default), webpack, esbuild, rollup]
```

In https://github.com/rails/rails/pull/43563 @eileencodes suggested I do this instead of renaming `--javascript` to `--js`

**Edit**: Also did the same for `--skip-js` / `--skip-javascript`