### PR TITLE
Upgrade maintenance policy to tell about 5.2 and 6.0 deprecation dates

### DIFF
--- a/guides/source/maintenance_policy.md
+++ b/guides/source/maintenance_policy.md
@@ -64,7 +64,7 @@ non-security related bugs resulting from a security patch may be published on a
 release's x-y-stable branch, and will only be released as a new gem in
 accordance with the Bug Fixes policy.
 
-**Currently included series:** `7.0.Z`, `6.1.Z`, `5.2.Z`.
+**Currently included series:** `7.0.Z`, `6.1.Z`.
 
 Severe Security Issues
 ----------------------
@@ -72,6 +72,9 @@ Severe Security Issues
 For severe security issues all releases in the current major series, and also the
 last release in the previous major series will receive patches and new versions. The
 classification of the security issue is judged by the core team.
+
+NOTE: Rails 5.2.Z is included in the list of supported series until June 1st 2022.
+NOTE: Rails 6.0.Z is included in the list of supported series until June 1st 2023.
 
 **Currently included series:** `7.0.Z`, `6.1.Z`, `6.0.Z`, `5.2.Z`.
 


### PR DESCRIPTION
Be specific when we will drop support to 5.2 and 6.0 so people know until when they have to upgrade.