### PR TITLE
Changes to activestorage default variant formats [ci-skip]

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -427,6 +427,16 @@ end
 
 You can configure specific variants per attachment by calling the `variant` method on yielded attachable object:
 
+If you are using **ruby-vips** (Rails 7+ default):
+```ruby
+class User < ApplicationRecord
+  has_one_attached :avatar do |attachable|
+    attachable.variant :thumb, resize_to_limit: [100, nil]
+  end
+end
+```
+
+If you are using **imagemajick**:
 ```ruby
 class User < ApplicationRecord
   has_one_attached :avatar do |attachable|

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -427,20 +427,10 @@ end
 
 You can configure specific variants per attachment by calling the `variant` method on yielded attachable object:
 
-If you are using **ruby-vips** (Rails 7+ default):
 ```ruby
 class User < ApplicationRecord
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, nil]
-  end
-end
-```
-
-If you are using **imagemajick**:
-```ruby
-class User < ApplicationRecord
-  has_one_attached :avatar do |attachable|
-    attachable.variant :thumb, resize: "100x100"
   end
 end
 ```


### PR DESCRIPTION
See https://github.com/rails/rails/pull/42744

### Summary

There aren't any code changes. However, Rails 7 updated the default image processing library to `ruby-vips`. The old `resize: "100x100"` format no longer works.

This merely updates the documentation as per this change.

### Other Information

Exception trace is:
```
TypeError (no implicit conversion to float from string):

ruby-vips (2.1.4) lib/vips/gvalue.rb:106:in `g_value_set_double'
ruby-vips (2.1.4) lib/vips/gvalue.rb:106:in `set'
ruby-vips (2.1.4) lib/vips/object.rb:252:in `set'
ruby-vips (2.1.4) lib/vips/operation.rb:286:in `set'
ruby-vips (2.1.4) lib/vips/operation.rb:464:in `block in call'
ruby-vips (2.1.4) lib/vips/operation.rb:456:in `each_index'
ruby-vips (2.1.4) lib/vips/operation.rb:456:in `call'
ruby-vips (2.1.4) lib/vips/image.rb:229:in `method_missing'
image_processing (1.12.1) lib/image_processing/processor.rb:63:in `public_send'
image_processing (1.12.1) lib/image_processing/processor.rb:63:in `apply_operation'
image_processing (1.12.1) lib/image_processing/processor.rb:39:in `apply_operation'
image_processing (1.12.1) lib/image_processing/processor.rb:19:in `block in call'
image_processing (1.12.1) lib/image_processing/processor.rb:18:in `each'
image_processing (1.12.1) lib/image_processing/processor.rb:18:in `call'
image_processing (1.12.1) lib/image_processing/pipeline.rb:50:in `call_processor'
image_processing (1.12.1) lib/image_processing/pipeline.rb:28:in `block in call'
image_processing (1.12.1) lib/image_processing/pipeline.rb:64:in `create_tempfile'
image_processing (1.12.1) lib/image_processing/pipeline.rb:27:in `call'
image_processing (1.12.1) lib/image_processing/builder.rb:14:in `block in call!'
image_processing (1.12.1) lib/image_processing/builder.rb:21:in `instrument'
image_processing (1.12.1) lib/image_processing/builder.rb:13:in `call!'
image_processing (1.12.1) lib/image_processing/chainable.rb:59:in `call'
activestorage (7.0.0) lib/active_storage/transformers/image_processing_transformer.rb:23:in `process'
activestorage (7.0.0) lib/active_storage/transformers/transformer.rb:22:in `transform'
activestorage (7.0.0) app/models/active_storage/variation.rb:56:in `block in transform'
activesupport (7.0.0) lib/active_support/notifications.rb:208:in `instrument'
activestorage (7.0.0) app/models/active_storage/variation.rb:55:in `transform'
activestorage (7.0.0) app/models/active_storage/variant_with_record.rb:35:in `block in transform_blob'
activestorage (7.0.0) lib/active_storage/downloader.rb:15:in `block in open'
activestorage (7.0.0) lib/active_storage/downloader.rb:24:in `open_tempfile'
activestorage (7.0.0) lib/active_storage/downloader.rb:12:in `open'
activestorage (7.0.0) lib/active_storage/service.rb:90:in `open'
activestorage (7.0.0) app/models/active_storage/blob.rb:301:in `open'
activestorage (7.0.0) app/models/active_storage/variant_with_record.rb:34:in `transform_blob'
activestorage (7.0.0) app/models/active_storage/variant_with_record.rb:19:in `process'
activestorage (7.0.0) app/models/active_storage/variant_with_record.rb:14:in `processed'
activestorage (7.0.0) app/controllers/active_storage/representations/base_controller.rb:14:in `set_representation'
activesupport (7.0.0) lib/active_support/callbacks.rb:400:in `block in make_lambda'
activesupport (7.0.0) lib/active_support/callbacks.rb:199:in `block (2 levels) in halting'
actionpack (7.0.0) lib/abstract_controller/callbacks.rb:34:in `block (2 levels) in <module:Callbacks>'
activesupport (7.0.0) lib/active_support/callbacks.rb:200:in `block in halting'
activesupport (7.0.0) lib/active_support/callbacks.rb:595:in `block in invoke_before'
activesupport (7.0.0) lib/active_support/callbacks.rb:595:in `each'
activesupport (7.0.0) lib/active_support/callbacks.rb:595:in `invoke_before'
activesupport (7.0.0) lib/active_support/callbacks.rb:116:in `block in run_callbacks'
actiontext (7.0.0) lib/action_text/rendering.rb:20:in `with_renderer'
actiontext (7.0.0) lib/action_text/engine.rb:69:in `block (4 levels) in <class:Engine>'
activesupport (7.0.0) lib/active_support/callbacks.rb:127:in `instance_exec'
activesupport (7.0.0) lib/active_support/callbacks.rb:127:in `block in run_callbacks'
activesupport (7.0.0) lib/active_support/callbacks.rb:138:in `run_callbacks'
actionpack (7.0.0) lib/abstract_controller/callbacks.rb:233:in `process_action'
actionpack (7.0.0) lib/action_controller/metal/rescue.rb:22:in `process_action'
actionpack (7.0.0) lib/action_controller/metal/instrumentation.rb:67:in `block in process_action'
activesupport (7.0.0) lib/active_support/notifications.rb:206:in `block in instrument'
activesupport (7.0.0) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
activesupport (7.0.0) lib/active_support/notifications.rb:206:in `instrument'
actionpack (7.0.0) lib/action_controller/metal/instrumentation.rb:66:in `process_action'
actionpack (7.0.0) lib/action_controller/metal/params_wrapper.rb:259:in `process_action'
activerecord (7.0.0) lib/active_record/railties/controller_runtime.rb:27:in `process_action'
actionpack (7.0.0) lib/abstract_controller/base.rb:151:in `process'
actionview (7.0.0) lib/action_view/rendering.rb:39:in `process'
actionpack (7.0.0) lib/action_controller/metal/live.rb:266:in `block (2 levels) in process'
activesupport (7.0.0) lib/active_support/concurrency/share_lock.rb:162:in `sharing'
activesupport (7.0.0) lib/active_support/dependencies/interlock.rb:37:in `running'
actionpack (7.0.0) lib/action_controller/metal/live.rb:258:in `block in process'
actionpack (7.0.0) lib/action_controller/metal/live.rb:343:in `block in new_controller_thread'
```

See also discussion at: 
* https://github.com/libvips/ruby-vips/issues/236
* https://gist.github.com/brenogazzola/a4369965a1da426d50f11d080fe2e563
