### PR TITLE
Update 20191206030411_create_active_storage_variant_records.rb

### DIFF
--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,12 +1,14 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
-    # Use Active Record's configured type for primary key
-    create_table :active_storage_variant_records, id: primary_key_type do |t|
-      t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
-      t.string :variation_digest, null: false
+    unless table_exists?(:active_storage_variant_records)
+      # Use Active Record's configured type for primary key
+      create_table :active_storage_variant_records, id: primary_key_type do |t|
+        t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
+        t.string :variation_digest, null: false
 
-      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
-      t.foreign_key :active_storage_blobs, column: :blob_id
+        t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+        t.foreign_key :active_storage_blobs, column: :blob_id
+      end
     end
   end
 


### PR DESCRIPTION
In the case of bootstrapping a project for the first time without active storage, when running `rails app:update` this migration would result in trying to create the table twice.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
