### PR TITLE
Fix default value for raise_on_open_redirects

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -907,7 +907,7 @@ Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
 
 #### `config.action_controller.raise_on_open_redirects`
 
-Raises an `ArgumentError` when an unpermitted open redirect occurs. The default value is `false`.
+Raises an `ArgumentError` when an unpermitted open redirect occurs. The default value is `true`.
 
 #### `config.action_controller.log_query_tags_around_actions`
 


### PR DESCRIPTION
'raise_on_open_redirects' has been introduced in the commit
https://github.com/rails/rails/commit/5e93cff83599833380b4cb3d99c020b5efc7dd96
Its default value is true.
This commit fixes its wrong documentation in the guide "Configuring Rails Applications".

Should also be backported to branch 7.0.