### PR TITLE
Reuse view_context_class when possible

### DIFF
--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -48,7 +48,18 @@ module ActionView
       def _helpers
       end
 
+      def inherit_view_context_class?
+        superclass.respond_to?(:view_context_class) &&
+          supports_path? == superclass.supports_path? &&
+          _routes.equal?(superclass._routes) &&
+          _helpers.equal?(superclass._helpers)
+      end
+
       def build_view_context_class(klass, supports_path, routes, helpers)
+        if inherit_view_context_class?
+          return superclass.view_context_class
+        end
+
         Class.new(klass) do
           if routes
             include routes.url_helpers(supports_path)


### PR DESCRIPTION
The generated view context classes tend to be fairly complex and use a lot of memory. Similar to how we only generate new helper classes when necessary (see https://github.com/rails/rails/pull/40204) we should be doing the same for view context classes.

In applications where most controllers can use the same helpers and therefore view_context_class this should improve view performance using the interpreter and especially when using a JIT.