### PR TITLE
Clean up initializer templates [ci-skip]

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
-# Define an application-wide content security policy
-# For further information see the following documentation
+# Define an application-wide content security policy.
+# For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 # Rails.application.configure do
@@ -16,7 +16,7 @@
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end
 #
-#   # Generate session nonces for permitted importmap and inline scripts
+#   # Generate session nonces for permitted importmap and inline scripts.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
 #   config.content_security_policy_nonce_directives = %w(script-src)
 #

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/permissions_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/permissions_policy.rb.tt
@@ -1,11 +1,13 @@
+# Be sure to restart your server when you modify this file.
+
 # Define an application-wide HTTP permissions policy. For further
-# information see https://developers.google.com/web/updates/2018/06/feature-policy
-#
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
+# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+
+# Rails.application.config.permissions_policy do |policy|
+#   policy.camera      :none
+#   policy.gyroscope   :none
+#   policy.microphone  :none
+#   policy.usb         :none
+#   policy.fullscreen  :self
+#   policy.payment     :self, "https://secure.example.com"
 # end


### PR DESCRIPTION
### Summary

Add some missing punctuation marks and make permissions_policy more
consistent with other initializers.
Also rename the `f` variable to the more clearer `policy` similar to
content_security_policy.rb.