### PR TITLE
Better proc/lambda route representation in `bin/rails routes`

### DIFF
--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -7,7 +7,14 @@ module ActionDispatch
   module Routing
     class RouteWrapper < SimpleDelegator # :nodoc:
       def endpoint
-        app.dispatcher? ? "#{controller}##{action}" : rack_app.inspect
+        case
+        when app.dispatcher?
+          "#{controller}##{action}"
+        when rack_app.is_a?(Proc)
+          "Inline handler (Proc/Lambda)"
+        else
+          rack_app.inspect
+        end
       end
 
       def constraints

--- a/actionpack/test/dispatch/routing/inspector_test.rb
+++ b/actionpack/test/dispatch/routing/inspector_test.rb
@@ -479,6 +479,16 @@ module ActionDispatch
         ], output
       end
 
+      def test_route_with_proc_handler
+        output = draw do
+          get "/health", to: proc { [200, {}, ["OK"]] }
+        end
+        assert_equal [
+          "Prefix Verb URI Pattern       Controller#Action",
+          "health GET  /health(.:format) Inline handler (Proc/Lambda)"
+        ], output
+      end
+
       private
         def draw(formatter: ActionDispatch::Routing::ConsoleFormatter::Sheet.new, **options, &block)
           @set.draw(&block)


### PR DESCRIPTION
### Summary

Change proc defined route representation from:
```
<Proc:RandomObjectId "/full/path/to/config/routes">
```
To:
```
"Inline handler (Proc/Lambda)"
```

We are using result of `bin/rails routes` inspection in CI automations. We recently added proc defined `/health` endpoint and found out that the result of `bin/rails routes` now changes on every run.
Looking deeper I confirmed that this is a result of `.inspect` call and added a condition for `Proc`s
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Feedback is greatly appreciated.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
