### PR TITLE
Fix a mistype when calling ArgumentError

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -569,7 +569,7 @@ module ActiveRecord
               else raise ArgumentError, "No integer type has byte size #{limit}. Use a numeric with scale 0 instead."
               end
             when "enum"
-              raise ArgumentError "enum_type is required for enums" if enum_type.nil?
+              raise ArgumentError, "enum_type is required for enums" if enum_type.nil?
 
               enum_type
             else


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

```
undefined method `ArgumentError' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
```

There is a mistype that was introduced here https://github.com/rails/rails/commit/4eef348584087c81f1e32ad971baf632b0149cd4
