### PR TITLE
Fix generated route revocation

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -279,26 +279,32 @@ module Rails
       #   route "root 'welcome#index'"
       #   route "root 'admin#index'", namespace: :admin
       def route(routing_code, namespace: nil)
-        routing_code = Array(namespace).reverse.reduce(routing_code) do |code, ns|
-          "namespace :#{ns} do\n#{optimize_indentation(code, 2)}end"
+        namespace = Array(namespace)
+        namespace_pattern = route_namespace_pattern(namespace)
+        routing_code = namespace.reverse.reduce(routing_code) do |code, name|
+          "namespace :#{name} do\n#{rebase_indentation(code, 2)}end"
         end
 
         log :route, routing_code
 
-        after_pattern = Array(namespace).each_with_index.reverse_each.reduce(nil) do |pattern, (ns, i)|
-          margin = "\\#{i + 1}[ ]{2}"
-          "(?:(?:^[ ]*\n|^#{margin}.*\n)*?^(#{margin})namespace :#{ns} do\n#{pattern})?"
-        end.then do |pattern|
-          /^([ ]*).+\.routes\.draw do[ ]*\n#{pattern}/
-        end
-
         in_root do
-          if existing = match_file("config/routes.rb", after_pattern)
-            base_indent, *, prev_indent = existing.captures.compact.map(&:length)
-            routing_code = optimize_indentation(routing_code, base_indent + 2).lines.grep_v(/^[ ]{,#{prev_indent}}\S/).join
+          if namespace_match = match_file("config/routes.rb", namespace_pattern)
+            base_indent, *, existing_block_indent = namespace_match.captures.compact.map(&:length)
+            existing_line_pattern = /^[ ]{,#{existing_block_indent}}\S.+\n?/
+            routing_code = rebase_indentation(routing_code, base_indent + 2).gsub(existing_line_pattern, "")
+            namespace_pattern = /#{Regexp.escape namespace_match.to_s}/
           end
 
-          inject_into_file "config/routes.rb", routing_code, after: after_pattern, verbose: false, force: false
+          inject_into_file "config/routes.rb", routing_code, after: namespace_pattern, verbose: false, force: false
+
+          if behavior == :revoke && namespace.any? && namespace_match
+            empty_block_pattern = /(#{namespace_pattern})((?:\s*end\n){1,#{namespace.size}})/
+            gsub_file "config/routes.rb", empty_block_pattern, verbose: false, force: true do |matched|
+              beginning, ending = empty_block_pattern.match(matched).captures
+              ending.sub!(/\A\s*end\n/, "") while !ending.empty? && beginning.sub!(/^[ ]*namespace .+ do\n\s*\z/, "")
+              beginning + ending
+            end
+          end
         end
       end
 
@@ -363,6 +369,7 @@ module Rails
           return "#{value}\n" unless value.is_a?(String)
           "#{value.strip_heredoc.indent(amount).chomp}\n"
         end
+        alias rebase_indentation optimize_indentation
 
         # Indent the +Gemfile+ to the depth of @indentation
         def indentation # :doc:
@@ -386,6 +393,16 @@ module Rails
 
         def match_file(path, pattern)
           File.read(path).match(pattern) if File.exist?(path)
+        end
+
+        def route_namespace_pattern(namespace)
+          namespace.each_with_index.reverse_each.reduce(nil) do |pattern, (name, i)|
+            cummulative_margin = "\\#{i + 1}[ ]{2}"
+            blank_or_indented_line = "^[ ]*\n|^#{cummulative_margin}.*\n"
+            "(?:(?:#{blank_or_indented_line})*?^(#{cummulative_margin})namespace :#{name} do\n#{pattern})?"
+          end.then do |pattern|
+            /^([ ]*).+\.routes\.draw do[ ]*\n#{pattern}/
+          end
         end
     end
   end


### PR DESCRIPTION
Follow-up to #41584.

Thor uses a [regexp with its own capture groups](https://github.com/rails/thor/blob/5c666b4c25e748e57eec2d529d94c5059030979e/lib/thor/actions/inject_into_file.rb#L75-L81) when revoking an `inject_into_file` call.  Thus an `:after` regexp containing capture groups will interfere with Thor's regexp.

This commit changes the `:after` regexp we pass to `inject_into_file` so that it no longer contains capture groups.  This commit also cleans up any newly-empty namespace blocks when revoking a route, since `inject_into_file` does not handle that.

The majority of this commit is refactoring and clean-up.  The actual regexp fix is just the following line:

```ruby
namespace_pattern = /#{Regexp.escape namespace_match.to_s}/
```

Fixes #43950.

---

I considered submitting a PR to Thor to automatically convert capture groups in given regexps into non-capturing groups.  However, if a regexp contains backreferences (as the one here does), attempting to convert it would raise an "invalid backref" error.
