### PR TITLE
Add net-http dependency to frameworks using mail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ PATH
       activestorage (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       mail (>= 2.7.1)
+      net-http
       net-imap
       net-pop
       net-smtp
@@ -68,6 +69,7 @@ PATH
       activejob (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       mail (~> 2.5, >= 2.5.4)
+      net-http
       net-imap
       net-pop
       net-smtp
@@ -363,6 +365,9 @@ GEM
     mustache (1.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
+    net-http (0.2.0)
+      net-protocol
+      uri
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     net-imap (0.2.2)
@@ -550,6 +555,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.1.0)
+    uri (0.11.0)
     useragent (0.16.10)
     vegas (0.1.11)
       rack (>= 1.0.0)

--- a/actionmailbox/actionmailbox.gemspec
+++ b/actionmailbox/actionmailbox.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |s|
   s.add_dependency "net-imap"
   s.add_dependency "net-pop"
   s.add_dependency "net-smtp"
+  s.add_dependency "net-http"
 end

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |s|
   s.add_dependency "net-imap"
   s.add_dependency "net-pop"
   s.add_dependency "net-smtp"
+  s.add_dependency "net-http"
   s.add_dependency "rails-dom-testing", "~> 2.0"
 end


### PR DESCRIPTION
In [5dd292f5][] we added net- gems as dependencies of actionmailbox  and
actionmailer.

That caused warnings in our Ruby 2.7 builds, where `net-protocol` is
getting loaded twice—both as a gem and as a Ruby library. These warnings
are visible in [buildkite][].

```
/usr/local/lib/ruby/2.7.0/net/protocol.rb:66: warning: already initialized constant Net::ProtocRetryError
/usr/local/bundle/gems/net-protocol-0.1.2/lib/net/protocol.rb:68: warning: previous definition of ProtocRetryError was here
```

[5dd292f5]: https://github.com/rails/rails/commit/5dd292f5511fedd91833dc8482baf696cb821af6
[buildkite]: https://buildkite.com/rails/rails/builds/84010#60f6c08a-f35d-4b87-a56d-2d06d43e8ee3

It's getting loaded twice because the net-http that ships with Ruby 2.7
has a [`require_relative "protocol"`][ruby lib] that causes it to always
load the library in Ruby instead of the gem. By using the `net-http` gem
as well, we [avoid this problem][gem].

[ruby lib]: https://github.com/ruby/ruby/blob/v2_7_3/lib/net/http.rb#L23
[gem]: https://github.com/ruby/net-http/blob/38d8a19454faa74d892380846a2ba4d3e86487b9/lib/net/http.rb#L23

These warnings are also visibile in brand new rails apps created off
main, for example by running:

```
ruby -v
=> 2.7.3
rails new my_app --main
cd my_app
rails test
```

Loading multiple versions of the same gem can also cause cryptic
warnings. For example if you install [webmock][] and enable it before
loading any Rails application files (something we do at GitHub), you can
end up with an error:

```
`<module:Net>': superclass mismatch for class InternetMessageIO (TypeError)
```

[webmock]: https://github.com/bblimke/webmock

This commit does pull in URI, which can cause warnings when using
versions of bundler older than 2.2.33. But we've already got warnings
related to the digest gem when using bundler versions older than 2.3.0:
before this [PR removing digest as a bundler dependency][digest] we end
up loading two version and getting the warnings:

```
ruby/2.7.3/lib/ruby/gems/2.7.0/gems/digest-3.1.0/lib/digest.rb:20: warning: already initialized constant Digest::REQUIRE_MUTEX
ruby/2.7.3/lib/ruby/2.7.0/digest.rb:6: warning: previous definition of REQUIRE_MUTEX was here
```

[digest]: https://github.com/rubygems/rubygems/pull/4989/commits/c19a9f2ff71e91387eca88708910bb6e99f54db6

With or without this commit, we may need to either drop Ruby 2.7 support
or bump the minimum version of bundler if we want the warnings to go
away entirely.

Co-authored-by: Nick Holden