### PR TITLE
Pass params to url_for that ONLY get used for named segments; otherwise discard them

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -33,7 +33,7 @@
     search_path("quin") # => /foo/search/quin
     ```
 
-    *Jason Meller*
+    *Jason Meller, Jeremy Beker*
 
 *   Change `action_dispatch.show_exceptions` to one of `:all`, `:rescuable`, or
     `:none`. `:all` and `:none` behave the same as the previous `true` and

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,38 @@
+*   THe url_for helpers now support a new option called `bind_params`.
+    This is very useful in situations where you only want to add a required param that is part of the route's URL but for other route not append an extraneous query param.
+
+    Given the following router...
+    ```ruby
+    Rails.application.routes.draw do
+      scope ":account_id" do
+        get 'dashboard' => 'pages#dashboard', as: :dashboard
+        get 'search/:term' => 'search#search', as: :search
+      end
+      delete 'signout' => 'sessions#destroy', as: :signout
+    end
+    ```
+
+    And given the following `ApplicationController`
+    ```ruby
+      class ApplicationController < ActionController::Base
+        def default_url_options
+          { bind_params: { account_id: "foo" } }
+        end
+      end
+    ```
+
+    The standard URLHelpers will now behave as follows:
+
+    ```ruby
+    dashboard_path # => /foo/dashboard
+    dashboard_path(account_id: "bar") # => /bar/dashboard
+    signout_path # => /signout
+    signout_path(account_id: "bar") # => /signout?account_id=bar
+    search_path("quin") # => /foo/search/quin
+    ```
+
+    *Jason Meller*
+
 *   Change `action_dispatch.show_exceptions` to one of `:all`, `:rescuable`, or
     `:none`. `:all` and `:none` behave the same as the previous `true` and
     `false` respectively. The new `:rescuable` option will only show exceptions

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,14 +1,14 @@
-*   THe url_for helpers now support a new option called `bind_params`.
+*   The url_for helpers now support a new option called `path_params`.
     This is very useful in situations where you only want to add a required param that is part of the route's URL but for other route not append an extraneous query param.
 
     Given the following router...
     ```ruby
     Rails.application.routes.draw do
       scope ":account_id" do
-        get 'dashboard' => 'pages#dashboard', as: :dashboard
-        get 'search/:term' => 'search#search', as: :search
+        get "dashboard" => "pages#dashboard", as: :dashboard
+        get "search/:term" => "search#search", as: :search
       end
-      delete 'signout' => 'sessions#destroy', as: :signout
+      delete "signout" => "sessions#destroy", as: :signout
     end
     ```
 
@@ -16,18 +16,20 @@
     ```ruby
       class ApplicationController < ActionController::Base
         def default_url_options
-          { bind_params: { account_id: "foo" } }
+          { path_params: { account_id: "foo" } }
         end
       end
     ```
 
-    The standard URLHelpers will now behave as follows:
+    The standard url_for helper and friends will now behave as follows:
 
     ```ruby
     dashboard_path # => /foo/dashboard
     dashboard_path(account_id: "bar") # => /bar/dashboard
+
     signout_path # => /signout
     signout_path(account_id: "bar") # => /signout?account_id=bar
