### PR TITLE
Fix nested bullet list indentation [ci skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -92,8 +92,8 @@ module ActionController
   # * +permit_all_parameters+ - If it's +true+, all the parameters will be
   #   permitted by default. The default is +false+.
   # * +action_on_unpermitted_parameters+ - Controls behavior when parameters that are not explicitly
-  #    permitted are found. The default value is <tt>:log</tt> in test and development environments,
-  #    +false+ otherwise. The values can be:
+  #   permitted are found. The default value is <tt>:log</tt> in test and development environments,
+  #   +false+ otherwise. The values can be:
   #   * +false+ to take no action.
   #   * <tt>:log</tt> to emit an <tt>ActiveSupport::Notifications.instrument</tt> event on the
   #     <tt>unpermitted_parameters.action_controller</tt> topic and log at the DEBUG level.


### PR DESCRIPTION
### Summary
This small patch just fixes the indentation of a nested bullet list in the documentation of `ActionController::Parameters` that appeared as inside a box in [api.rubyonrails.org](https://api.rubyonrails.org/classes/ActionController/Parameters.html) documentation website.

![image](https://user-images.githubusercontent.com/671550/150029126-b336d055-1144-42ae-bf2a-f6c83f2986af.png)