### PR TITLE
fix ApplicationController path on Action View guides

### DIFF
--- a/guides/source/action_view_overview.md
+++ b/guides/source/action_view_overview.md
@@ -423,7 +423,7 @@ For example, suppose you have an `ArticlesController` with a show action. By def
 
 You can use the same technique to localize the rescue files in your public directory. For example, setting `I18n.locale = :de` and creating `public/500.de.html` and `public/404.de.html` would allow you to have localized rescue pages.
 
-Since Rails doesn't restrict the symbols that you use to set I18n.locale, you can leverage this system to display different content depending on anything you like. For example, suppose you have some "expert" users that should see different pages from "normal" users. You could add the following to `app/controllers/application.rb`:
+Since Rails doesn't restrict the symbols that you use to set I18n.locale, you can leverage this system to display different content depending on anything you like. For example, suppose you have some "expert" users that should see different pages from "normal" users. You could add the following to `app/controllers/application_controller.rb`:
 
 ```ruby
 before_action :set_expert_locale


### PR DESCRIPTION
### Summary

Since Rails 2.3, the ApplicationController path is `app/controllers/application_controller.rb`, as stated on
its [release notes](https://guides.rubyonrails.org/2_3_release_notes.html#application-controller-renamed).

This Pull Requests fixes the outdated guides path.