### PR TITLE
[ci skip] Add Action Text guide to the navigation

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -135,7 +135,6 @@
       description: This guide describes how to use Action Mailbox to receive emails.
     -
       name: Action Text Overview
-      work_in_progress: true
       url: action_text_overview.html
       description: This guide describes how to use Action Text to handle rich text content.
     -


### PR DESCRIPTION
The Action Text guide is not visible in the guides navigation menu [because it has a `work_in_progress` flag](https://github.com/rails/rails/issues/42793), however the guide appears useful and complete enough to me to be included.