### PR TITLE
Temporarily add net-gems as dependencies of frameworks that use mail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,12 +35,6 @@ gem "terser", ">= 1.1.4", require: false
 # Explicitly avoid 1.x that doesn't support Ruby 2.4+
 gem "json", ">= 2.0.0"
 
-# net-smtp, net-imap and net-pop were removed from default gems in Ruby 3.1, but is used by the `mail` gem.
-# So we need to add them as dependencies until `mail` is fixed: https://github.com/mikel/mail/pull/1439
-gem "net-smtp", require: false
-gem "net-imap", require: false
-gem "net-pop", require: false
-
 group :rubocop do
   gem "rubocop", ">= 0.90", require: false
   gem "rubocop-minitest", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,12 +36,18 @@ PATH
       activestorage (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
     actionmailer (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)
       actionview (= 7.1.0.alpha)
       activejob (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
       rails-dom-testing (~> 2.0)
     actionpack (7.1.0.alpha)
       actionview (= 7.1.0.alpha)
@@ -367,6 +373,10 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     os (1.1.4)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -594,9 +604,6 @@ DEPENDENCIES
   minitest-ci
   minitest-retry
   mysql2 (~> 0.5)!
-  net-imap
-  net-pop
-  net-smtp
   nokogiri (>= 1.8.1, != 1.11.0)
   pg (~> 1.1)
   propshaft (>= 0.1.7)

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -39,4 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionpack",    version
 
   s.add_dependency "mail", ">= 2.7.1"
+  s.add_dependency "net-imap"
+  s.add_dependency "net-pop"
+  s.add_dependency "net-smtp"
 end

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -39,5 +39,8 @@ Gem::Specification.new do |s|
   s.add_dependency "activejob", version
 
   s.add_dependency "mail", ["~> 2.5", ">= 2.5.4"]
+  s.add_dependency "net-imap"
+  s.add_dependency "net-pop"
+  s.add_dependency "net-smtp"
   s.add_dependency "rails-dom-testing", "~> 2.0"
 end


### PR DESCRIPTION
In Ruby 3.1 those gems were dropped from the stdlib, so they need to be explicitly installed. Mail should be doing this for us, but since it cares about Ruby < 2.6, and those gems can't be installed there, they can't add them to the gemspec without dropping support to old rubies.

Since we don't care about Ruby < 2.7, we can just require them in all frameworks that use mail.

This is a temporary solution while mail doesn't decide what to do with those dependencies allowing us to release a version of Rails compatible with Ruby 3.1. For Rails 6.1 it will not be possible to use this workaround since it supports Ruby 2.2, so I think we will have to wait a new mail release and document this problem somewhere.