### PR TITLE
Remove AS::LoggerThreadSafeLevel#add patch

### DIFF
--- a/activesupport/lib/active_support/logger_thread_safe_level.rb
+++ b/activesupport/lib/active_support/logger_thread_safe_level.rb
@@ -44,26 +44,5 @@ module ActiveSupport
     ensure
       self.local_level = old_local_level
     end
-
-    # Redefined to check severity against #level, and thus the thread-local level, rather than +@level+.
-    # FIXME: Remove when the minimum Ruby version supports overriding Logger#level.
-    def add(severity, message = nil, progname = nil, &block) # :nodoc:
-      severity ||= UNKNOWN
-      progname ||= @progname
-
-      return true if @logdev.nil? || severity < level
-
-      if message.nil?
-        if block_given?
-          message  = yield
-        else
-          message  = progname
-          progname = @progname
-        end
-      end
-
-      @logdev.write \
-        format_message(format_severity(severity), Time.now, progname, message)
-    end
   end
 end


### PR DESCRIPTION
### Summary

The change in https://github.com/ruby/ruby/commit/eb18cb3e476db3bc44d489e090e1535237c4c6c9 was released with Ruby 2.7.0.rc1 and as Rails now has Ruby 2.7.0 as the minimum version, we should be able to remove this patch.

### Other Information

Follow-up to @georgeclaghorn's PR https://github.com/rails/rails/pull/37195