### PR TITLE
Allow CSRF tokens to be stored outside of session.

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add the ability to use custom logic for storing and retrieving CSRF tokens.
+
+    By default, the token will be stored in the session.  Custom classes can be
+    defined to specify arbitrary behaviour, but the ability to store them in
+    encrypted cookies is built in.
+
+    *Andrew Kowpak*
+
 *   Make ActionController::Parameters#values cast nested hashes into parameters.
 
     *Gannon McGibbon*

--- a/actionpack/lib/action_controller/test_case.rb
+++ b/actionpack/lib/action_controller/test_case.rb
@@ -182,11 +182,12 @@ module ActionController
   class TestSession < Rack::Session::Abstract::PersistedSecure::SecureSessionHash # :nodoc:
     DEFAULT_OPTIONS = Rack::Session::Abstract::Persisted::DEFAULT_OPTIONS
 
-    def initialize(session = {})
+    def initialize(session = {}, id = Rack::Session::SessionId.new(SecureRandom.hex(16)))
       super(nil, nil)
-      @id = Rack::Session::SessionId.new(SecureRandom.hex(16))
+      @id = id
       @data = stringify_keys(session)
       @loaded = true
+      @initially_empty = @data.empty?
     end
 
     def exists?
@@ -216,6 +217,10 @@ module ActionController
 
     def enabled?
       true
+    end
+
+    def id_was
+      @id
     end
 
     private

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -358,6 +358,7 @@ module ActionDispatch
 
     def reset_session
       session.destroy
+      controller_instance.reset_csrf_token(self) if controller_instance.respond_to?(:reset_csrf_token)
     end
 
     def session=(session) # :nodoc:
@@ -427,6 +428,10 @@ module ActionDispatch
 
     def inspect # :nodoc:
       "#<#{self.class.name} #{method} #{original_url.dump} for #{remote_ip}>"
+    end
+
+    def commit_csrf_token
+      controller_instance.commit_csrf_token(self) if controller_instance.respond_to?(:commit_csrf_token)
     end
 
     private

--- a/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb
@@ -67,6 +67,11 @@ module ActionDispatch
     end
 
     module SessionObject # :nodoc:
+      def commit_session(req, res)
+        req.commit_csrf_token
+        super(req, res)
+      end
+
       def prepare_session(req)
         Request::Session.create(self, req, @default_options)
       end

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -78,6 +78,8 @@ module ActionDispatch
         @loaded   = false
         @exists   = nil # We haven't checked yet.
         @enabled  = enabled
+        @id_was = nil
+        @id_was_initialized = false
       end
 
       def id
@@ -241,6 +243,11 @@ module ActionDispatch
         to_hash.each(&block)
       end
 
+      def id_was
+        load_for_read!
+        @id_was
+      end
+
       private
         def load_for_read!
           load! if !loaded? && exists?
@@ -260,10 +267,13 @@ module ActionDispatch
 
         def load!
           if enabled?
+            @id_was_initialized = true unless exists?
             id, session = @by.load_session @req
             options[:id] = id
             @delegate.replace(session.stringify_keys)
+            @id_was = id unless @id_was_initialized
           end
+          @id_was_initialized = true
           @loaded = true
         end
     end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -195,6 +195,50 @@ class SkipProtectionWhenUnprotectedController < ActionController::Base
   skip_forgery_protection
 end
 
+class CookieCsrfTokenStorageStrategyController < ActionController::Base
+  include RequestForgeryProtectionActions
+
+  after_action :commit_token, only: :cookie
+
+  protect_from_forgery only: %w(index meta same_origin_js negotiate_same_origin), with: :exception, store: :cookie
+
+  def reset
+    reset_csrf_token(request)
+    head :ok
+  end
+
+  def cookie
+    render inline: "<%= csrf_meta_tags %>"
+  end
+
+  private
+    def commit_token
+      request.commit_csrf_token
+    end
+end
+
+class CustomCsrfTokenStorageStrategyController < ActionController::Base
+  include RequestForgeryProtectionActions
+
+  class CustomStrategy
+    def fetch(request)
+      request.env[:custom_storage]
+    end
+
+    def store(request, csrf_token)
+      request.env[:custom_storage] = csrf_token
+    end
+
+    def reset(request)
+      request.env[:custom_storage] = nil
+    end
+  end
+
+  protect_from_forgery only: %w(index meta same_origin_js negotiate_same_origin),
+    with: :reset_session,
+    store: CustomStrategy.new
+end
+
 # common test methods
 module RequestForgeryProtectionTests
   def setup
