### PR TITLE
Avoid booting in development then test for test tasks

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Avoid booting in development then test for test tasks.
+
+    Running one of the rails test subtasks (e.g. test:system, test:models) would
+    go through Rake and cause the app to be booted twice. Now all the test:*
+    subtasks are defined as Thor tasks and directly load the test environment.
+
+    *Étienne Barrié*
+
 *   Deprecate `Rails::Generators::Testing::Behaviour` in favor of `Rails::Generators::Testing::Behavior`.
 
     *Gannon McGibbon*

--- a/railties/lib/rails/command/base.rb
+++ b/railties/lib/rails/command/base.rb
@@ -161,7 +161,8 @@ module Rails
           end
 
           def namespaced_commands
-            commands.keys.map do |key|
+            commands.filter_map do |key, command|
+              next if command.hidden?
               if command_root_namespace.match?(/(\A|:)#{key}\z/)
                 command_root_namespace
               else

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -32,6 +32,30 @@ module Rails
         Rails::TestUnit::Runner.parse_options(args)
         Rails::TestUnit::Runner.run(args)
       end
+
+      # Define Thor tasks to avoid going through Rake and booting twice when using bin/rails test:*
+
+      Rails::TestUnit::Runner::TEST_FOLDERS.each do |name|
+        define_method(name) do |*|
+          self.args.prepend("test/#{name}")
+          perform
+        end
+      end
+
+      def all
+        self.args = ["test/**/*_test.rb"]
+        perform
+      end
+
+      def system
+        self.args = ["test/system"]
+        perform
+      end
+
+      def generators
+        self.args = ["test/lib/generators"]
+        perform
+      end
     end
   end
 end

--- a/railties/lib/rails/commands/test/test_command.rb
+++ b/railties/lib/rails/commands/test/test_command.rb
@@ -42,6 +42,7 @@ module Rails
         end
       end
 
+      desc "test:all", "Runs all tests, including system tests", hide: true
       def all
         self.args = ["test/**/*_test.rb"]
         perform

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -9,6 +9,7 @@ require "active_support/core_ext/module/attribute_accessors"
 module Rails
   module TestUnit
     class Runner
+      TEST_FOLDERS = [:models, :helpers, :channels, :controllers, :mailers, :integration, :jobs, :mailboxes]
       mattr_reader :filters, default: []
 
       class << self

--- a/railties/lib/rails/test_unit/testing.rake
+++ b/railties/lib/rails/test_unit/testing.rake
@@ -29,7 +29,7 @@ namespace :test do
     success || exit(false)
   end
 
-  ["models", "helpers", "channels", "controllers", "mailers", "integration", "jobs", "mailboxes"].each do |name|
+  Rails::TestUnit::Runner::TEST_FOLDERS.each do |name|
     task name => "test:prepare" do
       Rails::TestUnit::Runner.rake_run(["test/#{name}"])
     end

--- a/railties/test/command/base_test.rb
+++ b/railties/test/command/base_test.rb
@@ -13,6 +13,15 @@ class Rails::Command::BaseTest < ActiveSupport::TestCase
     assert_equal %w(db:system:change), Rails::Command::Db::System::ChangeCommand.printing_commands
   end
 
+  test "printing commands hides hidden commands" do
+    class Rails::Command::HiddenCommand < Rails::Command::Base
+      desc "command", "Hidden command", hide: true
+      def command
+      end
+    end
+    assert_equal [], Rails::Command::HiddenCommand.printing_commands
+  end
+
   test "ARGV is populated" do
     class Rails::Command::ArgvCommand < Rails::Command::Base
       def check_populated(*args)


### PR DESCRIPTION
### Summary

Since #41132, we fork to run the tests from the test Rake tasks, which allows the tests to run when the task runs (previously it was only loading the tests, they ran at the process exit, which isn't helpful for rake tasks where you want to stop processing if a task dependency fails).

That means the app boots twice, first from the top of the Rakefile:
https://github.com/rails/rails/blob/b7c3b52ce530d9914717ceafc64990a225ad96c4/railties/lib/rails/generators/rails/app/templates/Rakefile.tt#L4
then in the fork that runs the test runner.

It's not ideal but it is the only way to run tests in a Rake task since they run at exit.

But that caused some weird behavior/bugs like #43937 since the application boots in development first to load the tasks and then forks to run the tests. We had mentioned some potential problems where the global state in Ruby changed from the Rakefile wouldn't be available to the test process, but we missed the opposite, where an environment variable would be set in development and then available in the child process in the test environment.

> #41132 This diverges from previous behavior because now, any changes made in the Rakefile or other code loaded by Rake won't be available to the child process.

But investigating this, I realized we could define the test tasks as Thor tasks, which take priority over Rake tasks.

We keep the Rake tasks for compatibility (`rake test:models` will continue to work), but `rails test:models` won't go through Rake anymore. 

I built it on 7-0-stable because I think it's a regression that we want to fix, but let me know if you'd rather push that as a feature for 7.1 on main.

### Other Information

There is some incompatibility as mentioned in the commit where we could run `rails test:models ARG=value --trace` but now it won't work.

Another important point is that the `test:prepare` hook won't run when it used to. If you had this in your Rakefile:
```ruby
Rake::Task['test:prepare'].enhance { puts "test:prepare enhancement" }
```

… it would run with `rails test:models` but not with `rails test`. I haven't found any mention of the `test:prepare` hook in guides or documentation so I'll look into deprecating it ([rspec calls it](https://github.com/rspec/rspec-rails/blob/v5.0.2/lib/rspec/rails/tasks/rspec.rake#L25-L26) but doesn't enhance it).

For both cases, I think it's fair since the same wouldn't work with the test task (`rails test ARG=value --trace` fails and `rails test` doesn't run the `test:prepare` task either since it's not a Rake task).

Fixes #43937 