### PR TITLE
Improve upgrade instructions for Bootsnap

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -934,8 +934,14 @@ For more information on changes made to Rails 5.2 please see the [release notes]
 ### Bootsnap
 
 Rails 5.2 adds bootsnap gem in the [newly generated app's Gemfile](https://github.com/rails/rails/pull/29313).
-The `app:update` command sets it up in `boot.rb`. If you want to use it, then add it in the Gemfile,
-otherwise change the `boot.rb` to not use bootsnap.
+The `app:update` command sets it up in `boot.rb`. If you want to use it, then add it in the Gemfile:
+
+```ruby
+# Reduces boot times through caching; required in config/boot.rb
+gem 'bootsnap', require: false
+```
+
+Otherwise change the `boot.rb` to not use bootsnap.
 
 ### Expiry in signed or encrypted cookie is now embedded in the cookies values
 


### PR DESCRIPTION
### Summary

Provide more clear instructions to add Bootsnap to the Gemfile, when upgrading for 5.1 to 5.2.

### Other Information

If the user decides to use it, but forget to add it to the Gemfile, the error below will pop-up.
```ruby
Traceback (most recent call last):
	3: from bin/rails:3:in `<main>'
	2: from bin/rails:3:in `require_relative'
	1: from <APP_BASE_FOLDER>/config/boot.rb:4:in `<top (required)>'
<APP_BASE_FOLDER>/config/boot.rb:4:in `require': cannot load such file -- bootsnap/setup (LoadError)
```