@@ -394,7 +438,7 @@ module RequestForgeryProtectionTests
   end
 
   def test_should_allow_post_with_token
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @controller.stub :form_authenticity_token, @token do
       assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
     end
@@ -403,60 +447,60 @@ module RequestForgeryProtectionTests
   def test_should_allow_post_with_strict_encoded_token
     token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
     token_including_url_unsafe_chars = "+/".ljust(token_length, "A")
-    session[:_csrf_token] = token_including_url_unsafe_chars
+    initialize_csrf_token(token_including_url_unsafe_chars)
     @controller.stub :form_authenticity_token, token_including_url_unsafe_chars do
       assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_unsafe_chars } }
     end
   end
 
   def test_should_allow_patch_with_token
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @controller.stub :form_authenticity_token, @token do
       assert_not_blocked { patch :index, params: { custom_authenticity_token: @token } }
     end
   end
 
   def test_should_allow_put_with_token
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @controller.stub :form_authenticity_token, @token do
       assert_not_blocked { put :index, params: { custom_authenticity_token: @token } }
     end
   end
 
   def test_should_allow_delete_with_token
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @controller.stub :form_authenticity_token, @token do
       assert_not_blocked { delete :index, params: { custom_authenticity_token: @token } }
     end
   end
 
   def test_should_allow_post_with_token_in_header
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @request.env["HTTP_X_CSRF_TOKEN"] = @token
     assert_not_blocked { post :index }
   end
 
   def test_should_allow_delete_with_token_in_header
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @request.env["HTTP_X_CSRF_TOKEN"] = @token
     assert_not_blocked { delete :index }
   end
 
   def test_should_allow_patch_with_token_in_header
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @request.env["HTTP_X_CSRF_TOKEN"] = @token
     assert_not_blocked { patch :index }
   end
 
   def test_should_allow_put_with_token_in_header
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     @request.env["HTTP_X_CSRF_TOKEN"] = @token
     assert_not_blocked { put :index }
   end
 
   def test_should_allow_post_with_origin_checking_and_correct_origin
     forgery_protection_origin_check do
-      session[:_csrf_token] = @token
+      initialize_csrf_token
       @controller.stub :form_authenticity_token, @token do
         assert_not_blocked do
           @request.set_header "HTTP_ORIGIN", "http://test.host"
@@ -468,7 +512,7 @@ module RequestForgeryProtectionTests
 
   def test_should_allow_post_with_origin_checking_and_no_origin
     forgery_protection_origin_check do
-      session[:_csrf_token] = @token
+      initialize_csrf_token
       @controller.stub :form_authenticity_token, @token do
         assert_not_blocked do
           post :index, params: { custom_authenticity_token: @token }
@@ -479,7 +523,7 @@ module RequestForgeryProtectionTests
 
   def test_should_raise_for_post_with_null_origin
     forgery_protection_origin_check do
-      session[:_csrf_token] = @token
+      initialize_csrf_token
       @controller.stub :form_authenticity_token, @token do
         exception = assert_raises(ActionController::InvalidAuthenticityToken) do
           @request.set_header "HTTP_ORIGIN", "null"
@@ -496,7 +540,7 @@ module RequestForgeryProtectionTests
     ActionController::Base.logger = logger
 
     forgery_protection_origin_check do
-      session[:_csrf_token] = @token
+      initialize_csrf_token
       @controller.stub :form_authenticity_token, @token do
         assert_blocked do
           @request.set_header "HTTP_ORIGIN", "http://bad.host"
@@ -512,6 +556,7 @@ module RequestForgeryProtectionTests
   ensure
     ActionController::Base.logger = old_logger
   end
