### PR TITLE
Fix empty request inside helpers test

### DIFF
--- a/actionview/lib/action_view/test_case.rb
+++ b/actionview/lib/action_view/test_case.rb
@@ -57,7 +57,7 @@ module ActionView
       include ActiveSupport::Testing::ConstantLookup
 
       delegate :lookup_context, to: :controller
-      attr_accessor :controller, :output_buffer, :rendered
+      attr_accessor :controller, :request, :output_buffer, :rendered
 
       module ClassMethods
         def tests(helper_class)

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -52,6 +52,10 @@ module ActionView
       assert params.is_a? ActionController::Parameters
     end
 
+    test "exposes request" do
+      assert request.is_a? ActionDispatch::Request
+    end
+
     test "exposes view as _view for backwards compatibility" do
       assert_same _view, view
     end


### PR DESCRIPTION
### Summary

During testing view helpers do not have access to the `request` object but they do when used inside of a view.

If we were to test a helper like this one :

```ruby
  def active?(test_path)
    request.path.match? test_path
  end
```

we would get this error : 

```
NoMethodError: undefined method `path' for nil:NilClass
```

Adding `:request` to the attr_accessor will make tests consistent with the default behavior.