### PR TITLE
Support reading `FormBuilder#id` from `id:` option

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Read `FormBuilder#id` from `form_with id: "..."` when `form_with html: { id: "..." }` is absent.
 
+    *Sean Doyle*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -469,7 +469,7 @@ module ActionView
         options[:html] ||= {}
         options[:html].reverse_merge!(
           class:  as ? "#{action}_#{as}" : dom_class(object, action),
-          id:     (as ? [namespace, action, as] : [namespace, dom_id(object, action)]).compact.join("_").presence,
+          id:     options.fetch(:id) { (as ? [namespace, action, as] : [namespace, dom_id(object, action)]).compact.join("_").presence },
         )
       end
       private :apply_form_for_options!
@@ -1734,7 +1734,7 @@ module ActionView
       # <tt><button></tt> element should be treated as the <tt><form></tt>
       # element's submit button, regardless of where it exists in the DOM.
       def id
-        options.dig(:html, :id)
+        options.dig(:html, :id) || options[:id]
       end
 
       # Generate an HTML <tt>id</tt> attribute value for the given field

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -477,6 +477,42 @@ class FormWithActsLikeFormForTest < FormWithTest
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_with_with_id_option
+    form_with(model: Post.new, id: "new_special_post") do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_with_id_option_nested_in_html
+    form_with(model: Post.new, html: { id: "new_special_post" }) do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_with_competing_id_option_nested_in_html
+    form_with(model: Post.new, id: "ignored", html: { id: "new_special_post" }) do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_with_attribute_not_on_model
     form_with(model: @post) do |f|
       concat f.text_field :this_dont_exist_on_post

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1644,6 +1644,42 @@ class FormHelperTest < ActionView::TestCase
     assert_dom_equal expected, output_buffer
   end
 
+  def test_form_for_with_id_option
+    form_for(Post.new, id: "new_special_post") do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post", "new_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_id_option_nested_in_html
+    form_for(Post.new, html: { id: "new_special_post" }) do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post", "new_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_competing_id_option_nested_in_html
+    form_for(Post.new, id: "ignored", html: { id: "new_special_post" }) do |form|
+      concat form.button(form: form.id)
+    end
+
+    expected = whole_form("/posts", "new_special_post", "new_post") do
+      '<button name="button" type="submit" form="new_special_post">Create Post</button>'
+    end
+
+    assert_dom_equal expected, output_buffer
+  end
+
   def test_form_for_false_url
     form_for(Post.new, url: false) do |form|
     end


### PR DESCRIPTION
### Summary


When `FormBuilder#id` was introduced in [59ca21c][], it only read the
value passed in as `html: { id: "..." }` and ignored any top-level `id:`
options.

In spite of that fact, since the `<form>` element's is rendered separate
from the builder's block argument, the element still consistently
rendered with an `[id]` attribute. That value is read from the nested
`html: { id: "..." }` option and falling back to any provided `id:
"..."` option.

This commit adds test suite coverage to retain the previous behavior,
along with new tests to support reading `FormBuilder#id` from the `id:`
option.

[59ca21c]: https://github.com/rails/rails/commit/59ca21c0119fff803e75e78d800c0c98aee7fd4c