### PR TITLE
Enable Lint/EnsureReturn cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -213,6 +213,9 @@ Lint/DuplicateMethods:
 
 Lint/ErbNewArguments:
   Enabled: true
+  
+Lint/EnsureReturn:
+  Enabled: true
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:


### PR DESCRIPTION
### Summary
From the cop description:

>This cop checks for `return` from an `ensure` block. `return` from an ensure block is a dangerous code smell as it will take precedence over any exception being raised, and the exception will be silently thrown away as if it were rescued.

Related to - https://github.com/rails/rails/pull/44342

Having this cop would have caught that one test doesn't behave as intended.
The test mentioned above had the only violation, so I thought perhaps it would be worth enabling this cop to prevent such cases in the future
