### PR TITLE
Active Record / PostgreSQL / timestamptz: handle blank inputs

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/timestamp_with_time_zone.rb
@@ -10,6 +10,8 @@ module ActiveRecord
           end
 
           def cast_value(value)
+            return if value.blank?
+
             time = super
             return time if time.is_a?(ActiveSupport::TimeWithZone)
 

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -171,6 +171,28 @@ if supports_datetime_with_precision?
       end
     end
 
+    def test_writing_a_blank_attribute
+      @connection.create_table(:foos, force: true) do |t|
+        t.datetime :happened_at
+      end
+
+      assert_nil Foo.create!(happened_at: nil).happened_at
+      assert_nil Foo.create!(happened_at: "").happened_at
+    end
+
+    if current_adapter?(:PostgreSQLAdapter)
+      def test_writing_a_blank_attribute
+        with_postgresql_datetime_type(:timestamptz) do
+          @connection.create_table(:foos, force: true) do |t|
+            t.datetime :happened_at
+          end
+
+          assert_nil Foo.create!(happened_at: nil).happened_at
+          assert_nil Foo.create!(happened_at: "").happened_at
+        end
+      end
+    end
+
     def test_schema_dump_includes_datetime_precision
       @connection.create_table(:foos, force: true) do |t|
         t.timestamps precision: 6


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/43961

This would also need backporting to `7-0-stable`