### PR TITLE
Document `ActiveSupport::Testing::Deprecation`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Document `ActiveSupport::Testing::Deprecation`.
+
+    *Sam Bostock & Sam Jordan*
+
 *   Add `Pathname#existence`.
 
     ```ruby

--- a/activesupport/lib/active_support/testing/deprecation.rb
+++ b/activesupport/lib/active_support/testing/deprecation.rb
@@ -4,7 +4,30 @@ require "active_support/deprecation"
 
 module ActiveSupport
   module Testing
-    module Deprecation # :nodoc:
+    module Deprecation
+      # Asserts that a matching deprecation warning was emitted by the given deprecator during the execution of the yielded block.
+      #
+      #   assert_deprecated(/foo/, CustomDeprecator) do
+      #     CustomDeprecator.warn "foo should no longer be used"
+      #   end
+      #
+      # The +match+ object may be a +Regexp+, or +String+ appearing in the message.
+      #
+      #   assert_deprecated('foo', CustomDeprecator) do
+      #     CustomDeprecator.warn "foo should no longer be used"
+      #   end
+      #
+      # If the +match+ is omitted (or explicitly +nil+), any deprecation warning will match.
+      #
+      #   assert_deprecated(nil, CustomDeprecator) do
+      #     CustomDeprecator.warn "foo should no longer be used"
+      #   end
+      #
+      # If no +deprecator+ is given, defaults to ActiveSupport::Deprecation.
+      #
+      #   assert_deprecated do
+      #     ActiveSupport::Deprecation.warn "foo should no longer be used"
+      #   end
       def assert_deprecated(match = nil, deprecator = nil, &block)
         result, warnings = collect_deprecations(deprecator, &block)
         assert !warnings.empty?, "Expected a deprecation warning within the block but received none"
@@ -15,12 +38,40 @@ module ActiveSupport
         result
       end
 
+      # Asserts that no deprecation warnings are emitted by the given deprecator during the execution of the yielded block.
+      #
+      #   assert_not_deprecated(CustomDeprecator) do
+      #     CustomDeprecator.warn "message" # fails assertion
+      #   end
+      #
+      # If no +deprecator+ is given, defaults to ActiveSupport::Deprecation.
+      #
+      #   assert_not_deprecated do
+      #     ActiveSupport::Deprecation.warn "message" # fails assertion
+      #   end
+      #
+      #   assert_not_deprecated do
+      #     CustomDeprecator.warn "message" # passes assertion
+      #   end
       def assert_not_deprecated(deprecator = nil, &block)
         result, deprecations = collect_deprecations(deprecator, &block)
         assert deprecations.empty?, "Expected no deprecation warning within the block but received #{deprecations.size}: \n  #{deprecations * "\n  "}"
         result
       end
 
+      # Returns an array of all the deprecation warnings emitted by the given
+      # +deprecator+ during the execution of the yielded block.
+      #
+      #   collect_deprecations(CustomDeprecator) do
+      #     CustomDeprecator.warn "message"
+      #   end # => ["message"]
+      #
+      # If no +deprecator+ is given, defaults to ActiveSupport::Deprecation.
+      #
+      #   collect_deprecations do
+      #     CustomDeprecator.warn "custom message"
+      #     ActiveSupport::Deprecation.warn "message"
+      #   end # => ["message"]
       def collect_deprecations(deprecator = nil)
         deprecator ||= ActiveSupport::Deprecation
         old_behavior = deprecator.behavior


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This makes `ActiveSupport::Testing::Deprecation` part of the documented public API, so consumers can use its assertions in their tests.

---
cc. @rafaelfranca (as per our discussion)