### PR TITLE
Add turbolinks=false on links to older guides

### DIFF
--- a/guides/source/_welcome.html.erb
+++ b/guides/source/_welcome.html.erb
@@ -16,17 +16,17 @@
 <% end %>
 <p>
 The guides for earlier releases:
-<a href="https://guides.rubyonrails.org/v7.0/">Rails 7.0</a>,
-<a href="https://guides.rubyonrails.org/v6.1/">Rails 6.1</a>,
-<a href="https://guides.rubyonrails.org/v6.0/">Rails 6.0</a>,
-<a href="https://guides.rubyonrails.org/v5.2/">Rails 5.2</a>,
-<a href="https://guides.rubyonrails.org/v5.1/">Rails 5.1</a>,
-<a href="https://guides.rubyonrails.org/v5.0/">Rails 5.0</a>,
-<a href="https://guides.rubyonrails.org/v4.2/">Rails 4.2</a>,
-<a href="https://guides.rubyonrails.org/v4.1/">Rails 4.1</a>,
-<a href="https://guides.rubyonrails.org/v4.0/">Rails 4.0</a>,
-<a href="https://guides.rubyonrails.org/v3.2/">Rails 3.2</a>,
-<a href="https://guides.rubyonrails.org/v3.1/">Rails 3.1</a>,
-<a href="https://guides.rubyonrails.org/v3.0/">Rails 3.0</a>, and
-<a href="https://guides.rubyonrails.org/v2.3/">Rails 2.3</a>.
+<a href="https://guides.rubyonrails.org/v7.0/" data-turbolinks="false">Rails 7.0</a>,
+<a href="https://guides.rubyonrails.org/v6.1/" data-turbolinks="false">Rails 6.1</a>,
+<a href="https://guides.rubyonrails.org/v6.0/" data-turbolinks="false">Rails 6.0</a>,
+<a href="https://guides.rubyonrails.org/v5.2/" data-turbolinks="false">Rails 5.2</a>,
+<a href="https://guides.rubyonrails.org/v5.1/" data-turbolinks="false">Rails 5.1</a>,
+<a href="https://guides.rubyonrails.org/v5.0/" data-turbolinks="false">Rails 5.0</a>,
+<a href="https://guides.rubyonrails.org/v4.2/" data-turbolinks="false">Rails 4.2</a>,
+<a href="https://guides.rubyonrails.org/v4.1/" data-turbolinks="false">Rails 4.1</a>,
+<a href="https://guides.rubyonrails.org/v4.0/" data-turbolinks="false">Rails 4.0</a>,
+<a href="https://guides.rubyonrails.org/v3.2/" data-turbolinks="false">Rails 3.2</a>,
+<a href="https://guides.rubyonrails.org/v3.1/" data-turbolinks="false">Rails 3.1</a>,
+<a href="https://guides.rubyonrails.org/v3.0/" data-turbolinks="false">Rails 3.0</a>, and
+<a href="https://guides.rubyonrails.org/v2.3/" data-turbolinks="false">Rails 2.3</a>.
 </p>


### PR DESCRIPTION
### Summary

Fixes #44302 by adding `data-turbolinks="false"` to each link to older versions of the guide, which forces a full page load and correct browser back button behavior. 