+
 
   def test_should_warn_on_missing_csrf_token
     old_logger = ActionController::Base.logger
@@ -598,7 +643,7 @@ module RequestForgeryProtectionTests
 
   # Allow non-GET requests since GET is all a remote <script> tag can muster.
   def test_should_allow_non_get_js_without_xhr_header
-    session[:_csrf_token] = @token
+    initialize_csrf_token
     assert_cross_origin_not_blocked { post :same_origin_js, params: { custom_authenticity_token: @token } }
     assert_cross_origin_not_blocked { post :same_origin_js, params: { format: "js", custom_authenticity_token: @token } }
     assert_cross_origin_not_blocked do
@@ -623,10 +668,23 @@ module RequestForgeryProtectionTests
     end
   end
 
+  def test_csrf_token_is_not_saved_if_it_is_nil
+    @controller.commit_csrf_token(@request)
+    assert_nil fetch_csrf_token
+  end
+
   def test_should_not_raise_error_if_token_is_not_a_string
     assert_blocked do
       patch :index, params: { custom_authenticity_token: { foo: "bar" } }
     end
+  end
+
+  def initialize_csrf_token(token = @token, session = self.session)
+    session[:_csrf_token] = token
+  end
+
+  def fetch_csrf_token
+    session[:_csrf_token]
   end
 
   def assert_blocked
@@ -637,7 +695,9 @@ module RequestForgeryProtectionTests
   end
 
   def assert_not_blocked(&block)
+    session[:something_like_user_id] = 1
     assert_nothing_raised(&block)
+    assert_equal 1, session[:something_like_user_id]
     assert_response :success
   end
 
@@ -713,7 +773,7 @@ class RequestForgeryProtectionControllerUsingExceptionTest < ActionController::T
 
   def test_raised_exception_message_explains_why_it_occurred
     forgery_protection_origin_check do
-      session[:_csrf_token] = @token
+      initialize_csrf_token
       @controller.stub :form_authenticity_token, @token do
         exception = assert_raises(ActionController::InvalidAuthenticityToken) do
           @request.set_header "HTTP_ORIGIN", "http://bad.host"
@@ -860,7 +920,7 @@ class PerFormTokensControllerTest < ActionController::TestCase
   def test_per_form_token_is_same_size_as_global_token
     get :index
     expected = ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH
-    actual = @controller.send(:per_form_csrf_token, session, "/path", "post").size
+    actual = @controller.send(:per_form_csrf_token, nil, "/path", "post").size
     assert_equal expected, actual
   end
 
@@ -998,7 +1058,7 @@ class PerFormTokensControllerTest < ActionController::TestCase
 
     unmasked_token = @controller.send(:unmask_token, Base64.urlsafe_decode64(token))
 
-    assert_not_equal @controller.send(:real_csrf_token, session), unmasked_token
+    assert_not_equal @controller.send(:real_csrf_token), unmasked_token
   end
 
   def test_returns_hmacd_token
@@ -1008,13 +1068,13 @@ class PerFormTokensControllerTest < ActionController::TestCase
 
     unmasked_token = @controller.send(:unmask_token, Base64.urlsafe_decode64(token))
 
-    assert_equal @controller.send(:global_csrf_token, session), unmasked_token
+    assert_equal @controller.send(:global_csrf_token), unmasked_token
   end
 
   def test_accepts_old_csrf_token
     get :index
 
-    non_hmac_token = @controller.send(:mask_token, @controller.send(:real_csrf_token, session))
+    non_hmac_token = @controller.send(:mask_token, @controller.send(:real_csrf_token))
 
     # This is required because PATH_INFO isn't reset between requests.
     @request.env["PATH_INFO"] = "/per_form_tokens/post_one"
@@ -1101,7 +1161,7 @@ class PerFormTokensControllerTest < ActionController::TestCase
 
     def assert_matches_session_token_on_server(form_token, method = "post")
       actual = @controller.send(:unmask_token, Base64.urlsafe_decode64(form_token))
