### PR TITLE
Add Active Model `Collection` attribute type

### DIFF
--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -7,6 +7,7 @@ require "active_model/type/value"
 require "active_model/type/big_integer"
 require "active_model/type/binary"
 require "active_model/type/boolean"
+require "active_model/type/collection"
 require "active_model/type/date"
 require "active_model/type/date_time"
 require "active_model/type/decimal"
@@ -43,6 +44,7 @@ module ActiveModel
     register(:big_integer, Type::BigInteger)
     register(:binary, Type::Binary)
     register(:boolean, Type::Boolean)
+    register(:collection, Type::Collection)
     register(:date, Type::Date)
     register(:datetime, Type::DateTime)
     register(:decimal, Type::Decimal)

--- a/activemodel/lib/active_model/type/collection.rb
+++ b/activemodel/lib/active_model/type/collection.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Type
+    # Attribute type for a collection of values. It is registered under
+    # the +:collection+ key. +:element_type+ option is used to specify elements type
+    #
+    #   class User
+    #     include ActiveModel::Attributes
+    #
+    #     attribute :lucky_numbers, :collection, element_type: :integer
+    #   end
+    #
+    #   user = User.new(lucky_numbers: [1, 2, 3])
+    #   user.lucky_numbers # => [1, 2, 3]
+    #
+    # Value is wrapped into an Array if not an Array already
+    #
+    #   User.new(lucky_numbers: 1).lucky_numbers # => [1]
+    #
+    # Collection elements are coerced by their +:element_type+ type
+    #
+    #   User.new(lucky_numbers: ["1"]).lucky_numbers # => [1]
+    #
+    class Collection < Value
+      def initialize(**args)
+        @element_type = args.delete(:element_type)
+        @type_object = Type.lookup(element_type, **args)
+        @serializer = args.delete(:serializer) || ActiveSupport::JSON
+        super()
+      end
+
+      def type
+        :collection
+      end
+
+      def cast(value)
+        return [] if value.nil?
+        Array(value).map { |el| @type_object.cast(el) }
+      end
+
+      def serializable?(value)
+        value.all? { |el| @type_object.serializable?(el) }
+      end
+
+      def serialize(value)
+        serializer.encode(value.map { |el| @type_object.serialize(el) })
+      end
+
+      def deserialize(value)
+        serializer.decode(value).map { |el| @type_object.deserialize(el) }
+      end
+
+      def assert_valid_value(value)
+        return if valid_value?(value)
+        raise ArgumentError, "'#{value}' is not a valid #{type} of #{element_type}"
+      end
+
+      def changed_in_place?(raw_old_value, new_value)
+        old_value = deserialize(raw_old_value)
+        return true if old_value.size != new_value.size
+
+        old_value.each_with_index.any? do |raw_old, i|
+          @type_object.changed_in_place?(raw_old, new_value[i])
+        end
+      end
+
+      def valid_value?(value)
+        value.is_a?(Array) && value.all? { |el| @type_object.valid_value?(el) }
+      end
+
+      private
+        attr_reader :element_type, :serializer
+    end
+  end
+end

--- a/activemodel/lib/active_model/type/value.rb
+++ b/activemodel/lib/active_model/type/value.rb
@@ -128,7 +128,13 @@ module ActiveModel
         [self.class, precision, scale, limit].hash
       end
 
-      def assert_valid_value(_)
+      def assert_valid_value(value)
+        return if valid_value?(value)
+        raise ArgumentError, "'#{value}' is not a valid #{type}"
+      end
+
+      def valid_value?(_)
+        true
       end
 
       def immutable_value(value) # :nodoc:

--- a/activemodel/test/cases/attributes_test.rb
+++ b/activemodel/test/cases/attributes_test.rb
@@ -14,6 +14,8 @@ module ActiveModel
       attribute :string_with_default, :string, default: "default string"
       attribute :date_field, :date, default: -> { Date.new(2016, 1, 1) }
       attribute :boolean_field, :boolean
+      attribute :integer_collection, :collection, element_type: :integer
+      attribute :string_collection, :collection, element_type: :string
     end
 
     class ChildModelForAttributesTest < ModelForAttributesTest
