### PR TITLE
Fix missing require of reverse_merge extension

### DIFF
--- a/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
+++ b/activerecord/lib/active_record/database_configurations/connection_url_resolver.rb
@@ -2,6 +2,7 @@
 
 require "uri"
 require "active_support/core_ext/enumerable"
+require "active_support/core_ext/hash/reverse_merge"
 
 module ActiveRecord
   class DatabaseConfigurations


### PR DESCRIPTION
### Summary

The private method `#raw_config` in `ConnectionUrlResolver` uses
`Hash#reverse_merge`, which is an `ActiveSupport` core extension.

This fixes an error

    NoMethodError: undefined method `reverse_merge' for {}:Hash


in code that uses `ActiveRecord` without having previously loaded the
`reverse_merge` core extension.

### Other Information

We ran into this in [our `nominatorbot` application](https://gitlab.com/gitlab-com/people-group/peopleops-eng/nominatorbot) (see [failing pipeline](https://gitlab.com/gitlab-com/people-group/peopleops-eng/nominatorbot/-/jobs/1998115120#L328)) after updating various dependencies.
