### PR TITLE
Allow arel node as value for InsertAll

### DIFF
--- a/activerecord/lib/active_record/insert_all.rb
+++ b/activerecord/lib/active_record/insert_all.rb
@@ -200,6 +200,7 @@ module ActiveRecord
 
           values_list = insert_all.map_key_with_value do |key, value|
             next value if Arel::Nodes::SqlLiteral === value
+            next Arel.sql(value.to_sql(model)) if Arel::Nodes::Node === value
             connection.with_yaml_fallback(types[key].serialize(value))
           end
 

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -673,6 +673,15 @@ class InsertAllTest < ActiveRecord::TestCase
     assert_match "#{ActiveRecord::Base.connection.class} does not support :unique_by", error.message
   end
 
+  def test_upsert_with_arel_nodes_as_attributes
+    lower_name = Arel::Nodes::NamedFunction.new("lower", [
+      Arel::Nodes.build_quoted("Reworking")
+    ])
+
+    Book.upsert_all([{ id: 101, name: lower_name, author_id: 1 }])
+    assert_equal "reworking", Book.find(101).name
+  end
+
   private
     def capture_log_output
       output = StringIO.new


### PR DESCRIPTION
You can already use any `Arel::Nodes::Node` on `where` clause and other query methods. We should follow the same convention for upsert as well.