### PR TITLE
Add support for YubiKey OTP codes during release

### DIFF
--- a/tasks/release.rb
+++ b/tasks/release.rb
@@ -99,12 +99,26 @@ npm_version = version.gsub(/\./).with_index { |s, i| i >= 2 ? "-" : s }
     end
 
     task push: :build do
-      sh "gem push #{gem}"
+      otp = ""
+      begin
+        otp = " --otp " + `ykman oath accounts code -s rubygems.org`.chomp
+      rescue
+        # User doesn't have ykman
+      end
+
+      sh "gem push #{gem}#{otp}"
 
       if File.exist?("#{framework}/package.json")
         Dir.chdir("#{framework}") do
           npm_tag = /[a-z]/.match?(version) ? "pre" : "latest"
-          sh "npm publish --tag #{npm_tag}"
+          npm_otp = ""
+          begin
+            npm_otp = " --otp " + `ykman oath accounts code -s npmjs.com`.chomp
+          rescue
+            # User doesn't have ykman
+          end
+
+          sh "npm publish --tag #{npm_tag}#{npm_otp}"
         end
       end
     end


### PR DESCRIPTION
This patch adds support for automatically getting OTP codes from your
YubiKey during release.  You must have the `ykman` commandline tool
installed, and have two accounts setup with the names `rubygems.org` and
`npmjs.com`.  For example, the output from `ykman oath accounts list` on
my machine is this:

```
$ ykman oath accounts list
npmjs.com:aaron.patterson@gmail.com
rubygems.org:aaron.patterson@gmail.com
```

If you meet these conditions, you can do `rake release` without typing
an OTP code for every gem.

If no `ykman` tool is found on your system, this will just fall back to
asking for an OTP code.