### PR TITLE
Stop generating buttons with default type and name

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Stop generating `<button>` elements with `[type="submit"]` and
+    `[name="button"]` by default.
 
+    *Sean Doyle*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actionview/CHANGELOG.md) for previous changes.

--- a/actionview/lib/action_view/helpers/form_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/form_tag_helper.rb
@@ -582,7 +582,7 @@ module ActionView
           options ||= {}
         end
 
-        options = { "name" => "button", "type" => "submit" }.merge!(options.stringify_keys)
+        options = options.stringify_keys
 
         if block_given?
           content_tag :button, options, &block

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -374,8 +374,8 @@ class FormWithActsLikeFormForTest < FormWithTest
       "<input name='post[secret]' checked='checked' type='checkbox' value='1' id='post_secret' />" \
       "<select name='post[category]' id='post_category'><option value='animal'>animal</option>\n<option value='economy'>economy</option>\n<option value='sports'>sports</option></select>" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
-      "<button name='button' type='submit'>Create post</button>" \
-      "<button name='button' type='submit'><span>Create post</span></button>"
+      "<button>Create post</button>" \
+      "<button><span>Create post</span></button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -387,7 +387,7 @@ class FormWithActsLikeFormForTest < FormWithTest
     end
 
     expected = whole_form("/posts/123", method: :patch) do
-      "<button name='button' type='submit'><span>Update Post</span></button>"
+      "<button><span>Update Post</span></button>"
     end
 
     assert_dom_equal expected, output_buffer

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -1593,8 +1593,8 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
-      "<button name='button' type='submit'>Create post</button>" \
-      "<button name='button' type='submit'><span>Create post</span></button>"
+      "<button>Create post</button>" \
+      "<button><span>Create post</span></button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1623,8 +1623,8 @@ class FormHelperTest < ActionView::TestCase
       "<input name='post[secret]' type='hidden' value='0' autocomplete='off' />" \
       "<input name='post[secret]' checked='checked' type='checkbox' id='post_secret' value='1' />" \
       "<input name='commit' data-disable-with='Create post' type='submit' value='Create post' />" \
-      "<button name='button' type='submit'>Create post</button>" \
-      "<button name='button' type='submit'><span>Create post</span></button>"
+      "<button>Create post</button>" \
+      "<button><span>Create post</span></button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -1638,7 +1638,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts", "new_post", "new_post") do
-      '<button name="button" type="submit" form="new_post">Create Post</button>'
+      '<button form="new_post">Create Post</button>'
     end
 
     assert_dom_equal expected, output_buffer
@@ -2607,7 +2607,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      %(<button type="submit" id="post_secret" name="post[secret]" value="true">Update Post</button>)
+      %(<button id="post_secret" name="post[secret]" value="true">Update Post</button>)
     end
 
     assert_dom_equal expected, output_buffer
@@ -2619,7 +2619,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      %(<button type="submit" id="not_generated" name="post[not_generated]" value="true">Update Post</button>)
+      %(<button name="post[not_generated]" id="not_generated" value="true">Update Post</button>)
     end
 
     assert_dom_equal expected, output_buffer
@@ -2631,7 +2631,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_post_123", "edit_post", method: "patch") do
-      %(<button type="submit" id="post_secret" name="post[secret]" value="true">Update secret Post</button>)
+      %(<button id="post_secret" name="post[secret]" value="true">Update secret Post</button>)
     end
 
     assert_dom_equal expected, output_buffer
@@ -2643,7 +2643,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
-      "<button type='submit' formmethod='get' name='button'>GET</button>"
+      "<button formmethod='get'>GET</button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2655,7 +2655,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
-      "<button type='submit' formmethod='post' name='button'>POST</button>"
+      "<button formmethod='post'>POST</button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2667,7 +2667,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
-      "<button type='submit' formmethod='post' name='_method' value='delete'>Delete</button>"
+      "<button formmethod='post' name='_method' value='delete'>Delete</button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2679,7 +2679,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
-      "<button type='submit' formmethod='delete' name='existing'>Delete</button>"
+      "<button formmethod='delete' name='existing'>Delete</button>"
     end
 
     assert_dom_equal expected, output_buffer
@@ -2691,7 +2691,7 @@ class FormHelperTest < ActionView::TestCase
     end
 
     expected = whole_form("/posts/123", "edit_another_post", "edit_another_post", method: "patch") do
-      "<button type='submit' formmethod='delete' name='button' value='existing'>Delete</button>"
+      "<button formmethod='delete' value='existing'>Delete</button>"
     end
 
     assert_dom_equal expected, output_buffer

