### PR TITLE
Move ExtendedDeterministicQueries rdoc to correct namespace [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
-# Automatically expand encrypted arguments to support querying both encrypted and unencrypted data
-#
-# Active Record Encryption supports querying the db using deterministic attributes. For example:
-#
-#   Contact.find_by(email_address: "jorge@hey.com")
-#
-# The value "jorge@hey.com" will get encrypted automatically to perform the query. But there is
-# a problem while the data is being encrypted. This won't work. During that time, you need these
-# queries to be:
-#
-#   Contact.find_by(email_address: [ "jorge@hey.com", "<encrypted jorge@hey.com>" ])
-#
-# This patches ActiveRecord to support this automatically. It addresses both:
-#
-# * ActiveRecord::Base: Used in +Contact.find_by_email_address(...)+
-# * ActiveRecord::Relation: Used in +Contact.internal.find_by_email_address(...)+
-#
-# +ActiveRecord::Base+ relies on +ActiveRecord::Relation+ (+ActiveRecord::QueryMethods+) but it does
-# some prepared statements caching. That's why we need to intercept +ActiveRecord::Base+ as soon
-# as it's invoked (so that the proper prepared statement is cached).
-#
-# When modifying this file run performance tests in +test/performance/extended_deterministic_queries_performance_test.rb+ to
-#   make sure performance overhead is acceptable.
-#
-# We will extend this to support previous "encryption context" versions in future iterations
-#
-# @TODO Experimental. Support for every kind of query is pending
-# @TODO It should not patch anything if not needed (no previous schemes or no support for previous encryption schemes)
 module ActiveRecord
   module Encryption
+    # Automatically expand encrypted arguments to support querying both encrypted and unencrypted data
+    #
+    # Active Record Encryption supports querying the db using deterministic attributes. For example:
+    #
+    #   Contact.find_by(email_address: "jorge@hey.com")
+    #
+    # The value "jorge@hey.com" will get encrypted automatically to perform the query. But there is
+    # a problem while the data is being encrypted. This won't work. During that time, you need these
+    # queries to be:
+    #
+    #   Contact.find_by(email_address: [ "jorge@hey.com", "<encrypted jorge@hey.com>" ])
+    #
+    # This patches ActiveRecord to support this automatically. It addresses both:
+    #
+    # * ActiveRecord::Base: Used in +Contact.find_by_email_address(...)+
+    # * ActiveRecord::Relation: Used in +Contact.internal.find_by_email_address(...)+
+    #
+    # +ActiveRecord::Base+ relies on +ActiveRecord::Relation+ (+ActiveRecord::QueryMethods+) but it does
+    # some prepared statements caching. That's why we need to intercept +ActiveRecord::Base+ as soon
+    # as it's invoked (so that the proper prepared statement is cached).
+    #
+    # When modifying this file run performance tests in +test/performance/extended_deterministic_queries_performance_test.rb+ to
+    #   make sure performance overhead is acceptable.
+    #
+    # We will extend this to support previous "encryption context" versions in future iterations
+    #
+    # @TODO Experimental. Support for every kind of query is pending
+    # @TODO It should not patch anything if not needed (no previous schemes or no support for previous encryption schemes)
     module ExtendedDeterministicQueries
       def self.install_support
         ActiveRecord::Relation.prepend(RelationQueries)


### PR DESCRIPTION
### Summary
The documentation for ExtendedDeterministicQueries currently ends up on
https://api.rubyonrails.org/classes/ActiveRecord.html which is
confusing. By moving it above the correct namespace it is moved to:
https://api.rubyonrails.org/classes/ActiveRecord/Encryption/ExtendedDeterministicQueries.html