### PR TITLE
Make multi db docs public

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -248,7 +248,6 @@
       description: This guide covers PostgreSQL specific usage of Active Record.
     -
       name: Multiple Databases with Active Record
-      work_in_progress: true
       url: active_record_multiple_databases.html
       description: This guide covers using multiple databases in your application.
     -


### PR DESCRIPTION
I think this documentation is in the pretty good shape. Without making it public it's hard to find how to configure and use the multiple databases.