### PR TITLE
Add support to locales with lowdash in Resolver::PathParser

### DIFF
--- a/actionpack/test/controller/localized_templates_test.rb
+++ b/actionpack/test/controller/localized_templates_test.rb
@@ -45,4 +45,11 @@ class LocalizedTemplatesTest < ActionController::TestCase
     assert_equal "Ciao Mondo", @response.body
     assert_equal "text/html",  @response.media_type
   end
+
+  def test_use_locale_with_lowdash
+    I18n.locale = :"de_AT"
+
+    get :hello_world
+    assert_equal "Guten Morgen", @response.body
+  end
 end

--- a/actionpack/test/fixtures/localized/hello_world.de_AT.html
+++ b/actionpack/test/fixtures/localized/hello_world.de_AT.html
@@ -1,0 +1,1 @@
+Guten Morgen

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -19,7 +19,7 @@ module ActionView
       def build_path_regex
         handlers = Template::Handlers.extensions.map { |x| Regexp.escape(x) }.join("|")
         formats = Template::Types.symbols.map { |x| Regexp.escape(x) }.join("|")
-        locales = "[a-z]{2}(?:-[A-Z]{2})?"
+        locales = "[a-z]{2}(?:[-_][A-Z]{2})?"
         variants = "[^.]*"
 
         %r{

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -232,4 +232,14 @@ module ResolverSharedTests
 
     assert_empty context.find_all("hello_world.html", "test", false, [], {})
   end
+
+  def test_finds_template_with_lowdash_format
+    with_file "test/hello_world.es_AR.text.erb", "Texto simple!"
+
+    es_ar = context.find_all("hello_world", "test", false, [], locale: [:es_AR])
+
+    assert_equal 1, es_ar.size
+
+    assert_equal "Texto simple!", es_ar[0].source
+  end
 end


### PR DESCRIPTION
In Rails 6.1.4.4, a dynamic regex was built to find templates.
After this commit https://github.com/rails/rails/commit/9e0c42b0bde91da41745e2bcf4a14bfefdc72fc0 `PathParser` started to be used to both match and sort templates. As the `PathParser` regex does not match locales with lowdash format (ex: `:es_AR`), templates including those locales have a wrong virtual path and get filtered.  

In this commit the regex gets modified to allow lowdash.

Further discussion: https://github.com/rails/rails/issues/44154

CC:  @jhawthorn 