-      expected = @controller.send(:per_form_csrf_token, session, "/per_form_tokens/post_one", method)
+      expected = @controller.send(:per_form_csrf_token, nil, "/per_form_tokens/post_one", method)
       assert_equal expected, actual
     end
 end
@@ -1135,5 +1195,171 @@ class SkipProtectionWhenUnprotectedControllerTest < ActionController::TestCase
   def assert_not_blocked(&block)
     assert_nothing_raised(&block)
     assert_response :success
+  end
+end
+
+class CookieCsrfTokenStorageStrategyControllerTest < ActionController::TestCase
+  include RequestForgeryProtectionTests
+
+  class TestSession < ActionController::TestSession
+    attr_reader :id_was
+
+    def initialize(id_was)
+      super()
+      @id_was = id_was
+    end
+  end
+
+  class NullSessionDummyKeyGenerator
+    def generate_key(secret, length = nil)
+      "03312270731a2ed0d11ed091c2338a06"
+    end
+  end
+
+  def setup
+    @request.env[ActionDispatch::Cookies::GENERATOR_KEY] = NullSessionDummyKeyGenerator.new
+    @request.env[ActionDispatch::Cookies::COOKIES_ROTATIONS] = ActiveSupport::Messages::RotationConfiguration.new
+    super
+  end
+
+  def test_csrf_token_is_stored_in_cookie
+    get :cookie
+    assert_not session.key?(:_csrf_token)
+    assert cookies.key?(:csrf_token)
+  end
+
+  def test_csrf_token_is_stored_in_custom_cookie
+    @controller.csrf_token_storage_strategy =
+      ActionController::RequestForgeryProtection::CookieStore.new(:custom_cookie)
+    get :cookie
+    assert_not cookies.key?(:csrf_token)
+    assert cookies.key?(:custom_cookie)
+  end
+
+  def test_csrf_token_cookie_has_same_site_lax
+    get :cookie
+    assert_match "SameSite=Lax", @response.headers["Set-Cookie"]
+  end
+
+  def test_csrf_token_cookie_is_http_only
+    get :cookie
+    assert_match "HttpOnly", @response.headers["Set-Cookie"]
+  end
+
+  def test_csrf_token_cookie_is_permanent
+    get :cookie
+    assert_match(%r(#{20.years.from_now.utc.year}), @response.headers["Set-Cookie"])
+  end
+
+  def test_reset_csrf_token_deletes_cookie
+    get :cookie
+    get :reset
+    assert_nil cookies[:csrf_token]
+  end
+
+  def test_should_allow_when_session_id_in_cookie_matches_session_id
+    initialize_csrf_token
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def test_should_not_allow_when_session_id_in_cookie_does_not_match_session_id
+    initialize_csrf_token(@token, ActionController::TestSession.new)
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def test_should_allow_when_session_id_in_cookie_and_session_id_are_nil
+    @request.session = ActionController::TestSession.new({}, nil)
+    initialize_csrf_token(@token, nil)
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def test_should_not_allow_when_session_id_in_cookie_but_session_id_is_nil
+    initialize_csrf_token
+    @request.session = ActionController::TestSession.new({}, nil)
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def test_should_allow_when_session_id_in_cookie_is_nil_and_session_created_before_token_validation
+    initialize_csrf_token(@token, nil)
+    @request.session = TestSession.new(nil)
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def test_should_allow_when_session_id_in_cookie_is_nil_and_session_reset_before_token_validation
+    initialize_csrf_token
+    @request.session = TestSession.new(session.id)
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_not_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def test_should_not_allow_when_session_id_in_cookie_but_request_made_with_no_session
+    initialize_csrf_token
+    @request.session = TestSession.new(nil)
+
+    @controller.stub :form_authenticity_token, @token do
+      assert_blocked { post :index, params: { custom_authenticity_token: @token } }
+    end
+  end
+
+  def initialize_csrf_token(token = @token, session = self.session)
+    cookies.encrypted[:csrf_token] = {
+      value: {
+        token: token,
+        session_id: session&.id,
+      }.to_json,
+      httponly: true,
+      same_site: :lax,
+    }
+  end
+
+  def fetch_csrf_token
+    contents = request.cookie_jar.encrypted[:csrf_token]
+    return nil if contents.nil?
+
+    value = JSON.parse(contents)
+    return nil unless value["session_id"]&.fetch("public_id") == request.session.id_was&.public_id
+
+    value["token"]
+  end
+
+  def assert_blocked(&block)
+    assert_raises(ActionController::InvalidAuthenticityToken, &block)
+  end
+
+  def assert_not_blocked(&block)
+    assert_nothing_raised(&block)
+    assert_response :success
+  end
+end
+
+class CustomCsrfTokenStorageStrategyControllerTest < ActionController::TestCase
+  include RequestForgeryProtectionTests
+
+  def test_csrf_token_is_stored_in_custom_location
+    post :index
+    @controller.commit_csrf_token(@request)
+    assert_not session.key?(:_csrf_token)
+    assert_not_nil request.env[:custom_storage]
+  end
+
+  def initialize_csrf_token(token = @token)
+    request.env[:custom_storage] = token
   end
 end

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -130,6 +130,40 @@ module ActionDispatch
         assert_nil session.dig("one", :two)
       end
 
+      def test_id_was_for_new_session_that_does_not_exist
+        session = Session.create(store_for_session_that_does_not_exist, req, {})
+        assert_nil session.id_was
+      end
+
+      def test_id_was_for_session_that_does_not_exist_after_writing
+        session = Session.create(store_for_session_that_does_not_exist, req, {})
+        session["one"] = "1"
+        assert_nil session.id_was
+      end
+
+      def test_id_was_for_session_that_does_not_exist_after_destroying
+        session = Session.create(store_for_session_that_does_not_exist, req, {})
+        session.destroy
+        assert_nil session.id_was
+      end
+
+      def test_id_was_for_existing_session
+        session = Session.create(store, req, {})
+        assert_equal 1, session.id_was
+      end
+
+      def test_id_was_for_existing_session_after_write
+        session = Session.create(store, req, {})
+        session["one"] = "1"
+        assert_equal 1, session.id_was
+      end
+
+      def test_id_was_for_existing_session_after_destroy
+        session = Session.create(store, req, {})
+        session.destroy
+        assert_equal 1, session.id_was
+      end
+
       private
         def store
           Class.new {
@@ -143,6 +177,14 @@ module ActionDispatch
           Class.new {
             def load_session(env); [1, { "sample_key" => "sample_value" }]; end
             def session_exists?(env); true; end
+            def delete_session(env, id, options); 123; end
+          }.new
+        end
+
+        def store_for_session_that_does_not_exist
+          Class.new {
+            def load_session(env); [1, {}]; end
+            def session_exists?(env); false; end
             def delete_session(env, id, options); 123; end
           }.new
         end

--- a/actionpack/test/dispatch/session/abstract_secure_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_secure_store_test.rb
@@ -30,6 +30,10 @@ module ActionDispatch
         def write_session(env, sid, session, options)
           @sessions[sid] = SessionId.new(sid, session)
         end
+
+        def session_exists?(req)
+          true
+        end
       end
 
       def test_session_is_set

--- a/actionpack/test/dispatch/session/abstract_store_test.rb
+++ b/actionpack/test/dispatch/session/abstract_store_test.rb
@@ -21,6 +21,10 @@ module ActionDispatch
         def write_session(env, sid, session, options)
           @sessions[sid] = session
         end
+
+        def session_exists?(req)
+          true
+        end
       end
 
       def test_session_is_set


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Add a new configuration option that allows a lambda to be provided that can store the CSRF token in a custom location.  

This is useful in cases where sessions are not stored in cookies.  For example, when using a redis session store, millions of sessions may be created for unauthenticated users where the session contains nothing but the CSRF token.  In such cases, the cache may be thrashing, constantly evicting old sessions.  This new configuration parameter will make it possible to store the CSRF token somewhere other than the session (i.e. in an encrypted cookie), making it possible for the session store to store only sessions for authenticated users.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
