### PR TITLE
Use same default host name in ActionController::Renderer as Integration::Session

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   `ActionController::Renderer` now uses the same default host (`www.example.com`)
+    as `ActionDispatch::Integration::Session`, preventing spurious test failures
+    when rendering templates outside of a controller action during integration tests.
 
+    *David Moles*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -37,7 +37,7 @@ module ActionController
     attr_reader :defaults, :controller
 
     DEFAULTS = {
-      http_host: "example.org",
+      http_host: "www.example.com",
       https: false,
       method: "get",
       script_name: "",

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -27,6 +27,11 @@ class SessionTest < ActiveSupport::TestCase
     assert_equal "rubyonrails.com", @session.host
   end
 
+  def test_default_host_matches_action_controller_renderer
+    expected_host = ActionController::Base.renderer.defaults[:http_host]
+    assert_equal expected_host, @session.host
+  end
+
   def test_follow_redirect_raises_when_no_redirect
     @session.stub :redirect?, false do
       assert_raise(RuntimeError) { @session.follow_redirect! }

--- a/actionpack/test/controller/renderer_test.rb
+++ b/actionpack/test/controller/renderer_test.rb
@@ -128,17 +128,21 @@ class RendererTest < ActiveSupport::TestCase
     renderer = ApplicationController.renderer
     content  = renderer.render inline: "<%= asset_url 'asset.jpg' %>"
 
-    assert_equal "http://example.org/asset.jpg", content
+    assert_equal "http://#{default_host}/asset.jpg", content
   end
 
   test "return valid asset URL when https is true" do
     renderer = ApplicationController.renderer.new https: true
     content  = renderer.render inline: "<%= asset_url 'asset.jpg' %>"
 
-    assert_equal "https://example.org/asset.jpg", content
+    assert_equal "https://#{default_host}/asset.jpg", content
   end
 
   private
+    def default_host
+      @default_host ||= ActionController::Renderer::DEFAULTS[:http_host]
+    end
+
     def render
       @render ||= ApplicationController.renderer.method(:render)
     end


### PR DESCRIPTION
### Summary

Changes `ActionController::Renderer::DEFAULTS[:http_host]` from `example.org` to `www.example.com` to match `ActionDispatch::Integration::Session::DEFAULT_HOST`.

Fixes #44071.