### PR TITLE
Avoid closing websockets in a connecting state to deal with Safari bug

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -166,7 +166,7 @@
       if (!allowReconnect) {
         this.monitor.stop();
       }
-      if (this.isActive()) {
+      if (this.isOpen()) {
         return this.webSocket.close();
       }
     }

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -172,7 +172,7 @@ class Connection {
     if (!allowReconnect) {
       this.monitor.stop();
     }
-    if (this.isActive()) {
+    if (this.isOpen()) {
       return this.webSocket.close();
     }
   }

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -166,7 +166,7 @@
       if (!allowReconnect) {
         this.monitor.stop();
       }
-      if (this.isActive()) {
+      if (this.isOpen()) {
         return this.webSocket.close();
       }
     }

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -44,7 +44,8 @@ class Connection {
 
   close({allowReconnect} = {allowReconnect: true}) {
     if (!allowReconnect) { this.monitor.stop() }
-    if (this.isActive()) {
+    // Avoid closing websockets in a "connecting" state due to Safari 15.1+ bug. See: https://github.com/rails/rails/issues/43835#issuecomment-1002288478
+    if (this.isOpen()) {
       return this.webSocket.close()
     }
   }


### PR DESCRIPTION
This addresses a problem where Safari's WebSockets gets permanently broken when closing them in a `connecting` state due to a [bug in Safari](https://bugs.webkit.org/show_bug.cgi).

This problem was introduced in recent Safari versions (15.1+), in their new WebSockets implementation, called *NSURLSession Websockets*. When it happens, it results in WebSockets being completely borked, requiring a full restart of Safari to fix (just reloading won't fix it).

This problem hit us with Basecamp campfires, and we validated this patch fixes the issue. It just avoids closing WebSockets in a `connecting` state. Other users have reported this same problem: see [this](https://github.com/rails/rails/issues/43835#issuecomment-1002288478) and [this](https://bugs.webkit.org/show_bug.cgi?id=228296#c22). It's not specific to ActionCable, but ActionCable's monitoring system can close connections in a `connecting` state as part of its stale-connection detection logic, triggering this problem.

Despite Safari-specific, we decided to upstream the patch to Rails because this will impact any app using ActionCable. It's also a very tricky problem to troubleshoot (we spent weeks tracking this one down). It won't cause trouble in other browsers, so we keep it simple without doing browser detection. The worst that can happen is that a websocket connection in a `connecting` state that is not closed might eventually connect, and then the browser would have 2 connections, but it would die on its own out of inactivity since it won't be monitored or used by Action cable.

At some point, I want to think that Safari will fix this for good and then we can consider reverting this change.

See https://github.com/rails/rails/issues/43835#issuecomment-1002288478 for more details. [There is a script to reproduce the problem here](https://bugs.webkit.org/show_bug.cgi?id=228296#c38).

@Jeremy @dhh 