### PR TITLE
Generator: Mark `<html>` with `[lang]`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Generate `app/views/layouts/application.html.erb` template's `<html>` with
+  the `[lang]` attribute set to the value of `I18n.locale`.
 
+  *Sean Doyle*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/app/views/layouts/application.html.erb.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%%= I18n.locale %>">
   <head>
     <title><%= camelized %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -550,6 +550,14 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  def test_html_lang_attribute_is_present
+    run_generator [destination_root]
+
+    assert_file "app/views/layouts/application.html.erb" do |contents|
+      assert_includes contents, %(<html lang="<%= I18n.locale %>">)
+    end
+  end
+
   def test_viewport_meta_tag_is_present
     run_generator [destination_root]
 


### PR DESCRIPTION
By default, elements declared without an ancestor with [lang][] set
default to "unknown", which can pose problems with Assistive
Technologies.

This commit modifies the generated
`app/views/layouts/application.html.erb` template to scope the entire
document to the value of the `I18n.locale`.

[lang]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang