### PR TITLE
Update rake tests to remove reference to removed tasks

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -471,7 +471,7 @@ module ApplicationTests
         assert_equal 2, Admin::Book.count
       end
 
-      test "db:schema:load and db:structure:load do not purge the existing database" do
+      test "db:schema:load does not purge the existing database" do
         rails "runner", "ActiveRecord::Base.connection.create_table(:posts) {|t| t.string :title }"
 
         app_file "db/schema.rb", <<-RUBY

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -586,19 +586,19 @@ module ApplicationTests
         db_migrate_name_dumps_the_schema("animals", "sql")
       end
 
-      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the primary database" do
+      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the primary database with a ruby schema" do
         db_migrate_and_schema_dump_and_load_one_database("primary", "ruby")
       end
 
-      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the animals database" do
+      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the animals database with a ruby schema" do
         db_migrate_and_schema_dump_and_load_one_database("animals", "ruby")
       end
 
-      test "db:migrate:name and db:structure:dump:name and db:structure:load:name works for the primary database" do
+      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the primary database with a sql schema" do
         db_migrate_and_schema_dump_and_load_one_database("primary", "sql")
       end
 
-      test "db:migrate:name and db:structure:dump:name and db:structure:load:name works for the animals database" do
+      test "db:migrate:name and db:schema:dump:name and db:schema:load:name works for the animals database with a sql schema" do
         db_migrate_and_schema_dump_and_load_one_database("animals", "sql")
       end
 


### PR DESCRIPTION
### Summary

As of cf269d51fbc4758cb6ae0110c6c151546c0889d9, db:structure:load has been removed and replaced by a unified use
of db:schema:load. Update the rake test names to remove reference to the removed task names
