### PR TITLE
Deprecate `[]` for non-scalar params (nested params and Arrays)

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,7 +22,7 @@ module Rails
       def new_mail
         Mail.new(mail_params.except(:attachments).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
-          mail_params[:attachments].to_a.each do |attachment|
+          mail_params.param_at(:attachments).to_a.each do |attachment|
             mail.add_file(filename: attachment.original_filename, content: attachment.read)
           end
         end

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Deprecate calling `[]` on non-scalar parameters
 
+    Calling `[]` is deprecated for non-scalar types.
+    This makes sure you never get a hash where you expect a scalar value.
+    For non-scalar types you can use `param_at` or `dig`.
+
+        params = ActionController::Parameters.new(
+          person: {
+            name: { "Matz" }
+          }
+        )
+
+        # Directly calling params[:person] isn't permitted, as it isn't a
+        # scalar type.
+        params[:person] # => nil
+
+        # Permitting the param still works
+        params.require(:person).permit(:name)[:name] # => "Matz"
+
+        # The old behaviour still works with `param_at`
+        params.param_at(:person)[:name] # => "Matz"
+
+    Fixes #42942
+
+    *Petrik de Heus*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionpack/CHANGELOG.md) for previous changes.

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -34,6 +34,11 @@ module ActionController
             app.config.action_controller.always_permitted_parameters
         end
 
+        if app.config.action_controller[:permit_accessor_on_non_scalar_parameter_types]
+          ActionController::Parameters.permit_accessor_on_non_scalar_parameter_types =
+            options.permit_accessor_on_non_scalar_parameter_types
+        end
+
         action_on_unpermitted_parameters = options.action_on_unpermitted_parameters
 
         if action_on_unpermitted_parameters.nil?
