### PR TITLE
Add `MessageVerifiers` and `MessageEncryptors` classes

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,23 @@
+*   Add `Rails.application.message_verifiers` as a central point to configure
+    and create message verifiers for an application.
+
+    This allows applications to, for example, rotate old `secret_key_base`
+    values:
+
+    ```ruby
+    config.before_initialize do |app|
+      app.message_verifiers.rotate(secret_key_base: "old secret_key_base")
+    end
+    ```
+
+    And for libraries to create preconfigured message verifiers:
+
+    ```ruby
+    ActiveStorage.verifier = Rails.application.message_verifiers["ActiveStorage"]
+    ```
+
+    *Jonathan Hefner*
+
 *   Add `assert_error_reported` and `assert_no_error_reported`
 
     Allows to easily asserts an error happened but was handled

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -69,7 +69,9 @@ module ActiveSupport
     autoload :JsonWithMarshalFallback
     autoload :KeyGenerator
     autoload :MessageEncryptor
+    autoload :MessageEncryptors
     autoload :MessageVerifier
+    autoload :MessageVerifiers
     autoload :Multibyte
     autoload :NumberHelper
     autoload :OptionMerger

--- a/activesupport/lib/active_support/message_encryptors.rb
+++ b/activesupport/lib/active_support/message_encryptors.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "active_support/messages/rotation_coordinator"
+
+module ActiveSupport
+  class MessageEncryptors < Messages::RotationCoordinator
+    ##
+    # :method: initialize
+    # :call-seq: initialize(&secret_generator)
+    #
+    # Initializes a new instance. +secret_generator+ must accept a salt and a
+    # +secret_length+ kwarg, and return a suitable secret (string) or secrets
+    # (array of strings). +secret_generator+ may also accept other arbitrary
+    # kwargs. If #rotate is called with any options matching those kwargs, those
+    # options will be passed to +secret_generator+ instead of to the message
+    # encryptor.
+    #
+    #   encryptors = ActiveSupport::MessageEncryptors.new do |salt, secret_length:, base:|
+    #     MySecretGenerator.new(base).generate(salt, secret_length)
+    #   end
+    #
+    #   encryptors.rotate(base: "...")
+
+    ##
+    # :method: []
+    # :call-seq: [](salt)
+    #
+    # Returns a MessageEncryptor configured with a secret derived from the
+    # given +salt+, and options from #rotate. MessageEncryptor instances will
+    # be memoized, so the same +salt+ will return the same instance.
+
+    ##
+    # :method: []=
+    # :call-seq: []=(salt, encryptor)
+    #
+    # Overrides a MessageEncryptor instance associated with a given +salt+.
+
+    ##
+    # :method: rotate
+    # :call-seq: rotate(**options)
+    #
+    # Adds +options+ to the list of option sets. Messages will be encrypted
+    # using the first set in the list. When decrypting, however, each set will
+    # be tried, in order, until one succeeds.
+    #
+    # Notably, the +:secret_generator+ option can specify a different secret
+    # generator than the one initially specified. The secret generator must
+    # respond to +call+, accept a salt and a +secret_length+ kwarg, and return
+    # a suitable secret (string) or secrets (array of strings). The secret
+    # generator may also accept other arbitrary kwargs.
+    #
+    # If any options match the kwargs of the operative secret generator, those
+    # options will be passed to the secret generator instead of to the message
+    # encryptor.
+
+    ##
+    # :method: rotate_defaults
+    # :call-seq: rotate_defaults
+    #
+    # Invokes #rotate with the default options.
+
+    ##
+    # :method: clear_rotations
+    # :call-seq: clear_rotations
+    #
+    # Clears the list of option sets.
+
+    ##
+    # :method: on_rotation
+    # :call-seq: on_rotation(&callback)
+    #
+    # Sets a callback to invoke when a message is decrypted using an option set
+    # other than the first.
+    #
+    # For example, this callback could log each time it is called, and thus
+    # indicate whether old option sets are still in use or can be removed from
+    # rotation.
+
+    private
+      def build(salt, secret_generator:, secret_generator_options:, **options)
+        secret_length = MessageEncryptor.key_len(*options[:cipher])
+        secret = secret_generator.call(salt, secret_length: secret_length, **secret_generator_options)
+        MessageEncryptor.new(*Array(secret), **options)
+      end
+  end
+end

