### PR TITLE
Use different cache namespace for proxy calls

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use different cache namespace for proxy calls
 
+	Models can currently have different attribute bodies for the same method
+	names, leading to conflicts. Adding a new namespace `:active_model_proxy`
+	fixes the issue.
+
+    *Chris Salzberg*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/activemodel/CHANGELOG.md) for previous changes.

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -319,7 +319,7 @@ module ActiveModel
               if respond_to?(generate_method, true)
                 send(generate_method, attr_name.to_s, owner: owner)
               else
-                define_proxy_call(owner, method_name, matcher.target, matcher.parameters, attr_name.to_s, namespace: :active_model)
+                define_proxy_call(owner, method_name, matcher.target, matcher.parameters, attr_name.to_s, namespace: :active_model_proxy)
               end
             end
           end

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -24,6 +24,33 @@ module ActiveModel
       attribute :string_field, default: "default string"
     end
 
+    class ModelWithGeneratedAttributeMethods
+      include ActiveModel::Attributes
+
+      attribute :foo
+    end
+
+    class ModelWithProxiedAttributeMethods
+      include ActiveModel::AttributeMethods
+
+      attribute_method_suffix "="
+
+      define_attribute_method(:foo)
+
+      def attribute=(_, _)
+      end
+    end
+
+    test "models that proxy attributes do not conflict with models with generated methods" do
+      ModelWithGeneratedAttributeMethods.new
+
+      model = ModelWithProxiedAttributeMethods.new
+
+      assert_nothing_raised do
+        model.foo = "foo"
+      end
+    end
+
     test "properties assignment" do
       data = ModelForAttributesTest.new(
         integer_field: "2.3",


### PR DESCRIPTION
### Summary

Related: https://github.com/rails/rails/pull/42095

Issue:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
end

require "active_model/railtie"

class Model1
  include ActiveModel::Attributes

  attribute :foo
end

class Model2
  include ActiveModel::AttributeMethods
  attribute_method_suffix '='

  define_attribute_method(:foo)
  define_attribute_method(:bar)

  private

  def attribute=(_, _)
  end
end

require "minitest/autorun"

class CachedAttributesTest < Minitest::Test
  def test_method_conflict
    Model1.new # define attribute methods

    model2 = Model2.new

    model2.bar = "thisworks"
    model2.foo = "thisdoesnt"
  end
end
```

This fails because the cache is shared between the two models, because they both use the same `:active_model` namespace.

### Other Information

I can add a test.
