### PR TITLE
fix ordered migrations for single db in multi db environment

### DIFF
--- a/activerecord/lib/active_record/tasks/database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/database_tasks.rb
@@ -257,8 +257,12 @@ module ActiveRecord
         scope = ENV["SCOPE"]
         verbose_was, Migration.verbose = Migration.verbose, verbose?
 
-        Base.connection.migration_context.migrate(target_version || version) do |migration|
-          scope.blank? || scope == migration.scope
+        Base.connection.migration_context.migrate(target_version) do |migration|
+          if version.blank?
+            scope.blank? || scope == migration.scope
+          else
+            migration.version == version
+          end
         end.tap do |migrations_ran|
           Migration.write("No migrations ran. (using #{scope} scope)") if scope.present? && migrations_ran.empty?
         end

--- a/railties/test/application/rake/multi_dbs_test.rb
+++ b/railties/test/application/rake/multi_dbs_test.rb
@@ -551,7 +551,7 @@ module ApplicationTests
 
         Dir.chdir(app_path) do
           rails "db:migrate:up:primary", "VERSION=01_one_migration.rb"
-          rails "db:migrate:up:primary", "VERSION=03_one_migration.rb"
+          rails "db:migrate:up:primary", "VERSION=03_three_migration.rb"
           output = rails "db:migrate"
           entries = output.scan(/^== (\d+).+migrated/).map(&:first).map(&:to_i)
           assert_equal [2], entries


### PR DESCRIPTION
### Summary

The migrations were not correctly ordered when we have intermediate migrations pending in multi-db environment and we did a 

`rails db:migrate`

This resulted in the last active migration being reverted.

Here is the issue:  https://github.com/rails/rails/issues/43833

This change helps possibly fixing it.
