### PR TITLE
Dump the database schema containing the current Rails version

### DIFF
--- a/activerecord/lib/active_record/schema.rb
+++ b/activerecord/lib/active_record/schema.rb
@@ -10,7 +10,7 @@ module ActiveRecord
   #
   # Usage:
   #
-  #   ActiveRecord::Schema.define do
+  #   ActiveRecord::Schema[7.0].define do
   #     create_table :authors do |t|
   #       t.string :name, null: false
   #     end
@@ -30,32 +30,47 @@ module ActiveRecord
   # ActiveRecord::Schema is only supported by database adapters that also
   # support migrations, the two features being very similar.
   class Schema < Migration::Current
-    # Eval the given block. All methods available to the current connection
-    # adapter are available within the block, so you can easily use the
-    # database definition DSL to build up your schema (
-    # {create_table}[rdoc-ref:ConnectionAdapters::SchemaStatements#create_table],
-    # {add_index}[rdoc-ref:ConnectionAdapters::SchemaStatements#add_index], etc.).
-    #
-    # The +info+ hash is optional, and if given is used to define metadata
-    # about the current schema (currently, only the schema's version):
-    #
-    #   ActiveRecord::Schema.define(version: 2038_01_19_000001) do
-    #     ...
-    #   end
-    def self.define(info = {}, &block)
-      new.define(info, &block)
-    end
+    module Definition
+      extend ActiveSupport::Concern
 
-    def define(info, &block) # :nodoc:
-      instance_eval(&block)
-
-      if info[:version].present?
-        connection.schema_migration.create_table
-        connection.assume_migrated_upto_version(info[:version])
+      module ClassMethods
+        # Eval the given block. All methods available to the current connection
+        # adapter are available within the block, so you can easily use the
+        # database definition DSL to build up your schema (
+        # {create_table}[rdoc-ref:ConnectionAdapters::SchemaStatements#create_table],
+        # {add_index}[rdoc-ref:ConnectionAdapters::SchemaStatements#add_index], etc.).
+        #
+        # The +info+ hash is optional, and if given is used to define metadata
+        # about the current schema (currently, only the schema's version):
+        #
+        #   ActiveRecord::Schema[7.0].define(version: 2038_01_19_000001) do
+        #     ...
+        #   end
+        def define(info = {}, &block)
+          new.define(info, &block)
+        end
       end
 
-      ActiveRecord::InternalMetadata.create_table
-      ActiveRecord::InternalMetadata[:environment] = connection.migration_context.current_environment
+      def define(info, &block) # :nodoc:
+        instance_eval(&block)
+
+        if info[:version].present?
+          connection.schema_migration.create_table
+          connection.assume_migrated_upto_version(info[:version])
+        end
+
+        ActiveRecord::InternalMetadata.create_table
+        ActiveRecord::InternalMetadata[:environment] = connection.migration_context.current_environment
+      end
+    end
+
+    include Definition
+
+    def self.[](version)
+      @class_for_version ||= {}
+      @class_for_version[version] ||= Class.new(Migration::Compatibility.find(version)) do
+        include Definition
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -73,23 +73,23 @@ module ActiveRecord
         @version ? "version: #{formatted_version}" : ""
       end
 
+      # TODO: Fix dumper
       def header(stream)
