### PR TITLE
Fix example related to `comparison` in Active Record Validations guide

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -395,7 +395,7 @@ value, proc, or symbol. Any class that includes Comparable can be compared.
 
 ```ruby
 class Promotion < ApplicationRecord
-  validates :start_date, comparison: { greater_than: :end_date }
+  validates :end_date, comparison: { greater_than: :start_date }
 end
 ```
 


### PR DESCRIPTION
Flipped the example, to show that `end_date` should be greater than `start_date`

Tried it this way:

```ruby
2.7.4 :002 > start_date = DateTime.now
 => Sun, 09 Jan 2022 11:54:00 +0530 
2.7.4 :003 > end_date = DateTime.now + 24.hours
 => Mon, 10 Jan 2022 11:54:08 +0530 
2.7.4 :004 > start_date > end_date
 => false 
 ```

