### PR TITLE
Include the model name when filtering encrypted attributes.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Use the model name as a prefix when filtering encrypted attributes from logs.
+
+    For example, when encrypting `Person#name` it will add `person.name` as a filter
+    parameter, instead of just `name`. This prevents unintended filtering of parameters
+    with a matching name in other models. 
+
+    *Jorge Manrubia*
+
 *   Fix `config.active_record.destroy_association_async_job` configuration
 
     `config.active_record.destroy_association_async_job` should allow

--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -52,9 +52,15 @@ module ActiveRecord
 
         def install_auto_filtered_parameters_hook(application) # :nodoc:
           ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, encrypted_attribute_name|
-            application.config.filter_parameters << encrypted_attribute_name unless ActiveRecord::Encryption.config.excluded_from_filter_parameters.include?(encrypted_attribute_name)
+            filter_parameter = [("#{klass.model_name.element}" if klass.name), encrypted_attribute_name.to_s].compact.join(".")
+            application.config.filter_parameters << filter_parameter unless excluded_from_filter_parameters?(filter_parameter)
           end
         end
+
+        private
+          def excluded_from_filter_parameters?(filter_parameter)
+            ActiveRecord::Encryption.config.excluded_from_filter_parameters.find { |excluded_filter| excluded_filter.to_s == filter_parameter }
+          end
       end
     end
   end

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -41,7 +41,19 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
     assert_equal :isbn, @attribute_name
   end
 
-  test "install autofiltered params" do
+  test "installing autofiltered parameters will add the encrypted attribute as a filter parameter using the dot notation" do
+    application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
+    ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
+
+    NamedPirate = Class.new(Pirate) do
+      self.table_name = "pirates"
+    end
+    NamedPirate.encrypts :catchphrase
+
+    assert_includes application.config.filter_parameters, "named_pirate.catchphrase"
+  end
+
+  test "installing autofiltered parameters will work with unnamed classes" do
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
     ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
 
@@ -50,7 +62,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
       encrypts :catchphrase
     end
 
-    assert_includes application.config.filter_parameters, :catchphrase
+    assert_includes application.config.filter_parameters, "catchphrase"
   end
 
   test "exclude the installation of autofiltered params" do

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -241,6 +241,8 @@ end
 
 By default, encrypted columns are configured to be [automatically filtered in Rails logs](https://guides.rubyonrails.org/action_controller_overview.html#parameters-filtering). You can disable this behavior by adding the following to your `application.rb`:
 
+When generating the filter parameter, it will use the model name as a prefix. E.g: For `Person#name` the filter parameter will be `person.name`.
+
 ```ruby
 config.active_record.encryption.add_to_filter_parameters = false
 ```


### PR DESCRIPTION
For example, when encrypting `Person#name` it will add `person.name` as a filter parameter, instead of just `name`. This prevents unintended filtering of parameters with a matching name in other models.

Addresses the second concern in https://github.com/rails/rails/issues/44330.

CC @rafaelfranca @nvasilevski 
