### PR TITLE
Handle broken encoding in `#write_query?`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -68,7 +68,7 @@ module ActiveRecord
       def self.build_read_query_regexp(*parts) # :nodoc:
         parts += DEFAULT_READ_QUERY
         parts = parts.map { |part| /#{part}/i }
-        /\A(?:[(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/
+        /\A(?:[(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/n
       end
 
       def self.quoted_column_names # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -26,6 +26,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def explain(arel, binds = [])

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -28,6 +28,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         # Executes an SQL statement, returning a PG::Result object on success

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -11,6 +11,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def explain(arel, binds = [])

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -51,6 +51,25 @@ module ActiveRecord
       end
     end
 
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_doesnt_error_when_a_select_query_has_encoding_errors
+        ActiveRecord::Base.while_preventing_writes do
+          # Contrary to other adapters, Postgres will eagerly fail on encoding errors.
+          # But at least we can assert it fails in the client and not before when trying to
+          # match the query.
+          assert_raises ActiveRecord::StatementInvalid do
+            @connection.select_all("SELECT '\xC8'")
+          end
+        end
+      end
+    else
+      def test_doesnt_error_when_a_select_query_has_encoding_errors
+        ActiveRecord::Base.while_preventing_writes do
+          @connection.select_all("SELECT '\xC8'")
+        end
+      end
+    end
+
     def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
       @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')")
 


### PR DESCRIPTION
If the SQL encoding somehow is invalid, `Regexp#match?` raises `ArgumentError`.

Best we can do is to copy the string and try to match the regexp in "binary" mode.

Hopefully these cases are rare enough that the string copy shouldn't be an important overhead.

cc @rafaelfranca (we might want to backport this to 7.0).
cc @CelineBen who initially reported the issue to me.
cc @kamipo @eileencodes because I believe you worked on this area.

Also PS: I though this code was introduced in 7, but it might actually be older than that.