### PR TITLE
HasOneThroughDisableJoinsAssociationsTest: Use  to support matching SQL of any adapter

### DIFF
--- a/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
@@ -76,10 +76,6 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
       assert_no_match(/INNER JOIN/, nj)
     end
 
-    if current_adapter?(:Mysql2Adapter)
-      assert_match(/`memberships`.`type`/, no_joins.first)
-    else
-      assert_match(/"memberships"."type"/, no_joins.first)
-    end
+    assert_match(/#{Regexp.escape(connection.quote_table_name('memberships.type'))}/, no_joins.first)
   end
 end


### PR DESCRIPTION
### Summary

`HasOneThroughDisableJoinsAssociationsTest` assert SQL generated but
doesn't handle SQL Server (quotes with `[]`).

SQL Server adapter
(https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/) need to be coerced and re-implemented that test
(https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/975)

This PR changes the test to handle all adapters.