@@ -69,6 +74,7 @@ module ActionController
         filtered_options = options.except(
           :log_query_tags_around_actions,
           :permit_all_parameters,
+          :permit_accessor_on_non_scalar_parameter_types,
           :action_on_unpermitted_parameters,
           :always_permitted_parameters,
           :wrap_parameters_by_default

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -7,9 +7,9 @@ class RespondToController < ActionController::Base
   layout :set_layout
 
   before_action {
-    case params[:v]
+    case params.param_at(:v)
     when String then request.variant = params[:v].to_sym
-    when Array then request.variant = params[:v].map(&:to_sym)
+    when Array then request.variant = params.param_at(:v).map(&:to_sym)
     end
   }
 

--- a/actionpack/test/controller/parameters/dup_test.rb
+++ b/actionpack/test/controller/parameters/dup_test.rb
@@ -46,11 +46,11 @@ class ParametersDupTest < ActiveSupport::TestCase
 
   test "deep_dup content" do
     dupped_params = @params.deep_dup
-    dupped_params[:person][:age] = "45"
-    dupped_params[:person][:addresses].clear
+    dupped_params.param_at(:person)[:age] = "45"
+    dupped_params.dig(:person, :addresses).clear
 
-    assert_not_equal @params[:person][:age], dupped_params[:person][:age]
-    assert_not_equal @params[:person][:addresses], dupped_params[:person][:addresses]
+    assert_not_equal @params.dig(:person, :age), dupped_params.dig(:person, :age)
+    assert_not_equal @params.dig(:person, :addresses), dupped_params.dig(:person, :addresses)
   end
 
   test "deep_dup @permitted" do

--- a/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
+++ b/actionpack/test/controller/parameters/multi_parameter_attributes_test.rb
@@ -23,17 +23,19 @@ class MultiParameterAttributesTest < ActiveSupport::TestCase
 
     assert_predicate permitted, :permitted?
 
-    assert_equal "2012", permitted[:book]["shipped_at(1i)"]
-    assert_equal "3", permitted[:book]["shipped_at(2i)"]
-    assert_equal "25", permitted[:book]["shipped_at(3i)"]
-    assert_equal "10", permitted[:book]["shipped_at(4i)"]
-    assert_equal "15", permitted[:book]["shipped_at(5i)"]
+    book_params = permitted.param_at(:book)
 
-    assert_equal "R$", permitted[:book]["price(1)"]
-    assert_equal "2.02", permitted[:book]["price(2f)"]
+    assert_equal "2012", book_params["shipped_at(1i)"]
+    assert_equal "3", book_params["shipped_at(2i)"]
+    assert_equal "25", book_params["shipped_at(3i)"]
+    assert_equal "10", book_params["shipped_at(4i)"]
+    assert_equal "15", book_params["shipped_at(5i)"]
 
-    assert_nil permitted[:book]["published_at(1i)"]
-    assert_nil permitted[:book]["published_at(2i)"]
-    assert_nil permitted[:book]["published_at(3i)"]
+    assert_equal "R$", book_params["price(1)"]
+    assert_equal "2.02", book_params["price(2f)"]
+
+    assert_nil book_params["published_at(1i)"]
+    assert_nil book_params["published_at(2i)"]
+    assert_nil book_params["published_at(3i)"]
   end
 end

--- a/actionpack/test/controller/parameters/mutators_test.rb
+++ b/actionpack/test/controller/parameters/mutators_test.rb
@@ -27,24 +27,24 @@ class ParametersMutatorsTest < ActiveSupport::TestCase
   end
 
   test "delete returns the value when the key is present" do
-    assert_equal "32", @params[:person].delete(:age)
+    assert_equal "32", @params.param_at(:person).delete(:age)
   end
 
   test "delete removes the entry when the key present" do
-    @params[:person].delete(:age)
-    assert_not @params[:person].key?(:age)
+    @params.param_at(:person).delete(:age)
+    assert_not @params.param_at(:person).key?(:age)
   end
 
   test "delete returns nil when the key is not present" do
-    assert_nil @params[:person].delete(:first_name)
+    assert_nil @params.param_at(:person).delete(:first_name)
   end
 
   test "delete returns the value of the given block when the key is not present" do
-    assert_equal "David", @params[:person].delete(:first_name) { "David" }
+    assert_equal "David", @params.param_at(:person).delete(:first_name) { "David" }
   end
 
   test "delete yields the key to the given block when the key is not present" do
-    assert_equal "first_name: David", @params[:person].delete(:first_name) { |k| "#{k}: David" }
+    assert_equal "first_name: David", @params.param_at(:person).delete(:first_name) { |k| "#{k}: David" }
   end
 
   test "delete_if retains permitted status" do

--- a/actionpack/test/controller/permitted_params_test.rb
+++ b/actionpack/test/controller/permitted_params_test.rb
@@ -4,11 +4,11 @@ require "abstract_unit"
 
 class PeopleController < ActionController::Base
   def create
-    render plain: params[:person].permitted? ? "permitted" : "forbidden"
+    render plain: params.param_at(:person).permitted? ? "permitted" : "forbidden"
   end
 
   def create_with_permit
-    render plain: params[:person].permit(:name).permitted? ? "permitted" : "forbidden"
+    render plain: params.param_at(:person).permit(:name).permitted? ? "permitted" : "forbidden"
   end
 end
 

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -115,16 +115,16 @@ class TestController < ActionController::Base
   end
 
   def dynamic_render
-    render params[:id] # => String, AC::Params
+    render params.param_at(:id) # => String, AC::Params
   end
 
   def dynamic_render_permit
-    render params[:id].permit(:file)
+    render params.param_at(:id).permit(:file)
   end
 
   def dynamic_render_with_file
     # This is extremely bad, but should be possible to do.
-    file = params[:id] # => String, AC::Params
+    file = params.param_at(:id) # => String, AC::Params
     render file: file
   end
 

--- a/actionpack/test/controller/webservice_test.rb
+++ b/actionpack/test/controller/webservice_test.rb
@@ -15,7 +15,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
     def dump_params_keys(hash = params)
       hash.keys.sort.each_with_object(+"") do |k, s|
-        value = hash[k]
+        value = hash.param_at(k)
 
         if value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
           value = "(#{dump_params_keys(value)})"
@@ -49,7 +49,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
       assert_equal "entry", @controller.response.body
       assert @controller.params.has_key?(:entry)
-      assert_equal "content...", @controller.params["entry"]["summary"]
+      assert_equal "content...", @controller.params.dig("entry", "summary")
     end
   end
 
@@ -61,7 +61,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
       assert_equal "entry", @controller.response.body
       assert @controller.params.has_key?(:entry)
-      assert_equal "content...", @controller.params["entry"]["summary"]
+      assert_equal "content...", @controller.params.dig("entry", "summary")
     end
   end
 
@@ -94,7 +94,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
         params: '{"first-key":{"sub-key":"..."}}',
         headers: { "CONTENT_TYPE" => "application/json" }
       assert_equal "action, controller, first-key(sub-key), full", @controller.response.body
-      assert_equal "...", @controller.params["first-key"]["sub-key"]
+      assert_equal "...", @controller.params.dig("first-key", "sub-key")
     end
   end
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -272,6 +272,10 @@ module Rails
               "Referrer-Policy" => "strict-origin-when-cross-origin"
             }
           end
