### PR TITLE
[ci skip] Pluck loads the records but omits attributes

### DIFF
--- a/activerecord/lib/active_record/relation/calculations.rb
+++ b/activerecord/lib/active_record/relation/calculations.rb
@@ -155,7 +155,7 @@ module ActiveRecord
     end
 
     # Use #pluck as a shortcut to select one or more attributes without
-    # loading a bunch of records just to grab the attributes you want.
+    # loading an entire record object per row.
     #
     #   Person.pluck(:name)
     #


### PR DESCRIPTION
### Summary

Pluck Doc incorrectly states "Use #pluck as a shortcut to select one or more attributes without loading a bunch of records just to grab the attributes you want."

Instead It loads the rows but omits the extra attributes. 

Updating the doc to be consistent with functionality of pluck.