### PR TITLE
Don't use schema cache when checking schema migrations

### DIFF
--- a/activerecord/lib/active_record/schema_migration.rb
+++ b/activerecord/lib/active_record/schema_migration.rb
@@ -41,6 +41,10 @@ module ActiveRecord
       def all_versions
         order(:version).pluck(:version)
       end
+
+      def table_exists?
+        connection.data_source_exists?(table_name)
+      end
     end
 
     def version


### PR DESCRIPTION
I noticed this while debugging a separate issue locally. When
`lazily_load_schema_cache` is set to true AND there's a schema cache,
running `db:drop` twice will raise a `no such table: schema_migrations`
error. The problem here was that when `check_protected_environments` is
run before drop, the task checks for the latest environment. That check
looks at `table_exists?` defined in `model_schema.rb`. The issue is that
the model schema is checking `connection.schema_cache.data_source_exists?`.

When checking whether the environment is protected on schema migrations
we don't want to use the schema cache. We want to check the database
directly. The schema cache really is for the app after boot, so it's
safe to skip the schema cache in this area since we want to check the
database directly.