### PR TITLE
Eager autoload JoinDependency

### DIFF
--- a/activerecord/lib/active_record/associations/join_dependency.rb
+++ b/activerecord/lib/active_record/associations/join_dependency.rb
@@ -3,8 +3,12 @@
 module ActiveRecord
   module Associations
     class JoinDependency # :nodoc:
-      autoload :JoinBase,        "active_record/associations/join_dependency/join_base"
-      autoload :JoinAssociation, "active_record/associations/join_dependency/join_association"
+      extend ActiveSupport::Autoload
+
+      eager_autoload do
+        autoload :JoinBase
+        autoload :JoinAssociation
+      end
 
       class Aliases # :nodoc:
         def initialize(tables)


### PR DESCRIPTION
Previously `JoinDependency` was being eagerly autoloaded, but its two dependencies under its namespace were not, causing them to be loaded at runtime.