### PR TITLE
Add status to scaffold template for unsuccessful requests.

### DIFF
--- a/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
+++ b/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt
@@ -31,7 +31,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.save %>
       redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully created.'" %>
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -40,7 +40,7 @@ class <%= controller_class_name %>Controller < ApplicationController
     if @<%= orm_instance.update("#{singular_table_name}_params") %>
       redirect_to <%= redirect_resource_name %>, notice: <%= "'#{human_name} was successfully updated.'" %>
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
### Summary

This aims to be consistent with the Rails 7 [scaffold template](https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/railties/lib/rails/generators/rails/scaffold_controller/templates/controller.rb.tt#L24-L41).

### Other Information

I think this is a nice improvement and will help encourage developers to set the correct status when calling `render`.