### PR TITLE
Update URLs for the blog

### DIFF
--- a/RELEASING_RAILS.md
+++ b/RELEASING_RAILS.md
@@ -158,7 +158,7 @@ break existing applications.
 If you used Markdown format for your email, you can just paste it into the
 blog.
 
-* https://weblog.rubyonrails.org
+* https://rubyonrails.org/blog
 
 ### Post the announcement to the Rails Twitter account.
 

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -32,7 +32,7 @@
         More Ruby on Rails
       </span>
       <ul class="more-info-links s-hidden">
-        <li class="more-info"><a href="https://weblog.rubyonrails.org/">Blog</a></li>
+        <li class="more-info"><a href="https://rubyonrails.org/blog">Blog</a></li>
         <li class="more-info"><a href="https://guides.rubyonrails.org/">Guides</a></li>
         <li class="more-info"><a href="https://api.rubyonrails.org/">API</a></li>
         <li class="more-info"><a href="https://discuss.rubyonrails.org/">Forum</a></li>


### PR DESCRIPTION
### Summary

The blog recently got moved to https://rubyonrails.org/blog/.
Redirects to older posts work fine but https://weblog.rubyonrails.org
redirects to https://rubyonrails.org.
