### PR TITLE
Fixes Options documentation formatting for has_rich_text

### DIFF
--- a/actiontext/lib/action_text/attribute.rb
+++ b/actiontext/lib/action_text/attribute.rb
@@ -26,10 +26,10 @@ module ActionText
       #   Message.all.with_rich_text_content_and_embeds # Avoids N+1 queries when you just want the body and attachments.
       #   Message.all.with_all_rich_text # Loads all rich text associations.
       #
-      #  === Options
+      # ==== Options
       #
-      #  * <tt>:encrypted</tt> - Pass true to encrypt the rich text attribute. The encryption will be non-deterministic. See
-      #  +ActiveRecord::Encryption::EncryptableRecord.encrypts+. Default: false.
+      # * <tt>:encrypted</tt> - Pass true to encrypt the rich text attribute. The encryption will be non-deterministic. See
+      #   +ActiveRecord::Encryption::EncryptableRecord.encrypts+. Default: false.
       def has_rich_text(name, encrypted: false)
         class_eval <<-CODE, __FILE__, __LINE__ + 1
           def #{name}


### PR DESCRIPTION
### Summary

Whilst reading up on [`has_rich_text`](https://api.rubyonrails.org/classes/ActionText/Attribute.html#method-i-has_rich_text ) I  noticed that the Options section of the method wasn't rendering correctly.

This PR fixes:

- The heading level of Options appeared to be incorrect
- The section was indented by an extra space resulting it being considered a code fragment

### Screenshots

#### Before

From https://api.rubyonrails.org/classes/ActionText/Attribute.html#method-i-has_rich_text:

<img width="1003" alt="Screen Shot 2022-01-22 at 2 01 31 PM" src="https://user-images.githubusercontent.com/13157/150653781-625a4bc9-3d9d-4de7-91db-35637237389f.png">

#### After

From local `doc/rdoc`:

<img width="1002" alt="Screen Shot 2022-01-22 at 2 01 45 PM" src="https://user-images.githubusercontent.com/13157/150653784-6684131b-8336-44db-9707-3201a03e9c3c.png">

