### PR TITLE
Prefer value before type cast in form tag helpers

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   When populating a form field for a model attribute, the following form tag
+    helpers will now use the attribute's value before type cast, just as the
+    `text_field` helper does:
+
+    * `color_field`
+    * `check_box`
+    * `collection_check_boxes`
+    * `radio_button`
+    * `collection_radio_buttons`
+    * `select`
+    * `collection_select`
+    * `grouped_collection_select`
+
+    *Jonathan Hefner*
+
 *   Fix and add protections for XSS in `ActionView::Helpers` and `ERB::Util`.
 
     Escape dangerous characters in names of tags and names of attributes in the

--- a/actionview/lib/action_view/helpers/tags/checkable.rb
+++ b/actionview/lib/action_view/helpers/tags/checkable.rb
@@ -9,7 +9,7 @@ module ActionView
             checked = options.delete "checked"
             checked == true || checked == "checked"
           else
-            checked?(value)
+            checked?(value_before_type_cast)
           end
         end
       end

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -15,7 +15,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value },
+            selected: @options.fetch(:selected) { value_before_type_cast },
             disabled: @options[:disabled]
           }
 

--- a/actionview/lib/action_view/helpers/tags/color_field.rb
+++ b/actionview/lib/action_view/helpers/tags/color_field.rb
@@ -6,7 +6,7 @@ module ActionView
       class ColorField < TextField # :nodoc:
         def render
           options = @options.stringify_keys
-          options["value"] ||= validate_color_string(value)
+          options["value"] ||= validate_color_string(value_before_type_cast)
           @options = options
           super
         end

--- a/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -17,7 +17,7 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value },
+            selected: @options.fetch(:selected) { value_before_type_cast },
             disabled: @options[:disabled]
           }
 

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -15,7 +15,10 @@ module ActionView
 
         def render
           option_tags_options = {
-            selected: @options.fetch(:selected) { value.nil? ? "" : value },
+            selected: @options.fetch(:selected) do
+              value = value_before_type_cast
+              value.nil? ? "" : value
+            end,
             disabled: @options[:disabled]
           }
 

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -811,6 +811,21 @@ class FormHelperTest < ActionView::TestCase
     assert_predicate check_box("post", "secret", {}, "on", nil), :html_safe?
   end
 
