### PR TITLE
Fix invalid durations with ActiveJob deserialization

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix deserialization of ActiveSupport::Duration
+
+    Previously, a deserialized Duration would return an array from Duration#parts.
+    It will now return a hash just like a regular Duration.
+
+    This also fixes an error when trying to add or subtract from a deserialized Duration
+    (eg `duration + 1.year`).
+
+    *Jonathan del Strother*
+
 *   `perform_enqueued_jobs` is now compatible with all Active Job adapters
 
     This means that methods that depend on it, like Action Mailer's `assert_emails`,

--- a/activejob/lib/active_job/serializers/duration_serializer.rb
+++ b/activejob/lib/active_job/serializers/duration_serializer.rb
@@ -4,14 +4,16 @@ module ActiveJob
   module Serializers
     class DurationSerializer < ObjectSerializer # :nodoc:
       def serialize(duration)
+        # Ideally duration.parts would be wrapped in an array before passing to Arguments.serialize,
+        # but we continue passing the bare hash for backwards compatibility:
         super("value" => duration.value, "parts" => Arguments.serialize(duration.parts))
       end
 
       def deserialize(hash)
         value = hash["value"]
         parts = Arguments.deserialize(hash["parts"])
-
-        klass.new(value, parts)
+        # `parts` is originally a hash, but will have been flattened to an array by Arguments.serialize
+        klass.new(value, parts.to_h)
       end
 
       private

--- a/activejob/test/cases/argument_serialization_test.rb
+++ b/activejob/test/cases/argument_serialization_test.rb
@@ -5,6 +5,8 @@ require "helper"
 require "active_job/arguments"
 require "models/person"
 require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/integer/time"
+require "active_support/duration"
 require "jobs/kwargs_job"
 require "jobs/arguments_round_trip_job"
 require "support/stubs/strong_parameters"
@@ -186,6 +188,12 @@ class ArgumentSerializationTest < ActiveSupport::TestCase
       assert_instance_of ActiveSupport::TimeWithZone, perform_round_trip([time_with_zone]).first
       assert_arguments_unchanged time_with_zone
     end
+  end
+
+  test "should maintain a functional duration" do
+    duration = perform_round_trip([1.year]).first
+    assert_kind_of Hash, duration.parts
+    assert_equal 2.years, duration + 1.year
   end
 
   test "should disallow non-string/symbol hash keys" do


### PR DESCRIPTION
### Summary

Durations that were round-tripped through ActiveJob::Arguments.serialize
would appear fine at a first glance, but trying to perform
duration-math on them would fail:

```
irb(main):001:0> d = ActiveJob::Arguments.deserialize(ActiveJob::Arguments.serialize([1.year]))[0]
=> 1 year
irb(main):002:0> d + 1.day
activesupport-6.1.4.4/lib/active_support/duration.rb:242:in `+': undefined method `merge' for [[:years, 1]]:Array (NoMethodError)
```

In [DurationSerializer](https://github.com/rails/rails/blob/bd41655d17ff85c3118a4c69d19bad47b6a2890f/activejob/lib/active_job/serializers/duration_serializer.rb#L7), `Arguments.serialize(duration.parts)` is silently converting the parts hash to an array (due to [arguments.map](https://github.com/rails/rails/blob/bd41655d17ff85c3118a4c69d19bad47b6a2890f/activejob/lib/active_job/arguments.rb#L34)).

I've fixed this in DurationSerializer ~and also added a raise in Arguments.serialize if the provided `arguments` aren't an array, since that seems like it would always be user-error~