### PR TITLE
Apply migration if_exists exception only on migrations >= v7.1

### DIFF
--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -33,6 +33,35 @@ module ActiveRecord
       V7_1 = Current
 
       class V7_0 < V7_1
+        module TableDefinition
+          private
+            def raise_on_if_exist_options(options)
+            end
+        end
+
+        def create_table(table_name, **options)
+          if block_given?
+            super { |t| yield compatible_table_definition(t) }
+          else
+            super
+          end
+        end
+
+        def change_table(table_name, **options)
+          if block_given?
+            super { |t| yield compatible_table_definition(t) }
+          else
+            super
+          end
+        end
+
+        private
+          def compatible_table_definition(t)
+            class << t
+              prepend TableDefinition
+            end
+            t
+          end
       end
 
       class V6_1 < V7_0
@@ -119,6 +148,10 @@ module ActiveRecord
             options[:precision] ||= nil
             super
           end
+
+          private
+            def raise_on_if_exist_options(options)
+            end
         end
 
         def create_table(table_name, **options)
@@ -171,6 +204,10 @@ module ActiveRecord
             options[:precision] ||= nil
             super
           end
+
+          private
+            def raise_on_if_exist_options(options)
+            end
         end
 
         module CommandRecorder
@@ -265,6 +302,10 @@ module ActiveRecord
             super(*args, type: :integer, **options)
           end
           alias :belongs_to :references
+
+          private
+            def raise_on_if_exist_options(options)
+            end
         end
 
         def create_table(table_name, **options)
@@ -331,6 +372,10 @@ module ActiveRecord
             options[:null] = true if options[:null].nil?
             super
           end
+
+          private
+            def raise_on_if_exist_options(options)
+            end
         end
 
         def add_reference(table_name, ref_name, **options)

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -520,7 +520,7 @@ module ActiveRecord
       end
 
       def test_change_table_allows_if_exists_option_on_6_1
-        migration = Class.new(ActiveRecord::Migration[6.1]) {
+        migration = Class.new(ActiveRecord::Migration[7.0]) {
           def migrate(x)
             change_table(:testings) do |t|
               t.remove :foo, if_exists: true


### PR DESCRIPTION
### Summary

Unknowingly merged https://github.com/rails/rails/pull/43576 right after
Rails 7.0 was released, so the new exception raised in that PR should only
apply to migrations of version 7.1 and onward.

Also fixes issues where the new exception behavior would apply to older
migration versions.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
