### PR TITLE
Assert sql_type disregarding case sensitiveness for sqlite3 tests

### DIFF
--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -558,7 +558,7 @@ module ActiveRecord
           ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
 
           testings_id_column = connection.columns(:more_testings).find { |el| el.name == "testings_id" }
-          assert_equal "integer", testings_id_column.sql_type
+          assert_match(/integer/i, testings_id_column.sql_type)
         ensure
           connection.drop_table :more_testings rescue nil
         end
@@ -583,7 +583,7 @@ module ActiveRecord
           ActiveRecord::Migrator.new(:up, [create_migration, migration], @schema_migration).migrate
 
           testings_id_column = connection.columns(:more_testings).find { |el| el.name == "testings_id" }
-          assert_equal "integer", testings_id_column.sql_type
+          assert_match(/integer/i, testings_id_column.sql_type)
         ensure
           connection.drop_table :more_testings rescue nil
         end


### PR DESCRIPTION
As mentioned here #43295 since sqlite3 3.37 sqlite3 returns the type of the columns in capital letters while in versions before it did return in lowercase, matching disregarging case sensitiveness will avoid the tests fail in more recent versions of sqlite3 since what matters is the name of the type and not if it is uppercase or lowercase.

Co-Authored-By: Name <pixeltrix@users.noreply.github.com>