### PR TITLE
Support declarative-style test name filters

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,29 @@
+*   Support declarative-style test name filters with `bin/rails test`.
+
+    This makes it possible to run a declarative-style test such as:
+
+    ```ruby
+    class MyTest < ActiveSupport::TestCase
+      test "does something" do
+        # ...
+      end
+    end
+    ```
+
+    Using its declared name:
+
+    ```bash
+    $ bin/rails test test/my_test.rb -n "does something"
+    ```
+
+    Instead of having to specify its expanded method name:
+
+    ```bash
+    $ bin/rails test test/my_test.rb -n test_does_something
+    ```
+
+    *Jonathan Hefner*
+
 *   Add `--js` and `--skip-javascript` options to `rails new`
 
     `--js` alias to `rails new --javascript ...`

--- a/railties/lib/rails/test_unit/runner.rb
+++ b/railties/lib/rails/test_unit/runner.rb
@@ -48,6 +48,8 @@ module Rails
         end
 
         def compose_filter(runnable, filter)
+          filter = escape_declarative_test_filter(filter)
+
           if filters.any? { |_, lines| lines.any? }
             CompositeFilter.new(runnable, filter, filters)
           else
@@ -98,6 +100,14 @@ module Rails
             tests = Rake::FileList[patterns.any? ? patterns : default_test_glob]
             tests.exclude(default_test_exclude_glob) if patterns.empty?
             tests
+          end
+
+          def escape_declarative_test_filter(filter)
+            if filter.is_a?(String) && !filter.start_with?("test_")
+              filter = "test_#{filter}" unless regexp_filter?(filter)
+              filter = filter.gsub(/\s+/, "_")
+            end
+            filter
           end
       end
     end

--- a/railties/test/application/test_runner_test.rb
+++ b/railties/test/application/test_runner_test.rb
@@ -497,6 +497,72 @@ module ApplicationTests
       end
     end
 
+    def test_declarative_style_string_filter
+      app_file "test/models/post_test.rb", <<~RUBY
+        require "test_helper"
+
+        class PostTest < ActiveSupport::TestCase
+          test "foo" do
+            puts "hello foo"
+            assert true
+          end
+
+          test "foo again" do
+            puts "hello again"
+            assert true
+          end
+
+          test "foo no more" do
+            assert false
+          end
+        end
+      RUBY
+
+      run_test_command("test/models/post_test.rb -n 'foo'").tap do |output|
+        assert_match "hello foo", output
+        assert_match "1 runs, 1 assertions, 0 failures", output
+      end
+
+      run_test_command("test/models/post_test.rb -n 'foo again'").tap do |output|
+        assert_match "hello again", output
+        assert_match "1 runs, 1 assertions, 0 failures", output
+      end
+    end
+
+    def test_declarative_style_regexp_filter
+      app_file "test/models/post_test.rb", <<~RUBY
+        require "test_helper"
+
+        class PostTest < ActiveSupport::TestCase
+          test "greets foo" do
+            puts "hello foo"
+            assert true
+          end
+
+          test "greets foo again" do
+            puts "hello again foo"
+            assert true
+          end
+
+          test "greets bar" do
+            puts "hello bar"
+            assert true
+          end
+
+          test "greets no one" do
+            assert false
+          end
+        end
+      RUBY
+
+      run_test_command("test/models/post_test.rb -n '/greets foo|greets bar/'").tap do |output|
+        assert_match "hello foo", output
+        assert_match "hello again foo", output
+        assert_match "hello bar", output
+        assert_match "3 runs, 3 assertions, 0 failures", output
+      end
+    end
+
     def test_run_app_without_rails_loaded
       # Simulate a real Rails app boot.
       app_file "config/boot.rb", <<-RUBY


### PR DESCRIPTION
This makes it possible to run a specific test such as:

```ruby
class MyTest < ActiveSupport::TestCase
  test "does something" do
    # ...
  end
end
```

Using its declared name:

```bash
$ rails test test/my_test.rb -n "does something"
```

Instead of having to specify the expanded method name:

```bash
$ rails test test/my_test.rb -n test_does_something
```
