### PR TITLE
Deprecate non-URL-safe CSRF tokens

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -92,7 +92,16 @@ module ActionController # :nodoc:
 
       # Controls whether URL-safe CSRF tokens are generated.
       config_accessor :urlsafe_csrf_tokens, instance_writer: false
-      self.urlsafe_csrf_tokens = false
+      self.urlsafe_csrf_tokens = true
+
+      singleton_class.redefine_method(:urlsafe_csrf_tokens=) do |urlsafe_csrf_tokens|
+        if urlsafe_csrf_tokens
+          ActiveSupport::Deprecation.warn("URL-safe CSRF tokens are now the default. Use 6.1 defaults or above.")
+        else
+          ActiveSupport::Deprecation.warn("Non-URL-safe CSRF tokens are deprecated. Use 6.1 defaults or above.")
+        end
+        config.urlsafe_csrf_tokens = urlsafe_csrf_tokens
+      end
 
       helper_method :form_authenticity_token
       helper_method :protect_against_forgery?

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -193,15 +193,12 @@ end
 # common test methods
 module RequestForgeryProtectionTests
   def setup
-    @old_urlsafe_csrf_tokens = ActionController::Base.urlsafe_csrf_tokens
-    ActionController::Base.urlsafe_csrf_tokens = true
     @token = Base64.urlsafe_encode64("railstestrailstestrailstestrails")
     @old_request_forgery_protection_token = ActionController::Base.request_forgery_protection_token
     ActionController::Base.request_forgery_protection_token = :custom_authenticity_token
   end
 
   def teardown
-    ActionController::Base.urlsafe_csrf_tokens = @old_urlsafe_csrf_tokens
     ActionController::Base.request_forgery_protection_token = @old_request_forgery_protection_token
   end
 
@@ -408,8 +405,9 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_allow_post_with_urlsafe_token_when_migrating
-    config_before = ActionController::Base.urlsafe_csrf_tokens
-    ActionController::Base.urlsafe_csrf_tokens = false
+    ActiveSupport::Deprecation.silence do
+      ActionController::Base.urlsafe_csrf_tokens = false
+    end
     token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
     token_including_url_safe_chars = "-_".ljust(token_length, "A")
     session[:_csrf_token] = token_including_url_safe_chars
@@ -417,7 +415,18 @@ module RequestForgeryProtectionTests
       assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_safe_chars } }
     end
   ensure
-    ActionController::Base.urlsafe_csrf_tokens = config_before
+    ActiveSupport::Deprecation.silence do
+      ActionController::Base.urlsafe_csrf_tokens = true
+    end
+  end
+
+  def test_should_warn_about_deprecation_for_urlsafe_config
+    assert_deprecated do
+      ActionController::Base.urlsafe_csrf_tokens = false
+    end
+    assert_deprecated do
+      ActionController::Base.urlsafe_csrf_tokens = true
+    end
   end
 
   def test_should_allow_patch_with_token

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -84,6 +84,7 @@ module Rails
           if respond_to?(:action_controller)
             action_controller.per_form_csrf_tokens = true
             action_controller.forgery_protection_origin_check = true
+            action_controller.urlsafe_csrf_tokens = false
           end
 
           ActiveSupport.to_time_preserves_timezone = true
@@ -169,7 +170,7 @@ module Rails
           end
 
           if respond_to?(:action_controller)
-            action_controller.urlsafe_csrf_tokens = true
+            action_controller.delete(:urlsafe_csrf_tokens)
           end
 
           if respond_to?(:action_view)


### PR DESCRIPTION
This also deprecates setting `urlsafe_csrf_tokens` to true, so that we can remove the configuration entirely in Rails 7.1.

### Summary

Follow-up to #39076. This deprecates the configuration option in Rails 7.0.
We will be able to remove the option in the next minor.

### Other Information

This doesn't need to go out in 7.0.0 but it should go in 7-0-stable since we want to deprecate during that minor to be able to remove the configuration in 7.1. If I'm not mistaken, PRs to main will go for 7.1 now, so I build this against 7-0-stable.

cc @byroot @rafaelfranca