### PR TITLE
Fix `assert_called_with` with empty `args` array

### DIFF
--- a/activerecord/test/cases/secure_password_test.rb
+++ b/activerecord/test/cases/secure_password_test.rb
@@ -68,11 +68,11 @@ class SecurePasswordTest < ActiveRecord::TestCase
   test "authenticate_by accepts any object that implements to_h" do
     params = Enumerator.new { raise "must access via to_h" }
 
-    assert_called_with(params, :to_h, [[]], returns: { token: @user.token, password: @user.password }) do
+    assert_called_with(params, :to_h, [], returns: { token: @user.token, password: @user.password }) do
       assert_equal @user, User.authenticate_by(params)
     end
 
-    assert_called_with(params, :to_h, [[]], returns: { token: "wrong", password: @user.password }) do
+    assert_called_with(params, :to_h, [], returns: { token: "wrong", password: @user.password }) do
       assert_nil User.authenticate_by(params)
     end
   end

--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -20,8 +20,8 @@ module ActiveSupport
         def assert_called_with(object, method_name, args, returns: nil, &block)
           mock = Minitest::Mock.new
 
-          if args.all?(Array)
-            args.each { |arg| mock.expect(:call, returns, arg) }
+          if !args.empty? && args.all?(Array)
+            args.each { |argv| mock.expect(:call, returns, argv) }
           else
             mock.expect(:call, returns, args)
           end


### PR DESCRIPTION
`[].all?(Array)` returns `true`.  Thus when an empty `args` array was passed to `assert_called_with`, `expect` would not be called on the mock object, eventually leading to an "unmocked method" error.

This commit allows an empty array to be passed as `args`, which behaves the same as passing `[[]]`.
