### PR TITLE
Add note in guide for a counter cache caveat [ci skip]

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -1037,7 +1037,15 @@ end
 NOTE: You only need to specify the `:counter_cache` option on the `belongs_to`
 side of the association.
 
-Counter cache columns are added to the containing model's list of read-only attributes through `attr_readonly`.
+Counter cache columns are added to the owner model's list of read-only
+attributes through `attr_readonly`.
+
+If for some reason you change the value of an owner model's primary key, and do
+not also update the foreign keys of the counted models, then the counter cache
+may have stale data. In other words, any orphaned models will still count
+towards the counter. To fix a stale counter cache, use [`reset_counters`][].
+
+[`reset_counters`]: https://api.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-reset_counters
 
 ##### `:dependent`
 


### PR DESCRIPTION
Counter cache can hold a stale value if user changes primary key's value.
This caveat is not mentioned in guides, but according to #16159
comments it should be.

### Summary

A small note for users using counter caches and updating primary keys which will result in counter cache being broken.
