### PR TITLE
Remove assert_not_called Object#=~ here for Ruby 3.2 compat

### DIFF
--- a/activerecord/test/cases/relation/mutation_test.rb
+++ b/activerecord/test/cases/relation/mutation_test.rb
@@ -32,10 +32,8 @@ module ActiveRecord
 
     test "#order! on non-string does not attempt regexp match for references" do
       obj = Object.new
-      assert_not_called(obj, :=~) do
-        assert relation.order!(obj)
-        assert_equal [obj], relation.order_values
-      end
+      assert relation.order!(obj)
+      assert_equal [obj], relation.order_values
     end
 
     test "extending!" do


### PR DESCRIPTION
Since Ruby 3.2 removes `Object#=~` this test no longer passes, so remove that assertion.

Fixes #44107 