### PR TITLE
use new vips syntax for named variant examples .

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -430,7 +430,7 @@ You can configure specific variants per attachment by calling the `variant` meth
 ```ruby
 class User < ApplicationRecord
   has_one_attached :avatar do |attachable|
-    attachable.variant :thumb, resize: "100x100"
+    attachable.variant :thumb, resize_to_limit: [100, 100]
   end
 end
 ```
@@ -506,7 +506,7 @@ Configuring specific variants is done the same way as `has_one_attached`, by cal
 ```ruby
 class Message < ApplicationRecord
   has_many_attached :images do |attachable|
-    attachable.variant :thumb, resize: "100x100"
+    attachable.variant :thumb, resize_to_limit: [100, 100]
   end
 end
 ```


### PR DESCRIPTION
### Summary

When trying to view the image url in the browser using the previous imagemagick-oriented examples of named variants when defining a has_one_attachment, I got the same error as described in the "Upgrading Ruby on Rails" guide for 7.0 when trying to view the image url in the browser. ("no implicit conversion to float from string").  Using the new vips syntax, everything works as expected.

