### PR TITLE
Use dynamic Rails version in framework dummy apps

### DIFF
--- a/actionmailbox/test/dummy/config/application.rb
+++ b/actionmailbox/test/dummy/config/application.rb
@@ -7,7 +7,7 @@ Bundler.require(*Rails.groups)
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults Rails::VERSION::STRING.to_f
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/actiontext/test/dummy/config/application.rb
+++ b/actiontext/test/dummy/config/application.rb
@@ -8,7 +8,7 @@ require "action_text"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults Rails::VERSION::STRING.to_f
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/activestorage/test/dummy/config/application.rb
+++ b/activestorage/test/dummy/config/application.rb
@@ -15,7 +15,7 @@ Bundler.require(*Rails.groups)
 
 module Dummy
   class Application < Rails::Application
-    config.load_defaults 7.1
+    config.load_defaults Rails::VERSION::STRING.to_f
 
     config.active_storage.service = :local
   end


### PR DESCRIPTION
This matches what we [currently generate for plugin dummy apps](https://github.com/rails/rails/blob/v7.0.0.rc1/railties/lib/rails/generators/rails/app/templates/config/application.rb.tt#L31).
