### PR TITLE
Allow localhost with a port by default in development

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -16,6 +16,8 @@ module ActionDispatch
   # responds with <tt>403 Forbidden</tt>. The body of the response contains debug info
   # if +config.consider_all_requests_local+ is set to true, otherwise the body is empty.
   class HostAuthorization
+    ALLOWED_HOSTS_IN_DEVELOPMENT = [".localhost", /\A([a-z0-9-]+\.)?localhost:\d+\z/, IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0")]
+
     class Permissions # :nodoc:
       def initialize(hosts)
         @hosts = sanitize_hosts(hosts)

--- a/actionpack/test/dispatch/host_authorization_test.rb
+++ b/actionpack/test/dispatch/host_authorization_test.rb
@@ -154,6 +154,18 @@ class HostAuthorizationTest < ActionDispatch::IntegrationTest
     assert_equal "Custom", body
   end
 
+  test "localhost works in dev" do
+    @app = ActionDispatch::HostAuthorization.new(App, ActionDispatch::HostAuthorization::ALLOWED_HOSTS_IN_DEVELOPMENT)
+
+    get "/", env: {
+      "HOST" => "localhost:3000",
+      "action_dispatch.show_detailed_exceptions" => true
+    }
+
+    assert_response :ok
+    assert_match "Success", response.body
+  end
+
   test "blocks requests with spoofed X-FORWARDED-HOST" do
     @app = ActionDispatch::HostAuthorization.new(App, [IPAddr.new("127.0.0.1")])
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -33,7 +33,7 @@ module Rails
         @filter_parameters                       = []
         @filter_redirect                         = []
         @helpers_paths                           = []
-        @hosts                                   = Array(([".localhost", IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0")] if Rails.env.development?))
+        @hosts                                   = Rails.env.development? ? ActionDispatch::HostAuthorization::ALLOWED_HOSTS_IN_DEVELOPMENT : []
         @hosts.concat(ENV["RAILS_DEVELOPMENT_HOSTS"].to_s.split(",").map(&:strip)) if Rails.env.development?
         @host_authorization                      = {}
         @public_file_server                      = ActiveSupport::OrderedOptions.new


### PR DESCRIPTION
Only "localhost" and ".localhost" were allowed by default in
development, but the port is also part of the header that is sent.  It
is a bad idea to try parsing whatever stuff is in the HTTP header, so
this commit specifically adds localhost with a port in the "allowed
hosts" list in development.

Fixes: #43864