### PR TITLE
Fix link formatting to turbo.hotwired.dev

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -1312,7 +1312,7 @@ In the above code, we're passing the `data` attribute with some options to `link
 The `turbo_method: :delete` option causes the link to make a `DELETE` request instead
 of a `GET` request. The `turbo_confirm: { confirm: "Are you sure?" }` option causes a
 confirmation dialog to appear when the link is clicked. If the user cancels the
-dialog, the request is aborted. Both of these options are powered by (Turbo)[https://turbo.hotwired.dev/]
+dialog, the request is aborted. Both of these options are powered by [Turbo](https://turbo.hotwired.dev/)
 called *Performing Visits*. The JavaScript file that
 implements these behaviors is included by default in fresh Rails applications.
 


### PR DESCRIPTION
I fixed the formatting of a link in the "Getting Started" Rails Guide.