### PR TITLE
Fix compatibility with psych 4.x for Rails 5.2

### DIFF
--- a/actionpack/test/controller/parameters/serialization_test.rb
+++ b/actionpack/test/controller/parameters/serialization_test.rb
@@ -24,30 +24,33 @@ class ParametersSerializationTest < ActiveSupport::TestCase
 
   test "yaml deserialization" do
     params = ActionController::Parameters.new(key: :value)
-    roundtripped = YAML.load(YAML.dump(params))
+    payload = YAML.dump(params)
+    roundtripped = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
 
     assert_equal params, roundtripped
     assert_not_predicate roundtripped, :permitted?
   end
 
   test "yaml backwardscompatible with psych 2.0.8 format" do
-    params = YAML.load <<-end_of_yaml.strip_heredoc
+    payload = <<~end_of_yaml
       --- !ruby/hash:ActionController::Parameters
       key: :value
     end_of_yaml
+    params = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
 
     assert_equal :value, params[:key]
     assert_not_predicate params, :permitted?
   end
 
   test "yaml backwardscompatible with psych 2.0.9+ format" do
-    params = YAML.load(<<-end_of_yaml.strip_heredoc)
+    payload = <<~end_of_yaml
       --- !ruby/hash-with-ivars:ActionController::Parameters
       elements:
         key: :value
       ivars:
         :@permitted: false
     end_of_yaml
+    params = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
 
     assert_equal :value, params[:key]
     assert_not_predicate params, :permitted?

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -431,7 +431,7 @@ class ErrorsTest < ActiveModel::TestCase
     messages: {}
     CODE
 
-    errors = YAML.load(yaml)
+    errors = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(yaml) : YAML.load(yaml)
     errors.add(:name, :invalid)
     assert_equal({ name: ["is invalid"] }, errors.messages)
     assert_equal({ name: [{ error: :invalid }] }, errors.details)

--- a/activerecord/lib/active_record/coders/yaml_column.rb
+++ b/activerecord/lib/active_record/coders/yaml_column.rb
@@ -23,7 +23,7 @@ module ActiveRecord
       def load(yaml)
         return object_class.new if object_class != Object && yaml.nil?
         return yaml unless yaml.is_a?(String) && /^---/.match?(yaml)
-        obj = YAML.load(yaml)
+        obj = yaml_load(yaml)
 
         assert_valid_value(obj, action: "load")
         obj ||= object_class.new if object_class != Object
@@ -44,6 +44,16 @@ module ActiveRecord
           load(nil)
         rescue ArgumentError
           raise ArgumentError, "Cannot serialize #{object_class}. Classes passed to `serialize` must have a 0 argument constructor."
+        end
+
+        if YAML.respond_to?(:unsafe_load)
+          def yaml_load(payload)
+            YAML.unsafe_load(payload)
+          end
+        else
+          def yaml_load(payload)
+            YAML.load(payload)
+          end
         end
     end
   end

--- a/activerecord/lib/active_record/fixture_set/file.rb
+++ b/activerecord/lib/active_record/fixture_set/file.rb
@@ -47,7 +47,8 @@ module ActiveRecord
 
         def raw_rows
           @raw_rows ||= begin
-            data = YAML.load(render(IO.read(@file)))
+            rendered = render(IO.read(@file))
+            data = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(rendered) : YAML.load(rendered)
             data ? validate(data).to_a : []
           rescue ArgumentError, Psych::SyntaxError => error
             raise Fixture::FormatError, "a YAML error occurred parsing #{@file}. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Please have a look at http://www.yaml.org/faq.html\nThe exact error was:\n  #{error.class}: #{error}", error.backtrace

--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -229,7 +229,8 @@ db_namespace = namespace :db do
       base_dir = ActiveRecord::Tasks::DatabaseTasks.fixtures_path
 
       Dir["#{base_dir}/**/*.yml"].each do |file|
-        if data = YAML.load(ERB.new(IO.read(file)).result)
+        result = ERB.new(IO.read(file)).result
+        if data = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(result) : YAML.load(result)
           data.each_key do |key|
             key_id = ActiveRecord::FixtureSet.identify(key)
 

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -153,7 +153,8 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
     assert_equal "fr", x.language
     assert_equal "GMT", x.timezone
 
