### PR TITLE
Link to valid time zones from "Invalid" error msg

### DIFF
--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -82,7 +82,7 @@ class Time
     def find_zone!(time_zone)
       return time_zone unless time_zone
 
-      ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid Timezone: #{time_zone}")
+      ActiveSupport::TimeZone[time_zone] || raise(ArgumentError, "Invalid Timezone: #{time_zone}! Find the valid identifiers with: ActiveSupport::TimeZone::MAPPING")
     end
 
     # Returns a TimeZone instance matching the time zone provided.

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -1263,10 +1263,10 @@ class TimeWithZoneMethodsForTimeAndDateTimeTest < ActiveSupport::TestCase
 
   def test_find_zone_with_bang_raises_if_time_zone_can_not_be_found
     error = assert_raise(ArgumentError) { Time.find_zone!("No such timezone exists") }
-    assert_equal "Invalid Timezone: No such timezone exists", error.message
+    assert_equal "Invalid Timezone: No such timezone exists! Find the valid identifiers with: ActiveSupport::TimeZone::MAPPING", error.message
 
     error = assert_raise(ArgumentError) { Time.find_zone!(-15.hours) }
-    assert_equal "Invalid Timezone: -54000", error.message
+    assert_equal "Invalid Timezone: -54000! Find the valid identifiers with: ActiveSupport::TimeZone::MAPPING", error.message
 
     error = assert_raise(ArgumentError) { Time.find_zone!(Object.new) }
     assert_match "invalid argument to TimeZone[]", error.message


### PR DESCRIPTION
### Summary

Over in [gitlab#27209 (Timezone rake task outputs wrong timezone format)](https://gitlab.com/gitlab-org/gitlab/-/issues/27209) we encountered a bit of confusion about which exact time zone strings can be used.

I wondered whether y'all consider a link to the file in which their identifiers are defined from that same error message to be a sensible solution to that problem.

I'm hoping that users can thus self-serve to find the solution directly in the moment of needing it.

### Other Information

1. Is maybe a different resources the preferred landing point for the piece of info?
2. Or a Rails command to list the ones in the user's installation?

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
