### PR TITLE
Improve ActiveStorage analyzer error message for missing ffprobe. Add…

### DIFF
--- a/activestorage/lib/active_storage/analyzer/audio_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/audio_analyzer.rb
@@ -54,7 +54,7 @@ module ActiveStorage
           end
         end
       rescue Errno::ENOENT
-        logger.info "Skipping audio analysis because FFmpeg isn't installed"
+        logger.info "Skipping audio analysis because ffprobe isn't installed"
         {}
       end
 

--- a/activestorage/lib/active_storage/analyzer/video_analyzer.rb
+++ b/activestorage/lib/active_storage/analyzer/video_analyzer.rb
@@ -133,7 +133,7 @@ module ActiveStorage
           end
         end
       rescue Errno::ENOENT
-        logger.info "Skipping video analysis because FFmpeg isn't installed"
+        logger.info "Skipping video analysis because ffprobe isn't installed"
         {}
       end
 

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -38,7 +38,7 @@ Various features of Active Storage depend on third-party software which Rails
 will not install, and must be installed separately:
 
 * [libvips](https://github.com/libvips/libvips) v8.6+ or [ImageMagick](https://imagemagick.org/index.php) for image analysis and transformations
-* [ffmpeg](http://ffmpeg.org/) v3.4+ for video/audio analysis and video previews
+* [ffmpeg](http://ffmpeg.org/) v3.4+ for video previews and ffprobe for video/audio analysis
 * [poppler](https://poppler.freedesktop.org/) or [muPDF](https://mupdf.com/) for PDF previews
 
 Image analysis and transformations also require the `image_processing` gem. Uncomment it in your `Gemfile`, or add it if necessary:


### PR DESCRIPTION
… mention to guides.

### Summary

ActiveStorage video and audio analyzers incorrectly report that FFmpeg is missing when they actually call ffprobe.

Changes: Updated error message to 'ffprobe' and added mention to guides.

Fixes: https://github.com/rails/rails/issues/44110

### Other Information