### PR TITLE
correct form_with doc by setting local: true

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -850,7 +850,7 @@ Let's create `app/views/articles/new.html.erb` with the following contents:
 ```html+erb
 <h1>New Article</h1>
 
-<%= form_with model: @article do |form| %>
+<%= form_with model: @article, local: true do |form| %>
   <div>
     <%= form.label :title %><br>
     <%= form.text_field :title %>
@@ -990,7 +990,7 @@ display any error messages for `title` and `body`:
 ```html+erb
 <h1>New Article</h1>
 
-<%= form_with model: @article do |form| %>
+<%= form_with model: @article, local: true do |form| %>
   <div>
     <%= form.label :title %><br>
     <%= form.text_field :title %>


### PR DESCRIPTION
### Summary

Hello !
I'm just a new learner for Rails who's about to get used to Rails.
There's a little pitfall about documenting the usage of `form_with` for creating article validation messages.
It SHOULD have explicitly set `local: true` to form_with to prevent sending xhr request
 ( e.g.  removing`data-remote="true"` from form tag )

### Other Information

https://guides.rubyonrails.org/getting_started.html v6.1.4