### PR TITLE
Ensure preload_link_tag preloads modules correctly

### DIFF
--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -325,16 +325,17 @@ module ActionView
         crossorigin = "anonymous" if crossorigin == true || (crossorigin.blank? && as_type == "font")
         integrity = options[:integrity]
         nopush = options.delete(:nopush) || false
+        rel = mime_type == "module" ? "modulepreload" : "preload"
 
         link_tag = tag.link(**{
-          rel: "preload",
+          rel: rel,
           href: href,
           as: as_type,
           type: mime_type,
           crossorigin: crossorigin
         }.merge!(options.symbolize_keys))
 
-        preload_link = "<#{href}>; rel=preload; as=#{as_type}"
+        preload_link = "<#{href}>; rel=#{rel}; as=#{as_type}"
         preload_link += "; type=#{mime_type}" if mime_type
         preload_link += "; crossorigin=#{crossorigin}" if crossorigin
         preload_link += "; integrity=#{integrity}" if integrity

--- a/actionview/test/template/asset_tag_helper_test.rb
+++ b/actionview/test/template/asset_tag_helper_test.rb
@@ -246,6 +246,7 @@ class AssetTagHelperTest < ActionView::TestCase
   }
 
   PreloadLinkToTag = {
+    %(preload_link_tag '/application.js', type: 'module') => %(<link rel="modulepreload" href="/application.js" as="script" type="module" >),
     %(preload_link_tag '/styles/custom_theme.css') => %(<link rel="preload" href="/styles/custom_theme.css" as="style" type="text/css" />),
     %(preload_link_tag '/videos/video.webm') => %(<link rel="preload" href="/videos/video.webm" as="video" type="video/webm" />),
     %(preload_link_tag '/posts.json', as: 'fetch') => %(<link rel="preload" href="/posts.json" as="fetch" type="application/json" />),
@@ -601,6 +602,14 @@ class AssetTagHelperTest < ActionView::TestCase
     with_preload_links_header do
       javascript_include_tag("http://example.com/all.js", type: "module")
       expected = "<http://example.com/all.js>; rel=modulepreload; as=script; nopush"
+      assert_equal expected, @response.headers["Link"]
+    end
+  end
+
+  def test_should_set_preload_early_hints_with_rel_modulepreload
+    with_preload_links_header do
+      preload_link_tag("http://example.com/all.js", type: "module")
+      expected = "<http://example.com/all.js>; rel=modulepreload; as=script; type=module"
       assert_equal expected, @response.headers["Link"]
     end
   end


### PR DESCRIPTION
### Summary 

This pull request fixes `preload_link_tag` to support preloading of [`module` scripts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).

When `type: 'module'` is provided, it will now use <kbd>[rel: 'modulepreload'](developer.mozilla.org/en-US/docs/Web/HTML/Link_types/modulepreload)</kbd> instead of <kbd>rel: 'preload'</kbd>.

### Background 📜

Previously, both the rendered tag and the early response hint sent in `preload_link_tag` were using <kbd>rel=preload</kbd> for all scripts, including [`module` scripts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).

Browsers will __ignore the pre-loaded resource__ because the types don't match (preloaded a script, but included a module).

### Screenshots 📷 

<img width="1438" alt="Screen Shot 2021-03-18 at 16 12 12" src="https://user-images.githubusercontent.com/1158253/111685545-ce76b700-8806-11eb-8732-ca0ea1a96570.png">

### References 🔗

- https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link
- https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/modulepreload
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
- https://developers.google.com/web/updates/2017/12/modulepreload