### PR TITLE
Fixes active storage changelog entry(#44244) formatting [ci skip]

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,11 +1,11 @@
 *   Don't stream responses in redirect mode
 
     Previously, both redirect mode and proxy mode streamed their
-	responses which caused a new thread to be created, and could end
-	up leaking connections in the connection pool. But since redirect
-	mode doesn't actually send any data, it doesn't need to be
-	streamed.
+    responses which caused a new thread to be created, and could end
+    up leaking connections in the connection pool. But since redirect
+    mode doesn't actually send any data, it doesn't need to be
+    streamed.
 
-	*Luke Lau*
+    *Luke Lau*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activestorage/CHANGELOG.md) for previous changes.


### PR DESCRIPTION
While reading the changes in the PR found the formatting was a bit off. The changelog formatting followed in the project is a bit different. Just fixed the formatting in PR. 😊 

Maybe a cosmetic change.