### PR TITLE
Allow collate for pg in Dangerous Query Methods

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -149,6 +149,7 @@ module ActiveRecord
               # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
               ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
             )
+            (?:\s+COLLATE\s+\w+)?
             (?:\s+ASC|\s+DESC)?
             (?:\s+NULLS\s+(?:FIRST|LAST))?
           )

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -166,6 +166,14 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     assert_equal ids_expected, ids
   end
 
+  test "pluck: allows collation" do
+    ids_expected = Post.order(Arel.sql("author_id, title COLLATE NOCASE")).pluck(:id)
+
+    ids = Post.order("author_id, title COLLATE en_US").pluck(:id)
+
+    assert_equal ids_expected, ids
+  end if current_adapter?(:PostgreSQLAdapter)
+
   test "order: logs deprecation warning for unrecognized column" do
     e = assert_raises(ActiveRecord::UnknownAttributeReference) do
       Post.order("REPLACE(title, 'misc', 'zzzz')")


### PR DESCRIPTION
### Summary

I think there's an opportunity to reduce additional false positives for
Dangerous Query Method deprecations/errors by accepting collation.

### Other Information

Mailing list thread: https://discuss.rubyonrails.org/t/feature-proposal-accept-nested-functions-w-r-t-dangerous-query-methods/78650