### PR TITLE
Add Rails configurations to "about" command and page.

### DIFF
--- a/railties/test/rails_info_test.rb
+++ b/railties/test/rails_info_test.rb
@@ -31,6 +31,17 @@ class InfoTest < ActiveSupport::TestCase
       File.read(File.realpath("../../RAILS_VERSION", __dir__)).chomp
   end
 
+  def test_to_s_includes_configuration
+    Rails::Info.module_eval do
+      property "Configuration", { "foo" => "bar" }
+    end
+
+    output = Rails::Info.to_s
+    properties.value_for("Configuration").each do |key, value|
+      assert_includes output, "Configuration      #{key}   #{value}"
+    end
+  end
+
   def test_html_includes_middleware
     Rails::Info.module_eval do
       property "Middleware", ["Rack::Lock", "Rack::Static"]
@@ -40,6 +51,17 @@ class InfoTest < ActiveSupport::TestCase
     assert_includes html, '<tr><td class="name">Middleware</td>'
     properties.value_for("Middleware").each do |value|
       assert_includes html, "<li>#{CGI.escapeHTML(value)}</li>"
+    end
+  end
+
+  def test_html_includes_configuration
+    Rails::Info.module_eval do
+      property "Configuration", { "foo" => "bar" }
+    end
+
+    html = Rails::Info.to_html
+    properties.value_for("Configuration").each do |config, config_value|
+      assert_includes html, "<tr><td>#{config}</td><td>#{config_value}</td></tr>"
     end
   end
 


### PR DESCRIPTION
### Summary

The `rails about` command and the rails info page (http://localhost:3000//rails/info/properties)
currently show some information like the Rails version, Ruby version,
Application root, etc.

We can expand the information with the framework configurations.
This can help with:
- fixing issues by asking for the configuration;
- debugging configuration changes by examining what changed;
- showing users what configurations are available;
- maybe later showing which configurations diverge from the framework
  defaults;

With this change the `rails about` output would look something like (an excerpt):
```
$ bin/rails about
Rails version             7.1.0.alpha
Ruby version              ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-darwin20]
RubyGems version          3.3.5
Rack version              2.2.3
Middleware                Webpacker::DevServerProxy, ActionDispatch::HostAuthorization, Rack::Sendfile, ActionDispatch::Static, ActionDispatch::Executor, ActiveSupport::Cache::Strategy::LocalCache::Middleware, Rack::Runtime, Rack::MethodOverride, ActionDispatch::RequestId, ActionDispatch::RemoteIp, Sprockets::Rails::QuietAssets, Rails::Rack::Logger, ActionDispatch::ShowExceptions, ActionDispatch::DebugExceptions, ActionDispatch::ActionableExceptions, ActionDispatch::Reloader, ActionDispatch::Callbacks, ActiveRecord::Migration::CheckPending, ActionDispatch::Cookies, ActionDispatch::Session::CookieStore, ActionDispatch::Flash, ActionDispatch::ContentSecurityPolicy::Middleware, ActionDispatch::PermissionsPolicy::Middleware, Rack::Head, Rack::ConditionalGet, Rack::ETag, Rack::TempfileReaper
Application root          /tmp/rails
Environment               development
Database adapter          sqlite3
Database schema version   20210710084447
Configuration             action_controller.asset_host                                     nil
                          action_controller.assets_dir                                     "/tmp/rails/public"
                          action_controller.cache_store                                    #<ActiveSupport::Cache::NullStore:0x00007fcb47c77d00 @options={:compress=>true, :compress_threshold=>1024}, @coder=ActiveSupport::Cache::Coders::Rails61Coder, @coder_supports_compression=true, @loc...
                          action_controller.default_protect_from_forgery                   true
                          action_controller.forgery_protection_origin_check                true
                          action_controller.javascripts_dir                                "/tmp/rails/public/javascripts"
                          action_controller.log_query_tags_around_actions                  true
                          action_controller.logger                                         #<ActiveSupport::Logger:0x00007fcb48e46388 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter:0x00007fcb48e46540 @datetime_format=nil>, @formatter=#<ActiveSupport::Logger::SimpleFormat...
                          action_controller.per_form_csrf_tokens                           true
                          action_controller.perform_caching                                false
                          action_controller.raise_on_open_redirects                        false
                          action_controller.relative_url_root                              nil
....
```

The about page could look something like:
<img width="905" alt="image" src="https://user-images.githubusercontent.com/28561/150015618-0b402ee8-26f4-492e-8ce3-c8fecc2f0042.png">

I can work on improving the layout/formatting if this PR is something we want in Rails.