### PR TITLE
Prepend actiontext.css to application.*.css

### DIFF
--- a/actiontext/lib/generators/action_text/install/install_generator.rb
+++ b/actiontext/lib/generators/action_text/install/install_generator.rb
@@ -38,7 +38,7 @@ module ActionText
 
         unless destination.join("app/assets/application.css").exist?
           if (stylesheets = Dir.glob "#{destination_root}/app/assets/stylesheets/application.*.{scss,css}").length > 0
-            insert_into_file stylesheets.first.to_s, %(@import 'actiontext.css';)
+            prepend_to_file stylesheets.first.to_s, %(@import 'actiontext.css';\n)
           else
             say <<~INSTRUCTIONS, :green
               To use the Trix editor, you must require 'app/assets/stylesheets/actiontext.css' in your base stylesheet.


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

In the case of Tailwind, it is necessary to import actiontext.css before
including the additional CSS rules.

This change does not cause Bulma, Bootstrap, Postcss, or SCSS to stop
working.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

This change is motivated by feedback in https://github.com/rails/rails/issues/43441#issuecomment-980149632.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

Edit: The failing tests in Buildkite don't appear to be failing locally, I'm not really sure what to make of those!