### PR TITLE
Generate `[id]` for `FormBuilder#button` called with method name

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2587,7 +2587,7 @@ module ActionView
       #   # => <button name='button' type='submit'>Create post</button>
       #
       #   button(:draft, value: true)
-      #   # => <button name="post[draft]" value="true" type="submit">Create post</button>
+      #   # => <button id="post_draft" name="post[draft]" value="true" type="submit">Create post</button>
       #
       #   button do
       #     content_tag(:strong, 'Ask me!')
@@ -2606,7 +2606,7 @@ module ActionView
       #   button(:draft, value: true) do
       #     content_tag(:strong, "Save as draft")
       #   end
-      #   # =>  <button name="post[draft]" value="true" type="submit">
+      #   # =>  <button id="post_draft" name="post[draft]" value="true" type="submit">
       #   #       <strong>Save as draft</strong>
       #   #     </button>
       #
@@ -2615,7 +2615,7 @@ module ActionView
         when Hash
           value, options = nil, value
         when Symbol
-          value, options[:name] = nil, field_name(value)
+          value, options = nil, { name: field_name(value), id: field_id(value) }.merge!(options.to_h)
         end
         value ||= submit_default_value
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -2607,7 +2607,19 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      %(<button type="submit" name="post[secret]" value="true">Update Post</button>)
+      %(<button type="submit" id="post_secret" name="post[secret]" value="true">Update Post</button>)
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_button_with_method_name_and_attributes
+    form_for(@post) do |f|
+      concat f.button(:secret, value: true, id: "not_generated", name: "post[not_generated]")
+    end
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
+      %(<button type="submit" id="not_generated" name="post[not_generated]" value="true">Update Post</button>)
     end
 
     assert_dom_equal expected, output_buffer
@@ -2619,7 +2631,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      %(<button type="submit" name="post[secret]" value="true">Update secret Post</button>)
+      %(<button type="submit" id="post_secret" name="post[secret]" value="true">Update secret Post</button>)
     end
 
     assert_dom_equal expected, output_buffer


### PR DESCRIPTION
Follow-up to [rails/rails#43411][] (merged in [15f6113][])


### Summary

By default, when generating a `<button>` element through a Form Builder
instance, the element's `[name]` attribute is populated by calling the
`FormBuilder#field_name` method. This commit assigns a matching default
`[id]` attribute generated by `FormBuilder#field_id`.

Additionally, it adds test coverage to ensure that calls that provide
their own `name:` and `id:` options are not overridden by the default
values.

[rails/rails#43411]: https://github.com/rails/rails/pull/43411
[15f6113]: https://github.com/rails/rails/commit/15f611362230b4e34bf157a52e3d90acb22128f2