+    signout_path(account_id: "bar", path_params: { account_id: "baz" }) # => /signout?account_id=bar
     search_path("quin") # => /foo/search/quin
     ```
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -57,6 +57,9 @@ module ActionDispatch
       end
 
       def generate(name, options, path_parameters)
+        bind_params = options.delete(:bind_params) || {}
+        original_options = options.dup
+        options = options.reverse_merge(bind_params)
         constraints = path_parameters.merge(options)
         missing_keys = nil
 
@@ -71,6 +74,9 @@ module ActionDispatch
           missing_keys = missing_keys(route, parameterized_parts)
           next if missing_keys && !missing_keys.empty?
           params = options.dup.delete_if do |key, _|
+            # top-level params' normal behavior of generating query_params
+            # should be preserved even if the same key is also a bind_param
+            (bind_params.key?(key) && !original_options.key?(key)) ||
             parameterized_parts.key?(key) || route.defaults.key?(key)
           end
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -76,8 +76,8 @@ module ActionDispatch
           params = options.delete_if do |key, _|
             # top-level params' normal behavior of generating query_params
             # should be preserved even if the same key is also a bind_param
-            (path_params.key?(key) && !original_options.key?(key)) ||
-              parameterized_parts.key?(key) || route.defaults.key?(key)
+            parameterized_parts.key?(key) || route.defaults.key?(key) ||
+              (path_params.key?(key) && !original_options.key?(key))
           end
 
           defaults       = route.defaults

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -58,8 +58,8 @@ module ActionDispatch
 
       def generate(name, options, path_parameters)
         original_options = options.dup
-        bind_params = options.delete(:bind_params) || {}
-        options = bind_params.merge(options)
+        path_params = options.delete(:path_params) || {}
+        options = path_params.merge(options)
         constraints = path_parameters.merge(options)
         missing_keys = nil
 
@@ -76,7 +76,7 @@ module ActionDispatch
           params = options.delete_if do |key, _|
             # top-level params' normal behavior of generating query_params
             # should be preserved even if the same key is also a bind_param
-            (bind_params.key?(key) && !original_options.key?(key)) ||
+            (path_params.key?(key) && !original_options.key?(key)) ||
               parameterized_parts.key?(key) || route.defaults.key?(key)
           end
 

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -57,9 +57,9 @@ module ActionDispatch
       end
 
       def generate(name, options, path_parameters)
-        bind_params = options.delete(:bind_params) || {}
         original_options = options.dup
-        options = options.reverse_merge(bind_params)
+        bind_params = options.delete(:bind_params) || {}
+        options = bind_params.merge(options)
         constraints = path_parameters.merge(options)
         missing_keys = nil
 
@@ -73,11 +73,11 @@ module ActionDispatch
 
           missing_keys = missing_keys(route, parameterized_parts)
           next if missing_keys && !missing_keys.empty?
-          params = options.dup.delete_if do |key, _|
+          params = options.delete_if do |key, _|
             # top-level params' normal behavior of generating query_params
             # should be preserved even if the same key is also a bind_param
             (bind_params.key?(key) && !original_options.key?(key)) ||
-            parameterized_parts.key?(key) || route.defaults.key?(key)
+              parameterized_parts.key?(key) || route.defaults.key?(key)
           end
 
           defaults       = route.defaults

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -76,8 +76,8 @@ module ActionDispatch
           params = options.delete_if do |key, _|
             # top-level params' normal behavior of generating query_params
             # should be preserved even if the same key is also a bind_param
-            (path_params.key?(key) && !original_options.key?(key)) ||
-              parameterized_parts.key?(key) || route.defaults.key?(key)
+              parameterized_parts.key?(key) || route.defaults.key?(key) ||
+                (path_params.key?(key) && !original_options.key?(key))
           end
 
           defaults       = route.defaults

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -76,8 +76,8 @@ module ActionDispatch
           params = options.delete_if do |key, _|
             # top-level params' normal behavior of generating query_params
             # should be preserved even if the same key is also a bind_param
-              parameterized_parts.key?(key) || route.defaults.key?(key) ||
-                (path_params.key?(key) && !original_options.key?(key))
+            parameterized_parts.key?(key) || route.defaults.key?(key) ||
+              (path_params.key?(key) && !original_options.key?(key))
           end
 
           defaults       = route.defaults

--- a/actionpack/lib/action_dispatch/journey/formatter.rb
+++ b/actionpack/lib/action_dispatch/journey/formatter.rb
@@ -76,8 +76,8 @@ module ActionDispatch
           params = options.delete_if do |key, _|
             # top-level params' normal behavior of generating query_params
             # should be preserved even if the same key is also a bind_param
-            parameterized_parts.key?(key) || route.defaults.key?(key) ||
-              (path_params.key?(key) && !original_options.key?(key))
+            (path_params.key?(key) && !original_options.key?(key)) ||
+              parameterized_parts.key?(key) || route.defaults.key?(key)
           end
 
           defaults       = route.defaults

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -282,7 +282,7 @@ module ActionDispatch
 
               if args.size < path_params_size
                 path_params -= controller_options.keys
-                path_params -= (result[:bind_params] || {}).merge(result).keys
+                path_params -= (result[:path_params] || {}).merge(result).keys
               else
                 path_params = path_params.dup
               end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -282,7 +282,8 @@ module ActionDispatch
 
               if args.size < path_params_size
                 path_params -= controller_options.keys
-                path_params -= result.keys
+                # take bind_params into account
+                path_params -= result.reverse_merge(result[:bind_params] || {}).keys
               else
                 path_params = path_params.dup
               end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -282,8 +282,7 @@ module ActionDispatch
 
               if args.size < path_params_size
                 path_params -= controller_options.keys
-                # take bind_params into account
-                path_params -= result.reverse_merge(result[:bind_params] || {}).keys
+                path_params -= (result[:bind_params] || {}).merge(result).keys
               else
                 path_params = path_params.dup
               end

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -136,6 +136,8 @@ module ActionDispatch
       # * <tt>:port</tt> - Optionally specify the port to connect to.
       # * <tt>:anchor</tt> - An anchor name to be appended to the path.
       # * <tt>:params</tt> - The query parameters to be appended to the path.
+      # * <tt>:path_params</tt> - The query parameters that will only be used
+      #   for the named dynamic segments of path. If unsued, they will be discarded.
       # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in <tt>"/archive/2009/"</tt>.
       # * <tt>:script_name</tt> - Specifies application path relative to domain root. If provided, prepends application path.
       #

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -137,7 +137,7 @@ module ActionDispatch
       # * <tt>:anchor</tt> - An anchor name to be appended to the path.
       # * <tt>:params</tt> - The query parameters to be appended to the path.
       # * <tt>:path_params</tt> - The query parameters that will only be used
-      #   for the named dynamic segments of path. If unsued, they will be discarded.
+      #   for the named dynamic segments of path. If unused, they will be discarded.
       # * <tt>:trailing_slash</tt> - If true, adds a trailing slash, as in <tt>"/archive/2009/"</tt>.
       # * <tt>:script_name</tt> - Specifies application path relative to domain root. If provided, prepends application path.
       #

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -321,6 +321,34 @@ module AbstractController
         end
       end
 
+      def test_bind_params
+        with_routing do |set|
+          set.draw do
+            scope ":account_id" do
+              get 'dashboard' => 'pages#dashboard', as: :dashboard
+              get 'search/:term' => 'search#search', as: :search
+            end
+            delete 'signout' => 'sessions#destroy', as: :signout
+          end
+
+          # We need to create a new class in order to install the new named route.
+          kls = Class.new do
+            include set.url_helpers
+              def default_url_options
+                { bind_params: { account_id: "foo" } }
+              end
+            end
+
+          controller = kls.new
+
+          assert_equal("/foo/dashboard", controller.dashboard_path)
+          assert_equal("/bar/dashboard", controller.dashboard_path(account_id: "bar"))
+          assert_equal("/signout", controller.signout_path)
+          assert_equal("/signout?account_id=bar", controller.signout_path(account_id: "bar"))
+          assert_equal("/foo/search/quin", controller.search_path("quin"))
+        end
+      end
+
       def test_using_nil_script_name_properly_concats_with_original_script_name
         add_host!
         assert_equal("https://www.basecamphq.com/subdir/c/a/i",

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -325,19 +325,19 @@ module AbstractController
         with_routing do |set|
           set.draw do
             scope ":account_id" do
-              get 'dashboard' => 'pages#dashboard', as: :dashboard
-              get 'search/:term' => 'search#search', as: :search
+              get "dashboard" => "pages#dashboard", as: :dashboard
+              get "search/:term" => "search#search", as: :search
             end
-            delete 'signout' => 'sessions#destroy', as: :signout
+            delete "signout" => "sessions#destroy", as: :signout
           end
 
           # We need to create a new class in order to install the new named route.
           kls = Class.new do
             include set.url_helpers
-              def default_url_options
-                { bind_params: { account_id: "foo" } }
-              end
+            def default_url_options
+              { bind_params: { account_id: "foo" } }
             end
+          end
 
           controller = kls.new
 

--- a/actionpack/test/controller/url_for_test.rb
+++ b/actionpack/test/controller/url_for_test.rb
@@ -321,21 +321,20 @@ module AbstractController
         end
       end
 
-      def test_bind_params
+      def test_path_params_with_default_url_options
         with_routing do |set|
           set.draw do
             scope ":account_id" do
               get "dashboard" => "pages#dashboard", as: :dashboard
-              get "search/:term" => "search#search", as: :search
+              get "search(/:term)" => "search#search", as: :search
             end
             delete "signout" => "sessions#destroy", as: :signout
           end
 
-          # We need to create a new class in order to install the new named route.
           kls = Class.new do
             include set.url_helpers
             def default_url_options
-              { bind_params: { account_id: "foo" } }
+              { path_params: { account_id: "foo" } }
             end
           end
 
@@ -345,7 +344,32 @@ module AbstractController
           assert_equal("/bar/dashboard", controller.dashboard_path(account_id: "bar"))
           assert_equal("/signout", controller.signout_path)
           assert_equal("/signout?account_id=bar", controller.signout_path(account_id: "bar"))
+          assert_equal("/signout?account_id=bar", controller.signout_path(account_id: "bar", path_params: { account_id: "baz" }))
           assert_equal("/foo/search/quin", controller.search_path("quin"))
+        end
+      end
+
+      def test_path_params_without_default_url_options
+        with_routing do |set|
+          set.draw do
+            scope ":account_id" do
+              get "dashboard" => "pages#dashboard", as: :dashboard
+              get "search(/:term)" => "search#search", as: :search
+            end
+            delete "signout" => "sessions#destroy", as: :signout
+          end
+
+          kls = Class.new { include set.url_helpers }
+          controller = kls.new
+
+          assert_raise(ActionController::UrlGenerationError) do
+            controller.dashboard_path # missing required keys :account_id
+          end
+
+          assert_equal("/bar/dashboard", controller.dashboard_path(path_params: { account_id: "bar" }))
+          assert_equal("/signout", controller.signout_path(path_params: { account_id: "bar" }))
+          assert_equal("/signout?account_id=bar", controller.signout_path(account_id: "bar", path_params: { account_id: "baz" }))
+          assert_equal("/foo/search/quin", controller.search_path("foo", "quin"))
         end
       end
 


### PR DESCRIPTION
### What Problem Does This PR Solve?

[In my app](https://dev.to/kolide/a-rails-multi-tenant-strategy-thats-30-lines-and-just-works-58cd) we scope many of our routes by an `account_id`. Some routes however, live outside this scope (like the auth routes or other pages not associated with the main app).

A simplified version of our router looks something like this...

```ruby
Rails.application.routes.draw do
  scope ":account_id" do
    get "dashboard" => "pages#dashboard", as: :dashboard
    get "search/:term" => "search#search", as: :search
  end
  delete "signout" => "sessions#destroy", as: :signout
