### PR TITLE
Prevent duplicate entries in plugin Gemfile

### DIFF
--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -313,6 +313,33 @@ module Rails
       end
 
     private
+      def gemfile_entries
+        [
+          rails_gemfile_entry,
+          simplify_gemfile_entries(
+            database_gemfile_entry,
+            asset_pipeline_gemfile_entry,
+          ),
+        ].flatten.compact
+      end
+
+      def rails_gemfile_entry
+        if options[:skip_gemspec]
+          super
+        elsif rails_prerelease?
+          super.dup.tap do |entry|
+            entry.comment = <<~COMMENT
+              Your gem is dependent on a prerelease version of Rails. Once you can lock this
+              dependency down to a specific version, move it to your gemspec.
+            COMMENT
+          end
+        end
+      end
+
+      def simplify_gemfile_entries(*gemfile_entries)
+        gemfile_entries.flatten.compact.map { |entry| GemfileEntry.floats(entry.name) }
+      end
+
       def create_dummy_app(path = nil)
         dummy_path(path) if path
 

--- a/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/plugin/templates/Gemfile.tt
@@ -1,36 +1,19 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+<% unless options[:skip_gemspec] -%>
 
-<% if options[:skip_gemspec] -%>
-<%= "# " if rails_prerelease? -%>gem "rails", "<%= Array(rails_version_specifier).join("', '") %>"
-<% else -%>
 # Specify your gem's dependencies in <%= name %>.gemspec.
 gemspec
 <% end -%>
-<% unless options[:skip_active_record] -%>
-
-group :development do
-  gem "<%= gem_for_database[0] %>"
-end
-<% end -%>
-
-<% if engine? && !skip_sprockets? -%>
-<%= asset_pipeline_gemfile_entry %>
-
-<% end -%>
-<% if rails_prerelease? -%>
-# Your gem is dependent on a prerelease version of Rails. Once you can lock this
-# dependency down to a specific version, move it to your gemspec.
-<% gemfile_entries.each do |gemfile_entry| -%>
+<% gemfile_entries.each do |gemfile_entry| %>
 <%= gemfile_entry %>
 <% end -%>
-
-<% end -%>
 <% if RUBY_ENGINE == "ruby" -%>
-# Start debugger with binding.b -- Read more: https://github.com/ruby/debug
-# gem "debug", ">= 1.0.0", group: %i[ development test ]
-<% end -%>
-<% if RUBY_PLATFORM.match(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
 
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby]
+# Start debugger with binding.b [https://github.com/ruby/debug]
+# gem "debug", ">= 1.0.0"
+<% end -%>
+<% if RUBY_PLATFORM.match?(/bccwin|cygwin|emx|mingw|mswin|wince|java/) -%>
+
+gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 <% end -%>


### PR DESCRIPTION
This commit refactors the plugin `Gemfile.tt` to abstract much of the logic into the `gemfile_entries` helper.  Doing so avoids adding duplicate `Gemfile` entries (e.g. `gem "sqlite3"`), as well as application-only `Gemfile` entries (e.g. `gem "puma"`), when generating a plugin with a prerelease flag (e.g. `--dev`).

---

Based on top of #44016.  I can rebase on top of `main` after #44016 is merged.