-        stream.puts <<HEADER
-# This file is auto-generated from the current state of the database. Instead
-# of editing this file, please use the migrations feature of Active Record to
-# incrementally modify your database, and then regenerate this schema definition.
-#
-# This file is the source Rails uses to define your schema when running `bin/rails
-# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
-# be faster and is potentially less error prone than running all of your
-# migrations from scratch. Old migrations may fail to apply correctly if those
-# migrations use external dependencies or application code.
-#
-# It's strongly recommended that you check this file into your version control system.
+        stream.puts <<~HEADER
+          # This file is auto-generated from the current state of the database. Instead
+          # of editing this file, please use the migrations feature of Active Record to
+          # incrementally modify your database, and then regenerate this schema definition.
+          #
+          # This file is the source Rails uses to define your schema when running `bin/rails
+          # db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+          # be faster and is potentially less error prone than running all of your
+          # migrations from scratch. Old migrations may fail to apply correctly if those
+          # migrations use external dependencies or application code.
+          #
+          # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(#{define_params}) do
-
-HEADER
+          ActiveRecord::Schema[#{ActiveRecord::Migration.current_version}].define(#{define_params}) do
+        HEADER
       end
 
       def trailer(stream)

--- a/activerecord/test/cases/active_record_schema_test.rb
+++ b/activerecord/test/cases/active_record_schema_test.rb
@@ -37,6 +37,19 @@ class ActiveRecordSchemaTest < ActiveRecord::TestCase
     ActiveRecord::Base.primary_key_prefix_type = old_primary_key_prefix_type
   end
 
+  def test_schema_without_version_is_the_current_version_schema
+    schema_class = ActiveRecord::Schema
+    assert schema_class < ActiveRecord::Migration[ActiveRecord::Migration.current_version]
+    assert_not schema_class < ActiveRecord::Migration[7.0]
+    assert schema_class < ActiveRecord::Schema::Definition
+  end
+
+  def test_schema_version_accessor
+    schema_class = ActiveRecord::Schema[6.1]
+    assert schema_class < ActiveRecord::Migration[6.1]
+    assert schema_class < ActiveRecord::Schema::Definition
+  end
+
   def test_schema_define
     ActiveRecord::Schema.define(version: 7) do
       create_table :fruits do |t|

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -38,6 +38,11 @@ class SchemaDumperTest < ActiveRecord::TestCase
     ActiveRecord::SchemaMigration.delete_all
   end
 
+  def test_schema_dump_include_migration_version
+    output = standard_dump
+    assert_match %r{ActiveRecord::Schema\[#{ActiveRecord::Migration.current_version}\]\.define}, output
+  end
+
   def test_schema_dump
     output = standard_dump
     assert_match %r{create_table "accounts"}, output

--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -1038,7 +1038,7 @@ If `:ruby` is selected, then the schema is stored in `db/schema.rb`. If you look
 at this file you'll find that it looks an awful lot like one very big migration:
 
 ```ruby
-ActiveRecord::Schema.define(version: 2008_09_06_171750) do
+ActiveRecord::Schema[7.1].define(version: 2008_09_06_171750) do
   create_table "authors", force: true do |t|
     t.string   "name"
     t.datetime "created_at"

--- a/guides/source/active_record_postgresql.md
+++ b/guides/source/active_record_postgresql.md
@@ -98,7 +98,7 @@ NOTE: You need to enable the `hstore` extension to use hstore.
 
 ```ruby
 # db/migrate/20131009135255_create_profiles.rb
-ActiveRecord::Schema.define do
+class CreateProfiles < ActiveRecord::Migration[7.0]
   enable_extension 'hstore' unless extension_enabled?('hstore')
   create_table :profiles do |t|
     t.hstore 'settings'

--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -388,6 +388,35 @@ You can invalidate the cache either by touching the product, or changing the cac
 <% end %>
 ```
 
+### Rails version is now included in the Active Record schema dump
+
+Rails 7.0 changed some default values for some column types. To avoid that application upgrading from 6.1 to 7.0
+load the current schema using the new 7.0 defaults, Rails now includes the version of the framework in the schema dump.
+
+Before loading the schema for the first time in Rails 7.0, make sure to run `rails app:update` to ensure that the
+version of the schema is included in the schema dump.
+
+The schema file will look like this:
+
+```ruby
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[6.1].define(version: 2022_01_28_123512) do
+```
+
+NOTE: The first time you dump the schema with Rails 7.0, you will see many changes to that file, including
+some column information. Make sure to review the new schema file content and commit it to your repository.
+
 Upgrading from Rails 6.0 to Rails 6.1
 -------------------------------------
 


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/42297, Rails now generate datetime columns on MySQL with a default precision of 6. This means that users upgrading to Rails 7.0 from 6.1, when loading the database schema, would get the new precision value, which would not match the production schema.

To avoid this, Rails will now freeze `ActiveRecord::Schema` class to be the 6.1 implementation, and will allow access to other version using the same mechanism of `ActiveRecord::Migration`.

The schema dumper will generate the new format which will include the Rails version and will look like this:

```
ActiveRecord::Schema[7.0].define
```

Related to #43934 and #43909.