### PR TITLE
Fix "warning: method redefined; discarding old test_writing_a_blank_attribute"

### DIFF
--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -171,15 +171,6 @@ if supports_datetime_with_precision?
       end
     end
 
-    def test_writing_a_blank_attribute
-      @connection.create_table(:foos, force: true) do |t|
-        t.datetime :happened_at
-      end
-
-      assert_nil Foo.create!(happened_at: nil).happened_at
-      assert_nil Foo.create!(happened_at: "").happened_at
-    end
-
     if current_adapter?(:PostgreSQLAdapter)
       def test_writing_a_blank_attribute
         with_postgresql_datetime_type(:timestamptz) do
@@ -190,6 +181,15 @@ if supports_datetime_with_precision?
           assert_nil Foo.create!(happened_at: nil).happened_at
           assert_nil Foo.create!(happened_at: "").happened_at
         end
+      end
+    else
+      def test_writing_a_blank_attribute
+        @connection.create_table(:foos, force: true) do |t|
+          t.datetime :happened_at
+        end
+
+        assert_nil Foo.create!(happened_at: nil).happened_at
+        assert_nil Foo.create!(happened_at: "").happened_at
       end
     end
 


### PR DESCRIPTION
```
$ ARCONN=postgresql ruby -I"lib:test" -w test/cases/date_time_precision_test.rb
Using postgresql
test/cases/date_time_precision_test.rb:184: warning: method redefined; discarding old test_writing_a_blank_attribute
test/cases/date_time_precision_test.rb:174: warning: previous definition of test_writing_a_blank_attribute was here
Run options: --seed 60168

# Running:

.............

Finished in 1.668744s, 7.7903 runs/s, 31.7604 assertions/s.
13 runs, 53 assertions, 0 failures, 0 errors, 0 skips
```