### PR TITLE
Fix NoMethodError in Action Mailbox Conductor 

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,8 +22,8 @@ module Rails
       def new_mail
         Mail.new(mail_params.except(:attachments).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
-          mail_params[:attachments].to_a.each do |attachment|
-            mail.add_file(filename: attachment.original_filename, content: attachment.read)
+          attachments.each do |attachment|
+            mail.add_file(filename: attachment.original_filename, content: attachment.read) 
           end
         end
       end
@@ -34,6 +34,10 @@ module Rails
 
       def create_inbound_email(mail)
         ActionMailbox::InboundEmail.create_and_extract_message_id!(mail.to_s)
+      end
+
+      def attachments
+        mail_params[:attachments].to_a.reject { |a| a.is_a?(String) && a.empty? }
       end
   end
 end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -71,6 +71,26 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
       assert_equal %w[ avatar1.jpeg avatar2.jpeg ], mail.attachments.collect(&:filename)
     end
   end
+  
+  test "create inbound email with no attachments" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_emails_path, params: {
+          mail: {
+            from: "Jason Fried <jason@37signals.com>",
+            to: "Replies <replies@example.com>",
+            subject: "Let's debate some attachments",
+            body: "I forgot my attachments",
+            attachments: [ "" ]
+          }
+        }
+      end
+
+      mail = ActionMailbox::InboundEmail.last.mail
+      assert_equal "I forgot my attachments", mail.body.decoded
+      assert_equal 0, mail.attachments.count
+    end
+  end
 
   private
     def with_rails_env(env)


### PR DESCRIPTION
Proposed fix for #43928 

`mail_params[:attachments]` is an array of attachments however the browser is passing the first element as a
blank string whether there are attachments or not. This is causing the NoMethodError as the original_filename
method is being called on the attachment elements.

Resolution is to strip out empty string from attachments array.