### PR TITLE
Cannot deliver new inbound email via form

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,7 +22,7 @@ module Rails
       def new_mail
         Mail.new(mail_params.except(:attachments).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
-          mail_params[:attachments].to_a.each do |attachment|
+          mail_params[:attachments].to_a.reject(&:blank?).each do |attachment|
             mail.add_file(filename: attachment.original_filename, content: attachment.read)
           end
         end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -14,7 +14,8 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
             bcc: "Bcc <bcc@example.com>",
             in_reply_to: "<4e6e35f5a38b4_479f13bb90078178@small-app-01.mail>",
             subject: "Hey there",
-            body: "How's it going?"
+            body: "How's it going?",
+            attachments: [ "" ]
           }
         }
       end
@@ -27,6 +28,7 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
       assert_equal "4e6e35f5a38b4_479f13bb90078178@small-app-01.mail", mail.in_reply_to
       assert_equal "Hey there", mail.subject
       assert_equal "How's it going?", mail.body.decoded
+      assert_equal [], mail.attachments
     end
   end
 


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

#### Steps to reproduce
1. Install ActionMailbox in your app
2. Visit `/rails/conductor/action_mailbox/inbound_emails` as specified in here https://guides.rubyonrails.org/action_mailbox_basics.html#working-with-action-mailbox-in-development
3. Click on "New inbound email by form"
4. Fill the form and submit

#### Expected
The inbound email is created successfully 

#### Actual
A `NoMethodError` is raised:

```
NoMethodError in Rails::Conductor::ActionMailbox::InboundEmailsController#create
undefined method `original_filename' for "":String
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

```
>> mail_params[:attachments]
=> [""]
```

This happens because of the hidden field tag the multiple select field uses under the hood. An easy fix for this problem is to exclude the empty string from the collection.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
