### PR TITLE
Actually run a `pg_dump` in the Postgres test suite

### DIFF
--- a/activerecord/test/cases/tasks/postgresql_rake_test.rb
+++ b/activerecord/test/cases/tasks/postgresql_rake_test.rb
@@ -351,15 +351,17 @@ if current_adapter?(:PostgreSQLAdapter)
         FileUtils.rm_f(@filename)
       end
 
+      # This test actually runs a dump so we can ensure all the arguments are parsed correctly.
+      # All other tests in this class just mock the call (using assert_called_with) to make the tests quicker.
       def test_structure_dump
-        assert_called_with(
-          Kernel,
-          :system,
-          [{}, "pg_dump", "--schema-only", "--no-privileges", "--no-owner", "--no-comments", "--file", @filename, "my-app-db"],
-          returns: true
-        ) do
-          ActiveRecord::Tasks::DatabaseTasks.structure_dump(@configuration, @filename)
-        end
+        assert_equal "", File.read(@filename)
+
+        config = @configuration.dup
+        config["database"] = ARTest.config["connections"]["postgresql"]["arunit"]["database"]
+
+        ActiveRecord::Tasks::DatabaseTasks.structure_dump(config, @filename)
+
+        assert File.read(@filename).include?("PostgreSQL database dump complete")
       end
 
       def test_structure_dump_header_comments_removed


### PR DESCRIPTION
https://github.com/rails/rails/pull/44028 came about because all the current Postgres tests just mock the `pg_dump` call made when you dump a DB structure.

By actaully running a dump at least once, we can test against a real database and ensure that all arguments are correctly handled. This PR implements that.
