### PR TITLE
Short circuit `authenticate_by` on empty password

### DIFF
--- a/activerecord/lib/active_record/secure_password.rb
+++ b/activerecord/lib/active_record/secure_password.rb
@@ -42,6 +42,8 @@ module ActiveRecord
         raise ArgumentError, "One or more password arguments are required" if passwords.empty?
         raise ArgumentError, "One or more finder arguments are required" if identifiers.empty?
 
+        return if passwords.any? { |name, value| value.nil? || value.empty? }
+
         if record = find_by(identifiers)
           record if passwords.count { |name, value| record.public_send(:"authenticate_#{name}", value) } == passwords.size
         else

--- a/activerecord/test/cases/secure_password_test.rb
+++ b/activerecord/test/cases/secure_password_test.rb
@@ -43,6 +43,18 @@ class SecurePasswordTest < ActiveRecord::TestCase
     assert_in_delta found_average_time_in_ms, not_found_average_time_in_ms, 0.5
   end
 
+  test "authenticate_by short circuits when password is nil" do
+    assert_no_queries do
+      assert_nil User.authenticate_by(token: @user.token, password: nil)
+    end
+  end
+
+  test "authenticate_by short circuits when password is an empty string" do
+    assert_no_queries do
+      assert_nil User.authenticate_by(token: @user.token, password: "")
+    end
+  end
+
   test "authenticate_by finds record using multiple attributes" do
     assert_equal @user, User.authenticate_by(token: @user.token, auth_token: @user.auth_token, password: @user.password)
     assert_nil User.authenticate_by(token: @user.token, auth_token: "wrong", password: @user.password)


### PR DESCRIPTION
Password setter methods [ignore empty strings](https://github.com/rails/rails/blob/bcd76f101e6f7998b51e18b1335df1759d9cbb7d/activemodel/lib/active_model/secure_password.rb#L99) and [treat `nil` values specially](https://github.com/rails/rails/blob/bcd76f101e6f7998b51e18b1335df1759d9cbb7d/activemodel/lib/active_model/secure_password.rb#L96).  Thus, empty or `nil` passwords will not be hashed when [passed to a model constructor](https://github.com/rails/rails/blob/bcd76f101e6f7998b51e18b1335df1759d9cbb7d/activerecord/lib/active_record/secure_password.rb#L48).  Passing such passwords to `authenticate_by` results in a large timing difference depending on whether the model's record is found.

This commit changes `authenticate_by` to return `nil` before querying the database when any of the given passwords are empty or `nil`.
