### PR TITLE
fix missing require leading to uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -7,6 +7,7 @@ require "bigdecimal/util"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/date_time/calculations"
+require "active_support/isolated_execution_state"
 
 module ActiveSupport
   # = XmlMini


### PR DESCRIPTION
fixes #43851, found via cocoapods usage of activesupport

### Summary

This constant was used but not loaded when doing:

```ruby
require 'active_support/core_ext/array/conversions'
```

### Other Information

Found when using cocoapods via `pod install` for instance