### PR TITLE
Fix backtrace cleaner example

### DIFF
--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -56,7 +56,7 @@ module ActiveSupport
     # mapped against this filter.
     #
     #   # Will turn "/my/rails/root/app/models/person.rb" into "/app/models/person.rb"
-    #   backtrace_cleaner.add_filter { |line| line.gsub(Rails.root, '') }
+    #   backtrace_cleaner.add_filter { |line| line.gsub(Rails.root.to_s, '') }
     def add_filter(&block)
       @filters << block
     end


### PR DESCRIPTION
### Summary

Minor documentation change here.

When using the current example of a backtrace filter in a Rails app, the following error is raised: `TypeError (wrong argument type Pathname (expected Regexp))`

I've appended `.to_s` to the `Rails.root` to match the example given here:

https://github.com/rails/rails/blob/de956f57733b309e5f7a0be1e9f86ab3e9160c64/activesupport/lib/active_support/backtrace_cleaner.rb#L18