### PR TITLE
Reverse the order of `INSERT` statements in `structure.sql` dumps

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Reversed the order of `INSERT` statements in `structure.sql` dumps
+
+    This should decrease the likelihood of merge conflicts. New migrations
+    will now be added at the top of the list.
+
+    For existing apps, there will be a large diff the next time `structure.sql`
+    is generated.
+
+    *Alex Ghiculescu*, *Matt Larraz*
+
 *   Fix PG.connect keyword arguments deprecation warning on ruby 2.7
 
     Fixes #44307.

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1675,7 +1675,7 @@ module ActiveRecord
 
           if versions.is_a?(Array)
             sql = +"INSERT INTO #{sm_table} (version) VALUES\n"
-            sql << versions.map { |v| "(#{quote(v)})" }.join(",\n")
+            sql << versions.reverse.map { |v| "(#{quote(v)})" }.join(",\n")
             sql << ";\n\n"
             sql
           else


### PR DESCRIPTION
### Summary

Today every new migration added adds a new line here, but also requires moving the semicolon from what was previously the most recent line:

```sql
INSERT INTO "schema_migrations" (version) VALUES
('20210924183850'),
('20211008165610'),
('20211108235701');
```

```diff
INSERT INTO "schema_migrations" (version) VALUES
('20190924183850'),
('20191008165610'),
+('20191108235701'),
-('20191108235701');
+('20191118181905');
```

This leads to merge conflicts if lots of migrations are being added at the same.

### How this PR came about

The fix in this PR was suggested as a better fix by @matthewd in https://github.com/rails/rails/pull/43414.

We've been running with a monkey patch for it for about a month, and can confirm, it's definitely an improvement. So I'm making this as an alternative suggestion to https://github.com/rails/rails/pull/43414

Adding @mlarraz as a co-author - thanks for the original inspiration.
For reference https://github.com/rails/rails/pull/3477 added the original sorting logic.