### PR TITLE
While loading fixtures disable triggers only for defined fixture tables

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -404,7 +404,7 @@ module ActiveRecord
         statements = table_deletes + fixture_inserts
 
         with_multi_statements do
-          disable_referential_integrity do
+          disable_referential_integrity(tables_to_delete) do
             transaction(requires_new: true) do
               execute_batch(statements, "Fixtures Load")
             end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -522,7 +522,7 @@ module ActiveRecord
       # REFERENTIAL INTEGRITY ====================================
 
       # Override to turn off referential integrity while executing <tt>&block</tt>.
-      def disable_referential_integrity
+      def disable_referential_integrity(_tables_to_disable = [])
         yield
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -180,7 +180,7 @@ module ActiveRecord
 
       # REFERENTIAL INTEGRITY ====================================
 
-      def disable_referential_integrity # :nodoc:
+      def disable_referential_integrity(_tables_to_disable = []) # :nodoc:
         old = query_value("SELECT @@FOREIGN_KEY_CHECKS")
 
         begin

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -4,12 +4,12 @@ module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL
       module ReferentialIntegrity # :nodoc:
-        def disable_referential_integrity # :nodoc:
+        def disable_referential_integrity(tables_to_disable = tables) # :nodoc:
           original_exception = nil
 
           begin
             transaction(requires_new: true) do
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
+              execute(tables_to_disable.collect { |name| "ALTER TABLE #{quote_table_name(name)} DISABLE TRIGGER ALL" }.join(";"))
             end
           rescue ActiveRecord::ActiveRecordError => e
             original_exception = e
@@ -32,7 +32,7 @@ Rails needs superuser privileges to disable referential integrity.
 
           begin
             transaction(requires_new: true) do
-              execute(tables.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
+              execute(tables_to_disable.collect { |name| "ALTER TABLE #{quote_table_name(name)} ENABLE TRIGGER ALL" }.join(";"))
             end
           rescue ActiveRecord::ActiveRecordError
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -197,7 +197,7 @@ module ActiveRecord
 
       # REFERENTIAL INTEGRITY ====================================
 
-      def disable_referential_integrity # :nodoc:
+      def disable_referential_integrity(_tables_to_disable = []) # :nodoc:
         old_foreign_keys = query_value("PRAGMA foreign_keys")
         old_defer_foreign_keys = query_value("PRAGMA defer_foreign_keys")
 


### PR DESCRIPTION
### Summary

Hey all,

While inserting fixtures to the PostgreSQL database we are disabling/enabling triggers (referential integrity) for ALL tables that have found the following schema search path. I suggest disabling/enabling triggers only for fixtures-specific tables. For example, I have overall 20 tables but only 2 fixtures. Looks like disabling/enabling triggers only for these 2 fixture-specific tables is enough. What do you think?
