### PR TITLE
Remove no longer needed workaround

### DIFF
--- a/activerecord/lib/active_record/type/adapter_specific_registry.rb
+++ b/activerecord/lib/active_record/type/adapter_specific_registry.rb
@@ -56,11 +56,7 @@ module ActiveRecord
       end
 
       def call(_registry, *args, adapter: nil, **kwargs)
-        if kwargs.any? # https://bugs.ruby-lang.org/issues/10856
-          block.call(*args, **kwargs)
-        else
-          block.call(*args)
-        end
+        block.call(*args, **kwargs)
       end
 
       def matches?(type_name, *args, **kwargs)


### PR DESCRIPTION
### Summary

It looks like https://bugs.ruby-lang.org/issues/10856 has fixed on Ruby 2.7, as Rails minimum requires 2.7, this workaround are no longer needed