@@ -56,7 +58,9 @@ module ActiveModel
         integer_field: "2.3",
         string_field: "Rails FTW",
         decimal_field: "12.3",
-        boolean_field: "0"
+        boolean_field: "0",
+        integer_collection: ["1", "2", "3"],
+        string_collection: [1, 2, 3]
       )
 
       assert_equal 2, data.integer_field
@@ -65,6 +69,9 @@ module ActiveModel
       assert_equal "default string", data.string_with_default
       assert_equal Date.new(2016, 1, 1), data.date_field
       assert_equal false, data.boolean_field
+      assert_equal [1, 2, 3], data.integer_collection
+      assert_equal ["1", "2", "3"], data.string_collection
+
 
       data.integer_field = 10
       data.string_with_default = nil
@@ -80,7 +87,9 @@ module ActiveModel
         integer_field: 1.1,
         string_field: 1.1,
         decimal_field: 1.1,
-        boolean_field: 1.1
+        boolean_field: 1.1,
+        string_collection: ["Rails"],
+        integer_collection: [1],
       )
 
       expected_attributes = {
@@ -89,7 +98,10 @@ module ActiveModel
         decimal_field: BigDecimal("1.1"),
         string_with_default: "default string",
         date_field: Date.new(2016, 1, 1),
-        boolean_field: true
+        boolean_field: true,
+        string_collection: ["Rails"],
+        integer_collection: [1]
+
       }.stringify_keys
 
       assert_equal expected_attributes, data.attributes
@@ -102,7 +114,9 @@ module ActiveModel
         "decimal_field",
         "string_with_default",
         "date_field",
-        "boolean_field"
+        "boolean_field",
+        "integer_collection",
+        "string_collection"
       ]
 
       assert_equal names, ModelForAttributesTest.attribute_names

--- a/activemodel/test/cases/type/collection_test.rb
+++ b/activemodel/test/cases/type/collection_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/user"
+
+module ActiveModel
+  module Type
+    class CollectionTest < ActiveModel::TestCase
+      setup do
+        @element_type = Minitest::Mock.new
+        @serializer = Minitest::Mock.new
+        ActiveModel::Type.stub(:lookup, @element_type) do
+          @collection = Collection.new(element_type: :element_type, serializer: @serializer)
+        end
+        @my_collection = [1, 2, 3]
+      end
+
+      test "#valid_value? returns false if value is not an array" do
+        assert_not @collection.valid_value?("Nikita")
+      end
+
+      test "#valid_value? returns false if value is not an array of valid type_objects" do
+        @element_type.expect(:valid_value?, false, ["Nikita"])
+        assert_not @collection.valid_value?(["Nikita"])
+      end
+
+      test "#assert_valid_value doesn't raise if valid_value? returns true" do
+        assert_nothing_raised do
+          @collection.stub(:valid_value?, true) do
+            @collection.assert_valid_value(["Nikita"])
+          end
+        end
+      end
+
+      test "#assert_valid_value raises ArgumentError if valid_value? returns false" do
+        err = assert_raises(ArgumentError) do
+          @collection.stub(:valid_value?, false) do
+            @collection.assert_valid_value({ name: "Nikita" })
+          end
+        end
+
+        assert_equal "'{:name=>\"Nikita\"}' is not a valid collection of element_type", err.message
+      end
+
+      test "#valid_value? delegates valid_value? check to the element type" do
+        @my_collection.each { |i| @element_type.expect(:valid_value?, true, [i]) }
+        assert @collection.valid_value?(@my_collection)
+      end
+
+      test "#serialize delegates serialize check to the element type" do
+        serialized_items = @my_collection.map { |i| "serialized #{i}" }
+        @my_collection.each_with_index do |item, index|
+          @element_type.expect(:serialize, serialized_items[index], [item])
+        end
+        expected = "serialized_collection: #{serialized_items}"
+        @serializer.expect(:encode, expected, [serialized_items])
+        assert_equal expected, @collection.serialize(@my_collection)
+      end
+
+      test "#deserialize delegates deserialize check to the element type" do
+        serialized_collection = "serialized collection"
+        @my_collection.each { |i| @element_type.expect(:deserialize, "deserialized #{i}", [i]) }
+        expected = @my_collection.map { |i| "deserialized #{i}" }
+        @serializer.expect(:decode, @my_collection, [serialized_collection])
+
+        assert_equal expected, @collection.deserialize(serialized_collection)
+      end
+
+      test "#serializable? delegates serializable? check to the element type" do
+        @my_collection.each { |i| @element_type.expect(:serializable?, true, [i]) }
+        assert @collection.serializable?(@my_collection)
+      end
+
+      test "#changed_in_place? delegates changed_in_place? check to the element type" do
+        my_collection_raw = "my_serialized_collection"
+        @my_collection.each do |el|
+          @element_type.expect(:changed_in_place?, false, [el, el])
+        end
+
+        @collection.stub(:deserialize, @my_collection, [my_collection_raw]) do
+          assert_not @collection.changed_in_place?(my_collection_raw, @my_collection)
+        end
+      end
+
+      test "#changed_in_place? returns true if size of new and old collections is different" do
+        my_collection_raw = "my_serialized_collection"
+
+        @collection.stub(:deserialize, @my_collection, [my_collection_raw]) do
+          assert @collection.changed_in_place?(my_collection_raw, [1])
+        end
+      end
+
+      test "#changed_in_place? returns true if collections are the same size but with different elements" do
+        new_collection = [1, "changed", 3]
+        my_collection_raw = "my_serialized_collection"
+        @element_type.expect(:changed_in_place?, false, [1, 1])
+        @element_type.expect(:changed_in_place?, true, [2, "changed"])
+
+        @collection.stub(:deserialize, @my_collection, [my_collection_raw]) do
+          assert @collection.changed_in_place?(my_collection_raw, new_collection)
+        end
+      end
+
+      test "#cast returns an empty array if value is nil" do
+        assert_equal [], @collection.cast(nil)
+      end
+
+      test "#cast wraps false value in an array" do
+        @element_type.expect(:cast, false, [false])
+        assert_equal [false], @collection.cast(false)
+      end
+
+      test "#cast wraps value in an array if value is not an array" do
+        @element_type.expect(:cast, 1, [1])
+        assert_equal [1], @collection.cast(1)
+      end
+
+      test "#cast delegates cast to the element type" do
+        string_collection = ["1", "2", "3"]
+        string_collection.each { |el| @element_type.expect(:cast, el.to_i, [el]) }
+
+        assert_equal @my_collection, @collection.cast(string_collection)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

