### PR TITLE
Fix #43978 migrations on multidb

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Migrations with a custom context and fixtures utilizing a `#connected_to` block now use the shard specified in the method call.
+
+    Fixes #43978.
+
+    * Sammy Larbi *
+
 *   Fix `config.active_record.destroy_association_async_job` configuration
 
     `config.active_record.destroy_association_async_job` should allow

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -138,7 +138,7 @@ module ActiveRecord
 
       if ActiveRecord.dump_schema_after_migration
         ActiveRecord::Tasks::DatabaseTasks.dump_schema(
-          ActiveRecord::Base.connection_db_config
+          migrate_on_base_class.connection_db_config
         )
       end
     end
@@ -153,7 +153,7 @@ module ActiveRecord
         message += " RAILS_ENV=#{::Rails.env}" if defined?(Rails.env)
         message += "\n\n"
 
-        pending_migrations = ActiveRecord::Base.connection.migration_context.open.pending_migrations
+        pending_migrations = migrate_on_base_class.connection.migration_context.open.pending_migrations
 
         message += "You have #{pending_migrations.size} pending #{pending_migrations.size > 1 ? 'migrations:' : 'migration:'}\n\n"
 
@@ -162,6 +162,10 @@ module ActiveRecord
         end
 
         message
+      end
+
+      def migrate_on_base_class
+        ActiveRecord.application_record_class || ActiveRecord::Base
       end
   end
 
@@ -617,7 +621,11 @@ module ActiveRecord
         end
 
         def connection
-          ActiveRecord::Base.connection
+          migrate_on_base_class.connection
+        end
+
+        def migrate_on_base_class
+          ActiveRecord.application_record_class || ActiveRecord::Base
         end
     end
 
@@ -630,12 +638,12 @@ module ActiveRecord
       end
 
       # Raises <tt>ActiveRecord::PendingMigrationError</tt> error if any migrations are pending.
-      def check_pending!(connection = Base.connection)
+      def check_pending!(connection = (ActiveRecord.application_record_class || Base).connection)
         raise ActiveRecord::PendingMigrationError if connection.migration_context.needs_migration?
       end
 
       def load_schema_if_pending!
-        current_db_config = Base.connection_db_config
+        current_db_config = (ActiveRecord.application_record_class || Base).connection_db_config
         all_configs = ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
 
         needs_update = !all_configs.all? do |db_config|
@@ -856,7 +864,7 @@ module ActiveRecord
       end
 
       time = nil
-      ActiveRecord::Base.connection_pool.with_connection do |conn|
+      migrate_on_base_class.connection_pool.with_connection do |conn|
         time = Benchmark.measure do
           exec_migration(conn, direction)
         end
@@ -919,7 +927,7 @@ module ActiveRecord
     end
 
     def connection
-      @connection || ActiveRecord::Base.connection
+      @connection || migrate_on_base_class.connection
     end
 
     def method_missing(method, *arguments, &block)
@@ -1035,6 +1043,10 @@ module ActiveRecord
 
       def command_recorder
         CommandRecorder.new(connection)
+      end
+
+      def migrate_on_base_class
+        ActiveRecord.application_record_class || ActiveRecord::Base
       end
   end
 
@@ -1345,7 +1357,7 @@ module ActiveRecord
       # Stores the current environment in the database.
       def record_environment
         return if down?
-        ActiveRecord::InternalMetadata[:environment] = ActiveRecord::Base.connection.migration_context.current_environment
+        ActiveRecord::InternalMetadata[:environment] = @schema_migration.connection.migration_context.current_environment
       end
 
       def ran?(migration)
@@ -1415,18 +1427,18 @@ module ActiveRecord
       # Wrap the migration in a transaction only if supported by the adapter.
       def ddl_transaction(migration, &block)
         if use_transaction?(migration)
-          Base.transaction(&block)
+          @schema_migration.transaction(&block)
         else
           yield
         end
       end
 
       def use_transaction?(migration)
-        !migration.disable_ddl_transaction && Base.connection.supports_ddl_transactions?
+        !migration.disable_ddl_transaction && @schema_migration.connection.supports_ddl_transactions?
       end
 
       def use_advisory_lock?
-        Base.connection.advisory_locks_enabled?
+        @schema_migration.connection.advisory_locks_enabled?
       end
 
       def with_advisory_lock
@@ -1448,7 +1460,7 @@ module ActiveRecord
 
       def with_advisory_lock_connection(&block)
         pool = ActiveRecord::ConnectionAdapters::ConnectionHandler.new.establish_connection(
-          ActiveRecord::Base.connection_db_config
+          @schema_migration.connection_db_config
         )
 
         pool.with_connection(&block)
@@ -1458,7 +1470,7 @@ module ActiveRecord
 
       MIGRATOR_SALT = 2053462845
       def generate_migrator_advisory_lock_id
-        db_name_hash = Zlib.crc32(Base.connection.current_database)
+        db_name_hash = Zlib.crc32(@schema_migration.connection.current_database)
         MIGRATOR_SALT * db_name_hash
       end
   end


### PR DESCRIPTION
### Summary

Possible fix for #43978, and other issues I found when trying to load schema.rb within a `connected_to` block and run migrations with a custom migration context. 

### Other Information

As part of this, would it make sense to [move this code](https://github.com/rails/rails/blob/7-0-stable/activerecord/lib/active_record/schema_migration.rb#L12-L52) into a module that could then be included in `SchemaMigration` (and in particular, for client code to be able to re-use when they need their own `ApplicationSchemaMigration` with the same code but a different superclass?

This is a duplicate of #43979 which will be closed in favor of this, since I originally wrote that one on the wrong branch, and Github won't let me change my branch of the PR, (and I neglected to create my own, using 7-0-stable from the rails/rails repo)

@rafaelfranca tagging you, since you had asked for this adjustment. 