### PR TITLE
Fix documentation comments for form_tag

### DIFF
--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -62,7 +62,7 @@ module ActionView
       #
       #   <%= form_tag('/posts', remote: true) %>
       #   # => <form action="/posts" method="post" data-remote="true">
-
+      #
       #   form_tag(false, method: :get)
       #   # => <form method="get">
       #


### PR DESCRIPTION
### Summary
The comment break caused a break in documentation. Adding the hash back in should fix it.

<img width="1010" alt="Screen Shot 2022-01-11 at 6 24 45 AM" src="https://user-images.githubusercontent.com/1431996/148934611-0c3e1912-dc68-474b-be27-28bd66b9b2e5.png">
