### PR TITLE
ActiveRecord::RelationTest: Sort results before asserting equality

### DIFF
--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -293,7 +293,7 @@ module ActiveRecord
       skip_if_sqlite3_version_includes_quoting_bug
       quoted_join = ActiveRecord::Base.connection.quote_table_name("join")
       selected = Post.select(:join).from(Post.select("id as #{quoted_join}")).map(&:join)
-      assert_equal Post.pluck(:id), selected
+      assert_equal Post.pluck(:id).sort, selected.sort
     end
 
     def test_selecting_aliased_attribute_quotes_column_name_when_from_is_used


### PR DESCRIPTION
### Summary

For the SQL Server adapter
(https://github.com/rails-sqlserver/activerecord-sqlserver-adapter/) the `ActiveRecord::RelationTest#test_select_quotes_when_using_from_clause` test need to be coerced and re-implemented (rails-sqlserver/activerecord-sqlserver-adapter#996) because the test implicitly expects the database to return the results in a specific order, which SQL Server does not always do. This results in the test randomly failing on the CI.

The changes in this PR do not affect the purpose of the Rails test and remove the need to coerce & re-implement the same test in the SQL Server adapter.