### PR TITLE
Add test case for AbstractMysqlAdapter#execute

### DIFF
--- a/activerecord/test/cases/adapters/abstract_mysql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/abstract_mysql_adapter_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class AbstractMysqlAdapterTest < ActiveRecord::Mysql2TestCase
+  class ExampleMysqlAdapter < ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter; end
+
+  def setup
+    @conn = ExampleMysqlAdapter.new(
+      ActiveRecord::ConnectionAdapters::Mysql2Adapter.new_client({}),
+      ActiveRecord::Base.logger,
+      nil,
+      { socket: File::NULL }
+    )
+  end
+
+  def test_execute_not_raising_error
+    assert_nothing_raised do
+      @conn.execute("SELECT 1")
+    end
+  end
+end


### PR DESCRIPTION
### Summary

This commit is a follow-up for 7ad7550601a19d94a4bb41b8c49e3bbc3c12b150 to prevent future regression as we currently do not have any tests that execute `AbstractMysqlAdapter#execute`, causing us failing to catch _wrong number of arguments_ error.

### Other Information

I decided to create a new file for this test as I couldn't really find where else this test should live. I feel like we might want to add more tests on the abstract adapter as well if we found that they are not being tested. However, if you think that this can live in other files, please let me know.

/cc @rafaelfranca 
