### PR TITLE
add job perform_now!

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Add `ActiveJob::Base.perform_now!` and `ActiveJob::Base#perform_now!`.
 
+     *Timo Schilling*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activejob/CHANGELOG.md) for previous changes.

--- a/activejob/test/cases/rescue_test.rb
+++ b/activejob/test/cases/rescue_test.rb
@@ -22,6 +22,13 @@ class RescueTest < ActiveSupport::TestCase
     end
   end
 
+  test "let through perform exception" do
+    job = RescueJob.new("david")
+    assert_raises(ArgumentError) do
+      job.perform_now!
+    end
+  end
+
   test "rescue from deserialization errors" do
     RescueJob.perform_later Person.new(404)
     assert_includes JobBuffer.values, "rescued from DeserializationError"

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -73,6 +73,7 @@ class GuestsCleanupJob < ApplicationJob
 
   def perform(*guests)
     # Do something later
+    "#{guests.count} guests cleaned up."
   end
 end
 ```
@@ -100,7 +101,18 @@ GuestsCleanupJob.set(wait: 1.week).perform_later(guest)
 ```
 
 ```ruby
-# `perform_now` and `perform_later` will call `perform` under the hood so
+# Run a job inline without enqueing them, returns the result of `perform`.
+GuestsCleanupJob.perform_now(guest1, guest2) # => "2 guests cleaned up."
+```
+
+```ruby
+# Run a job inline without enqueing them, returns the result of `perform` and raises exceptions of the job.
+GuestsCleanupJob.perform_now!(guest1, guest2) # => "2 guests cleaned up."
+GuestsCleanupJob.perform_now!(nil) # => ArgumentError: no guests given.
+```
+
+```ruby
+# `perform_now`, `perform_now!` and `perform_later` will call `perform` under the hood so
 # you can pass as many arguments as defined in the latter.
 GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
 ```

--- a/guides/source/active_job_basics.md
+++ b/guides/source/active_job_basics.md
@@ -101,12 +101,12 @@ GuestsCleanupJob.set(wait: 1.week).perform_later(guest)
 ```
 
 ```ruby
-# Run a job inline without enqueing them, returns the result of `perform`.
+# Run a job inline without enqueuing them, returns the result of `perform`.
 GuestsCleanupJob.perform_now(guest1, guest2) # => "2 guests cleaned up."
 ```
 
 ```ruby
-# Run a job inline without enqueing them, returns the result of `perform` and raises exceptions of the job.
+# Run a job inline without enqueuing them, returns the result of `perform` and raises exceptions of the job.
 GuestsCleanupJob.perform_now!(guest1, guest2) # => "2 guests cleaned up."
 GuestsCleanupJob.perform_now!(nil) # => ArgumentError: no guests given.
 ```


### PR DESCRIPTION
### Summary

```ruby
class RescueJob < ActiveJob::Base
  rescue_from(ArgumentError) do
    # do something
  end

  def perform(foo)
    raise ArgumentError if foo.nil?
  end
end
```

If you need to run a ActiveJob inline in your code and you need to get accesses to the exceptions you need to run them like this:
```ruby
RescueJob.new.perform(nil) # => ArgumentError
```
This has the problem of that the perform callbacks are't running.

With this change you can run them like you already know it from `perform_now` and `perform_later`.
```ruby
RescueJob.perform_now!(nil) # => ArgumentError
```