### PR TITLE
Fix NoMethod "flash" on ActionDispatch::Request error

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "rack/session/abstract/id"
 require "action_controller/metal/exceptions"
 require "active_support/security_utils"
 
@@ -183,38 +182,8 @@ module ActionController # :nodoc:
 
         # This is the method that defines the application behavior when a request is found to be unverified.
         def handle_unverified_request
-          request = @controller.request
-          request.session = NullSessionHash.new(request)
-          request.flash = nil
-          request.session_options = { skip: true }
-          request.cookie_jar = NullCookieJar.build(request, {})
+          @controller.request.nullify_state
         end
-
-        private
-          class NullSessionHash < Rack::Session::Abstract::SessionHash # :nodoc:
-            def initialize(req)
-              super(nil, req)
-              @data = {}
-              @loaded = true
-            end
-
-            # no-op
-            def destroy; end
-
-            def exists?
-              true
-            end
-
-            def enabled?
-              false
-            end
-          end
-
-          class NullCookieJar < ActionDispatch::Cookies::CookieJar # :nodoc:
-            def write(*)
-              # nothing
-            end
-          end
       end
 
       class ResetSession

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -363,7 +363,6 @@ module ActionDispatch
 
     def nullify_state
       self.session = NullSessionHash.new(self)
-      self.flash = nil
       self.session_options = { skip: true }
       self.cookie_jar = NullCookieJar.build(self, {})
     end

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -364,7 +364,6 @@ module ActionDispatch
     def nullify_state
       self.session = NullSessionHash.new(self)
       self.session_options = { skip: true }
-      self.cookie_jar = NullCookieJar.build(self, {})
     end
 
     def session=(session) # :nodoc:
@@ -462,12 +461,6 @@ module ActionDispatch
 
         def enabled?
           false
-        end
-      end
-
-      class NullCookieJar < ActionDispatch::Cookies::CookieJar #:nodoc:
-        def write(*)
-          # nothing
         end
       end
   end

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -21,6 +21,11 @@ module ActionDispatch
       end
     }
 
+    def nullify_state
+      self.cookie_jar = NullCookieJar.build(self, {})
+      super
+    end
+
     def have_cookie_jar?
       has_header? "action_dispatch.cookies"
     end
@@ -528,6 +533,12 @@ module ActionDispatch
         def commit(name, options)
           options[:expires] = 20.years.from_now
         end
+    end
+
+    class NullCookieJar < ActionDispatch::Cookies::CookieJar #:nodoc:
+      def write(*)
+        # nothing
+      end
     end
 
     class MarshalWithJsonFallback # :nodoc:

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -76,6 +76,11 @@ module ActionDispatch
         super
         self.flash = nil
       end
+
+      def nullify_state # :nodoc:
+        super
+        self.flash = nil
+      end
     end
 
     class FlashNow # :nodoc:


### PR DESCRIPTION
### Summary

Steps to reproduce:

- Load rails in api_only mode. This will not load the flash middleware
  and the flash request mixin.
- Create a POST route/action that is protected with null_session.
- Run the post action. You should get the NoMethodError "flash" on Request.

This repo contains a single example route that causes the error as well: https://github.com/kwstannard/rails-bug

### Other Information

I split the change into two more reviewable commits.

I don't know how to test this change and it appears that the tests that exist for null session are "No error occurred" type tests and don't check any of the null session code is run. I can add some tests if someone can point me toward something I can put expectations on.