### PR TITLE
Correct doc typo [ci skip]

### DIFF
--- a/activerecord/lib/active_record/database_configurations.rb
+++ b/activerecord/lib/active_record/database_configurations.rb
@@ -38,7 +38,7 @@ module ActiveRecord
     #   the returned list. Most of the time we're only iterating over the write
     #   connection (i.e. migrations don't need to run for the write and read connection).
     #   Defaults to +false+.
-    # * <tt>include_hidden:</tte Determines whether to include replicas and configurations
+    # * <tt>include_hidden:</tt> Determines whether to include replicas and configurations
     #   hidden by +database_tasks: false+ in the returned list. Most of the time we're only
     #   iterating over the primary connections (i.e. migrations don't need to run for the
     #   write and read connection). Defaults to +false+.


### PR DESCRIPTION
### Summary

Found a tag typo while backporting the newer `database_tasks: false` db config option to a Rails 6 app.
