### PR TITLE
EncryptableRecordTest: Use column limit to build invalid records

### DIFF
--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -247,12 +247,12 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
   end
 
   # Only run for adapters that add a default string limit when not provided (MySQL, 255)
-  if EncryptedAuthor.columns_hash["name"].limit
+  if author_name_limit = EncryptedAuthor.columns_hash["name"].limit
     # No column limits in SQLite
     test "validate column sizes" do
       assert EncryptedAuthor.new(name: "jorge").valid?
-      assert_not EncryptedAuthor.new(name: "a" * 256).valid?
-      author = EncryptedAuthor.create(name: "a" * 256)
+      assert_not EncryptedAuthor.new(name: "a" * (author_name_limit + 1)).valid?
+      author = EncryptedAuthor.create(name: "a" * (author_name_limit + 1))
       assert_not author.valid?
     end
   end


### PR DESCRIPTION
### Summary

`validate column sizes` test assumes a string limit of 255 but SQL Server adapter
(https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/)
uses 4000.

This PR changes the test to use column definition. This removes the
need coerce & re-implement the same tests in the SQL Server adapter.
