### PR TITLE
Improve requiring of scalar parameters

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mailgun/inbound_emails_controller.rb
@@ -51,8 +51,8 @@ module ActionMailbox
 
     private
       def mail
-        params.require("body-mime").tap do |raw_email|
-          raw_email.prepend("X-Original-To: ", params.require(:recipient), "\n") if params.key?(:recipient)
+        params.require_scalar("body-mime").tap do |raw_email|
+          raw_email.prepend("X-Original-To: ", params.require_scalar(:recipient), "\n") if params.key?(:recipient)
         end
       end
 
@@ -64,9 +64,9 @@ module ActionMailbox
         if key.present?
           Authenticator.new(
             key:       key,
-            timestamp: params.require(:timestamp),
-            token:     params.require(:token),
-            signature: params.require(:signature)
+            timestamp: params.require_scalar(:timestamp),
+            token:     params.require_scalar(:token),
+            signature: params.require_scalar(:signature)
           ).authenticated?
         else
           raise ArgumentError, <<~MESSAGE.squish

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/mandrill/inbound_emails_controller.rb
@@ -35,7 +35,7 @@ module ActionMailbox
       end
 
       def events
-        JSON.parse params.require(:mandrill_events)
+        JSON.parse params.require_scalar(:mandrill_events)
       end
 
 

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/postmark/inbound_emails_controller.rb
@@ -48,7 +48,7 @@ module ActionMailbox
     before_action :authenticate_by_password
 
     def create
-      ActionMailbox::InboundEmail.create_and_extract_message_id! params.require("RawEmail")
+      ActionMailbox::InboundEmail.create_and_extract_message_id! params.require_scalar("RawEmail")
     rescue ActionController::ParameterMissing => error
       logger.error <<~MESSAGE
         #{error.message}

--- a/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/ingresses/sendgrid/inbound_emails_controller.rb
@@ -56,13 +56,13 @@ module ActionMailbox
 
     private
       def mail
-        params.require(:email).tap do |raw_email|
+        params.require_scalar(:email).tap do |raw_email|
           envelope["to"].each { |to| raw_email.prepend("X-Original-To: ", to, "\n") } if params.key?(:envelope)
         end
       end
 
       def envelope
-        JSON.parse(params.require(:envelope))
+        JSON.parse(params.require_scalar(:envelope))
       end
   end
 end


### PR DESCRIPTION
### Summary

The usage of `ActionController::Parameters#require` is a bit ambiguous.
It can be called for hashes, arrays and scalar values.
When a scalar value is expected but a hash is passed you might get
unexpected results:

```ruby
ActionController::Parameters.new(name: { first: "Francesco" }).require(:name).downcase
# => NoMethodError (undefined method `downcase' for #<ActionController::Parameters:0x00007f8c631264b0>)
```

Similarly, when a hash is expected but a scalar value is passed:

```ruby
ActionController::Parameters.new(person: "Francesco").require(:person).permit(:name)
# => NoMethodError (undefined method `permit' for "Francesco":String)
```

This requires developers to handle these unexpected exceptions instead
of just rescuing/ignoring `ActionController::ParameterMissing`.

There even is a [warning documented](https://github.com/rails/rails/blob/abde74c118a2391c90f4c8ac197a9628ef2acf9b/actionpack/lib/action_controller/metal/strong_parameters.rb#L474-L488) in the rdoc of `require` to be
careful when requiring terminal values. For example, calling require
without permit can have unexpected results if unpermitted values are
passed:

```ruby
ActionController::Parameters.new(name: Object.new).require(:name)
# => #<Object:0x00007f8c58637180>
```

### Separate `require` methods for scalar and non scalar params

By restricting `require` to arrays and hashes, and adding a
`require_scalar` method for scalar values we can prevent these problems.

This allows us to raise an `ActionController::ParameterMissing` if a
required param doesn't have the expected type:

```ruby
# when a hash is passed but a scalar value is expected
ActionController::Parameters.new(name: { first: "Francesco" }).require_scalar(:name).downcase
# => ActionController::ParameterMissing (param is missing or the value is empty: name)

# when a scalar value is passed but a hash is expected
ActionController::Parameters.new(person: "Francesco").require(:person).permit(:name)
# => ActionController::ParameterMissing (param is missing or the value is empty: person)
```

`require_scalar` also restricts the required values to permitted
scalar values.

```ruby
ActionController::Parameters.new(name: Object.new).require_scalar(:name)
# => ActionController::ParameterMissing (param is missing or the value is empty: name)
```

Fixes: #42953

### Other Information

This would be a breaking change requiring deprecation warnings.

Maybe we should make it even stricter and introduce methods
for each permited scalar type. This allows us to have stricter
checks and maybe even coerce to the proper type:

```ruby
params = ActionController::Parameters.new(name: "Francesco", age: "22", active: "true")
params.require_string(:name) # => "Francesco"
params.require_integer(:age) # => 22
params.require_boolean(:active) # => true
```