### PR TITLE
updating the Rails logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://rubyonrails.org/" target="_blank" rel="noopener noreferrer">
-    <img src="https://rubyonrails.org/images/rails-logo.svg" width="400">
+    <img src="https://rubyonrails.org/assets/images/logo.svg" width="400" style="filter: invert(15%) sepia(95%) saturate(3482%) hue-rotate(354deg) brightness(82%) contrast(124%)">
   </a>
 </p>
 


### PR DESCRIPTION
### Summary

Updating the broken logo in the README. 

### Other Information

Could not find a red logo in the new website and the CSS filters do not work in Github, unfortunately.
