### PR TITLE
Speed up missing query 

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -65,12 +65,12 @@ module ActiveRecord
       #    # SELECT "posts".* FROM "posts"
       #    # INNER JOIN "authors" ON "authors"."id" = "posts"."author_id"
       #    # INNER JOIN "comments" ON "comments"."post_id" = "posts"."id"
-      #    # WHERE "authors"."id" IS NOT NULL AND "comments"."id" IS NOT NULL
+      #    # WHERE "authors"."id" IS NOT NULL AND "comments"."post_id" IS NOT NULL
       def associated(*associations)
         associations.each do |association|
           reflection = @scope.klass._reflect_on_association(association)
           @scope.joins!(association)
-          self.not(reflection.table_name => { reflection.association_primary_key => nil })
+          self.not(reflection.table_name => { reflection.join_primary_key => nil })
         end
 
         @scope
@@ -93,7 +93,7 @@ module ActiveRecord
       #    # SELECT "posts".* FROM "posts"
       #    # LEFT OUTER JOIN "authors" ON "authors"."id" = "posts"."author_id"
       #    # LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id"
-      #    # WHERE "authors"."id" IS NULL AND "comments"."id" IS NULL
+      #    # WHERE "authors"."id" IS NULL AND "comments"."post_id" IS NULL
       def missing(*associations)
         associations.each do |association|
           reflection = @scope.klass._reflect_on_association(association)
@@ -101,7 +101,7 @@ module ActiveRecord
             raise ArgumentError.new("An association named `:#{association}` does not exist on the model `#{@scope.name}`.")
           end
           @scope.left_outer_joins!(association)
-          @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
+          @scope.where!(reflection.table_name => { reflection.join_primary_key => nil })
         end
 
         @scope

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -121,8 +121,8 @@ module ActiveRecord
     end
 
     def test_rewhere_with_nested_condition
-      relation = Post.where.missing(:comments).rewhere("comments.id": comments(:does_it_hurt))
-      expected = Post.left_joins(:comments).where("comments.id": comments(:does_it_hurt))
+      relation = Post.where.missing(:comments).rewhere("comments.post_id": posts(:thinking))
+      expected = Post.left_joins(:comments).where("comments.post_id": posts(:thinking))
 
       assert_equal expected.to_a, relation.to_a
     end


### PR DESCRIPTION
Doing the WHERE on the `join_primary_key` allows postgresql to use an Anti Join:

```
activerecord_unittest=# EXPLAIN SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" WHERE "comments"."post_id" IS NULL;
                              QUERY PLAN
-----------------------------------------------------------------------
 Hash Anti Join  (cost=16.30..42.53 rows=240 width=140)
   Hash Cond: (posts.id = comments.post_id)
   ->  Seq Scan on posts  (cost=0.00..14.80 rows=480 width=140)
   ->  Hash  (cost=12.80..12.80 rows=280 width=4)
         ->  Seq Scan on comments  (cost=0.00..12.80 rows=280 width=4)
```

Previously postgresql would use a Right Join (with a filter):

```
activerecord_unittest=# EXPLAIN SELECT "posts".* FROM "posts" LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id" WHERE "comments"."id" IS NULL;
                              QUERY PLAN
----------------------------------------------------------------------
 Hash Right Join  (cost=20.80..34.35 rows=2 width=140)
   Hash Cond: (comments.post_id = posts.id)
   Filter: (comments.id IS NULL)
   ->  Seq Scan on comments  (cost=0.00..12.80 rows=280 width=12)
   ->  Hash  (cost=14.80..14.80 rows=480 width=140)
         ->  Seq Scan on posts  (cost=0.00..14.80 rows=480 width=140)
```
This is true for all postgresql versions 9.3 upwards.

On mysql 8.x, MS Server and Oracle 11 there is no difference in query plans (http://sqlfiddle.com/#!9/42c92d2/1):

```
mysql> EXPLAIN SELECT posts.* FROM posts LEFT OUTER JOIN comments ON comments.post_id = posts.id WHERE comments.post_id IS NULL;
+----+-------------+----------+------------+------+---------------+------+---------+------+------+----------+----------------------------------------------------------------+
| id | select_type | table    | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra                                                          |
+----+-------------+----------+------------+------+---------------+------+---------+------+------+----------+----------------------------------------------------------------+
|  1 | SIMPLE      | posts    | NULL       | ALL  | NULL          | NULL | NULL    | NULL |   11 |   100.00 | NULL                                                           |
|  1 | SIMPLE      | comments | NULL       | ALL  | NULL          | NULL | NULL    | NULL |   12 |    10.00 | Using where; Not exists; Using join buffer (Block Nested Loop) |
+----+-------------+----------+------------+------+---------------+------+---------+------+------+----------+----------------------------------------------------------------+
```

On mysql 5.6 with `WHERE comments.id IS NULL` (i.e. using the primary key so before this change) has the same query plan as above.
With this change the query plan is worse:
`WHERE comments.post_id IS NULL` uses "Using where; Using join buffer (Block Nested Loop)"

If users are expecting missing to be using the primary key and overriding with a rewhere,
as in the specs, then this is not backwards compatiable.  That seems a strange case to
support.