### PR TITLE
Remove hard dependency on actionpack from railties

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,6 @@ PATH
       bundler (>= 1.15.0)
       railties (= 7.1.0.alpha)
     railties (7.1.0.alpha)
-      actionpack (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       method_source
       rake (>= 12.2)

--- a/railties/lib/rails.rb
+++ b/railties/lib/rails.rb
@@ -15,7 +15,12 @@ require "rails/version"
 require "rails/autoloaders"
 
 require "active_support/railtie"
-require "action_dispatch/railtie"
+
+begin
+  require "action_dispatch/railtie"
+rescue LoadError => e
+  raise unless e.path == "action_dispatch/railtie"
+end
 
 # UTF-8 is the default internal and external encoding.
 silence_warnings do

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -62,7 +62,7 @@ module Rails
         unless Rails.cache
           Rails.cache = ActiveSupport::Cache.lookup_store(*config.cache_store)
 
-          if Rails.cache.respond_to?(:middleware)
+          if Rails.cache.respond_to?(:middleware) && config.respond_to?(:action_dispatch)
             config.middleware.insert_before(::Rack::Runtime, Rails.cache.middleware)
           end
         end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -33,7 +33,7 @@ module Rails
         @filter_parameters                       = []
         @filter_redirect                         = []
         @helpers_paths                           = []
-        if Rails.env.development?
+        if Rails.env.development? && defined?(ActionDispatch)
           @hosts = ActionDispatch::HostAuthorization::ALLOWED_HOSTS_IN_DEVELOPMENT +
             ENV["RAILS_DEVELOPMENT_HOSTS"].to_s.split(",").map(&:strip)
         else

--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require "active_support/all"
-require "action_controller"
+begin
+  require "action_controller"
+rescue LoadError => e
+  raise unless e.path == "action_controller"
+end
 
 module Rails
   module ConsoleMethods
@@ -17,6 +21,11 @@ module Rails
     # create a new session. If a block is given, the new session will be yielded
     # to the block before being returned.
     def new_session
+      unless defined?(::ActionDispatch)
+        warn "Missing actionpack in your Gemfile, testing session not available."
+        return
+      end
+
       app = Rails.application
       session = ActionDispatch::Integration::Session.new(app)
       yield session if block_given?

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -583,15 +583,17 @@ module Rails
       config.eager_load_paths.freeze
     end
 
-    initializer :add_routing_paths do |app|
-      routing_paths = paths["config/routes.rb"].existent
-      external_paths = self.paths["config/routes"].paths
-      routes.draw_paths.concat(external_paths)
+    if defined?(::ActionDispatch)
+      initializer :add_routing_paths do |app|
+        routing_paths = paths["config/routes.rb"].existent
+        external_paths = self.paths["config/routes"].paths
+        routes.draw_paths.concat(external_paths)
 
-      if routes? || routing_paths.any?
-        app.routes_reloader.paths.unshift(*routing_paths)
-        app.routes_reloader.route_sets << routes
-        app.routes_reloader.external_routes.unshift(*external_paths)
+        if routes? || routing_paths.any?
+          app.routes_reloader.paths.unshift(*routing_paths)
+          app.routes_reloader.route_sets << routes
+          app.routes_reloader.external_routes.unshift(*external_paths)
+        end
       end
     end
 

--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   # https://edgeguides.rubyonrails.org/security.html#dependency-management-and-cves
 
   s.add_dependency "activesupport", version
-  s.add_dependency "actionpack",    version
 
   s.add_dependency "rake", ">= 12.2"
   s.add_dependency "thor", "~> 1.0"


### PR DESCRIPTION
### Summary
When rails are being used without a webserver (for example in a service that runs activejobs with activerecord on some schedule or handle a message queue etc.), railties still pulls unnecessary heavy dependencies (namely nokogiri, around 15mb) through actionpack.

This PR removes hard dependency from railties and makes it possible to make a smaller app via adding only necessary rails parts to gemfile.