### PR TITLE
Fix install_auto_filtered_parameters method rename

### DIFF
--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -57,7 +57,7 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
     ActiveRecord::Encryption.config.excluded_from_filter_parameters = [:catchphrase]
 
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
-    ActiveRecord::Encryption.install_auto_filtered_parameters(application)
+    ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
 
     Class.new(Pirate) do
       self.table_name = "pirates"


### PR DESCRIPTION
There is a test that is failing on the main branch

The failure started after - https://github.com/rails/rails/pull/44329/files has been merged
And the rename was introduced - https://github.com/rails/rails/pull/44355

I should have asked for a rebase after merging the rename PR 