### PR TITLE
Better handle SQL queries with invalid encoding

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,17 @@
+* Better handle SQL queries with invalid encoding.
+
+  ```ruby
+  Post.create(name: "broken \xC8 UTF-8")
+  ```
+
+  Would cause all adapters to fail in a non controlled way in the code
+  responsible to detect write queries.
+
+  The query is now properly passed to the database connection, which might or might
+  not be able to handle it, but will either succeed or failed in a more correct way.
+
+  *Jean Boussier*
+
 ## Rails 7.0.0.rc1 (December 06, 2021) ##
 
 *   Move database and shard selection config options to a generator.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -68,7 +68,7 @@ module ActiveRecord
       def self.build_read_query_regexp(*parts) # :nodoc:
         parts += DEFAULT_READ_QUERY
         parts = parts.map { |part| /#{part}/i }
-        /\A(?:[(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/
+        /\A(?:[(\s]|#{COMMENT_REGEX})*#{Regexp.union(*parts)}/n
       end
 
       def self.quoted_column_names # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -26,6 +26,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def explain(arel, binds = [])

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -28,6 +28,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         # Executes an SQL statement, returning a PG::Result object on success

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -11,6 +11,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def explain(arel, binds = [])

--- a/activerecord/test/cases/adapter_prevent_writes_test.rb
+++ b/activerecord/test/cases/adapter_prevent_writes_test.rb
@@ -51,6 +51,25 @@ module ActiveRecord
       end
     end
 
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_doesnt_error_when_a_select_query_has_encoding_errors
+        ActiveRecord::Base.while_preventing_writes do
+          # Contrary to other adapters, Postgres will eagerly fail on encoding errors.
+          # But at least we can assert it fails in the client and not before when trying to
+          # match the query.
+          assert_raises ActiveRecord::StatementInvalid do
+            @connection.select_all("SELECT '\xC8'")
+          end
+        end
+      end
+    else
+      def test_doesnt_error_when_a_select_query_has_encoding_errors
+        ActiveRecord::Base.while_preventing_writes do
+          @connection.select_all("SELECT '\xC8'")
+        end
+      end
+    end
+
     def test_doesnt_error_when_a_select_query_is_called_while_preventing_writes
       @connection.insert("INSERT INTO subscribers(nick) VALUES ('138853948594')")
 


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/43821

If the SQL encoding somehow is invalid, `Regexp#match?` raises `ArgumentError`.

Best we can do is to copy the string and try to match the regexp in "binary" mode.

Hopefully these cases are rare enough that the string copy should be an important overhead.

cc @rafaelfranca 