### PR TITLE
Fix passing options to check_constraint from change_table

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -838,8 +838,8 @@ module ActiveRecord
       #  t.check_constraint("price > 0", name: "price_check")
       #
       # See {connection.add_check_constraint}[rdoc-ref:SchemaStatements#add_check_constraint]
-      def check_constraint(*args)
-        @base.add_check_constraint(name, *args)
+      def check_constraint(*args, **options)
+        @base.add_check_constraint(name, *args, **options)
       end
 
       # Removes the given check constraint from the table.
@@ -847,8 +847,8 @@ module ActiveRecord
       #  t.remove_check_constraint(name: "price_check")
       #
       # See {connection.remove_check_constraint}[rdoc-ref:SchemaStatements#remove_check_constraint]
-      def remove_check_constraint(*args)
-        @base.remove_check_constraint(name, *args)
+      def remove_check_constraint(*args, **options)
+        @base.remove_check_constraint(name, *args, **options)
       end
 
       private

--- a/activerecord/test/cases/migration/check_constraint_test.rb
+++ b/activerecord/test/cases/migration/check_constraint_test.rb
@@ -170,6 +170,26 @@ if ActiveRecord::Base.connection.supports_check_constraints?
             @connection.remove_check_constraint :trades, name: "nonexistent"
           end
         end
+
+        def test_add_constraint_from_change_table_with_options
+          @connection.change_table :trades do |t|
+            t.check_constraint "price > 0", name: "price_check"
+          end
+
+          constraint = @connection.check_constraints("trades").first
+          assert_equal "trades", constraint.table_name
+          assert_equal "price_check", constraint.name
+        end
+
+        def test_remove_constraint_from_change_table_with_options
+          @connection.add_check_constraint :trades, "price > 0", name: "price_check"
+
+          @connection.change_table :trades do |t|
+            t.remove_check_constraint "price > 0", name: "price_check"
+          end
+
+          assert_equal 0, @connection.check_constraints("trades").size
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary

The `check_constraint` and `remove_check_constraint` methods on ActiveRecord::ConnectionAdapters::Table just forward to `add_check_constraint` and `remove_check_constraint` on the actual connection.

However they were only forwarding positional arguments (*args) and not the keyword arguments used for options. This worked on ruby <= 2.7 (albeit with warnings on 2.7) , due to how hashes were converted transparently to keyword arguments, but raises `ArgumentError: wrong number of arguments` on 3.0

