### PR TITLE
Add `Range#intersection(other)` and `Range#inverted?` methods

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `Range#intersection(other)` and `Range#inverted?` methods
+
+    Given ranges `r1` and `r2`, `r1.intersection(r2)` returns the overlapping range (or `nil` if no overlap)
+
+        (1..5).intersection(2..6) => (2..5)
+
+    Given range `r`, `r.inverted?` is true if `r.begin > r.end` else false
+
+        (5..1).inverted? => true
+
+    *Chris Natali*
+
 *   Improve `File.atomic_write` error handling
 
 *   Fix `Class#descendants` and `DescendantsTracker#descendants` compatibility with Ruby 3.1.

--- a/activesupport/lib/active_support/core_ext/range.rb
+++ b/activesupport/lib/active_support/core_ext/range.rb
@@ -5,3 +5,5 @@ require "active_support/core_ext/range/deprecated_conversions" unless ENV["RAILS
 require "active_support/core_ext/range/compare_range"
 require "active_support/core_ext/range/overlaps"
 require "active_support/core_ext/range/each"
+require "active_support/core_ext/range/inverted"
+require "active_support/core_ext/range/intersection"

--- a/activesupport/lib/active_support/core_ext/range/intersection.rb
+++ b/activesupport/lib/active_support/core_ext/range/intersection.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Range
+  # The maximum sized range covered by both self AND other
+  # Returns nil if there is no overlap between self and other
+  def intersection(other)
+    unless other.is_a?(::Range)
+      raise TypeError, "Can't intersect a range by a(n) #{other.class}"
+    end
+
+    if (inverted_range = [self, other].find { |r| r.inverted? })
+      raise ArgumentError, "Intersection of inverted range (#{inverted_range}) is undefined"
+    end
+
+    if overlaps?(other)
+      new_end = [self.end, other.end].compact.min
+      # Determine the "end-exclusiveness" of the new range
+      # end-exclusive is more constraining than end-inclusive so we choose end-exclusive in case of "tie"
+      exclude_end = [self, other].any? { |r| r.end == new_end && r.exclude_end? }
+
+      new_begin = [self.begin, other.begin].compact.max
+      Range.new(new_begin, new_end, exclude_end)
+    else
+      nil
+    end
+  end
+end

--- a/activesupport/lib/active_support/core_ext/range/inverted.rb
+++ b/activesupport/lib/active_support/core_ext/range/inverted.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Range
+  # An inverted range is one where the beginning is greater than the end
+  def inverted?
+    # Since `nil` implies negative infinity at the beginning and positive infinity at the end
+    # endless ranges are NOT considered inverted
+    return false if [self.begin, self.end].any?(&:nil?)
+
+    # Note we do NOT consider the special case `self.begin == self.end && exclude_end?` as inverted
+    self.end < self.begin
+  end
+end


### PR DESCRIPTION
### Summary

Given ranges `r1` and `r2`, `r1.intersection(r2)` returns the range
that overlaps between `r1` and `r2`.

    (1..5).intersection(2..6) => (2..5)

If there's no overlap, it returns nil.

Given range `r1`, `Range#inverted?` returns `r1.begin > r1.end`.

    (5..1).inverted? = true

If a range is inverted, it cannot be used with `Range#intersection`
(an exception will be raised).
