### PR TITLE
Fix document `config.active_storage.video_preview_arguments` description. [skip ci]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1733,14 +1733,16 @@ The default is `:rails_storage_redirect`.
 
 Can be used to alter the way ffmpeg generates video preview images.
 
-By default, this is defined as:
+With `config.load_defaults 7.0`, the default is:
 
 ```ruby
 config.active_storage.video_preview_arguments = "-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"
 ```
 
+Which has the following behavior:
+
 1. `select=eq(n\,0)+eq(key\,1)+gt(scene\,0.015)`: Select the first video frame, plus keyframes, plus frames that meet the scene change threshold.
-2. `loop=loop=-1:size=2,trim=start_frame=1`: To use the first video frame as a fallback when no other frames meet the criteria, loop the first (one or) two selected frames, then drop the first looped frame.
+2. `loop=loop=-1:size=2,trim=start_frame=1`: Use the first video frame as a fallback when no other frames meet the criteria by looping the first (one or) two selected frames, then dropping the first looped frame.
 
 #### `config.active_storage.multiple_file_field_include_hidden`
 


### PR DESCRIPTION
### Summary

Removed default value and move arguments description.
`config.active_storage.video_preview_arguments`

Following the discussion of https://github.com/rails/rails/pull/39387, omit the default value `config.active_storage.video_preview_arguments` from the description of the settings. This is because it depends on `config.load_defaults`.

However, I think the rails 7.0 settings description is a good way to help developers understand, so I moved this description to the version 7.0 default settings section.
