### PR TITLE
Address ActionView::Template::Error at CI

### DIFF
--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -125,6 +125,10 @@ module ActionView
   end
 
   class HelperInclusionTest < ActionView::TestCase
+    def teardown
+      ActionController::Base.view_paths.map(&:clear_cache)
+    end
+
     module RenderHelper
       def render_from_helper
         render partial: "customer", collection: @customers


### PR DESCRIPTION
### Summary

This commit addresses the following CI error.
https://buildkite.com/rails/rails/builds/84207#3bc8eb7f-c86d-4f6f-8932-e2e8c26cf893

There were similar pull requests #36189 #39949

```ruby
$ bin/test test/template/test_case_test.rb test/template/render_test.rb -n "/^(?:ActionView::HelperInclusionTest#(?:test_helper_class_that_is_being_tested_is_always_included_in_view_instance)|FrozenStringLiteralEnabledViewRenderTest#(?:test_render_partial_collection_for_non_array))$/" --seed 41598
Run options: -n "/^(?:ActionView::HelperInclusionTest#(?:test_helper_class_that_is_being_tested_is_always_included_in_view_instance)|FrozenStringLiteralEnabledViewRenderTest#(?:test_render_partial_collection_for_non_array))$/" --seed 41598

.E

Error:
FrozenStringLiteralEnabledViewRenderTest#test_render_partial_collection_for_non_array:
ActionView::Template::Error: undefined method `__home_yahonda_src_github_com_rails_rails_actionview_test_fixtures_test__customer_erb__1256308179417979847_7880' for #<ActionView::Base:0x00000000003de0>
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:244:in `public_send'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:244:in `_run'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:157:in `block in render'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:208:in `instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:361:in `instrument_render_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/template.rb:155:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:189:in `block in collection_with_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:70:in `block in each_with_info'
    /home/yahonda/src/github.com/rails/rails/actionview/test/template/render_test.rb:385:in `yield'
    /home/yahonda/src/github.com/rails/rails/actionview/test/template/render_test.rb:385:in `block in test_render_partial_collection_for_non_array'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:70:in `each'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:70:in `each'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:70:in `each_with_info'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:180:in `each'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:180:in `map'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:180:in `collection_with_template'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:162:in `block (2 levels) in render_collection'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/partial_renderer/collection_caching.rb:21:in `cache_collection_render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:161:in `block in render_collection'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:206:in `block in instrument'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    /home/yahonda/src/github.com/rails/rails/activesupport/lib/active_support/notifications.rb:206:in `instrument'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:147:in `render_collection'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/collection_renderer.rb:119:in `render_collection_with_partial'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:72:in `render_partial_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:27:in `render_to_object'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/renderer/renderer.rb:22:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/helpers/rendering_helper.rb:38:in `block in render'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/base.rb:270:in `in_rendering_context'
    /home/yahonda/src/github.com/rails/rails/actionview/lib/action_view/helpers/rendering_helper.rb:34:in `render'
    /home/yahonda/src/github.com/rails/rails/actionview/test/template/render_test.rb:388:in `test_render_partial_collection_for_non_array'

bin/test test/template/render_test.rb:383

Finished in 0.047002s, 42.5514 runs/s, 63.8271 assertions/s.
2 runs, 3 assertions, 0 failures, 1 errors, 0 skips
$
```
