### PR TITLE
Keep configuration of smtp_settings consistent between 6.1 and 7.0

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -23,6 +23,7 @@ module ActionMailer
       options.stylesheets_dir ||= paths["public/stylesheets"].first
       options.show_previews = Rails.env.development? if options.show_previews.nil?
       options.cache_store ||= Rails.cache
+      options.smtp_settings ||= {}
 
       if options.show_previews
         options.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/test/mailers/previews" : nil
@@ -45,13 +46,9 @@ module ActionMailer
           self.delivery_job = delivery_job.constantize
         end
 
-        if smtp_settings = options.delete(:smtp_settings)
-          self.smtp_settings = smtp_settings
-        end
-
         if smtp_timeout = options.delete(:smtp_timeout)
-          self.smtp_settings[:open_timeout] ||= smtp_timeout
-          self.smtp_settings[:read_timeout] ||= smtp_timeout
+          options.smtp_settings[:open_timeout] ||= smtp_timeout
+          options.smtp_settings[:read_timeout] ||= smtp_timeout
         end
 
         options.each { |k, v| send("#{k}=", v) }

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2745,21 +2745,31 @@ module ApplicationTests
 
     test "Rails.application.config.action_mailer.smtp_settings have open_timeout and read_timeout defined as 5 in 7.0 defaults" do
       remove_from_config '.*config\.load_defaults.*\n'
-      add_to_config 'config.load_defaults "7.0"'
+      add_to_config <<-RUBY
+        config.action_mailer.smtp_settings = { domain: "example.com" }
+        config.load_defaults "7.0"
+      RUBY
 
       app "development"
 
-      assert_equal 5, ActionMailer::Base.smtp_settings[:open_timeout]
-      assert_equal 5, ActionMailer::Base.smtp_settings[:read_timeout]
+      smtp_settings = { domain: "example.com", open_timeout: 5, read_timeout: 5 }
+
+      assert_equal smtp_settings, ActionMailer::Base.smtp_settings
+      assert_equal smtp_settings, Rails.configuration.action_mailer.smtp_settings
     end
 
     test "Rails.application.config.action_mailer.smtp_settings does not have open_timeout and read_timeout configured on other versions" do
       remove_from_config '.*config\.load_defaults.*\n'
+      add_to_config <<-RUBY
+        config.action_mailer.smtp_settings = { domain: "example.com" }
+      RUBY
 
       app "development"
 
-      assert_nil ActionMailer::Base.smtp_settings[:open_timeout]
-      assert_nil ActionMailer::Base.smtp_settings[:read_timeout]
+      smtp_settings = { domain: "example.com" }
+
+      assert_equal smtp_settings, ActionMailer::Base.smtp_settings
+      assert_equal smtp_settings, ActionMailer::Base.smtp_settings
     end
 
     test "ActiveSupport.utc_to_local_returns_utc_offset_times is true in 6.1 defaults" do


### PR DESCRIPTION
### Summary

When configuring a new default for smtp_settings we ended up deleting the key from Rails.configuration.action_mailer.smtp_settings [here](https://github.com/rails/rails/commit/52db7f2ef3c4a902227cac163657c89282986e25#diff-b2555388d34f4657f98f10cd106ccac94433e322044fb9455724b09247984850R48-R50).

Ideally I think people should rely on ActionMailer::Base.smtp_settings instead of Rails.configuration.action_mailer.smtp_settings.

But in order to keep the same behavior as previous versions, this is an attempt to keep things as they were while adding the new defaults for smtp_timeouts.

Fixes #44059