### PR TITLE
Add missing :author_addresses in `PreloaderTest`

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -395,7 +395,7 @@ class OverridingAssociationsTest < ActiveRecord::TestCase
 end
 
 class PreloaderTest < ActiveRecord::TestCase
-  fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories
+  fixtures :posts, :comments, :books, :authors, :tags, :taggings, :essays, :categories, :author_addresses
 
   def test_preload_with_scope
     post = posts(:welcome)


### PR DESCRIPTION
### Summary

This pull request addresses the CI failure https://buildkite.com/rails/rails/builds/83346#2ac29d83-54bf-4123-8a94-c483218ebaf6

Fix #43872

```ruby
$ ARCONN=postgresql bin/test test/cases/associations_test.rb test/cases/fixtures_test.rb -n "/^(?:PreloaderTest#(?:test_preload_grouped_queries_of_middle_records)|FixturesWithForeignKeyViolationsTest#(?:test_does_not_raise_if_no_fk_violations))$/" --seed 62142
Using postgresql
Run options: -n "/^(?:PreloaderTest#(?:test_preload_grouped_queries_of_middle_records)|FixturesWithForeignKeyViolationsTest#(?:test_does_not_raise_if_no_fk_violations))$/" --seed 62142

.E

Error:
FixturesWithForeignKeyViolationsTest#test_does_not_raise_if_no_fk_violations:
RuntimeError: Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations.
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:633:in `block in insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:621:in `each'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:621:in `insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:607:in `read_and_insert'
    /home/yahonda/src/github.com/rails/rails/activerecord/lib/active_record/fixtures.rb:567:in `create_fixtures'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:846:in `block (2 levels) in test_does_not_raise_if_no_fk_violations'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/testing/assertions.rb:34:in `assert_nothing_raised'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:845:in `block in test_does_not_raise_if_no_fk_violations'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:859:in `with_verify_foreign_keys_for_fixtures'
    /home/yahonda/src/github.com/rails/rails/activerecord/test/cases/fixtures_test.rb:844:in `test_does_not_raise_if_no_fk_violations'

bin/test test/cases/fixtures_test.rb:837

Finished in 0.237820s, 8.4097 runs/s, 4.2049 assertions/s.
2 runs, 1 assertions, 0 failures, 1 errors, 0 skips
$
```
