### PR TITLE
Add 'type' to query notification payload

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb
@@ -149,7 +149,8 @@ module ActiveRecord
             type_casted_binds: -> { type_casted_binds(binds) },
             name: name,
             connection: self,
-            cached: true
+            cached: true,
+            type: :read
           }
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -798,6 +798,7 @@ module ActiveRecord
             type_casted_binds: type_casted_binds,
             statement_name:    statement_name,
             async:             async,
+            type:              write_query?(sql) ? :write : :read,
             connection:        self) do
             @lock.synchronize(&block)
           rescue => e

--- a/activerecord/test/cases/instrumentation_test.rb
+++ b/activerecord/test/cases/instrumentation_test.rb
@@ -15,6 +15,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("SELECT")
           assert_equal "Book Load", event.payload[:name]
+          assert_equal :read, event.payload[:type]
         end
       end
       Book.first
@@ -27,6 +28,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("INSERT")
           assert_equal "Book Create", event.payload[:name]
+          assert_equal :write, event.payload[:type]
         end
       end
       Book.create(name: "test book")
@@ -39,6 +41,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("UPDATE")
           assert_equal "Book Update", event.payload[:name]
+          assert_equal :write, event.payload[:type]
         end
       end
       book = Book.create(name: "test book", format: "paperback")
@@ -52,6 +55,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("UPDATE")
           assert_equal "Book Update All", event.payload[:name]
+          assert_equal :write, event.payload[:type]
         end
       end
       Book.update_all(format: "ebook")
@@ -64,6 +68,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("DELETE")
           assert_equal "Book Destroy", event.payload[:name]
+          assert_equal :write, event.payload[:type]
         end
       end
       book = Book.create(name: "test book")
@@ -77,6 +82,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("DELETE")
           assert_equal "Book Delete All", event.payload[:name]
+          assert_equal :write, event.payload[:type]
         end
       end
       Book.delete_all
@@ -89,6 +95,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("SELECT")
           assert_equal "Book Pluck", event.payload[:name]
+          assert_equal :read, event.payload[:type]
         end
       end
       Book.pluck(:name)
@@ -101,6 +108,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("SELECT")
           assert_equal "Book Count", event.payload[:name]
+          assert_equal :read, event.payload[:type]
         end
       end
       Book.count
@@ -113,6 +121,7 @@ module ActiveRecord
         event = ActiveSupport::Notifications::Event.new(*args)
         if event.payload[:sql].match?("SELECT")
           assert_equal "Book Count", event.payload[:name]
+          assert_equal :read, event.payload[:type]
         end
       end
       Book.group(:status).count
@@ -125,6 +134,7 @@ module ActiveRecord
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
         assert_equal connection, event.payload[:connection]
+        assert_equal :read, event.payload[:type]
       end
       Book.first
     ensure
@@ -136,6 +146,7 @@ module ActiveRecord
       subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
         event = ActiveSupport::Notifications::Event.new(*args)
         assert_equal connection, event.payload[:connection]
+        assert_equal :read, event.payload[:type]
       end
       Book.cache do
         Book.first


### PR DESCRIPTION
GitHub has been using an added type field to this payload as part of our adapter for the Trilogy library. This field can contain values of `:read` or `:write` to describe the types of queries that were executed.

With this addition, one could use this information to answer questions involving the number of reads and writes for instrumentation purposes.

cc @eileencodes 

Co-authored-by: Daniel Colson <composerinteralia@github.com>