### PR TITLE
Improve `ActiveModel::Name#human` performance

### DIFF
--- a/activemodel/test/cases/translation_test.rb
+++ b/activemodel/test/cases/translation_test.rb
@@ -84,9 +84,8 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal "person model", Person.model_name.human
   end
 
-  def test_translated_model_names_with_sti
-    I18n.backend.store_translations "en", activemodel: { models: { child: "child model" } }
-    assert_equal "child model", Child.model_name.human
+  def test_translated_model_when_missing_translation
+    assert_equal "Person", Person.model_name.human
   end
 
   def test_translated_model_with_namespace
@@ -94,9 +93,26 @@ class ActiveModelI18nTests < ActiveModel::TestCase
     assert_equal "gender model", Person::Gender.model_name.human
   end
 
-  def test_translated_model_names_with_ancestors_fallback
+  def test_translated_subclass_model
+    I18n.backend.store_translations "en", activemodel: { models: { child: "child model" } }
+    assert_equal "child model", Child.model_name.human
+  end
+
+  def test_translated_subclass_model_when_ancestor_translation
     I18n.backend.store_translations "en", activemodel: { models: { person: "person model" } }
     assert_equal "person model", Child.model_name.human
+  end
+
+  def test_translated_subclass_model_when_missing_translation
+    assert_equal "Child", Child.model_name.human
+  end
+
+  def test_translated_model_with_default_value_when_missing_translation
+    assert_equal "dude", Person.model_name.human(default: "dude")
+  end
+
+  def test_translated_model_with_default_key_when_missing_both_translations
+    assert_equal "Person", Person.model_name.human(default: :this_key_does_not_exist)
   end
 
   def test_human_does_not_modify_options


### PR DESCRIPTION
This refactors `ActiveModel::Name#human` to reduce allocations and improve performance by ~2x when a translation is not defined.

Benchmark script:

```ruby
require "benchmark/memory"
require "benchmark/ips"

class BaseModel
  extend ActiveModel::Translation
end

BlogPost = Class.new(BaseModel)

Benchmark.memory do |x|
  x.report("warmup") { BlogPost.model_name.human }
  x.report("human")  { BlogPost.model_name.human }
end

Benchmark.ips do |x|
  x.report("human")  { BlogPost.model_name.human }
end
```

**Before:**

```
Calculating -------------------------------------
              warmup   964.242k memsize (    23.575k retained)
                         2.157k objects (   310.000  retained)
                        50.000  strings (    50.000  retained)
               human     4.144k memsize (     0.000  retained)
                        32.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)

Warming up --------------------------------------
               human   870.000  i/100ms
Calculating -------------------------------------
               human      8.434k (± 0.8%) i/s -     42.630k in   5.054943s
```

**After:**

```
Calculating -------------------------------------
              warmup   962.418k memsize (    23.607k retained)
                         2.143k objects (   310.000  retained)
                        50.000  strings (    50.000  retained)
               human     2.112k memsize (     0.000  retained)
                        16.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Warming up --------------------------------------
               human     1.851k i/100ms
Calculating -------------------------------------
               human     18.492k (± 0.7%) i/s -     92.550k in   5.005100s
```
