### PR TITLE
docs: bitstring attributes are strings [ci-skip]

### DIFF
--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -399,7 +399,7 @@ irb> user.settings
 => "01010011"
 irb> user.settings = "0xAF"
 irb> user.settings
-=> 10101111
+=> "10101111"
 irb> user.save!
 ```
 


### PR DESCRIPTION
### Summary

I got a little bit confused by this line in the guide. I tested it out, and it ended up being incorrect. Bit string attributes on an active record model always return strings, never integers.