### PR TITLE
QueryLogsTest: Remove requirement that query ends with comments

### DIFF
--- a/activerecord/test/cases/query_logs_test.rb
+++ b/activerecord/test/cases/query_logs_test.rb
@@ -151,7 +151,7 @@ class QueryLogsTest < ActiveRecord::TestCase
   def test_custom_basic_tags
     ActiveRecord::QueryLogs.tags = [ :application, { custom_string: "test content" } ]
 
-    assert_sql(%r{/\*application:active_record,custom_string:test content\*/$}) do
+    assert_sql(%r{/\*application:active_record,custom_string:test content\*/}) do
       Dashboard.first
     end
   end
@@ -159,7 +159,7 @@ class QueryLogsTest < ActiveRecord::TestCase
   def test_custom_proc_tags
     ActiveRecord::QueryLogs.tags = [ :application, { custom_proc: -> { "test content" } } ]
 
-    assert_sql(%r{/\*application:active_record,custom_proc:test content\*/$}) do
+    assert_sql(%r{/\*application:active_record,custom_proc:test content\*/}) do
       Dashboard.first
     end
   end
@@ -170,7 +170,7 @@ class QueryLogsTest < ActiveRecord::TestCase
       { custom_proc: -> { "test content" }, another_proc: -> { "more test content" } },
     ]
 
-    assert_sql(%r{/\*application:active_record,custom_proc:test content,another_proc:more test content\*/$}) do
+    assert_sql(%r{/\*application:active_record,custom_proc:test content,another_proc:more test content\*/}) do
       Dashboard.first
     end
   end
@@ -179,7 +179,7 @@ class QueryLogsTest < ActiveRecord::TestCase
     ActiveSupport::ExecutionContext[:foo] = "bar"
     ActiveRecord::QueryLogs.tags = [ :application, { custom_context_proc: ->(context) { context[:foo] } } ]
 
-    assert_sql(%r{/\*application:active_record,custom_context_proc:bar\*/$}) do
+    assert_sql(%r{/\*application:active_record,custom_context_proc:bar\*/}) do
       Dashboard.first
     end
   end


### PR DESCRIPTION
### Summary

For the SQL Server adapter
(https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/) the tests in QueryLogsTest need to be coerced and re-implemented (https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/pull/972) because the tests are expecting the SQL to end with the comment but the SQL generated by the SQL Server adapter ends with prepare statement bindings. This PR just removes the end of string check in the regular expressions.

These changes do not affect the purpose of the tests and remove the need to coerce & re-implement the same tests in the SQL Server adapter.
