### PR TITLE
activesupport `Object#as_json` more thorough implicit conversion

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -142,11 +142,13 @@ class Regexp
   end
 end
 
+ActiveSupport::KERNEL_RESPOND_TO = Kernel.instance_method(:respond_to?)
+
 module Enumerable
   def as_json(options = nil) # :nodoc:
-    if respond_to?(:to_hash)
+    if ActiveSupport::KERNEL_RESPOND_TO.bind_call(self, :to_hash)
       to_hash.as_json(options)
-    elsif respond_to?(:to_ary)
+    elsif ActiveSupport::KERNEL_RESPOND_TO.bind_call(self, :to_ary)
       to_ary.as_json(options)
     else
       to_a.as_json(options)

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -59,6 +59,12 @@ class Object
   def as_json(options = nil) # :nodoc:
     if respond_to?(:to_hash)
       to_hash.as_json(options)
+    elsif respond_to?(:to_ary)
+      to_ary.as_json(options)
+    elsif respond_to?(:to_str)
+      to_str.as_json(options)
+    elsif respond_to?(:to_int)
+      to_int.as_json(options)
     else
       instance_values.as_json(options)
     end

--- a/activesupport/lib/active_support/core_ext/object/json.rb
+++ b/activesupport/lib/active_support/core_ext/object/json.rb
@@ -144,7 +144,13 @@ end
 
 module Enumerable
   def as_json(options = nil) # :nodoc:
-    to_a.as_json(options)
+    if respond_to?(:to_hash)
+      to_hash.as_json(options)
+    elsif respond_to?(:to_ary)
+      to_ary.as_json(options)
+    else
+      to_a.as_json(options)
+    end
   end
 end
 

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -25,6 +25,16 @@ module JSONTest
     end
   end
 
+  class EnumerableHashlike < Hashlike
+    include Enumerable
+    # note: #each is unused so not defined
+  end
+
+  class EnumerableArraylike < Arraylike
+    include Enumerable
+    # note: #each is unused so not defined
+  end
+
   class Stringlike
     def to_str
       "foo"
@@ -93,6 +103,8 @@ module JSONTest
     ObjectTests   = [[ Foo.new(1, 2), %({\"a\":1,\"b\":2}) ]]
     HashlikeTests = [[ Hashlike.new, %({\"bar\":\"world\",\"foo\":\"hello\"}) ]]
     ArraylikeTests = [[ Arraylike.new, %([\"foo\",[\"bar\"]]) ]]
+    EnumerableHashlikeTests = [[ EnumerableHashlike.new, %({\"bar\":\"world\",\"foo\":\"hello\"}) ]]
+    EnumerableArraylikeTests = [[ EnumerableArraylike.new, %([\"foo\",[\"bar\"]]) ]]
     StringlikeTests = [[ Stringlike.new, %(\"foo\") ]]
     IntegerlikeTests = [[ Integerlike.new, %(999) ]]
     StructTests   = [[ MyStruct.new(:foo, "bar"), %({\"name\":\"foo\",\"value\":\"bar\"}) ],

--- a/activesupport/test/json/encoding_test_cases.rb
+++ b/activesupport/test/json/encoding_test_cases.rb
@@ -19,6 +19,24 @@ module JSONTest
     end
   end
 
+  class Arraylike
+    def to_ary
+      [:foo, [:bar]]
+    end
+  end
+
+  class Stringlike
+    def to_str
+      "foo"
+    end
+  end
+
+  class Integerlike
+    def to_int
+      999
+    end
+  end
+
   class Custom
     def initialize(serialized)
       @serialized = serialized
@@ -74,6 +92,9 @@ module JSONTest
                      [ ActiveSupport::MessageEncryptor, %("ActiveSupport::MessageEncryptor") ]]
     ObjectTests   = [[ Foo.new(1, 2), %({\"a\":1,\"b\":2}) ]]
     HashlikeTests = [[ Hashlike.new, %({\"bar\":\"world\",\"foo\":\"hello\"}) ]]
+    ArraylikeTests = [[ Arraylike.new, %([\"foo\",[\"bar\"]]) ]]
+    StringlikeTests = [[ Stringlike.new, %(\"foo\") ]]
+    IntegerlikeTests = [[ Integerlike.new, %(999) ]]
     StructTests   = [[ MyStruct.new(:foo, "bar"), %({\"name\":\"foo\",\"value\":\"bar\"}) ],
                      [ MyStruct.new(nil, nil), %({\"name\":null,\"value\":null}) ]]
     CustomTests   = [[ Custom.new("custom"), '"custom"' ],


### PR DESCRIPTION
### Summary

currently activesupport's `Object#as_json` checks if self is implicitly convertible to a hash (implicit conversion as documented at https://docs.ruby-lang.org/en/master/doc/implicit_conversion_rdoc.html ). while this makes sense and is good, it omits the other three implicit conversion that ruby documents.

this PR adds the other implicit conversions in `Object#as_json`. also, since hashlike and arraylike objects are pretty likely to be Enumerable, I also added implicit conversion of those two to `Enumerable#as_json`.

(small tangent: Enumerable defines `#to_a`, and if `#to_ary` is defined as well, the difference or benefit of one over the other is questionable. `#to_ary` might be more performant, since the object would be defining that itself, whereas `Enumerable#to_a` goes through `Enumerable#each`, but that depends on the particular implementation. anyway, `#to_ary` is unlikely to be any worse, and if `#to_ary` is defined, it seems good to use it.)

### Other Information

I work on a library that wraps json data and adds functionality, which defines `#to_ary` and friends as appropriate. I do define an `as_json` method too, for activesupport, but for libraries that don't go out of their way for activesupport, but do support ruby-defined implicit conversion, this increases compatibility. it doesn't get all the way there, since the other basic types have no defined implicit conversion, but it helps.
