### PR TITLE
Add option to not draw Active Storage routes for default proxy and redirect controllers

### DIFF
--- a/activestorage/config/routes.rb
+++ b/activestorage/config/routes.rb
@@ -2,13 +2,15 @@
 
 Rails.application.routes.draw do
   scope ActiveStorage.routes_prefix do
-    get "/blobs/redirect/:signed_id/*filename" => "active_storage/blobs/redirect#show", as: :rails_service_blob
-    get "/blobs/proxy/:signed_id/*filename" => "active_storage/blobs/proxy#show", as: :rails_service_blob_proxy
-    get "/blobs/:signed_id/*filename" => "active_storage/blobs/redirect#show"
+    unless ActiveStorage.without_default_controllers
+      get "/blobs/redirect/:signed_id/*filename" => "active_storage/blobs/redirect#show", as: :rails_service_blob
+      get "/blobs/proxy/:signed_id/*filename" => "active_storage/blobs/proxy#show", as: :rails_service_blob_proxy
+      get "/blobs/:signed_id/*filename" => "active_storage/blobs/redirect#show"
 
-    get "/representations/redirect/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show", as: :rails_blob_representation
-    get "/representations/proxy/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/proxy#show", as: :rails_blob_representation_proxy
-    get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show"
+      get "/representations/redirect/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show", as: :rails_blob_representation
+      get "/representations/proxy/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/proxy#show", as: :rails_blob_representation_proxy
+      get "/representations/:signed_blob_id/:variation_key/*filename" => "active_storage/representations/redirect#show"
+    end
 
     get  "/disk/:encoded_key/*filename" => "active_storage/disk#show", as: :rails_disk_service
     put  "/disk/:encoded_token" => "active_storage/disk#update", as: :update_rails_disk_service

--- a/activestorage/lib/active_storage.rb
+++ b/activestorage/lib/active_storage.rb
@@ -65,6 +65,7 @@ module ActiveStorage
 
   mattr_accessor :routes_prefix, default: "/rails/active_storage"
   mattr_accessor :draw_routes, default: true
+  mattr_accessor :without_default_controllers, default: false
   mattr_accessor :resolve_model_to_route, default: :rails_storage_redirect
 
   mattr_accessor :replace_on_assign_to_many, default: false

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -90,6 +90,7 @@ module ActiveStorage
         ActiveStorage.paths             = app.config.active_storage.paths || {}
         ActiveStorage.routes_prefix     = app.config.active_storage.routes_prefix || "/rails/active_storage"
         ActiveStorage.draw_routes       = app.config.active_storage.draw_routes != false
+        ActiveStorage.without_default_controllers = app.config.active_storage.without_default_controllers != false
         ActiveStorage.resolve_model_to_route = app.config.active_storage.resolve_model_to_route || :rails_storage_redirect
 
         ActiveStorage.variable_content_types = app.config.active_storage.variable_content_types || []


### PR DESCRIPTION
### Summary

This PR adds a `without_default_controllers` (default `false`) config flag to Active Storage's engine to disable the creation of those routes associated with the default Active Storage controllers that redirect to (signed URLs) or proxy blobs and representations.

The purpose of the config flag is to provide a middle ground between `ActiveStorage.draw_routes = false` for apps where the disk / direct upload routes should be kept but the potentially harmful routes (regarding missing authentication/authorization) to the default proxy and redirect controllers should be excluded.

I wasn't completely sure how to name this config flag. I ended up with `without_default_controllers`. Something like `without_default_proxy_and_redirect_controllers` seemed too verbose to me.