### PR TITLE
Only configure smtp_settings if provided on configuration

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -23,7 +23,6 @@ module ActionMailer
       options.stylesheets_dir ||= paths["public/stylesheets"].first
       options.show_previews = Rails.env.development? if options.show_previews.nil?
       options.cache_store ||= Rails.cache
-      options.smtp_settings ||= {}
 
       if options.show_previews
         options.preview_path ||= defined?(Rails.root) ? "#{Rails.root}/test/mailers/previews" : nil
@@ -46,9 +45,15 @@ module ActionMailer
           self.delivery_job = delivery_job.constantize
         end
 
-        if smtp_timeout = options.delete(:smtp_timeout)
-          options.smtp_settings[:open_timeout] ||= smtp_timeout
-          options.smtp_settings[:read_timeout] ||= smtp_timeout
+        if options.smtp_settings
+          self.smtp_settings = options.smtp_settings
+        end
+
+        smtp_timeout = options.delete(:smtp_timeout)
+
+        if self.smtp_settings && smtp_timeout
+          self.smtp_settings[:open_timeout] ||= smtp_timeout
+          self.smtp_settings[:read_timeout] ||= smtp_timeout
         end
 
         options.each { |k, v| send("#{k}=", v) }


### PR DESCRIPTION
### Summary

There's a bug when `ActionMailer::Base.smtp_settings=` is set before ActionMailer gets initialized and `config.action_mailer.smtp_settings` is not set. This ends up overriding ActionMailer::Base.smtp_settings.

Some users may configure ActionMailer::Base.smtp_directly instead of using it via `config.action_mailer.smtp_settings`. 

In order to fix that this PR does not try to configure smtp_settings when it's not present on the config hash.   

Fixes #44161 and Follow up from #44061