--- a/activesupport/lib/active_support/message_verifiers.rb
+++ b/activesupport/lib/active_support/message_verifiers.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "active_support/messages/rotation_coordinator"
+
+module ActiveSupport
+  class MessageVerifiers < Messages::RotationCoordinator
+    ##
+    # :method: initialize
+    # :call-seq: initialize(&secret_generator)
+    #
+    # Initializes a new instance. +secret_generator+ must accept a salt, and
+    # return a suitable secret (string). +secret_generator+ may also accept
+    # arbitrary kwargs. If #rotate is called with any options matching those
+    # kwargs, those options will be passed to +secret_generator+ instead of to
+    # the message verifier.
+    #
+    #   verifiers = ActiveSupport::MessageVerifiers.new do |salt, base:|
+    #     MySecretGenerator.new(base).generate(salt)
+    #   end
+    #
+    #   verifiers.rotate(base: "...")
+
+    ##
+    # :method: []
+    # :call-seq: [](salt)
+    #
+    # Returns a MessageVerifier configured with a secret derived from the
+    # given +salt+, and options from #rotate. MessageVerifier instances will
+    # be memoized, so the same +salt+ will return the same instance.
+
+    ##
+    # :method: []=
+    # :call-seq: []=(salt, verifier)
+    #
+    # Overrides a MessageVerifier instance associated with a given +salt+.
+
+    ##
+    # :method: rotate
+    # :call-seq: rotate(**options)
+    #
+    # Adds +options+ to the list of option sets. Messages will be signed using
+    # the first set in the list. When verifying, however, each set will be
+    # tried, in order, until one succeeds.
+    #
+    # Notably, the +:secret_generator+ option can specify a different secret
+    # generator than the one initially specified. The secret generator must
+    # respond to +call+, accept a salt, and return a suitable secret (string).
+    # The secret generator may also accept arbitrary kwargs.
+    #
+    # If any options match the kwargs of the operative secret generator, those
+    # options will be passed to the secret generator instead of to the message
+    # verifier.
+
+    ##
+    # :method: rotate_defaults
+    # :call-seq: rotate_defaults
+    #
+    # Invokes #rotate with the default options.
+
+    ##
+    # :method: clear_rotations
+    # :call-seq: clear_rotations
+    #
+    # Clears the list of option sets.
+
+    ##
+    # :method: on_rotation
+    # :call-seq: on_rotation(&callback)
+    #
+    # Sets a callback to invoke when a message is verified using an option set
+    # other than the first.
+    #
+    # For example, this callback could log each time it is called, and thus
+    # indicate whether old option sets are still in use or can be removed from
+    # rotation.
+
+    private
+      def build(salt, secret_generator:, secret_generator_options:, **options)
+        MessageVerifier.new(secret_generator.call(salt, **secret_generator_options), **options)
+      end
+  end
+end

--- a/activesupport/lib/active_support/messages/rotation_coordinator.rb
+++ b/activesupport/lib/active_support/messages/rotation_coordinator.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/hash/slice"
+
+module ActiveSupport
+  module Messages
+    class RotationCoordinator # :nodoc:
+      def initialize(&secret_generator)
+        raise ArgumentError, "A secret generator block is required" unless secret_generator
+        @secret_generator = secret_generator
+        @rotate_options = []
+        @codecs = {}
+      end
+
+      def [](salt)
+        @codecs[salt] ||= build_with_rotations(salt.to_s)
+      end
+
+      def []=(salt, codec)
+        @codecs[salt] = codec
+      end
+
+      def rotate(**options)
+        changing_configuration!
+
+        options[:secret_generator] ||= @secret_generator
+        secret_generator_kwargs = options[:secret_generator].parameters.
+          filter_map { |type, name| name if type == :key || type == :keyreq }
+        options[:secret_generator_options] = options.extract!(*secret_generator_kwargs)
+
+        @rotate_options << options
+
+        self
+      end
+
+      def rotate_defaults
+        rotate()
+      end
+
+      def clear_rotations
+        changing_configuration!
+        @rotate_options.clear
+        self
+      end
+
+      def on_rotation(&callback)
+        changing_configuration!
+        @on_rotation = callback
+      end
+
+      private
+        def changing_configuration!
+          if @codecs.any?
+            raise <<~MESSAGE
+              Cannot change #{self.class} configuration after it has already been applied.
+
+              The configuration has been applied with the following salts:
+              #{@codecs.keys.map { |salt| "- #{salt.inspect}" }.join("\n")}
+            MESSAGE
+          end
+        end
+
+        def build_with_rotations(salt)
+          raise "No options have been configured" if @rotate_options.empty?
+          @rotate_options.map { |options| build(salt, **options, on_rotation: @on_rotation) }.reduce(&:fall_back_to)
+        end
+
+        def build(salt, secret_generator:, secret_generator_options:, **options)
+          raise NotImplementedError
+        end
+    end
+  end
+end

