### PR TITLE
List changed attrs in pessimistic lock error

### DIFF
--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -71,6 +71,7 @@ module ActiveRecord
               Locking a record with unpersisted changes is not supported. Use
               `save` to persist the changes, or `reload` to discard them
               explicitly.
+              Changed attributes: #{changed.map(&:inspect).join(', ')}.
             MSG
           end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -706,9 +706,10 @@ unless in_memory_db?
     def test_lock_raises_when_the_record_is_dirty
       person = Person.find 1
       person.first_name = "fooman"
-      assert_raises(RuntimeError) do
+      error = assert_raises(RuntimeError) do
         person.lock!
       end
+      assert_match(/Changed attributes: "first_name"/, error.message)
     end
 
     def test_locking_in_after_save_callback


### PR DESCRIPTION
### Summary
If `record.lock!` fails because the record has unpersisted changes, it can help
to see which attributes changed. For example attributes set in a `after_initialize` callback.