### PR TITLE
Remove Node and Yarn references from Guides as Rails 7 no longer require them

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -441,11 +441,10 @@ $ bin/rails destroy model Oops
 ```bash
 $ bin/rails about
 About your application's environment
-Rails version             6.0.0
+Rails version             7.0.0
 Ruby version              2.7.0 (x86_64-linux)
 RubyGems version          2.7.3
 Rack version              2.0.4
-JavaScript Runtime        Node.js (V8)
 Middleware:               Rack::Sendfile, ActionDispatch::Static, ActionDispatch::Executor, ActiveSupport::Cache::Strategy::LocalCache::Middleware, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, ActionDispatch::RemoteIp, Sprockets::Rails::QuietAssets, Rails::Rack::Logger, ActionDispatch::ShowExceptions, WebConsole::Middleware, ActionDispatch::DebugExceptions, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies, ActionDispatch::Session::CookieStore, ActionDispatch::Flash, Rack::Head, Rack::ConditionalGet, Rack::ETag
 Application root          /home/foobar/commandsapp
 Environment               development

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -83,8 +83,6 @@ proper prerequisites installed. These include:
 
 * Ruby
 * SQLite3
-* Node.js
-* Yarn
 
 #### Installing Ruby
 
@@ -120,31 +118,6 @@ $ sqlite3 --version
 ```
 
 The program should report its version.
-
-#### Installing Node.js and Yarn
-
-Finally, you'll need Node.js and Yarn installed to manage your application's JavaScript.
-
-Find the installation instructions at the [Node.js website](https://nodejs.org/en/download/) and
-verify it's installed correctly with the following command:
-
-```bash
-$ node --version
-```
-
-The version of your Node.js runtime should be printed out. Make sure it's greater
-than 8.16.0.
-
-To install Yarn, follow the installation
-instructions at the [Yarn website](https://classic.yarnpkg.com/en/docs/install).
-
-Running this command should print out Yarn version:
-
-```bash
-$ yarn --version
-```
-
-If it says something like "1.22.0", Yarn has been installed correctly.
 
 #### Installing Rails
 


### PR DESCRIPTION
### Summary

This PR removes `Node` and `Yarn` references from the guides since Rails 7 no longer requires Node.js locally:
https://world.hey.com/dhh/modern-web-apps-without-javascript-bundling-or-transpiling-a20f2755