### PR TITLE
Extend `dom_id` and `dom_class` to accept var-args

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Extend `dom_id` and `dom_class` to accept a variable set of prefixes:
 
+    ```ruby
+    dom_class @post, :first_prefix, :second_prefix
+    # => "first_prefix_second_prefix_post"
+    dom_class @post, [:first_prefix, :second_prefix]
+    # => "first_prefix_second_prefix_post"
+    dom_id @post, :first_prefix, :second_prefix
+    # => "first_prefix_second_prefix_post_123"
+    dom_id @post, [:first_prefix, :second_prefix]
+    # => "first_prefix_second_prefix_post_123"
+    ```
+
+    *Sean Doyle*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/record_identifier.rb
+++ b/actionview/lib/action_view/record_identifier.rb
@@ -71,9 +71,12 @@ module ActionView
     #
     #   dom_class(post, :edit)   # => "edit_post"
     #   dom_class(Person, :edit) # => "edit_person"
-    def dom_class(record_or_class, prefix = nil)
+    #   dom_class(post, :edit, :special)   # => "edit_special_post"
+    #   dom_class(Person, :edit, :special) # => "edit_special_person"
+    def dom_class(record_or_class, *prefixes)
       singular = model_name_from_record_or_class(record_or_class).param_key
-      prefix ? "#{prefix}#{JOIN}#{singular}" : singular
+      prefixes << singular
+      prefixes.join(JOIN)
     end
 
     # The DOM id convention is to use the singular form of an object or class with the id following an underscore.
@@ -86,11 +89,14 @@ module ActionView
     #
     #   dom_id(Post.find(45), :edit) # => "edit_post_45"
     #   dom_id(Post.new, :custom)    # => "custom_post"
-    def dom_id(record, prefix = nil)
+    #   dom_id(Post.find(45), :edit, :special) # => "edit_special_post_45"
+    #   dom_id(Post.new, :custom, :special)    # => "custom_special_post"
+    def dom_id(record, *prefixes)
       if record_id = record_key_for_dom_id(record)
-        "#{dom_class(record, prefix)}#{JOIN}#{record_id}"
+        "#{dom_class(record, *prefixes)}#{JOIN}#{record_id}"
+
       else
-        dom_class(record, prefix || NEW)
+        dom_class(record, *prefixes.presence || NEW)
       end
     end
 

--- a/actionview/test/template/record_identifier_test.rb
+++ b/actionview/test/template/record_identifier_test.rb
@@ -19,6 +19,8 @@ class RecordIdentifierTest < ActiveSupport::TestCase
 
   def test_dom_id_with_new_record_and_prefix
     assert_equal "custom_prefix_#{@singular}", dom_id(@record, :custom_prefix)
+    assert_equal "custom_prefix_second_prefix_#{@singular}", dom_id(@record, :custom_prefix, :second_prefix)
+    assert_equal "custom_prefix_second_prefix_#{@singular}", dom_id(@record, [:custom_prefix, :second_prefix])
   end
 
   def test_dom_id_with_saved_record
@@ -37,6 +39,8 @@ class RecordIdentifierTest < ActiveSupport::TestCase
 
   def test_dom_class_with_prefix
     assert_equal "custom_prefix_#{@singular}", dom_class(@record, :custom_prefix)
+    assert_equal "custom_prefix_second_prefix_#{@singular}", dom_class(@record, :custom_prefix, :second_prefix)
+    assert_equal "custom_prefix_second_prefix_#{@singular}", dom_class(@record, [:custom_prefix, :second_prefix])
   end
 
   def test_dom_id_as_singleton_method


### PR DESCRIPTION
### Summary


Changes `dom_id` and `dom_class` to accept a variable set of prefixes:

```ruby
dom_class @post, :first_prefix, :second_prefix
  # => "first_prefix_second_prefix_post"
dom_class @post, [:first_prefix, :second_prefix]
  # => "first_prefix_second_prefix_post"
dom_id @post, :first_prefix, :second_prefix
  # => "first_prefix_second_prefix_post_123"
dom_id @post, [:first_prefix, :second_prefix]
  # => "first_prefix_second_prefix_post_123"
```

These changes align with the [FormBuilder#field_id][] interface, which
accepts multiple `suffixes` arguments.

[FormBuilder#field_id]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-field_id