### PR TITLE
Remove X-Download-Options default header

### DIFF
--- a/actionpack/test/dispatch/response_test.rb
+++ b/actionpack/test/dispatch/response_test.rb
@@ -333,14 +333,13 @@ class ResponseTest < ActiveSupport::TestCase
     end
   end
 
-  test "read x_frame_options, x_content_type_options, x_xss_protection, x_download_options and x_permitted_cross_domain_policies, referrer_policy" do
+  test "read x_frame_options, x_content_type_options, x_xss_protection, x_permitted_cross_domain_policies and referrer_policy" do
     original_default_headers = ActionDispatch::Response.default_headers
     begin
       ActionDispatch::Response.default_headers = {
         "X-Frame-Options" => "DENY",
         "X-Content-Type-Options" => "nosniff",
         "X-XSS-Protection" => "0",
-        "X-Download-Options" => "noopen",
         "X-Permitted-Cross-Domain-Policies" => "none",
         "Referrer-Policy" => "strict-origin-when-cross-origin"
       }
@@ -352,7 +351,6 @@ class ResponseTest < ActiveSupport::TestCase
       assert_equal("DENY", resp.headers["X-Frame-Options"])
       assert_equal("nosniff", resp.headers["X-Content-Type-Options"])
       assert_equal("0", resp.headers["X-XSS-Protection"])
-      assert_equal("noopen", resp.headers["X-Download-Options"])
       assert_equal("none", resp.headers["X-Permitted-Cross-Domain-Policies"])
       assert_equal("strict-origin-when-cross-origin", resp.headers["Referrer-Policy"])
     ensure

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1038,7 +1038,6 @@ config.action_dispatch.default_headers = {
   'X-Frame-Options' => 'SAMEORIGIN',
   'X-XSS-Protection' => '0',
   'X-Content-Type-Options' => 'nosniff',
-  'X-Download-Options' => 'noopen',
   'X-Permitted-Cross-Domain-Policies' => 'none',
   'Referrer-Policy' => 'strict-origin-when-cross-origin'
 }

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Remove default `X-Download-Options` header
 
+    This header is currently only used by Internet Explorer which
+    will be discontinued in 2022 and since Rails 7 does not fully
+    support Internet Explorer this header should not be a default one.
+
+    *Harun Sabljaković*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/railties/CHANGELOG.md) for previous changes.

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -257,6 +257,16 @@ module Rails
           end
         when "7.1"
           load_defaults "7.0"
+
+          if respond_to?(:action_dispatch)
+            action_dispatch.default_headers = {
+              "X-Frame-Options" => "SAMEORIGIN",
+              "X-XSS-Protection" => "0",
+              "X-Content-Type-Options" => "nosniff",
+              "X-Permitted-Cross-Domain-Policies" => "none",
+              "Referrer-Policy" => "strict-origin-when-cross-origin"
+            }
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -8,3 +8,13 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+# Remove the default X-Download-Options headers since it is used only by Internet Explorer.
+# If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
+# Rails.application.config.action_dispatch.default_headers = {
+#   "X-Frame-Options" => "SAMEORIGIN",
+#   "X-XSS-Protection" => "0",
+#   "X-Content-Type-Options" => "nosniff",
+#   "X-Permitted-Cross-Domain-Policies" => "none",
+#   "Referrer-Policy" => "strict-origin-when-cross-origin"
+# }


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Since `X-Download-Options` header is only used by the soon deprecated Internet Explorer to prevent phishing attacks. 
It makes sense to remove this header as a default one.

This PR solves [#43948](https://github.com/rails/rails/issues/43948)

Added new header defaults as a framework default from Rails 7.1.

<!--  ### Other Information -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information. -->

