### PR TITLE
Setup on_encrypted_attribute_declared hook only once

### DIFF
--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -50,7 +50,7 @@ module ActiveRecord
           end
         end
 
-        def install_auto_filtered_parameters(application) # :nodoc:
+        def install_auto_filtered_parameters_hook(application) # :nodoc:
           ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, encrypted_attribute_name|
             application.config.filter_parameters << encrypted_attribute_name unless ActiveRecord::Encryption.config.excluded_from_filter_parameters.include?(name)
           end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -360,9 +360,9 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
 
       # Filtered params
-      ActiveSupport.on_load(:action_controller) do
+      ActiveSupport.on_load(:action_controller, run_once: true) do
         if ActiveRecord::Encryption.config.add_to_filter_parameters
-          ActiveRecord::Encryption.install_auto_filtered_parameters(app)
+          ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
         end
       end
     end

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -43,7 +43,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
 
   test "install autofiltered params" do
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
-    ActiveRecord::Encryption.install_auto_filtered_parameters(application)
+    ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
 
     Class.new(Pirate) do
       self.table_name = "pirates"


### PR DESCRIPTION
### Summary

Partially addresses https://github.com/rails/rails/issues/44330

https://github.com/rails/rails/blob/6f02a2aec9b8147db07e89fa2855592ac8edcddc/activerecord/lib/active_record/railtie.rb#L363-L365

Currently it's possible to get the "encrypted attributes" hook to be registered twice because both:

`ActionController::API` 
https://github.com/rails/rails/blob/cc79283518e7dafc8520d8fe031ae81655f7e9ab/actionpack/lib/action_controller/api.rb#L148

and `ActionController::Base` constants run the `action_controller` load hooks on load

https://github.com/rails/rails/blob/90e710d7672b928ce6bb3ec05f8f2c05338be6c9/actionpack/lib/action_controller/base.rb#L271

So by default any `rails new` app with `jbuilder` gem ends up having duplicated `:body` value in the `filter_parameters`
https://github.com/rails/jbuilder/blob/main/lib/jbuilder/railtie.rb#L20

https://github.com/rails/rails/blob/638a92f7344963c7e42eeb84eb816e4592bda7e4/actiontext/app/models/action_text/encrypted_rich_text.rb#L7


In order to fix this I'm passing `run_once: true` option to the `on_load` hook to prevent registering the same hook for the second time. I also decided to change the name of the method a little bit to be explicit about it's behaviour. I feel like current name may make an impression that we populate `filter_parameters` immediately when we only setting up a hook.


### Question for reviewers

I feel like there might be an option for a better "root cause" fix. For example I wonder if both `base` and `api` constants should trigger the `action_controller` hooks. I guess it's expected because we have API-only apps that do not load `base` constant, as far as I understand.

However, should `jbuilder` trigger loading of the `API` constant for a non-api application? In our case the line `if self == ActionController::API` is triggering the load, but I feel like we should be able to improve it to not do the comparison. The reason for that is, as far as I understand,  that `self` can not be equal to the `API` constant as long as `API` constant is not loaded.

I'll look into changing `jbuilder`, however I believe this PR is still reasonable because we don't want to register the encryption hook twice, regardless of what caused the `on_load` hook to be triggered

