### PR TITLE
Log redirects from router similarly to controller redirects

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,5 +1,8 @@
-*   Prevent `ActionDispatch::ServerTiming` from overwriting existing values in `Server-Timing`.
+*   Log redirects from routes the same way as redirects from controllers.
 
+    *Dennis Paagman*
+
+*   Prevent `ActionDispatch::ServerTiming` from overwriting existing values in `Server-Timing`.
     Previously, if another middleware down the chain set `Server-Timing` header,
     it would overwritten by `ActionDispatch::ServerTiming`.
 

--- a/actionpack/lib/action_dispatch/log_subscriber.rb
+++ b/actionpack/lib/action_dispatch/log_subscriber.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ActionDispatch
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def redirect(event)
+      payload = event.payload
+
+      info { "Redirected to #{payload[:location]}" }
+
+      info do
+        status = payload[:status]
+
+        message = +"Completed #{status} #{Rack::Utils::HTTP_STATUS_CODES[status]} in #{event.duration.round}ms"
+        message << "\n\n" if defined?(Rails.env) && Rails.env.development?
+
+        message
+      end
+    end
+  end
+end
+
+ActionDispatch::LogSubscriber.attach_to :action_dispatch

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_dispatch"
+require "action_dispatch/log_subscriber"
 require "active_support/messages/rotation_configuration"
 
 module ActionDispatch

--- a/actionpack/test/dispatch/routing/log_subscriber_test.rb
+++ b/actionpack/test/dispatch/routing/log_subscriber_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "active_support/log_subscriber/test_helper"
+require "action_dispatch/log_subscriber"
+
+class TestLogSubscriber < ActionDispatch::IntegrationTest
+  include ActiveSupport::LogSubscriber::TestHelper
+
+  def setup
+    super
+    ActionDispatch::LogSubscriber.attach_to :action_dispatch
+  end
+
+  def test_redirect_logging
+    draw do
+      get "redirect", to: redirect("/login")
+    end
+
+    get "/redirect"
+    wait
+    assert_equal 2, logs.size
+    assert_equal "Redirected to http://www.example.com/login", logs.first
+    assert_match(/Completed 301/, logs.last)
+  end
+
+private
+  def draw(&block)
+    self.class.stub_controllers do |routes|
+      routes.default_url_options = { host: "www.example.com" }
+      routes.draw(&block)
+      @app = RoutedRackApp.new routes
+    end
+  end
+
+  def logs
+    @logs ||= @logger.logged(:info)
+  end
+end


### PR DESCRIPTION
_Note: I've [posted this on the discussion forum](https://discuss.rubyonrails.org/t/log-redirects-from-routes-similarly-as-redirects-from-controllers/79163) before (as per the guidelines), but didn't get a response there. That's why I'm opening a PR now, feel free to close if necessary._

### Summary

I want to propose a change to add logging to redirects that happen directly from routes.

Right now when a redirect happens in a route, it’s not clear from the log that an actual redirect happened. I was trying to find where a redirect originated and it took me some time to realize this, as redirects from controllers are logged differently.

For example with these routes:

```ruby
get :moo, to: "rails/welcome#index"
get :redirect, to: "regular#redirect"
root to: redirect("moo")
```

When requesting the route with the direct redirect, the logs only shows a line for the initial GET and then the GET for the redirected page:

> Started GET "/" for 127.0.0.1 at 2021-10-21 13:09:51 +0200
Started GET "/moo" for 127.0.0.1 at 2021-10-21 13:09:51 +0200
Processing by Rails::WelcomeController#index as */*                                                                 
...

While a redirect generated in a controller shows a lot more info:

> Started GET "/redirect" for 127.0.0.1 at 2021-10-21 13:11:33 +0200
> Processing by RegularController#redirect as */*
> Redirected to http://localhost:3000/moo
> Completed 302 Found in 0ms (ActiveRecord: 0.0ms | Allocations: 414)
>
>
> Started GET "/moo" for 127.0.0.1 at 2021-10-21 13:11:33 +0200
> Processing by Rails::WelcomeController#index as */*
> ...

I've added some instrumentation to ActionDispatch::Routing::Redirect that creates a similar log output for redirects from a route.

With these changes a redirect from a route would look like this in the logs:

> Started GET "/" for 127.0.0.1 at 2021-10-21 13:14:49 +0200
> Redirected to http://localhost:3000/moo
> Completed 301 Moved Permanently in 0ms
> 
> 
> Started GET "/moo" for 127.0.0.1 at 2021-10-21 13:14:49 +0200
> Processing by Rails::WelcomeController#index as */*
> ...

Happy to hear your thoughts. I'm open for suggestions and improvements.