### PR TITLE
Dump the precision for datetime columns following the new defaults

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_dumper.rb
@@ -3,6 +3,8 @@
 module ActiveRecord
   module ConnectionAdapters # :nodoc:
     class SchemaDumper < SchemaDumper # :nodoc:
+      DEFAULT_DATETIME_PRECISION = 6 # :nodoc:
+
       def self.create(connection, options)
         new(connection, options)
       end
@@ -63,7 +65,18 @@ module ActiveRecord
         end
 
         def schema_precision(column)
-          column.precision.inspect if column.precision
+          if column.type == :datetime
+            case column.precision
+            when nil
+              "nil"
+            when DEFAULT_DATETIME_PRECISION
+              nil
+            else
+              column.precision.inspect
+            end
+          elsif column.precision
+            column.precision.inspect
+          end
         end
 
         def schema_scale(column)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_dumper.rb
@@ -53,7 +53,13 @@ module ActiveRecord
           end
 
           def schema_precision(column)
-            super unless /\Atime(?:stamp)?\b/.match?(column.sql_type) && column.precision == 0
+            if /\Atime(?:stamp)?\b/.match?(column.sql_type) && column.precision == 0
+              nil
+            elsif column.type == :datetime
+              column.precision == 0 ? "nil" : super
+            else
+              super
+            end
           end
 
           def schema_collation(column)

--- a/activerecord/test/cases/date_time_precision_test.rb
+++ b/activerecord/test/cases/date_time_precision_test.rb
@@ -193,13 +193,22 @@ if supports_datetime_with_precision?
       end
     end
 
-    def test_schema_dump_includes_datetime_precision
+    def test_schema_dump_with_default_precision_is_not_dumped
       @connection.create_table(:foos, force: true) do |t|
         t.timestamps precision: 6
       end
       output = dump_table_schema("foos")
-      assert_match %r{t\.datetime\s+"created_at",\s+precision: 6,\s+null: false$}, output
-      assert_match %r{t\.datetime\s+"updated_at",\s+precision: 6,\s+null: false$}, output
+      assert_match %r{t\.datetime\s+"created_at",\s+null: false$}, output
+      assert_match %r{t\.datetime\s+"updated_at",\s+null: false$}, output
+    end
+
+    def test_schema_dump_with_without_precision_has_precision_as_nil
+      @connection.create_table(:foos, force: true) do |t|
+        t.timestamps precision: nil
+      end
+      output = dump_table_schema("foos")
+      assert_match %r{t\.datetime\s+"created_at",\s+precision: nil,\s+null: false$}, output
+      assert_match %r{t\.datetime\s+"updated_at",\s+precision: nil,\s+null: false$}, output
     end
 
     if current_adapter?(:PostgreSQLAdapter, :SQLServerAdapter)

--- a/activerecord/test/cases/defaults_test.rb
+++ b/activerecord/test/cases/defaults_test.rb
@@ -118,13 +118,15 @@ if current_adapter?(:PostgreSQLAdapter)
       output = dump_table_schema("defaults")
       if ActiveRecord::Base.connection.database_version >= 100000
         assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
-        assert_match %r/t\.datetime\s+"modified_time",\s+precision: 6,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+        assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
       else
         assert_match %r/t\.date\s+"modified_date",\s+default: -> { "\('now'::text\)::date" }/, output
-        assert_match %r/t\.datetime\s+"modified_time",\s+precision: 6,\s+default: -> { "now\(\)" }/, output
+        assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "now\(\)" }/, output
       end
       assert_match %r/t\.date\s+"modified_date_function",\s+default: -> { "now\(\)" }/, output
-      assert_match %r/t\.datetime\s+"modified_time_function",\s+precision: 6,\s+default: -> { "now\(\)" }/, output
+      assert_match %r/t\.datetime\s+"modified_time_function",\s+default: -> { "now\(\)" }/, output
+      assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+      assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
     end
   end
 end
@@ -143,17 +145,17 @@ if current_adapter?(:Mysql2Adapter)
     if supports_datetime_with_precision?
       test "schema dump datetime includes default expression" do
         output = dump_table_schema("datetime_defaults")
-        assert_match %r/t\.datetime\s+"modified_datetime",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP(?:\(\))?" }/i, output
+        assert_match %r/t\.datetime\s+"modified_datetime",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP(?:\(\))?" }/i, output
       end
 
       test "schema dump datetime includes precise default expression" do
         output = dump_table_schema("datetime_defaults")
-        assert_match %r/t\.datetime\s+"precise_datetime",\s+precision: 6,\s+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
+        assert_match %r/t\.datetime\s+"precise_datetime",\s+default: -> { "CURRENT_TIMESTAMP\(6\)" }/i, output
       end
 
       test "schema dump datetime includes precise default expression with on update" do
         output = dump_table_schema("datetime_defaults")
-        assert_match %r/t\.datetime\s+"updated_datetime",\s+precision: 6,\s+default: -> { "CURRENT_TIMESTAMP\(6\) ON UPDATE CURRENT_TIMESTAMP\(6\)" }/i, output
+        assert_match %r/t\.datetime\s+"updated_datetime",\s+default: -> { "CURRENT_TIMESTAMP\(6\) ON UPDATE CURRENT_TIMESTAMP\(6\)" }/i, output
       end
 
       test "schema dump timestamp includes default expression" do
@@ -174,19 +176,6 @@ if current_adapter?(:Mysql2Adapter)
       test "schema dump timestamp without default expression" do
         output = dump_table_schema("timestamp_defaults")
         assert_match %r/t\.timestamp\s+"nullable_timestamp"$/, output
