### PR TITLE
fix que integration in Active Job tests part 2

### DIFF
--- a/activejob/test/support/que/inline.rb
+++ b/activejob/test/support/que/inline.rb
@@ -15,3 +15,9 @@ Que::Job.class_eval do
     run(*args)
   end
 end
+
+Que::ActiveJob::WrapperExtensions.class_eval do
+  def run(args)
+    super(args.deep_stringify_keys)
+  end
+end


### PR DESCRIPTION
### Summary

Fixing the synchronous setting uncovered some more errors with Que 1.0:
exception tests with retry_on started failing due to an assertion in
Que's Active Job integration that running jobs won't nest. However, this
is not the case when running retriable jobs synchronously.

This change overrides Que's Active Job wrapper to not make this
assertion.

### Other Information

I also opened an issue in the que repo: https://github.com/que-rb/que/issues/329