### PR TITLE
Extract `on update CURRENT_TIMESTAMP` for mysql2 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb
@@ -163,6 +163,7 @@ module ActiveRecord
             default, default_function = field[:Default], nil
 
             if type_metadata.type == :datetime && /\ACURRENT_TIMESTAMP(?:\([0-6]?\))?\z/i.match?(default)
+              default = "#{default} ON UPDATE #{default}" if /on update CURRENT_TIMESTAMP/i.match?(field[:Extra])
               default, default_function = nil, default
             elsif type_metadata.extra == "DEFAULT_GENERATED"
               default = +"(#{default})" unless default.start_with?("(")

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -151,6 +151,11 @@ if current_adapter?(:Mysql2Adapter)
         assert_match %r/t\.datetime\s+"precise_datetime",.+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
       end
 
+      test "schema dump datetime includes precise default expression with on update" do
+        output = dump_table_schema("datetime_defaults")
+        assert_match %r/t\.datetime\s+"updated_datetime",.+default: -> { "CURRENT_TIMESTAMP\(6\) ON UPDATE CURRENT_TIMESTAMP\(6\)" }/i, output
+      end
+
       test "schema dump timestamp includes default expression" do
         output = dump_table_schema("timestamp_defaults")
         assert_match %r/t\.timestamp\s+"modified_timestamp",\s+default: -> { "CURRENT_TIMESTAMP(?:\(\))?" }/i, output
@@ -159,6 +164,11 @@ if current_adapter?(:Mysql2Adapter)
       test "schema dump timestamp includes precise default expression" do
         output = dump_table_schema("timestamp_defaults")
         assert_match %r/t\.timestamp\s+"precise_timestamp",.+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
+      end
+
+      test "schema dump timestamp includes precise default expression with on update" do
+        output = dump_table_schema("timestamp_defaults")
+        assert_match %r/t\.timestamp\s+"updated_timestamp",.+default: -> { "CURRENT_TIMESTAMP\(6\) ON UPDATE CURRENT_TIMESTAMP\(6\)" }/i, output
       end
 
       test "schema dump timestamp without default expression" do

--- a/activerecord/test/schema/mysql2_specific_schema.rb
+++ b/activerecord/test/schema/mysql2_specific_schema.rb
@@ -5,12 +5,14 @@ ActiveRecord::Schema.define do
     create_table :datetime_defaults, force: true do |t|
       t.datetime :modified_datetime, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
       t.datetime :precise_datetime, default: -> { "CURRENT_TIMESTAMP(6)" }
+      t.datetime :updated_datetime, default: -> { "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)" }
     end
 
     create_table :timestamp_defaults, force: true do |t|
       t.timestamp :nullable_timestamp
       t.timestamp :modified_timestamp, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
       t.timestamp :precise_timestamp, precision: 6, default: -> { "CURRENT_TIMESTAMP(6)" }
+      t.timestamp :updated_timestamp, precision: 6, default: -> { "CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)" }
     end
   end
 


### PR DESCRIPTION
### Summary

If `on update CURRENT_TIMESTAMP` is specified in the Extra field, it is now included in default.

### Other Information

This PR solves https://github.com/ridgepole/ridgepole/issues/375