### PR TITLE
Display invalid value in error

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -657,7 +657,7 @@ module ActiveRecord
     #   => #<ActiveRecord::Associations::CollectionProxy>
     def strict_loading!(value = true, mode: :all)
       unless [:all, :n_plus_one_only].include?(mode)
-        raise ArgumentError, "The :mode option must be one of [:all, :n_plus_one_only]."
+        raise ArgumentError, "The :mode option '#{mode}' must be one of [:all, :n_plus_one_only]."
       end
 
       @strict_loading_mode = mode

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -657,7 +657,7 @@ module ActiveRecord
     #   => #<ActiveRecord::Associations::CollectionProxy>
     def strict_loading!(value = true, mode: :all)
       unless [:all, :n_plus_one_only].include?(mode)
-        raise ArgumentError, "The :mode option '#{mode}' must be one of [:all, :n_plus_one_only]."
+        raise ArgumentError, "The :mode option must be one of [:all, :n_plus_one_only] but #{mode.inspect} was provided."
       end
 
       @strict_loading_mode = mode


### PR DESCRIPTION
### Summary
Upon upgrading a Rails 6.1 to Rails 7 application, we saw errors like:

```
ActionView::Template::Error
The :mode option must be one of [:all, :n_plus_one_only].
```

Showing the invalid value is more informative.