### PR TITLE
Fix dbconsole for 3-tier config.

### DIFF
--- a/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
+++ b/railties/lib/rails/commands/dbconsole/dbconsole_command.rb
@@ -97,15 +97,18 @@ module Rails
     def db_config
       return @db_config if defined?(@db_config)
 
-      # We need to check whether the user passed the database the
-      # first time around to show a consistent error message to people
-      # relying on 2-level database configuration.
-
-      @db_config = configurations.configs_for(env_name: environment, name: database, include_hidden: true)
+      # If the user provided a database, use that. Otherwise find
+      # the first config in the database.yml
+      if database
+        @db_config = configurations.configs_for(env_name: environment, name: database, include_hidden: true)
+      else
+        @db_config = configurations.find_db_config(environment)
+      end
 
       unless @db_config
+        missing_db = database ? "'#{database}' database is not" : "No databases are"
         raise ActiveRecord::AdapterNotSpecified,
-          "'#{database}' database is not configured for '#{environment}'. Available configuration: #{configurations.inspect}"
+          "#{missing_db} configured for '#{environment}'. Available configuration: #{configurations.inspect}"
       end
 
       @db_config
@@ -116,7 +119,7 @@ module Rails
     end
 
     def database
-      @options.fetch(:database, "primary")
+      @options[:database]
     end
 
     private

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -271,7 +271,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
         Rails::Command.invoke(:dbconsole)
       end
 
-      assert_includes e.message, "'primary' database is not configured for 'test'."
+      assert_includes e.message, "No databases are configured for 'test'."
     end
   end
 


### PR DESCRIPTION
It's possible that applications using a 3-tier config don't have a
"primary" database entry. When booting the db console we should take the
first database, not assume there's a primary.

This also changes the message to be more clear. If no database is
provided and there are no databases for the environment we shouldn't
say that "primary" didn't exist - instead it should say no databases
exist.

This should not have any change in behavior (other than error message)
for existing applications. We need to backport this to versions that support
multi-db as this is broken with apps that don't have a `primary`.