### PR TITLE
Generated Gemfile will automatically pickup the latest version on first bundle

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -172,7 +172,7 @@ module Rails
         return [] if options[:skip_asset_pipeline]
 
         if options[:asset_pipeline] == "sprockets"
-          GemfileEntry.floats "sprockets-rails", 
+          GemfileEntry.floats "sprockets-rails",
             "The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]"
         elsif options[:asset_pipeline] == "propshaft"
           GemfileEntry.floats "propshaft", "The modern asset pipeline for Rails [https://github.com/rails/propshaft]"

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -172,10 +172,10 @@ module Rails
         return [] if options[:skip_asset_pipeline]
 
         if options[:asset_pipeline] == "sprockets"
-          GemfileEntry.new "sprockets-rails", nil,
+          GemfileEntry.floats "sprockets-rails", 
             "The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]"
         elsif options[:asset_pipeline] == "propshaft"
-          GemfileEntry.new "propshaft", nil, "The modern asset pipeline for Rails [https://github.com/rails/propshaft]"
+          GemfileEntry.floats "propshaft", "The modern asset pipeline for Rails [https://github.com/rails/propshaft]"
         else
           []
         end
@@ -255,6 +255,10 @@ module Rails
           new(name, version, comment)
         end
 
+        def self.floats(name, comment = nil)
+          new(name, nil, comment)
+        end
+
         def self.path(name, path, comment = nil)
           new(name, nil, comment, path: path)
         end
@@ -306,17 +310,16 @@ module Rails
 
       def jbuilder_gemfile_entry
         return [] if options[:skip_jbuilder]
-        comment = "Build JSON APIs with ease [https://github.com/rails/jbuilder]"
-        GemfileEntry.new "jbuilder", nil, comment, {}, options[:api]
+        GemfileEntry.new "jbuilder", nil, "Build JSON APIs with ease [https://github.com/rails/jbuilder]", {}, options[:api]
       end
 
       def javascript_gemfile_entry
         return [] if options[:skip_javascript]
 
         if adjusted_javascript_option == "importmap"
-          GemfileEntry.new("importmap-rails", nil, "Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]")
+          GemfileEntry.floats "importmap-rails", "Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]"
         else
-          GemfileEntry.new "jsbundling-rails", nil, "Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]"
+          GemfileEntry.floats "jsbundling-rails", "Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]"
         end
       end
 
@@ -324,10 +327,10 @@ module Rails
         return [] if options[:skip_javascript] || options[:skip_hotwire]
 
         turbo_rails_entry =
-          GemfileEntry.new("turbo-rails", nil, "Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]")
+          GemfileEntry.floats "turbo-rails", "Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]"
 
         stimulus_rails_entry =
-          GemfileEntry.new("stimulus-rails", nil, "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]")
+          GemfileEntry.floats "stimulus-rails", "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]"
 
         [ turbo_rails_entry, stimulus_rails_entry ]
       end
@@ -350,9 +353,9 @@ module Rails
         return [] unless options[:css]
 
         if !using_node? && options[:css] == "tailwind"
-          GemfileEntry.new("tailwindcss-rails", nil, "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]")
+          GemfileEntry.floats "tailwindcss-rails", "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]"
         else
-          GemfileEntry.new("cssbundling-rails", nil, "Bundle and process CSS [https://github.com/rails/cssbundling-rails]")
+          GemfileEntry.floats "cssbundling-rails", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]"
         end
       end
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -172,10 +172,10 @@ module Rails
         return [] if options[:skip_asset_pipeline]
 
         if options[:asset_pipeline] == "sprockets"
-          GemfileEntry.version "sprockets-rails", ">= 3.4.1",
+          GemfileEntry.new "sprockets-rails", nil,
             "The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]"
         elsif options[:asset_pipeline] == "propshaft"
-          GemfileEntry.version "propshaft", ">= 0.4.1", "The modern asset pipeline for Rails [https://github.com/rails/propshaft]"
+          GemfileEntry.new "propshaft", nil, "The modern asset pipeline for Rails [https://github.com/rails/propshaft]"
         else
           []
         end
@@ -307,16 +307,16 @@ module Rails
       def jbuilder_gemfile_entry
         return [] if options[:skip_jbuilder]
         comment = "Build JSON APIs with ease [https://github.com/rails/jbuilder]"
-        GemfileEntry.new "jbuilder", "~> 2.11", comment, {}, options[:api]
+        GemfileEntry.new "jbuilder", nil, comment, {}, options[:api]
       end
 
       def javascript_gemfile_entry
         return [] if options[:skip_javascript]
 
         if adjusted_javascript_option == "importmap"
-          GemfileEntry.version("importmap-rails", ">= 0.9.2", "Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]")
+          GemfileEntry.new("importmap-rails", nil, "Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]")
         else
-          GemfileEntry.version "jsbundling-rails", ">= 0.2.2", "Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]"
+          GemfileEntry.new "jsbundling-rails", nil, "Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]"
         end
       end
 
@@ -324,10 +324,10 @@ module Rails
         return [] if options[:skip_javascript] || options[:skip_hotwire]
 
         turbo_rails_entry =
-          GemfileEntry.version("turbo-rails", ">= 0.9.0", "Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]")
+          GemfileEntry.new("turbo-rails", nil, "Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]")
 
         stimulus_rails_entry =
-          GemfileEntry.version("stimulus-rails", ">= 0.7.3", "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]")
+          GemfileEntry.new("stimulus-rails", nil, "Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]")
 
         [ turbo_rails_entry, stimulus_rails_entry ]
       end
@@ -350,9 +350,9 @@ module Rails
         return [] unless options[:css]
 
         if !using_node? && options[:css] == "tailwind"
-          GemfileEntry.version("tailwindcss-rails", ">= 0.5.3", "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]")
+          GemfileEntry.new("tailwindcss-rails", nil, "Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]")
         else
-          GemfileEntry.version("cssbundling-rails", ">= 0.2.7", "Bundle and process CSS [https://github.com/rails/cssbundling-rails]")
+          GemfileEntry.new("cssbundling-rails", nil, "Bundle and process CSS [https://github.com/rails/cssbundling-rails]")
         end
       end
 

--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -24,12 +24,12 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", ">= 1.4.4", require: false
+gem "bootsnap", require: false
 <% end -%>
 <% unless skip_sprockets? || options.minimal? -%>
 
 # Use Sass to process CSS
-# gem "sassc-rails", "~> 2.1"
+# gem "sassc-rails"
 <% end -%>
 <% unless skip_active_storage? -%>
 
@@ -45,17 +45,17 @@ gem "bootsnap", ">= 1.4.4", require: false
 
 group :development, :test do
   # See https://edgeguides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", ">= 1.0.0", platforms: %i[ mri mingw x64_mingw ]
+  gem "debug", platforms: %i[ mri mingw x64_mingw ]
 end
 <% end -%>
 
 group :development do
 <%- unless options.api? || options.skip_dev_gems? -%>
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem "web-console", ">= 4.1.0"
+  gem "web-console"
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
-  # gem "rack-mini-profiler", ">= 2.3.3"
+  # gem "rack-mini-profiler"
 
 <%- end -%>
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
@@ -65,8 +65,8 @@ end
 <%- if depends_on_system_test? -%>
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara", ">= 3.26"
-  gem "selenium-webdriver", ">= 4.0.0"
+  gem "capybara"
+  gem "selenium-webdriver"
   gem "webdrivers"
 end
 <%- end -%>


### PR DESCRIPTION
No need to prescribe the lower boundary for a newly generated Gemfile, since the first bundle will automatically lock-in the latest version.