### PR TITLE
Explicitly list negative currency format

### DIFF
--- a/activesupport/lib/active_support/locale/en.yml
+++ b/activesupport/lib/active_support/locale/en.yml
@@ -57,6 +57,7 @@ en:
       format:
         # Where is the currency sign? %u is the currency unit, %n is the number (default: $5.00)
         format: "%u%n"
+        negative_format: "-%u%n"
         unit: "$"
         # These six are to override number.format and are optional
         separator: "."


### PR DESCRIPTION
Downstream bases some tests on the original translation files to make sure no unknown keys are introduced. The negative currency format is currently not in the original Rails translations, making it difficult to translate this for Dutch downstream (see https://github.com/svenfuchs/rails-i18n/pull/858).

Apparently there is a fallback in the source code to derive this negative format at runtime: https://github.com/rails/rails/blob/984c3ef2775781d47efa9f541ce570daa2434a80/activesupport/lib/active_support/number_helper/number_to_currency_converter.rb#L41 This PR makes it explicit in the translation files.