### PR TITLE
Allow app to opt out of precompiling activestorage js assets

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -25,8 +25,8 @@ module ActionCable
 
     initializer "action_cable.asset" do
       config.after_initialize do |app|
-        if Rails.application.config.respond_to?(:assets) && app.config.action_cable.precompile_assets
-          Rails.application.config.assets.precompile += %w( actioncable.js actioncable.esm.js )
+        if app.config.respond_to?(:assets) && app.config.action_cable.precompile_assets
+          app.config.assets.precompile += %w( actioncable.js actioncable.esm.js )
         end
       end
     end

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -30,6 +30,7 @@ module ActiveStorage
     config.active_storage.analyzers = [ ActiveStorage::Analyzer::ImageAnalyzer::Vips, ActiveStorage::Analyzer::ImageAnalyzer::ImageMagick, ActiveStorage::Analyzer::VideoAnalyzer, ActiveStorage::Analyzer::AudioAnalyzer ]
     config.active_storage.paths = ActiveSupport::OrderedOptions.new
     config.active_storage.queues = ActiveSupport::InheritableOptions.new
+    config.active_storage.precompile_assets = true
 
     config.active_storage.variable_content_types = %w(
       image/png
@@ -167,8 +168,10 @@ module ActiveStorage
     end
 
     initializer "active_storage.asset" do
-      if Rails.application.config.respond_to?(:assets)
-        Rails.application.config.assets.precompile += %w( activestorage activestorage.esm )
+      config.after_initialize do |app|
+        if app.config.respond_to?(:assets) && app.config.active_storage.precompile_assets
+          app.config.assets.precompile += %w( activestorage activestorage.esm )
+        end
       end
     end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1972,6 +1972,11 @@ Cable as part of your normal Rails server.
 You can find more detailed configuration options in the
 [Action Cable Overview](action_cable_overview.html#configuration).
 
+#### `config.action_cable.precompile_assets`
+
+Determines whether the Action Cable assets should be added to the asset pipeline precompilation. It
+has no effect if Sprockets is not used. The default value is `true`.
+
 ### Configuring Active Storage
 
 `config.active_storage` provides the following configuration options:
@@ -2191,6 +2196,11 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `false`              |
 | 7.0                   | `true`               |
+
+#### `config.active_storage.precompile_assets`
+
+Determines whether the Active Storage assets should be added to the asset pipeline precompilation. It
+has no effect if Sprockets is not used. The default value is `true`.
 
 ### Configuring Action Text
 


### PR DESCRIPTION
### Summary

Since PR #42895, Active Storage adds 2 JS assets to precompile:

https://github.com/rails/rails/blob/a8d088fbdc7744d1806729dc8b4e477677056dce/activestorage/lib/active_storage/engine.rb#L169-L173

It's currently not possible to opt out. Our app does not use this Active Storage JS and it causes some issues with Sprockets and Uglifier. It would be helpful if we could disable this assets addition in the config.

### Other Information

Action Cable has the same behavior of adding assets to precompile (introduced in #42856), but as you can see below it can be disabled:

https://github.com/rails/rails/blob/a8d088fbdc7744d1806729dc8b4e477677056dce/actioncable/lib/action_cable/engine.rb#L26-L32

Specifically, this opt-out option was introduced by DHH in 3fd4185d971b12086dbf45c3bc8f67e21f3ddc94 so basically I mimicked this commit.


