### PR TITLE
Fix `link_to` with a model passed as an argument twice

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -208,7 +208,6 @@ module ActionView
       #
       def link_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options, name = options, name, block if block_given?
-        options ||= {}
 
         html_options = convert_options_to_data_attributes(options, html_options)
 
@@ -743,7 +742,7 @@ module ActionView
         end
 
         def url_target(name, options)
-          if name.respond_to?(:model_name) && options.empty?
+          if name.respond_to?(:model_name) && options.is_a?(Hash) && options.empty?
             url_for(name)
           else
             url_for(options)

--- a/actionview/test/template/url_helper_test.rb
+++ b/actionview/test/template/url_helper_test.rb
@@ -16,7 +16,7 @@ class Workshop
   end
 
   def to_s
-    id.to_s
+    "Workshop #{id}"
   end
 end
 
@@ -621,7 +621,13 @@ class UrlHelperTest < ActiveSupport::TestCase
   def test_link_tag_using_active_record_model
     @workshop = Workshop.new(1.to_s)
     link = link_to(@workshop)
-    assert_dom_equal %{<a href="/workshops/1">1</a>}, link
+    assert_dom_equal %{<a href="/workshops/1">Workshop 1</a>}, link
+  end
+
+  def test_link_tag_using_active_record_model_twice
+    @workshop = Workshop.new(1.to_s)
+    link = link_to(@workshop, @workshop)
+    assert_dom_equal %{<a href="/workshops/1">Workshop 1</a>}, link
   end
 
   def test_link_to_unless


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/43913 which found a regression in https://github.com/rails/rails/pull/42234
