### PR TITLE
Make #to_fs the default replacement for #to_s(:format)

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -26,7 +26,7 @@ module ActionController
   #
   #   module FormattedTimeHelper
   #     def format_time(time, format=:long, blank_message="&nbsp;")
-  #       time.blank? ? blank_message : time.to_formatted_s(format)
+  #       time.blank? ? blank_message : time.to_fs(format)
   #     end
   #   end
   #

--- a/actionview/test/fixtures/replies.yml
+++ b/actionview/test/fixtures/replies.yml
@@ -3,7 +3,7 @@ witty_retort:
   topic_id: 1
   developer_id: 1
   content: Birdman is better!
-  created_at: <%= 6.hours.ago.to_formatted_s(:db) %>
+  created_at: <%= 6.hours.ago.to_fs(:db) %>
   updated_at: nil
 
 another:
@@ -11,5 +11,5 @@ another:
   topic_id: 2
   developer_id: 1
   content: Nuh uh!
-  created_at: <%= 1.hour.ago.to_formatted_s(:db) %>
+  created_at: <%= 1.hour.ago.to_fs(:db) %>
   updated_at: nil

--- a/actionview/test/fixtures/topics.yml
+++ b/actionview/test/fixtures/topics.yml
@@ -3,7 +3,7 @@ futurama:
   title: Isn't futurama awesome?
   subtitle: It really is, isn't it.
   content: I like futurama
-  created_at: <%= 1.day.ago.to_formatted_s(:db) %>
+  created_at: <%= 1.day.ago.to_fs(:db) %>
   updated_at:
 
 harvey_birdman:
@@ -11,7 +11,7 @@ harvey_birdman:
   title: Harvey Birdman is the king of all men
   subtitle: yup
   content: It really is
-  created_at: <%= 2.hours.ago.to_formatted_s(:db) %>
+  created_at: <%= 2.hours.ago.to_fs(:db) %>
   updated_at:
 
 rails:
@@ -19,4 +19,4 @@ rails:
   title: Rails is nice
   subtitle: It makes me happy
   content: except when I have to hack internals to fix pagination. even then really.
-  created_at: <%= 20.minutes.ago.to_formatted_s(:db) %>
+  created_at: <%= 20.minutes.ago.to_fs(:db) %>

--- a/activemodel/lib/active_model/type/date.rb
+++ b/activemodel/lib/active_model/type/date.rb
@@ -11,7 +11,7 @@ module ActiveModel
       end
 
       def type_cast_for_schema(value)
-        value.to_formatted_s(:db).inspect
+        value.to_fs(:db).inspect
       end
 
       private

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -36,7 +36,7 @@ module ActiveModel
         end
 
         def type_cast_for_schema(value)
-          value.to_formatted_s(:db).inspect
+          value.to_fs(:db).inspect
         end
 
         def user_input_in_time_zone(value)

--- a/activerecord/lib/active_record/attribute_methods.rb
+++ b/activerecord/lib/active_record/attribute_methods.rb
@@ -413,7 +413,7 @@ module ActiveRecord
           inspected_value = if value.is_a?(String) && value.length > 50
             "#{value[0, 50]}...".inspect
           elsif value.is_a?(Date) || value.is_a?(Time)
-            %("#{value.to_formatted_s(:inspect)}")
+            %("#{value.to_fs(:inspect)}")
           else
             value.inspect
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb
@@ -128,7 +128,7 @@ module ActiveRecord
           end
         end
 
-        result = value.to_formatted_s(:db)
+        result = value.to_fs(:db)
         if value.respond_to?(:usec) && value.usec > 0
           result << "." << sprintf("%06d", value.usec)
         else

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -407,7 +407,7 @@ module ActiveRecord
   # defaults:
   #
   #   DEFAULTS: &DEFAULTS
-  #     created_on: <%= 3.weeks.ago.to_formatted_s(:db) %>
+  #     created_on: <%= 3.weeks.ago.to_fs(:db) %>
   #
   #   first:
   #     name: Smurf

--- a/activerecord/lib/active_record/integration.rb
+++ b/activerecord/lib/active_record/integration.rb
@@ -79,7 +79,7 @@ module ActiveRecord
           timestamp = max_updated_column_timestamp
 
           if timestamp
-            timestamp = timestamp.utc.to_formatted_s(cache_timestamp_format)
+            timestamp = timestamp.utc.to_fs(cache_timestamp_format)
             "#{model_name.cache_key}/#{id}-#{timestamp}"
           else
             "#{model_name.cache_key}/#{id}"
@@ -103,7 +103,7 @@ module ActiveRecord
           raw_timestamp_to_cache_version(timestamp)
 
         elsif timestamp = updated_at
-          timestamp.utc.to_formatted_s(cache_timestamp_format)
+          timestamp.utc.to_fs(cache_timestamp_format)
         end
       elsif self.class.has_attribute?("updated_at")
         raise ActiveModel::MissingAttributeError, "missing attribute: updated_at"

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -388,7 +388,7 @@ module ActiveRecord
       end
 
       if timestamp
-        "#{size}-#{timestamp.utc.to_formatted_s(cache_timestamp_format)}"
+        "#{size}-#{timestamp.utc.to_fs(cache_timestamp_format)}"
       else
         "#{size}"
       end

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -87,7 +87,7 @@ module ActiveRecord
 
     delegate :to_xml, :encode_with, :length, :each, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :in_groups, :in_groups_of,
-             :to_sentence, :to_formatted_s, :as_json,
+             :to_sentence, :to_fs, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
     delegate :primary_key, :connection, to: :klass

--- a/activerecord/lib/active_record/relation/delegation.rb
+++ b/activerecord/lib/active_record/relation/delegation.rb
@@ -87,7 +87,7 @@ module ActiveRecord
 
     delegate :to_xml, :encode_with, :length, :each, :join,
              :[], :&, :|, :+, :-, :sample, :reverse, :rotate, :compact, :in_groups, :in_groups_of,
-             :to_sentence, :to_fs, :as_json,
+             :to_sentence, :to_fs, :to_formatted_s, :as_json,
              :shuffle, :split, :slice, :index, :rindex, to: :records
 
     delegate :primary_key, :connection, to: :klass

--- a/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/quoting_test.rb
@@ -57,7 +57,7 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
         t = Time.new(2000, 7, 1, 0, 0, 0, "+04:30")
 
         expected = t.change(year: 2000, month: 1, day: 1)
-        expected = expected.getutc.to_formatted_s(:db).sub(/\A\d\d\d\d-\d\d-\d\d /, "2000-01-01 ")
+        expected = expected.getutc.to_fs(:db).sub(/\A\d\d\d\d-\d\d-\d\d /, "2000-01-01 ")
 
         assert_equal expected, @conn.quoted_time(t)
       end
@@ -70,7 +70,7 @@ class SQLite3QuotingTest < ActiveRecord::SQLite3TestCase
         t = Time.new(2000, 7, 1, 0, 0, 0, "+04:30")
 
         expected = t.change(year: 2000, month: 1, day: 1)
-        expected = expected.getlocal.to_formatted_s(:db).sub(/\A\d\d\d\d-\d\d-\d\d /, "2000-01-01 ")
+        expected = expected.getlocal.to_fs(:db).sub(/\A\d\d\d\d-\d\d-\d\d /, "2000-01-01 ")
 
         assert_equal expected, @conn.quoted_time(t)
       end

--- a/activerecord/test/cases/attribute_methods_test.rb
+++ b/activerecord/test/cases/attribute_methods_test.rb
@@ -41,7 +41,7 @@ class AttributeMethodsTest < ActiveRecord::TestCase
   test "attribute_for_inspect with a date" do
     t = topics(:first)
 
-    assert_equal %("#{t.written_on.to_formatted_s(:inspect)}"), t.attribute_for_inspect(:written_on)
+    assert_equal %("#{t.written_on.to_fs(:inspect)}"), t.attribute_for_inspect(:written_on)
   end
 
   test "attribute_for_inspect with an array" do

--- a/activerecord/test/cases/cache_key_test.rb
+++ b/activerecord/test/cases/cache_key_test.rb
@@ -44,10 +44,10 @@ module ActiveRecord
 
     test "cache_key_with_version always has both key and version" do
       r1 = CacheMeWithVersion.create
-      assert_equal "active_record/cache_key_test/cache_me_with_versions/#{r1.id}-#{r1.updated_at.utc.to_formatted_s(:usec)}", r1.cache_key_with_version
+      assert_equal "active_record/cache_key_test/cache_me_with_versions/#{r1.id}-#{r1.updated_at.utc.to_fs(:usec)}", r1.cache_key_with_version
 
       r2 = CacheMe.create
-      assert_equal "active_record/cache_key_test/cache_mes/#{r2.id}-#{r2.updated_at.utc.to_formatted_s(:usec)}", r2.cache_key_with_version
+      assert_equal "active_record/cache_key_test/cache_mes/#{r2.id}-#{r2.updated_at.utc.to_fs(:usec)}", r2.cache_key_with_version
     end
 
     test "cache_version is the same when it comes from the DB or from the user" do

--- a/activerecord/test/cases/collection_cache_key_test.rb
+++ b/activerecord/test/cases/collection_cache_key_test.rb
@@ -27,7 +27,7 @@ module ActiveRecord
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
-      assert_equal last_developer_timestamp.to_formatted_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
     test "cache_key for relation with limit" do
@@ -40,7 +40,7 @@ module ActiveRecord
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
-      assert_equal last_developer_timestamp.to_formatted_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
     test "cache_key for relation with custom select and limit" do
@@ -54,7 +54,7 @@ module ActiveRecord
 
       assert_equal ActiveSupport::Digest.hexdigest(developers_with_select.to_sql), $1
       assert_equal developers.count.to_s, $2
-      assert_equal last_developer_timestamp.to_formatted_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
     test "cache_key for loaded relation" do
@@ -67,7 +67,7 @@ module ActiveRecord
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
-      assert_equal last_developer_timestamp.to_formatted_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
     test "cache_key for relation with table alias" do
@@ -89,7 +89,7 @@ module ActiveRecord
 
       assert_equal ActiveSupport::Digest.hexdigest(developers.to_sql), $1
       assert_equal developers.count.to_s, $2
-      assert_equal last_developer_timestamp.to_formatted_s(ActiveRecord::Base.cache_timestamp_format), $3
+      assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $3
     end
 
     test "cache_key for relation with includes" do
@@ -182,7 +182,7 @@ module ActiveRecord
 
     test "cache_key with custom timestamp column" do
       topics = Topic.where("title like ?", "%Topic%")
-      last_topic_timestamp = topics(:fifth).written_on.utc.to_formatted_s(:usec)
+      last_topic_timestamp = topics(:fifth).written_on.utc.to_fs(:usec)
       assert_match(last_topic_timestamp, topics.cache_key(:written_on))
     end
 
@@ -250,7 +250,7 @@ module ActiveRecord
         /(\d+)-(\d+)\z/ =~ developers.cache_version
 
         assert_equal developers.count.to_s, $1
-        assert_equal last_developer_timestamp.to_formatted_s(ActiveRecord::Base.cache_timestamp_format), $2
+        assert_equal last_developer_timestamp.to_fs(ActiveRecord::Base.cache_timestamp_format), $2
       end
     end
 

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -18,7 +18,7 @@ class CoreTest < ActiveRecord::TestCase
 
   def test_inspect_instance
     topic = topics(:first)
-    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_formatted_s(:inspect)}", bonus_time: "#{topic.bonus_time.to_formatted_s(:inspect)}", last_read: "#{topic.last_read.to_formatted_s(:inspect)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_formatted_s(:inspect)}", updated_at: "#{topic.updated_at.to_formatted_s(:inspect)}">), topic.inspect
+    assert_equal %(#<Topic id: 1, title: "The First Topic", author_name: "David", author_email_address: "david@loudthinking.com", written_on: "#{topic.written_on.to_fs(:inspect)}", bonus_time: "#{topic.bonus_time.to_fs(:inspect)}", last_read: "#{topic.last_read.to_fs(:inspect)}", content: "Have a nice day", important: nil, approved: false, replies_count: 1, unique_replies_count: 0, parent_id: nil, parent_title: nil, type: nil, group: nil, created_at: "#{topic.created_at.to_fs(:inspect)}", updated_at: "#{topic.updated_at.to_fs(:inspect)}">), topic.inspect
   end
 
   def test_inspect_instance_with_lambda_date_formatter

--- a/activerecord/test/cases/integration_test.rb
+++ b/activerecord/test/cases/integration_test.rb
@@ -108,12 +108,12 @@ class IntegrationTest < ActiveRecord::TestCase
 
   def test_cache_key_format_for_existing_record_with_updated_at
     dev = Developer.first
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_formatted_s(:usec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_fs(:usec)}", dev.cache_key
   end
 
   def test_cache_key_format_for_existing_record_with_updated_at_and_custom_cache_timestamp_format
     dev = CachedDeveloper.first
-    assert_equal "cached_developers/#{dev.id}-#{dev.updated_at.utc.to_formatted_s(:number)}", dev.cache_key
+    assert_equal "cached_developers/#{dev.id}-#{dev.updated_at.utc.to_fs(:number)}", dev.cache_key
   end
 
   def test_cache_key_changes_when_child_touched
@@ -138,19 +138,19 @@ class IntegrationTest < ActiveRecord::TestCase
   def test_cache_key_for_updated_on
     dev = Developer.first
     dev.updated_at = nil
-    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_formatted_s(:usec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_fs(:usec)}", dev.cache_key
   end
 
   def test_cache_key_for_newer_updated_at
     dev = Developer.first
     dev.updated_at += 3600
-    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_formatted_s(:usec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_at.utc.to_fs(:usec)}", dev.cache_key
   end
 
   def test_cache_key_for_newer_updated_on
     dev = Developer.first
     dev.updated_on += 3600
-    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_formatted_s(:usec)}", dev.cache_key
+    assert_equal "developers/#{dev.id}-#{dev.updated_on.utc.to_fs(:usec)}", dev.cache_key
   end
 
   def test_cache_key_format_is_precise_enough

--- a/activerecord/test/cases/multiparameter_attributes_test.rb
+++ b/activerecord/test/cases/multiparameter_attributes_test.rb
@@ -107,8 +107,8 @@ class MultiParameterAttributeTest < ActiveRecord::TestCase
     }
     topic = Topic.find(1)
     topic.attributes = attributes
-    # testing against to_formatted_s(:db) representation because either a Time or a DateTime might be returned, depending on platform
-    assert_equal "1850-06-24 16:24:00", topic.written_on.to_formatted_s(:db)
+    # testing against to_fs(:db) representation because either a Time or a DateTime might be returned, depending on platform
+    assert_equal "1850-06-24 16:24:00", topic.written_on.to_fs(:db)
   end
 
   def test_multiparameter_attributes_on_time_will_raise_on_big_time_if_missing_date_parts

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -49,20 +49,20 @@ module ActiveRecord
 
       def test_quoted_date
         t = Date.today
-        assert_equal t.to_formatted_s(:db), @quoter.quoted_date(t)
+        assert_equal t.to_fs(:db), @quoter.quoted_date(t)
       end
 
       def test_quoted_timestamp_utc
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0)
-          assert_equal t.getutc.to_formatted_s(:db), @quoter.quoted_date(t)
+          assert_equal t.getutc.to_fs(:db), @quoter.quoted_date(t)
         end
       end
 
       def test_quoted_timestamp_local
         with_timezone_config default: :local do
           t = Time.now.change(usec: 0)
-          assert_equal t.getlocal.to_formatted_s(:db), @quoter.quoted_date(t)
+          assert_equal t.getlocal.to_fs(:db), @quoter.quoted_date(t)
         end
       end
 
@@ -71,7 +71,7 @@ module ActiveRecord
           t = Time.now.change(usec: 0)
 
           expected = t.change(year: 2000, month: 1, day: 1)
-          expected = expected.getutc.to_formatted_s(:db).slice(11..-1)
+          expected = expected.getutc.to_fs(:db).slice(11..-1)
 
           assert_equal expected, @quoter.quoted_time(t)
         end
@@ -82,7 +82,7 @@ module ActiveRecord
           t = Time.now.change(usec: 0)
 
           expected = t.change(year: 2000, month: 1, day: 1)
-          expected = expected.getlocal.to_formatted_s(:db).sub("2000-01-01 ", "")
+          expected = expected.getlocal.to_fs(:db).sub("2000-01-01 ", "")
 
           assert_equal expected, @quoter.quoted_time(t)
         end
@@ -94,7 +94,7 @@ module ActiveRecord
             t = Time.new(2000, 7, 1, 0, 0, 0, "+04:30")
 
             expected = t.change(year: 2000, month: 1, day: 1)
