### PR TITLE
Fixes typo in 7_0 release notes

### DIFF
--- a/guides/source/7_0_release_notes.md
+++ b/guides/source/7_0_release_notes.md
@@ -117,7 +117,7 @@ Please refer to the [Changelog][active-record] for detailed changes.
 
 *   Remove deprecated support to YAML load `ActiveRecord::Base` instance in the Rails 4.2 and 4.1 formats.
 
-*   Remove deprecation warning when using `:interval` column is used in PostgreSQL database.
+*   Remove deprecation warning when `:interval` column is used in PostgreSQL database.
 
     Now, interval columns will return `ActiveSupport::Duration` objects instead of strings.
 


### PR DESCRIPTION
### Summary
Quick typo fix in the 7_0 guides
Please edit further if required for better readability.