### PR TITLE
fix test method naming

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -336,7 +336,7 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_equal "1974522598", book.isbn, "Should have updated the isbn"
   end
 
-  def test_passing_both_on_update_and_update_only_will_raise_an_error
+  def test_upsert_all_passing_both_on_duplicate_and_update_only_will_raise_an_error
     assert_raises ArgumentError do
       Book.upsert_all [{ id: 101, name: "Perelandra", author_id: 7, isbn: "1974522598" }], on_duplicate: "NAME=values(name)", update_only: :name
     end


### PR DESCRIPTION
### Replaces test method name. 

I was reading this PR https://github.com/rails/rails/pull/43470 and I noticed a test method with a strange naming. 

Maybe it's better to replace `on_update` with `on_duplicate` to make the test name clear and add `upsert_all` in the begging of the method name after the word "test", to keep all the tests for **upsert_all** with the same "prefix".

currently: `test_passing_both_on_update_and_update_only_will_raise_an_error` 

suggestion: `test_upsert_all_passing_both_on_duplicate_and_update_only_will_raise_an_error`