--- a/activesupport/lib/active_support/secure_compare_rotator.rb
+++ b/activesupport/lib/active_support/secure_compare_rotator.rb
@@ -44,7 +44,7 @@ module ActiveSupport
     end
 
     private
-      def build_rotation(previous_value, _options)
+      def build_rotation(previous_value, **_options)
         self.class.new(previous_value)
       end
   end

--- a/activesupport/test/message_encryptors_test.rb
+++ b/activesupport/test/message_encryptors_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative "rotation_coordinator_tests"
+
+class MessageEncryptorsTest < ActiveSupport::TestCase
+  include RotationCoordinatorTests
+
+  test "can override secret generator" do
+    secret_generator = ->(salt, secret_length:) { salt[0] * secret_length }
+    coordinator = make_coordinator.rotate(secret_generator: secret_generator)
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+    assert_nil roundtrip("message", @coordinator["salt"], coordinator["salt"])
+  end
+
+  test "supports arbitrary secret generator kwargs" do
+    secret_generator = ->(salt, secret_length:, foo:, bar: nil) { foo[bar] * secret_length }
+    coordinator = ActiveSupport::MessageEncryptors.new(&secret_generator)
+    coordinator.rotate(foo: "foo", bar: 0)
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+  end
+
+  test "supports separate secrets for encryption and signing" do
+    secret_generator = proc { |*args, **kwargs| [SECRET_GENERATOR.call(*args, **kwargs), "signing secret"] }
+    coordinator = ActiveSupport::MessageEncryptors.new(&secret_generator)
+    coordinator.rotate_defaults
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+    assert_nil roundtrip("message", @coordinator["salt"], coordinator["salt"])
+  end
+
+  private
+    SECRET_GENERATOR = proc { |salt, secret_length:| "".ljust(secret_length, salt) }
+
+    def make_coordinator
+      ActiveSupport::MessageEncryptors.new(&SECRET_GENERATOR)
+    end
+
+    def roundtrip(message, encryptor, decryptor = encryptor)
+      decryptor.decrypt_and_verify(encryptor.encrypt_and_sign(message))
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      nil
+    end
+end

--- a/activesupport/test/message_verifiers_test.rb
+++ b/activesupport/test/message_verifiers_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "rotation_coordinator_tests"
+
+class MessageVerifiersTest < ActiveSupport::TestCase
+  include RotationCoordinatorTests
+
+  test "can override secret generator" do
+    secret_generator = ->(salt) { salt + "!" }
+    coordinator = make_coordinator.rotate(secret_generator: secret_generator)
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+    assert_nil roundtrip("message", @coordinator["salt"], coordinator["salt"])
+  end
+
+  test "supports arbitrary secret generator kwargs" do
+    secret_generator = ->(salt, foo:, bar: nil) { foo + bar }
+    coordinator = ActiveSupport::MessageVerifiers.new(&secret_generator)
+    coordinator.rotate(foo: "foo", bar: "bar")
+
+    assert_equal "message", roundtrip("message", coordinator["salt"])
+  end
+
+  private
+    def make_coordinator
+      ActiveSupport::MessageVerifiers.new { |salt| salt * 10 }
+    end
+
+    def roundtrip(message, signer, verifier = signer)
+      verifier.verified(signer.generate(message))
+    end
+end

