### PR TITLE
Fix asset pipeline errors for plugin dummy apps

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -226,6 +226,10 @@ module Rails
       def initialize(*args)
         @dummy_path = nil
         super
+
+        if !engine? || !with_dummy_app?
+          self.options = options.merge(skip_asset_pipeline: true).freeze
+        end
       end
 
       public_task :set_default_accessors!

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -944,26 +944,25 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_minimal_rails_app
-    app_root = File.join(destination_root, "myapp")
-    run_generator [app_root, "--minimal"]
+    run_generator [destination_root, "--minimal"]
 
-    assert_no_file "#{app_root}/config/storage.yml"
-    assert_no_file "#{app_root}/config/cable.yml"
-    assert_no_file "#{app_root}/views/layouts/mailer.html.erb"
-    assert_no_file "#{app_root}/app/jobs/application.rb"
-    assert_file "#{app_root}/app/views/layouts/application.html.erb" do |content|
+    assert_no_file "config/storage.yml"
+    assert_no_file "config/cable.yml"
+    assert_no_file "views/layouts/mailer.html.erb"
+    assert_no_file "app/jobs/application.rb"
+    assert_file "app/views/layouts/application.html.erb" do |content|
       assert_no_match(/data-turbo-track/, content)
     end
-    assert_file "#{app_root}/config/environments/development.rb" do |content|
+    assert_file "config/environments/development.rb" do |content|
       assert_no_match(/config\.active_storage/, content)
     end
-    assert_file "#{app_root}/config/environments/production.rb" do |content|
+    assert_file "config/environments/production.rb" do |content|
       assert_no_match(/config\.active_job/, content)
     end
-    assert_file "#{app_root}/config/boot.rb" do |content|
+    assert_file "config/boot.rb" do |content|
       assert_no_match(/require "bootsnap\/setup"/, content)
     end
-    assert_file "#{app_root}/config/application.rb" do |content|
+    assert_file "config/application.rb" do |content|
       assert_match(/#\s+require\s+["']active_job\/railtie["']/, content)
       assert_match(/#\s+require\s+["']active_storage\/engine["']/, content)
       assert_match(/#\s+require\s+["']action_mailer\/railtie["']/, content)
@@ -972,8 +971,8 @@ class AppGeneratorTest < Rails::Generators::TestCase
       assert_match(/#\s+require\s+["']action_cable\/engine["']/, content)
     end
 
-    assert_no_gem "jbuilder", app_root
-    assert_no_gem "web-console", app_root
+    assert_no_gem "jbuilder"
+    assert_no_gem "web-console"
   end
 
   private
@@ -984,19 +983,5 @@ class AppGeneratorTest < Rails::Generators::TestCase
 
     def action(*args, &block)
       capture(:stdout) { generator.send(*args, &block) }
-    end
-
-    def assert_gem(gem, constraint = nil, app_path = ".")
-      if constraint
-        assert_file File.join(app_path, "Gemfile"), /^\s*gem\s+["']#{gem}["'], #{constraint}$*/
-      else
-        assert_file File.join(app_path, "Gemfile"), /^\s*gem\s+["']#{gem}["']$*/
-      end
-    end
-
-    def assert_no_gem(gem, app_path = ".")
-      assert_file File.join(app_path, "Gemfile") do |content|
-        assert_no_match(gem, content)
-      end
     end
 end

--- a/railties/test/generators/plugin_test_helper.rb
+++ b/railties/test/generators/plugin_test_helper.rb
@@ -23,4 +23,15 @@ module PluginTestHelper
       f.puts contents
     end
   end
+
+  def fill_in_gemspec_fields(gemspec_path = "#{plugin_path}/#{File.basename plugin_path}.gemspec")
+    # Some fields must be a valid URL.
+    filled_in = File.read(gemspec_path).gsub(/"TODO.*"/, "http://example.com".inspect)
+    File.write(gemspec_path, filled_in)
+  end
+
+  def resolve_rails_gem_to_repository(gemfile_path = "#{plugin_path}/Gemfile")
+    repository_path = File.expand_path("../../..", __dir__)
+    File.write(gemfile_path, "gem 'rails', path: #{repository_path.inspect}\n", mode: "a")
+  end
 end

--- a/railties/test/generators/shared_generator_tests.rb
+++ b/railties/test/generators/shared_generator_tests.rb
@@ -387,4 +387,15 @@ module SharedGeneratorTests
         assert_equal gemfile[rails_gem_pattern], bundle_command_rails_gems[1]
       end
     end
+
+    def assert_gem(name, constraint = nil)
+      constraint_pattern = /, #{Regexp.escape constraint}/ if constraint
+      assert_file "Gemfile", %r/^\s*gem ["']#{name}["']#{constraint_pattern}/
+    end
+
+    def assert_no_gem(name)
+      assert_file "Gemfile" do |content|
+        assert_no_match %r/gem ["']#{name}["']/, content
+      end
+    end
 end

--- a/railties/test/generators/test_runner_in_engine_test.rb
+++ b/railties/test/generators/test_runner_in_engine_test.rb
@@ -1,18 +1,26 @@
 # frozen_string_literal: true
 
 require "generators/plugin_test_helper"
+require "env_helpers"
 
 class TestRunnerInEngineTest < ActiveSupport::TestCase
   include PluginTestHelper
+  include EnvHelpers
 
   def setup
     @destination_root = Dir.mktmpdir("bukkits")
     Dir.chdir(@destination_root) { `bundle exec rails plugin new bukkits --full --skip-bundle` }
+    fill_in_gemspec_fields
+    resolve_rails_gem_to_repository
     plugin_file "test/dummy/db/schema.rb", ""
   end
 
   def teardown
     FileUtils.rm_rf(@destination_root)
+  end
+
+  def test_run_default
+    assert_match "0 failures, 0 errors", run_test_command
   end
 
   def test_rerun_snippet_is_relative_path
@@ -28,7 +36,9 @@ class TestRunnerInEngineTest < ActiveSupport::TestCase
       "#{@destination_root}/bukkits"
     end
 
-    def run_test_command(arguments)
-      Dir.chdir(plugin_path) { `bin/rails test #{arguments}` }
+    def run_test_command(arguments = "")
+      Dir.chdir(plugin_path) do
+        switch_env("BUNDLE_GEMFILE", "") { `bin/rails test #{arguments}` }
+      end
     end
 end


### PR DESCRIPTION
To fix #43920, f292daad7051275f7b557b352876cfeb3988f639 added `sprockets-rails` to the generated `Gemfile` for engine plugins because their dummy apps use Sprockets.  However, non-engine plugins exhibit the same issue because their dummy apps also use Sprockets.

This commit forces `skip_asset_pipeline` to be true when a plugin is not an engine, and fixes several tests that failed to detect these issues because they were accidentally using the `rails/rails` `Gemfile` instead of the generated plugin `Gemfile`.
