### PR TITLE
Rename serviceName to directUploadToken in AS' DirectUpload

### DIFF
--- a/activestorage/app/assets/javascripts/activestorage.esm.js
+++ b/activestorage/app/assets/javascripts/activestorage.esm.js
@@ -608,11 +608,11 @@ class BlobUpload {
 let id = 0;
 
 class DirectUpload {
-  constructor(file, url, serviceName, attachmentName, delegate) {
+  constructor(file, url, directUploadToken, attachmentName, delegate) {
     this.id = ++id;
     this.file = file;
     this.url = url;
-    this.serviceName = serviceName;
+    this.directUploadToken = directUploadToken;
     this.attachmentName = attachmentName;
     this.delegate = delegate;
   }
@@ -622,7 +622,7 @@ class DirectUpload {
         callback(error);
         return;
       }
-      const blob = new BlobRecord(this.file, checksum, this.url, this.serviceName, this.attachmentName);
+      const blob = new BlobRecord(this.file, checksum, this.url, this.directUploadToken, this.attachmentName);
       notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr);
       blob.create((error => {
         if (error) {

--- a/activestorage/app/assets/javascripts/activestorage.js
+++ b/activestorage/app/assets/javascripts/activestorage.js
@@ -600,11 +600,11 @@
   }
   let id = 0;
   class DirectUpload {
-    constructor(file, url, serviceName, attachmentName, delegate) {
+    constructor(file, url, directUploadToken, attachmentName, delegate) {
       this.id = ++id;
       this.file = file;
       this.url = url;
-      this.serviceName = serviceName;
+      this.directUploadToken = directUploadToken;
       this.attachmentName = attachmentName;
       this.delegate = delegate;
     }
@@ -614,7 +614,7 @@
           callback(error);
           return;
         }
-        const blob = new BlobRecord(this.file, checksum, this.url, this.serviceName, this.attachmentName);
+        const blob = new BlobRecord(this.file, checksum, this.url, this.directUploadToken, this.attachmentName);
         notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr);
         blob.create((error => {
           if (error) {

--- a/activestorage/app/javascript/activestorage/direct_upload.js
+++ b/activestorage/app/javascript/activestorage/direct_upload.js
@@ -5,11 +5,11 @@ import { BlobUpload } from "./blob_upload"
 let id = 0
 
 export class DirectUpload {
-  constructor(file, url, serviceName, attachmentName, delegate) {
+  constructor(file, url, directUploadToken, attachmentName, delegate) {
     this.id = ++id
     this.file = file
     this.url = url
-    this.serviceName = serviceName
+    this.directUploadToken = directUploadToken
     this.attachmentName = attachmentName
     this.delegate = delegate
   }
@@ -21,7 +21,7 @@ export class DirectUpload {
         return
       }
 
-      const blob = new BlobRecord(this.file, checksum, this.url, this.serviceName, this.attachmentName)
+      const blob = new BlobRecord(this.file, checksum, this.url, this.directUploadToken, this.attachmentName)
       notify(this.delegate, "directUploadWillCreateBlobWithXHR", blob.xhr)
 
       blob.create(error => {


### PR DESCRIPTION
### Summary

in ActiveStorage's `DirectUpload` class, one parameter was (presumably) incorrectly named `serviceName`, while the `BlobRecord` class, which it is passed into, refers to it as `directUploadToken`. I think the latter is correct and the first is a bit misleading, since the [Rails Guides](https://edgeguides.rubyonrails.org/active_storage_overview.html#integrating-with-libraries-or-frameworks) refer to it as `token`, too.
