### PR TITLE
Allow aliases in encrypted configuration

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -49,7 +49,8 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        YAML.load(config).presence || {}
+        doc = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(config) : YAML.load(config)
+        doc.presence || {}
       end
   end
 end


### PR DESCRIPTION
### Summary

Because encrypted configuration files are normally trusted input, it seems safe to use `YAML.unsafe_load`.

### Other Information

The default behaviour of YAML.load changed (for the better!) with Psych v4 (https://github.com/ruby/psych/pull/487). I was upgrading an app that used aliases in an encrypted config file when I noticed this.

The first version of this patch was only allowing the `aliases` option, but that doesn't work with Psych 3.