### PR TITLE
Refine `authenticate_by` security guarantee [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/secure_password.rb
+++ b/activerecord/lib/active_record/secure_password.rb
@@ -12,10 +12,11 @@ module ActiveRecord
       # attributes. Returns the record if authentication succeeds; otherwise,
       # returns +nil+.
       #
-      # Regardless of whether a record is found or authentication succeeds,
-      # +authenticate_by+ will take the same amount of time. This prevents
-      # timing-based enumeration attacks, wherein an attacker can determine if a
-      # passworded record exists even without knowing the password.
+      # Regardless of whether a record is found, +authenticate_by+ will
+      # cryptographically digest the given password attributes. This behavior
+      # helps mitigate timing-based enumeration attacks, wherein an attacker can
+      # determine if a passworded record exists even without knowing the
+      # password.
       #
       # Raises an ArgumentError if the set of attributes doesn't contain at
       # least one password and one non-password attribute.


### PR DESCRIPTION
We are not in a position to guarantee exactly how long `authenticate_by` will take.  For example, if the `find_by` query is not backed by an index, the database will need to perform a full table scan, and the query time will vary based on where the record is in the heap, if it is found at all.  Therefore, we should be more specific about what we guarantee.