-            expected = expected.getutc.to_formatted_s(:db).slice(11..-1)
+            expected = expected.getutc.to_fs(:db).slice(11..-1)
 
             assert_equal expected, @quoter.quoted_time(t)
           end
@@ -107,7 +107,7 @@ module ActiveRecord
             t = Time.new(2000, 7, 1, 0, 0, 0, "+04:30")
 
             expected = t.change(year: 2000, month: 1, day: 1)
-            expected = expected.getlocal.to_formatted_s(:db).slice(11..-1)
+            expected = expected.getlocal.to_fs(:db).slice(11..-1)
 
             assert_equal expected, @quoter.quoted_time(t)
           end
@@ -117,7 +117,7 @@ module ActiveRecord
       def test_quoted_datetime_utc
         with_timezone_config default: :utc do
           t = Time.now.change(usec: 0).to_datetime
-          assert_equal t.getutc.to_formatted_s(:db), @quoter.quoted_date(t)
+          assert_equal t.getutc.to_fs(:db), @quoter.quoted_date(t)
         end
       end
 
@@ -126,7 +126,7 @@ module ActiveRecord
       def test_quoted_datetime_local
         with_timezone_config default: :local do
           t = Time.now.change(usec: 0).to_datetime
-          assert_equal t.to_formatted_s(:db), @quoter.quoted_date(t)
+          assert_equal t.to_fs(:db), @quoter.quoted_date(t)
         end
       end
 

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       :map, :none?, :one?, :partition, :reject, :reverse, :rotate,
       :sample, :second, :sort, :sort_by, :slice, :third, :index, :rindex,
       :to_ary, :to_set, :to_xml, :to_yaml, :join,
-      :in_groups, :in_groups_of, :to_sentence, :to_formatted_s, :as_json
+      :in_groups, :in_groups_of, :to_sentence, :to_fs, :as_json
     ]
 
     ARRAY_DELEGATES.each do |method|

--- a/activerecord/test/cases/relation/delegation_test.rb
+++ b/activerecord/test/cases/relation/delegation_test.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       :map, :none?, :one?, :partition, :reject, :reverse, :rotate,
       :sample, :second, :sort, :sort_by, :slice, :third, :index, :rindex,
       :to_ary, :to_set, :to_xml, :to_yaml, :join,
-      :in_groups, :in_groups_of, :to_sentence, :to_fs, :as_json
+      :in_groups, :in_groups_of, :to_sentence, :to_formatted_s, :to_fs, :as_json
     ]
 
     ARRAY_DELEGATES.each do |method|

--- a/activerecord/test/fixtures/memberships.yml
+++ b/activerecord/test/fixtures/memberships.yml
@@ -1,40 +1,40 @@
 membership_of_boring_club:
-  joined_on: <%= 3.weeks.ago.to_formatted_s(:db) %>
+  joined_on: <%= 3.weeks.ago.to_fs(:db) %>
   club: boring_club
   member_id: 1
   favorite: false
   type: CurrentMembership
 
 membership_of_favorite_club:
-  joined_on: <%= 3.weeks.ago.to_formatted_s(:db) %>
+  joined_on: <%= 3.weeks.ago.to_fs(:db) %>
   club: moustache_club
   member_id: 1
   favorite: true
   type: Membership
 
 other_guys_membership:
-  joined_on: <%= 4.weeks.ago.to_formatted_s(:db) %>
+  joined_on: <%= 4.weeks.ago.to_fs(:db) %>
   club: boring_club
   member_id: 2
   favorite: false
   type: CurrentMembership
 
 blarpy_winkup_outrageous_club:
-  joined_on: <%= 4.weeks.ago.to_formatted_s(:db) %>
+  joined_on: <%= 4.weeks.ago.to_fs(:db) %>
   club: outrageous_club
   member_id: 3
   favorite: false
   type: CurrentMembership
 
 super_membership_of_boring_club:
-  joined_on: <%= 3.weeks.ago.to_formatted_s(:db) %>
+  joined_on: <%= 3.weeks.ago.to_fs(:db) %>
   club: boring_club
   member_id: 1
   favorite: false
   type: SuperMembership
 
 selected_membership_of_boring_club:
-  joined_on: <%= 3.weeks.ago.to_formatted_s(:db) %>
+  joined_on: <%= 3.weeks.ago.to_fs(:db) %>
   club: boring_club
   member_id: 1
   favorite: false

--- a/activerecord/test/fixtures/pirates.yml
+++ b/activerecord/test/fixtures/pirates.yml
@@ -5,8 +5,8 @@ blackbeard:
 redbeard:
   catchphrase: "Avast!"
   parrot: louis
-  created_on: "<%= 2.weeks.ago.to_formatted_s(:db) %>"
-  updated_on: "<%= 2.weeks.ago.to_formatted_s(:db) %>"
+  created_on: "<%= 2.weeks.ago.to_fs(:db) %>"
+  updated_on: "<%= 2.weeks.ago.to_fs(:db) %>"
 
 mark:
   catchphrase: "X $LABELs the spot!"

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -89,10 +89,10 @@ class Array
   #
   # This method is aliased to <tt>to_fs</tt>.
   #
-  #   Blog.all.to_formatted_s(:db)  # => "1,2,3"
-  #   Blog.none.to_formatted_s(:db) # => "null"
-  #   [1,2].to_formatted_s          # => "[1, 2]"
-  def to_formatted_s(format = :default)
+  #   Blog.all.to_fs(:db)  # => "1,2,3"
+  #   Blog.none.to_fs(:db) # => "null"
+  #   [1,2].to_fs          # => "[1, 2]"
+  def to_fs(format = :default)
     case format
     when :db
       if empty?
@@ -104,7 +104,7 @@ class Array
       to_default_s
     end
   end
-  alias_method :to_fs, :to_formatted_s
+  alias_method :to_fs, :to_fs
   alias_method :to_default_s, :to_s
 
   # Returns a string that represents the array in XML by invoking +to_xml+

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -104,7 +104,7 @@ class Array
       to_default_s
     end
   end
-  alias_method :to_fs, :to_fs
+  alias_method :to_formatted_s, :to_fs
   alias_method :to_default_s, :to_s
 
   # Returns a string that represents the array in XML by invoking +to_xml+

--- a/activesupport/lib/active_support/core_ext/array/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/conversions.rb
@@ -87,7 +87,7 @@ class Array
   # Extends <tt>Array#to_s</tt> to convert a collection of elements into a
   # comma separated id list if <tt>:db</tt> argument is given as the format.
   #
-  # This method is aliased to <tt>to_fs</tt>.
+  # This method is aliased to <tt>to_formatted_s</tt>.
   #
   #   Blog.all.to_fs(:db)  # => "1,2,3"
   #   Blog.none.to_fs(:db) # => "null"

--- a/activesupport/lib/active_support/core_ext/array/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/array/deprecated_conversions.rb
@@ -6,7 +6,7 @@ class Array
     case format
     when :db
       ActiveSupport::Deprecation.warn(
-        "Array#to_s(#{format.inspect}) is deprecated. Please use Array#to_formatted_s(#{format.inspect}) instead."
+        "Array#to_s(#{format.inspect}) is deprecated. Please use Array#to_fs(#{format.inspect}) instead."
       )
       if empty?
         "null"
@@ -17,7 +17,7 @@ class Array
       to_default_s
     else
       ActiveSupport::Deprecation.warn(
-        "Array#to_s(#{format.inspect}) is deprecated. Please use Array#to_formatted_s(#{format.inspect}) instead."
+        "Array#to_s(#{format.inspect}) is deprecated. Please use Array#to_fs(#{format.inspect}) instead."
       )
       to_default_s
     end

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -22,7 +22,7 @@ class Date
 
   # Convert to a formatted string. See DATE_FORMATS for predefined formats.
   #
-  # This method is aliased to <tt>to_fs</tt>.
+  # This method is aliased to <tt>to_formatted_s</tt>.
   #
   #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
   #

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -26,17 +26,17 @@ class Date
   #
   #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
   #
-  #   date.to_formatted_s(:db)            # => "2007-11-10"
+  #   date.to_fs(:db)            # => "2007-11-10"
   #   date.to_fs(:db)                     # => "2007-11-10"
   #
-  #   date.to_formatted_s(:short)         # => "10 Nov"
-  #   date.to_formatted_s(:number)        # => "20071110"
-  #   date.to_formatted_s(:long)          # => "November 10, 2007"
-  #   date.to_formatted_s(:long_ordinal)  # => "November 10th, 2007"
-  #   date.to_formatted_s(:rfc822)        # => "10 Nov 2007"
-  #   date.to_formatted_s(:iso8601)       # => "2007-11-10"
+  #   date.to_fs(:short)         # => "10 Nov"
+  #   date.to_fs(:number)        # => "20071110"
+  #   date.to_fs(:long)          # => "November 10, 2007"
+  #   date.to_fs(:long_ordinal)  # => "November 10th, 2007"
+  #   date.to_fs(:rfc822)        # => "10 Nov 2007"
+  #   date.to_fs(:iso8601)       # => "2007-11-10"
   #
-  # == Adding your own date formats to to_formatted_s
+  # == Adding your own date formats to to_fs
   # You can add your own formats to the Date::DATE_FORMATS hash.
   # Use the format name as the hash key and either a strftime string
   # or Proc instance that takes a date argument as the value.
@@ -44,7 +44,7 @@ class Date
   #   # config/initializers/date_formats.rb
   #   Date::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Date::DATE_FORMATS[:short_ordinal] = ->(date) { date.strftime("%B #{date.day.ordinalize}") }
-  def to_formatted_s(format = :default)
+  def to_fs(format = :default)
     if formatter = DATE_FORMATS[format]
       if formatter.respond_to?(:call)
         formatter.call(self).to_s
@@ -55,7 +55,7 @@ class Date
       to_default_s
     end
   end
-  alias_method :to_fs, :to_formatted_s
+  alias_method :to_formatted_s, :to_fs
   alias_method :to_default_s, :to_s
 
   # Overrides the default inspect method with a human readable one, e.g., "Mon, 21 Feb 2005"

--- a/activesupport/lib/active_support/core_ext/date/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/conversions.rb
@@ -26,8 +26,8 @@ class Date
   #
   #   date = Date.new(2007, 11, 10)       # => Sat, 10 Nov 2007
   #
-  #   date.to_fs(:db)            # => "2007-11-10"
   #   date.to_fs(:db)                     # => "2007-11-10"
+  #   date.to_formatted_s(:db)            # => "2007-11-10"
   #
   #   date.to_fs(:short)         # => "10 Nov"
   #   date.to_fs(:number)        # => "20071110"

--- a/activesupport/lib/active_support/core_ext/date/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date/deprecated_conversions.rb
@@ -7,7 +7,7 @@ class Date
   def to_s(format = NOT_SET) # :nodoc:
     if formatter = DATE_FORMATS[format]
       ActiveSupport::Deprecation.warn(
-        "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_formatted_s(#{format.inspect}) instead."
+        "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_fs(#{format.inspect}) instead."
       )
       if formatter.respond_to?(:call)
         formatter.call(self).to_s
@@ -18,7 +18,7 @@ class Date
       to_default_s
     else
       ActiveSupport::Deprecation.warn(
-        "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_formatted_s(#{format.inspect}) instead."
+        "Date#to_s(#{format.inspect}) is deprecated. Please use Date#to_fs(#{format.inspect}) instead."
       )
       to_default_s
     end

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -9,7 +9,7 @@ require "active_support/values/time_zone"
 class DateTime
   # Convert to a formatted string. See Time::DATE_FORMATS for predefined formats.
   #
-  # This method is aliased to <tt>to_fs</tt>.
+  # This method is aliased to <tt>to_formatted_s</tt>.
   #
   # === Examples
   #   datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -15,7 +15,7 @@ class DateTime
   #   datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000
   #
   #   datetime.to_fs(:db)            # => "2007-12-04 00:00:00"
-  #   datetime.to_fs(:db)                     # => "2007-12-04 00:00:00"
+  #   datetime.to_formatted_s(:db)   # => "2007-12-04 00:00:00"
   #   datetime.to_fs(:number)        # => "20071204000000"
   #   datetime.to_fs(:short)         # => "04 Dec 00:00"
   #   datetime.to_fs(:long)          # => "December 04, 2007 00:00"

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -32,7 +32,7 @@ class DateTime
   #   # config/initializers/time_formats.rb
   #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Time::DATE_FORMATS[:short_ordinal] = lambda { |time| time.strftime("%B #{time.day.ordinalize}") }
-  def to_fs :default)
+  def to_fs(format = :default)
     if formatter = ::Time::DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     else

--- a/activesupport/lib/active_support/core_ext/date_time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/conversions.rb
@@ -14,16 +14,16 @@ class DateTime
   # === Examples
   #   datetime = DateTime.civil(2007, 12, 4, 0, 0, 0, 0)   # => Tue, 04 Dec 2007 00:00:00 +0000
   #
-  #   datetime.to_formatted_s(:db)            # => "2007-12-04 00:00:00"
+  #   datetime.to_fs(:db)            # => "2007-12-04 00:00:00"
   #   datetime.to_fs(:db)                     # => "2007-12-04 00:00:00"
-  #   datetime.to_formatted_s(:number)        # => "20071204000000"
-  #   datetime.to_formatted_s(:short)         # => "04 Dec 00:00"
-  #   datetime.to_formatted_s(:long)          # => "December 04, 2007 00:00"
-  #   datetime.to_formatted_s(:long_ordinal)  # => "December 4th, 2007 00:00"
-  #   datetime.to_formatted_s(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
-  #   datetime.to_formatted_s(:iso8601)       # => "2007-12-04T00:00:00+00:00"
+  #   datetime.to_fs(:number)        # => "20071204000000"
+  #   datetime.to_fs(:short)         # => "04 Dec 00:00"
+  #   datetime.to_fs(:long)          # => "December 04, 2007 00:00"
+  #   datetime.to_fs(:long_ordinal)  # => "December 4th, 2007 00:00"
+  #   datetime.to_fs(:rfc822)        # => "Tue, 04 Dec 2007 00:00:00 +0000"
+  #   datetime.to_fs(:iso8601)       # => "2007-12-04T00:00:00+00:00"
   #
-  # == Adding your own datetime formats to to_formatted_s
+  # == Adding your own datetime formats to to_fs
   # DateTime formats are shared with Time. You can add your own to the
   # Time::DATE_FORMATS hash. Use the format name as the hash key and
   # either a strftime string or Proc instance that takes a time or
@@ -32,14 +32,14 @@ class DateTime
   #   # config/initializers/time_formats.rb
   #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Time::DATE_FORMATS[:short_ordinal] = lambda { |time| time.strftime("%B #{time.day.ordinalize}") }
-  def to_formatted_s(format = :default)
+  def to_fs :default)
     if formatter = ::Time::DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     else
       to_default_s
     end
   end
-  alias_method :to_fs, :to_formatted_s
+  alias_method :to_formatted_s, :to_fs
   alias_method :to_default_s, :to_s if instance_methods(false).include?(:to_s)
 
   # Returns a formatted string of the offset from UTC, or an alternative
@@ -54,7 +54,7 @@ class DateTime
 
   # Overrides the default inspect method with a human readable one, e.g., "Mon, 21 Feb 2005 14:30:00 +0000".
   def readable_inspect
-    to_formatted_s(:rfc822)
+    to_fs(:rfc822)
   end
   alias_method :default_inspect, :inspect
   alias_method :inspect, :readable_inspect

--- a/activesupport/lib/active_support/core_ext/date_time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/date_time/deprecated_conversions.rb
@@ -7,14 +7,14 @@ class DateTime
   def to_s(format = NOT_SET) # :nodoc:
     if formatter = ::Time::DATE_FORMATS[format]
       ActiveSupport::Deprecation.warn(
-        "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_formatted_s(#{format.inspect}) instead."
+        "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_fs(#{format.inspect}) instead."
       )
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     elsif format == NOT_SET
       to_default_s
     else
       ActiveSupport::Deprecation.warn(
-        "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_formatted_s(#{format.inspect}) instead."
+        "DateTime#to_s(#{format.inspect}) is deprecated. Please use DateTime#to_fs(#{format.inspect}) instead."
       )
       to_default_s
     end

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -18,97 +18,97 @@ module ActiveSupport
     # ==== Examples
     #
     #  Phone Numbers:
