### PR TITLE
Fix schema dumping column default SQL values for sqlite

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -45,6 +45,19 @@ module ActiveRecord
           0
         end
 
+        def quote_default_expression(value, column) # :nodoc:
+          if value.is_a?(Proc)
+            value = value.call
+            if value.match?(/\A\w+\(.*\)\z/)
+              "(#{value})"
+            else
+              value
+            end
+          else
+            super
+          end
+        end
+
         def type_cast(value) # :nodoc:
           case value
           when BigDecimal

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -127,20 +127,20 @@ module ActiveRecord
           end
 
           def new_column_from_field(table_name, field)
-            default = \
-              case field["dflt_value"]
-              when /^null$/i
-                nil
-              when /^'(.*)'$/m
-                $1.gsub("''", "'")
-              when /^"(.*)"$/m
-                $1.gsub('""', '"')
-              else
-                field["dflt_value"]
-              end
+            default = field["dflt_value"]
 
             type_metadata = fetch_type_metadata(field["type"])
-            Column.new(field["name"], default, type_metadata, field["notnull"].to_i == 0, collation: field["collation"])
+            default_value = extract_value_from_default(default)
+            default_function = extract_default_function(default_value, default)
+
+            Column.new(
+              field["name"],
+              default_value,
+              type_metadata,
+              field["notnull"].to_i == 0,
+              default_function,
+              collation: field["collation"]
+            )
           end
 
           def data_source_sql(name = nil, type: nil)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -386,6 +386,34 @@ module ActiveRecord
         end
         alias column_definitions table_structure
 
+        def extract_value_from_default(default)
+          case default
+          when /^null$/i
+            nil
+          # Quoted types
+          when /^'(.*)'$/m
+            $1.gsub("''", "'")
+          # Quoted types
+          when /^"(.*)"$/m
+            $1.gsub('""', '"')
+          # Numeric types
+          when /\A-?\d+(\.\d*)?\z/
+            $&
+          else
+            # Anything else is blank or some function
+            # and we can't know the value of that, so return nil.
+            nil
+          end
+        end
+
+        def extract_default_function(default_value, default)
+          default if has_default_function?(default_value, default)
+        end
+
+        def has_default_function?(default_value, default)
+          !default_value && %r{\w+\(.*\)|CURRENT_TIME|CURRENT_DATE|CURRENT_TIMESTAMP}.match?(default)
+        end
+
         # See: https://www.sqlite.org/lang_altertable.html
         # SQLite has an additional restriction on the ALTER TABLE statement
         def invalid_alter_table_type?(type, options)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -168,6 +168,19 @@ if current_adapter?(:Mysql2Adapter)
     end
   end
 
+  if current_adapter?(:SQLite3Adapter)
+    class Sqlite3DefaultExpressionTest < ActiveRecord::TestCase
+      include SchemaDumpingHelper
+
+      test "schema dump includes default expression" do
+        output = dump_table_schema("defaults")
+        assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
+        assert_match %r/t\.datetime\s+"modified_time",\s+precision: 6,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+        assert_match %r/t\.integer\s+"random_number",\s+default: -> { "random()" }/, output
+      end
+    end
+  end
+
   class DefaultsTestWithoutTransactionalFixtures < ActiveRecord::TestCase
     # ActiveRecord::Base#create! (and #save and other related methods) will
     # open a new transaction. When in transactional tests mode, this will

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -2,8 +2,11 @@
 
 ActiveRecord::Schema.define do
   create_table :defaults, force: true do |t|
+    t.date :modified_date, default: -> { "CURRENT_DATE" }
     t.date :fixed_date, default: "2004-01-01"
     t.datetime :fixed_time, default: "2004-01-01 00:00:00"
+    t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
+    t.integer :random_number, default: -> { "random()" }
     t.column :char1, "char(1)", default: "Y"
     t.string :char2, limit: 50, default: "a varchar field"
     t.text :char3, limit: 50, default: "a text field"


### PR DESCRIPTION
Before this changes, default SQL values were (almost) correctly created in the database, but entirely were not dumped.

Sqlite [supports as default values](https://www.sqlite.org/syntaxdiagrams.html#column-constraint): 1) literals, 2) expressions and 3) signed numbers. 

1) [supported literals](https://www.sqlite.org/syntaxdiagrams.html#literal-value). Fixed dumping of `CURRENT_...` literals, other literals are already working as expected
2) expressions were not working properly (`ALTER TABLE` was incorrect), because they need to be wrapped by `(` and `)`. Fixed this also
3) is working as expected

Fixes #43989