### PR TITLE
CSP default_src Should Include :blob if Using importmaps

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1093,6 +1093,8 @@ Rails.application.config.content_security_policy do |policy|
 end
 ```
 
+WARNING: _If you're using import maps you should add `:blob` to `policy.default_src`_
+
 Example controller overrides:
 
 ```ruby


### PR DESCRIPTION
### Summary

This is documentation change to warn user that they should add `:blob` to list of protocols in `content_security_policy.rb` initializer.