### PR TITLE
Backport #42684 and #42685 to `7-0-stable`

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -94,10 +94,6 @@ module Rails
     def test
       template "test/test_helper.rb"
       template "test/%namespaced_name%_test.rb"
-      append_file "Rakefile", <<~EOF
-        #{rakefile_test_tasks}
-        task default: :test
-      EOF
 
       if engine?
         empty_directory_with_keep_file "test/fixtures/files"
@@ -416,18 +412,6 @@ module Rails
 
       def get_builder_class
         defined?(::PluginBuilder) ? ::PluginBuilder : Rails::PluginBuilder
-      end
-
-      def rakefile_test_tasks
-        <<-RUBY
-require "rake/testtask"
-
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.pattern = "test/**/*_test.rb"
-  t.verbose = false
-end
-        RUBY
       end
 
       def dummy_path(path = nil)

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -394,6 +394,10 @@ module Rails
         end
       end
 
+      def rails_version_specifier(gem_version = Rails.gem_version)
+        [">= #{gem_version}"]
+      end
+
       def valid_const?
         if /-\d/.match?(original_name)
           raise Error, "Invalid plugin name #{original_name}. Please give a name which does not contain a namespace starting with numeric characters."

--- a/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/test/test_helper.rb.tt
@@ -10,11 +10,6 @@ ActiveRecord::Migrator.migrations_paths << File.expand_path("../db/migrate", __d
 <% end -%>
 require "rails/test_help"
 
-<% unless engine? -%>
-require "rails/test_unit/reporter"
-Rails::TestUnitReporter.executable = "bin/test"
-<% end -%>
-
 <% unless options[:skip_active_record] -%>
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -537,6 +537,16 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "bukkits.gemspec", /spec\.version\s+ = Bukkits::VERSION/
   end
 
+  def test_gemspec_uses_optimistic_rails_version_constraint
+    rails_version = "1.2.3.4.pre5"
+
+    Rails.stub(:gem_version, Gem::Version.new(rails_version)) do
+      run_generator
+    end
+
+    assert_file "bukkits.gemspec", /add_dependency "rails", ">= #{Regexp.escape rails_version}"/
+  end
+
   def test_usage_of_engine_commands
     run_generator [destination_root, "--full"]
     assert_file "bin/rails", /ENGINE_PATH = File\.expand_path\("\.\.\/lib\/bukkits\/engine", __dir__\)/

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -71,7 +71,6 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     assert_file "test/test_helper.rb" do |content|
       assert_match(/require_relative.+test\/dummy\/config\/environment/, content)
       assert_match(/ActiveRecord::Migrator\.migrations_paths.+test\/dummy\/db\/migrate/, content)
-      assert_match(/Rails::TestUnitReporter\.executable = "bin\/test"/, content)
     end
     assert_file "lib/bukkits/railtie.rb", /module Bukkits\n  class Railtie < ::Rails::Railtie\n  end\nend/
     assert_file "lib/bukkits.rb" do |content|
@@ -317,7 +316,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
     run_generator [destination_root, "--full", "--skip_active_record"]
     FileUtils.cd destination_root
     quietly { system "bundle install" }
-    assert_match(/1 runs, 1 assertions, 0 failures, 0 errors/, `bundle exec rake test 2>&1`)
+    assert_match(/1 runs, 1 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
   end
 
   def test_ensure_that_migration_tasks_work_with_mountable_option

--- a/railties/test/generators/plugin_test_runner_test.rb
+++ b/railties/test/generators/plugin_test_runner_test.rb
@@ -105,12 +105,6 @@ class PluginTestRunnerTest < ActiveSupport::TestCase
       capture(:stderr) { run_test_command("test/models/warnings_test.rb -w") })
   end
 
-  def test_run_rake_test
-    create_test_file "foo"
-    result = Dir.chdir(plugin_path) { `rake test TEST=test/foo_test.rb` }
-    assert_match "1 runs, 1 assertions, 0 failures", result
-  end
-
   private
     def plugin_path
       "#{@destination_root}/bukkits"


### PR DESCRIPTION
Since #42684 and #42685 affect newly generated plugins, I thought it would be good to get them in to 7.0.