-    y = YAML.load(YAML.dump(x))
+    payload = YAML.dump(x)
+    y = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     assert_equal "fr", y.language
     assert_equal "GMT", y.timezone
   end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -715,7 +715,8 @@ class AttributeMethodsTest < ActiveRecord::TestCase
     in_time_zone "Pacific Time (US & Canada)" do
       record = Topic.new(id: 1)
       record.written_on = "Jan 01 00:00:00 2014"
-      assert_equal record, YAML.load(YAML.dump(record))
+      payload = YAML.dump(record)
+      assert_equal record, YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     end
   end
 

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -20,7 +20,8 @@ module ActiveRecord
         @cache.data_sources("posts")
         @cache.primary_keys("posts")
 
-        new_cache = YAML.load(YAML.dump(@cache))
+        new_cache = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(YAML.dump(@cache)) : YAML.load(YAML.dump(@cache))
+
         assert_no_queries do
           assert_equal 12, new_cache.columns("posts").size
           assert_equal 12, new_cache.columns_hash("posts").size
@@ -31,7 +32,7 @@ module ActiveRecord
 
       def test_yaml_loads_5_1_dump
         body = File.open(schema_dump_path).read
-        cache = YAML.load(body)
+        cache = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(body) : YAML.load(body)
 
         assert_no_queries do
           assert_equal 11, cache.columns("posts").size

--- a/activerecord/test/cases/json_shared_test_cases.rb
+++ b/activerecord/test/cases/json_shared_test_cases.rb
@@ -146,7 +146,8 @@ module JSONSharedTestCases
     x = klass.new(resolution: "320×480")
     assert_equal "320×480", x.resolution
 
-    y = YAML.load(YAML.dump(x))
+    payload = YAML.dump(x)
+    y = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     assert_equal "320×480", y.resolution
   end
 

--- a/activerecord/test/cases/locking_test.rb
+++ b/activerecord/test/cases/locking_test.rb
@@ -502,7 +502,8 @@ class OptimisticLockingTest < ActiveRecord::TestCase
 
   def test_yaml_dumping_with_lock_column
     t1 = LockWithoutDefault.new
-    t2 = YAML.load(YAML.dump(t1))
+    payload = YAML.dump(t1)
+    t2 = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
 
     assert_equal t1.attributes, t2.attributes
   end

--- a/activerecord/test/cases/store_test.rb
+++ b/activerecord/test/cases/store_test.rb
@@ -188,10 +188,11 @@ class StoreTest < ActiveRecord::TestCase
 
   test "dump, load and dump again a model" do
     dumped = YAML.dump(@john)
-    loaded = YAML.load(dumped)
+    loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(dumped) : YAML.load(dumped)
     assert_equal @john, loaded
 
     second_dump = YAML.dump(loaded)
-    assert_equal @john, YAML.load(second_dump)
+    second_loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(second_dump) : YAML.load(second_dump)
+    assert_equal @john, second_loaded
   end
 end

--- a/activerecord/test/cases/yaml_serialization_test.rb
+++ b/activerecord/test/cases/yaml_serialization_test.rb
@@ -19,26 +19,26 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_roundtrip
     topic = Topic.first
     assert topic
-    t = YAML.load YAML.dump topic
+    t = yaml_load YAML.dump topic
     assert_equal topic, t
   end
 
   def test_roundtrip_serialized_column
     topic = Topic.new(content: { omg: :lol })
-    assert_equal({ omg: :lol }, YAML.load(YAML.dump(topic)).content)
+    assert_equal({ omg: :lol }, yaml_load(YAML.dump(topic)).content)
   end
 
   def test_psych_roundtrip
     topic = Topic.first
     assert topic
-    t = Psych.load Psych.dump topic
+    t = yaml_load Psych.dump topic
     assert_equal topic, t
   end
 
   def test_psych_roundtrip_new_object
     topic = Topic.new
     assert topic
-    t = Psych.load Psych.dump topic
+    t = yaml_load Psych.dump topic
     assert_equal topic.attributes, t.attributes
   end
 
@@ -49,30 +49,30 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_raw_types_are_not_changed_on_round_trip
     topic = Topic.new(parent_id: "123")
     assert_equal "123", topic.parent_id_before_type_cast
