### PR TITLE
Update sdoc to 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.2.0"
+  gem "sdoc", ">= 2.3.0"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,8 +458,8 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
-    sdoc (2.2.0)
-      rdoc (>= 5.0)
+    sdoc (2.3.0)
+      rdoc (>= 5.0, < 6.4.0)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -620,7 +620,7 @@ DEPENDENCIES
   rubocop-packaging
   rubocop-performance
   rubocop-rails
-  sdoc (>= 2.2.0)
+  sdoc (>= 2.3.0)
   selenium-webdriver (>= 4.0.0)
   sequel
   sidekiq


### PR DESCRIPTION
### Summary
With the migration of SDoc to a frameless layout, the URLs to assets
were made absolute instead of relative because of Turbolinks asset
tracking.  But absolute URLs fail when we have multiple versions of the
docs in subdirectories like: https://api.rubyonrails.org/v6.1/

This version of SDoc restores relative URLs by disabling the Turbolinks
asset tracking.

Fixes #44042
Changelog: https://github.com/zzak/sdoc/blob/master/CHANGELOG.md#230

RDoc dependency constraint
-----------------------------

The RDoc version is constrained to > 6.4.0.
RDoc 6.4.0 added psych 4.0 as a dependency which isn't compatible with
ruby 2.5 and lower resulting in the following error:

         ArgumentError: wrong number of arguments (given 4, expected 1)
           /home/runner/work/sdoc/sdoc/vendor/bundle/ruby/2.5.0/gems/psych-4.0.3/lib/psych.rb:323:in `safe_load'

Also see: https://github.com/ruby/rdoc/issues/857

SDoc still supports rubies lower than 2.5 so the constraint was added.
Rails main currently has RDoc locked to 6.3.3 in the Gemfile.lock