### PR TITLE
Better handle SQL queries with invalid encoding

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+* Better handle SQL queries with invalid encoding.
+
+    ```ruby
+    Post.create(name: "broken \xC8 UTF-8")
+    ```
+
+    Would cause all adapters to fail in a non controlled way in the code
+    responsible to detect write queries.
+
+    The query is now properly passed to the database connection, which might or might
+    not be able to handle it, but will either succeed or failed in a more correct way.
+
+    *Jean Boussier*
+
+
 *   Ignore persisted in-memory records when merging target lists.
 
     *Kevin Sjöberg*

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -26,6 +26,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def explain(arel, binds = [])

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -28,6 +28,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         # Executes an SQL statement, returning a PG::Result object on success

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -11,6 +11,8 @@ module ActiveRecord
 
         def write_query?(sql) # :nodoc:
           !READ_QUERY.match?(sql)
+        rescue ArgumentError # Invalid encoding
+          !READ_QUERY.match?(sql.b)
         end
 
         def explain(arel, binds = [])


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/43821

If the SQL encoding somehow is invalid, `Regexp#match?` raises `ArgumentError`.

Best we can do is to copy the string and try to match
the regexp in "binary" mode.

Hopefully these cases are rare enough that the string copy
should be an important overhead.
