### PR TITLE
Warn on instantiating records w/ ambiguous columns

### DIFF
--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -77,6 +77,12 @@ module ActiveRecord
         column_types = column_types.reject { |k, _| attribute_types.key?(k) }
       end
 
+      duplicate_column_names = result_set.columns.tally.filter_map { |column, count| column if count > 1 }
+      unless duplicate_column_names.empty?
+        logger&.warn "Duplicate column names detected: #{duplicate_column_names.join(', ')}. " \
+                     "Use explicit column selection (e.g., 'posts.*') to avoid ambiguous results."
+      end
+
       message_bus = ActiveSupport::Notifications.instrumenter
 
       payload = {

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -779,11 +779,16 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
   end
 
   def test_warn_if_duplicate_column_names_detected
+    previous_logger = ActiveRecord::Base.logger
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new(nil)
+
     expected_message = "Duplicate column names detected: id. " \
                        "Use explicit column selection (e.g., 'posts.*') to avoid ambiguous results."
     assert_called_with(ActiveRecord::Base.logger, :warn, [expected_message]) do
       Post.joins(:author).select("*").first
     end
+  ensure
+    ActiveRecord::Base.logger = previous_logger
   end
 
   private

--- a/activerecord/test/cases/associations/join_model_test.rb
+++ b/activerecord/test/cases/associations/join_model_test.rb
@@ -778,6 +778,14 @@ class AssociationsJoinModelTest < ActiveRecord::TestCase
     end
   end
 
+  def test_warn_if_duplicate_column_names_detected
+    expected_message = "Duplicate column names detected: id. " \
+                       "Use explicit column selection (e.g., 'posts.*') to avoid ambiguous results."
+    assert_called_with(ActiveRecord::Base.logger, :warn, [expected_message]) do
+      Post.joins(:author).select("*").first
+    end
+  end
+
   private
     # create dynamic Post models to allow different dependency options
     def find_post_with_dependency(post_id, association, association_name, dependency)


### PR DESCRIPTION
### Summary

It is possible to query for models with a result that has duplicate
columns. For example:

```ruby
Post.joins(:author).select("*").first
```

will have at least two `id` columns (and possibly more).

Loading record matches the column names and will overwrite
the resulting column several times on duplicates which might
lead to unexpected query results.

Fixes #41151


### Other Information

I'd love to have a better warning message and some feedback if this is the right place to issue this warning.

I've decided to check for duplicates in-line instead of adding another method as it seems `ActiveRecord::Querying` is intentionally slim. I also decided against any clever way of finding duplicate names faster than O(n^2) since the number of columns isn't usually large.
