### PR TITLE
Fix typo in #to_s deprecation in 7.0 release notes

### DIFF
--- a/guides/source/7_0_release_notes.md
+++ b/guides/source/7_0_release_notes.md
@@ -270,7 +270,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
     `BigDecimal`, `Float` and, `Integer`.
 
     This deprecation is to allow Rails application to take advantage of a Ruby 3.1
-    [optimization][https://github.com/ruby/ruby/commit/b08dacfea39ad8da3f1fd7fdd0e4538cc892ec44] that makes
+    [optimization](https://github.com/ruby/ruby/commit/b08dacfea39ad8da3f1fd7fdd0e4538cc892ec44) that makes
     interpolation of some types of objects faster.
 
     New applications will not have the `#to_s` method overridden on those classes, existing applications can use


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### Summary

Fixes a single typo in the `#to_s` deprecation in [7.0 release notes](https://edgeguides.rubyonrails.org/7_0_release_notes.html), introduced in 16e010bae40b2f971b252f0f12b875c78be849cb.

### Other Information

- 16e010bae40b2f971b252f0f12b875c78be849cb by @rafaelfranca