### PR TITLE
Stringify keys of `other` hash when performing a merge

### DIFF
--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -176,9 +176,14 @@ module ActionDispatch
       #   session.to_hash
       #   # => {"session_id"=>"e29b9ea315edf98aad94cc78c34cc9b2", "foo" => "bar"}
       def update(hash)
+        unless hash.respond_to?(:to_hash)
+          raise TypeError, "no implicit conversion of #{hash.class.name} into Hash"
+        end
+
         load_for_write!
-        @delegate.update hash.stringify_keys
+        @delegate.update hash.to_hash.stringify_keys
       end
+      alias :merge! :update
 
       # Deletes given key from the session.
       def delete(key)
@@ -230,11 +235,6 @@ module ActionDispatch
       def empty?
         load_for_read!
         @delegate.empty?
-      end
-
-      def merge!(other)
-        load_for_write!
-        @delegate.merge!(other)
       end
 
       def each(&block)

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -48,6 +48,17 @@ module ActionDispatch
         assert_equal session.to_hash, session1.to_hash
       end
 
+      def test_update_raises_an_exception_if_arg_not_hashable
+        env = {}
+        as = MemoryStore.new app
+        as.call(env)
+        session = Request::Session.find ActionDispatch::Request.new env
+
+        assert_raise TypeError do
+          session.update("Not hashable")
+        end
+      end
+
       private
         def app(&block)
           @env = nil

--- a/actionpack/test/dispatch/session/test_session_test.rb
+++ b/actionpack/test/dispatch/session/test_session_test.rb
@@ -74,4 +74,10 @@ class ActionController::TestSessionTest < ActiveSupport::TestCase
     assert_instance_of String, session.id.public_id
     assert_equal(session.id.public_id, session["session_id"])
   end
+
+  def test_merge!
+    session = ActionController::TestSession.new
+    session.merge!({ key: "value" })
+    assert_equal("value", session["key"])
+  end
 end


### PR DESCRIPTION
### Summary

We’re given a couple of methods to modify the `ActionDispatch::Request::Session` object. All work as expected except `merge!`:

```ruby
session.to_hash
#=> {"session_id"=>"abc123"}
session.update({ foo: "bar" })
#=> {"session_id"=>"abc123", "foo" => "bar"}
session[:foo]
#=> "bar"
session[:bar] = "baz"
#=> {"session_id"=>"abc123", "foo" => "bar", "bar" => "baz"}
session[:bar]
#=> "baz"
session.merge!({ fizz: "buzz" })
#=> {"session_id"=>"abc123", "foo" => "bar", "bar" => "baz", fizz: "buzz"}
session[:fizz]
#=> nil
```

While `[]=` and `update` stringify the key before updating the “hash”, `merge!` does not. The session is properly loaded with stringified keys on the next request but within the request that the session is updated attempting to access by key will fail.

I ran into an issue when trying to write a failing test for this because the tests use `ActionController::TestSession` not `ActionDispatch::Request::Session`.  When you call `merge!` on this type of session it uses code in `rack/lib/rack/session/abstract/id.rb` which is already stringifying the keys. EDIT: And it turns out I'm an idiot and was running the wrong test 🤦‍♂️ 

Basically, this PR just mimics the same behavior as rack by stringifying the keys of the `other` hash passed into `merge!`