-    #  5551234.to_formatted_s(:phone)                                     # => "555-1234"
-    #  1235551234.to_formatted_s(:phone)                                  # => "123-555-1234"
-    #  1235551234.to_formatted_s(:phone, area_code: true)                 # => "(123) 555-1234"
-    #  1235551234.to_formatted_s(:phone, delimiter: ' ')                  # => "123 555 1234"
-    #  1235551234.to_formatted_s(:phone, area_code: true, extension: 555) # => "(123) 555-1234 x 555"
-    #  1235551234.to_formatted_s(:phone, country_code: 1)                 # => "+1-123-555-1234"
-    #  1235551234.to_formatted_s(:phone, country_code: 1, extension: 1343, delimiter: '.')
+    #  5551234.to_fs(:phone)                                     # => "555-1234"
+    #  1235551234.to_fs(:phone)                                  # => "123-555-1234"
+    #  1235551234.to_fs(:phone, area_code: true)                 # => "(123) 555-1234"
+    #  1235551234.to_fs(:phone, delimiter: ' ')                  # => "123 555 1234"
+    #  1235551234.to_fs(:phone, area_code: true, extension: 555) # => "(123) 555-1234 x 555"
+    #  1235551234.to_fs(:phone, country_code: 1)                 # => "+1-123-555-1234"
+    #  1235551234.to_fs(:phone, country_code: 1, extension: 1343, delimiter: '.')
     #  # => "+1.123.555.1234 x 1343"
     #
     #  Currency:
-    #  1234567890.50.to_formatted_s(:currency)                     # => "$1,234,567,890.50"
-    #  1234567890.506.to_formatted_s(:currency)                    # => "$1,234,567,890.51"
-    #  1234567890.506.to_formatted_s(:currency, precision: 3)      # => "$1,234,567,890.506"
-    #  1234567890.506.to_formatted_s(:currency, round_mode: :down) # => "$1,234,567,890.50"
-    #  1234567890.506.to_formatted_s(:currency, locale: :fr)       # => "1 234 567 890,51 €"
-    #  -1234567890.50.to_formatted_s(:currency, negative_format: '(%u%n)')
+    #  1234567890.50.to_fs(:currency)                     # => "$1,234,567,890.50"
+    #  1234567890.506.to_fs(:currency)                    # => "$1,234,567,890.51"
+    #  1234567890.506.to_fs(:currency, precision: 3)      # => "$1,234,567,890.506"
+    #  1234567890.506.to_fs(:currency, round_mode: :down) # => "$1,234,567,890.50"
+    #  1234567890.506.to_fs(:currency, locale: :fr)       # => "1 234 567 890,51 €"
+    #  -1234567890.50.to_fs(:currency, negative_format: '(%u%n)')
     #  # => "($1,234,567,890.50)"
-    #  1234567890.50.to_formatted_s(:currency, unit: '&pound;', separator: ',', delimiter: '')
+    #  1234567890.50.to_fs(:currency, unit: '&pound;', separator: ',', delimiter: '')
     #  # => "&pound;1234567890,50"
-    #  1234567890.50.to_formatted_s(:currency, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
+    #  1234567890.50.to_fs(:currency, unit: '&pound;', separator: ',', delimiter: '', format: '%n %u')
     #  # => "1234567890,50 &pound;"
     #
     #  Percentage:
-    #  100.to_formatted_s(:percentage)                                  # => "100.000%"
-    #  100.to_formatted_s(:percentage, precision: 0)                    # => "100%"
-    #  1000.to_formatted_s(:percentage, delimiter: '.', separator: ',') # => "1.000,000%"
-    #  302.24398923423.to_formatted_s(:percentage, precision: 5)        # => "302.24399%"
-    #  302.24398923423.to_formatted_s(:percentage, round_mode: :down)   # => "302.243%"
-    #  1000.to_formatted_s(:percentage, locale: :fr)                    # => "1 000,000%"
-    #  100.to_formatted_s(:percentage, format: '%n  %')                 # => "100.000  %"
+    #  100.to_fs(:percentage)                                  # => "100.000%"
+    #  100.to_fs(:percentage, precision: 0)                    # => "100%"
+    #  1000.to_fs(:percentage, delimiter: '.', separator: ',') # => "1.000,000%"
+    #  302.24398923423.to_fs(:percentage, precision: 5)        # => "302.24399%"
+    #  302.24398923423.to_fs(:percentage, round_mode: :down)   # => "302.243%"
+    #  1000.to_fs(:percentage, locale: :fr)                    # => "1 000,000%"
+    #  100.to_fs(:percentage, format: '%n  %')                 # => "100.000  %"
     #
     #  Delimited:
-    #  12345678.to_formatted_s(:delimited)                     # => "12,345,678"
-    #  12345678.05.to_formatted_s(:delimited)                  # => "12,345,678.05"
-    #  12345678.to_formatted_s(:delimited, delimiter: '.')     # => "12.345.678"
-    #  12345678.to_formatted_s(:delimited, delimiter: ',')     # => "12,345,678"
-    #  12345678.05.to_formatted_s(:delimited, separator: ' ')  # => "12,345,678 05"
-    #  12345678.05.to_formatted_s(:delimited, locale: :fr)     # => "12 345 678,05"
-    #  98765432.98.to_formatted_s(:delimited, delimiter: ' ', separator: ',')
+    #  12345678.to_fs(:delimited)                     # => "12,345,678"
+    #  12345678.05.to_fs(:delimited)                  # => "12,345,678.05"
+    #  12345678.to_fs(:delimited, delimiter: '.')     # => "12.345.678"
+    #  12345678.to_fs(:delimited, delimiter: ',')     # => "12,345,678"
+    #  12345678.05.to_fs(:delimited, separator: ' ')  # => "12,345,678 05"
+    #  12345678.05.to_fs(:delimited, locale: :fr)     # => "12 345 678,05"
+    #  98765432.98.to_fs(:delimited, delimiter: ' ', separator: ',')
     #  # => "98 765 432,98"
     #
     #  Rounded:
-    #  111.2345.to_formatted_s(:rounded)                                      # => "111.235"
-    #  111.2345.to_formatted_s(:rounded, precision: 2)                        # => "111.23"
-    #  111.2345.to_formatted_s(:rounded, precision: 2, round_mode: :up)       # => "111.24"
-    #  13.to_formatted_s(:rounded, precision: 5)                              # => "13.00000"
-    #  389.32314.to_formatted_s(:rounded, precision: 0)                       # => "389"
-    #  111.2345.to_formatted_s(:rounded, significant: true)                   # => "111"
-    #  111.2345.to_formatted_s(:rounded, precision: 1, significant: true)     # => "100"
-    #  13.to_formatted_s(:rounded, precision: 5, significant: true)           # => "13.000"
-    #  111.234.to_formatted_s(:rounded, locale: :fr)                          # => "111,234"
-    #  13.to_formatted_s(:rounded, precision: 5, significant: true, strip_insignificant_zeros: true)
+    #  111.2345.to_fs(:rounded)                                      # => "111.235"
+    #  111.2345.to_fs(:rounded, precision: 2)                        # => "111.23"
+    #  111.2345.to_fs(:rounded, precision: 2, round_mode: :up)       # => "111.24"
+    #  13.to_fs(:rounded, precision: 5)                              # => "13.00000"
+    #  389.32314.to_fs(:rounded, precision: 0)                       # => "389"
+    #  111.2345.to_fs(:rounded, significant: true)                   # => "111"
+    #  111.2345.to_fs(:rounded, precision: 1, significant: true)     # => "100"
+    #  13.to_fs(:rounded, precision: 5, significant: true)           # => "13.000"
+    #  111.234.to_fs(:rounded, locale: :fr)                          # => "111,234"
+    #  13.to_fs(:rounded, precision: 5, significant: true, strip_insignificant_zeros: true)
     #  # => "13"
-    #  389.32314.to_formatted_s(:rounded, precision: 4, significant: true)    # => "389.3"
-    #  1111.2345.to_formatted_s(:rounded, precision: 2, separator: ',', delimiter: '.')
+    #  389.32314.to_fs(:rounded, precision: 4, significant: true)    # => "389.3"
+    #  1111.2345.to_fs(:rounded, precision: 2, separator: ',', delimiter: '.')
     #  # => "1.111,23"
     #
     #  Human-friendly size in Bytes:
-    #  123.to_formatted_s(:human_size)                                    # => "123 Bytes"
-    #  1234.to_formatted_s(:human_size)                                   # => "1.21 KB"
-    #  12345.to_formatted_s(:human_size)                                  # => "12.1 KB"
-    #  1234567.to_formatted_s(:human_size)                                # => "1.18 MB"
-    #  1234567890.to_formatted_s(:human_size)                             # => "1.15 GB"
-    #  1234567890123.to_formatted_s(:human_size)                          # => "1.12 TB"
-    #  1234567890123456.to_formatted_s(:human_size)                       # => "1.1 PB"
-    #  1234567890123456789.to_formatted_s(:human_size)                    # => "1.07 EB"
-    #  1234567.to_formatted_s(:human_size, precision: 2)                  # => "1.2 MB"
-    #  1234567.to_formatted_s(:human_size, precision: 2, round_mode: :up) # => "1.3 MB"
-    #  483989.to_formatted_s(:human_size, precision: 2)                   # => "470 KB"
-    #  1234567.to_formatted_s(:human_size, precision: 2, separator: ',')  # => "1,2 MB"
-    #  1234567890123.to_formatted_s(:human_size, precision: 5)            # => "1.1228 TB"
-    #  524288000.to_formatted_s(:human_size, precision: 5)                # => "500 MB"
+    #  123.to_fs(:human_size)                                    # => "123 Bytes"
+    #  1234.to_fs(:human_size)                                   # => "1.21 KB"
+    #  12345.to_fs(:human_size)                                  # => "12.1 KB"
+    #  1234567.to_fs(:human_size)                                # => "1.18 MB"
+    #  1234567890.to_fs(:human_size)                             # => "1.15 GB"
+    #  1234567890123.to_fs(:human_size)                          # => "1.12 TB"
+    #  1234567890123456.to_fs(:human_size)                       # => "1.1 PB"
+    #  1234567890123456789.to_fs(:human_size)                    # => "1.07 EB"
+    #  1234567.to_fs(:human_size, precision: 2)                  # => "1.2 MB"
+    #  1234567.to_fs(:human_size, precision: 2, round_mode: :up) # => "1.3 MB"
+    #  483989.to_fs(:human_size, precision: 2)                   # => "470 KB"
+    #  1234567.to_fs(:human_size, precision: 2, separator: ',')  # => "1,2 MB"
+    #  1234567890123.to_fs(:human_size, precision: 5)            # => "1.1228 TB"
+    #  524288000.to_fs(:human_size, precision: 5)                # => "500 MB"
     #
     #  Human-friendly format:
-    #  123.to_formatted_s(:human)                                       # => "123"
-    #  1234.to_formatted_s(:human)                                      # => "1.23 Thousand"
-    #  12345.to_formatted_s(:human)                                     # => "12.3 Thousand"
-    #  1234567.to_formatted_s(:human)                                   # => "1.23 Million"
-    #  1234567890.to_formatted_s(:human)                                # => "1.23 Billion"
-    #  1234567890123.to_formatted_s(:human)                             # => "1.23 Trillion"
-    #  1234567890123456.to_formatted_s(:human)                          # => "1.23 Quadrillion"
-    #  1234567890123456789.to_formatted_s(:human)                       # => "1230 Quadrillion"
-    #  489939.to_formatted_s(:human, precision: 2)                      # => "490 Thousand"
-    #  489939.to_formatted_s(:human, precision: 2, round_mode: :down)   # => "480 Thousand"
-    #  489939.to_formatted_s(:human, precision: 4)                      # => "489.9 Thousand"
-    #  1234567.to_formatted_s(:human, precision: 4,
+    #  123.to_fs(:human)                                       # => "123"
+    #  1234.to_fs(:human)                                      # => "1.23 Thousand"
+    #  12345.to_fs(:human)                                     # => "12.3 Thousand"
+    #  1234567.to_fs(:human)                                   # => "1.23 Million"
+    #  1234567890.to_fs(:human)                                # => "1.23 Billion"
+    #  1234567890123.to_fs(:human)                             # => "1.23 Trillion"
+    #  1234567890123456.to_fs(:human)                          # => "1.23 Quadrillion"
+    #  1234567890123456789.to_fs(:human)                       # => "1230 Quadrillion"
+    #  489939.to_fs(:human, precision: 2)                      # => "490 Thousand"
+    #  489939.to_fs(:human, precision: 2, round_mode: :down)   # => "480 Thousand"
+    #  489939.to_fs(:human, precision: 4)                      # => "489.9 Thousand"
+    #  1234567.to_fs(:human, precision: 4,
     #                   significant: false)                             # => "1.2346 Million"
-    #  1234567.to_formatted_s(:human, precision: 1,
+    #  1234567.to_fs(:human, precision: 1,
     #                   separator: ',',
     #                   significant: false)                             # => "1,2 Million"
-    def to_formatted_s(format = nil, options = nil)
+    def to_fs(format = nil, options = nil)
       return to_s if format.nil?
 
       case format
@@ -134,7 +134,7 @@ module ActiveSupport
         to_s(format)
       end
     end
-    alias_method :to_fs, :to_formatted_s
+    alias_method :to_fs, :to_fs
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -9,7 +9,7 @@ module ActiveSupport
     # Options are provided for phone numbers, currency, percentage,
     # precision, positional notation, file size and pretty printing.
     #
-    # This method is aliased to <tt>to_fs</tt>.
+    # This method is aliased to <tt>to_formatted_s</tt>.
     #
     # ==== Options
     #

--- a/activesupport/lib/active_support/core_ext/numeric/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/conversions.rb
@@ -134,7 +134,7 @@ module ActiveSupport
         to_s(format)
       end
     end
-    alias_method :to_fs, :to_fs
+    alias_method :to_formatted_s, :to_fs
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/numeric/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/numeric/deprecated_conversions.rb
@@ -10,42 +10,42 @@ module ActiveSupport
         super(format)
       when :phone
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_phone(self, options || {})
       when :currency
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_currency(self, options || {})
       when :percentage
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_percentage(self, options || {})
       when :delimited
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_delimited(self, options || {})
       when :rounded
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_rounded(self, options || {})
       when :human
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_human(self, options || {})
       when :human_size
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         ActiveSupport::NumberHelper.number_to_human_size(self, options || {})
       when Symbol
         ActiveSupport::Deprecation.warn(
-          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_formatted_s(#{format.inspect}) instead."
+          "#{self.class}#to_s(#{format.inspect}) is deprecated. Please use #{self.class}#to_fs(#{format.inspect}) instead."
         )
         super()
       else

--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -14,7 +14,7 @@ module ActiveSupport
 
     # Convert range to a formatted string. See RANGE_FORMATS for predefined formats.
     #
-    # This method is aliased to <tt>to_fs</tt>.
+    # This method is aliased to <tt>to_formatted_s</tt>.
     #
     #   range = (1..100)           # => 1..100
     #

--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -27,7 +27,7 @@ module ActiveSupport
     #
     #   # config/initializers/range_formats.rb
     #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_fs(:db)} and #{stop.to_fs(:db)}" }
-    def to_fs :default)
+    def to_fs(format = :default)
       if formatter = RANGE_FORMATS[format]
         formatter.call(first, last)
       else

--- a/activesupport/lib/active_support/core_ext/range/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/conversions.rb
@@ -7,7 +7,7 @@ module ActiveSupport
         case start
         when String then "BETWEEN '#{start}' AND '#{stop}'"
         else
-          "BETWEEN '#{start.to_formatted_s(:db)}' AND '#{stop.to_formatted_s(:db)}'"
+          "BETWEEN '#{start.to_fs(:db)}' AND '#{stop.to_fs(:db)}'"
         end
       end
     }
@@ -19,22 +19,22 @@ module ActiveSupport
     #   range = (1..100)           # => 1..100
     #
     #   range.to_s                 # => "1..100"
-    #   range.to_formatted_s(:db)            # => "BETWEEN '1' AND '100'"
+    #   range.to_fs(:db)            # => "BETWEEN '1' AND '100'"
     #
     # == Adding your own range formats to to_s
     # You can add your own formats to the Range::RANGE_FORMATS hash.
     # Use the format name as the hash key and a Proc instance.
     #
     #   # config/initializers/range_formats.rb
-    #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_formatted_s(:db)} and #{stop.to_formatted_s(:db)}" }
-    def to_formatted_s(format = :default)
+    #   Range::RANGE_FORMATS[:short] = ->(start, stop) { "Between #{start.to_fs(:db)} and #{stop.to_fs(:db)}" }
+    def to_fs :default)
       if formatter = RANGE_FORMATS[format]
         formatter.call(first, last)
       else
         to_s
       end
     end
-    alias_method :to_fs, :to_formatted_s
+    alias_method :to_formatted_s, :to_fs
   end
 end
 

