### PR TITLE
Allow subsecond resolution in `travel_to` helper

### DIFF
--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -186,6 +186,41 @@ class TimeTravelTest < ActiveSupport::TestCase
     end
   end
 
+  def test_time_helper_travel_to_with_usec
+    Time.stub(:now, Time.now) do
+      duration_usec = 0.1.seconds
+      traveled_time = Time.new(2004, 11, 24, 1, 4, 44) + duration_usec
+      expected_time = Time.new(2004, 11, 24, 1, 4, 44)
+
+      assert_nothing_raised do
+        travel_to traveled_time
+
+        assert_equal expected_time, Time.now
+
+        travel_back
+      end
+    ensure
+      travel_back
+    end
+  end
+
+  def test_time_helper_travel_to_with_usec_true
+    Time.stub(:now, Time.now) do
+      duration_usec = 0.1.seconds
+      expected_time = Time.new(2004, 11, 24, 1, 4, 44) + duration_usec
+
+      assert_nothing_raised do
+        travel_to expected_time, with_usec: true
+
+        assert_equal expected_time.to_f, Time.now.to_f
+
+        travel_back
+      end
+    ensure
+      travel_back
+    end
+  end
+
   def test_time_helper_travel_with_subsequent_block
     Time.stub(:now, Time.now) do
       outer_expected_time = Time.new(2004, 11, 24, 1, 4, 44)


### PR DESCRIPTION
### Summary

Hej! :wave: I’m working on [a change for GitLab](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/76034), which aims to replace the [`Timecop` gem](https://github.com/travisjeffery/timecop) with ActiveSupport’s native time helpers (read more about that effort [in this issue](https://gitlab.com/gitlab-org/gitlab/-/issues/214432)). Some of the affected specs test time-related features in milliseconds.

However, both `travel` and `travel_to` helpers in [`Testing::TimeHelpers`](https://api.rubyonrails.org/classes/ActiveSupport/Testing/TimeHelpers.html#method-i-travel) are currently limited to seconds. That’s because the current implementation of  `travel_to` uses [`Time#to_i`](https://ruby-doc.org/core-3.1.0/Time.html#method-i-to_i) to stub `Time.now`. `to_i` returns the unix timestamp in seconds, although the `Time` object can use a smaller resolution than seconds if it is available on the platform.

According to the documentation, this is to “prevent rounding errors with external services”. But the behavior of discarding a part of the `Time` object passed to the time helpers makes testing subsecond code complex if not impossible with ActiveSupport.

This PR therefore makes it possible for `travel_to` to stub `Time.now` with the accurate time passed to it as `date_or_time` if the `with_usec` optional argument is set to true:

```rb
Time.now.inspect # => 2022-01-05 22:36:54.613371959 +0000
travel_to(0.1.seconds.from_now, with_usec: true)
Time.now.inspect # => 2022-01-05 22:36:54.713371959 +0000
```

### Other Information

I’ve added the `with_usec` argument (feel free to suggest a different name!) to keep the intended & documented behavior by default.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
