### PR TITLE
Remove bootsnap require false

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Gemfile.tt
@@ -20,7 +20,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 <% if depend_on_bootsnap? -%>
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "bootsnap", require: false
+gem "bootsnap"
 <% end -%>
 <% unless skip_sprockets? || options.minimal? -%>
 


### PR DESCRIPTION
### Summary

This isn't needed since requiring bootsnap doesn't actually make it do the caching work. That happens with `require "bootsnap/setup"` which gets called in `config/boot.rb`.