--- a/activesupport/lib/active_support/core_ext/range/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/range/deprecated_conversions.rb
@@ -6,14 +6,14 @@ module ActiveSupport
     def to_s(format = NOT_SET)
       if formatter = RangeWithFormat::RANGE_FORMATS[format]
         ActiveSupport::Deprecation.warn(
-          "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_formatted_s(#{format.inspect}) instead."
+          "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_fs(#{format.inspect}) instead."
         )
         formatter.call(first, last)
       elsif format == NOT_SET
         super()
       else
         ActiveSupport::Deprecation.warn(
-          "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_formatted_s(#{format.inspect}) instead."
+          "Range#to_s(#{format.inspect}) is deprecated. Please use Range#to_fs(#{format.inspect}) instead."
         )
         super()
       end

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -31,8 +31,8 @@ class Time
   #
   #   time = Time.now                    # => 2007-01-18 06:10:17 -06:00
   #
-  #   time.to_fs(:time)         # => "06:10"
   #   time.to_fs(:time)                  # => "06:10"
+  #   time.to_formatted_s(:time)         # => "06:10"
   #
   #   time.to_fs(:db)           # => "2007-01-18 06:10:17"
   #   time.to_fs(:number)       # => "20070118061017"

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -27,7 +27,7 @@ class Time
 
   # Converts to a formatted string. See DATE_FORMATS for built-in formats.
   #
-  # This method is aliased to <tt>to_fs</tt>.
+  # This method is aliased to <tt>to_formatted_s</tt>.
   #
   #   time = Time.now                    # => 2007-01-18 06:10:17 -06:00
   #

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -31,18 +31,18 @@ class Time
   #
   #   time = Time.now                    # => 2007-01-18 06:10:17 -06:00
   #
-  #   time.to_formatted_s(:time)         # => "06:10"
+  #   time.to_fs(:time)         # => "06:10"
   #   time.to_fs(:time)                  # => "06:10"
   #
-  #   time.to_formatted_s(:db)           # => "2007-01-18 06:10:17"
-  #   time.to_formatted_s(:number)       # => "20070118061017"
-  #   time.to_formatted_s(:short)        # => "18 Jan 06:10"
-  #   time.to_formatted_s(:long)         # => "January 18, 2007 06:10"
-  #   time.to_formatted_s(:long_ordinal) # => "January 18th, 2007 06:10"
-  #   time.to_formatted_s(:rfc822)       # => "Thu, 18 Jan 2007 06:10:17 -0600"
-  #   time.to_formatted_s(:iso8601)      # => "2007-01-18T06:10:17-06:00"
+  #   time.to_fs(:db)           # => "2007-01-18 06:10:17"
+  #   time.to_fs(:number)       # => "20070118061017"
+  #   time.to_fs(:short)        # => "18 Jan 06:10"
+  #   time.to_fs(:long)         # => "January 18, 2007 06:10"
+  #   time.to_fs(:long_ordinal) # => "January 18th, 2007 06:10"
+  #   time.to_fs(:rfc822)       # => "Thu, 18 Jan 2007 06:10:17 -0600"
+  #   time.to_fs(:iso8601)      # => "2007-01-18T06:10:17-06:00"
   #
-  # == Adding your own time formats to +to_formatted_s+
+  # == Adding your own time formats to +to_fs+
   # You can add your own formats to the Time::DATE_FORMATS hash.
   # Use the format name as the hash key and either a strftime string
   # or Proc instance that takes a time argument as the value.
@@ -50,7 +50,7 @@ class Time
   #   # config/initializers/time_formats.rb
   #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
-  def to_formatted_s(format = :default)
+  def to_fs :default)
     if formatter = DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     else
@@ -58,7 +58,7 @@ class Time
       to_default_s
     end
   end
-  alias_method :to_fs, :to_formatted_s
+  alias_method :to_formatted_s, :to_fs
   alias_method :to_default_s, :to_s
 
   # Returns a formatted string of the offset from UTC, or an alternative

--- a/activesupport/lib/active_support/core_ext/time/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/conversions.rb
@@ -50,7 +50,7 @@ class Time
   #   # config/initializers/time_formats.rb
   #   Time::DATE_FORMATS[:month_and_year] = '%B %Y'
   #   Time::DATE_FORMATS[:short_ordinal]  = ->(time) { time.strftime("%B #{time.day.ordinalize}") }
-  def to_fs :default)
+  def to_fs(format = :default)
     if formatter = DATE_FORMATS[format]
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     else

--- a/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
+++ b/activesupport/lib/active_support/core_ext/time/deprecated_conversions.rb
@@ -7,14 +7,14 @@ class Time
   def to_s(format = NOT_SET) # :nodoc:
     if formatter = DATE_FORMATS[format]
       ActiveSupport::Deprecation.warn(
-        "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_formatted_s(#{format.inspect}) instead."
+        "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_fs(#{format.inspect}) instead."
       )
       formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
     elsif format == NOT_SET
       to_default_s
     else
       ActiveSupport::Deprecation.warn(
-        "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_formatted_s(#{format.inspect}) instead."
+        "Time#to_s(#{format.inspect}) is deprecated. Please use Time#to_fs(#{format.inspect}) instead."
       )
       to_default_s
     end

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -232,7 +232,7 @@ module ActiveSupport
 
     # Returns a string of the object's date and time.
     #
-    # This method is aliased to <tt>to_fs</tt>.
+    # This method is aliased to <tt>to_formatted_s</tt>.
     #
     # Accepts an optional <tt>format</tt>:
     # * <tt>:default</tt> - default value, mimics Ruby Time#to_s format.

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -33,7 +33,7 @@ module ActiveSupport
   #   t.dst?                                # => true
   #   t.utc_offset                          # => -14400
   #   t.zone                                # => "EDT"
-  #   t.to_fs(:rfc822)             # => "Sun, 18 May 2008 13:27:25 -0400"
+  #   t.to_fs(:rfc822)                      # => "Sun, 18 May 2008 13:27:25 -0400"
   #   t + 1.day                             # => Mon, 19 May 2008 13:27:25.031505668 EDT -04:00
   #   t.beginning_of_year                   # => Tue, 01 Jan 2008 00:00:00.000000000 EST -05:00
   #   t > Time.utc(1999)                    # => true

--- a/activesupport/lib/active_support/time_with_zone.rb
+++ b/activesupport/lib/active_support/time_with_zone.rb
@@ -33,7 +33,7 @@ module ActiveSupport
   #   t.dst?                                # => true
   #   t.utc_offset                          # => -14400
   #   t.zone                                # => "EDT"
-  #   t.to_formatted_s(:rfc822)             # => "Sun, 18 May 2008 13:27:25 -0400"
+  #   t.to_fs(:rfc822)             # => "Sun, 18 May 2008 13:27:25 -0400"
   #   t + 1.day                             # => Mon, 19 May 2008 13:27:25.031505668 EDT -04:00
   #   t.beginning_of_year                   # => Tue, 01 Jan 2008 00:00:00.000000000 EST -05:00
   #   t > Time.utc(1999)                    # => true
@@ -202,7 +202,7 @@ module ActiveSupport
     #
     #   Time.zone.now.rfc2822  # => "Tue, 01 Jan 2013 04:51:39 +0000"
     def rfc2822
-      to_formatted_s(:rfc822)
+      to_fs(:rfc822)
     end
     alias_method :rfc822, :rfc2822
 
@@ -212,19 +212,19 @@ module ActiveSupport
     def to_s(format = NOT_SET)
       if format == :db
         ActiveSupport::Deprecation.warn(
-          "TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_formatted_s(:db) instead."
+          "TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead."
         )
-        utc.to_formatted_s(format)
+        utc.to_fs(format)
       elsif formatter = ::Time::DATE_FORMATS[format]
         ActiveSupport::Deprecation.warn(
-          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_formatted_s(#{format.inspect}) instead."
+          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
         )
         formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
       elsif format == NOT_SET
         "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
       else
         ActiveSupport::Deprecation.warn(
-          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_formatted_s(#{format.inspect}) instead."
+          "TimeWithZone#to_s(#{format.inspect}) is deprecated. Please use TimeWithZone#to_fs(#{format.inspect}) instead."
         )
         "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}" # mimicking Ruby Time#to_s format
       end
@@ -236,11 +236,11 @@ module ActiveSupport
     #
     # Accepts an optional <tt>format</tt>:
     # * <tt>:default</tt> - default value, mimics Ruby Time#to_s format.
-    # * <tt>:db</tt> - format outputs time in UTC :db time. See Time#to_formatted_s(:db).
+    # * <tt>:db</tt> - format outputs time in UTC :db time. See Time#to_fs(:db).
     # * Any key in <tt>Time::DATE_FORMATS</tt> can be used. See active_support/core_ext/time/conversions.rb.
-    def to_formatted_s(format = :default)
+    def to_fs(format = :default)
       if format == :db
-        utc.to_formatted_s(format)
+        utc.to_fs(format)
       elsif formatter = ::Time::DATE_FORMATS[format]
         formatter.respond_to?(:call) ? formatter.call(self).to_s : strftime(formatter)
       else
@@ -248,7 +248,7 @@ module ActiveSupport
         "#{time.strftime("%Y-%m-%d %H:%M:%S")} #{formatted_offset(false, 'UTC')}"
       end
     end
-    alias_method :to_fs, :to_formatted_s
+    alias_method :to_formatted_s, :to_fs
 
     # Replaces <tt>%Z</tt> directive with +zone before passing to Time#strftime,
     # so that zone information is correct.

--- a/activesupport/lib/active_support/xml_mini.rb
+++ b/activesupport/lib/active_support/xml_mini.rb
@@ -54,7 +54,7 @@ module ActiveSupport
 
     FORMATTING = {
       "symbol"   => Proc.new { |symbol| symbol.to_s },
-      "date"     => Proc.new { |date| date.to_formatted_s(:db) },
+      "date"     => Proc.new { |date| date.to_fs(:db) },
       "dateTime" => Proc.new { |time| time.xmlschema },
       "binary"   => Proc.new { |binary| ::Base64.encode64(binary) },
       "yaml"     => Proc.new { |yaml| yaml.to_yaml }

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -116,8 +116,8 @@ class ToSTest < ActiveSupport::TestCase
 
     assert_equal "null", [].to_fs(:db)
     assert_equal "1,2,3", collection.to_fs(:db)
-    assert_equal "null", [].to_fs(:db)
-    assert_equal "4,5,6", collection.to_fs(:db)
+    assert_equal "null", [].to_formatted_s(:db)
+    assert_equal "4,5,6", collection.to_formatted_s(:db)
   end
 end
 

--- a/activesupport/test/core_ext/array/conversions_test.rb
+++ b/activesupport/test/core_ext/array/conversions_test.rb
@@ -111,11 +111,11 @@ class ToSTest < ActiveSupport::TestCase
     end
   end
 
-  def test_to_formatted_s_db
+  def test_to_fs_db
     collection = [TestDB.new, TestDB.new, TestDB.new]
 
-    assert_equal "null", [].to_formatted_s(:db)
-    assert_equal "1,2,3", collection.to_formatted_s(:db)
+    assert_equal "null", [].to_fs(:db)
+    assert_equal "1,2,3", collection.to_fs(:db)
     assert_equal "null", [].to_fs(:db)
     assert_equal "4,5,6", collection.to_fs(:db)
   end

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -79,27 +79,27 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_to_formatted_s
+  def test_to_fs
     date = Date.new(2005, 2, 21)
-    assert_equal "21 Feb",              date.to_formatted_s(:short)
-    assert_equal "February 21, 2005",   date.to_formatted_s(:long)
-    assert_equal "February 21st, 2005", date.to_formatted_s(:long_ordinal)
-    assert_equal "2005-02-21",          date.to_formatted_s(:db)
-    assert_equal "2005-02-21",          date.to_formatted_s(:inspect)
-    assert_equal "21 Feb 2005",         date.to_formatted_s(:rfc822)
-    assert_equal "2005-02-21",          date.to_formatted_s(:iso8601)
+    assert_equal "21 Feb",              date.to_fs(:short)
+    assert_equal "February 21, 2005",   date.to_fs(:long)
+    assert_equal "February 21st, 2005", date.to_fs(:long_ordinal)
+    assert_equal "2005-02-21",          date.to_fs(:db)
+    assert_equal "2005-02-21",          date.to_fs(:inspect)
+    assert_equal "21 Feb 2005",         date.to_fs(:rfc822)
+    assert_equal "2005-02-21",          date.to_fs(:iso8601)
     assert_equal "21 Feb",              date.to_fs(:short)
   end
 
-  def test_to_formatted_s_with_single_digit_day
+  def test_to_fs_with_single_digit_day
     date = Date.new(2005, 2, 1)
-    assert_equal "01 Feb",              date.to_formatted_s(:short)
-    assert_equal "February 01, 2005",   date.to_formatted_s(:long)
-    assert_equal "February 1st, 2005",  date.to_formatted_s(:long_ordinal)
-    assert_equal "2005-02-01",          date.to_formatted_s(:db)
-    assert_equal "2005-02-01",          date.to_formatted_s(:inspect)
-    assert_equal "01 Feb 2005",         date.to_formatted_s(:rfc822)
-    assert_equal "2005-02-01",          date.to_formatted_s(:iso8601)
+    assert_equal "01 Feb",              date.to_fs(:short)
+    assert_equal "February 01, 2005",   date.to_fs(:long)
+    assert_equal "February 1st, 2005",  date.to_fs(:long_ordinal)
+    assert_equal "2005-02-01",          date.to_fs(:db)
+    assert_equal "2005-02-01",          date.to_fs(:inspect)
+    assert_equal "01 Feb 2005",         date.to_fs(:rfc822)
+    assert_equal "2005-02-01",          date.to_fs(:iso8601)
   end
 
   def test_readable_inspect

--- a/activesupport/test/core_ext/date_ext_test.rb
+++ b/activesupport/test/core_ext/date_ext_test.rb
@@ -88,7 +88,7 @@ class DateExtCalculationsTest < ActiveSupport::TestCase
     assert_equal "2005-02-21",          date.to_fs(:inspect)
     assert_equal "21 Feb 2005",         date.to_fs(:rfc822)
     assert_equal "2005-02-21",          date.to_fs(:iso8601)
-    assert_equal "21 Feb",              date.to_fs(:short)
+    assert_equal "21 Feb",              date.to_formatted_s(:short)
   end
 
   def test_to_fs_with_single_digit_day

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -72,7 +72,7 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
       assert_equal "2009-02-05T14:30:05+00:00", DateTime.civil(2009, 2, 5, 14, 30, 5).to_fs(:iso8601)
     end
 
-    assert_equal "2005-02-21 14:30:00",                 datetime.to_fs(:db)
+    assert_equal "2005-02-21 14:30:00",                 datetime.to_formatted_s(:db)
   end
 
   def test_readable_inspect

--- a/activesupport/test/core_ext/date_time_ext_test.rb
+++ b/activesupport/test/core_ext/date_time_ext_test.rb
@@ -54,22 +54,22 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_to_formatted_s
+  def test_to_fs
     datetime = DateTime.new(2005, 2, 21, 14, 30, 0, 0)
-    assert_equal "2005-02-21 14:30:00",                 datetime.to_formatted_s(:db)
-    assert_equal "2005-02-21 14:30:00.000000000 +0000", datetime.to_formatted_s(:inspect)
-    assert_equal "14:30",                               datetime.to_formatted_s(:time)
-    assert_equal "21 Feb 14:30",                        datetime.to_formatted_s(:short)
-    assert_equal "February 21, 2005 14:30",             datetime.to_formatted_s(:long)
-    assert_equal "Mon, 21 Feb 2005 14:30:00 +0000",     datetime.to_formatted_s(:rfc822)
-    assert_equal "February 21st, 2005 14:30",           datetime.to_formatted_s(:long_ordinal)
-    assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,    datetime.to_formatted_s)
-    assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,    datetime.to_formatted_s(:not_existent))
+    assert_equal "2005-02-21 14:30:00",                 datetime.to_fs(:db)
+    assert_equal "2005-02-21 14:30:00.000000000 +0000", datetime.to_fs(:inspect)
+    assert_equal "14:30",                               datetime.to_fs(:time)
+    assert_equal "21 Feb 14:30",                        datetime.to_fs(:short)
+    assert_equal "February 21, 2005 14:30",             datetime.to_fs(:long)
+    assert_equal "Mon, 21 Feb 2005 14:30:00 +0000",     datetime.to_fs(:rfc822)
+    assert_equal "February 21st, 2005 14:30",           datetime.to_fs(:long_ordinal)
+    assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,    datetime.to_fs)
+    assert_match(/^2005-02-21T14:30:00(Z|\+00:00)$/,    datetime.to_fs(:not_existent))
 
     with_env_tz "US/Central" do
