### PR TITLE
HasOneThroughDisableJoinsAssociationsTest: solve undefined local variable or method 'connection'

### DIFF
--- a/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_through_disable_joins_associations_test.rb
@@ -76,6 +76,6 @@ class HasOneThroughDisableJoinsAssociationsTest < ActiveRecord::TestCase
       assert_no_match(/INNER JOIN/, nj)
     end
 
-    assert_match(/#{Regexp.escape(connection.quote_table_name('memberships.type'))}/, no_joins.first)
+    assert_match(/#{Regexp.escape(Member.connection.quote_table_name('memberships.type'))}/, no_joins.first)
   end
 end


### PR DESCRIPTION
### Summary

Fixes the error introduced in #44051
```
Error:
HasOneThroughDisableJoinsAssociationsTest#test_disable_joins_through_with_enum_type:
NameError: undefined local variable or method `connection' for #<HasOneThroughDisableJoinsAssociationsTest:...
```