### PR TITLE
Fix Active Record build for `6-1-stable`

### DIFF
--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -722,7 +722,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
   end
 
   def test_with_hash_many_inversing_does_not_add_duplicate_associated_objects
-    with_has_many_inversing(Interest) do
+    with_has_many_inversing do
       human = Human.new
       interest = Interest.new(human: human)
       human.interests << interest


### PR DESCRIPTION
`with_has_many_inversing` was changed to accept an argument in 24de1ab4f55e660e64d23983a25ab1122a412908, to support implementing `has_many_inversing` via `class_attribute`.  However, that commit was not backported to `6-1-stable`, so passing an argument is not possible.

---

There are other [build failures in Active Support](https://buildkite.com/rails/rails/builds/81920#c9c2cf52-3744-4c07-9a9f-d3a0b9d593a7/990-1009).  Those started after 711b241dfd45a56323c647fc82ad7e574e3282c3 (they do not appear in [`711b241~1`](https://github.com/rails/rails/commit/711b241dfd45a56323c647fc82ad7e574e3282c3~1)), but they don't seem to be related.