-      assert_equal "2009-02-05T14:30:05-06:00", DateTime.civil(2009, 2, 5, 14, 30, 5, Rational(-21600, 86400)).to_formatted_s(:iso8601)
-      assert_equal "2008-06-09T04:05:01-05:00", DateTime.civil(2008, 6, 9, 4, 5, 1, Rational(-18000, 86400)).to_formatted_s(:iso8601)
-      assert_equal "2009-02-05T14:30:05+00:00", DateTime.civil(2009, 2, 5, 14, 30, 5).to_formatted_s(:iso8601)
+      assert_equal "2009-02-05T14:30:05-06:00", DateTime.civil(2009, 2, 5, 14, 30, 5, Rational(-21600, 86400)).to_fs(:iso8601)
+      assert_equal "2008-06-09T04:05:01-05:00", DateTime.civil(2008, 6, 9, 4, 5, 1, Rational(-18000, 86400)).to_fs(:iso8601)
+      assert_equal "2009-02-05T14:30:05+00:00", DateTime.civil(2009, 2, 5, 14, 30, 5).to_fs(:iso8601)
     end
 
     assert_equal "2005-02-21 14:30:00",                 datetime.to_fs(:db)
@@ -90,9 +90,9 @@ class DateTimeExtCalculationsTest < ActiveSupport::TestCase
     Time::DATE_FORMATS.delete(:custom)
   end
 
-  def test_to_formatted_s_with_custom_date_format
+  def test_to_fs_with_custom_date_format
     Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
-    assert_equal "20050221143000", DateTime.new(2005, 2, 21, 14, 30, 0).to_formatted_s(:custom)
+    assert_equal "20050221143000", DateTime.new(2005, 2, 21, 14, 30, 0).to_fs(:custom)
   ensure
     Time::DATE_FORMATS.delete(:custom)
   end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -157,300 +157,300 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
     petabytes(number) * 1024
   end
 
-  def test_to_formatted_s__phone
+  def test_to_fs__phone
     assert_deprecated do
       assert_equal("555-1234", 5551234.to_s(:phone))
     end
-    assert_equal("555-1234", 5551234.to_formatted_s(:phone))
     assert_equal("555-1234", 5551234.to_fs(:phone))
-    assert_equal("800-555-1212", 8005551212.to_formatted_s(:phone))
-    assert_equal("(800) 555-1212", 8005551212.to_formatted_s(:phone, area_code: true))
-    assert_equal("800 555 1212", 8005551212.to_formatted_s(:phone, delimiter: " "))
-    assert_equal("(800) 555-1212 x 123", 8005551212.to_formatted_s(:phone, area_code: true, extension: 123))
-    assert_equal("800-555-1212", 8005551212.to_formatted_s(:phone, extension: "  "))
-    assert_equal("555.1212", 5551212.to_formatted_s(:phone, delimiter: "."))
-    assert_equal("+1-800-555-1212", 8005551212.to_formatted_s(:phone, country_code: 1))
-    assert_equal("+18005551212", 8005551212.to_formatted_s(:phone, country_code: 1, delimiter: ""))
-    assert_equal("22-555-1212", 225551212.to_formatted_s(:phone))
-    assert_equal("+45-22-555-1212", 225551212.to_formatted_s(:phone, country_code: 45))
+    assert_equal("555-1234", 5551234.to_fs(:phone))
+    assert_equal("800-555-1212", 8005551212.to_fs(:phone))
+    assert_equal("(800) 555-1212", 8005551212.to_fs(:phone, area_code: true))
+    assert_equal("800 555 1212", 8005551212.to_fs(:phone, delimiter: " "))
+    assert_equal("(800) 555-1212 x 123", 8005551212.to_fs(:phone, area_code: true, extension: 123))
+    assert_equal("800-555-1212", 8005551212.to_fs(:phone, extension: "  "))
+    assert_equal("555.1212", 5551212.to_fs(:phone, delimiter: "."))
+    assert_equal("+1-800-555-1212", 8005551212.to_fs(:phone, country_code: 1))
+    assert_equal("+18005551212", 8005551212.to_fs(:phone, country_code: 1, delimiter: ""))
+    assert_equal("22-555-1212", 225551212.to_fs(:phone))
+    assert_equal("+45-22-555-1212", 225551212.to_fs(:phone, country_code: 45))
   end
 
-  def test_to_formatted_s__currency
+  def test_to_fs__currency
     assert_deprecated do
       assert_equal("$1,234,567,890.50", 1234567890.50.to_s(:currency))
     end
-    assert_equal("$1,234,567,890.50", 1234567890.50.to_formatted_s(:currency))
     assert_equal("$1,234,567,890.50", 1234567890.50.to_fs(:currency))
-    assert_equal("$1,234,567,890.51", 1234567890.506.to_formatted_s(:currency))
-    assert_equal("-$1,234,567,890.50", -1234567890.50.to_formatted_s(:currency))
-    assert_equal("-$ 1,234,567,890.50", -1234567890.50.to_formatted_s(:currency, format: "%u %n"))
-    assert_equal("($1,234,567,890.50)", -1234567890.50.to_formatted_s(:currency, negative_format: "(%u%n)"))
-    assert_equal("$1,234,567,892", 1234567891.50.to_formatted_s(:currency, precision: 0))
-    assert_equal("$1,234,567,891", 1234567891.50.to_formatted_s(:currency, precision: 0, round_mode: :down))
-    assert_equal("$1,234,567,890.5", 1234567890.50.to_formatted_s(:currency, precision: 1))
-    assert_equal("&pound;1234567890,50", 1234567890.50.to_formatted_s(:currency, unit: "&pound;", separator: ",", delimiter: ""))
+    assert_equal("$1,234,567,890.50", 1234567890.50.to_fs(:currency))
+    assert_equal("$1,234,567,890.51", 1234567890.506.to_fs(:currency))
+    assert_equal("-$1,234,567,890.50", -1234567890.50.to_fs(:currency))
+    assert_equal("-$ 1,234,567,890.50", -1234567890.50.to_fs(:currency, format: "%u %n"))
+    assert_equal("($1,234,567,890.50)", -1234567890.50.to_fs(:currency, negative_format: "(%u%n)"))
+    assert_equal("$1,234,567,892", 1234567891.50.to_fs(:currency, precision: 0))
+    assert_equal("$1,234,567,891", 1234567891.50.to_fs(:currency, precision: 0, round_mode: :down))
+    assert_equal("$1,234,567,890.5", 1234567890.50.to_fs(:currency, precision: 1))
+    assert_equal("&pound;1234567890,50", 1234567890.50.to_fs(:currency, unit: "&pound;", separator: ",", delimiter: ""))
   end
 
-  def test_to_formatted_s__rounded
+  def test_to_fs__rounded
     assert_deprecated do
       assert_equal("-111.235", -111.2346.to_s(:rounded))
     end
-    assert_equal("-111.235", -111.2346.to_formatted_s(:rounded))
     assert_equal("-111.235", -111.2346.to_fs(:rounded))
-    assert_equal("111.235", 111.2346.to_formatted_s(:rounded))
-    assert_equal("31.83", 31.825.to_formatted_s(:rounded, precision: 2))
-    assert_equal("31.82", 31.825.to_formatted_s(:rounded, precision: 2, round_mode: :down))
-    assert_equal("111.23", 111.2346.to_formatted_s(:rounded, precision: 2))
-    assert_equal("111.00", 111.to_formatted_s(:rounded, precision: 2))
-    assert_equal("3268", (32.6751 * 100.00).to_formatted_s(:rounded, precision: 0))
-    assert_equal("112", 111.50.to_formatted_s(:rounded, precision: 0))
-    assert_equal("1234567892", 1234567891.50.to_formatted_s(:rounded, precision: 0))
-    assert_equal("0", 0.to_formatted_s(:rounded, precision: 0))
-    assert_equal("0.00100", 0.001.to_formatted_s(:rounded, precision: 5))
-    assert_equal("0.001", 0.00111.to_formatted_s(:rounded, precision: 3))
-    assert_equal("10.00", 9.995.to_formatted_s(:rounded, precision: 2))
-    assert_equal("11.00", 10.995.to_formatted_s(:rounded, precision: 2))
-    assert_equal("0.00", -0.001.to_formatted_s(:rounded, precision: 2))
+    assert_equal("-111.235", -111.2346.to_fs(:rounded))
+    assert_equal("111.235", 111.2346.to_fs(:rounded))
+    assert_equal("31.83", 31.825.to_fs(:rounded, precision: 2))
+    assert_equal("31.82", 31.825.to_fs(:rounded, precision: 2, round_mode: :down))
+    assert_equal("111.23", 111.2346.to_fs(:rounded, precision: 2))
+    assert_equal("111.00", 111.to_fs(:rounded, precision: 2))
+    assert_equal("3268", (32.6751 * 100.00).to_fs(:rounded, precision: 0))
+    assert_equal("112", 111.50.to_fs(:rounded, precision: 0))
+    assert_equal("1234567892", 1234567891.50.to_fs(:rounded, precision: 0))
+    assert_equal("0", 0.to_fs(:rounded, precision: 0))
+    assert_equal("0.00100", 0.001.to_fs(:rounded, precision: 5))
+    assert_equal("0.001", 0.00111.to_fs(:rounded, precision: 3))
+    assert_equal("10.00", 9.995.to_fs(:rounded, precision: 2))
+    assert_equal("11.00", 10.995.to_fs(:rounded, precision: 2))
+    assert_equal("0.00", -0.001.to_fs(:rounded, precision: 2))
   end
 
-  def test_to_formatted_s__rounded_with_custom_delimiter_and_separator
-    assert_equal "31,83",       31.825.to_formatted_s(:rounded, precision: 2, separator: ",")
-    assert_equal "1.231,83",    1231.825.to_formatted_s(:rounded, precision: 2, separator: ",", delimiter: ".")
+  def test_to_fs__rounded_with_custom_delimiter_and_separator
+    assert_equal "31,83",       31.825.to_fs(:rounded, precision: 2, separator: ",")
+    assert_equal "1.231,83",    1231.825.to_fs(:rounded, precision: 2, separator: ",", delimiter: ".")
   end
 
-  def test_to_formatted_s__rounded__with_significant_digits
-    assert_equal "124000", 123987.to_formatted_s(:rounded, precision: 3, significant: true)
-    assert_equal "120000000", 123987876.to_formatted_s(:rounded, precision: 2, significant: true)
-    assert_equal "9775", 9775.to_formatted_s(:rounded, precision: 4, significant: true)
-    assert_equal "5.4", 5.3923.to_formatted_s(:rounded, precision: 2, significant: true)
-    assert_equal "5", 5.3923.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "1", 1.232.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "7", 7.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "1", 1.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "53", 52.7923.to_formatted_s(:rounded, precision: 2, significant: true)
-    assert_equal "9775.00", 9775.to_formatted_s(:rounded, precision: 6, significant: true)
-    assert_equal "5.392900", 5.3929.to_formatted_s(:rounded, precision: 7, significant: true)
-    assert_equal "0.0", 0.to_formatted_s(:rounded, precision: 2, significant: true)
-    assert_equal "0", 0.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "0.0001", 0.0001.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "0.000100", 0.0001.to_formatted_s(:rounded, precision: 3, significant: true)
-    assert_equal "0.0001", 0.0001111.to_formatted_s(:rounded, precision: 1, significant: true)
-    assert_equal "10.0", 9.995.to_formatted_s(:rounded, precision: 3, significant: true)
-    assert_equal "9.99", 9.994.to_formatted_s(:rounded, precision: 3, significant: true)
-    assert_equal "11.0", 10.995.to_formatted_s(:rounded, precision: 3, significant: true)
-    assert_equal "10.9", 10.995.to_formatted_s(:rounded, precision: 3, significant: true, round_mode: :down)
+  def test_to_fs__rounded__with_significant_digits
+    assert_equal "124000", 123987.to_fs(:rounded, precision: 3, significant: true)
+    assert_equal "120000000", 123987876.to_fs(:rounded, precision: 2, significant: true)
+    assert_equal "9775", 9775.to_fs(:rounded, precision: 4, significant: true)
+    assert_equal "5.4", 5.3923.to_fs(:rounded, precision: 2, significant: true)
+    assert_equal "5", 5.3923.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "1", 1.232.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "7", 7.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "1", 1.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "53", 52.7923.to_fs(:rounded, precision: 2, significant: true)
+    assert_equal "9775.00", 9775.to_fs(:rounded, precision: 6, significant: true)
+    assert_equal "5.392900", 5.3929.to_fs(:rounded, precision: 7, significant: true)
+    assert_equal "0.0", 0.to_fs(:rounded, precision: 2, significant: true)
+    assert_equal "0", 0.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "0.0001", 0.0001.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "0.000100", 0.0001.to_fs(:rounded, precision: 3, significant: true)
+    assert_equal "0.0001", 0.0001111.to_fs(:rounded, precision: 1, significant: true)
+    assert_equal "10.0", 9.995.to_fs(:rounded, precision: 3, significant: true)
+    assert_equal "9.99", 9.994.to_fs(:rounded, precision: 3, significant: true)
+    assert_equal "11.0", 10.995.to_fs(:rounded, precision: 3, significant: true)
+    assert_equal "10.9", 10.995.to_fs(:rounded, precision: 3, significant: true, round_mode: :down)
   end
 
-  def test_to_formatted_s__rounded__with_strip_insignificant_zeros
-    assert_equal "9775.43", 9775.43.to_formatted_s(:rounded, precision: 4, strip_insignificant_zeros: true)
-    assert_equal "9775.2", 9775.2.to_formatted_s(:rounded, precision: 6, significant: true, strip_insignificant_zeros: true)
-    assert_equal "0", 0.to_formatted_s(:rounded, precision: 6, significant: true, strip_insignificant_zeros: true)
+  def test_to_fs__rounded__with_strip_insignificant_zeros
+    assert_equal "9775.43", 9775.43.to_fs(:rounded, precision: 4, strip_insignificant_zeros: true)
+    assert_equal "9775.2", 9775.2.to_fs(:rounded, precision: 6, significant: true, strip_insignificant_zeros: true)
+    assert_equal "0", 0.to_fs(:rounded, precision: 6, significant: true, strip_insignificant_zeros: true)
   end
 
-  def test_to_formatted_s__rounded__with_significant_true_and_zero_precision
+  def test_to_fs__rounded__with_significant_true_and_zero_precision
     # Zero precision with significant is a mistake (would always return zero),
     # so we treat it as if significant was false (increases backwards compatibility for number_to_human_size)
-    assert_equal "124", 123.987.to_formatted_s(:rounded, precision: 0, significant: true)
-    assert_equal "12", 12.to_formatted_s(:rounded, precision: 0, significant: true)
+    assert_equal "124", 123.987.to_fs(:rounded, precision: 0, significant: true)
+    assert_equal "12", 12.to_fs(:rounded, precision: 0, significant: true)
   end
 
-  def test_to_formatted_s__percentage
+  def test_to_fs__percentage
     assert_deprecated do
       assert_equal("100.000%", 100.to_s(:percentage))
     end
-    assert_equal("100.000%", 100.to_formatted_s(:percentage))
     assert_equal("100.000%", 100.to_fs(:percentage))
-    assert_equal("100%", 100.to_formatted_s(:percentage, precision: 0))
-    assert_equal("302.06%", 302.0574.to_formatted_s(:percentage, precision: 2))
-    assert_equal("302.05%", 302.0574.to_formatted_s(:percentage, precision: 2, round_mode: :down))
-    assert_equal("123.4%", 123.400.to_formatted_s(:percentage, precision: 3, strip_insignificant_zeros: true))
-    assert_equal("1.000,000%", 1000.to_formatted_s(:percentage, delimiter: ".", separator: ","))
-    assert_equal("1000.000  %", 1000.to_formatted_s(:percentage, format: "%n  %"))
+    assert_equal("100.000%", 100.to_fs(:percentage))
+    assert_equal("100%", 100.to_fs(:percentage, precision: 0))
+    assert_equal("302.06%", 302.0574.to_fs(:percentage, precision: 2))
+    assert_equal("302.05%", 302.0574.to_fs(:percentage, precision: 2, round_mode: :down))
+    assert_equal("123.4%", 123.400.to_fs(:percentage, precision: 3, strip_insignificant_zeros: true))
+    assert_equal("1.000,000%", 1000.to_fs(:percentage, delimiter: ".", separator: ","))
+    assert_equal("1000.000  %", 1000.to_fs(:percentage, format: "%n  %"))
   end
 
