### PR TITLE
Replaced `database_version` private method to `get_database_version`

### DIFF
--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -58,7 +58,7 @@ module ActiveRecord
           end
 
         args = ["--schema-only", "--no-privileges", "--no-owner"]
-        args << "--no-comments" if connection.database_version >= 110_000
+        args << "--no-comments" if connection.get_database_version >= 110_000
         args.concat(["--file", filename])
 
         args.concat(Array(extra_flags)) if extra_flags


### PR DESCRIPTION
### Summary

In order to avoid the error: 
- NoMethodError:** private method `database_version` called for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter

This replaces the private method `database_version` for the public method `get_database_version`.

### Other Information

![image](https://user-images.githubusercontent.com/13732132/147965199-17827ddb-0505-4ab3-b685-beeaa23cd306.png)

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
