### PR TITLE
Typo in the Security Policy URL

### DIFF
--- a/.github/security.md
+++ b/.github/security.md
@@ -3,10 +3,10 @@
 ## Reporting a Vulnerability
 
 **Do not open up a GitHub issue if the bug is a security vulnerability in Rails**.
-Instead, refer to our [security policy](https://rubyonrails.org/security/).
+Instead, refer to our [security policy](https://rubyonrails.org/security).
 
 ## Supported Versions
 
 Security backports are provided for some previous release series. For details
 of which release series are currently receiving security backports see our
-[security policy](https://rubyonrails.org/security/).
+[security policy](https://rubyonrails.org/security).


### PR DESCRIPTION
### Summary

The URL `https://github.com/rails/rails/security/policy` has a link to Rails Privacy policy with `/` at the end.
When opening `https://rubyonrails.org/security/`, rails returns 404 not found.
While `https://rubyonrails.org/security` display the correct security page.
