### PR TITLE
fix Que integration tests for Active Job

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,7 +403,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
-    que (0.14.3)
+    que (1.0.0)
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.3)


### PR DESCRIPTION
### Summary

Replace Que.* settings that were removed in Que 1.0 with options passed
to Que::Locker. The Locker class creates its own thread for managing
work distribution, so the Thread created in the QueJobsManager was also
removed.
