### PR TITLE
Extend audio_tag and video_tag to accept Active Storage attachments

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Extend audio_tag and video_tag to accept Active Storage attachments.
+
+    Now it's possible to write
+
+    ```ruby
+    audio_tag(user.audio_file)
+    video_tag(user.video_file)
+    ```
+
+    Instead of
+
+    ```ruby
+    audio_tag(polymorphic_path(user.audio_file))
+    video_tag(polymorphic_path(user.video_file))
+    ```
+
+    `image_tag` already supported that, so this follows the same pattern.
+
+    *Matheus Richard*
+
 *   Ensure models passed to `form_for` attempt to call `to_model`.
 
     *Sean Doyle*

--- a/activestorage/test/models/reflection_test.rb
+++ b/activestorage/test/models/reflection_test.rb
@@ -39,8 +39,8 @@ class ActiveStorage::ReflectionTest < ActiveSupport::TestCase
   test "reflecting on all attachments" do
     reflections = User.reflect_on_all_attachments.sort_by(&:name)
     assert_equal [ User ], reflections.collect(&:active_record).uniq
-    assert_equal %i[ avatar avatar_with_variants cover_photo highlights highlights_with_variants vlogs ], reflections.collect(&:name)
-    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_many_attached ], reflections.collect(&:macro)
-    assert_equal [ :purge_later, :purge_later, false, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
+    assert_equal %i[ avatar avatar_with_variants cover_photo highlights highlights_with_variants intro_video name_pronunciation_audio vlogs ], reflections.collect(&:name)
+    assert_equal %i[ has_one_attached has_one_attached has_one_attached has_many_attached has_many_attached has_one_attached has_one_attached has_many_attached ], reflections.collect(&:macro)
+    assert_equal [ :purge_later, :purge_later, false, :purge_later, :purge_later, :purge_later, :purge_later, false ], reflections.collect { |reflection| reflection.options[:dependent] }
   end
 end

--- a/activestorage/test/template/audio_tag_test.rb
+++ b/activestorage/test/template/audio_tag_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::AudioTagTest < ActionView::TestCase
+  tests ActionView::Helpers::AssetTagHelper
+
+  setup do
+    @blob = create_file_blob filename: "audio.mp3"
+  end
+
+  test "blob" do
+    assert_dom_equal %(<audio src="#{polymorphic_url @blob}" />), audio_tag(@blob)
+  end
+
+  test "attachment" do
+    attachment = ActiveStorage::Attachment.new(blob: @blob)
+    assert_dom_equal %(<audio src="#{polymorphic_url attachment}" />), audio_tag(attachment)
+  end
+
+  test "error when attachment's empty" do
+    @user = User.create!(name: "DHH")
+
+    assert_not_predicate @user.name_pronunciation_audio, :attached?
+    assert_raises(ArgumentError) { audio_tag(@user.name_pronunciation_audio) }
+  end
+
+  test "error when object can't be resolved into URL" do
+    unresolvable_object = ActionView::Helpers::AssetTagHelper
+    assert_raises(ArgumentError) { audio_tag(unresolvable_object) }
+  end
+end

--- a/activestorage/test/template/video_tag_test.rb
+++ b/activestorage/test/template/video_tag_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+class ActiveStorage::VideoTagTest < ActionView::TestCase
+  tests ActionView::Helpers::AssetTagHelper
+
+  setup do
+    @blob = create_file_blob filename: "video.mp4"
+  end
+
+  test "blob" do
+    assert_dom_equal %(<video src="#{polymorphic_url @blob}" />), video_tag(@blob)
+  end
+
+  test "attachment" do
+    attachment = ActiveStorage::Attachment.new(blob: @blob)
+    assert_dom_equal %(<video src="#{polymorphic_url attachment}" />), video_tag(attachment)
+  end
+
+  test "error when attachment's empty" do
+    @user = User.create!(name: "DHH")
+
+    assert_not_predicate @user.intro_video, :attached?
+    assert_raises(ArgumentError) { video_tag(@user.intro_video) }
+  end
+
+  test "error when object can't be resolved into URL" do
+    unresolvable_object = ActionView::Helpers::AssetTagHelper
+    assert_raises(ArgumentError) { video_tag(unresolvable_object) }
+  end
+end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -174,6 +174,8 @@ class User < ActiveRecord::Base
   has_one_attached :avatar_with_variants do |attachable|
     attachable.variant :thumb, resize_to_limit: [100, 100]
   end
+  has_one_attached :intro_video
+  has_one_attached :name_pronunciation_audio
 
   has_many_attached :highlights
   has_many_attached :vlogs, dependent: false, service: :local


### PR DESCRIPTION
Now it's possible to write

```ruby
audio_tag(user.audio_file)
video_tag(user.video_file)
```

Instead of

```ruby
audio_tag(polymorphic_path(user.audio_file))
video_tag(polymorphic_path(user.video_file))
```

`image_tag` already supported that, so this follows the same pattern.