--- a/activesupport/test/rotation_coordinator_tests.rb
+++ b/activesupport/test/rotation_coordinator_tests.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module RotationCoordinatorTests
+  extend ActiveSupport::Concern
+
+  included do
+    setup do
+      @coordinator = make_coordinator.rotate_defaults
+    end
+
+    test "builds working codecs" do
+      codec = @coordinator["salt"]
+      other_codec = @coordinator["other salt"]
+
+      assert_equal "message", roundtrip("message", codec)
+      assert_nil roundtrip("message", codec, other_codec)
+    end
+
+    test "memoizes codecs" do
+      assert_same @coordinator["salt"], @coordinator["salt"]
+    end
+
+    test "can override codecs" do
+      @coordinator["other salt"] = @coordinator["salt"]
+      assert_same @coordinator["salt"], @coordinator["other salt"]
+    end
+
+    test "configures codecs with rotations" do
+      @coordinator.rotate(digest: "MD5")
+      codec = @coordinator["salt"]
+      obsolete_codec = (make_coordinator.rotate(digest: "MD5"))["salt"]
+
+      assert_equal "message", roundtrip("message", obsolete_codec, codec)
+      assert_nil roundtrip("message", codec, obsolete_codec)
+    end
+
+    test "can clear rotations" do
+      @coordinator.clear_rotations.rotate(digest: "MD5")
+      codec = @coordinator["salt"]
+      similar_codec = (make_coordinator.rotate(digest: "MD5"))["salt"]
+
+      assert_equal "message", roundtrip("message", codec, similar_codec)
+    end
+
+    test "configures codecs with on_rotation" do
+      rotated = 0
+      @coordinator.on_rotation { rotated += 1 }
+      @coordinator.rotate(digest: "MD5")
+      codec = @coordinator["salt"]
+      obsolete_codec = (make_coordinator.rotate(digest: "MD5"))["salt"]
+
+      assert_equal "message", roundtrip("message", obsolete_codec, codec)
+      assert_equal 1, rotated
+    end
+
+    test "prevents adding a rotation after rotations have been applied" do
+      @coordinator["salt"]
+      assert_raises { @coordinator.rotate(digest: "MD5") }
+    end
+
+    test "prevents clearing rotations after rotations have been applied" do
+      @coordinator["salt"]
+      assert_raises { @coordinator.clear_rotations }
+    end
+
+    test "prevents changing on_rotation after on_rotation has been applied" do
+      @coordinator["salt"]
+      assert_raises { @coordinator.on_rotation { "this block will not be evaluated" } }
+    end
+
+    test "raises when building an codec and no rotations are configured" do
+      @coordinator.clear_rotations
+      assert_raises { @coordinator["salt"] }
+    end
+  end
+end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -4,7 +4,7 @@ require "yaml"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/object/blank"
 require "active_support/key_generator"
-require "active_support/message_verifier"
+require "active_support/message_verifiers"
 require "active_support/encrypted_configuration"
 require "active_support/hash_with_indifferent_access"
 require "active_support/configuration_file"
@@ -111,7 +111,8 @@ module Rails
       @app_env_config    = nil
       @ordered_railties  = nil
       @railties          = nil
-      @message_verifiers = {}
+      @key_generators    = {}
+      @message_verifiers = nil
       @ran_load_hooks    = false
 
       @executor          = Class.new(ActiveSupport::Executor)
@@ -149,13 +150,51 @@ module Rails
       routes_reloader.reload!
     end
 
-    # Returns the application's KeyGenerator
-    def key_generator
+    # Returns a key generator (ActiveSupport::CachingKeyGenerator) for a
+    # specified +secret_key_base+. The return value is memoized, so additional
+    # calls with the same +secret_key_base+ will return the same key generator
+    # instance.
+    def key_generator(secret_key_base = self.secret_key_base)
       # number of iterations selected based on consultation with the google security
       # team. Details at https://github.com/rails/rails/pull/6952#issuecomment-7661220
