### PR TITLE
Prefer I18n over i18n when referencing internationalization

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -9,7 +9,7 @@ The process of "internationalization" usually means to abstract all strings and 
 
 So, in the process of _internationalizing_ your Rails application you have to:
 
-* Ensure you have support for i18n.
+* Ensure you have support for I18n.
 * Tell Rails where to find locale dictionaries.
 * Tell Rails how to set, preserve, and switch locales.
 
@@ -48,7 +48,7 @@ To localize store and update _content_ in your application (e.g. translate blog 
 
 Thus, the Ruby I18n gem is split into two parts:
 
-* The public API of the i18n framework - a Ruby module with public methods that define how the library works
+* The public API of the I18n framework - a Ruby module with public methods that define how the library works
 * A default backend (which is intentionally named _Simple_ backend) that implements these methods
 
 As a user you should always only access the public methods on the I18n module, but it is useful to know about the capabilities of the backend.
@@ -135,7 +135,7 @@ I18n.available_locales = [:en, :pt]
 I18n.default_locale = :pt
 ```
 
-Note that appending directly to `I18n.load_path` instead of to the application's configured i18n will _not_ override translations from external gems.
+Note that appending directly to `I18n.load_path` instead of to the application's configured I18n will _not_ override translations from external gems.
 
 ### Managing the Locale across Requests
 


### PR DESCRIPTION
### Summary

The `I18n` guide currently has varied usages of `i18n` and `I18n` throughout the documentation when referring to "Internationalization", the noun. This PR attempts to unify the references by **preferring the capitalized version in all contexts other than code, links, and the library itself**.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

I hold the opinion that when referencing the `I18n` as the acronym for the noun, the "I" should be capitalized. I'm open to being convinced otherwise, but in any case, I believe usages should be consistent.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
