### PR TITLE
Deprication Warning for dynamic :controller and :action segments in routes

### DIFF
--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -596,14 +596,14 @@ module ActionDispatch
         if route.segment_keys.include?(:controller)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :controller segment in a route is deprecated and
-            will be removed in Rails 7.0.
+            will be removed in Rails 7.1.
           MSG
         end
 
         if route.segment_keys.include?(:action)
           ActiveSupport::Deprecation.warn(<<-MSG.squish)
             Using a dynamic :action segment in a route is deprecated and
-            will be removed in Rails 7.0.
+            will be removed in Rails 7.1.
           MSG
         end
 


### PR DESCRIPTION
The deprecation warnings for dynamic :controller and :action segments say that they will be removed in Rails 7.0 - which has already been released. 

This PR  updates the deprecation message to say it will be removed in Rails 7.1 as that is the next release that would be able to remove them.
