### PR TITLE
Fix RoutingConcerns#concerns_executes_block_in_context_of_current_mapper test

### DIFF
--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -114,11 +114,15 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
 
   def test_concerns_executes_block_in_context_of_current_mapper
     mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
+    self_from_concern_block = nil
+
     mapper.concern :test_concern do
       resources :things
-      return self
+      self_from_concern_block = self
     end
 
-    assert_equal mapper, mapper.concerns(:test_concern)
+    mapper.concerns(:test_concern)
+
+    assert_equal mapper, self_from_concern_block
   end
 end


### PR DESCRIPTION
### Summary

Fix test that wasn't asserting anything

### Other Information

The test wasn't asserting anything because `return` statement in the block returns from the whole test.
As long as the closure defined in the `test_concerns_executes_block_in_context_of_current_mapper` method, calling it will return from the test method and not the method it was called from.

This is a very abstract explanation:

```ruby
class A
  def method_from_another_context(my_block)
    Object.new.instance_exec(&my_block)
    puts "I'll never print"
  end
end


def my_test
  my_block = proc { return "return_value" }

  A.new.method_from_another_context(my_block)
  puts "I'll never print as well"
end

raise unless "return_value" == my_test
```

I could have fixed it by defining `lambda` concern instead of a block proc, like:
```ruby
    concern_block = lambda do
      resources :things
      return self
    end
    mapper.concern(:test_concern, &concern_block)
```

But that would test a non-realistic scenario and at the end of the day won't work as well, because `Mapper#concerns` doesn't return value of the block, it returns enumerable it iterated over, which is `[:test_concern]` for our case.

https://github.com/rails/rails/blob/05136e5c0b3d7b841bdec53847879321309604d3/actionpack/lib/action_dispatch/routing/mapper.rb#L1681-L1690


In order to verify that the test tests basically nothing you could modify it like:

```ruby
  def test_concerns_executes_block_in_context_of_current_mapper
    mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
    mapper.concern :test_concern do
      resources :things
      return self
    end

    #returns on this line
    result = mapper.concerns(:test_concern)

    assert_equal "i don't care", result
  end
```

And it still passes


### Solution

Instead of returning from the block I'm capturing a variable from the current context, assigning `self` (which is expected to be an instance of the `Mapper`), and comparing it afterwards
Let me know if you think there is a better way to assert this. Thanks!



