### PR TITLE
Provide change summary before details for all gems

### DIFF
--- a/tasks/release_announcement_draft.erb
+++ b/tasks/release_announcement_draft.erb
@@ -11,15 +11,15 @@ If you find one, please open an [issue on GitHub](https://github.com/rails/rails
 
 ## CHANGES since <%= version.previous %>
 
+To see a summary of changes, please read the release on GitHub:
+
+<%= "[#{version} CHANGELOG](https://github.com/rails/rails/releases/tag/v#{version})" %>
+
 To view the changes for each gem, please read the changelogs on GitHub:
 <% FRAMEWORKS.sort.each do |framework| %>
 <%= "* [#{FRAMEWORK_NAMES[framework]} CHANGELOG](https://github.com/rails/rails/blob/v#{version}/#{framework}/CHANGELOG.md)" %>
 
 <% end %>
-
-To see a summary of changes, please read the release on GitHub:
-
-<%= "[#{version} CHANGELOG](https://github.com/rails/rails/releases/tag/v#{version})" %>
 
 
 *Full listing*


### PR DESCRIPTION
Update announcement template to have summary of changes since previous release before the details for each gem.

### Summary

The release announcement includes the details for each gem first and then only the summary of changes. I think it's better to have the summary first so that someone can scan changes since last release more quickly and at one shot, see which items have not been changed at all. This reorders it in the template.
