### PR TITLE
Add Action Mailbox deprecations to 6.1 release notes

### DIFF
--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -441,7 +441,7 @@ Please refer to the [Changelog][action-mailbox] for detailed changes.
 
 ### Deprecations
 
-*   Deprecate Rails.application.credentials.action_mailbox.api_key and MAILGUN_INGRESS_API_KEY in favor of Rails.application.   credentials.action_mailbox.signing_key and MAILGUN_INGRESS_SIGNING_KEY.
+*   Deprecate `Rails.application.credentials.action_mailbox.api_key` and `MAILGUN_INGRESS_API_KEY` in favor of `Rails.application.credentials.action_mailbox.signing_key` and `MAILGUN_INGRESS_SIGNING_KEY`.
 
 ### Notable changes
 

--- a/guides/source/6_1_release_notes.md
+++ b/guides/source/6_1_release_notes.md
@@ -441,6 +441,8 @@ Please refer to the [Changelog][action-mailbox] for detailed changes.
 
 ### Deprecations
 
+*   Deprecate Rails.application.credentials.action_mailbox.api_key and MAILGUN_INGRESS_API_KEY in favor of Rails.application.   credentials.action_mailbox.signing_key and MAILGUN_INGRESS_SIGNING_KEY.
+
 ### Notable changes
 
 Ruby on Rails Guides


### PR DESCRIPTION
### Summary

Update 6.1 release notes to include Action Mailbox deprecations

According to the [Action Mailbox changelog](https://github.com/rails/rails/blob/6-1-stable/actionmailbox/CHANGELOG.md#rails-610-december-09-2020) version 6.1 includes

```
Deprecate Rails.application.credentials.action_mailbox.api_key and MAILGUN_INGRESS_API_KEY in favor of Rails.application.credentials.action_mailbox.signing_key and MAILGUN_INGRESS_SIGNING_KEY.
```

This information is missing on https://guides.rubyonrails.org/6_1_release_notes.html
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
