### PR TITLE
Fix the ability to exclude encryption params from being autofiltered

### DIFF
--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -52,7 +52,7 @@ module ActiveRecord
 
         def install_auto_filtered_parameters(application) # :nodoc:
           ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, encrypted_attribute_name|
-            application.config.filter_parameters << encrypted_attribute_name unless ActiveRecord::Encryption.config.excluded_from_filter_parameters.include?(name)
+            application.config.filter_parameters << encrypted_attribute_name unless ActiveRecord::Encryption.config.excluded_from_filter_parameters.include?(encrypted_attribute_name)
           end
         end
       end

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -52,4 +52,20 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
 
     assert_includes application.config.filter_parameters, :catchphrase
   end
+
+  test "exclude the installation of autofiltered params" do
+    ActiveRecord::Encryption.config.excluded_from_filter_parameters = [:catchphrase]
+
+    application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
+    ActiveRecord::Encryption.install_auto_filtered_parameters(application)
+
+    Class.new(Pirate) do
+      self.table_name = "pirates"
+      encrypts :catchphrase
+    end
+
+    assert_equal application.config.filter_parameters, []
+
+    ActiveRecord::Encryption.config.excluded_from_filter_parameters = []
+  end
 end


### PR DESCRIPTION
### Summary

A bug is preventing the exclusion of params from being auto-filtered in conjunction with ActiveRecord encryption. 

This fixes it by exposing the bug in a test, then using the correct variable in the code.
