### PR TITLE
Add America/Punta_Arenas to Rails timezones

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add America/Punta_Arenas Rails timezone (Bruno Prieto)
+
 *   Improve `File.atomic_write` error handling
 
 *   Fix `Class#descendants` and `DescendantsTracker#descendants` compatibility with Ruby 3.1.

--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -56,6 +56,7 @@ module ActiveSupport
       "La Paz"                       => "America/La_Paz",
       "Santiago"                     => "America/Santiago",
       "Newfoundland"                 => "America/St_Johns",
+      "Punta Arenas" => "America/Punta_Arenas",
       "Brasilia"                     => "America/Sao_Paulo",
       "Buenos Aires"                 => "America/Argentina/Buenos_Aires",
       "Montevideo"                   => "America/Montevideo",


### PR DESCRIPTION
### Summary

Hello!

Rails time zones are not up to date. For example, a few years ago, in Chile the time zone of the Magallanes region was changed. This pr adds that time zone, but I think it would be correct to check some way to keep them updated. I don't know if using TZInfo::Timezone.all_identifiers and giving them a friendly name will be a correct way, knowing that the goal is Lazily load TZInfo::Timezone instances only when they're needed.

This is my first pr to Rails. If you tell me a better way to do this or update more time zones I can help.

Thanks!
