### PR TITLE
Remove the deprecated urlsafe_csrf_tokens configuration

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -90,19 +90,6 @@ module ActionController # :nodoc:
       config_accessor :default_protect_from_forgery
       self.default_protect_from_forgery = false
 
-      # Controls whether URL-safe CSRF tokens are generated.
-      config_accessor :urlsafe_csrf_tokens, instance_writer: false
-      self.urlsafe_csrf_tokens = true
-
-      singleton_class.redefine_method(:urlsafe_csrf_tokens=) do |urlsafe_csrf_tokens|
-        if urlsafe_csrf_tokens
-          ActiveSupport::Deprecation.warn("URL-safe CSRF tokens are now the default. Use 6.1 defaults or above.")
-        else
-          ActiveSupport::Deprecation.warn("Non-URL-safe CSRF tokens are deprecated. Use 6.1 defaults or above.")
-        end
-        config.urlsafe_csrf_tokens = urlsafe_csrf_tokens
-      end
-
       helper_method :form_authenticity_token
       helper_method :protect_against_forgery?
     end
@@ -517,31 +504,15 @@ module ActionController # :nodoc:
       end
 
       def generate_csrf_token # :nodoc:
-        if urlsafe_csrf_tokens
-          SecureRandom.urlsafe_base64(AUTHENTICITY_TOKEN_LENGTH)
-        else
-          SecureRandom.base64(AUTHENTICITY_TOKEN_LENGTH)
-        end
+        SecureRandom.urlsafe_base64(AUTHENTICITY_TOKEN_LENGTH)
       end
 
       def encode_csrf_token(csrf_token) # :nodoc:
-        if urlsafe_csrf_tokens
-          Base64.urlsafe_encode64(csrf_token, padding: false)
-        else
-          Base64.strict_encode64(csrf_token)
-        end
+        Base64.urlsafe_encode64(csrf_token, padding: false)
       end
 
       def decode_csrf_token(encoded_csrf_token) # :nodoc:
-        if urlsafe_csrf_tokens
-          Base64.urlsafe_decode64(encoded_csrf_token)
-        else
-          begin
-            Base64.strict_decode64(encoded_csrf_token)
-          rescue ArgumentError
-            Base64.urlsafe_decode64(encoded_csrf_token)
-          end
-        end
+        Base64.urlsafe_decode64(encoded_csrf_token)
       end
   end
 end

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -404,31 +404,6 @@ module RequestForgeryProtectionTests
     end
   end
 
-  def test_should_allow_post_with_urlsafe_token_when_migrating
-    ActiveSupport::Deprecation.silence do
-      ActionController::Base.urlsafe_csrf_tokens = false
-    end
-    token_length = (ActionController::RequestForgeryProtection::AUTHENTICITY_TOKEN_LENGTH * 4.0 / 3).ceil
-    token_including_url_safe_chars = "-_".ljust(token_length, "A")
-    session[:_csrf_token] = token_including_url_safe_chars
-    @controller.stub :form_authenticity_token, token_including_url_safe_chars do
-      assert_not_blocked { post :index, params: { custom_authenticity_token: token_including_url_safe_chars } }
-    end
-  ensure
-    ActiveSupport::Deprecation.silence do
-      ActionController::Base.urlsafe_csrf_tokens = true
-    end
-  end
-
-  def test_should_warn_about_deprecation_for_urlsafe_config
-    assert_deprecated do
-      ActionController::Base.urlsafe_csrf_tokens = false
-    end
-    assert_deprecated do
-      ActionController::Base.urlsafe_csrf_tokens = true
-    end
-  end
-
   def test_should_allow_patch_with_token
     session[:_csrf_token] = @token
     @controller.stub :form_authenticity_token, @token do

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -91,7 +91,6 @@ module Rails
           if respond_to?(:action_controller)
             action_controller.per_form_csrf_tokens = true
             action_controller.forgery_protection_origin_check = true
-            action_controller.urlsafe_csrf_tokens = false
           end
 
           ActiveSupport.to_time_preserves_timezone = true
@@ -174,10 +173,6 @@ module Rails
           if respond_to?(:action_dispatch)
             action_dispatch.cookies_same_site_protection = :lax
             action_dispatch.ssl_default_redirect_status = 308
-          end
-
-          if respond_to?(:action_controller)
-            action_controller.delete(:urlsafe_csrf_tokens)
           end
 
           if respond_to?(:action_view)


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43817

Normally we remove deprecated code much later, but in this case it's in the way of https://github.com/rails/rails/pull/44283 so I think it would make sense to remove it now.

@rafaelfranca is it all good?

cc @etiennebarrie @simbasdad 