-    assert_equal "123", YAML.load(YAML.dump(topic)).parent_id_before_type_cast
+    assert_equal "123", yaml_load(YAML.dump(topic)).parent_id_before_type_cast
   end
 
   def test_cast_types_are_not_changed_on_round_trip
     topic = Topic.new(parent_id: "123")
     assert_equal 123, topic.parent_id
-    assert_equal 123, YAML.load(YAML.dump(topic)).parent_id
+    assert_equal 123, yaml_load(YAML.dump(topic)).parent_id
   end
 
   def test_new_records_remain_new_after_round_trip
     topic = Topic.new
 
     assert topic.new_record?, "Sanity check that new records are new"
-    assert YAML.load(YAML.dump(topic)).new_record?, "Record should be new after deserialization"
+    assert yaml_load(YAML.dump(topic)).new_record?, "Record should be new after deserialization"
 
     topic.save!
 
     assert_not topic.new_record?, "Saved records are not new"
-    assert_not YAML.load(YAML.dump(topic)).new_record?, "Saved record should not be new after deserialization"
+    assert_not yaml_load(YAML.dump(topic)).new_record?, "Saved record should not be new after deserialization"
 
     topic = Topic.select("title").last
 
     assert_not topic.new_record?, "Loaded records without ID are not new"
-    assert_not YAML.load(YAML.dump(topic)).new_record?, "Record should not be new after deserialization"
+    assert_not yaml_load(YAML.dump(topic)).new_record?, "Record should not be new after deserialization"
   end
 
   def test_types_of_virtual_columns_are_not_changed_on_round_trip
@@ -80,7 +80,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
       .joins(:posts)
       .group("authors.id")
       .first
-    dumped = YAML.load(YAML.dump(author))
+    dumped = yaml_load(YAML.dump(author))
 
     assert_equal 5, author.posts_count
     assert_equal 5, dumped.posts_count
@@ -94,7 +94,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_41_yaml
-    topic = YAML.load(yaml_fixture("rails_4_1"))
+    topic = yaml_load(yaml_fixture("rails_4_1"))
 
     assert_predicate topic, :new_record?
     assert_nil topic.id
@@ -103,7 +103,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   end
 
   def test_deserializing_rails_4_2_0_yaml
-    topic = YAML.load(yaml_fixture("rails_4_2_0"))
+    topic = yaml_load(yaml_fixture("rails_4_2_0"))
 
     assert_not_predicate topic, :new_record?
     assert_equal 1, topic.id
@@ -114,7 +114,7 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_yaml_encoding_keeps_mutations
     author = Author.first
     author.name = "Sean"
-    dumped = YAML.load(YAML.dump(author))
+    dumped = yaml_load(YAML.dump(author))
 
     assert_equal "Sean", dumped.name
     assert_equal author.name_was, dumped.name_was
@@ -124,12 +124,15 @@ class YamlSerializationTest < ActiveRecord::TestCase
   def test_yaml_encoding_keeps_false_values
     topic = Topic.first
     topic.approved = false
-    dumped = YAML.load(YAML.dump(topic))
+    dumped = yaml_load(YAML.dump(topic))
 
     assert_equal false, dumped.approved
   end
 
   private
