### PR TITLE
Add Ruby on Rails version on title

### DIFF
--- a/railties/lib/rails/templates/rails/welcome/index.html.erb
+++ b/railties/lib/rails/templates/rails/welcome/index.html.erb
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Ruby on Rails</title>
+  <title>Ruby on Rails <%= Rails.version %></title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <link rel="icon" href="<%= ruby_on_rails_logo_favicon_data_uri %>" />


### PR DESCRIPTION
I just thought it's a good idea to have the `Rails.version` in the browser tab.