### PR TITLE
`form_for`: Attempt to call `to_model` on first argument

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Ensure models passed to `form_for` attempt to call `to_model`.
 
+    *Sean Doyle*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -438,7 +438,7 @@ module ActionView
           model       = nil
           object_name = record
         else
-          model       = record
+          model       = convert_to_model(record)
           object      = _object_for_form_builder(record)
           raise ArgumentError, "First argument in form cannot contain nil or be empty" unless object
           object_name = options[:as] || model_name_from_record_or_class(object).param_key

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -309,6 +309,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     @controller.singleton_class.include Routes.url_helpers
   end
 
+  RecordForm = Struct.new(:to_model, keyword_init: true)
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
     resources :posts do
@@ -377,6 +378,26 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<button name='button' type='submit'>Create post</button>" \
       "<button name='button' type='submit'><span>Create post</span></button>"
     end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_with_persisted_to_model
+    post_form = RecordForm.new(to_model: @post)
+
+    form_with(model: post_form) { }
+
+    expected = whole_form("/posts/123", method: :post) { "" }
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_with_with_new_record_to_model
+    post_form = RecordForm.new(to_model: Post.new)
+
+    form_with(model: post_form) { }
+
+    expected = whole_form("/posts", method: :post) { "" }
 
     assert_dom_equal expected, output_buffer
   end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -143,6 +143,7 @@ class FormHelperTest < ActionView::TestCase
     @controller.singleton_class.include Routes.url_helpers
   end
 
+  RecordForm = Struct.new(:to_model, keyword_init: true)
   Routes = ActionDispatch::Routing::RouteSet.new
   Routes.draw do
     resources :posts do
@@ -2072,6 +2073,26 @@ class FormHelperTest < ActionView::TestCase
       "<input checked='checked' id='post_1_tag_ids_1' name='post[1][tag_ids][]' type='checkbox' value='1' />" \
       "<label for='post_1_tag_ids_1'>Tag 1</label>"
     end
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_persisted_to_model
+    post_form = RecordForm.new(to_model: @post)
+
+    form_for(post_form) { }
+
+    expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: :patch) { "" }
+
+    assert_dom_equal expected, output_buffer
+  end
+
+  def test_form_for_with_new_record_to_model
+    post_form = RecordForm.new(to_model: Post.new)
+
+    form_for(post_form) { }
+
+    expected = whole_form("/posts", "new_post", "new_post", method: :post) { "" }
 
     assert_dom_equal expected, output_buffer
   end


### PR DESCRIPTION
### Summary

The changes introduced in [rails/rails#43421][] did not account for
attempting to coerce the record with [#to_model][]. This commit resolves
that issue and adds test coverage to guard against future regressions.

Additionally, this adds tests to exercise `form_with` to ensure that it
_does not_ call `#to_model` on its `model:` argument, since that was the
behavior in [6.1.4.4][]

[rails/rails#43421]: https://github.com/rails/rails/pull/43421
[#to_model]: https://edgeapi.rubyonrails.org/classes/ActiveModel/Conversion.html#method-i-to_model
[6.1.4.4]: https://github.com/rails/rails/issues/44326#issuecomment-1029344241


### Other Information

Related to https://github.com/rails/rails/issues/44326