### PR TITLE
Move "Sprockets is now an optional dependency" to rails 7 upgrade notes

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -91,6 +91,15 @@ undefined method `mechanism=' for ActiveSupport::Dependencies:Module
 
 Also, make sure `config.cache_classes` is set to `false` in `config/environments/test.rb`.
 
+### Sprockets is now an optional dependency
+
+The gem `rails` doesn't depend on `sprockets-rails` anymore. If your application still needs to use Sprockets,
+make sure to add `sprockets-rails` to your Gemfile.
+
+```
+gem "sprockets-rails"
+```
+
 ### Applications need to run in `zeitwerk` mode
 
 Applications still running in `classic` mode have to switch to `zeitwerk` mode. Please check the [Classic to Zeitwerk HOWTO](https://guides.rubyonrails.org/classic_to_zeitwerk_howto.html) guide for details.
@@ -532,15 +541,6 @@ dependencies before you can upgrade them to `6.0.0`:
 actioncable   → @rails/actioncable
 activestorage → @rails/activestorage
 rails-ujs     → @rails/ujs
-```
-
-### Sprockets is now an optional dependency
-
-The gem `rails` doesn't depend on `sprockets-rails` anymore. If your application still needs to use Sprockets,
-make sure to add `sprockets-rails` to your Gemfile.
-
-```
-gem "sprockets-rails"
 ```
 
 ### Action Cable JavaScript API Changes


### PR DESCRIPTION
### Summary

This section was added in 411ffb464743829925d0d39d913df29f3431ac61 under the "Upgrading from Rails 5.2 to Rails 6.0" chapter:

![image](https://user-images.githubusercontent.com/1863540/145139661-5c77909a-e47b-4077-ae60-f4e58de48ae5.png)

I'm guessing this was a mistake because the `sprockets-rails` dependency wasn't removed until https://github.com/rails/rails/pull/43261 which is part of Rails 7.0. So this PR moves the "Sprockets is now an optional dependency" section to the "Upgrading from Rails 6.1 to Rails 7.0" chapter. I put it just after the note about the Spring version compatibility since both are about potential changes that should be made to the `Gemfile` when upgrading.

cc @rafaelfranca