### PR TITLE
fix LocalCache#read_multi_entries

### DIFF
--- a/activesupport/lib/active_support/cache/strategy/local_cache.rb
+++ b/activesupport/lib/active_support/cache/strategy/local_cache.rb
@@ -123,6 +123,9 @@ module ActiveSupport
             return super unless local_cache
 
             local_entries = local_cache.read_multi_entries(keys)
+            local_entries.transform_values! do |payload|
+              deserialize_entry(payload).value
+            end
             missed_keys = keys - local_entries.keys
 
             if missed_keys.any?

--- a/activesupport/test/cache/behaviors/local_cache_behavior.rb
+++ b/activesupport/test/cache/behaviors/local_cache_behavior.rb
@@ -286,4 +286,13 @@ module LocalCacheBehavior
       assert_equal false, @cache.read(key)
     end
   end
+
+  def test_local_cache_should_deserialize_entries_on_multi_get
+    keys = Array.new(5) { SecureRandom.uuid }
+    values = keys.index_with(true)
+    @cache.with_local_cache do
+      assert @cache.write_multi(values)
+      assert_equal values, @cache.read_multi(*keys)
+    end
+  end
 end


### PR DESCRIPTION
In cache stores prepending `LocalCache`, serialized `Entry`
instances are stored in `LocalCache::LocalStore`. This
speeds up hot key lookups without a network roundtrip in a
context of a single given request.

However, with these entries being stored in their serialized
form, `#read_multi_entries` returns them directly to cache
consumers.

Instead, we will now deserialize these entries first.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
