### PR TITLE
Improve the performance of ActiveSupport::MessageEncryptor

### DIFF
--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -121,6 +121,11 @@ module ActiveSupport
     class InvalidMessage < StandardError; end
     OpenSSLCipherError = OpenSSL::Cipher::CipherError
 
+    AUTH_TAG_LENGTH = 16 # :nodoc:
+    AUTH_TAG_LENGTH_IN_BASE64 = ((4 * AUTH_TAG_LENGTH / 3) + 3) & ~3 # :nodoc:
+    SEPARATOR = "--" # :nodoc:
+    SEPARATOR_LENGTH = SEPARATOR.length # :nodoc:
+
     # Initialize a new MessageEncryptor. +secret+ must be at least as long as
     # the cipher key size. For the default 'aes-256-gcm' cipher, this is 256
     # bits. If you are using a user-entered secret, you can generate a suitable
@@ -177,19 +182,25 @@ module ActiveSupport
         encrypted_data = cipher.update(Messages::Metadata.wrap(@serializer.dump(value), **metadata_options))
         encrypted_data << cipher.final
 
-        blob = "#{::Base64.strict_encode64 encrypted_data}--#{::Base64.strict_encode64 iv}"
-        blob = "#{blob}--#{::Base64.strict_encode64 cipher.auth_tag}" if aead_mode?
-        blob
+        encoded_encrypted_data = ::Base64.strict_encode64(encrypted_data)
+        encoded_iv = ::Base64.strict_encode64(iv)
+
+        if aead_mode?
+          encoded_auth_tag = ::Base64.strict_encode64(cipher.auth_tag(AUTH_TAG_LENGTH))
+          "#{encoded_encrypted_data}#{SEPARATOR}#{encoded_iv}#{SEPARATOR}#{encoded_auth_tag}"
+        else
+          "#{encoded_encrypted_data}#{SEPARATOR}#{encoded_iv}"
+        end
       end
 
       def _decrypt(encrypted_message, purpose)
         cipher = new_cipher
-        encrypted_data, iv, auth_tag = encrypted_message.split("--").map { |v| ::Base64.strict_decode64(v) }
+        encrypted_data, iv, auth_tag = get_encrypted_data_and_iv_and_auth_tag_from(encrypted_message)
 
         # Currently the OpenSSL bindings do not raise an error if auth_tag is
         # truncated, which would allow an attacker to easily forge it. See
         # https://github.com/ruby/openssl/issues/63
-        raise InvalidMessage if aead_mode? && (auth_tag.nil? || auth_tag.bytes.length != 16)
+        raise InvalidMessage if aead_mode? && (auth_tag.nil? || auth_tag.bytes.length != AUTH_TAG_LENGTH)
 
         cipher.decrypt
         cipher.key = @secret
@@ -206,6 +217,37 @@ module ActiveSupport
         @serializer.load(message) if message
       rescue OpenSSLCipherError, TypeError, ArgumentError
         raise InvalidMessage
+      end
+
+      def iv_length_in_base64
+        @iv_length_in_base64 ||= ((4 * new_cipher.iv_len / 3) + 3) & ~3
+      end
+
+      def separator_at?(encrypted_message, index)
+        encrypted_message[index, SEPARATOR_LENGTH] == SEPARATOR
+      end
+
+      def auth_tag_and_iv_separators_indexes_for(encrypted_message)
+        if aead_mode?
+          auth_tag_separator_index = encrypted_message.length - AUTH_TAG_LENGTH_IN_BASE64 - SEPARATOR_LENGTH
+          return if auth_tag_separator_index < SEPARATOR_LENGTH || !separator_at?(encrypted_message, auth_tag_separator_index)
+        end
+
+        iv_separator_index = (auth_tag_separator_index || encrypted_message.length) - iv_length_in_base64 - SEPARATOR_LENGTH
+        return if iv_separator_index.negative? || !separator_at?(encrypted_message, iv_separator_index)
+
+        [auth_tag_separator_index, iv_separator_index]
+      end
+
+      def get_encrypted_data_and_iv_and_auth_tag_from(encrypted_message)
+        auth_tag_separator_index, iv_separator_index = auth_tag_and_iv_separators_indexes_for(encrypted_message)
+        return if iv_separator_index.nil? || (aead_mode? && auth_tag_separator_index.nil?)
+
+        encrypted_data = encrypted_message[0, iv_separator_index]
+        iv = encrypted_message[iv_separator_index + SEPARATOR_LENGTH, iv_length_in_base64]
+        auth_tag = encrypted_message[auth_tag_separator_index + SEPARATOR_LENGTH, AUTH_TAG_LENGTH_IN_BASE64] if aead_mode?
+
+        [encrypted_data, iv, auth_tag].map! { |v| ::Base64.strict_decode64(v) if v.present? }
       end
 
       def new_cipher

--- a/activesupport/lib/active_support/message_verifier.rb
+++ b/activesupport/lib/active_support/message_verifier.rb
@@ -211,9 +211,13 @@ module ActiveSupport
         @digest_length_in_hex ||= OpenSSL::Digest.new(@digest).digest_length * 2
       end
 
