### PR TITLE
Fix test name in `PathnameExistenceTest`

### DIFF
--- a/activesupport/test/core_ext/pathname/existence_test.rb
+++ b/activesupport/test/core_ext/pathname/existence_test.rb
@@ -4,7 +4,7 @@ require_relative "../../abstract_unit"
 require "active_support/core_ext/pathname/existence"
 
 class PathnameExistenceTest < ActiveSupport::TestCase
-  def test_presence
+  def test_existence
     existing = Pathname.new(__FILE__)
     not_existing = Pathname.new("not existing")
     assert_equal existing, existing.existence


### PR DESCRIPTION
### Summary

This was introduced in https://github.com/rails/rails/pull/43726 likely as a copy-paste typo from
https://github.com/rails/rails/blob/00fb4e6bbdeefe3b4ffc48a6c74f593666f7d594/activesupport/test/core_ext/object/blank_test.rb#L32

But it should be `test_existence` given that `Pathname#existence` is the method being tested.