### PR TITLE
Unify select tag helpers nil value handling

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   When populating a form field for a model attribute, the `collection_select`
+    and `grouped_collection_select` form tag helpers will now match a `nil`
+    attribute value with a `nil` choice value, just as the `select` helper does.
+
+    *Jonathan Hefner*
+
 *   Fix and add protections for XSS in `ActionView::Helpers` and `ERB::Util`.
 
     Escape dangerous characters in names of tags and names of attributes in the

--- a/actionview/lib/action_view/helpers/tags/collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/collection_select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class CollectionSelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, collection, value_method, text_method, options, html_options)
           @collection   = collection
           @value_method = value_method
@@ -13,17 +17,10 @@ module ActionView
           super(object_name, method_name, template_object, options)
         end
 
-        def render
-          option_tags_options = {
-            selected: @options.fetch(:selected) { value },
-            disabled: @options[:disabled]
-          }
-
-          select_content_tag(
-            options_from_collection_for_select(@collection, @value_method, @text_method, option_tags_options),
-            @options, @html_options
-          )
-        end
+        private
+          def option_tags
+            options_from_collection_for_select(@collection, @value_method, @text_method, option_tags_options)
+          end
       end
     end
   end

--- a/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
+++ b/actionview/lib/action_view/helpers/tags/grouped_collection_select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class GroupedCollectionSelect < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
           @collection          = collection
           @group_method        = group_method
@@ -15,16 +19,10 @@ module ActionView
           super(object_name, method_name, template_object, options)
         end
 
-        def render
-          option_tags_options = {
-            selected: @options.fetch(:selected) { value },
-            disabled: @options[:disabled]
-          }
-
-          select_content_tag(
-            option_groups_from_collection_for_select(@collection, @group_method, @group_label_method, @option_key_method, @option_value_method, option_tags_options), @options, @html_options
-          )
-        end
+        private
+          def option_tags
+            option_groups_from_collection_for_select(@collection, @group_method, @group_label_method, @option_key_method, @option_value_method, option_tags_options)
+          end
       end
     end
   end

--- a/actionview/lib/action_view/helpers/tags/select.rb
+++ b/actionview/lib/action_view/helpers/tags/select.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "action_view/helpers/tags/select_renderer"
+
 module ActionView
   module Helpers
     module Tags # :nodoc:
       class Select < Base # :nodoc:
+        include SelectRenderer
+
         def initialize(object_name, method_name, template_object, choices, options, html_options)
           @choices = block_given? ? template_object.capture { yield || "" } : choices
           @choices = @choices.to_a if @choices.is_a?(Range)
@@ -13,21 +17,6 @@ module ActionView
           super(object_name, method_name, template_object, options)
         end
 
-        def render
-          option_tags_options = {
-            selected: @options.fetch(:selected) { value.nil? ? "" : value },
-            disabled: @options[:disabled]
-          }
-
-          option_tags = if grouped_choices?
-            grouped_options_for_select(@choices, option_tags_options)
-          else
-            options_for_select(@choices, option_tags_options)
-          end
-
-          select_content_tag(option_tags, @options, @html_options)
-        end
-
         private
           # Grouped choices look like this:
           #
@@ -35,6 +24,14 @@ module ActionView
           #   { nil => [] }
           def grouped_choices?
             !@choices.blank? && @choices.first.respond_to?(:last) && Array === @choices.first.last
+          end
+
+          def option_tags
+            if grouped_choices?
+              grouped_options_for_select(@choices, option_tags_options)
+            else
+              options_for_select(@choices, option_tags_options)
+            end
           end
       end
     end

--- a/actionview/lib/action_view/helpers/tags/select_renderer.rb
+++ b/actionview/lib/action_view/helpers/tags/select_renderer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+### require "action_view/helpers/tags/checkable"
+
+module ActionView
+  module Helpers
+    module Tags # :nodoc:
+      module SelectRenderer # :nodoc:
+        def render
+          select_content_tag(option_tags, @options, @html_options)
+        end
+
+        private
+          def selected_value
+            value = self.value
+            value.nil? ? "" : value
+          end
+
+          def option_tags_options
+            { selected: @options.fetch(:selected) { selected_value }, disabled: @options[:disabled] }
+          end
+      end
+    end
+  end
+end

