### PR TITLE
Fix RDoc comment for MigrationContext.migrate

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1080,7 +1080,7 @@ module ActiveRecord
     # 0 then an empty array will be returned and no migrations
     # will be run.
     #
-    # If the +current_version+ in the schema is less than
+    # If the +current_version+ in the schema is greater than
     # the +target_version+, then +down+ will be run.
     #
     # If none of the conditions are met, +up+ will be run with


### PR DESCRIPTION
### Summary

👋 This is a RDoc comment change only -- no code changes here :v: 

The RDoc comment for `MigrationContext.migrate` said that the `down` method would be called if the `current_version` is _less_ than the `target_version`. However, the code clearly shows that the `down` method is called when the `current_version` is _greater_ than `target_version`, not less. 

```ruby
  MigrationContext.migrate
    def migrate(target_version = nil, &block)
      case
      when target_version.nil?
        up(target_version, &block)
      when current_version == 0 && target_version == 0
        []
      when current_version > target_version  # <---- this line here 😄 
        down(target_version, &block)
      else
        up(target_version, &block)
      end
    end
```