end
```

When writing views in our app, we don't always want to supply the `account_id` to every single URL helper method (ex: `dashboard_path(account_id: Current.account)` because we'd be writing it everywhere. So in our `ApplicationController` we mix-in the following method...

```ruby
def default_url_options
 { account_id: Current.account.id }
end
```

This works great, save for one extremely annoying consequence; routes that live outside the scope (like `signout_path`) will have `?account_id=foo` tacked on the end of them. Not only does this look ugly, it can also introduce caching issues with things like CDNs when using [stuff like this.](https://edgeguides.rubyonrails.org/active_storage_overview.html#putting-a-cdn-in-front-of-active-storage)

I spent hours trying to figure out an elegant/supported way to have the params in `default_url_options` be used only if they were part of a named segment in the route. I came up short, so I decided to write a feature for it in Rails.

### Introducing the new `path_params` option for `url_for`

With this PR, the `url_for` helper now supports a new option called `path_params`. If you pass a hash of params to this key,
they will _only_ be used for the named segments portion of the route. If they aren't used, they are discarded instead of tacked on the end as query params. 

Using the same router as above and given the following `ApplicationController`...

```ruby
  class ApplicationController < ActionController::Base
    def default_url_options
      { path_params: { account_id: "foo" } }
    end
  end
```

...the standard `url_for` helpers will now behave as follows:

```ruby
dashboard_path # => /foo/dashboard
dashboard_path(account_id: "bar") # => /bar/dashboard
signout_path # => /signout
signout_path(account_id: "bar") # => /signout?account_id=bar
search_path("quin") # => /foo/search/quin
```

### Closing Thoughts
We are using this code in production so far without issue. I am open to changes here (especially the name of the option), but I really think other apps with a similar router goals could benefit immensely from this enhancement. I hope you will consider it for inclusion in a future version of Rails.