### PR TITLE
changed example cookie rotator to be in after_initialize block

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -203,17 +203,20 @@ to register a rotator.
 The following is an example for rotator for the encrypted cookies.
 
 ```ruby
-Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-  salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-  secret_key_base = Rails.application.secrets.secret_key_base
+# config/initializers/cookie_rotator.rb
+Rails.application.config.after_initialize do
+  Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
+    salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
+    secret_key_base = Rails.application.secrets.secret_key_base
 
-  key_generator = ActiveSupport::KeyGenerator.new(
-    secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-  )
-  key_len = ActiveSupport::MessageEncryptor.key_len
-  secret = key_generator.generate_key(salt, key_len)
+    key_generator = ActiveSupport::KeyGenerator.new(
+      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
+    )
+    key_len = ActiveSupport::MessageEncryptor.key_len
+    secret = key_generator.generate_key(salt, key_len)
 
-  cookies.rotate :encrypted, secret
+    cookies.rotate :encrypted, secret
+  end
 end
 ```
 


### PR DESCRIPTION
I made a small change to the docs to clear up something that I found confusing. After upgrading, I wasn't sure where to put the cookie rotator example code from the docs. I put it in an initializer, but I ran into an error because `secret_key_base` was `nil` when the initializer ran. Putting the example code inside an `after_initialize` callback fixed it.



