### PR TITLE
Fix bind_parameter_test regexp

### DIFF
--- a/activerecord/test/cases/bind_parameter_test.rb
+++ b/activerecord/test/cases/bind_parameter_test.rb
@@ -310,7 +310,7 @@ if ActiveRecord::Base.connection.prepared_statements
           }.new
 
           logger.sql(event)
-          assert_match %r([[auth_token, [FILTERED]]]), logger.debugs.first
+          assert_match %r/#{Regexp.escape '[["auth_token", "[FILTERED]"]]'}/, logger.debugs.first
         end
     end
   end


### PR DESCRIPTION
The previous regexp consisted of a single character class pattern.  i.e. `assert_match` would always pass if the given string contained at least one of the characters in the regexp.

This commit changes the regexp to check for the intended substring.
