### PR TITLE
Convert attributes to Hash in authenticate_by

### DIFF
--- a/activerecord/test/cases/secure_password_test.rb
+++ b/activerecord/test/cases/secure_password_test.rb
@@ -64,4 +64,16 @@ class SecurePasswordTest < ActiveRecord::TestCase
       User.authenticate_by(password: @user.password)
     end
   end
+
+  test "authenticate_by accepts any object that implements to_h" do
+    params = Enumerator.new { raise "must access via to_h" }
+
+    assert_called_with(params, :to_h, [[]], returns: { token: @user.token, password: @user.password }) do
+      assert_equal @user, User.authenticate_by(params)
+    end
+
+    assert_called_with(params, :to_h, [[]], returns: { token: "wrong", password: @user.password }) do
+      assert_nil User.authenticate_by(params)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #43765.

This ensures that `authenticate_by` supports controller params, e.g.:

```ruby
User.authenticate_by(params.permit(:email, :password))
```

Note that `ActionController::Parameters#to_h` will raise an error when there are unpermitted params.  This guards against unsafe usage such as:

```ruby
User.authenticate_by(params)
```

---

/cc @kaspth, @rafaelfranca 