-      @caching_key_generator ||= ActiveSupport::CachingKeyGenerator.new(
+      @key_generators[secret_key_base] ||= ActiveSupport::CachingKeyGenerator.new(
         ActiveSupport::KeyGenerator.new(secret_key_base, iterations: 1000)
       )
+    end
+
+    # Returns a message verifier factory (ActiveSupport::MessageVerifiers). This
+    # factory can be used as a central point to configure and create message
+    # verifiers (ActiveSupport::MessageVerifier) for your application.
+    #
+    # By default, message verifiers created by this factory will generate
+    # messages using the default ActiveSupport::MessageVerifier options. You can
+    # override these options with a combination of
+    # ActiveSupport::MessageVerifiers#clear_rotations and
+    # ActiveSupport::MessageVerifiers#rotate. However, this must be done prior
+    # to building any message verifier instances. For example, in a
+    # +before_initialize+ block:
+    #
+    #   # Use `url_safe: true` when generating messages
+    #   config.before_initialize do |app|
+    #     app.message_verifiers.clear_rotations
+    #     app.message_verifiers.rotate(url_safe: true)
+    #   end
+    #
+    # Message verifiers created by this factory will always use a secret derived
+    # from #secret_key_base when generating messages. +clear_rotations+ will not
+    # affect this behavior. However, older +secret_key_base+ values can be
+    # rotated for verifying messages:
+    #
+    #   # Fall back to old `secret_key_base` when verifying messages
+    #   config.before_initialize do |app|
+    #     app.message_verifiers.rotate(secret_key_base: "old secret_key_base")
+    #   end
+    #
+    def message_verifiers
+      @message_verifiers ||=
+        ActiveSupport::MessageVerifiers.new do |salt, secret_key_base: self.secret_key_base|
+          key_generator(secret_key_base).generate_key(salt)
+        end.rotate_defaults
     end
 
     # Returns a message verifier object.
@@ -177,10 +216,7 @@ module Rails
     #
     # See the ActiveSupport::MessageVerifier documentation for more information.
     def message_verifier(verifier_name)
-      @message_verifiers[verifier_name] ||= begin
-        secret = key_generator.generate_key(verifier_name.to_s)
-        ActiveSupport::MessageVerifier.new(secret)
-      end
+      message_verifiers[verifier_name]
     end
 
     # Convenience for loading config/foo.yml for the current Rails env.


### PR DESCRIPTION
Currently, `Rails.application.message_verifier(name)` returns a `MessageVerifier` instance using a secret derived from the given `name`.  Instances created this way always generate messages using the default options for `MessageVerifier.new`.  Also, if there are older options to rotate for message verification, each instance created this way must be configured individually.  In cases where Rails itself uses `Rails.application.message_verifier` (e.g. [in Active Storage](https://github.com/rails/rails/blob/83a4fa414bc9e5008825f47857fdd80e85c82033/activestorage/lib/active_storage/engine.rb#L121)), discovering the name of the instance may require digging through Rails' source code.

To alleviate these issues, this commit adds a `MessageVerifiers` factory class, which acts as a central point for configuring and creating `MessageVerifier` instances.  Options passed to `MessageVerifiers#rotate` will be applied to `MessageVerifier` instances that `MessageVerifiers#[]` creates.  So the following:

  ```ruby
  foo_verifier = Rails.application.message_verifier(:foo)
  foo_verifier.rotate(old_options)
  bar_verifier = Rails.application.message_verifier(:bar)
  bar_verifier.rotate(old_options)
  ```

Can be rewritten as:

  ```ruby
  Rails.application.message_verifiers.rotate(old_options)
  foo_verifier = Rails.application.message_verifiers[:foo]
  bar_verifier = Rails.application.message_verifiers[:bar]
  ```

Additionally, `Rails.application.message_verifiers` supports a `:secret_key_base` option, so old `secret_key_base` values can be rotated:

  ```ruby
  Rails.application.message_verifiers.rotate(secret_key_base: "old secret_key_base")
  ```

`MessageVerifiers` memoizes `MessageVerifier` instances.  This also allows `MessageVerifier` instances to be overridden entirely:

  ```ruby
  Rails.application.message_verifiers[:foo] = ActiveSupport::MessageVerifier.new(other_secret)
  ```

For parity, this commit also adds a `MessageEncryptors` factory class, which fulfills the same role for `MessageEncryptor` instances.