### PR TITLE
ActiveRecord ignores attribute serializer if serialized value responds to `id`

### DIFF
--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -55,7 +55,7 @@ module ActiveRecord
     end
 
     def build(attribute, value, operator = nil)
-      value = value.id if value.respond_to?(:id)
+      value = value.id if value.respond_to?(:id) && !table.type(attribute.name).is_a?(Type::Serialized)
       if operator ||= table.type(attribute.name).force_equality?(value) && :eq
         bind = build_bind_attribute(attribute.name, value)
         attribute.public_send(operator, bind)


### PR DESCRIPTION

### Summary
Fixes: https://github.com/rails/rails/issues/43990
We should keep the original behavior from here https://github.com/rails/rails/pull/40554 but only if the value is not a custom serializer that has an `id` attribute.
The current behavior implies that the value is an active record object when in this case it isn't.

