### PR TITLE
Fix ActiveSupport::Instrumenter: nil can't be coerced into Float

### DIFF
--- a/activesupport/lib/active_support/notifications/instrumenter.rb
+++ b/activesupport/lib/active_support/notifications/instrumenter.rb
@@ -62,9 +62,9 @@ module ActiveSupport
       def initialize(name, start, ending, transaction_id, payload)
         @name           = name
         @payload        = payload.dup
-        @time           = start ? start.to_f * 1_000.0 : start
+        @time           = start.to_f * 1_000.0
         @transaction_id = transaction_id
-        @end            = ending ? ending.to_f * 1_000.0 : ending
+        @end            = ending.to_f * 1_000.0
         @children       = []
         @cpu_time_start = 0.0
         @cpu_time_finish = 0.0

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -448,6 +448,12 @@ module Notifications
       assert_equal 0, event.cpu_time
     end
 
+    def test_event_with_nil_time_and_nil_ending
+      event = event(:foo, nil, nil, random_id, {})
+
+      assert_equal 0.0, event.duration
+    end
+
     def test_events_consumes_information_given_as_payload
       event = event(:foo, Process.clock_gettime(Process::CLOCK_MONOTONIC), Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1, random_id, payload: :bar)
       assert_equal Hash[payload: :bar], event.payload


### PR DESCRIPTION
### Summary

- Fixes: https://github.com/rails/rails/issues/44167

