### PR TITLE
Add missing `cookies_serializer` config default

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1775,6 +1775,7 @@ Accepts a string for the HTML tag used to wrap attachments. Defaults to `"action
 - `config.active_support.use_rfc4122_namespaced_uuids`: `true`
 - `config.active_support.disable_to_s_conversion`: `true`
 - `config.action_dispatch.return_only_request_media_type_on_content_type`: `false`
+- `config.action_dispatch.cookies_serializer`: `:json`
 - `config.action_mailer.smtp_timeout`: `5`
 - `config.active_storage.video_preview_arguments`: `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 - `config.active_storage.multiple_file_field_include_hidden`: `true`


### PR DESCRIPTION
As noted in https://github.com/rails/rails/pull/42538#discussion_r778246983 this is missing from the docs.

cc @dbussink