### PR TITLE
Use Psych4.x `unsafe_load` for credentials

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -49,7 +49,8 @@ module ActiveSupport
       end
 
       def deserialize(config)
-        YAML.load(config).presence || {}
+        loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(config) : YAML.load(config)
+        loaded.presence || {}
       end
   end
 end


### PR DESCRIPTION
### Summary

This allows using anchors and aliases in credentials file in
Psych4.x which is the default for Ruby 3.1

Fixes #44209