+    def yaml_load(payload)
+      YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
+    end
 
     def yaml_fixture(file_name)
       path = File.expand_path(

--- a/activestorage/lib/active_storage/engine.rb
+++ b/activestorage/lib/active_storage/engine.rb
@@ -91,8 +91,9 @@ module ActiveStorage
 
             require "yaml"
             require "erb"
+            result = ERB.new(config_file.read).result
 
-            YAML.load(ERB.new(config_file.read).result) || {}
+            YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(result) : YAML.load(result) || {}
           rescue Psych::SyntaxError => e
             raise "YAML syntax error occurred while parsing #{config_file}. " \
                   "Please note that YAML must be consistently indented using spaces. Tabs are not allowed. " \

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -25,7 +25,7 @@ Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 require "yaml"
 SERVICE_CONFIGURATIONS = begin
   erb = ERB.new(Pathname.new(File.expand_path("service/configurations.yml", __dir__)).read)
-  configuration = YAML.load(erb.result) || {}
+  configuration = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(erb.result) : YAML.load(erb.result) || {}
   configuration.deep_symbolize_keys
 rescue Errno::ENOENT
   puts "Missing service configuration file in test/service/configurations.yml"

--- a/activesupport/test/core_ext/duration_test.rb
+++ b/activesupport/test/core_ext/duration_test.rb
@@ -668,7 +668,8 @@ class DurationTest < ActiveSupport::TestCase
   end
 
   def test_durations_survive_yaml_serialization
-    d1 = YAML.load(YAML.dump(10.minutes))
+    payload = YAML.dump(10.minutes)
+    d1 = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
     assert_equal 600, d1.to_i
     assert_equal 660, (d1 + 60).to_i
   end

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -196,7 +196,8 @@ class TimeWithZoneTest < ActiveSupport::TestCase
       time: 1999-12-31 19:00:00.000000000 Z
     EOF
 
-    assert_equal(@twz, YAML.load(yaml))
+    loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(yaml) : YAML.load(yaml)
+    assert_equal(@twz, loaded)
   end
 
   def test_ruby_yaml_load
@@ -209,7 +210,8 @@ class TimeWithZoneTest < ActiveSupport::TestCase
         time: 1999-12-31 19:00:00.000000000 Z
     EOF
 
-    assert_equal({ "twz" => @twz }, YAML.load(yaml))
+    loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(yaml) : YAML.load(yaml)
+    assert_equal({ "twz" => @twz }, loaded)
   end
 
   def test_httpdate

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -791,6 +791,8 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_yaml_load
-    assert_equal(ActiveSupport::TimeZone["Pacific/Honolulu"], YAML.load("--- !ruby/object:ActiveSupport::TimeZone\nname: Pacific/Honolulu\n"))
+    payload = "--- !ruby/object:ActiveSupport::TimeZone\nname: Pacific/Honolulu\n"
+    loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
+    assert_equal(ActiveSupport::TimeZone["Pacific/Honolulu"], loaded)
   end
 end

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -232,7 +232,8 @@ module Rails
 
       if yaml.exist?
         require "erb"
-        (YAML.load(ERB.new(yaml.read).result) || {})[env] || {}
+        result = ERB.new(yaml.read).result
+        (YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(result) : YAML.load(result) || {})[env] || {}
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -169,7 +169,11 @@ module Rails
         config = if yaml && yaml.exist?
           require "yaml"
           require "erb"
-          loaded_yaml = YAML.load(ERB.new(yaml.read).result) || {}
+          loaded_yaml = if YAML.respond_to?(:unsafe_load)
+            YAML.unsafe_load(ERB.new(yaml.read).result) || {}
+          else
+            YAML.load(ERB.new(yaml.read).result) || {}
+          end
           shared = loaded_yaml.delete("shared")
           if shared
             loaded_yaml.each do |_k, values|

--- a/railties/lib/rails/secrets.rb
+++ b/railties/lib/rails/secrets.rb
@@ -26,7 +26,8 @@ module Rails
         paths.each_with_object(Hash.new) do |path, all_secrets|
           require "erb"
 
-          secrets = YAML.load(ERB.new(preprocess(path)).result) || {}
+          result = ERB.new(preprocess(path)).result
+          secrets = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(result) : YAML.load(result) || {}
           all_secrets.merge!(secrets["shared"].deep_symbolize_keys) if secrets["shared"]
           all_secrets.merge!(secrets[env].deep_symbolize_keys) if secrets[env]
         end

--- a/railties/test/generators/model_generator_test.rb
+++ b/railties/test/generators/model_generator_test.rb
@@ -464,6 +464,7 @@ class ModelGeneratorTest < Rails::Generators::TestCase
   private
     def assert_generated_fixture(path, parsed_contents)
       fixture_file = File.new File.expand_path(path, destination_root)
-      assert_equal(parsed_contents, YAML.load(fixture_file))
+      result = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(fixture_file) : YAML.load(fixture_file)
+      assert_equal(parsed_contents, result)
     end
 end


### PR DESCRIPTION
Ruby master ships with Psych 4.0.0 which makes `YAML.load`
defaults to safe mode (ruby/psych#487).

However since these YAML files are trustworthy sources
we can parse them with `unsafe_load`.

Original patch made by @byroot, I've backported the changes
to 5.2 and fixed a couple more places that used `YAML.load`.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This addresses #44209, at least the part of it mentioning a backport for older Rails and author's example app (which is 5.2.6).

### Other Information

Although Rails 5.2 doesn't support Ruby 3.1 there is nothing preventing user from installing Psych 4.x with an older Ruby which will break their Rails 5.2 app.




