### PR TITLE
[Backport] [7-0-stable] fix: equivalent negative durations add to the same time

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -191,13 +191,14 @@ module ActiveSupport
         end
 
         parts = {}
-        remainder = value.round(9)
+        remainder_sign = value <=> 0
+        remainder = value.round(9).abs
         variable = false
 
         PARTS.each do |part|
           unless part == :seconds
             part_in_seconds = PARTS_IN_SECONDS[part]
-            parts[part] = remainder.div(part_in_seconds)
+            parts[part] = remainder.div(part_in_seconds) * remainder_sign
             remainder %= part_in_seconds
 
             unless parts[part].zero?
@@ -206,7 +207,7 @@ module ActiveSupport
           end
         end unless value == 0
 
-        parts[:seconds] = remainder
+        parts[:seconds] = remainder * remainder_sign
 
         new(value, parts, variable)
       end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -752,6 +752,17 @@ class DurationTest < ActiveSupport::TestCase
     assert (1.day + 12.hours).variable?
   end
 
+  def test_duration_symmetry
+    time = Time.parse("Dec 7, 2021")
+    expected_time = Time.parse("2021-12-06 23:59:59")
+
+    assert_equal expected_time, time + -1.second
+    assert_equal expected_time, time + ActiveSupport::Duration.build(1) * -1
+    assert_equal expected_time, time + -ActiveSupport::Duration.build(1)
+    assert_equal expected_time, time + ActiveSupport::Duration::Scalar.new(-1)
+    assert_equal expected_time, time + ActiveSupport::Duration.build(-1)
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
See: https://github.com/rails/rails/pull/43795