-  def test_to_formatted_s__delimited
+  def test_to_fs__delimited
     assert_deprecated do
       assert_equal("12,345,678", 12345678.to_s(:delimited))
     end
-    assert_equal("12,345,678", 12345678.to_formatted_s(:delimited))
     assert_equal("12,345,678", 12345678.to_fs(:delimited))
-    assert_equal("0", 0.to_formatted_s(:delimited))
-    assert_equal("123", 123.to_formatted_s(:delimited))
-    assert_equal("123,456", 123456.to_formatted_s(:delimited))
-    assert_equal("123,456.78", 123456.78.to_formatted_s(:delimited))
-    assert_equal("123,456.789", 123456.789.to_formatted_s(:delimited))
-    assert_equal("123,456.78901", 123456.78901.to_formatted_s(:delimited))
-    assert_equal("123,456,789.78901", 123456789.78901.to_formatted_s(:delimited))
-    assert_equal("0.78901", 0.78901.to_formatted_s(:delimited))
+    assert_equal("12,345,678", 12345678.to_fs(:delimited))
+    assert_equal("0", 0.to_fs(:delimited))
+    assert_equal("123", 123.to_fs(:delimited))
+    assert_equal("123,456", 123456.to_fs(:delimited))
+    assert_equal("123,456.78", 123456.78.to_fs(:delimited))
+    assert_equal("123,456.789", 123456.789.to_fs(:delimited))
+    assert_equal("123,456.78901", 123456.78901.to_fs(:delimited))
+    assert_equal("123,456,789.78901", 123456789.78901.to_fs(:delimited))
+    assert_equal("0.78901", 0.78901.to_fs(:delimited))
   end
 
-  def test_to_formatted_s__delimited__with_options_hash
-    assert_equal "12 345 678", 12345678.to_formatted_s(:delimited, delimiter: " ")
-    assert_equal "12,345,678-05", 12345678.05.to_formatted_s(:delimited, separator: "-")
-    assert_equal "12.345.678,05", 12345678.05.to_formatted_s(:delimited, separator: ",", delimiter: ".")
-    assert_equal "12.345.678,05", 12345678.05.to_formatted_s(:delimited, delimiter: ".", separator: ",")
+  def test_to_fs__delimited__with_options_hash
+    assert_equal "12 345 678", 12345678.to_fs(:delimited, delimiter: " ")
+    assert_equal "12,345,678-05", 12345678.05.to_fs(:delimited, separator: "-")
+    assert_equal "12.345.678,05", 12345678.05.to_fs(:delimited, separator: ",", delimiter: ".")
+    assert_equal "12.345.678,05", 12345678.05.to_fs(:delimited, delimiter: ".", separator: ",")
   end
 
-  def test_to_formatted_s__human_size
+  def test_to_fs__human_size
     assert_deprecated do
       assert_equal "0 Bytes",   0.to_s(:human_size)
     end
-    assert_equal "0 Bytes",   0.to_formatted_s(:human_size)
-    assert_equal "1 Byte",    1.to_formatted_s(:human_size)
-    assert_equal "3 Bytes",   3.14159265.to_formatted_s(:human_size)
-    assert_equal "123 Bytes", 123.0.to_formatted_s(:human_size)
-    assert_equal "123 Bytes", 123.to_formatted_s(:human_size)
-    assert_equal "1.21 KB",   1234.to_formatted_s(:human_size)
-    assert_equal "12.1 KB",   12345.to_formatted_s(:human_size)
-    assert_equal "1.18 MB",   1234567.to_formatted_s(:human_size)
-    assert_equal "1.15 GB",   1234567890.to_formatted_s(:human_size)
-    assert_equal "1.12 TB",   1234567890123.to_formatted_s(:human_size)
-    assert_equal "1.1 PB",    1234567890123456.to_formatted_s(:human_size)
-    assert_equal "1.07 EB",   1234567890123456789.to_formatted_s(:human_size)
-    assert_equal "1030 EB",   exabytes(1026).to_formatted_s(:human_size)
-    assert_equal "444 KB",    kilobytes(444).to_formatted_s(:human_size)
-    assert_equal "1020 MB",   megabytes(1023).to_formatted_s(:human_size)
-    assert_equal "3 TB",      terabytes(3).to_formatted_s(:human_size)
-    assert_equal "1.2 MB",    1234567.to_formatted_s(:human_size, precision: 2)
-    assert_equal "3 Bytes",   3.14159265.to_formatted_s(:human_size, precision: 4)
-    assert_equal "1 KB",      kilobytes(1.0123).to_formatted_s(:human_size, precision: 2)
-    assert_equal "1.01 KB",   kilobytes(1.0100).to_formatted_s(:human_size, precision: 4)
-    assert_equal "10 KB",     kilobytes(10.000).to_formatted_s(:human_size, precision: 4)
-    assert_equal "1 Byte",    1.1.to_formatted_s(:human_size)
-    assert_equal "10 Bytes",  10.to_formatted_s(:human_size)
+    assert_equal "0 Bytes",   0.to_fs(:human_size)
+    assert_equal "1 Byte",    1.to_fs(:human_size)
+    assert_equal "3 Bytes",   3.14159265.to_fs(:human_size)
+    assert_equal "123 Bytes", 123.0.to_fs(:human_size)
+    assert_equal "123 Bytes", 123.to_fs(:human_size)
+    assert_equal "1.21 KB",   1234.to_fs(:human_size)
+    assert_equal "12.1 KB",   12345.to_fs(:human_size)
+    assert_equal "1.18 MB",   1234567.to_fs(:human_size)
+    assert_equal "1.15 GB",   1234567890.to_fs(:human_size)
+    assert_equal "1.12 TB",   1234567890123.to_fs(:human_size)
+    assert_equal "1.1 PB",    1234567890123456.to_fs(:human_size)
+    assert_equal "1.07 EB",   1234567890123456789.to_fs(:human_size)
+    assert_equal "1030 EB",   exabytes(1026).to_fs(:human_size)
+    assert_equal "444 KB",    kilobytes(444).to_fs(:human_size)
+    assert_equal "1020 MB",   megabytes(1023).to_fs(:human_size)
+    assert_equal "3 TB",      terabytes(3).to_fs(:human_size)
+    assert_equal "1.2 MB",    1234567.to_fs(:human_size, precision: 2)
+    assert_equal "3 Bytes",   3.14159265.to_fs(:human_size, precision: 4)
+    assert_equal "1 KB",      kilobytes(1.0123).to_fs(:human_size, precision: 2)
+    assert_equal "1.01 KB",   kilobytes(1.0100).to_fs(:human_size, precision: 4)
+    assert_equal "10 KB",     kilobytes(10.000).to_fs(:human_size, precision: 4)
+    assert_equal "1 Byte",    1.1.to_fs(:human_size)
+    assert_equal "10 Bytes",  10.to_fs(:human_size)
   end
 
-  def test_to_formatted_s__human_size_with_options_hash
-    assert_equal "1.2 MB",   1234567.to_formatted_s(:human_size, precision: 2)
-    assert_equal "3 Bytes",  3.14159265.to_formatted_s(:human_size, precision: 4)
-    assert_equal "1 KB",     kilobytes(1.0123).to_formatted_s(:human_size, precision: 2)
-    assert_equal "1.01 KB",  kilobytes(1.0100).to_formatted_s(:human_size, precision: 4)
-    assert_equal "10 KB",    kilobytes(10.000).to_formatted_s(:human_size, precision: 4)
-    assert_equal "1 TB",     1234567890123.to_formatted_s(:human_size, precision: 1)
-    assert_equal "500 MB",   524288000.to_formatted_s(:human_size, precision: 3)
-    assert_equal "10 MB",    9961472.to_formatted_s(:human_size, precision: 0)
-    assert_equal "40 KB",    41010.to_formatted_s(:human_size, precision: 1)
-    assert_equal "40 KB",    41100.to_formatted_s(:human_size, precision: 2)
-    assert_equal "50 KB",    41100.to_formatted_s(:human_size, precision: 1, round_mode: :up)
-    assert_equal "1.0 KB",   kilobytes(1.0123).to_formatted_s(:human_size, precision: 2, strip_insignificant_zeros: false)
-    assert_equal "1.012 KB", kilobytes(1.0123).to_formatted_s(:human_size, precision: 3, significant: false)
-    assert_equal "1 KB",     kilobytes(1.0123).to_formatted_s(:human_size, precision: 0, significant: true) # ignores significant it precision is 0
+  def test_to_fs__human_size_with_options_hash
+    assert_equal "1.2 MB",   1234567.to_fs(:human_size, precision: 2)
+    assert_equal "3 Bytes",  3.14159265.to_fs(:human_size, precision: 4)
+    assert_equal "1 KB",     kilobytes(1.0123).to_fs(:human_size, precision: 2)
+    assert_equal "1.01 KB",  kilobytes(1.0100).to_fs(:human_size, precision: 4)
+    assert_equal "10 KB",    kilobytes(10.000).to_fs(:human_size, precision: 4)
+    assert_equal "1 TB",     1234567890123.to_fs(:human_size, precision: 1)
+    assert_equal "500 MB",   524288000.to_fs(:human_size, precision: 3)
+    assert_equal "10 MB",    9961472.to_fs(:human_size, precision: 0)
+    assert_equal "40 KB",    41010.to_fs(:human_size, precision: 1)
+    assert_equal "40 KB",    41100.to_fs(:human_size, precision: 2)
+    assert_equal "50 KB",    41100.to_fs(:human_size, precision: 1, round_mode: :up)
+    assert_equal "1.0 KB",   kilobytes(1.0123).to_fs(:human_size, precision: 2, strip_insignificant_zeros: false)
+    assert_equal "1.012 KB", kilobytes(1.0123).to_fs(:human_size, precision: 3, significant: false)
+    assert_equal "1 KB",     kilobytes(1.0123).to_fs(:human_size, precision: 0, significant: true) # ignores significant it precision is 0
   end
 
-  def test_to_formatted_s__human_size_with_custom_delimiter_and_separator
-    assert_equal "1,01 KB",     kilobytes(1.0123).to_formatted_s(:human_size, precision: 3, separator: ",")
-    assert_equal "1,01 KB",     kilobytes(1.0100).to_formatted_s(:human_size, precision: 4, separator: ",")
-    assert_equal "1.000,1 TB",  terabytes(1000.1).to_formatted_s(:human_size, precision: 5, delimiter: ".", separator: ",")
+  def test_to_fs__human_size_with_custom_delimiter_and_separator
+    assert_equal "1,01 KB",     kilobytes(1.0123).to_fs(:human_size, precision: 3, separator: ",")
+    assert_equal "1,01 KB",     kilobytes(1.0100).to_fs(:human_size, precision: 4, separator: ",")
+    assert_equal "1.000,1 TB",  terabytes(1000.1).to_fs(:human_size, precision: 5, delimiter: ".", separator: ",")
   end
 
   def test_number_to_human
     assert_deprecated do
       assert_equal "-123", -123.to_s(:human)
     end
-    assert_equal "-123", -123.to_formatted_s(:human)
     assert_equal "-123", -123.to_fs(:human)
-    assert_equal "-0.5", -0.5.to_formatted_s(:human)
-    assert_equal "0",   0.to_formatted_s(:human)
-    assert_equal "0.5", 0.5.to_formatted_s(:human)
-    assert_equal "123", 123.to_formatted_s(:human)
-    assert_equal "1.23 Thousand", 1234.to_formatted_s(:human)
-    assert_equal "12.3 Thousand", 12345.to_formatted_s(:human)
-    assert_equal "1.23 Million", 1234567.to_formatted_s(:human)
-    assert_equal "1.23 Billion", 1234567890.to_formatted_s(:human)
-    assert_equal "1.23 Trillion", 1234567890123.to_formatted_s(:human)
-    assert_equal "1.23 Quadrillion", 1234567890123456.to_formatted_s(:human)
-    assert_equal "1230 Quadrillion", 1234567890123456789.to_formatted_s(:human)
-    assert_equal "490 Thousand", 489939.to_formatted_s(:human, precision: 2)
-    assert_equal "489.9 Thousand", 489939.to_formatted_s(:human, precision: 4)
-    assert_equal "489 Thousand", 489000.to_formatted_s(:human, precision: 4)
-    assert_equal "480 Thousand", 489939.to_formatted_s(:human, precision: 2, round_mode: :down)
-    assert_equal "489.0 Thousand", 489000.to_formatted_s(:human, precision: 4, strip_insignificant_zeros: false)
-    assert_equal "1.2346 Million", 1234567.to_formatted_s(:human, precision: 4, significant: false)
-    assert_equal "1,2 Million", 1234567.to_formatted_s(:human, precision: 1, significant: false, separator: ",")
-    assert_equal "1 Million", 1234567.to_formatted_s(:human, precision: 0, significant: true, separator: ",") # significant forced to false
+    assert_equal "-123", -123.to_fs(:human)
+    assert_equal "-0.5", -0.5.to_fs(:human)
+    assert_equal "0",   0.to_fs(:human)
+    assert_equal "0.5", 0.5.to_fs(:human)
+    assert_equal "123", 123.to_fs(:human)
+    assert_equal "1.23 Thousand", 1234.to_fs(:human)
+    assert_equal "12.3 Thousand", 12345.to_fs(:human)
+    assert_equal "1.23 Million", 1234567.to_fs(:human)
+    assert_equal "1.23 Billion", 1234567890.to_fs(:human)
+    assert_equal "1.23 Trillion", 1234567890123.to_fs(:human)
+    assert_equal "1.23 Quadrillion", 1234567890123456.to_fs(:human)
+    assert_equal "1230 Quadrillion", 1234567890123456789.to_fs(:human)
+    assert_equal "490 Thousand", 489939.to_fs(:human, precision: 2)
+    assert_equal "489.9 Thousand", 489939.to_fs(:human, precision: 4)
+    assert_equal "489 Thousand", 489000.to_fs(:human, precision: 4)
+    assert_equal "480 Thousand", 489939.to_fs(:human, precision: 2, round_mode: :down)
+    assert_equal "489.0 Thousand", 489000.to_fs(:human, precision: 4, strip_insignificant_zeros: false)
+    assert_equal "1.2346 Million", 1234567.to_fs(:human, precision: 4, significant: false)
+    assert_equal "1,2 Million", 1234567.to_fs(:human, precision: 1, significant: false, separator: ",")
+    assert_equal "1 Million", 1234567.to_fs(:human, precision: 0, significant: true, separator: ",") # significant forced to false
   end
 
   def test_number_to_human_with_custom_units
     # Only integers
     volume = { unit: "ml", thousand: "lt", million: "m3" }
-    assert_equal "123 lt", 123456.to_formatted_s(:human, units: volume)
-    assert_equal "12 ml", 12.to_formatted_s(:human, units: volume)
-    assert_equal "1.23 m3", 1234567.to_formatted_s(:human, units: volume)
+    assert_equal "123 lt", 123456.to_fs(:human, units: volume)
+    assert_equal "12 ml", 12.to_fs(:human, units: volume)
+    assert_equal "1.23 m3", 1234567.to_fs(:human, units: volume)
 
     # Including fractionals
     distance = { mili: "mm", centi: "cm", deci: "dm", unit: "m", ten: "dam", hundred: "hm", thousand: "km" }
-    assert_equal "1.23 mm", 0.00123.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 cm", 0.0123.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 dm", 0.123.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 m",  1.23.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 dam", 12.3.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 hm", 123.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 km", 1230.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 km", 1230.to_formatted_s(:human, units: distance)
-    assert_equal "1.23 km", 1230.to_formatted_s(:human, units: distance)
-    assert_equal "12.3 km", 12300.to_formatted_s(:human, units: distance)
+    assert_equal "1.23 mm", 0.00123.to_fs(:human, units: distance)
+    assert_equal "1.23 cm", 0.0123.to_fs(:human, units: distance)
+    assert_equal "1.23 dm", 0.123.to_fs(:human, units: distance)
+    assert_equal "1.23 m",  1.23.to_fs(:human, units: distance)
+    assert_equal "1.23 dam", 12.3.to_fs(:human, units: distance)
+    assert_equal "1.23 hm", 123.to_fs(:human, units: distance)
+    assert_equal "1.23 km", 1230.to_fs(:human, units: distance)
+    assert_equal "1.23 km", 1230.to_fs(:human, units: distance)
+    assert_equal "1.23 km", 1230.to_fs(:human, units: distance)
+    assert_equal "12.3 km", 12300.to_fs(:human, units: distance)
 
     # The quantifiers don't need to be a continuous sequence
     gangster = { hundred: "hundred bucks", million: "thousand quids" }
