### PR TITLE
Fix `RackupTest#test_config.ru_can_be_racked_up` failure

### DIFF
--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -95,7 +95,7 @@ module TestHelpers
       assert_equal 200, resp[0]
       assert_match "text/html", resp[1]["Content-Type"]
       assert_match "charset=utf-8", resp[1]["Content-Type"]
-      assert extract_body(resp).match(/Yay! You.*re on Rails!/)
+      assert extract_body(resp).match(/<title>Ruby on Rails<\/title>/)
     end
   end
 


### PR DESCRIPTION
### Summary

This pull request follows up the boot screen change since https://github.com/rails/rails/commit/5889e6ba9255a6ae6eb14992b297dd1021d01c21

```ruby
$ cd railties
$ bin/test test/application/rackup_test.rb -n test_config.ru_can_be_racked_up
Run options: -n test_config.ru_can_be_racked_up --seed 54440

F

Failure:
ApplicationTests::RackupTest#test_config.ru_can_be_racked_up [/home/yahonda/src/github.com/rails/rails/railties/test/application/rackup_test.rb:30]:
Expected nil to be truthy.

bin/test test/application/rackup_test.rb:27

Finished in 0.644876s, 1.5507 runs/s, 9.3041 assertions/s.
1 runs, 6 assertions, 1 failures, 0 errors, 0 skips
$
```
