### PR TITLE
Increment assertions count on assert_nothing_raised

### DIFF
--- a/activesupport/lib/active_support/testing/assertions.rb
+++ b/activesupport/lib/active_support/testing/assertions.rb
@@ -31,7 +31,7 @@ module ActiveSupport
       #     perform_service(param: 'no_exception')
       #   end
       def assert_nothing_raised
-        yield
+        yield.tap { assert(true) }
       rescue => error
         raise Minitest::UnexpectedError.new(error)
       end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -229,7 +229,7 @@ module ApplicationTests
       end
       output = rails("test")
 
-      assert_match(/7 runs, 9 assertions, 0 failures, 0 errors/, output)
+      assert_match(/7 runs, 11 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
     end
 
@@ -247,7 +247,7 @@ module ApplicationTests
       with_rails_env("test") { rails("db:migrate") }
       output = rails("test")
 
-      assert_match(/5 runs, 7 assertions, 0 failures, 0 errors/, output)
+      assert_match(/5 runs, 9 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
     end
 
@@ -260,7 +260,7 @@ module ApplicationTests
       end
       output = rails("test")
 
-      assert_match(/7 runs, 9 assertions, 0 failures, 0 errors/, output)
+      assert_match(/7 runs, 11 assertions, 0 failures, 0 errors/, output)
       assert_no_match(/Errors running/, output)
     end
 

--- a/railties/test/generators/scaffold_generator_test.rb
+++ b/railties/test/generators/scaffold_generator_test.rb
@@ -573,7 +573,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
       end
-      assert_match(/8 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
     end
   end
 
@@ -593,7 +593,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         assert_match(/class UsersController < ApplicationController/, content)
       end
 
-      assert_match(/8 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
     end
   end
 
@@ -607,7 +607,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
       end
-      assert_match(/8 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/8 runs, 12 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
     end
   end
 
@@ -621,7 +621,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
       end
-      assert_match(/6 runs, 8 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/6 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
     end
   end
 
@@ -635,7 +635,7 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
         `bin/rails g scaffold User name:string age:integer;
         bin/rails db:migrate`
       end
-      assert_match(/6 runs, 8 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
+      assert_match(/6 runs, 10 assertions, 0 failures, 0 errors/, `bin/rails test 2>&1`)
     end
   end
 


### PR DESCRIPTION
### Summary

`assert_nothing_raised` is not considered as an assertion by reporters.

Minitest increments `assertions` count on every `assert` method call:
https://github.com/seattlerb/minitest/blob/fe3992e85b40792cf7bff2a876887d8d9e392068/lib/minitest/assertions.rb#L179

But custom assert method, or just tests that implicitly rely on code to not raise anything to be considered as "passed" get excluded from total reports.

For example, let's have a look on the:
`actioncable/test/test_helper_test.rb` test file
Running the whole file on the `main` branch produces:
```
Finished in 0.038287s, 287.3003 runs/s, 652.9552 assertions/s.
11 runs, 25 assertions, 0 failures, 0 errors, 0 skips
```

And after counting the `assert_nothing_raised` method as an assertion, we get:
```
Finished in 0.040604s, 270.9100 runs/s, 1009.7555 assertions/s.
11 runs, 41 assertions, 0 failures, 0 errors, 0 skips
```

So, 16 assertions being unaccounted at the moment.

I would agree that the impact of this change is really low, and perhaps those minitest reports is not something that being often looked at. However, I believe the price to make this change is also very low so it should be worth it

On a side note, I'm working on a tool that heavily relies on `assertions` count to be accurate, so for this work having this fix implemented would be great
Thanks!