-    assert_equal "1 hundred bucks", 100.to_formatted_s(:human, units: gangster)
-    assert_equal "25 hundred bucks", 2500.to_formatted_s(:human, units: gangster)
-    assert_equal "25 thousand quids", 25000000.to_formatted_s(:human, units: gangster)
-    assert_equal "12300 thousand quids", 12345000000.to_formatted_s(:human, units: gangster)
+    assert_equal "1 hundred bucks", 100.to_fs(:human, units: gangster)
+    assert_equal "25 hundred bucks", 2500.to_fs(:human, units: gangster)
+    assert_equal "25 thousand quids", 25000000.to_fs(:human, units: gangster)
+    assert_equal "12300 thousand quids", 12345000000.to_fs(:human, units: gangster)
 
     # Spaces are stripped from the resulting string
-    assert_equal "4", 4.to_formatted_s(:human, units: { unit: "", ten: "tens " })
-    assert_equal "4.5  tens", 45.to_formatted_s(:human, units: { unit: "", ten: " tens   " })
+    assert_equal "4", 4.to_fs(:human, units: { unit: "", ten: "tens " })
+    assert_equal "4.5  tens", 45.to_fs(:human, units: { unit: "", ten: " tens   " })
   end
 
   def test_number_to_human_with_custom_format
-    assert_equal "123 times Thousand", 123456.to_formatted_s(:human, format: "%n times %u")
+    assert_equal "123 times Thousand", 123456.to_fs(:human, format: "%n times %u")
     volume = { unit: "ml", thousand: "lt", million: "m3" }
-    assert_equal "123.lt", 123456.to_formatted_s(:human, units: volume, format: "%n.%u")
+    assert_equal "123.lt", 123456.to_fs(:human, units: volume, format: "%n.%u")
   end
 
-  def test_to_formatted_s__injected_on_proper_types
-    assert_equal "1.23 Thousand", 1230.to_formatted_s(:human)
-    assert_equal "1.23 Thousand", Float(1230).to_formatted_s(:human)
-    assert_equal "100000 Quadrillion", (100**10).to_formatted_s(:human)
-    assert_equal "1 Million", BigDecimal("1000010").to_formatted_s(:human)
+  def test_to_fs__injected_on_proper_types
+    assert_equal "1.23 Thousand", 1230.to_fs(:human)
+    assert_equal "1.23 Thousand", Float(1230).to_fs(:human)
+    assert_equal "100000 Quadrillion", (100**10).to_fs(:human)
+    assert_equal "1 Million", BigDecimal("1000010").to_fs(:human)
   end
 
-  def test_to_formatted_s_with_invalid_formatter
+  def test_to_fs_with_invalid_formatter
     assert_deprecated do
       assert_equal "123", 123.to_s(:invalid)
     end
-    assert_equal "123", 123.to_formatted_s(:invalid)
     assert_equal "123", 123.to_fs(:invalid)
-    assert_equal "2.5", 2.5.to_formatted_s(:invalid)
-    assert_equal "100000000000000000000", (100**10).to_formatted_s(:invalid)
-    assert_equal "1000010.0", BigDecimal("1000010").to_formatted_s(:invalid)
+    assert_equal "123", 123.to_fs(:invalid)
+    assert_equal "2.5", 2.5.to_fs(:invalid)
+    assert_equal "100000000000000000000", (100**10).to_fs(:invalid)
+    assert_equal "1000010.0", BigDecimal("1000010").to_fs(:invalid)
   end
 
-  def test_default_to_formatted_s
+  def test_default_to_fs
     assert_equal "123", 123.to_s
-    assert_equal "123", 123.to_formatted_s
+    assert_equal "123", 123.to_fs
     assert_equal "123", 123.to_fs
     assert_equal "1111011", 123.to_s(2)
-    assert_equal "1111011", 123.to_formatted_s(2)
+    assert_equal "1111011", 123.to_fs(2)
 
     assert_equal "2.5", 2.5.to_s
-    assert_equal "2.5", 2.5.to_formatted_s
+    assert_equal "2.5", 2.5.to_fs
 
     assert_equal "100000000000000000000", (100**10).to_s
-    assert_equal "100000000000000000000", (100**10).to_formatted_s
+    assert_equal "100000000000000000000", (100**10).to_fs
     assert_equal "1010110101111000111010111100010110101100011000100000000000000000000", (100**10).to_s(2)
-    assert_equal "1010110101111000111010111100010110101100011000100000000000000000000", (100**10).to_formatted_s(2)
+    assert_equal "1010110101111000111010111100010110101100011000100000000000000000000", (100**10).to_fs(2)
 
     assert_equal "1000010.0", BigDecimal("1000010").to_s
-    assert_equal "1000010.0", BigDecimal("1000010").to_formatted_s
+    assert_equal "1000010.0", BigDecimal("1000010").to_fs
     assert_equal "10000 10.0", BigDecimal("1000010").to_s("5F")
-    assert_equal "10000 10.0", BigDecimal("1000010").to_formatted_s("5F")
+    assert_equal "10000 10.0", BigDecimal("1000010").to_fs("5F")
 
     assert_raises TypeError do
       1.to_s({})
     end
     assert_raises TypeError do
-      1.to_formatted_s({})
+      1.to_fs({})
     end
   end
 end

--- a/activesupport/test/core_ext/numeric_ext_test.rb
+++ b/activesupport/test/core_ext/numeric_ext_test.rb
@@ -162,7 +162,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal("555-1234", 5551234.to_s(:phone))
     end
     assert_equal("555-1234", 5551234.to_fs(:phone))
-    assert_equal("555-1234", 5551234.to_fs(:phone))
+    assert_equal("555-1234", 5551234.to_formatted_s(:phone))
     assert_equal("800-555-1212", 8005551212.to_fs(:phone))
     assert_equal("(800) 555-1212", 8005551212.to_fs(:phone, area_code: true))
     assert_equal("800 555 1212", 8005551212.to_fs(:phone, delimiter: " "))
@@ -180,7 +180,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal("$1,234,567,890.50", 1234567890.50.to_s(:currency))
     end
     assert_equal("$1,234,567,890.50", 1234567890.50.to_fs(:currency))
-    assert_equal("$1,234,567,890.50", 1234567890.50.to_fs(:currency))
+    assert_equal("$1,234,567,890.50", 1234567890.50.to_formatted_s(:currency))
     assert_equal("$1,234,567,890.51", 1234567890.506.to_fs(:currency))
     assert_equal("-$1,234,567,890.50", -1234567890.50.to_fs(:currency))
     assert_equal("-$ 1,234,567,890.50", -1234567890.50.to_fs(:currency, format: "%u %n"))
@@ -196,7 +196,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal("-111.235", -111.2346.to_s(:rounded))
     end
     assert_equal("-111.235", -111.2346.to_fs(:rounded))
-    assert_equal("-111.235", -111.2346.to_fs(:rounded))
+    assert_equal("-111.235", -111.2346.to_formatted_s(:rounded))
     assert_equal("111.235", 111.2346.to_fs(:rounded))
     assert_equal("31.83", 31.825.to_fs(:rounded, precision: 2))
     assert_equal("31.82", 31.825.to_fs(:rounded, precision: 2, round_mode: :down))
@@ -259,7 +259,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal("100.000%", 100.to_s(:percentage))
     end
     assert_equal("100.000%", 100.to_fs(:percentage))
-    assert_equal("100.000%", 100.to_fs(:percentage))
+    assert_equal("100.000%", 100.to_formatted_s(:percentage))
     assert_equal("100%", 100.to_fs(:percentage, precision: 0))
     assert_equal("302.06%", 302.0574.to_fs(:percentage, precision: 2))
     assert_equal("302.05%", 302.0574.to_fs(:percentage, precision: 2, round_mode: :down))
@@ -273,7 +273,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal("12,345,678", 12345678.to_s(:delimited))
     end
     assert_equal("12,345,678", 12345678.to_fs(:delimited))
-    assert_equal("12,345,678", 12345678.to_fs(:delimited))
+    assert_equal("12,345,678", 12345678.to_formatted_s(:delimited))
     assert_equal("0", 0.to_fs(:delimited))
     assert_equal("123", 123.to_fs(:delimited))
     assert_equal("123,456", 123456.to_fs(:delimited))
@@ -348,7 +348,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal "-123", -123.to_s(:human)
     end
     assert_equal "-123", -123.to_fs(:human)
-    assert_equal "-123", -123.to_fs(:human)
+    assert_equal "-123", -123.to_formatted_s(:human)
     assert_equal "-0.5", -0.5.to_fs(:human)
     assert_equal "0",   0.to_fs(:human)
     assert_equal "0.5", 0.5.to_fs(:human)
@@ -420,7 +420,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
       assert_equal "123", 123.to_s(:invalid)
     end
     assert_equal "123", 123.to_fs(:invalid)
-    assert_equal "123", 123.to_fs(:invalid)
+    assert_equal "123", 123.to_formatted_s(:invalid)
     assert_equal "2.5", 2.5.to_fs(:invalid)
     assert_equal "100000000000000000000", (100**10).to_fs(:invalid)
     assert_equal "1000010.0", BigDecimal("1000010").to_fs(:invalid)
@@ -429,7 +429,7 @@ class NumericExtFormattingTest < ActiveSupport::TestCase
   def test_default_to_fs
     assert_equal "123", 123.to_s
     assert_equal "123", 123.to_fs
-    assert_equal "123", 123.to_fs
+    assert_equal "123", 123.to_formatted_s
     assert_equal "1111011", 123.to_s(2)
     assert_equal "1111011", 123.to_fs(2)
 

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -6,25 +6,25 @@ require "active_support/core_ext/numeric"
 require "active_support/core_ext/range"
 
 class RangeTest < ActiveSupport::TestCase
-  def test_to_formatted_s_from_dates
+  def test_to_fs_from_dates
     date_range = Date.new(2005, 12, 10)..Date.new(2005, 12, 12)
-    assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_formatted_s(:db)
+    assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_fs(:db)
     assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_fs(:db)
   end
 
-  def test_to_formatted_s_from_times
+  def test_to_fs_from_times
     date_range = Time.utc(2005, 12, 10, 15, 30)..Time.utc(2005, 12, 10, 17, 30)
-    assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_formatted_s(:db)
+    assert_equal "BETWEEN '2005-12-10 15:30:00' AND '2005-12-10 17:30:00'", date_range.to_fs(:db)
   end
 
-  def test_to_formatted_s_with_alphabets
+  def test_to_fs_with_alphabets
     alphabet_range = ("a".."z")
-    assert_equal "BETWEEN 'a' AND 'z'", alphabet_range.to_formatted_s(:db)
+    assert_equal "BETWEEN 'a' AND 'z'", alphabet_range.to_fs(:db)
   end
 
-  def test_to_formatted_s_with_numeric
+  def test_to_fs_with_numeric
     number_range = (1..100)
-    assert_equal "BETWEEN '1' AND '100'", number_range.to_formatted_s(:db)
+    assert_equal "BETWEEN '1' AND '100'", number_range.to_fs(:db)
   end
 
   def test_to_s_with_format

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -9,7 +9,7 @@ class RangeTest < ActiveSupport::TestCase
   def test_to_fs_from_dates
     date_range = Date.new(2005, 12, 10)..Date.new(2005, 12, 12)
     assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_fs(:db)
-    assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_fs(:db)
+    assert_equal "BETWEEN '2005-12-10' AND '2005-12-12'", date_range.to_formatted_s(:db)
   end
 
   def test_to_fs_from_times

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -642,29 +642,29 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     end
   end
 
-  def test_to_formatted_s
+  def test_to_fs
     time = Time.utc(2005, 2, 21, 17, 44, 30.12345678901)
-    assert_equal time.to_s,                         time.to_formatted_s(:doesnt_exist)
-    assert_equal "2005-02-21 17:44:30",             time.to_formatted_s(:db)
-    assert_equal "21 Feb 17:44",                    time.to_formatted_s(:short)
-    assert_equal "17:44",                           time.to_formatted_s(:time)
-    assert_equal "20050221174430",                  time.to_formatted_s(:number)
-    assert_equal "20050221174430123456789",         time.to_formatted_s(:nsec)
-    assert_equal "20050221174430123456",            time.to_formatted_s(:usec)
-    assert_equal "February 21, 2005 17:44",         time.to_formatted_s(:long)
-    assert_equal "February 21st, 2005 17:44",       time.to_formatted_s(:long_ordinal)
+    assert_equal time.to_s,                         time.to_fs(:doesnt_exist)
+    assert_equal "2005-02-21 17:44:30",             time.to_fs(:db)
+    assert_equal "21 Feb 17:44",                    time.to_fs(:short)
+    assert_equal "17:44",                           time.to_fs(:time)
+    assert_equal "20050221174430",                  time.to_fs(:number)
+    assert_equal "20050221174430123456789",         time.to_fs(:nsec)
+    assert_equal "20050221174430123456",            time.to_fs(:usec)
+    assert_equal "February 21, 2005 17:44",         time.to_fs(:long)
+    assert_equal "February 21st, 2005 17:44",       time.to_fs(:long_ordinal)
     with_env_tz "UTC" do
-      assert_equal "Mon, 21 Feb 2005 17:44:30 +0000", time.to_formatted_s(:rfc822)
-      assert_equal "2005-02-21 17:44:30.123456789 +0000", time.to_formatted_s(:inspect)
+      assert_equal "Mon, 21 Feb 2005 17:44:30 +0000", time.to_fs(:rfc822)
+      assert_equal "2005-02-21 17:44:30.123456789 +0000", time.to_fs(:inspect)
     end
     with_env_tz "US/Central" do
-      assert_equal "Thu, 05 Feb 2009 14:30:05 -0600", Time.local(2009, 2, 5, 14, 30, 5).to_formatted_s(:rfc822)
-      assert_equal "Mon, 09 Jun 2008 04:05:01 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_formatted_s(:rfc822)
-      assert_equal "2009-02-05T14:30:05-06:00", Time.local(2009, 2, 5, 14, 30, 5).to_formatted_s(:iso8601)
-      assert_equal "2008-06-09T04:05:01-05:00", Time.local(2008, 6, 9, 4, 5, 1).to_formatted_s(:iso8601)
-      assert_equal "2009-02-05T14:30:05Z", Time.utc(2009, 2, 5, 14, 30, 5).to_formatted_s(:iso8601)
-      assert_equal "2009-02-05 14:30:05.000000000 -0600", Time.local(2009, 2, 5, 14, 30, 5).to_formatted_s(:inspect)
-      assert_equal "2008-06-09 04:05:01.000000000 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_formatted_s(:inspect)
+      assert_equal "Thu, 05 Feb 2009 14:30:05 -0600", Time.local(2009, 2, 5, 14, 30, 5).to_fs(:rfc822)
+      assert_equal "Mon, 09 Jun 2008 04:05:01 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_fs(:rfc822)
+      assert_equal "2009-02-05T14:30:05-06:00", Time.local(2009, 2, 5, 14, 30, 5).to_fs(:iso8601)
+      assert_equal "2008-06-09T04:05:01-05:00", Time.local(2008, 6, 9, 4, 5, 1).to_fs(:iso8601)
+      assert_equal "2009-02-05T14:30:05Z", Time.utc(2009, 2, 5, 14, 30, 5).to_fs(:iso8601)
+      assert_equal "2009-02-05 14:30:05.000000000 -0600", Time.local(2009, 2, 5, 14, 30, 5).to_fs(:inspect)
+      assert_equal "2008-06-09 04:05:01.000000000 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_fs(:inspect)
     end
 
     assert_equal "2005-02-21 17:44:30",             time.to_fs(:db)
@@ -679,9 +679,9 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
     Time::DATE_FORMATS.delete(:custom)
   end
 
-  def test_to_formatted_s_custom_date_format
+  def test_to_fs_custom_date_format
     Time::DATE_FORMATS[:custom] = "%Y%m%d%H%M%S"
-    assert_equal "20050221143000", Time.local(2005, 2, 21, 14, 30, 0).to_formatted_s(:custom)
+    assert_equal "20050221143000", Time.local(2005, 2, 21, 14, 30, 0).to_fs(:custom)
   ensure
     Time::DATE_FORMATS.delete(:custom)
   end

--- a/activesupport/test/core_ext/time_ext_test.rb
+++ b/activesupport/test/core_ext/time_ext_test.rb
@@ -667,7 +667,7 @@ class TimeExtCalculationsTest < ActiveSupport::TestCase
       assert_equal "2008-06-09 04:05:01.000000000 -0500", Time.local(2008, 6, 9, 4, 5, 1).to_fs(:inspect)
     end
 
