### PR TITLE
Don't render layout in `ActionText::Content#inspect`

### DIFF
--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -100,7 +100,7 @@ module ActionText
     end
 
     def inspect
-      "#<#{self.class.name} #{to_s.truncate(25).inspect}>"
+      "#<#{self.class.name} #{to_html.truncate(25).inspect}>"
     end
 
     def ==(other)


### PR DESCRIPTION
Prior to this commit, `ActionText::Content#inspect` called `#to_s` and truncated the result to 25 characters.  However, `#to_s` calls `#to_rendered_html_with_layout` which, by default, renders the same first 25 characters for every instance.

For example, with models such as:

```ruby
class Message < ActiveRecord::Base
  has_rich_text :content
end

Message.create(content: "first message")
Message.create(content: "second message")
Message.create(content: "third message")
```

The output of `#inspect` is indistinguishable:

```irb
irb> Message.all.map { |message| message.content.body }
  Rendered .../actiontext/app/views/action_text/contents/_content.html.erb within layouts/action_text/contents/_content (Duration: 2.4ms | Allocations: 881)
  Rendered .../actiontext/app/views/action_text/contents/_content.html.erb within layouts/action_text/contents/_content (Duration: 0.7ms | Allocations: 257)
  Rendered .../actiontext/app/views/action_text/contents/_content.html.erb within layouts/action_text/contents/_content (Duration: 0.6ms | Allocations: 257)
=> [#<ActionText::Content "<div class=\"trix-conte...">,
    #<ActionText::Content "<div class=\"trix-conte...">,
    #<ActionText::Content "<div class=\"trix-conte...">]
```

This commit changes `#inspect` to call `#to_html`, which does not render the Action Text layout.  So the output of `#inspect` will be:

```irb
irb> Message.all.map { |message| message.content.body }
=> [#<ActionText::Content "first message">,
    #<ActionText::Content "second message">,
    #<ActionText::Content "third message">]
```
