### PR TITLE
Optimize `Object#instance_variable_names`

### DIFF
--- a/activesupport/lib/active_support/core_ext/object/instance_variables.rb
+++ b/activesupport/lib/active_support/core_ext/object/instance_variables.rb
@@ -15,16 +15,24 @@ class Object
     Hash[instance_variables.map { |name| [name[1..-1], instance_variable_get(name)] }]
   end
 
-  # Returns an array of instance variable names as strings including "@".
-  #
-  #   class C
-  #     def initialize(x, y)
-  #       @x, @y = x, y
-  #     end
-  #   end
-  #
-  #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
-  def instance_variable_names
-    instance_variables.map(&:to_s)
+  if Symbol.method_defined?(:name) # RUBY_VERSION >= "3.0"
+    # Returns an array of instance variable names as strings including "@".
+    #
+    #   class C
+    #     def initialize(x, y)
+    #       @x, @y = x, y
+    #     end
+    #   end
+    #
+    #   C.new(0, 1).instance_variable_names # => ["@y", "@x"]
+    def instance_variable_names
+      instance_variables.map(&:name)
+    end
+  else
+    def instance_variable_names
+      variables = instance_variables
+      variables.map! { |s| s.to_s.freeze }
+      variables
+    end
   end
 end


### PR DESCRIPTION
Reviewing https://github.com/rails/rails/pull/44213 prompted me to look at the performance of `as_json`. `Object#instance_variable_names` can use some simple optimizations.

First we use `map!` to avoid allocating a second `Array`.

Then if possible we use `Symbol#name` (Ruby 3.0+) to avoid allocating one `String` per variable.

```ruby
require 'benchmark/ips'

puts RUBY_VERSION

class Object
  def instance_variable_names
    instance_variables.map(&:to_s)
  end

  if Symbol.method_defined?(:name)
    puts "Symbol#name available"
    def instance_variable_names_opt
      variables = instance_variables
      variables.map!(&:name)
      variables
    end
  else
    puts "Symbol#name NOT available"
    def instance_variable_names_opt
      variables = instance_variables
      variables.map! { |s| s.to_s.freeze }
      variables
    end
  end
end

EMPTY = Object.new

SMALL = Object.new
2.times { |i| SMALL.instance_variable_set(:"@v#{i}", i) }

LARGE = Object.new
15.times { |i| LARGE.instance_variable_set(:"@v#{i}", i) }

{'EMPTY' => EMPTY, 'SMALL' => SMALL, 'LARGE' => LARGE}.each do |size, object|
  puts "=== #{size} ==="
  Benchmark.ips do |x|
    x.report('original') { object.instance_variable_names }
    x.report('patched') { object.instance_variable_names_opt }
    x.compare!
  end
end
```

```
2.7.4
Symbol#name NOT available
=== EMPTY ===
Warming up --------------------------------------
            original   724.324k i/100ms
             patched   848.630k i/100ms
Calculating -------------------------------------
            original      7.327M (± 1.2%) i/s -     36.941M in   5.042732s
             patched      8.506M (± 0.9%) i/s -     43.280M in   5.088726s

Comparison:
             patched:  8505865.6 i/s
            original:  7326561.6 i/s - 1.16x  (± 0.00) slower

=== SMALL ===
Warming up --------------------------------------
            original   203.493k i/100ms
             patched   191.396k i/100ms
Calculating -------------------------------------
            original      2.060M (± 1.1%) i/s -     10.378M in   5.038283s
             patched      1.926M (± 0.9%) i/s -      9.761M in   5.069539s

Comparison:
            original:  2060092.1 i/s
             patched:  1925628.2 i/s - 1.07x  (± 0.00) slower

=== LARGE ===
Warming up --------------------------------------
            original    49.485k i/100ms
             patched    41.184k i/100ms
Calculating -------------------------------------
            original    495.882k (± 1.5%) i/s -      2.524M in   5.090599s
             patched    411.758k (± 0.9%) i/s -      2.059M in   5.001395s

Comparison:
            original:   495882.3 i/s
             patched:   411758.0 i/s - 1.20x  (± 0.00) slower
```

```
3.1.0
Symbol#name available
=== EMPTY ===
Warming up --------------------------------------
            original   615.493k i/100ms
             patched   708.028k i/100ms
Calculating -------------------------------------
            original      6.146M (± 1.1%) i/s -     30.775M in   5.007957s
             patched      7.086M (± 1.0%) i/s -     36.109M in   5.096263s

Comparison:
             patched:  7086187.0 i/s
            original:  6145919.7 i/s - 1.15x  (± 0.00) slower

=== SMALL ===
Warming up --------------------------------------
            original   261.532k i/100ms
             patched   345.988k i/100ms
Calculating -------------------------------------
            original      2.607M (± 1.1%) i/s -     13.077M in   5.017455s
             patched      3.504M (± 0.7%) i/s -     17.645M in   5.036049s

Comparison:
             patched:  3503979.3 i/s
            original:  2606558.7 i/s - 1.34x  (± 0.00) slower

=== LARGE ===
Warming up --------------------------------------
            original    58.156k i/100ms
             patched    87.136k i/100ms
Calculating -------------------------------------
            original    581.008k (± 0.8%) i/s -      2.908M in   5.005101s
             patched    873.801k (± 1.0%) i/s -      4.444M in   5.086316s

Comparison:
             patched:   873801.4 i/s
            original:   581008.4 i/s - 1.50x  (± 0.00) slower
```
