### PR TITLE
Link to association guide from docs [ci skip]

### DIFF
--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1140,7 +1140,8 @@ module ActiveRecord
       #      belongs_to :dungeon, inverse_of: :evil_wizard
       #    end
       #
-      # For more information, see the documentation for the +:inverse_of+ option.
+      # For more information, see the documentation for the +:inverse_of+ option and the
+      # {Active Record Associations guide}[https://guides.rubyonrails.org/association_basics.html#bi-directional-associations].
       #
       # == Deleting from associations
       #


### PR DESCRIPTION
The documentation for the inverse_of option doesn't provide much more
information than what is already in this section, and it references back
up to this section.

The guide, on the other hand has some more detailed information about
the benefits of inverses.