--- a/actionview/test/template/form_options_helper_test.rb
+++ b/actionview/test/template/form_options_helper_test.rb
@@ -1105,6 +1105,28 @@ class FormOptionsHelperTest < ActionView::TestCase
     )
   end
 
+  def test_collection_select_without_selected_option_when_value_is_nil
+    countries = [Country.new(nil, "Atlantis"), Country.new("ca", "Canada")]
+    @post = Post.new
+    @post.origin = nil
+
+    assert_dom_equal(
+      %(<select id="post_origin" name="post[origin]"><option value="" selected="selected">Atlantis</option>\n<option value="ca">Canada</option></select>),
+      collection_select(:post, :origin, countries, :country_id, :country_name)
+    )
+  end
+
+  def test_collection_select_with_nil_selected_option_when_value_is_nil
+    countries = [Country.new(nil, "Atlantis"), Country.new("ca", "Canada")]
+    @post = Post.new
+    @post.origin = nil
+
+    assert_dom_equal(
+      %(<select id="post_origin" name="post[origin]"><option value="">Atlantis</option>\n<option value="ca">Canada</option></select>),
+      collection_select(:post, :origin, countries, :country_id, :country_name, selected: nil)
+    )
+  end
+
   def test_collection_select_with_disabled
     @post = Post.new
     @post.author_name = "Babe"
@@ -1482,6 +1504,34 @@ class FormOptionsHelperTest < ActionView::TestCase
     assert_dom_equal(
       %Q{<select id="post_origin" name="post[origin]"><optgroup label="&lt;Africa&gt;"><option value="&lt;sa&gt;">&lt;South Africa&gt;</option>\n<option value="so">Somalia</option></optgroup><optgroup label="Europe"><option value="dk" selected="selected">Denmark</option>\n<option value="ie">Ireland</option></optgroup></select>},
       grouped_collection_select("post", "origin", dummy_continents, :countries, :continent_name, :country_id, :country_name, selected: "dk")
+    )
+  end
+
+  def test_grouped_collection_select_without_selected_option_when_value_is_nil
+    continents = [
+      Continent.new("Atlantic Ocean", [Country.new(nil, "Atlantis")]),
+      Continent.new("North America", [Country.new("ca", "Canada")]),
+    ]
+    @post = Post.new
+    @post.origin = nil
+
+    assert_dom_equal(
+      %(<select id="post_origin" name="post[origin]"><optgroup label="Atlantic Ocean"><option value="" selected="selected">Atlantis</option></optgroup><optgroup label="North America"><option value="ca">Canada</option></optgroup></select>),
+      grouped_collection_select(:post, :origin, continents, :countries, :continent_name, :country_id, :country_name)
+    )
+  end
+
+  def test_grouped_collection_select_with_nil_selected_option_when_value_is_nil
+    continents = [
+      Continent.new("Atlantic Ocean", [Country.new(nil, "Atlantis")]),
+      Continent.new("North America", [Country.new("ca", "Canada")]),
+    ]
+    @post = Post.new
+    @post.origin = nil
+
+    assert_dom_equal(
+      %(<select id="post_origin" name="post[origin]"><optgroup label="Atlantic Ocean"><option value="">Atlantis</option></optgroup><optgroup label="North America"><option value="ca">Canada</option></optgroup></select>),
+      grouped_collection_select(:post, :origin, continents, :countries, :continent_name, :country_id, :country_name, selected: nil)
     )
   end
 


### PR DESCRIPTION
Follow-up to #34809 and #40522.

This extends the `select` helper's `nil` handling behavior to `collection_select` and `grouped_collection_select`, for consistency.
