### PR TITLE
[ci skip] Add Mobility Action Text to the guides

### DIFF
--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -242,4 +242,8 @@ Message.all.with_rich_text_content_and_embeds # Preload both body and attachment
     <action-text-attachment sgid="BAh7CEkiCG…"></action-text-attachment>
     ```
 
+## Internationalization (I18n)
+
+Action Text rich text can be translated using [Mobility Action Text](https://github.com/sedubois/mobility-actiontext).
+
 This is based on Basecamp, so if you still can't find what you are looking for, check this [Basecamp Doc](https://github.com/basecamp/bc3-api/blob/master/sections/rich_text.md).

--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -1190,6 +1190,7 @@ The I18n API described in this guide is primarily intended for translating inter
 Several gems can help with this:
 
 * [Mobility](https://github.com/shioyama/mobility): Provides support for storing translations in many formats, including translation tables, json columns (PostgreSQL), etc.
+* [Mobility Action Text](https://github.com/sedubois/mobility-actiontext): Translate Action Text rich text with Mobility.
 * [Traco](https://github.com/barsoom/traco): Translatable columns stored in the model table itself
 
 Conclusion


### PR DESCRIPTION
Adds the [Mobility Action Text](https://github.com/sedubois/mobility-actiontext) gem to the i18n and Action Text guides, in case it could be useful to others (NB: I am the gem's author).