### PR TITLE
Use the safe navigation operator on response.sending?

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -542,7 +542,7 @@ module ActionView
         MAX_HEADER_SIZE = 8_000 # Some HTTP client and proxies have a 8kiB header limit
         def send_preload_links_header(preload_links, max_header_size: MAX_HEADER_SIZE)
           return if preload_links.empty?
-          return if respond_to?(:response) && response.sending?
+          return if respond_to?(:response) && response&.sending?
 
           if respond_to?(:request) && request
             request.send_early_hints("Link" => preload_links.join("\n"))


### PR DESCRIPTION
When testing ViewComponent against 7.0, test can fail when `response`
isn't set in the tests where `stylesheet_link_tag` and similar helpers
are being used. The view does respond to `response`, but it is unset and
the call to `#sending?` fails.

See the discussion at https://github.com/github/view_component/discussions/1238 for some details.