### PR TITLE
Show 7.0 Release Notes in the guides index

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -324,10 +324,9 @@
       description: Release notes for Rails 7.1.
       work_in_progress: true
     -
-      name: Version 7.0 - ?
+      name: Version 7.0 - December 2021
       url: 7_0_release_notes.html
       description: Release notes for Rails 7.0.
-      work_in_progress: true
     -
       name: Version 6.1 - December 2020
       url: 6_1_release_notes.html


### PR DESCRIPTION
Without this, the release notes doesn't appear in the guides index.
