### PR TITLE
doc: ActionDispatch::ServerTiming & rails_on_rack guide update [ci-skip]

### DIFF
--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -203,6 +203,7 @@ An API application comes with the following middleware by default:
 - `Rack::Sendfile`
 - `ActionDispatch::Static`
 - `ActionDispatch::Executor`
+- `ActionDispatch::ServerTiming`
 - `ActiveSupport::Cache::Strategy::LocalCache::Middleware`
 - `Rack::Runtime`
 - `ActionDispatch::RequestId`

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -103,9 +103,11 @@ $ bin/rails middleware
 For a freshly generated Rails application, this might produce something like:
 
 ```ruby
+use ActionDispatch::HostAuthorization
 use Rack::Sendfile
 use ActionDispatch::Static
 use ActionDispatch::Executor
+use ActionDispatch::ServerTiming
 use ActiveSupport::Cache::Strategy::LocalCache::Middleware
 use Rack::Runtime
 use Rack::MethodOverride
@@ -217,6 +219,10 @@ config.middleware.delete! ActionDispatch::Executor
 
 Much of Action Controller's functionality is implemented as Middlewares. The following list explains the purpose of each of them:
 
+**`ActionDispatch::HostAuthorization`**
+
+* Guards from DNS rebinding attacks by explicitly permitting the hosts a request can be sent to. See the [configuration guide](configuring.html#actiondispatch-hostauthorization) for configuration instructions.
+
 **`Rack::Sendfile`**
 
 * Sets server specific X-Sendfile header. Configure this via `config.action_dispatch.x_sendfile_header` option.
@@ -232,6 +238,10 @@ Much of Action Controller's functionality is implemented as Middlewares. The fol
 **`ActionDispatch::Executor`**
 
 * Used for thread safe code reloading during development.
+
+**`ActionDispatch::ServerTiming`**
+
+* Sets a [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) header containing performance metrics for the request.
 
 **`ActiveSupport::Cache::Strategy::LocalCache::Middleware`**
 


### PR DESCRIPTION
### Summary

- Added API documentation for the `ActionDispatch::ServerTiming` directly from the commit itself: https://github.com/rails/rails/commit/0547b1646d09a80d0685a03c932fb0ba09c3e614

- Updated `rails_on_rack.md` docs with missing middleware and explanations.