### PR TITLE
Move "show" link from partial to index template.

### DIFF
--- a/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/index.html.erb.tt
@@ -3,7 +3,12 @@
 <h1><%= human_name.pluralize %></h1>
 
 <div id="<%= plural_table_name %>">
-  <%%= render @<%= plural_table_name %> %>
+  <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
+    <%%= render <%= singular_table_name %> %>
+    <p>
+      <%%= link_to "Show this <%= human_name.downcase %>", <%= singular_name %> %>
+    </p>
+  <%% end %>
 </div>
 
 <%%= link_to "New <%= human_name.downcase %>", new_<%= singular_route_name %>_path %>

--- a/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
+++ b/railties/lib/rails/generators/erb/scaffold/templates/partial.html.erb.tt
@@ -14,7 +14,4 @@
   </p>
 
 <% end -%>
-  <p>
-    <%%= link_to "Show this <%= human_name.downcase %>", <%= singular_name %> %>
-  </p>
 </div>


### PR DESCRIPTION
### Summary

The redesigned scaffold template is rendering a link to the `show` action of a resource on the `show` page.  This PR moves that link to the `index` page.

fixes #43843