--- a/actionview/test/template/form_tag_helper_test.rb
+++ b/actionview/test/template/form_tag_helper_test.rb
@@ -704,48 +704,48 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_button_tag
     assert_dom_equal(
-      %(<button name="button" type="submit">Button</button>),
+      %(<button>Button</button>),
       button_tag
     )
   end
 
   def test_button_tag_with_submit_type
     assert_dom_equal(
-      %(<button name="button" type="submit">Save</button>),
+      %(<button type="submit">Save</button>),
       button_tag("Save", type: "submit")
     )
   end
 
   def test_button_tag_with_button_type
     assert_dom_equal(
-      %(<button name="button" type="button">Button</button>),
+      %(<button type="button">Button</button>),
       button_tag("Button", type: "button")
     )
   end
 
   def test_button_tag_with_reset_type
     assert_dom_equal(
-      %(<button name="button" type="reset">Reset</button>),
+      %(<button type="reset">Reset</button>),
       button_tag("Reset", type: "reset")
     )
   end
 
   def test_button_tag_with_disabled_option
     assert_dom_equal(
-      %(<button name="button" type="reset" disabled="disabled">Reset</button>),
+      %(<button type="reset" disabled="disabled">Reset</button>),
       button_tag("Reset", type: "reset", disabled: true)
     )
   end
 
   def test_button_tag_escape_content
     assert_dom_equal(
-      %(<button name="button" type="reset" disabled="disabled">&lt;b&gt;Reset&lt;/b&gt;</button>),
+      %(<button type="reset" disabled="disabled">&lt;b&gt;Reset&lt;/b&gt;</button>),
       button_tag("<b>Reset</b>", type: "reset", disabled: true)
     )
   end
 
   def test_button_tag_with_block
-    assert_dom_equal('<button name="button" type="submit">Content</button>', button_tag { "Content" })
+    assert_dom_equal("<button>Content</button>", button_tag { "Content" })
   end
 
   def test_button_tag_with_block_and_options
@@ -755,19 +755,19 @@ class FormTagHelperTest < ActionView::TestCase
 
   def test_button_tag_defaults_with_block_and_options
     output = button_tag(name: "temptation", value: "within") { content_tag(:strong, "Do not press me") }
-    assert_dom_equal('<button name="temptation" value="within" type="submit" ><strong>Do not press me</strong></button>', output)
+    assert_dom_equal('<button name="temptation" value="within" ><strong>Do not press me</strong></button>', output)
   end
 
   def test_button_tag_with_confirmation
     assert_dom_equal(
-      %(<button name="button" type="submit" data-confirm="Are you sure?">Save</button>),
+      %(<button type="submit" data-confirm="Are you sure?">Save</button>),
       button_tag("Save", type: "submit", data: { confirm: "Are you sure?" })
     )
   end
 
   def test_button_tag_with_data_disable_with_option
     assert_dom_equal(
-      %(<button name="button" type="submit" data-disable-with="Please wait...">Checkout</button>),
+      %(<button data-disable-with="Please wait...">Checkout</button>),
       button_tag("Checkout", data: { disable_with: "Please wait..." })
     )
   end


### PR DESCRIPTION
### Summary

[FormTagHelper#button_tag][] (and transitively, [FormBuilder#button][])
generates a `<button>` with default `[type="submit"]` and
`[name="button"]` attributes.

This commit removes both keys from the hash of default attributes for a
`<button>`.

#### `[type="submit]`

According to the MDN documentation, `<button>` elements will default to
[type="submit"][]:

> `submit`: The button submits the form data to the server. This is the
> default if the attribute is not specified for buttons associated with
> a `<form>`, or if the attribute is an empty or invalid value.

#### `[name="button"]`

Encoding a `[name]` attribute into a `<button>` means that when the
button is clicked, browsers will include the `[name]` (and `[value]`,
when provided) in the submission. In the case of a `[method="get"]`
form, that means the name-value pairing are URL encoded into the
redirect URL. In the case of a `[method="post"]`, that value is URL
encoded (or multi-part form encoded, when an `<input type="file">` is
present) into the body.

It's likely that on the server side, the `button` key is largely ignored
by applications. While the `params[:button]` key is present, the value
is `nil`. Even if the `<button>` element were generated with a `[value]`
attribute, it's unlikely that the pairing would bear any significance in
most applications.

[FormTagHelper#button_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-button_tag
[FormBuilder#button]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-button
[type="submit"]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type
[name]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-name