### PR TITLE
Ruby 3.1.0 installs `digest` 3.1.0 as standard library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -183,7 +183,4 @@ if RUBY_VERSION >= "3.1"
   gem "net-smtp", require: false
   gem "net-imap", require: false
   gem "net-pop", require: false
-
-  # digest gem, which is one of the default gems has bumped to 3.1.0.pre for ruby 3.1.0dev.
-  gem "digest", "~> 3.1.0.pre", require: false
 end

--- a/guides/bug_report_templates/action_mailbox_gem.rb
+++ b/guides/bug_report_templates/action_mailbox_gem.rb
@@ -14,10 +14,6 @@ gemfile(true) do
     # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
     # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
     gem "net-smtp", require: false
-
-    # digest gem, which is one of the default gems has bumped to 3.1.0.pre for ruby 3.1.0dev.
-    # Also `net-smtp` v0.2.2 adds dependency to digest gem which attempts to install digest 3.0.0.
-    gem "digest", "~> 3.1.0.pre", require: false
   end
 end
 

--- a/guides/bug_report_templates/action_mailbox_main.rb
+++ b/guides/bug_report_templates/action_mailbox_main.rb
@@ -13,10 +13,6 @@ gemfile(true) do
     # net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
     # So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
     gem "net-smtp", require: false
-
-    # digest gem, which is one of the default gems has bumped to 3.1.0.pre for ruby 3.1.0dev.
-    # Also `net-smtp` v0.2.2 adds dependency to digest gem which attempts to install digest 3.0.0.
-    gem "digest", "~> 3.1.0.pre", require: false
   end
 end
 


### PR DESCRIPTION
### Summary

No need to add digest gem explicitly anymore.

Refer:
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

> Standard libraries updates
> The following default gem are updated.
> digest 3.1.0

This commit is kind of reverting these pull requests.

https://github.com/rails/rails/pull/42902
https://github.com/rails/rails/pull/43424
https://github.com/rails/rails/pull/43433