### PR TITLE
Reversed attribute precedence in insert_all

### DIFF
--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -646,6 +646,16 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_on_scope_precedence
+    author = Author.create!(name: "Jimmy")
+
+    assert_difference "author.books.count", +1 do
+      assert_difference "author.books.written.count", +1 do
+        author.books.published.insert_all!([{ name: "My little book", isbn: "1974522598", status: :written }])
+      end
+    end
+  end
+
   def test_insert_all_create_with
     assert_difference "Book.where(format: 'X').count", +2 do
       Book.create_with(format: "X").insert_all!([ { name: "A" }, { name: "B" } ])
@@ -675,6 +685,18 @@ class InsertAllTest < ActiveRecord::TestCase
 
     assert_difference "author.books.count", +1 do
       author.books.upsert_all([{ name: "My little book", isbn: "1974522598", author_id: second_author.id }])
+    end
+  end
+
+  def test_upsert_all_on_scope_precedence
+    skip unless supports_insert_on_duplicate_update?
+
+    author = Author.create!(name: "Jimmy")
+
+    assert_difference "author.books.count", +1 do
+      assert_difference "author.books.written.count", +1 do
+        author.books.published.upsert_all([{ name: "My little book", isbn: "1974522598", status: :written }])
+      end
     end
   end
 


### PR DESCRIPTION
### Summary

Rails 6.1 (via #38899) introduced incorporating relationship scopes into the attributes inserted when using `insert_all`/`upsert_all`. This allowed `author.books.insert_all({ title: "Out of the Silent Planet" })` to work as expected. Neat!

However, the attributes from the scope were combined with attributes passed in as arguments with `merge!`. This meant that attributes on the scope would overwrite those passed in, which can be surprising in some cases, especially when using default scopes.

The example in the test for attribute precedence prior to this PR was a bit contrived:
```ruby
assert_difference "author.books.count", +1 do
  author.books.insert_all({ title: "Out of the Silent Planet", isbn: "XXX", author_id: second_author.id })
end
```

... but one could perhaps see the logic of it: `author.books` as the scope is a strong contender for what should win out when inserting the new record.

However, I believe it's more surprising that the attributes explicitly passed in to `insert_all` don't ultimately take precedence; these seem to be the stronger indicator of intent, more even than the scope. A different example illustrates what I mean:

```ruby
class Book < ActiveRecord
  default_scope where(archived_at: nil)

  def archived?
    archived_at.nil?
  end

end

book = Book.insert_all({ title: "Perelandra", archived_at: Time.now })
book.archived?
# => false
```

In this example, books may be archived using a timestamp. By default, we only ever want to work with un-archived books, and so we've set up a `default_scope` to accomplish this (it could just as easily be a scope on a relationship as well, e.g., an Author `has_many :books, ->{ where(archived_at: nil) }`). But should we want to insert a book as already archived, passing in a timestamp for `archived_at` is not enough! We also have to remember to also call `unscope(where: :archived_at)` before `insert_all`. That's surprising.

What I suggest is reversing the precedence and deferring to the attributes passed into the method over what we get from the scope (i.e., using `reverse_merge!` instead of `merge!`); the attributes passed in are stronger signals of intent than the scope on which one calls `insert_all`.

This would be a reversal from current behavior, though I don't believe the current behavior is noted in the documentation (cf. #41639). It would, however, make other attributes more consistent with the automatically-added timestamps, which already use `reverse_merge!` to defer to the passed-in attributes over the default values (cf. #43003).

Thanks for your thoughts and consideration!

