### PR TITLE
Delete `concerns executes block in context of current mapper` test

### DIFF
--- a/actionpack/test/dispatch/routing/concerns_test.rb
+++ b/actionpack/test/dispatch/routing/concerns_test.rb
@@ -111,14 +111,4 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
 
     assert_equal "No concern named foo was found!", e.message
   end
-
-  def test_concerns_executes_block_in_context_of_current_mapper
-    mapper = ActionDispatch::Routing::Mapper.new(ActionDispatch::Routing::RouteSet.new)
-    mapper.concern :test_concern do
-      resources :things
-      return self
-    end
-
-    assert_equal mapper, mapper.concerns(:test_concern)
-  end
 end


### PR DESCRIPTION
### Summary

Follow-up to https://github.com/rails/rails/pull/44338

The test has been asserting nothing for a while.  `mapper.concerns(:test_concern)` call basically returns from the test. You may find detailed explanation in the PR linked above

After an attempt to fix the test and a quick discussion we decided to completely remove the test as it doesn't seem to bring a lot of sense or coverage, considering that we have the "mapper scoping" logic covered by some "integration-like" tests defined in the same file
