### PR TITLE
Use released version of pg 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,7 @@ platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
   gem "sqlite3", "~> 1.4"
 
   group :db do
-    gem "pg", ">= 1.3.0.rc1"
+    gem "pg", "~> 1.3"
     gem "mysql2", "~> 0.5", github: "brianmario/mysql2"
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     path_expander (1.1.0)
-    pg (1.3.0.rc1)
+    pg (1.3.0)
     propshaft (0.4.4)
       actionpack (>= 7.0.0.alpha2)
       activesupport (>= 7.0.0.alpha2)
@@ -615,7 +615,7 @@ DEPENDENCIES
   minitest-retry
   mysql2 (~> 0.5)!
   nokogiri (>= 1.8.1, != 1.11.0)
-  pg (>= 1.3.0.rc1)
+  pg (~> 1.3)
   propshaft (>= 0.1.7)
   psych (~> 3.0)
   puma


### PR DESCRIPTION
### Summary

pg 1.3.0 which supports Ruby 3.2.0dev has been released.
https://rubygems.org/gems/pg/versions/1.3.0

Follow up #44007

### Other Information

I was wondering if this pull request restores Gemfile as follows and let bundler uses the latest version of pg 1.y to make these versions consistent with https://github.com/rails/rails/blob/e5e035eefd8c38211fddf5d8e4c425dcd0644d18/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L3

```ruby
  group :db do
    gem "pg", "~> 1.1"
  end
```