### PR TITLE
Export other ActiveStorage JavaScript modules.

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -853,4 +853,4 @@ function autostart() {
 
 setTimeout(autostart, 1);
 
-export { DirectUpload, start };
+export { DirectUpload, DirectUploadController, DirectUploadsController, start };

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -828,6 +828,8 @@
   }
   setTimeout(autostart, 1);
   exports.DirectUpload = DirectUpload;
+  exports.DirectUploadController = DirectUploadController;
+  exports.DirectUploadsController = DirectUploadsController;
   exports.start = start;
   Object.defineProperty(exports, "__esModule", {
     value: true

--- a/activestorage/app/javascript/activestorage/index.js
+++ b/activestorage/app/javascript/activestorage/index.js
@@ -1,6 +1,8 @@
 import { start } from "./ujs"
 import { DirectUpload } from "./direct_upload"
-export { start, DirectUpload }
+import { DirectUploadController } from "./direct_upload_controller"
+import { DirectUploadsController } from "./direct_uploads_controller"
+export { start, DirectUpload, DirectUploadController, DirectUploadsController }
 
 function autostart() {
   if (window.ActiveStorage) {


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

With this change, devs that need to make custom direct upload scripts can import the module directly from `@rails/activestorage` instead of `@rails/activestorage/src/direct_upload_controller`.

