### PR TITLE
Improve associated with no reflection error

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -68,7 +68,7 @@ module ActiveRecord
       #    # WHERE "authors"."id" IS NOT NULL AND "comments"."id" IS NOT NULL
       def associated(*associations)
         associations.each do |association|
-          reflection = @scope.klass._reflect_on_association(association)
+          reflection = scope_association_reflection(association)
           @scope.joins!(association)
           self.not(reflection.table_name => { reflection.association_primary_key => nil })
         end
@@ -96,16 +96,22 @@ module ActiveRecord
       #    # WHERE "authors"."id" IS NULL AND "comments"."id" IS NULL
       def missing(*associations)
         associations.each do |association|
-          reflection = @scope.klass._reflect_on_association(association)
-          unless reflection
-            raise ArgumentError.new("An association named `:#{association}` does not exist on the model `#{@scope.name}`.")
-          end
+          reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
           @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
         end
 
         @scope
       end
+
+      private
+        def scope_association_reflection(association)
+          reflection = @scope.klass._reflect_on_association(association)
+          unless reflection
+            raise ArgumentError.new("An association named `:#{association}` does not exist on the model `#{@scope.name}`.")
+          end
+          reflection
+        end
     end
 
     FROZEN_EMPTY_ARRAY = [].freeze

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -28,6 +28,14 @@ module ActiveRecord
       end
     end
 
+    def test_associated__with_invalid_association_name
+      e = assert_raises(ArgumentError) do
+        Post.where.associated(:cars).to_a
+      end
+
+      assert_match(/An association named `:cars` does not exist on the model `Post`\./, e.message)
+    end
+
     def test_missing_with_association
       assert posts(:authorless).author.blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a


### PR DESCRIPTION
### Summary

Based on https://github.com/rails/rails/commit/fbbbfa84dbb78dc436ffaea3d8ca69f5b6e371b2 so thanks to @ykpythemind

before:

```
Post.where.associated(:cars).to_a # Post does not have association named `cars`

=> NoMethodError: undefined method `table_name' for nil:NilClass
```

after:

```
Post.where.associated(:cars).to_a
=> ArgumentError: An association named `:cars` does not exist on the model `Post`.
```