-    assert_equal "2005-02-21 17:44:30",             time.to_fs(:db)
+    assert_equal "2005-02-21 17:44:30",             time.to_formatted_s(:db)
   end
 
   def test_to_s_custom_date_format

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -139,7 +139,7 @@ class TimeWithZoneTest < ActiveSupport::TestCase
 
   def test_to_fs_db
     assert_equal "2000-01-01 00:00:00", @twz.to_fs(:db)
-    assert_equal "2000-01-01 00:00:00", @twz.to_fs(:db)
+    assert_equal "2000-01-01 00:00:00", @twz.to_formatted_s(:db)
   end
 
   def test_to_fs_inspect

--- a/activesupport/test/core_ext/time_with_zone_test.rb
+++ b/activesupport/test/core_ext/time_with_zone_test.rb
@@ -133,17 +133,17 @@ class TimeWithZoneTest < ActiveSupport::TestCase
     assert_equal "1999-12-31 19:00:00 -0500", @twz.to_s
   end
 
-  def test_to_formatted_s
-    assert_equal "1999-12-31 19:00:00 -0500", @twz.to_formatted_s
+  def test_to_fs
+    assert_equal "1999-12-31 19:00:00 -0500", @twz.to_fs
   end
 
-  def test_to_formatted_s_db
-    assert_equal "2000-01-01 00:00:00", @twz.to_formatted_s(:db)
+  def test_to_fs_db
+    assert_equal "2000-01-01 00:00:00", @twz.to_fs(:db)
     assert_equal "2000-01-01 00:00:00", @twz.to_fs(:db)
   end
 
-  def test_to_formatted_s_inspect
-    assert_equal "1999-12-31 19:00:00.000000000 -0500", @twz.to_formatted_s(:inspect)
+  def test_to_fs_inspect
+    assert_equal "1999-12-31 19:00:00.000000000 -0500", @twz.to_fs(:inspect)
   end
 
   def test_to_s_db

--- a/activesupport/test/time_travel_test.rb
+++ b/activesupport/test/time_travel_test.rb
@@ -18,9 +18,9 @@ class TimeTravelTest < ActiveSupport::TestCase
       expected_time = Time.now + 1.day
       travel 1.day
 
-      assert_equal expected_time.to_formatted_s(:db), Time.now.to_formatted_s(:db)
+      assert_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
       assert_equal expected_time.to_date, Date.today
-      assert_equal expected_time.to_datetime.to_formatted_s(:db), DateTime.now.to_formatted_s(:db)
+      assert_equal expected_time.to_datetime.to_fs(:db), DateTime.now.to_fs(:db)
     ensure
       travel_back
     end
@@ -31,14 +31,14 @@ class TimeTravelTest < ActiveSupport::TestCase
       expected_time = Time.now + 1.day
 
       travel 1.day do
-        assert_equal expected_time.to_formatted_s(:db), Time.now.to_formatted_s(:db)
+        assert_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
         assert_equal expected_time.to_date, Date.today
-        assert_equal expected_time.to_datetime.to_formatted_s(:db), DateTime.now.to_formatted_s(:db)
+        assert_equal expected_time.to_datetime.to_fs(:db), DateTime.now.to_fs(:db)
       end
 
-      assert_not_equal expected_time.to_formatted_s(:db), Time.now.to_formatted_s(:db)
+      assert_not_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
       assert_not_equal expected_time.to_date, Date.today
-      assert_not_equal expected_time.to_datetime.to_formatted_s(:db), DateTime.now.to_formatted_s(:db)
+      assert_not_equal expected_time.to_datetime.to_fs(:db), DateTime.now.to_fs(:db)
     end
   end
 
@@ -78,7 +78,7 @@ class TimeTravelTest < ActiveSupport::TestCase
           expected_time = 5.minutes.ago
 
           travel_to 5.minutes.ago do
-            assert_equal expected_time.to_formatted_s(:db), Time.zone.now.to_formatted_s(:db)
+            assert_equal expected_time.to_fs(:db), Time.zone.now.to_fs(:db)
           end
         end
       end
@@ -92,7 +92,7 @@ class TimeTravelTest < ActiveSupport::TestCase
           expected_time = Time.new(2004, 11, 24, 1, 4, 44)
 
           travel_to "2004-11-24 01:04:44" do
-            assert_equal expected_time.to_formatted_s(:db), Time.zone.now.to_formatted_s(:db)
+            assert_equal expected_time.to_fs(:db), Time.zone.now.to_fs(:db)
           end
         end
       end
@@ -272,7 +272,7 @@ class TimeTravelTest < ActiveSupport::TestCase
     freeze_time
     sleep(1)
 
-    assert_equal expected_time.to_formatted_s(:db), Time.now.to_formatted_s(:db)
+    assert_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
   ensure
     travel_back
   end
@@ -283,10 +283,10 @@ class TimeTravelTest < ActiveSupport::TestCase
     freeze_time do
       sleep(1)
 
-      assert_equal expected_time.to_formatted_s(:db), Time.now.to_formatted_s(:db)
+      assert_equal expected_time.to_fs(:db), Time.now.to_fs(:db)
     end
 
-    assert_operator expected_time.to_formatted_s(:db), :<, Time.now.to_formatted_s(:db)
+    assert_operator expected_time.to_fs(:db), :<, Time.now.to_fs(:db)
   end
 
   def test_time_helper_unfreeze_time

--- a/guides/source/7_0_release_notes.md
+++ b/guides/source/7_0_release_notes.md
@@ -266,7 +266,7 @@ Please refer to the [Changelog][active-support] for detailed changes.
 
 ### Deprecations
 
-*   Deprecate passing a format to `#to_s` in favor of `#to_formatted_s` in `Array`, `Range`, `Date`, `DateTime`, `Time`,
+*   Deprecate passing a format to `#to_s` in favor of `#to_fs` in `Array`, `Range`, `Date`, `DateTime`, `Time`,
     `BigDecimal`, `Float` and, `Integer`.
 
     This deprecation is to allow Rails application to take advantage of a Ruby 3.1

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -1988,84 +1988,84 @@ Enables the formatting of numbers in a variety of ways.
 Produce a string representation of a number as a telephone number:
 
 ```ruby
-5551234.to_formatted_s(:phone)
+5551234.to_fs(:phone)
 # => 555-1234
-1235551234.to_formatted_s(:phone)
+1235551234.to_fs(:phone)
 # => 123-555-1234
-1235551234.to_formatted_s(:phone, area_code: true)
+1235551234.to_fs(:phone, area_code: true)
 # => (123) 555-1234
-1235551234.to_formatted_s(:phone, delimiter: " ")
+1235551234.to_fs(:phone, delimiter: " ")
 # => 123 555 1234
-1235551234.to_formatted_s(:phone, area_code: true, extension: 555)
+1235551234.to_fs(:phone, area_code: true, extension: 555)
 # => (123) 555-1234 x 555
-1235551234.to_formatted_s(:phone, country_code: 1)
+1235551234.to_fs(:phone, country_code: 1)
 # => +1-123-555-1234
 ```
 
 Produce a string representation of a number as currency:
 
 ```ruby
-1234567890.50.to_formatted_s(:currency)                 # => $1,234,567,890.50
-1234567890.506.to_formatted_s(:currency)                # => $1,234,567,890.51
-1234567890.506.to_formatted_s(:currency, precision: 3)  # => $1,234,567,890.506
+1234567890.50.to_fs(:currency)                 # => $1,234,567,890.50
+1234567890.506.to_fs(:currency)                # => $1,234,567,890.51
+1234567890.506.to_fs(:currency, precision: 3)  # => $1,234,567,890.506
 ```
 
 Produce a string representation of a number as a percentage:
 
 ```ruby
-100.to_formatted_s(:percentage)
+100.to_fs(:percentage)
 # => 100.000%
-100.to_formatted_s(:percentage, precision: 0)
+100.to_fs(:percentage, precision: 0)
 # => 100%
-1000.to_formatted_s(:percentage, delimiter: '.', separator: ',')
+1000.to_fs(:percentage, delimiter: '.', separator: ',')
 # => 1.000,000%
-302.24398923423.to_formatted_s(:percentage, precision: 5)
+302.24398923423.to_fs(:percentage, precision: 5)
 # => 302.24399%
 ```
 
 Produce a string representation of a number in delimited form:
 
 ```ruby
-12345678.to_formatted_s(:delimited)                     # => 12,345,678
-12345678.05.to_formatted_s(:delimited)                  # => 12,345,678.05
-12345678.to_formatted_s(:delimited, delimiter: ".")     # => 12.345.678
-12345678.to_formatted_s(:delimited, delimiter: ",")     # => 12,345,678
-12345678.05.to_formatted_s(:delimited, separator: " ")  # => 12,345,678 05
+12345678.to_fs(:delimited)                     # => 12,345,678
+12345678.05.to_fs(:delimited)                  # => 12,345,678.05
+12345678.to_fs(:delimited, delimiter: ".")     # => 12.345.678
+12345678.to_fs(:delimited, delimiter: ",")     # => 12,345,678
+12345678.05.to_fs(:delimited, separator: " ")  # => 12,345,678 05
 ```
 
 Produce a string representation of a number rounded to a precision:
 
 ```ruby
-111.2345.to_formatted_s(:rounded)                     # => 111.235
-111.2345.to_formatted_s(:rounded, precision: 2)       # => 111.23
-13.to_formatted_s(:rounded, precision: 5)             # => 13.00000
-389.32314.to_formatted_s(:rounded, precision: 0)      # => 389
-111.2345.to_formatted_s(:rounded, significant: true)  # => 111
+111.2345.to_fs(:rounded)                     # => 111.235
+111.2345.to_fs(:rounded, precision: 2)       # => 111.23
+13.to_fs(:rounded, precision: 5)             # => 13.00000
+389.32314.to_fs(:rounded, precision: 0)      # => 389
+111.2345.to_fs(:rounded, significant: true)  # => 111
 ```
 
 Produce a string representation of a number as a human-readable number of bytes:
 
 ```ruby
-123.to_formatted_s(:human_size)                  # => 123 Bytes
-1234.to_formatted_s(:human_size)                 # => 1.21 KB
-12345.to_formatted_s(:human_size)                # => 12.1 KB
-1234567.to_formatted_s(:human_size)              # => 1.18 MB
-1234567890.to_formatted_s(:human_size)           # => 1.15 GB
-1234567890123.to_formatted_s(:human_size)        # => 1.12 TB
-1234567890123456.to_formatted_s(:human_size)     # => 1.1 PB
-1234567890123456789.to_formatted_s(:human_size)  # => 1.07 EB
+123.to_fs(:human_size)                  # => 123 Bytes
+1234.to_fs(:human_size)                 # => 1.21 KB
+12345.to_fs(:human_size)                # => 12.1 KB
+1234567.to_fs(:human_size)              # => 1.18 MB
+1234567890.to_fs(:human_size)           # => 1.15 GB
+1234567890123.to_fs(:human_size)        # => 1.12 TB
+1234567890123456.to_fs(:human_size)     # => 1.1 PB
+1234567890123456789.to_fs(:human_size)  # => 1.07 EB
 ```
 
 Produce a string representation of a number in human-readable words:
 
 ```ruby
-123.to_formatted_s(:human)               # => "123"
-1234.to_formatted_s(:human)              # => "1.23 Thousand"
-12345.to_formatted_s(:human)             # => "12.3 Thousand"
-1234567.to_formatted_s(:human)           # => "1.23 Million"
-1234567890.to_formatted_s(:human)        # => "1.23 Billion"
-1234567890123.to_formatted_s(:human)     # => "1.23 Trillion"
-1234567890123456.to_formatted_s(:human)  # => "1.23 Quadrillion"
+123.to_fs(:human)               # => "123"
+1234.to_fs(:human)              # => "1.23 Thousand"
+12345.to_fs(:human)             # => "12.3 Thousand"
+1234567.to_fs(:human)           # => "1.23 Million"
+1234567890.to_fs(:human)        # => "1.23 Billion"
+1234567890123.to_fs(:human)     # => "1.23 Trillion"
+1234567890123456.to_fs(:human)  # => "1.23 Quadrillion"
 ```
 
 NOTE: Defined in `active_support/core_ext/numeric/conversions.rb`.
@@ -2466,25 +2466,25 @@ NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
 
 [Array#to_sentence]: https://api.rubyonrails.org/classes/Array.html#method-i-to_sentence
 
-#### `to_formatted_s`
+#### `to_fs`
 
-The method [`to_formatted_s`][Array#to_formatted_s] acts like `to_s` by default.
+The method [`to_fs`][Array#to_fs] acts like `to_s` by default.
 
 If the array contains items that respond to `id`, however, the symbol
 `:db` may be passed as argument. That's typically used with
 collections of Active Record objects. Returned strings are:
 
 ```ruby
-[].to_formatted_s(:db)            # => "null"
-[user].to_formatted_s(:db)        # => "8456"
-invoice.lines.to_formatted_s(:db) # => "23,567,556,12"
+[].to_fs(:db)            # => "null"
+[user].to_fs(:db)        # => "8456"
+invoice.lines.to_fs(:db) # => "23,567,556,12"
 ```
 
 Integers in the example above are supposed to come from the respective calls to `id`.
 
 NOTE: Defined in `active_support/core_ext/array/conversions.rb`.
 
-[Array#to_formatted_s]: https://api.rubyonrails.org/classes/Array.html#method-i-to_formatted_s
+[Array#to_fs]: https://api.rubyonrails.org/classes/Array.html#method-i-to_fs
 
 #### `to_xml`
 

--- a/guides/source/api_documentation_guidelines.md
+++ b/guides/source/api_documentation_guidelines.md
@@ -114,7 +114,7 @@ Short docs do not need an explicit "Examples" label to introduce snippets; they 
 # Converts a collection of elements into a formatted string by
 # calling +to_s+ on all elements and joining them.
 #
-#   Blog.all.to_formatted_s # => "First PostSecond PostThird Post"
+#   Blog.all.to_fs # => "First PostSecond PostThird Post"
 ```
 
 On the other hand, big chunks of structured documentation may have a separate "Examples" section:

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -216,7 +216,7 @@ One possibility is to set the expiry time-stamp of the cookie with the session I
 ```ruby
 class Session < ApplicationRecord
   def self.sweep(time = 1.hour)
-    where("updated_at < ?", time.ago.to_formatted_s(:db)).delete_all
+    where("updated_at < ?", time.ago.to_fs(:db)).delete_all
   end
 end
 ```
@@ -224,7 +224,7 @@ end
 The section about session fixation introduced the problem of maintained sessions. An attacker maintaining a session every five minutes can keep the session alive forever, although you are expiring sessions. A simple solution for this would be to add a `created_at` column to the sessions table. Now you can delete sessions that were created a long time ago. Use this line in the sweep method above:
 
 ```ruby
-where("updated_at < ? OR created_at < ?", time.ago.to_formatted_s(:db), 2.days.ago.to_formatted_s(:db)).delete_all
+where("updated_at < ? OR created_at < ?", time.ago.to_fs(:db), 2.days.ago.to_fs(:db)).delete_all
 ```
 
 Cross-Site Request Forgery (CSRF)

--- a/railties/lib/rails/generators/generated_attribute.rb
+++ b/railties/lib/rails/generators/generated_attribute.rb
@@ -123,8 +123,8 @@ module Rails
                      when :integer                     then 1
                      when :float                       then 1.5
                      when :decimal                     then "9.99"
-                     when :datetime, :timestamp, :time then Time.now.to_formatted_s(:db)
-                     when :date                        then Date.today.to_formatted_s(:db)
+                     when :datetime, :timestamp, :time then Time.now.to_fs(:db)
+                     when :date                        then Date.today.to_fs(:db)
                      when :string                      then name == "type" ? "" : "MyString"
                      when :text                        then "MyText"
                      when :boolean                     then false

--- a/railties/test/generators/generated_attribute_test.rb
+++ b/railties/test/generators/generated_attribute_test.rb
@@ -91,12 +91,12 @@ class GeneratedAttributeTest < Rails::Generators::TestCase
 
   def test_default_value_is_datetime
     %w(datetime timestamp time).each do |attribute_type|
-      assert_field_default_value attribute_type, Time.now.to_formatted_s(:db)
+      assert_field_default_value attribute_type, Time.now.to_fs(:db)
     end
   end
 
   def test_default_value_is_date
-    assert_field_default_value :date, Date.today.to_formatted_s(:db)
+    assert_field_default_value :date, Date.today.to_fs(:db)
   end
 
   def test_default_value_is_string


### PR DESCRIPTION
The first take of #to_formatted_s was just too cumbersome for a method used that frequently. It also mixed abbreviation and not in a bit of an unholy mix.