### PR TITLE
Reduce allocations made by HashWithIndifferentAccess.new and #update with a block

### DIFF
--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -129,10 +129,10 @@ module ActiveSupport
     #   hash_1.update(hash_2) { |key, old, new| old + new } # => {"key"=>22}
     def update(*other_hashes, &block)
       if other_hashes.size == 1
-        update_with_single_argument(other_hashes.first, block)
+        update_with_single_argument(other_hashes.first, &block)
       else
         other_hashes.each do |other_hash|
-          update_with_single_argument(other_hash, block)
+          update_with_single_argument(other_hash, &block)
         end
       end
       self
@@ -405,7 +405,7 @@ module ActiveSupport
         end
       end
 
-      def update_with_single_argument(other_hash, block)
+      def update_with_single_argument(other_hash, &block)
         if other_hash.is_a? HashWithIndifferentAccess
           regular_update(other_hash, &block)
         else

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -68,7 +68,7 @@ module ActiveSupport
     def initialize(constructor = nil)
       if constructor.respond_to?(:to_hash)
         super()
-        update(constructor)
+        update_with_single_argument(constructor)
 
         hash = constructor.is_a?(Hash) ? constructor : constructor.to_hash
         self.default = hash.default if hash.default

--- a/activesupport/lib/active_support/hash_with_indifferent_access.rb
+++ b/activesupport/lib/active_support/hash_with_indifferent_access.rb
@@ -410,8 +410,8 @@ module ActiveSupport
           regular_update(other_hash, &block)
         else
           other_hash.to_hash.each_pair do |key, value|
-            if block && key?(key)
-              value = block.call(convert_key(key), self[key], value)
+            if block_given? && key?(key)
+              value = yield(convert_key(key), self[key], value)
             end
             regular_writer(convert_key(key), convert_value(value))
           end


### PR DESCRIPTION
Benchmark:
```ruby
require 'active_support/hash_with_indifferent_access'
require 'objspace'
hash1 = {foo: 1}
hash2 = {foo: 2}

GC.disable
arrays = ObjectSpace.each_object(Array).count
procs = ObjectSpace.each_object(Proc).count
10000.times do
  ActiveSupport::HashWithIndifferentAccess.new(hash1).update(hash2) do |key, old, new|
    old & new
  end
end
p(Array: ObjectSpace.each_object(Array).count - arrays,
  Proc: ObjectSpace.each_object(Proc).count - procs)
```

I have tested the changes after every commit.

Before changes:
{:Array=>20002,:Proc=>10000}

1. Use standard way to pass a block - no penalty since Ruby 2.5
{:Array=>20002,:Proc=>10000}

2. Use yield instead of block.call to avoid allocating a Proc object
{:Array=>20002,:Proc=>0}

3. Avoid extra Array allocation
{:Array=>10002,:Proc=>0}
