### PR TITLE
fix MessageEncryptor isolation tests

### DIFF
--- a/activesupport/lib/active_support/json_with_marshal_fallback.rb
+++ b/activesupport/lib/active_support/json_with_marshal_fallback.rb
@@ -26,7 +26,7 @@ module ActiveSupport
 
       def load(value)
         if self.fallback_to_marshal_deserialization
-          if value.starts_with?(MARSHAL_SIGNATURE)
+          if value.start_with?(MARSHAL_SIGNATURE)
             logger.warn("JsonWithMarshalFallback: Marshal load fallback occurred.") if logger
             Marshal.load(value)
           else


### PR DESCRIPTION
### Summary

5d0c2b0 added a usage of String#starts_with? which won't work in
isolation tests because its a core extension alias