+      def separator_at?(signed_message, index)
+        signed_message[index, SEPARATOR_LENGTH] == SEPARATOR
+      end
+
       def separator_index_for(signed_message)
         index = signed_message.length - digest_length_in_hex - SEPARATOR_LENGTH
-        return if index.negative? || signed_message[index, SEPARATOR_LENGTH] != SEPARATOR
+        return if index.negative? || !separator_at?(signed_message, index)
 
         index
       end
@@ -224,8 +228,8 @@ module ActiveSupport
         separator_index = separator_index_for(signed_message)
         return if separator_index.nil?
 
-        data = signed_message[0...separator_index]
-        digest = signed_message[separator_index + SEPARATOR_LENGTH..-1]
+        data = signed_message[0, separator_index]
+        digest = signed_message[separator_index + SEPARATOR_LENGTH, digest_length_in_hex]
 
         [data, digest]
       end


### PR DESCRIPTION
### Summary

Following up on the work I did in #42919, this introduces the same logic to `ActiveSupport::MessageEncryptor`.

By calculating the position of the IV and auth tags, instead of using `String#split`, we increase our resistance to invalid messages, those that don't feature the separator. The new code is not sensitive to the size of the input whenever it doesn't feature the separator.

Besides the above, I'm making sure that the auth tag is 16 bytes, OpenSSL bindings' current default. A change to that default would break things for us, namely making it impossible to decrypt previously encrypted messages.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

#### Benchmarks

**4 kB**

Attempting to decrypt an invalid message (no separator).

Currently:
```
Warming up --------------------------------------
 #decrypt_and_verify     5.403k i/100ms
   #encrypt_and_sign     6.674k i/100ms
Calculating -------------------------------------
 #decrypt_and_verify     54.628k (± 4.6%) i/s -    545.703k in  10.013536s
   #encrypt_and_sign     66.277k (± 5.3%) i/s -    667.400k in  10.100746s
````

This PR:
```
Warming up --------------------------------------
 #decrypt_and_verify     7.098k i/100ms
   #encrypt_and_sign     7.577k i/100ms
Calculating -------------------------------------
 #decrypt_and_verify     74.996k (± 4.5%) i/s -    752.388k in  10.054574s
   #encrypt_and_sign     73.336k (± 4.0%) i/s -    734.969k in  10.039760s
```

A 1.37x speedup for `#decrypt_and_verify`, and a 1.10x speedup for `#encrypt_and_sign`.

---

Attempting to decrypt a valid message.

Currently:
```
Warming up --------------------------------------
 #decrypt_and_verify     5.366k i/100ms
   #encrypt_and_sign     6.464k i/100ms
Calculating -------------------------------------
 #decrypt_and_verify     52.541k (± 2.9%) i/s -    525.868k in  10.017648s
   #encrypt_and_sign     68.079k (± 3.8%) i/s -    685.184k in  10.080207s
```

This PR:
```
Warming up --------------------------------------
 #decrypt_and_verify     5.787k i/100ms
   #encrypt_and_sign     7.331k i/100ms
Calculating -------------------------------------
 #decrypt_and_verify     57.518k (± 5.6%) i/s -    578.700k in  10.094993s
   #encrypt_and_sign     72.982k (± 4.4%) i/s -    733.100k in  10.066154s
```

A 1.09x speedup for `#decrypt_and_verify`, and a 1.07x speedup for `#encrypt_and_sign`.

**4 MB**

Attempting to decrypt an invalid message (no separator).

Currently:
```
Warming up --------------------------------------
 #decrypt_and_verify    21.000  i/100ms
   #encrypt_and_sign    10.000  i/100ms
Calculating -------------------------------------
 #decrypt_and_verify    239.920  (± 1.7%) i/s -      2.415k in  10.069074s
   #encrypt_and_sign    113.399  (± 2.6%) i/s -      1.140k in  10.058523s
```

This PR:
```
Warming up --------------------------------------
 #decrypt_and_verify     7.257k i/100ms
   #encrypt_and_sign    12.000  i/100ms
Calculating -------------------------------------
 #decrypt_and_verify     78.076k (± 1.9%) i/s -    783.756k in  10.042234s
   #encrypt_and_sign    132.422  (± 3.8%) i/s -      1.332k in  10.074115s
```

A **326x** speedup for `#decrypt_and_verify`, and a 1.16x speedup for `#encrypt_and_sign`.

---

Attempting to decrypt a valid message.

Currently:
```
Warming up --------------------------------------
 #decrypt_and_verify    10.000  i/100ms
   #encrypt_and_sign    11.000  i/100ms
Calculating -------------------------------------
 #decrypt_and_verify    100.046  (± 4.0%) i/s -      1.000k in  10.013520s
   #encrypt_and_sign    122.601  (± 4.1%) i/s -      1.232k in  10.068093s
```

This PR:
```
Warming up --------------------------------------
 #decrypt_and_verify    12.000  i/100ms
   #encrypt_and_sign    14.000  i/100ms
Calculating -------------------------------------
 #decrypt_and_verify    152.493  (± 3.3%) i/s -      1.524k in  10.005288s
   #encrypt_and_sign    137.735  (± 1.5%) i/s -      1.386k in  10.065756s
```

A 1.52x speedup for `#decrypt_and_verify`, and a 1.12x speedup for `#encrypt_and_sign`.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
