### PR TITLE
Fix typo in the rdoc for EncryptableRecord.encrypts

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -37,7 +37,7 @@ module ActiveRecord
         #   in preserving it.
         # * <tt>:ignore_case</tt> - When true, it behaves like +:downcase+ but, it also preserves the original case in a specially
         #   designated column +original_<name>+. When reading the encrypted content, the version with the original case is
-        #   server. But you can still execute queries that will ignore the case. This option can only be used when +:deterministic+
+        #   served. But you can still execute queries that will ignore the case. This option can only be used when +:deterministic+
         #   is true.
         # * <tt>:context_properties</tt> - Additional properties that will override +Context+ settings when this attribute is
         #   encrypted and decrypted. E.g: +encryptor:+, +cipher:+, +message_serializer:+, etc.


### PR DESCRIPTION
### Summary

This fixes a minor typo in the EncryptableRecord.encrypts rdoc.
