### PR TITLE
Don't start the server for the failure screenshot

### DIFF
--- a/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
+++ b/actionpack/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb
@@ -42,7 +42,7 @@ module ActionDispatch
         #
         # +take_failed_screenshot+ is called during system test teardown.
         def take_failed_screenshot
-          take_screenshot if failed? && supports_screenshot?
+          take_screenshot if failed? && supports_screenshot? && Capybara::Session.instance_created?
         end
 
         private


### PR DESCRIPTION
### Summary

When `before_setup` fails, for example with fixture errors, the failure is stored, `setup` is skipped, and `take_failed_screenshot` is called.  Taking a screenshot triggers starting the server which will probably fail since fixtures are not properly loaded.  This generates another failure and makes it harder to debug the fixture failure.

If the server was not already started, it makes no sense to take a screenshot since it is not relevant.

This commit skips taking a failure screenshot if no browser session has been started.

### Other Information

Tested with Rails 6.1.4.1.
