### PR TITLE
Use built-in bundler-cache from setup-ruby action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,24 +5,17 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: default doc job cable storage ujs test db
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Cache gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle config set without 'default doc job cable storage ujs test db'
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
+
     - name: Run RuboCop
       run: bundle exec rubocop --parallel


### PR DESCRIPTION
### Summary

ruby/setup-ruby action can install and cache gems, so I use this features to simplify the workflow.

### Other Information

I removed path, jobs and retry configs because the defaults are almost the same:

- path is the same
- retry is the same
- jobs defaults to 1 on Windows, and to the number of processors on other platforms.