### PR TITLE
Fix test_tag_attributes_escapes_values assertion

### DIFF
--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -404,7 +404,11 @@ class TagHelperTest < ActionView::TestCase
   end
 
   def test_tag_attributes_escapes_values
-    assert_not_includes "<script>alert()</script>", render_erb(<<~HTML.strip)
+    expected_output = <<~HTML.strip
+      <input type="text" xss="&quot;&gt;&lt;script&gt;alert()&lt;/script&gt;">
+    HTML
+
+    assert_equal expected_output, render_erb(<<~HTML.strip)
       <input type="text" <%= tag.attributes xss: '"><script>alert()</script>' %>>
     HTML
   end


### PR DESCRIPTION
The 1st argument to [`assert_not_includes`](https://www.rubydoc.info/gems/minitest/5.9.0/Minitest%2FAssertions:refute_includes) is the collection to search; the 2nd argument is the element to search for.  Thus this test was checking if the output was included in the forbidden string, rather than checking the if the forbidden string was included in the output.

Because negative assertions like this one can be fooled more easily, this commit changes the test to use `assert_equal`, as the other tests do.
