### PR TITLE
Adjust association inverse_of docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1353,8 +1353,8 @@ module ActiveRecord
         #   of this class in lower-case and "_id" suffixed. So a Person class that makes a #has_many
         #   association will use "person_id" as the default <tt>:foreign_key</tt>.
         #
-        #   If you are going to modify the association (rather than just read from it), then it is
-        #   a good idea to set the <tt>:inverse_of</tt> option.
+        #   Setting the <tt>:foreign_key</tt> option prevents automatic detection of the association's
+        #   inverse, so it is generally a good idea to set the <tt>:inverse_of</tt> option as well.
         # [:foreign_type]
         #   Specify the column used to store the associated object's type, if this is a polymorphic
         #   association. By default this is guessed to be the name of the polymorphic association
@@ -1410,7 +1410,7 @@ module ActiveRecord
         #   a good idea to set the <tt>:inverse_of</tt> option on the source association on the
         #   join model. This allows associated records to be built which will automatically create
         #   the appropriate join model records when they are saved. (See the 'Association Join Models'
-        #   section above.)
+        #   and 'Setting Inverses' sections above.)
         # [:disable_joins]
         #   Specifies whether joins should be skipped for an association. If set to true, two or more queries
         #   will be generated. Note that in some cases, if order or limit is applied, it will be done in-memory
@@ -1548,8 +1548,8 @@ module ActiveRecord
         #   of this class in lower-case and "_id" suffixed. So a Person class that makes a #has_one association
         #   will use "person_id" as the default <tt>:foreign_key</tt>.
         #
-        #   If you are going to modify the association (rather than just read from it), then it is
-        #   a good idea to set the <tt>:inverse_of</tt> option.
+        #   Setting the <tt>:foreign_key</tt> option prevents automatic detection of the association's
+        #   inverse, so it is generally a good idea to set the <tt>:inverse_of</tt> option as well.
         # [:foreign_type]
         #   Specify the column used to store the associated object's type, if this is a polymorphic
         #   association. By default this is guessed to be the name of the polymorphic association
@@ -1575,7 +1575,7 @@ module ActiveRecord
         #   a good idea to set the <tt>:inverse_of</tt> option on the source association on the
         #   join model. This allows associated records to be built which will automatically create
         #   the appropriate join model records when they are saved. (See the 'Association Join Models'
-        #   section above.)
+        #   and 'Setting Inverses' sections above.)
         # [:disable_joins]
         #   Specifies whether joins should be skipped for an association. If set to true, two or more queries
         #   will be generated. Note that in some cases, if order or limit is applied, it will be done in-memory
@@ -1701,8 +1701,8 @@ module ActiveRecord
         #   <tt>belongs_to :favorite_person, class_name: "Person"</tt> will use a foreign key
         #   of "favorite_person_id".
         #
-        #   If you are going to modify the association (rather than just read from it), then it is
-        #   a good idea to set the <tt>:inverse_of</tt> option.
+        #   Setting the <tt>:foreign_key</tt> option prevents automatic detection of the association's
+        #   inverse, so it is generally a good idea to set the <tt>:inverse_of</tt> option as well.
         # [:foreign_type]
         #   Specify the column used to store the associated object's type, if this is a polymorphic
         #   association. By default this is guessed to be the name of the association with a "_type"
@@ -1930,8 +1930,8 @@ module ActiveRecord
         #   a #has_and_belongs_to_many association to Project will use "person_id" as the
         #   default <tt>:foreign_key</tt>.
         #
-        #   If you are going to modify the association (rather than just read from it), then it is
-        #   a good idea to set the <tt>:inverse_of</tt> option.
+        #   Setting the <tt>:foreign_key</tt> option prevents automatic detection of the association's
+        #   inverse, so it is generally a good idea to set the <tt>:inverse_of</tt> option as well.
         # [:association_foreign_key]
         #   Specify the foreign key used for the association on the receiving side of the association.
         #   By default this is guessed to be the name of the associated class in lower-case and "_id" suffixed.


### PR DESCRIPTION
Before this commit the `inverse_of` note in the `:foreign_key` option docs was a bit misleading. The text was originally added in [91fd6510][] to describe adding `inverse_of` to any `belongs_to` associations on a join model:

> If you are going to modify the association (rather than just read from it), then it is
> a good idea to set the <tt>:inverse_of</tt> option.

That text makes sense for the `:through` option, but it got copied over to all the `:foreign_key` option docs as well in https://github.com/rails/rails/pull/31446. Adding `:inverse_of` to an association with a custom `:foreign_key` is often desirable even if you are only reading the associations, since it can prevent N+1 queries (e.g. `post.comments.map(&:post)`).

This commit changes the text to suggest adding `:inverse_of` all the time when `:foreign_key` is set, rather than only when the association gets modified.

This commit also points to the `Setting Inverses` section from the `:through` option docs. `Setting Inverses` directly follows `Association Join Models` and is perhaps better named `Setting Inverses on Association Join Models`. It's probably the more relevant part for the `:through` option docs, but it's easy to miss because of the section break. This seemed like the easiest fix, but I could also rename the section or remove the section break entirely.

[91fd6510]: https://github.com/rails/rails/commit/91fd6510563f84ee473bb217bc63ed598abe3f24
