### PR TITLE
format the numbers in comparison validator error messages

### DIFF
--- a/activemodel/lib/active_model/validations/comparability.rb
+++ b/activemodel/lib/active_model/validations/comparability.rb
@@ -3,6 +3,7 @@
 module ActiveModel
   module Validations
     module Comparability # :nodoc:
+      include ActiveSupport::NumberHelper
       COMPARE_CHECKS = { greater_than: :>, greater_than_or_equal_to: :>=,
         equal_to: :==, less_than: :<, less_than_or_equal_to: :<=,
         other_than: :!= }.freeze
@@ -19,6 +20,7 @@ module ActiveModel
       end
 
       def error_options(value, option_value)
+        option_value = number_to_delimited(option_value) if option_value.is_a?(Numeric)
         options.except(*COMPARE_CHECKS.keys).merge!(
           count: option_value,
           value: value

--- a/activemodel/test/cases/validations/comparison_validation_test.rb
+++ b/activemodel/test/cases/validations/comparison_validation_test.rb
@@ -5,6 +5,7 @@ require "cases/helper"
 require "models/topic"
 require "models/person"
 
+
 class ComparisonValidationTest < ActiveModel::TestCase
   def teardown
     Topic.clear_validators!
@@ -15,6 +16,12 @@ class ComparisonValidationTest < ActiveModel::TestCase
 
     assert_invalid_values([-12, 10], "must be greater than 10")
     assert_valid_values([11])
+  end
+
+  def test_validates_comparison_with_greater_than_using_numeric_formats_the_message
+    Topic.validates_comparison_of :approved, greater_than: 10000
+    assert_invalid_values([-12, 10], "must be greater than 10,000")
+    assert_valid_values([11000])
   end
 
   def test_validates_comparison_with_greater_than_using_date


### PR DESCRIPTION
### Summary

Currently, the comparison validator error messages are not formatting the numbers, so one can end up with messages like `must be greater than or equal to 1000000`. This PR changes the error messages to format the numbers with `number_to_delimited` in validation errors which results in a more readable message like `must be greater than 1,000,000`

