### PR TITLE
Clarify `button_to` helper changes in Rails 7.0

### DIFF
--- a/guides/source/7_0_release_notes.md
+++ b/guides/source/7_0_release_notes.md
@@ -88,6 +88,15 @@ Please refer to the [Changelog][action-view] for detailed changes.
 
 ### Notable changes
 
+*  `button_to` infers HTTP verb [method] from an Active Record object if object is used to build URL
+
+    ```ruby
+    button_to("Do a POST", [:do_post_action, Workshop.find(1)])
+    # Before
+    #=>   <input type="hidden" name="_method" value="post" autocomplete="off" />
+    # After
+    #=>   <input type="hidden" name="_method" value="patch" autocomplete="off" />
+
 Action Mailer
 -------------
 

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -81,6 +81,23 @@ Upgrading from Rails 7.0 to Rails 7.1
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 
+### `ActionView::Helpers::UrlHelper#button_to` changed behavior
+
+Starting from Rails 7.0 `button_to` renders a `form` tag with `patch` HTTP verb if a persisted Active Record object is used to build button URL.
+To keep current behavior consider explicitly passing `method:` option:
+
+```diff
+-button_to("Do a POST", [:my_custom_post_action_on_workshop, Workshop.find(1)])
++button_to("Do a POST", [:my_custom_post_action_on_workshop, Workshop.find(1)], method: :post)
+```
+
+or using helper to build the URL:
+
+```diff
+-button_to("Do a POST", [:my_custom_post_action_on_workshop, Workshop.find(1)])
++button_to("Do a POST", my_custom_post_action_on_workshop_workshop_path(Workshop.find(1)))
+```
+
 ### Spring
 
 If your application uses Spring, it needs to be upgraded to at least version 3.0.0. Otherwise you'll get


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/43413 PR introduced some handy changes to the `button_to` helper behaviour 

However it may be a breaking change for some applications. 

I would like to make the chance as explicit as possible and help developers during Rails upgrades by updating release notes & upgrade guide.
Release notes just mentions the change in the behaviour and upgrade guide has a few examples on how to keep the current behaviour

Please feel free to suggest any changes in wording or examples. Thanks! 
