### PR TITLE
Use `pg` gem 1.3.0.rc1 or higher for Ruby 3.2.0dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,7 +139,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "sqlite3", "~> 1.4"
 
   group :db do
-    gem "pg", "~> 1.1"
+    gem "pg", ">= 1.3.0.rc1"
     gem "mysql2", "~> 0.5", github: "brianmario/mysql2"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     path_expander (1.1.0)
-    pg (1.2.3)
+    pg (1.3.0.rc1)
     propshaft (0.4.4)
       actionpack (>= 7.0.0.alpha2)
       activesupport (>= 7.0.0.alpha2)
@@ -605,7 +605,7 @@ DEPENDENCIES
   minitest-retry
   mysql2 (~> 0.5)!
   nokogiri (>= 1.8.1, != 1.11.0)
-  pg (~> 1.1)
+  pg (>= 1.3.0.rc1)
   propshaft (>= 0.1.7)
   psych (~> 3.0)
   puma


### PR DESCRIPTION
### Summary

Ruby 3.2.0dev removed `rb_cData`, `pg` gem cannot be installed with Ruby 3.2.0dev.
Refer Rails CI build failure at:
https://buildkite.com/rails/rails/builds/83631#fbe41b47-08d3-4b4a-8f17-692da1ab1ddf

This fix has been released as `1.3.0.rc1`
Refer:
https://github.com/ged/ruby-pg/issues/413
https://github.com/ruby/ruby/commit/7c738ce5e649b82bdc1305d5c347e81886ee759a
