### PR TITLE
Fix rollbacks following serialization failures or deadlocks

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Fix dropping DB connections after serialization failures and deadlocks.
+
+    Prior to 6.1.4, serialization failures and deadlocks caused rollbacks to be
+    issued for both real transactions and savepoints. This breaks MySQL which
+    disallows rollbacks of savepoints following a deadlock.
+
+    6.1.4 removed these rollbacks, for both transactions and savepoints, causing
+    the DB connection to be left in an unknown state and thus discarded.
+
+    These rollbacks are now restored, except for savepoints on MySQL.
+
+    *Thomas Morgan*
+
 *   Make `ActiveRecord::ConnectionPool` Fiber-safe
 
     When `ActiveSupport::IsolatedExecutionState.isolation_level` is set to `:fiber`,

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -329,6 +329,12 @@ module ActiveRecord
         false
       end
 
+      # Do TransactionRollbackErrors on savepoints affect the parent
+      # transaction?
+      def savepoint_errors_invalidate_transactions?
+        false
+      end
+
       # Does this adapter support application-enforced advisory locking?
       def supports_advisory_locks?
         false

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -84,6 +84,10 @@ module ActiveRecord
         true
       end
 
+      def savepoint_errors_invalidate_transactions?
+        true
+      end
+
       def supports_lazy_transactions?
         true
       end

--- a/activerecord/test/cases/adapters/mysql2/transaction_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_test.rb
@@ -36,6 +36,7 @@ module ActiveRecord
     end
 
     test "raises Deadlocked when a deadlock is encountered" do
+      connection = Sample.connection
       assert_raises(ActiveRecord::Deadlocked) do
         barrier = Concurrent::CyclicBarrier.new(2)
 
@@ -60,6 +61,7 @@ module ActiveRecord
           thread.join
         end
       end
+      assert_predicate connection, :active?
     end
 
     test "raises LockWaitTimeout when lock wait timeout exceeded" do

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -50,6 +50,8 @@ class TransactionTest < ActiveRecord::TestCase
 
       assert_not connection.active?
       assert_not Topic.connection_pool.connections.include?(connection)
+    ensure
+      ActiveRecord::Base.clear_all_connections!
     end
 
     def test_rollback_dirty_changes_even_with_raise_during_rollback_doesnt_commit_transaction
@@ -74,6 +76,8 @@ class TransactionTest < ActiveRecord::TestCase
       end
 
       assert_equal "The Fifth Topic of the day", topic.reload.title
+    ensure
+      ActiveRecord::Base.clear_all_connections!
     end
   end
 


### PR DESCRIPTION
### Summary

This PR restores rollbacks for real/parent transactions after encountering serialization failures or deadlocks. This fixes the current problem (introduced in 6.1.4) of the database connection being dropped when encountering these two errors.

It continues to skip rollbacks for savepoint/child transactions.

Fixes #43130
Replaces #43381


### Other Information

PR #30922 identified that MySQL cannot handle rollbacks of savepoints once a serialization failure or deadlock has occurred. It added an `:invalidated` transaction state to track this and used it to skip *all* rollbacks.

With these transactions no longer being rolled back, the underlying connections began to be thrown away. The connection discard facility was added in #40541 to address errors *during* rollback.

Unfortunately, the combination of #30922 and #40541 resulted in throwing away the connection upon every deadlock and serialization failure--assuredly not what either PR intended.

Note that PostgreSQL allows rollbacks of savepoints and skipping them is only necessary for MySQL. ~~However, skipping savepoint rollbacks in the case at hand does not appear to harm PostgreSQL so the implemented logic is not database specific. An alternative would be to add another supports-type flag to the database adapters and limit the skip behavior to only MySQL.~~ (edited to add:) Accordingly, a database adapter flag has been added to limit the skip behavior to MySQL only.


### Monkeypatch

For anyone that wants to test this on v6.1.4.1 or v7.0.1, here's a monkeypatch that can be added to an initializer. Using it with a v6.1.4.1 app here results in tests passing without excess dropped connections.

```ruby
require 'active_record/connection_adapters/abstract/transaction'
module ActiveRecord
  module ConnectionAdapters
    class SavepointTransaction < Transaction
      def rollback
        unless @state.invalidated?
          connection.rollback_to_savepoint(savepoint_name) if materialized?
        end
        @state.rollback!
      end
    end
    class TransactionManager
      def rollback_transaction(transaction = nil)
        @connection.lock.synchronize do
          transaction ||= @stack.pop
          transaction.rollback
          transaction.rollback_records
        end
      end
    end
  end
end
```
