### PR TITLE
Fixes order(ArelNode => direction) in ActiveRecord::QueryMethods

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1626,7 +1626,9 @@ module ActiveRecord
           when String, Symbol
             arg
           when Hash
-            arg.keys
+            arg.keys.map do |key|
+              key if key.is_a?(String) || key.is_a?(Symbol)
+            end
           end
         end
         references.map! { |arg| arg =~ /^\W?(\w+)\W?\./ && $1 }.compact!

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1602,7 +1602,7 @@ module ActiveRecord
           when Hash
             arg.map { |field, dir|
               case field
-              when Arel::Nodes::SqlLiteral
+              when Arel::Nodes::SqlLiteral, Arel::Nodes::Node, Arel::Attribute
                 field.public_send(dir.downcase)
               else
                 order_column(field.to_s).public_send(dir.downcase)

--- a/activerecord/test/cases/scoping/relation_scoping_test.rb
+++ b/activerecord/test/cases/scoping/relation_scoping_test.rb
@@ -42,15 +42,24 @@ class RelationScopingTest < ActiveRecord::TestCase
     assert_equal Developer.order("id DESC").to_a.reverse, Developer.order("id DESC").reverse_order
   end
 
-  def test_reverse_order_with_arel_node
+  def test_reverse_order_with_arel_attribute
     assert_equal Developer.order("id DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).reverse_order
   end
 
-  def test_reverse_order_with_multiple_arel_nodes
+  def test_reverse_order_with_arel_attribute_as_hash
+    assert_equal Developer.order("id DESC").to_a.reverse, Developer.order(Developer.arel_table[:id] => :desc).reverse_order
+  end
+
+  def test_reverse_order_with_arel_node_as_hash
+    node = Developer.arel_table[:id] + 0 # converts to Arel::Nodes::Grouping
+    assert_equal Developer.order("id DESC").to_a.reverse, Developer.order(node => :desc).reverse_order
+  end
+
+  def test_reverse_order_with_multiple_arel_attributes
     assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order(Developer.arel_table[:id].desc).order(Developer.arel_table[:name].desc).reverse_order
   end
 
-  def test_reverse_order_with_arel_nodes_and_strings
+  def test_reverse_order_with_arel_attributes_and_strings
     assert_equal Developer.order("id DESC").order("name DESC").to_a.reverse, Developer.order("id DESC").order(Developer.arel_table[:name].desc).reverse_order
   end
 


### PR DESCRIPTION
### Summary

When passing a hash to the `order` method that has an arel node as a key, the preprocess_order_args tries to convert it into a string that causes the generated query to fail.

Steps to reproduce:
```
# app/models/model.rb
class Model < ApplicationRecord
  SORT_BY_VERSION = Arel::Nodes::NamedFunction.new(
    'CAST',
    [
      Arel::Nodes::NamedFunction.new(
        'string_to_array',
        [arel_table[:version], Arel::Nodes::Quoted.new('.')]
      ).as('int[]')
    ]
  )
end

# and then in rails console:

Model(Model::SORT_BY_VERSION).to_sql
=> "SELECT \"models\".* FROM \"models\" ORDER BY CAST(string_to_array(\"model\".\"version\", '.') AS int[])"
Model.order(Model::SORT_BY_VERSION => :desc).to_sql
=> "SELECT \"models\".* FROM \"models\" ORDER BY \"#<Arel::Nodes::NamedFunction:0x0000555b049c12b0>\" DESC"
```

### Other Information

Fixes #44282