### PR TITLE
Fix #43978 - Use the application record class when doing migrations

### DIFF
--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -1407,7 +1407,7 @@ module ActiveRecord
       # Wrap the migration in a transaction only if supported by the adapter.
       def ddl_transaction(migration, &block)
         if use_transaction?(migration)
-          @schema_migration.class.transaction(&block)
+          @schema_migration.transaction(&block)
         else
           yield
         end

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -610,7 +610,7 @@ module ActiveRecord
         end
 
         def connection
-          ActiveRecord::Base.connection
+          (ActiveRecord.application_record_class || ActiveRecord::Base).connection
         end
     end
 
@@ -911,7 +911,7 @@ module ActiveRecord
     end
 
     def connection
-      @connection || ActiveRecord::Base.connection
+      @connection || (ActiveRecord.application_record_class || ActiveRecord::Base).connection
     end
 
     def method_missing(method, *arguments, &block)


### PR DESCRIPTION
So they will be performed in the correct database specified by `ApplicationRecord.connected_to(...)` when using the block syntax to perform everything in a specific database/shard

### Summary
Possible fix for #43978 
