### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ We encourage you to contribute to Ruby on Rails! Please check out the
 [Contributing to Ruby on Rails guide](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) for guidelines about how to proceed. [Join us!](https://contributors.rubyonrails.org)
 
 Trying to report a possible security vulnerability in Rails? Please
-check out our [security policy](https://rubyonrails.org/security/) for
+check out our [security policy](https://rubyonrails.org/security) for
 guidelines about how to proceed.
 
-Everyone interacting in Rails and its sub-projects' codebases, issue trackers, chat rooms, and mailing lists is expected to follow the Rails [code of conduct](https://rubyonrails.org/conduct/).
+Everyone interacting in Rails and its sub-projects' codebases, issue trackers, chat rooms, and mailing lists is expected to follow the Rails [code of conduct](https://rubyonrails.org/conduct).
 
 ## License
 


### PR DESCRIPTION
### Summary
After Rails website update some pages have broken path like this:
**Before:** https://rubyonrails.org/security/ (404 Not found)
**Current:** https://rubyonrails.org/security (200 OK)

### Other Information
Also there is a problem when you google "Rails Code of Conduct" and it provides broken link with old path.