### PR TITLE
Fix missing return from ActionView::Helpers::NumberHelper#parse_float

### DIFF
--- a/actionview/lib/action_view/helpers/number_helper.rb
+++ b/actionview/lib/action_view/helpers/number_helper.rb
@@ -450,6 +450,7 @@ module ActionView
         def parse_float(number, raise_error)
           result = Float(number, exception: false)
           raise InvalidNumberError, number if result.nil? && raise_error
+          result
         end
     end
   end

--- a/actionview/test/template/number_helper_test.rb
+++ b/actionview/test/template/number_helper_test.rb
@@ -201,4 +201,34 @@ class NumberHelperTest < ActionView::TestCase
     end
     assert_equal "x", exception.number
   end
+
+  def test_number_helpers_should_not_raise_error_if_valid_when_specified
+    assert_nothing_raised do
+      number_to_human("3.33", raise: true)
+    end
+
+    assert_nothing_raised do
+      number_to_human_size("3.33", raise: true)
+    end
+
+    assert_nothing_raised do
+      number_with_precision("3.33", raise: true)
+    end
+
+    assert_nothing_raised do
+      number_to_currency("3.33", raise: true)
+    end
+
+    assert_nothing_raised do
+      number_to_percentage("3.33", raise: true)
+    end
+
+    assert_nothing_raised do
+      number_with_delimiter("3.33", raise: true)
+    end
+
+    assert_nothing_raised do
+      number_to_phone("3.33", raise: true)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

- Fixes #43853
- Add test case for number helpers not raising exception when `raise: true` is passed and input is valid
