### PR TITLE
Fix RenameTableTest#test_rename_table_should_work_with_reserved_words

### DIFF
--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -25,19 +25,20 @@ module ActiveRecord
         def test_rename_table_should_work_with_reserved_words
           renamed = false
 
-          add_column :test_models, :url, :string
           connection.rename_table :references, :old_references
           connection.rename_table :test_models, :references
 
           renamed = true
 
           # Using explicit id in insert for compatibility across all databases
-          connection.execute "INSERT INTO 'references' (url, created_at, updated_at) VALUES ('http://rubyonrails.com', 0, 0)"
-          assert_equal "http://rubyonrails.com", connection.select_value("SELECT url FROM 'references' WHERE id=1")
+          table_name = connection.quote_table_name("references")
+          connection.execute "INSERT INTO #{table_name} (id, url) VALUES (123, 'http://rubyonrails.com')"
+          assert_equal "http://rubyonrails.com", connection.select_value("SELECT url FROM #{table_name} WHERE id=123")
         ensure
-          return unless renamed
-          connection.rename_table :references, :test_models
-          connection.rename_table :old_references, :references
+          if renamed
+            connection.rename_table :references, :test_models
+            connection.rename_table :old_references, :references
+          end
         end
       end
 


### PR DESCRIPTION
### Summary

Currently the test asserts nothing because it silently returns on `add_column :test_models, :url, :string`.

`add_column` statement is failing with `ActiveRecord::StatementInvalid: SQLite3::SQLException: duplicate column name: url` because we already have this column added in the `setup` block:
https://github.com/rails/rails/blob/7ff9b334e1a3c194fb5354560d6f1c3282adcd1f/activerecord/test/cases/migration/rename_table_test.rb#L14

But the exception never fails the test because it silently returns from `ensure`:
https://github.com/rails/rails/blob/7ff9b334e1a3c194fb5354560d6f1c3282adcd1f/activerecord/test/cases/migration/rename_table_test.rb#L38

### Other Information

Changes made to fix the test:
1. Get rid of `return` in the ensure block and wrap ensure block into an `if` condition
2. Remove unnecessary `add_column` statement from the test as it duplicates the test `setup`
3. Insert row with a pre-defined id to make it compatible across databases as comment on the line 33 suggests:
https://github.com/rails/rails/blob/8f438fefa38be337e9cf9028e6ff21484ae81692/activerecord/test/cases/migration/rename_table_test.rb#L33
4. Use `connection.quote_table_name("references")` to build the table name for compatibility across databases 
5. Do not try to insert `created_at, updated_at` into the `test_models` table (that goes by `references` because of the rename) because we don't have these columns, `setup` removes them:
https://github.com/rails/rails/blob/27fad66b22cf3bff497c7a420c29f9ff94774bdf/activerecord/test/cases/migration/rename_table_test.rb#L15-L16
