### PR TITLE
Fix flakey test in notifications_test.rb

### DIFF
--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -438,7 +438,7 @@ module Notifications
       event = event(:foo, time, time + 0.01, random_id, {})
 
       assert_equal :foo, event.name
-      assert_in_delta 10.0, event.duration, 0.0001
+      assert_in_epsilon 10.0, event.duration, 0.01
     end
 
     def test_event_cpu_time_does_not_raise_error_when_start_or_finished_not_called


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/82905#80d6c6ec-943d-4ba3-b360-1ef6c4aa5d89/1012-1022

The test designates the event end time as 0.01 seconds (i.e. 10 milliseconds) after the start time.  It then asserts that the event duration is 10 ± 0.0001 milliseconds.  This sometimes fails due to floating point precision errors.

This commit changes the assertion to instead check that the duration is within 1% of the expected value.
