### PR TITLE
Dup arrays that get "converted"

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -963,7 +963,7 @@ module ActionController
         when Array
           return value if converted_arrays.member?(value)
           converted = value.map { |_| convert_value_to_parameters(_) }
-          converted_arrays << converted
+          converted_arrays << converted.dup
           converted
         when Hash
           self.class.new(value)

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -253,6 +253,19 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_not_predicate permitted[:users].last, :permitted?
   end
 
+  test "grow until set rehashes" do
+    params = ActionController::Parameters.new(users: [{ id: 1 }])
+
+    permitted = params.permit(users: [:id])
+    permitted[:users] << { injected: 1 }
+    20.times { |i|
+      list = ["foo#{i}"]
+      permitted[:xx] = list
+      assert_equal permitted[:xx], list
+    }
+    assert_not_predicate permitted[:users].last, :permitted?
+  end
+
   test "fetch doesn't raise ParameterMissing exception if there is a default" do
     assert_equal "monkey", @params.fetch(:foo, "monkey")
     assert_equal "monkey", @params.fetch(:foo) { "monkey" }


### PR DESCRIPTION
We don't want to expose these cache keys to users because users can
mutate the key causing the cache to behave inconsistently.

Fixes: #43681
