### PR TITLE
Disable config.add_autoload_paths_to_load_path by default in Rails 7.1

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -78,6 +78,14 @@ To allow you to upgrade to new defaults one by one, the update task has created 
 Upgrading from Rails 7.0 to Rails 7.1
 -------------------------------------
 
+### Autoloaded paths are no longer in load path
+
+Starting from Rails 7.1, all paths managed by the autoloader will no longer be added to `$LOAD_PATH`.
+This means it won't be possible to load them with a manual `require` call, the class or module can be referenced instead.
+
+Reducing the size of `$LOAD_PATH` speed-up `require` calls for apps not using `bootsnap`, and reduce the
+size of the `bootsnap` cache for the others.
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   No longer add autoloaded paths to `$LOAD_PATH`.
+
+    This means it won't be possible to load them with a manual `require` call, the class or module can be referenced instead.
+
+    Reducing the size of `$LOAD_PATH` speed-up `require` calls for apps not using `bootsnap`, and reduce the
+    size of the `bootsnap` cache for the others.
+
+    *Jean Boussier*
+
 *   Remove default `X-Download-Options` header
 
     This header is currently only used by Internet Explorer which

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -261,6 +261,8 @@ module Rails
         when "7.1"
           load_defaults "7.0"
 
+          self.add_autoload_paths_to_load_path = false
+
           if respond_to?(:action_dispatch)
             action_dispatch.default_headers = {
               "X-Frame-Options" => "SAMEORIGIN",

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -9,6 +9,12 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
+# No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
+# to manually require files that are managed by the autoloader, which you shouldn't do anyway.
+# This reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
+# of the bootsnap cache if you use it.
+# Rails.application.config.add_autoload_paths_to_load_path = false
+
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 # Rails.application.config.action_dispatch.default_headers = {


### PR DESCRIPTION
Ref: https://github.com/rails/rails/commit/668673f7793be1ce318a32bb622ed411029d00a9

Now that Zeitwerk is the only autoloader, there no reason to add autoloaded paths to `$LOAD_PATH` (we should probably have done it in 7.0, but hey...).

@fxn let me know if it's good with you and I can merge.