### PR TITLE
Fix exception on EtagWithFlash when api_only

### DIFF
--- a/actionpack/lib/action_controller/metal/etag_with_flash.rb
+++ b/actionpack/lib/action_controller/metal/etag_with_flash.rb
@@ -12,7 +12,7 @@ module ActionController
     include ActionController::ConditionalGet
 
     included do
-      etag { flash unless flash.empty? }
+      etag { flash if request.respond_to?(:flash) && !flash.empty? }
     end
   end
 end


### PR DESCRIPTION
### Summary

Fixes https://github.com/rails/rails/issues/44181

### Other Information

It seems that `combine_etags` from https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/conditional_get.rb#L322 adds the flash content on Etag https://github.com/rails/rails/blob/main/actionpack/lib/action_controller/metal/etag_with_flash.rb without considering that Flash might not be defined in api_only applications.