### PR TITLE
fix que integration in Active Job tests

### DIFF
--- a/activejob/test/adapters/que.rb
+++ b/activejob/test/adapters/que.rb
@@ -3,4 +3,4 @@
 require "support/que/inline"
 
 ActiveJob::Base.queue_adapter = :que
-Que.mode = :sync
+Que.run_synchronously = true


### PR DESCRIPTION
### Summary

Que.mode was removed in https://github.com/que-rb/que/commit/6783fdd68a1bf6dda135e393dd2dd7f626e30128
and replaced by Que.run_synchronously = true per changelog:
https://github.com/que-rb/que/blob/fa4988ee33444c5a2db379f112000330434abac1/CHANGELOG.md?plain=1#L120

It looks like it started failing because Que 1.0 was released yesterday.