### PR TITLE
Better error messages when association name is invalid in the argument of `ActiveRecord::QueryMethods::WhereChain#missing`

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -97,6 +97,9 @@ module ActiveRecord
       def missing(*associations)
         associations.each do |association|
           reflection = @scope.klass._reflect_on_association(association)
+          unless reflection
+            raise ArgumentError.new("An association named `:#{association}` does not exist on the model `#{@scope.name}`.")
+          end
           @scope.left_outer_joins!(association)
           @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
         end

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -33,6 +33,14 @@ module ActiveRecord
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
     end
 
+    def test_missing_with_invalid_association_name
+      e = assert_raises(ArgumentError) do
+        Post.where.missing(:cars).to_a
+      end
+
+      assert_match(/An association named `:cars` does not exist on the model `Post`\./, e.message)
+    end
+
     def test_missing_with_multiple_association
       assert posts(:authorless).comments.empty?
       assert_equal [posts(:authorless)], Post.where.missing(:author, :comments).to_a


### PR DESCRIPTION


### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

before:

```ruby
Post.where.missing(:cars).to_a # Post does not have association named `cars`
=> NoMethodError: undefined method `table_name' for nil:NilClass
```

It is complicated message.

after:

```ruby
Post.where.missing(:cars).to_a
=> ArgumentError: An association named `:cars` does not exist on the model `Post`.
```
