### PR TITLE
Remove memoization for limited_count

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -33,7 +33,6 @@ module ActiveRecord
       @delegate_to_klass = false
       @future_result = nil
       @records = nil
-      @limited_count = nil
     end
 
     def initialize_copy(other)
@@ -699,7 +698,6 @@ module ActiveRecord
       @offsets = @take = nil
       @cache_keys = nil
       @records = nil
-      @limited_count = nil
       self
     end
 
@@ -974,7 +972,7 @@ module ActiveRecord
       end
 
       def limited_count
-        @limited_count ||= limit_value ? count : limit(2).count
+        limit_value ? count : limit(2).count
       end
   end
 end

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1216,6 +1216,18 @@ class RelationTest < ActiveRecord::TestCase
     assert_predicate posts, :loaded?
   end
 
+  def test_one_with_destroy
+    posts = Post.all
+    assert_queries(1) do
+      assert_not posts.one?
+    end
+
+    posts.where.not(id: Post.first).destroy_all
+
+    assert_equal 1, posts.size
+    assert posts.one?
+  end
+
   def test_to_a_should_dup_target
     posts = Post.all
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

If a relation's records are not loaded and `@limited_count` gets set, when some of the records are subsequently deleted then the memoized value for `@limited_count` is inconsistent with the value returned by a call to size. In such a case calls to `one?` and `many?` can be incorrect. This is a fix for https://github.com/rails/rails/issues/43801.

### Other Information 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
