### PR TITLE
fix missing require for pp in 546de0f

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pp"
 require "cases/helper"
 require "models/tag"
 require "models/tagging"


### PR DESCRIPTION
### Summary

This fixes errors in the isolated active record tests such as:

```
Error:
RelationTest#test_already-loaded_relations_don't_perform_a_new_query_in_#pretty_print:
NameError: uninitialized constant RelationTest::PP

      PP.pp relation, StringIO.new # avoid outputting.
      ^^
    test/cases/relations_test.rb:2049:in `block (2 levels) in <class:RelationTest>'
    /rails/activerecord/test/cases/test_case.rb:54:in `assert_queries'
    /rails/activerecord/test/cases/test_case.rb:67:in `assert_no_queries'
    test/cases/relations_test.rb:2048:in `block in <class:RelationTest>'
```