+  def test_check_box_uses_value_before_type_cast
+    def @post.secret_before_type_cast; "before"; end
+    @post.secret = "after"
+
+    assert_dom_equal(
+      '<input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="before" />',
+      check_box("post", "secret", {}, "before", nil)
+    )
+
+    assert_dom_equal(
+      '<input id="post_secret" name="post[secret]" type="checkbox" value="after" />',
+      check_box("post", "secret", {}, "after", nil)
+    )
+  end
+
   def test_check_box_with_multiple_behavior
     @post.comment_ids = [2, 3]
     assert_dom_equal(
@@ -870,6 +885,21 @@ class FormHelperTest < ActionView::TestCase
   def test_radio_button_with_negative_integer_value
     assert_dom_equal('<input id="post_secret_-1" name="post[secret]" type="radio" value="-1" />',
       radio_button("post", "secret", "-1"))
+  end
+
+  def test_radio_button_uses_value_before_type_cast
+    def @post.secret_before_type_cast; "before"; end
+    @post.secret = "after"
+
+    assert_dom_equal(
+      '<input checked="checked" id="post_secret_before" name="post[secret]" type="radio" value="before" />',
+      radio_button("post", "secret", "before")
+    )
+
+    assert_dom_equal(
+      '<input id="post_secret_after" name="post[secret]" type="radio" value="after" />',
+      radio_button("post", "secret", "after")
+    )
   end
 
   def test_radio_button_respects_passed_in_id
@@ -1005,6 +1035,11 @@ class FormHelperTest < ActionView::TestCase
 
   def test_inputs_use_before_type_cast_to_retain_information_from_validations_like_numericality
     assert_dom_equal(
+      %{<input id="post_id" name="post[id]" type="text" value="omg" />},
+      text_field("post", "id")
+    )
+
+    assert_dom_equal(
       %{<textarea id="post_id" name="post[id]">\nomg</textarea>},
       text_area("post", "id")
     )
@@ -1017,13 +1052,26 @@ class FormHelperTest < ActionView::TestCase
     end
 
     assert_dom_equal(
+      %{<input id="post_id" name="post[id]" type="text" value="0" />},
+      text_field("post", "id")
+    )
+
+    assert_dom_equal(
       %{<textarea id="post_id" name="post[id]">\n0</textarea>},
       text_area("post", "id")
     )
   end
 
-  def test_inputs_use_before_typecast_when_object_doesnt_respond_to_came_from_user
-    class << @post; undef id_came_from_user?; end
+  def test_inputs_use_before_type_cast_when_object_doesnt_respond_to_came_from_user
+    class << @post
+      undef id_came_from_user?
+    end
+
+    assert_dom_equal(
+      %{<input id="post_id" name="post[id]" type="text" value="omg" />},
+      text_field("post", "id")
+    )
+
     assert_dom_equal(
       %{<textarea id="post_id" name="post[id]">\nomg</textarea>},
       text_area("post", "id")
@@ -1059,6 +1107,14 @@ class FormHelperTest < ActionView::TestCase
   def test_color_field_with_value_attr
     expected = %{<input id="car_color" name="car[color]" type="color" value="#00FF00" />}
     assert_dom_equal(expected, color_field("car", "color", value: "#00FF00"))
+  end
+
+  def test_color_field_uses_value_before_type_cast
+    def @car.color_before_type_cast; "#00ff00"; end
+    @car.color = "(0,255,0)"
+
+    expected = %{<input id="car_color" name="car[color]" type="color" value="#00ff00" />}
+    assert_dom_equal(expected, color_field("car", "color"))
   end
 
   def test_search_field

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1009,6 +1009,17 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_select_uses_value_before_type_cast
+    @post = Post.new
+    def @post.category_before_type_cast; "before"; end
+    @post.category = "after"
+
+    assert_dom_equal(
+      %(<select name="post[category]" id="post_category"><option value="after">bad</option>\n<option selected="selected" value="before">good</option></select>),
+      select(:post, :category, { bad: "after", good: "before" })
+    )
+  end
+
   def test_collection_select
     @post = Post.new
     @post.author_name = "Babe"
@@ -1130,6 +1141,17 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       "<select id=\"post_author_name\" name=\"post[author_name]\"><option value=\"&lt;Abe&gt;\">&lt;Abe&gt; went home</option>\n<option value=\"Babe\">Babe went home</option>\n<option value=\"Cabe\">Cabe went home</option></select>",
       collection_select("post", "author_name", dummy_posts, "author_name", lambda { |p| p.title })
+    )
+  end
+
+  def test_collection_select_uses_value_before_type_cast
+    @post = Post.new
+    def @post.category_before_type_cast; "before"; end
+    @post.category = "after"
+
+    assert_dom_equal(
+      %(<select name="post[category]" id="post_category"><option value="after">bad</option>\n<option selected="selected" value="before">good</option></select>),
+      collection_select(:post, :category, { bad: "after", good: "before" }, :last, :first)
     )
   end
 
@@ -1505,6 +1527,17 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
       output_buffer
+    )
+  end
+
+  def test_grouped_collection_select_uses_value_before_type_cast
+    @post = Post.new
+    def @post.category_before_type_cast; "before"; end
+    @post.category = "after"
+
+    assert_dom_equal(
+      %(<select id="post_category" name="post[category]"><optgroup label="grouped"><option value="after">bad</option>\n<option selected="selected" value="before">good</option></optgroup></select>),
+      grouped_collection_select(:post, :category, { grouped: { bad: "after", good: "before" } }, :last, :first, :last, :first)
     )
   end
 


### PR DESCRIPTION
Many form tag helpers, such as `text_field`, [populate their fields using `value_before_type_cast`](https://github.com/rails/rails/blob/91f80a899f448b44e79937ae6972bd0f46b280d9/actionview/lib/action_view/helpers/tags/text_field.rb#L15).  However, a few helpers use `value`, the value after type cast.  When `value.to_s` != `value_before_type_cast`, those helpers may populate their fields incorrectly or not at all.

For example, when building a model with a custom attribute type such as:

```ruby
class ColorQuery
  include ActiveModel::API
  include ActiveModel::Attributes
  include ActiveRecord::AttributeMethods::BeforeTypeCast

  class RGB < ActiveModel::Type::Value
    def cast(value)
      # converts e.g. "#00ff00" to [0, 255, 0]
      value.is_a?(String) ? [value[-6..].hex].pack("N").unpack("xCCC") : value
    end
  end

  attribute :rgb, RGB.new
end
```

All of the following form fields will fail to re-populate between form submissions:

```erb
<%= form.color_field :rgb %>

<%= form.select :rgb,
      { red: "#ff0000", green: "#00ff00" },
      include_blank: true %>

<%= form.collection_select :rgb,
      { red: "#ff0000", green: "#00ff00" },
      :last, :first,
      include_blank: true %>

<%= form.radio_button :rgb, "#ff0000" %>
<%= form.label :rgb, "red", value: "#ff0000" %>
<%= form.radio_button :rgb, "#00ff00" %>
<%= form.label :rgb, "green", value: "#00ff00" %>

<%= form.collection_radio_buttons :rgb,
      { red: "#ff0000", green: "#00ff00" },
      :last, :first %>
```

This commit changes the relevant helpers to use the value before type cast when possible, just as the `text_field` helper does.
