### PR TITLE
Accept nested functions in Dangerous Query Methods

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow nested functions as safe SQL string
+
+    *Michael Siegfried*
+
 *   Allow `destroy_association_async_job=` to be configured with a class string instead of a constant.
 
     Defers an autoloading dependency between `ActiveRecord::Base` and `ActiveJob::Base`

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -167,7 +167,7 @@ module ActiveRecord
         (
           (?:
             # table_name.column_name | function(one or no argument)
-            ((?:\w+\.)?\w+) | \w+\((?:|\g<2>)\)
+            ((?:\w+\.)?\w+ | \w+\((?:|\g<2>)\))
           )
           (?:(?:\s+AS)?\s+\w+)?
         )
@@ -191,7 +191,7 @@ module ActiveRecord
         (
           (?:
             # table_name.column_name | function(one or no argument)
-            ((?:\w+\.)?\w+) | \w+\((?:|\g<2>)\)
+            ((?:\w+\.)?\w+ | \w+\((?:|\g<2>)\))
           )
           (?:\s+ASC|\s+DESC)?
           (?:\s+NULLS\s+(?:FIRST|LAST))?

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           (
             (?:
               # `table_name`.`column_name` | function(one or no argument)
-              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)) | \w+\((?:|\g<2>)\)
+              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`) | \w+\((?:|\g<2>)\))
             )
             (?:(?:\s+AS)?\s+(?:\w+|`\w+`))?
           )
@@ -97,7 +97,7 @@ module ActiveRecord
           (
             (?:
               # `table_name`.`column_name` | function(one or no argument)
-              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)) | \w+\((?:|\g<2>)\)
+              ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`) | \w+\((?:|\g<2>)\))
             )
             (?:\s+COLLATE\s+(?:\w+|"\w+"))?
             (?:\s+ASC|\s+DESC)?

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -134,7 +134,7 @@ module ActiveRecord
           (
             (?:
               # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
-              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
+              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)? | \w+\((?:|\g<2>)\)(?:::\w+)?)
             )
             (?:(?:\s+AS)?\s+(?:\w+|"\w+"))?
           )
@@ -147,7 +147,7 @@ module ActiveRecord
           (
             (?:
               # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
-              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
+              ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)? | \w+\((?:|\g<2>)\)(?:::\w+)?)
             )
             (?:\s+COLLATE\s+"\w+")?
             (?:\s+ASC|\s+DESC)?

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -86,7 +86,7 @@ module ActiveRecord
           (
             (?:
               # "table_name"."column_name" | function(one or no argument)
-              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")) | \w+\((?:|\g<2>)\)
+              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
             )
             (?:(?:\s+AS)?\s+(?:\w+|"\w+"))?
           )
@@ -99,7 +99,7 @@ module ActiveRecord
           (
             (?:
               # "table_name"."column_name" | function(one or no argument)
-              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")) | \w+\((?:|\g<2>)\)
+              ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+") | \w+\((?:|\g<2>)\))
             )
             (?:\s+COLLATE\s+(?:\w+|"\w+"))?
             (?:\s+ASC|\s+DESC)?

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -180,6 +180,14 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     assert_equal ids_expected, ids
   end
 
+  test "order: allows nested functions" do
+    ids_expected = Post.order(Arel.sql("author_id, length(trim(title))")).pluck(:id)
+
+    ids = Post.order("author_id, length(trim(title))").pluck(:id)
+
+    assert_equal ids_expected, ids
+  end
+
   test "order: logs deprecation warning for unrecognized column" do
     e = assert_raises(ActiveRecord::UnknownAttributeReference) do
       Post.order("REPLACE(title, 'misc', 'zzzz')")
@@ -251,6 +259,14 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     titles = Post.pluck(quoted_title)
 
     assert_equal titles_expected, titles
+  end
+
+  test "pluck: allows nested functions" do
+    title_lengths_expected = Post.pluck(Arel.sql("length(trim(title))"))
+
+    title_lengths = Post.pluck("length(trim(title))")
+
+    assert_equal title_lengths_expected, title_lengths
   end
 
   test "pluck: disallows invalid column name" do


### PR DESCRIPTION
### Summary

I think there’s an opportunity to reduce additional false positives for
Dangerous Query Method deprecations/errors. Similar to https://github.com/rails/rails/pull/36448, it seems
reasonable to allow functions that accept other functions (e.g.
`length(trim(title))`).

### Other Information

Mailing list thread: https://discuss.rubyonrails.org/t/feature-proposal-accept-nested-functions-w-r-t-dangerous-query-methods/78650

*Background*
* PR accepting non-nested functions: https://github.com/rails/rails/pull/36448
* Deep background on deprecation and false positives: https://github.com/rails/rails/issues/32995
* Constants: `COLUMN_NAME` for the first and `COLUMN_NAME_WITH_ORDER` for both
