### PR TITLE
Remove trailing slash from comment linking to propshaft repository

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -175,7 +175,7 @@ module Rails
           GemfileEntry.version "sprockets-rails", ">= 3.4.1",
             "The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]"
         elsif options[:asset_pipeline] == "propshaft"
-          GemfileEntry.version "propshaft", ">= 0.4.1", "The modern asset pipeline for Rails [https://github.com/rails/propshaft/]"
+          GemfileEntry.version "propshaft", ">= 0.4.1", "The modern asset pipeline for Rails [https://github.com/rails/propshaft]"
         else
           []
         end


### PR DESCRIPTION
### Summary

With rails v7.0.0.rc1 released, I was [testing generating a new rails 7 app with the propshaft asset pipeline](https://github.com/rails/rails/issues/43422#issuecomment-987559424) and I noticed that the comment above the propshaft gemfile entry includes a trailing slash in the repository link, unlike the rest of the repository links:

![image](https://user-images.githubusercontent.com/1863540/144972727-f2c323cd-6d58-4120-ab36-233f3aa2a1c9.png)

Let's remove it to keep things consistent and clean.