### PR TITLE
Fixes an issue with the ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate method, which affects Ruby 2.6

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix `ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate` for Ruby 2.6.
+
+    Ruby 2.6 and 2.7 have slightly different implementations of the String#@- method. In Ruby 2.6, the receiver of the String#@- method is modified under certain circumstances. This was later identified as a bug (https://bugs.ruby-lang.org/issues/15926) and only fixed in Ruby 2.7.
+
+    Before the changes in this commit, the ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate method, which internally calls the String#@- method, could also modify an input string argument in Ruby 2.6 -- changing a tainted, unfrozen string into a tainted, frozen string.
+
+    Fixes #43056
+
+    *Eric O'Hanlon*
+
 *   Fix migration compatibility to create SQLite references/belongs_to column as integer when migration version is 6.0.
 
     Reference/belongs_to in migrations with version 6.0 were creating columns as

--- a/activerecord/test/cases/connection_adapters/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/schema_cache_test.rb
@@ -269,6 +269,22 @@ module ActiveRecord
         assert_not @cache.columns_hash?("posts")
       end
 
+      # This test covers a patch for a Ruby 2.6 bug that was only fixed in Ruby 2.7.
+      # See: https://bugs.ruby-lang.org/issues/15926
+      test "#deep_duplicate does not modify the frozen/ufrozen state of untainted or tainted string arguments" do
+        test_string = "banana"
+        [
+          test_string.dup,
+          test_string.dup.taint,
+          test_string.dup.freeze,
+          test_string.dup.taint.freeze
+        ].each do |str|
+          starting_frozen_state = str.frozen?
+          @cache.send(:deep_deduplicate, str)
+          assert_equal(starting_frozen_state, str.frozen?)
+        end
+      end
+
       private
         def schema_dump_path
           "#{ASSETS_ROOT}/schema_dump_5_1.yml"


### PR DESCRIPTION
### Summary

Ruby 2.6 and 2.7 have slightly different implementations of the String#@- method. In Ruby 2.6, the receiver of the String#@- method is modified under certain circumstances. This was later identified as a bug (https://bugs.ruby-lang.org/issues/15926) and only fixed in Ruby 2.7.

Before the changes in this commit, the ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate method, which internally calls the String#@- method, could also modify an input string argument in Ruby 2.6 -- changing a tainted, unfrozen string into a tainted, frozen string.

This PR fixes: https://github.com/rails/rails/issues/43056