### PR TITLE
Fix `config.active_record.destroy_association_async_job` configuration

### DIFF
--- a/activejob/lib/active_job/railtie.rb
+++ b/activejob/lib/active_job/railtie.rb
@@ -43,7 +43,7 @@ module ActiveJob
       end
 
       ActiveSupport.on_load(:active_record) do
-        self.destroy_association_async_job = ActiveRecord::DestroyAssociationAsyncJob
+        self.destroy_association_async_job ||= ActiveRecord::DestroyAssociationAsyncJob
       end
     end
 

--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Fix `config.active_record.destroy_association_async_job` configuration
+
+    `config.active_record.destroy_association_async_job` should allow
+    applications to specify the job that will be used to destroy associated
+    records in the background for `has_many` associations with the
+    `dependent: :destroy_async` option. Previously, that was ignored, which
+    meant the default `ActiveRecord::DestroyAssociationAsyncJob` always
+    destroyed records in the background.
+
+    *Nick Holden*
+
 *   Fix quoting of `ActiveSupport::Duration` and `Rational` numbers in the MySQL adapter.
 
     *Kevin McPhillips*

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -2444,6 +2444,20 @@ module ApplicationTests
       assert_equal ActiveRecord::DestroyAssociationAsyncJob, ActiveRecord::Base.destroy_association_async_job
     end
 
+    test "ActiveRecord::Base.destroy_association_async_job can be configured via config.active_record.destroy_association_job" do
+      class ::DummyDestroyAssociationAsyncJob; end
+
+      app_file "config/environments/test.rb", <<-RUBY
+        Rails.application.configure do
+          config.active_record.destroy_association_async_job = DummyDestroyAssociationAsyncJob
+        end
+      RUBY
+
+      app "test"
+
+      assert_equal DummyDestroyAssociationAsyncJob, ActiveRecord::Base.destroy_association_async_job
+    end
+
     test "ActionView::Helpers::FormTagHelper.default_enforce_utf8 is false by default" do
       app "development"
       assert_equal false, ActionView::Helpers::FormTagHelper.default_enforce_utf8


### PR DESCRIPTION
[`config.active_record.destroy_association_async_job`](https://guides.rubyonrails.org/configuring.html#config-active-record-destroy-association-async-job) should allow applications to specify the job that will be used to destroy associated records in the background for `has_many` associations with the [`dependent: :destroy_async` option](https://edgeguides.rubyonrails.org/association_basics.html#options-for-belongs-to-dependent). That's being ignored, which means the default `ActiveRecord::DestroyAssociationAsyncJob` always destroys records in the
background.

This PR stops ignoring the `config.active_record.destroy_association_async_job` configuration.