### PR TITLE
Remove obsolete option from new Rails 7.0 defaults

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1742,7 +1742,6 @@ Accepts a string for the HTML tag used to wrap attachments. Defaults to `"action
 - `config.active_support.use_rfc4122_namespaced_uuids`: `true`
 - `config.active_support.disable_to_s_conversion`: `true`
 - `config.action_dispatch.return_only_request_media_type_on_content_type`: `false`
-- `config.action_controller.silence_disabled_session_errors`: `false`
 - `config.action_mailer.smtp_timeout`: `5`
 - `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 - `config.active_record.automatic_scope_inversing`: `true`

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt
@@ -9,10 +9,6 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
-# Raise an error when trying to use forgery protection without a working
-# session.
-# Rails.application.config.action_controller.silence_disabled_session_errors = false
-
 # `button_to` view helper will render `<button>` element, regardless of whether
 # or not the content is passed as the first argument or as a block.
 # Rails.application.config.action_view.button_to_generates_button_tag = true


### PR DESCRIPTION
Option `silence_disabled_session_errors` was removed in 4e3504f thus
setting it results in `Invalid option key` runtime error.
