### PR TITLE
Always heed `ActiveModel::Name#human` `:count` option

### DIFF
--- a/activemodel/lib/active_model/naming.rb
+++ b/activemodel/lib/active_model/naming.rb
@@ -175,6 +175,7 @@ module ActiveModel
       @uncountable  = @plural == @singular
       @element      = ActiveSupport::Inflector.underscore(ActiveSupport::Inflector.demodulize(@name))
       @human        = ActiveSupport::Inflector.humanize(@element)
+      @plural_human = ActiveSupport::Inflector.pluralize(@human, locale)
       @collection   = ActiveSupport::Inflector.tableize(@name)
       @param_key    = (namespace ? _singularize(@unnamespaced) : @singular)
       @i18n_key     = @name.underscore.to_sym
@@ -195,14 +196,15 @@ module ActiveModel
     #
     # Specify +options+ with additional translating options.
     def human(options = {})
-      return @human if i18n_keys.empty? || i18n_scope.empty?
+      fallback = plural_count?(options[:count]) ? @plural_human : @human
+      return fallback if i18n_keys.empty? || i18n_scope.empty?
 
       key, *defaults = i18n_keys
       defaults << options[:default] if options[:default]
       defaults << MISSING_TRANSLATION
 
       translation = I18n.translate(key, scope: i18n_scope, count: 1, **options, default: defaults)
-      translation = @human if translation == MISSING_TRANSLATION
+      translation = fallback if translation == MISSING_TRANSLATION
       translation
     end
 
@@ -215,6 +217,10 @@ module ActiveModel
 
       def _singularize(string)
         ActiveSupport::Inflector.underscore(string).tr("/", "_")
+      end
+
+      def plural_count?(count)
+        (count || 1) != 1
       end
 
       def i18n_keys

--- a/activemodel/test/cases/naming_test.rb
+++ b/activemodel/test/cases/naming_test.rb
@@ -295,6 +295,14 @@ class NameWithAnonymousClassTest < ActiveModel::TestCase
     model_name = ActiveModel::Name.new(Class.new, nil, "Anonymous")
     assert_equal "Anonymous", model_name
   end
+
+  def test_human_with_count
+    model_name = ActiveModel::Name.new(Class.new, nil, "UntranslatedModel")
+
+    assert_equal "Untranslated models", model_name.human(count: 0)
+    assert_equal "Untranslated model", model_name.human(count: 1)
+    assert_equal "Untranslated models", model_name.human(count: 2)
+  end
 end
 
 class NamingMethodDelegationTest < ActiveModel::TestCase

--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -115,6 +115,32 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal "Person", Person.model_name.human(default: :this_key_does_not_exist)
   end
 
+  def test_translated_model_with_count
+    I18n.backend.store_translations "en", activemodel: { models: { person: { one: "dude", other: "peeps" } } }
+
+    assert_equal "peeps", Person.model_name.human(count: 0)
+    assert_equal "dude", Person.model_name.human(count: 1)
+    assert_equal "peeps", Person.model_name.human(count: 2)
+  end
+
+  def test_translated_model_with_count_when_missing_translation
+    assert_equal "People", Person.model_name.human(count: 0)
+    assert_equal "Person", Person.model_name.human(count: 1)
+    assert_equal "People", Person.model_name.human(count: 2)
+  end
+
+  def test_translated_model_with_count_when_custom_plural_rule_and_missing_translation
+    I18n.backend = Class.new(I18n::Backend::Simple) do
+      include I18n::Backend::Pluralization
+    end.new
+
+    I18n.backend.store_translations "en", i18n: { plural: { keys: [:few], rule: -> (n) { :few } } }
+
+    assert_equal "People", Person.model_name.human(count: 0)
+    assert_equal "Person", Person.model_name.human(count: 1)
+    assert_equal "People", Person.model_name.human(count: 2)
+  end
+
   def test_human_does_not_modify_options
     options = { default: "person model" }
     Person.model_name.human(options)


### PR DESCRIPTION
Prior to this commit, when the model class did not extend `ActiveModel::Translation` or the relevant I18n keys were missing, `ActiveModel::Name#human` would effectively ignore the `:count` option.

This commit makes `ActiveModel::Name#human` heed the `:count` option in either scenario.
