### PR TITLE
Add missing `isolated_execution_state` require to `xml_mini`

### DIFF
--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -7,6 +7,7 @@ require "bigdecimal/util"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/date_time/calculations"
+require "active_support/isolated_execution_state"
 
 module ActiveSupport
   # = XmlMini


### PR DESCRIPTION
It is currently impossible to unitarily require `active_support/core_ext/numeric/time`, as a require to `active_support/isolated_execution_state` is missing since https://github.com/rails/rails/commit/0ea374c81f6b3af1e8adac6d6337a4ae54e8d73b

