### PR TITLE
Fix error when saving an association with a relation named record

### DIFF
--- a/activerecord/lib/active_record/autosave_association.rb
+++ b/activerecord/lib/active_record/autosave_association.rb
@@ -446,7 +446,7 @@ module ActiveRecord
           elsif autosave != false
             key = reflection.options[:primary_key] ? public_send(reflection.options[:primary_key]) : id
 
-            if (autosave && record.changed_for_autosave?) || record_changed?(reflection, record, key)
+            if (autosave && record.changed_for_autosave?) || _record_changed?(reflection, record, key)
               unless reflection.through_reflection
                 record[reflection.foreign_key] = key
                 association.set_inverse_instance(record)
@@ -461,7 +461,7 @@ module ActiveRecord
       end
 
       # If the record is new or it has changed, returns true.
-      def record_changed?(reflection, record, key)
+      def _record_changed?(reflection, record, key)
         record.new_record? ||
           association_foreign_key_changed?(reflection, record, key) ||
           record.will_save_change_to_attribute?(reflection.foreign_key)

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -34,6 +34,8 @@ require "models/organization"
 require "models/guitar"
 require "models/tuning_peg"
 require "models/reply"
+require "models/attachment"
+require "models/translation"
 
 class TestAutosaveAssociationsInGeneral < ActiveRecord::TestCase
   def test_autosave_works_even_when_other_callbacks_update_the_parent_model
@@ -2006,5 +2008,16 @@ class TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAcceptsNe
     valid_project.reload
 
     assert_equal "Updated", valid_project.name
+  end
+end
+
+class TestAutosaveAssociationOnABelongsToAssociationDefinedAsRecord < ActiveRecord::TestCase
+  def test_should_not_raise_error
+    translation = Translation.create(locale: "fr", key: "bread", value: "Baguette 🥖")
+    author = Author.create(name: "Dorian Marié")
+    translation.build_attachment(record: author)
+    assert_nothing_raised do
+      translation.save!
+    end
   end
 end

--- a/activerecord/test/models/attachment.rb
+++ b/activerecord/test/models/attachment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Attachment < ActiveRecord::Base
+  belongs_to :record, polymorphic: true
+
+  has_one :translation
+end

--- a/activerecord/test/models/translation.rb
+++ b/activerecord/test/models/translation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Translation < ActiveRecord::Base
+  belongs_to :attachment, optional: true
+
+  validates :locale, presence: true
+  validates :key, presence: true
+  validates :value, presence: true
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -58,6 +58,10 @@ ActiveRecord::Schema.define do
     t.references :tag
   end
 
+  create_table :attachments, force: true do |t|
+    t.references :record, polymorphic: true, null: false
+  end
+
   create_table :audit_logs, force: true do |t|
     t.column :message, :string, null: false
     t.column :developer_id, :integer, null: false
@@ -1105,6 +1109,13 @@ ActiveRecord::Schema.define do
     t.text     :long_state, null: false
     t.datetime :created_at
     t.datetime :updated_at
+  end
+
+  create_table :translations, force: true do |t|
+    t.string :locale, null: false
+    t.string :key, null: false
+    t.string :value, null: false
+    t.references :attachment
   end
 
   create_table :tuning_pegs, force: true do |t|


### PR DESCRIPTION
```
ArgumentError: wrong number of arguments (given 3, expected 0)
    /Users/dorianmariefr/.rvm/rubies/ruby-3.0.2/lib/ruby/gems/3.0.0/gems/activerecord-7.0.1/lib/active_record/associations/builder/belongs_to.rb:132:in `record_changed?'
    /Users/dorianmariefr/.rvm/rubies/ruby-3.0.2/lib/ruby/gems/3.0.0/gems/activerecord-7.0.1/lib/active_record/autosave_association.rb:450:in `save_has_one_association'
```

### Summary

When saving a record that has a relation to a model with an association with the name "record" (a polymorphic one for instance), active record would raise an error because record_changed? was overwritten by the `belongs_to :record`

### Other Information

This is a private method and no tests seems to depend on it so I think the rename is safe

I have no other issues with having a relation named record and ActiveStorage also has a record_type/record_id for active storage attachments so this is already acceptable I think and even maybe common.

This can be temporarily fixed by disabling autosave on the association but not a great option

Also redefining the method can fix it but could break other things

I'm using an Attachment model in my app, which has a `has_one_attached :file` and `belongs_to :record, polymorphic: true`, I use it to store all kinds of files