### PR TITLE
Avoid passing {format:nil} from form_for/form_with to polymorphic_path

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -754,7 +754,11 @@ module ActionView
 
         if model
           if url != false
-            url ||= polymorphic_path(model, format: format)
+            url ||= if format.nil?
+              polymorphic_path(model, {})
+            else
+              polymorphic_path(model, format: format)
+            end
           end
 
           model   = _object_for_form_builder(model)

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2057,6 +2057,18 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_new_form_for_without_format
+    form_for(@post, html: { id: "edit_post_123", class: "edit_post" }) do |f|
+      concat f.label(:title)
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      "<label for='post_title'>Title</label>"
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_with_model_using_relative_model_naming
     blog_post = Blog::Post.new("And his name will be forty and four.", 44)
 


### PR DESCRIPTION
### Summary

In https://github.com/rails/rails/pull/43421 part of the functionalities of `form_for` was delegated to `form_with`, this could potentially cause some issues in that the following code in `form_for`:

```ruby
if options[:url] != false
  options[:url] ||= if options.key?(:format)
    polymorphic_path(record, format: options.delete(:format))
  else
    polymorphic_path(record, {})
  end
end
```
is removed and replace with functionality inside `form_with`:

```ruby
if url != false
  url ||= polymorphic_path(model, format: format)
end
```

This caused some noticeable issues in the latest rails upgrade for GitHub. As when `format` is not passed, `polymorphic_path(model, {format: nil})` is called instead of the original `polymorphic_path(model, {})` and 

```ruby
if options.empty?
  recipient.public_send(method, *args)
else
  recipient.public_send(method, *args, options)
end
```

and the extra `options` in `recipient.public_send(method, *args, options)` is potentially a breaking change for the underlying method.

This PR adds back the condition to pass `{}` if option is empty in `form_with` and added a test to make sure it doesn't break `form_with`.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

Thanks to @TooManyBees for help with debug this 🙇‍♀️ 