### PR TITLE
`form_with`: close tag when block omitted

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Include closing `</form>` tag when calling `form_with` without a block:
+
+    ```ruby
+    form_with url: "https://example.com"
+    # => <form action="https://example.com" method="post"><!-- Rails-generated hidden fields -->
+
+    config.action_view.close_form_with_without_block = true
+
+    form_with url: "https://example.com"
+    # => <form action="https://example.com" method="post"><!-- Rails-generated hidden fields --></form>
+    ```
+
+    *Sean Doyle*
+
 *   Extract `current_page?`, `button_to`, and `link_to` methods to
     `ActionView::Helpers::NavigationHelper`
 

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -118,6 +118,10 @@ module ActionView
       include ModelNaming
       include RecordIdentifier
 
+      # Controls whether or not calls to +form_with+ without a block will render without a closing tag. Defaults to +false+
+      mattr_accessor :close_form_with_without_block
+      self.close_form_with_without_block = false
+
       attr_internal :default_form_builder
 
       # Creates a form that allows the user to create or update the attributes
@@ -775,6 +779,9 @@ module ActionView
           output  = capture(builder, &block)
           options[:multipart] ||= builder.multipart?
 
+          html_options = html_options_for_form_with(url, model, **options)
+          form_tag_with_body(html_options, output)
+        elsif close_form_with_without_block
           html_options = html_options_for_form_with(url, model, **options)
           form_tag_with_body(html_options, output)
         else

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -14,6 +14,7 @@ module ActionView
     config.action_view.image_decoding = nil
     config.action_view.apply_stylesheet_media_default = true
     config.action_view.prepend_content_exfiltration_prevention = false
+    config.action_view.close_form_with_without_block = false
 
     config.eager_load_namespaces << ActionView
 
@@ -22,6 +23,9 @@ module ActionView
     config.after_initialize do |app|
       ActionView::Helpers::FormTagHelper.embed_authenticity_token_in_remote_forms =
         app.config.action_view.delete(:embed_authenticity_token_in_remote_forms)
+
+      ActionView::Helpers::FormHelper.close_form_with_without_block =
+        app.config.action_view.delete(:close_form_with_without_block)
     end
 
     config.after_initialize do |app|

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -2,6 +2,7 @@
 
 require "abstract_unit"
 require "controller/fake_models"
+require "active_support/core_ext/object/with"
 
 class FormWithTest < ActionView::TestCase
   include RenderERBUtils
@@ -160,6 +161,22 @@ class FormWithActsLikeFormTagTest < FormWithTest
 
     expected = whole_form { "Hello world!" }
     assert_dom_equal expected, @rendered
+  end
+
+  def test_form_with_rendered_without_block_close_form_tag_when_configured_to
+    ActionView::Helpers::FormHelper.with close_form_with_without_block: true do
+      output_buffer = render_erb("<%= form_with(url: false) %>")
+
+      assert_match %r|</form>\Z|, output_buffer, "includes closing </form> tag"
+    end
+  end
+
+  def test_form_with_rendered_without_block_does_not_close_form_tag_when_configured_not_to
+    ActionView::Helpers::FormHelper.with close_form_with_without_block: false do
+      output_buffer = render_erb("<%= form_with(url: false) %>")
+
+      assert_no_match %r|</form>\Z|, output_buffer, "excludes closing </form> tag"
+    end
   end
 
   def test_form_with_with_block_and_method_in_erb

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,6 +65,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.action_controller.rescue_from_event_backtrace`](#config-action-controller-rescue-from-event-backtrace): `:array`
 - [`config.action_dispatch.default_headers`](#config-action-dispatch-default-headers): `{ "X-Frame-Options" => "SAMEORIGIN", "X-Content-Type-Options" => "nosniff", "X-Permitted-Cross-Domain-Policies" => "none", "Referrer-Policy" => "strict-origin-when-cross-origin" }`
 - [`config.action_dispatch.strict_accept_header`](#config-action-dispatch-strict-accept-header): `true`
+- [`config.action_view.close_form_with_without_block`](#config-action-view-close-form-with-without-block): `true`
 - [`config.active_job.enqueue_after_transaction_commit`](#config-active-job-enqueue-after-transaction-commit): `true`
 - [`config.active_record.postgresql_adapter_decode_bytea`](#config-active-record-postgresql-adapter-decode-bytea): `true`
 - [`config.active_record.postgresql_adapter_decode_money`](#config-active-record-postgresql-adapter-decode-money): `true`
@@ -2762,6 +2763,30 @@ The default value depends on the `config.load_defaults` target version:
 | --------------------- | -------------------- |
 | (original)            | `true`               |
 | 7.0                   | `false`              |
+
+#### `config.action_view.close_form_with_without_block`
+
+Controls whether or not calls to `form_with` without a block will render without a closing tag.
+
+When set to `false`, calls without a block will render `<form>` elements as open tags:
+
+```ruby
+form_with url: "https://example.com"
+# => <form action="https://example.com" method="post"><!-- Rails-generated hidden fields -->
+```
+
+When set to `true`, calls without a block will render `<form>` elements with closing tags:
+
+```ruby
+form_with url: "https://example.com"
+# => <form action="https://example.com" method="post"><!-- Rails-generated hidden fields --></form>
+```
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `false`              |
+| 8.2                   | `true`               |
+
 
 #### `config.action_view.prepend_content_exfiltration_prevention`
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -363,6 +363,7 @@ module Rails
           end
 
           if respond_to?(:action_view)
+            action_view.close_form_with_without_block = true
             action_view.render_tracker = :ruby
             action_view.remove_hidden_field_autocomplete = true
           end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_8_2.rb.tt
@@ -108,3 +108,8 @@
 # `Accept: application/json, */*` now returns JSON.
 #++
 # Rails.application.config.action_dispatch.strict_accept_header = true
+
+###
+# Controls whether or not to close the <form> element rendered by a call to form_with without a block
+#++
+# Rails.application.config.action_view.close_form_with_without_block = true


### PR DESCRIPTION
### Motivation / Background

Related to https://github.com/rails/rails/issues/34282
Related to https://github.com/rails/rails/pull/34285

`form_with`: close tag when block omitted
===

Prior to this change, calling `form_with` without passing a block
generates a `<form>` element without a closing `</form>` tag.

The [form_for][] version of building a `<form>` element requires a block
to execute, so omitting the closing `</form>` element isn't a
possibility.

A current work-around to achieve the desired behavior is to call
`form_with` call an empty block:

```erb
<%= form_with url: "https://example.com" do %>
<% end %>
```

Unfortunately, being unaware of this issue will likely yield HTML that
is silently invalid, which can cause surprising nesting and behavior,
such as elements declared after the `<form>` becoming descendants
instead of siblings.

### Detail

Introduce the `config.action_view.closes_form_with_without_block`
configuration value.

By default (in versions prior to 8.2), that value is `false` and
preserves backwards compatibility. When set to `true`, calls to
`form_with` without a block will result in elements that close
themselves.

[form_for]: https://github.com/rails/rails/blob/efae65d005ee298207d720fb4f61c28a38973e8e/actionview/test/template/form_helper_test.rb#L1555-L1560

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.