### PR TITLE
Don't stream redirect controller responses

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Don't stream responses in redirect mode
 
+    Previously, both redirect mode and proxy mode streamed their
+	responses which caused a new thread to be created, and could end
+	up leaking connections in the connection pool. But since redirect
+	mode doesn't actually send any data, it doesn't need to be
+	streamed.
+
+	*Luke Lau*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activestorage/CHANGELOG.md) for previous changes.

--- a/activestorage/app/controllers/active_storage/base_controller.rb
+++ b/activestorage/app/controllers/active_storage/base_controller.rb
@@ -2,7 +2,7 @@
 
 # The base class for all Active Storage controllers.
 class ActiveStorage::BaseController < ActionController::Base
-  include ActiveStorage::SetCurrent, ActiveStorage::Streaming
+  include ActiveStorage::SetCurrent
 
   protect_from_forgery with: :exception
 

--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -8,6 +8,7 @@
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   include ActiveStorage::SetBlob
+  include ActiveStorage::Streaming
 
   def show
     if request.headers["Range"].present?

--- a/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/representations/proxy_controller.rb
@@ -7,6 +7,8 @@
 # require a higher level of protection consider implementing
 # {Authenticated Controllers}[https://guides.rubyonrails.org/active_storage_overview.html#authenticated-controllers].
 class ActiveStorage::Representations::ProxyController < ActiveStorage::Representations::BaseController
+  include ActiveStorage::Streaming
+
   def show
     http_cache_forever public: true do
       send_blob_stream @representation.image, disposition: params[:disposition]


### PR DESCRIPTION
They don't need to be streamed and by including
ActiveStorage::Streaming, they spin up new threads which can cause
problems with connection pools as detailed in #44242

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