One case that is not yet covered by the current standard types is for attributes that represent a collection of multiple values. For example, one might need to represent a subset of strings as a list in a single attribute; or even an entire group of associated models that are all embedded in a named collection. 


This PR aims to implement a new Collection type.
It subclasses the base Value class and overrides the necessary methods so casting and serialization work for an array of objects that are themselves valid for one of the types in the Registry. This ensures that each element of the collection can be cast and serialized individually by delegating the operation to the appropriate type instance.

Collection serializes itself as a JSON array on the database. For casting, it attempts to convert values to a Ruby array.

Methods:

- `type`: returns the :collection symbol.
- `serializable?`: checks if the given value is an array containing only elements in which are all serializable for the collection type. It will instantiate the type passed during its own initialization and call serializable? for each element.
- `serialize`: returns a JSON string of an array with all elements serialized by the collection type.
- `deserialize`: expects a JSON array string and converts it into a Ruby array with each element deserialized by the collection type.
- `cast`: converts the given array into a normalized collection of cast values. It will map the given array to a new one in which each element is cast into a new value by the collection type.
- `changed_in_place?`: Accepts raw serialized value, deserializes it and checks if any of the elements of the collections were mutated according to the collection type method of the same name.
- `assert_valid_value`: checks if all elements of the given array are accepted by the collection type method of the same name.



### Other Information

This change also introduces additional `Value#valid_value?` method that is supposed to separate the assertion, which raises an exception from a boolean check that can be reused in other places. This way new types won't have to override the whole `assert_valid_value` method if they want to keep the default error message.

Let me know if this change should be implemented in a separate PR. I decided to keep it in this PR for better readability of the change but definitely willing to extract it and have a discussion is a different PR. Thanks!

### Documentation

Currently only the class itself is covered with documentation. But we have plans to cover public methods as well.
Either in this PR, in a separate one or perhaps as part of the https://github.com/rails/rails/pull/44306
