### PR TITLE
abandon_results! after every multi statement batch

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -100,8 +100,8 @@ module ActiveRecord
             statements = statements.map { |sql| transform_query(sql) }
             combine_multi_statements(statements).each do |statement|
               raw_execute(statement, name)
+              @connection.abandon_results!
             end
-            @connection.abandon_results!
           end
 
           def default_insert_value(column)


### PR DESCRIPTION
### Summary

Fix `Mysql2::Error: Commands out of sync; you can't run this command now` when bulk-inserting fixtures that exceed `max_allowed_packet` configuration.

### Other Information

This issue doesn't seem to have been encountered because it's unusual for an average Rails app to have that many fixtures to exceed `max_allowed_packet` configuration, which is `4MB` by default.

Increasing `max_allowed_packet` fixes the problem as well but it's not a proper fix, we just making fixtures to fit into a single batch by increasing the value

However when you exceed the limit, Rails makes batches out of statements and querying (executing) the second batch is causing `mysql2` gem to raise an exception because we run into situation described here:
https://github.com/brianmario/mysql2/blob/8193dc412c6a266045b9d13a9da36c16750939a4/ext/mysql2/statement.c#L419-L424
```c
  // From stmt_execute to mysql_stmt_result_metadata to stmt_store_result, no
  // Ruby API calls are allowed so that GC is not invoked. If the connection is
  // in results-streaming-mode for Statement A, and in the middle Statement B
  // gets garbage collected, a message will be sent to the server notifying it
  // to release Statement B, resulting in the following error:
  //   Commands out of sync; you can't run this command now
``` 

There is also a test that describes correct usage for our scenario:
https://github.dev/brianmario/mysql2/blob/8193dc412c6a266045b9d13a9da36c16750939a4/spec/mysql2/client_spec.rb#L800

I'm not adding any test since it seems excessive to perform an integration test for the default `max_allowed_packet` value. And I can't seem to be able to safely change this value per-connection. 
Let me know if you think it would be reasonable to at least have a unit-test with an assertion that we call N times where N is a number of batches. Thanks!

Script to reproduce:

For testing purposes I was using `2M` max packet size
```sql
MariaDB [(none)]> show variables like 'max_allowed_packet';
+--------------------+---------+
| Variable_name      | Value   |
+--------------------+---------+
| max_allowed_packet | 2097152 |
```

On main branch the test is going to fail with `ActiveRecord::ConnectionNotEstablished: MySQL client is not connected` most likely when we try to close the transaction but it's caused by the  `Commands out of sync` error. 

```ruby
require "bundler/inline"
require "debug"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"

  # fix:
  #gem "rails", github: "nvasilevski/rails", branch: "abandon-results-on-every-batch"
  
  # local playground:
  # gem "rails", path: "./"
  gem "mysql2"
end

require "active_record"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "mysql2", database: "demo", username: "dev", host: "localhost", password: "", port: 3306)

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :content
  end
end

class Post < ActiveRecord::Base
end

class BugTest < Minitest::Test
  def test_association_stuff
    conn = ActiveRecord::Base.connection
    raw_conn = conn.raw_connection
    statement = "insert into posts (content) values ('content')"
    max_packet = conn.send :max_allowed_packet
    statements_number_to_overflow = (max_packet / statement.bytesize) + 1
    statements = Array.new(statements_number_to_overflow) { "#{statement}" };
    conn = ActiveRecord::Base.connection
    conn.send(:with_multi_statements) do
      conn.transaction(requires_new: true) do
        conn.send :execute_batch, statements, "Fixtures Load"
      end
    end

    assert_equal statements_number_to_overflow, Post.count
  end
end
```
