### PR TITLE
Improve handling of overlapping events

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix an issue with `ActiveSupport::Notification` that caused random requests to fail in dev env and led to incorrect event data in some cases.
+
+    Fixes #44167, #44348.
+
+    *Janosch Müller*
+
 *   Add `ActiveSupport::TestCase#stub_const` to stub a constant for the duration of a yield.
 
     *DHH*


### PR DESCRIPTION
fixes #44167 and #44348.

note that this does not fix every problem with this code, though.

one remaining (moderate?) issue is that events with the same name can still have incorrect data after this PR, if multiple of them overlap. e.g. the start times of `request.action_dispatch` will still be mixed up on a multi-threaded server. within the current framework, i think this could only be fixed by introducing something like an "event UUID" or "event token" (maybe just an `Object.new`). such a token could be passed to `#start` and `#finish`, and in `Fanout` we could use it for further isolating events from each other.

however, the amount of indirection and multi-dispatching in the `Notification` module is already pretty crazy for what it accomplishes, and i'm not sure how much more should be added.

it seems like a good candidate for refactoring, but i don't use it and don't know it well enough to do that.

so this is primarily a quickfix to get dev env less buggy again.

@jhawthorn adding you because you looked at a related PR, #43241