### PR TITLE
Fix flakey test in Active Record dirty_test.rb

### DIFF
--- a/activerecord/test/cases/dirty_test.rb
+++ b/activerecord/test/cases/dirty_test.rb
@@ -948,10 +948,11 @@ class DirtyTest < ActiveRecord::TestCase
         assert_equal "Boeing", aircraft.name
 
         aircraft.save!
+        expected_manufactured_at = Time.now
         aircraft.reload
 
         assert_equal "Boeing", aircraft.name
-        assert_equal Time.now.utc.strftime("%Y-%m-%d %H:%M:%S"), aircraft.manufactured_at.strftime("%Y-%m-%d %H:%M:%S")
+        assert_in_delta expected_manufactured_at, aircraft.manufactured_at, 1
       end
     end
 


### PR DESCRIPTION
Example failure: https://buildkite.com/rails/rails/builds/82957#44f56e67-28e9-4193-9175-695e300a9756/1110-1120

The test asserts that `manufactured_at` [defaults to `CURRENT_TIMESTAMP`](https://github.com/rails/rails/blob/0b10efcc4cd08732eba5c78d9267d90451d18c7d/activerecord/test/schema/schema.rb#L41) from the database by comparing it to `Time.now`, with both timestamps truncated to seconds precision.  However, if the record is saved during the final milliseconds of a second, and `Time.now` is evaluated during the first milliseconds of the next second, the truncated timestamps will still differ.

This commit changes the assertion to instead check that the timestamps are within 1 second of each other.
