### PR TITLE
Defer loading XmlMini until it's needed

### DIFF
--- a/activejob/test/adapters/delayed_job.rb
+++ b/activejob/test/adapters/delayed_job.rb
@@ -3,6 +3,7 @@
 ActiveJob::Base.queue_adapter = :delayed_job
 
 $LOAD_PATH << File.expand_path("../support/delayed_job", __dir__)
+require "active_support/core_ext/kernel/reporting"
 
 Delayed::Worker.delay_jobs = false
 Delayed::Worker.backend    = :test

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -8,6 +8,7 @@ require "active_record"
 require "cases/test_case"
 require "active_support/dependencies"
 require "active_support/logger"
+require "active_support/core_ext/kernel/reporting"
 require "active_support/core_ext/kernel/singleton_class"
 
 require "support/config"

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/xml_mini"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/object/to_param"

--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/xml_mini"
 require "active_support/core_ext/object/blank"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/to_query"


### PR DESCRIPTION
It's used for `{Array,Hash}#to_xml`, but that doesn't seem worth loading by default.


It is already defined as an (eager) autoload in `active_support.rb`: https://github.com/rails/rails/blob/ed4d81caf7af6022c37a7e850f279ac77c29f120/activesupport/lib/active_support.rb#L80


(For the record, XmlMini already defers loading REXML, so this is not a substantial saving.)

---

For better or worse, this change will incidentally fix the instances of people requiring some individual files from Active Support without first loading `active_support.rb` that, while not officially supported, were previously working and recently started failing. (#43851 #43852 #43889 #43908 #44336) This is not a reversal of that supported-usage policy, and a future change could re-break it at any time.