### PR TITLE
fix: equivalent negative durations add to the same time

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Fix `ActiveSupport::Duration.build` to support negative values.
 
+    The algorithm to collect the `parts` of the `ActiveSupport::Duration`
+    ignored the sign of the `value` and accumulated incorrect part values. This
+    impacted `ActiveSupport::Duration#sum` (which is dependent on `parts`) but
+    not `ActiveSupport::Duration#eql?` (which is dependent on `value`).
+
+    *Caleb Buxton*, *Braden Staudacher*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activesupport/CHANGELOG.md) for previous changes.

--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -191,13 +191,14 @@ module ActiveSupport
         end
 
         parts = {}
-        remainder = value.round(9)
+        remainder_sign = value <=> 0
+        remainder = value.round(9).abs
         variable = false
 
         PARTS.each do |part|
           unless part == :seconds
             part_in_seconds = PARTS_IN_SECONDS[part]
-            parts[part] = remainder.div(part_in_seconds)
+            parts[part] = remainder.div(part_in_seconds) * remainder_sign
             remainder %= part_in_seconds
 
             unless parts[part].zero?
@@ -206,7 +207,7 @@ module ActiveSupport
           end
         end unless value == 0
 
-        parts[:seconds] = remainder
+        parts[:seconds] = remainder * remainder_sign
 
         new(value, parts, variable)
       end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -752,6 +752,17 @@ class DurationTest < ActiveSupport::TestCase
     assert (1.day + 12.hours).variable?
   end
 
+  def test_duration_symmetry
+    time = Time.parse("Dec 7, 2021")
+    expected_time = Time.parse("2021-12-06 23:59:59")
+
+    assert_equal expected_time, time + -1.second
+    assert_equal expected_time, time + ActiveSupport::Duration.build(1) * -1
+    assert_equal expected_time, time + -ActiveSupport::Duration.build(1)
+    assert_equal expected_time, time + ActiveSupport::Duration::Scalar.new(-1)
+    assert_equal expected_time, time + ActiveSupport::Duration.build(-1)
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
### Summary

[Modulo does not work as needed for negative numbers.](https://github.com/rails/rails/pull/43795/files#diff-66736b99a8c384223141d239817575d5903b2eed49fd0481a9fa843cee8ab2e0R197) (thanks @bradenchime for digging into that).

This PR avoids sending negative values into the modulo based parts calculating algorithm of `ActiveSupport::Duration.build`

### Context

I want to help the next person who attempts to use `ActiveSupport::Duration.build` and has negative numbers slip into there in their use case.

This PR makes `ActiveSupport::Duration.build(-1)` not only `== -ActiveSupport::Duration.build(1)` but also results in the same `Time` when added.

I've noticed, in the closed Issues related to `ActiveSupport::Duration` that there is counter intuitive behaviour associated with duration math. However, because `-1.second` or even `ActiveSupport::Duration::Scalar.new(-1)` modifies `Time` as I expected `ActiveSupport::Duration.build(-1)` to, I thought: perhaps this is unexpected behaviour.

### Alternatives

If it is decided to not change the behaviour of `ActiveSupport::Duration.build(-1)` then I humbly propose changing my last `assert_equal` to `refute_equal` and adding (at least) documentation to `ActiveSupport::Duration.build` that it is not expected to work with negative values, and to use `Numeric#second` or `ActiveSupport::Duration::Scalar` (for example) instead.

### Observed Error Rate

This is a single sample of the slippage or error rate in the modification of `Time` with a `ActiveSupport::Duration.build` with a negative value. When I complete collecting the data for the range of whole numbers in a year, I'll be able to share a chart that illustrates the range of errors.

This will ultimately be a graph of the errors introduced in the algorithm by taking a modulo of a negative number.

``` ruby
time = Time.now

a = time + ActiveSupport::Duration.build(-1)
b = time + -ActiveSupport::Duration.build(1)

ActiveSupport::Duration.build((a-b).abs) # => `10 hours, 29 minutes, and 6.0 seconds`
```