+
+          if respond_to?(:action_controller)
+            action_controller.permit_accessor_on_non_scalar_parameter_types = false
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -24,3 +24,7 @@
 #   "X-Permitted-Cross-Domain-Policies" => "none",
 #   "Referrer-Policy" => "strict-origin-when-cross-origin"
 # }
+#
+# Only allow calling `[]` on scalar-types.
+# Rails.application.config.permit_accessor_on_non_scalar_parameter_types = false
+

--- a/railties/test/json_params_parsing_test.rb
+++ b/railties/test/json_params_parsing_test.rb
@@ -21,8 +21,8 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     app = ->(env) {
       request = ActionDispatch::Request.new env
       params = ActionController::Parameters.new request.parameters
-      if params[:t]
-        klass.find_by_title(params[:t])
+      if params.param_at(:t)
+        klass.find_by_title(params.param_at(:t))
       else
         nil
       end


### PR DESCRIPTION
### Summary

Wrap results of `Parameters#[]` in a `DeprecatedObjectProxy` for non-scalar params.

Calling `Parameters#[]` can have unexpected results as it allows access
to the unfiltered parameters.
For example a parameter might be used in a view:

    params = ActionController::Parameters.new(query: "ruby!")
    "You searched for: #{params[:query]}"
    # => "You searched for: ruby!"

When the parameter is a nested parameter, the inspect of the parameter
is outputted instead.

    params = ActionController::Parameters.new(query: { name: "ruby!" })
    "You searched for: #{params[:query]}"
    # => "You searched for: <ActionController::Parameters {"name"=>"ruby!"} permitted: false>

By not allowing `[]` for non-scalar types, we can prevent the problem.
For backwards compatibility to get the non-scalar parameter, the `param_at` method is added.

### After this change

Calling `[]` on scalar types still works.

    params = ActionController::Parameters.new(query: "ruby!")
    params[:query] => # "ruby!"

Calling `[]` on nested params results in deprecation warnings:

    params = ActionController::Parameters.new(
      person: {
        name: { "Matz" }
      }
    )
    # calling any methods on the result of params[:person]
    # results in a deprecation warning, as it isn't a scalar type.
    params[:person][:name]           # is deprecated
    params[:person].to_h            # is deprecated

    # The old behaviour still works with `param_at`
    params.param_at(:person)[:name] # => "Matz"
    
Fixes: #42942

### Other Information

I've chosen `param_at` but maybe we should more clearly communicate
its unsafe usage and rename it to `unsafe_param_at` or `unfiltered_param_at`?

`dig` still allows access to unfiltered parameters, but maybe it's better to change
that as well, so that all parameter methods are safe unless the name contains `unsafe`.
We could add a `unsafe_dig` for the original behaviour.