### PR TITLE
Use Ruby regex for email validation in guide example

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -1094,7 +1094,7 @@ instance.
 ```ruby
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless value =~ URI::MailTo::EMAIL_REGEXP
       record.errors.add attribute, (options[:message] || "is not an email")
     end
   end


### PR DESCRIPTION
existing email regex allowed for invalid emails and invalidated valid emails

- The following emails are shown to be valid emails when they are not:
    - `email_<script></script>_123@example.co.in`
    - `email"123@example.com`

- The following email is shown to be an invalid email when it is valid:
    - `email@123.123.12.123`

Lets use the default ruby regex instead