### PR TITLE
atomic write race condition

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Improve `File.atomic_write` error handling
+
 *   Fix `Class#descendants` and `DescendantsTracker#descendants` compatibility with Ruby 3.1.
 
     [The native `Class#descendants` was reverted prior to Ruby 3.1 release](https://bugs.ruby-lang.org/issues/14394#note-33),

--- a/activesupport/lib/active_support/core_ext/file/atomic.rb
+++ b/activesupport/lib/active_support/core_ext/file/atomic.rb
@@ -64,6 +64,8 @@ class File
     file_name = join(dir, basename)
     FileUtils.touch(file_name)
     stat(file_name)
+  rescue Errno::ENOENT
+    file_name = nil
   ensure
     FileUtils.rm_f(file_name) if file_name
   end

--- a/activesupport/test/core_ext/file_test.rb
+++ b/activesupport/test/core_ext/file_test.rb
@@ -83,6 +83,10 @@ class AtomicWriteTest < ActiveSupport::TestCase
     File.unlink(file_name) rescue nil
   end
 
+  def test_probe_stat_in_when_no_dir
+    assert_nil File.probe_stat_in("/dir/does/not/exist")
+  end
+
   private
     def file_name
       "atomic-#{Process.pid}.file"


### PR DESCRIPTION
### Summary

There is a bug related atomic_write we're seeing in production (along with many [others](https://www.google.com/search?q=permissions_check+rails+Errno%3A%3AENOENT)).  The stack trace suggests that `FileUtils.touch` is operating on a path who's basedir no longer exists, hence it raises a `Errno::ENOENT` exception.  Might be due to a race condition somewhere?  Regardless, `File.probe_stat_in` probably shouldn't explode even if atomic_write does since it's not helpful for debugging.


```
Errno::ENOENT: No such file or directory @ rb_sysopen - /app/tmp/cache/BD7/E60/.permissions_check.17860.74.234014
/usr/local/lib/ruby/2.7.0/fileutils.rb:1150:in `initialize': No such file or directory @ rb_sysopen - /app/tmp/cache/BD7/E60/.permissions_check.17860.74.234014 (Errno::ENOENT)
	from /usr/local/lib/ruby/2.7.0/fileutils.rb:1150:in `open'
	from /usr/local/lib/ruby/2.7.0/fileutils.rb:1150:in `rescue in block in touch'
	from /usr/local/lib/ruby/2.7.0/fileutils.rb:1146:in `block in touch'
	from /usr/local/lib/ruby/2.7.0/fileutils.rb:1144:in `each'
	from /usr/local/lib/ruby/2.7.0/fileutils.rb:1144:in `touch'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/core_ext/file/atomic.rb:65:in `probe_stat_in'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/core_ext/file/atomic.rb:35:in `block in atomic_write'
	from /usr/local/lib/ruby/2.7.0/tempfile.rb:291:in `open'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/core_ext/file/atomic.rb:24:in `atomic_write'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache/file_store.rb:88:in `write_entry'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache/strategy/local_cache.rb:165:in `write_entry'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache.rb:476:in `block in write'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache.rb:726:in `block in instrument'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/notifications.rb:205:in `instrument'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache.rb:726:in `instrument'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache.rb:474:in `write'
	from /usr/local/bundle/ruby/2.7.0/gems/ddtrace-0.54.1/lib/ddtrace/contrib/active_support/cache/instrumentation.rb:199:in `write'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache.rb:755:in `save_block_result_to_cache'
	from /usr/local/bundle/ruby/2.7.0/gems/activesupport-6.1.4.4/lib/active_support/cache.rb:343:in `fetch'
...
```

repro
```
Dir.mkdir('/tmp/foo')
File.atomic_write('/tmp/foo/bar', temp_dir = '/tmp') do |f|
  Dir.rmdir('/tmp/foo')
end

Traceback (most recent call last):
        ... 13 levels...
         5: from /Users/daniel.pepper/.rvm/gems/ruby-2.7.4/gems/activesupport-6.1.4.4/lib/active_support/core_ext/file/atomic.rb:35:in `block in atomic_write'
         4: from /Users/daniel.pepper/.rvm/gems/ruby-2.7.4/gems/activesupport-6.1.4.4/lib/active_support/core_ext/file/atomic.rb:65:in `probe_stat_in'
         3: from /Users/daniel.pepper/.rvm/rubies/ruby-2.7.4/lib/ruby/2.7.0/fileutils.rb:1144:in `touch'
         2: from /Users/daniel.pepper/.rvm/rubies/ruby-2.7.4/lib/ruby/2.7.0/fileutils.rb:1144:in `each'
         1: from /Users/daniel.pepper/.rvm/rubies/ruby-2.7.4/lib/ruby/2.7.0/fileutils.rb:1147:in `block in touch'
/Users/daniel.pepper/.rvm/rubies/ruby-2.7.4/lib/ruby/2.7.0/fileutils.rb:1147:in `utime': No such file or directory @ apply2files - /tmp/foo/.permissions_check.2000.38512.716681 (Errno::ENOENT)
```