### PR TITLE
Fix PG.connect keyword arguments deprecation warning on ruby 2.7

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix PG.connect keyword arguments deprecation warning on ruby 2.7
+
+    Fixes #44307.
+
+    *Nikita Vasilevsky*
+
 *   Fix dropping DB connections after serialization failures and deadlocks.
 
     Prior to 6.1.4, serialization failures and deadlocks caused rollbacks to be

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -75,7 +75,7 @@ module ActiveRecord
 
       class << self
         def new_client(conn_params)
-          PG.connect(conn_params)
+          PG.connect(**conn_params)
         rescue ::PG::Error => error
           if conn_params && conn_params[:dbname] && error.message.include?(conn_params[:dbname])
             raise ActiveRecord::NoDatabaseError.db_error(conn_params[:dbname])
@@ -281,7 +281,7 @@ module ActiveRecord
       def initialize(connection, logger, connection_parameters, config)
         super(connection, logger, config)
 
-        @connection_parameters = connection_parameters
+        @connection_parameters = connection_parameters || {}
 
         # @local_tz is initialized as nil to avoid warnings when connect tries to use it
         @local_tz = nil


### PR DESCRIPTION
### Summary

Fixes - https://github.com/rails/rails/issues/44307

As the issue description states, currently, calling `ActiveRecord::Base.postgresql_connection(params)` with a hash prints the `Using the last argument as keyword parameters is deprecated` warning on Ruby 2.7
Or essentially it could be reproduced by calling:
```ruby
ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.new_client({:port=>5432, dbname: "activerecord_unittest"})
``` 

I believe this warning was not addressed mainly because on Ruby 3.0+ `PG.connect`, which is essentially `PG::Connection.new` supports hash as a configuration
https://github.com/ged/ruby-pg/blob/6c436bda9aaf7bc053ef348afd99e2e035d5d0a3/lib/pg.rb#L68-L70
https://github.com/ged/ruby-pg/blob/6c436bda9aaf7bc053ef348afd99e2e035d5d0a3/lib/pg/connection.rb#L651

Also had to tweak the `connection_parameters` initialization in order to support `nil` values, like in this test:

https://github.com/rails/rails/blob/724b733c454a56d8a32be54fdbdf6a0a60379642/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb#L49-L54

I wonder if it would be worth adding a new test that explicitly tests the `nil` value passed as connection params. Or it's sufficient to have the one mentioned above that tests the behaviour implicitly 🤔 

Feel free to let me know if you think there is a better way to handle `nil` connection params or perhaps we shouldn't support passing `nil` at all? Thanks!
