### PR TITLE
[Backport] [6-1-stable] fix: equivalent negative durations add to the same time

### DIFF
--- a/activesupport/lib/active_support/duration.rb
+++ b/activesupport/lib/active_support/duration.rb
@@ -186,17 +186,18 @@ module ActiveSupport
         end
 
         parts = {}
-        remainder = value.round(9)
+        remainder_sign = value <=> 0
+        remainder = value.round(9).abs
 
         PARTS.each do |part|
           unless part == :seconds
             part_in_seconds = PARTS_IN_SECONDS[part]
-            parts[part] = remainder.div(part_in_seconds)
+            parts[part] = remainder.div(part_in_seconds) * remainder_sign
             remainder %= part_in_seconds
           end
         end unless value == 0
 
-        parts[:seconds] = remainder
+        parts[:seconds] = remainder * remainder_sign
 
         new(value, parts)
       end

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -735,6 +735,17 @@ class DurationTest < ActiveSupport::TestCase
     assert_equal "can't build an ActiveSupport::Duration from a NilClass", error.message
   end
 
+  def test_duration_symmetry
+    time = Time.parse("Dec 7, 2021")
+    expected_time = Time.parse("2021-12-06 23:59:59")
+
+    assert_equal expected_time, time + -1.second
+    assert_equal expected_time, time + ActiveSupport::Duration.build(1) * -1
+    assert_equal expected_time, time + -ActiveSupport::Duration.build(1)
+    assert_equal expected_time, time + ActiveSupport::Duration::Scalar.new(-1)
+    assert_equal expected_time, time + ActiveSupport::Duration.build(-1)
+  end
+
   private
     def eastern_time_zone
       if Gem.win_platform?


### PR DESCRIPTION
See: https://github.com/rails/rails/pull/43795