### PR TITLE
add hint to ActionView's fields_for

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1018,9 +1018,10 @@ module ActionView
       #   <% end %>
       #
       # Note that fields_for will automatically generate a hidden field
-      # to store the ID of the record. There are circumstances where this
-      # hidden field is not needed and you can pass <tt>include_id: false</tt>
-      # to prevent fields_for from rendering it automatically.
+      # to store the ID of the record if it responds to <tt>persisted?</tt>.
+      # There are circumstances where this hidden field is not needed and you
+      # can pass <tt>include_id: false</tt> to prevent fields_for from
+      # rendering it automatically.
       def fields_for(record_name, record_object = nil, options = {}, &block)
         options = { model: record_object, allow_method_names_outside_object: false, skip_default_ids: false }.merge!(options)
 


### PR DESCRIPTION
### Summary

Add a hint to the documentation for `ActionView::Helpers::FormHelper#fields_for` when hidden `id` fields are generated.

### Other Information

I am a little embarrassed that this is such a small change. This missing bit of documentation had me spend unnecessary time when trying to figure out why there was no `id` rendered for sub-forms.