### PR TITLE
Remove feature checking for `Class#descendants`

### DIFF
--- a/activesupport/lib/active_support/core_ext/class/subclasses.rb
+++ b/activesupport/lib/active_support/core_ext/class/subclasses.rb
@@ -3,29 +3,27 @@
 require "active_support/ruby_features"
 
 class Class
-  unless ActiveSupport::RubyFeatures::CLASS_DESCENDANTS
-    if ActiveSupport::RubyFeatures::CLASS_SUBCLASSES
-      def descendants
-        subclasses.concat(subclasses.flat_map(&:descendants))
-      end
-    else
-      # Returns an array with all classes that are < than its receiver.
-      #
-      #   class C; end
-      #   C.descendants # => []
-      #
-      #   class B < C; end
-      #   C.descendants # => [B]
-      #
-      #   class A < B; end
-      #   C.descendants # => [B, A]
-      #
-      #   class D < C; end
-      #   C.descendants # => [B, A, D]
-      def descendants
-        ObjectSpace.each_object(singleton_class).reject do |k|
-          k.singleton_class? || k == self
-        end
+  if ActiveSupport::RubyFeatures::CLASS_SUBCLASSES
+    def descendants
+      subclasses.concat(subclasses.flat_map(&:descendants))
+    end
+  else
+    # Returns an array with all classes that are < than its receiver.
+    #
+    #   class C; end
+    #   C.descendants # => []
+    #
+    #   class B < C; end
+    #   C.descendants # => [B]
+    #
+    #   class A < B; end
+    #   C.descendants # => [B, A]
+    #
+    #   class D < C; end
+    #   C.descendants # => [B, A, D]
+    def descendants
+      ObjectSpace.each_object(singleton_class).reject do |k|
+        k.singleton_class? || k == self
       end
     end
   end

--- a/activesupport/lib/active_support/descendants_tracker.rb
+++ b/activesupport/lib/active_support/descendants_tracker.rb
@@ -51,7 +51,6 @@ module ActiveSupport
           unless @clear_disabled
             @clear_disabled = true
             remove_method(:subclasses)
-            remove_method(:descendants) if RubyFeatures::CLASS_DESCENDANTS
             @@excluded_descendants = nil
           end
         end
@@ -86,16 +85,8 @@ module ActiveSupport
         subclasses
       end
 
-      if RubyFeatures::CLASS_DESCENDANTS
-        def descendants
-          descendants = super
-          descendants.reject! { |d| @@excluded_descendants[d] }
-          descendants
-        end
-      else
-        def descendants
-          subclasses.concat(subclasses.flat_map(&:descendants))
-        end
+      def descendants
+        subclasses.concat(subclasses.flat_map(&:descendants))
       end
 
       def direct_descendants

--- a/activesupport/lib/active_support/ruby_features.rb
+++ b/activesupport/lib/active_support/ruby_features.rb
@@ -3,6 +3,5 @@
 module ActiveSupport
   module RubyFeatures # :nodoc:
     CLASS_SUBCLASSES = Class.method_defined?(:subclasses) # RUBY_VERSION >= "3.1"
-    CLASS_DESCENDANTS = Class.method_defined?(:descendants)
   end
 end


### PR DESCRIPTION
Followup: #43481
Ref: https://bugs.ruby-lang.org/issues/14394#note-38

Based on Matz's last comment, it's not so clear whether `Class#descendants` will come back in the same form or at all. So lets' not assume anything.