-      end
-    end
-  end
-
-  if current_adapter?(:SQLite3Adapter)
-    class Sqlite3DefaultExpressionTest < ActiveRecord::TestCase
-      include SchemaDumpingHelper
-
-      test "schema dump includes default expression" do
-        output = dump_table_schema("defaults")
-        assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
-        assert_match %r/t\.datetime\s+"modified_time",\s+precision: 6,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
-        assert_match %r/t\.integer\s+"random_number",\s+default: -> { "random()" }/, output
       end
     end
   end
@@ -272,6 +261,21 @@ if current_adapter?(:Mysql2Adapter)
       yield klass
     ensure
       klass.connection.drop_table(klass.table_name) rescue nil
+    end
+  end
+end
+
+if current_adapter?(:SQLite3Adapter)
+  class Sqlite3DefaultExpressionTest < ActiveRecord::TestCase
+    include SchemaDumpingHelper
+
+    test "schema dump includes default expression" do
+      output = dump_table_schema("defaults")
+      assert_match %r/t\.date\s+"modified_date",\s+default: -> { "CURRENT_DATE" }/, output
+      assert_match %r/t\.datetime\s+"modified_time",\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+      assert_match %r/t\.datetime\s+"modified_time_without_precision",\s+precision: nil,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+      assert_match %r/t\.datetime\s+"modified_time_with_precision_0",\s+precision: 0,\s+default: -> { "CURRENT_TIMESTAMP" }/, output
+      assert_match %r/t\.integer\s+"random_number",\s+default: -> { "random\(\)" }/, output
     end
   end
 end

--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -321,7 +321,7 @@ class PrimaryKeyAnyTypeTest < ActiveRecord::TestCase
     test "schema typed primary key column" do
       @connection.create_table(:scheduled_logs, id: :timestamp, precision: 6, force: true)
       schema = dump_table_schema("scheduled_logs")
-      assert_match %r/create_table "scheduled_logs", id: { type: :timestamp, precision: 6.* }/, schema
+      assert_match %r/create_table "scheduled_logs", id: :timestamp.*/, schema
     end
   end
 end

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -845,9 +845,9 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     assert_match %r{t\.date\s+"date_with_default",\s+default: "2014-06-05"}, output
 
     if supports_datetime_with_precision?
-      assert_match %r{t\.datetime\s+"datetime_with_default",\s+precision: 6,\s+default: "2014-06-05 07:17:04"}, output
-    else
       assert_match %r{t\.datetime\s+"datetime_with_default",\s+default: "2014-06-05 07:17:04"}, output
+    else
+      assert_match %r{t\.datetime\s+"datetime_with_default",\s+precision: nil,\s+default: "2014-06-05 07:17:04"}, output
     end
 
     assert_match %r{t\.time\s+"time_with_default",\s+default: "2000-01-01 07:17:04"}, output
@@ -864,8 +864,8 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     output = dump_table_schema("infinity_defaults")
     assert_match %r{t\.float\s+"float_with_inf_default",\s+default: ::Float::INFINITY}, output
     assert_match %r{t\.float\s+"float_with_nan_default",\s+default: ::Float::NAN}, output
-    assert_match %r{t\.datetime\s+"beginning_of_time",\s+precision: 6,\s+default: -::Float::INFINITY}, output
-    assert_match %r{t\.datetime\s+"end_of_time",\s+precision: 6,\s+default: ::Float::INFINITY}, output
+    assert_match %r{t\.datetime\s+"beginning_of_time",\s+default: -::Float::INFINITY}, output
+    assert_match %r{t\.datetime\s+"end_of_time",\s+default: ::Float::INFINITY}, output
     assert_match %r{t\.date\s+"date_with_neg_inf_default",\s+default: -::Float::INFINITY}, output
     assert_match %r{t\.date\s+"date_with_pos_inf_default",\s+default: ::Float::INFINITY}, output
   end if current_adapter?(:PostgreSQLAdapter)

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define do
     t.date :modified_date_function, default: -> { "now()" }
     t.date :fixed_date, default: "2004-01-01"
     t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_without_precision, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_with_precision_0, precision: 0, default: -> { "CURRENT_TIMESTAMP" }
     t.datetime :modified_time_function, default: -> { "now()" }
     t.datetime :fixed_time, default: "2004-01-01 00:00:00.000000-00"
     t.timestamptz :fixed_time_with_time_zone, default: "2004-01-01 01:00:00+1"

--- a/activerecord/test/schema/sqlite_specific_schema.rb
+++ b/activerecord/test/schema/sqlite_specific_schema.rb
@@ -6,6 +6,8 @@ ActiveRecord::Schema.define do
     t.date :fixed_date, default: "2004-01-01"
     t.datetime :fixed_time, default: "2004-01-01 00:00:00"
     t.datetime :modified_time, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_without_precision, precision: nil, default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime :modified_time_with_precision_0, precision: 0, default: -> { "CURRENT_TIMESTAMP" }
     t.integer :random_number, default: -> { "random()" }
     t.column :char1, "char(1)", default: "Y"
     t.string :char2, limit: 50, default: "a varchar field"


### PR DESCRIPTION
Since Rails 7.0 the datetime column precision is 6 by default.

That means that `t.datetime` calls without setting the `:precision`
option would have its precision set to 6.

The schema dumper was generating a call without precision for columns
with the precision set to `nil` (which has the same effect of 0), making
the schema dump incorrect for the next load since that would be interpreted
as if the precision was 6.

This didn't affect MySQL since #44171, since MySQL precision is 0 by default
not `nil` but it affected PostgreSQL and SQLite3.

Now the dumper will generate the precision as 0 for columns without
precision and omit it when the precision is 6.

Related to #43909.