### PR TITLE
Raise exception if Active Storage is configured and `config.active_storage.service` is not explicitly set

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,4 +1,12 @@
-*   Fixes proxy downloads of files over 5mb 
+*   Raise an exception if `config.active_storage.service` is not set.
+
+    If Active Storage is configured and `config.active_storage.service` is not
+    set in the respective environment's configuration file, then an exception
+    is raised with a meaningful message when attempting to use Active Storage.
+
+    *Ghouse Mohamed*
+
+*   Fixes proxy downloads of files over 5mb
 
     Previously, trying to view and/or download files larger than 5mb stored in
     services like S3 via proxy mode could return corrupted files at around

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -215,6 +215,14 @@ module ActiveStorage
             ActiveStorage::Blob.services.fetch(service) do
               raise ArgumentError, "Cannot configure service :#{service} for #{name}##{association_name}"
             end
+          else
+            validate_global_service_configuration
+          end
+        end
+
+        def validate_global_service_configuration
+          if connected? && ActiveStorage::Blob.table_exists? && Rails.configuration.active_storage.service.nil?
+            raise RuntimeError, "Missing Active Storage service name. Specify Active Storage service name for config.active_storage.service in config/environments/#{Rails.env}.rb"
           end
         end
     end

--- a/activestorage/test/dummy/config/environments/test.rb
+++ b/activestorage/test/dummy/config/environments/test.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Store uploaded files on the local file system in a temporary directory
+  config.active_storage.service = :test
+
   # Raises error for missing translations
   # config.i18n.raise_on_missing_translations = true
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -761,6 +761,18 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal highlights.third.filename.to_s, @user.highlights.third.filename.to_s
   end
 
+  test "raises error when global service configuration is missing" do
+    Rails.configuration.active_storage.stub(:service, nil) do
+      error = assert_raises RuntimeError do
+        User.class_eval do
+          has_one_attached :featured_photos
+        end
+      end
+
+      assert_match(/Missing Active Storage service name. Specify Active Storage service name for config.active_storage.service in config\/environments\/test.rb/, error.message)
+    end
+  end
+
   test "raises error when misconfigured service is passed" do
     error = assert_raises ArgumentError do
       User.class_eval do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -667,6 +667,18 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "raises error when global service configuration is missing" do
+    Rails.configuration.active_storage.stub(:service, nil) do
+      error = assert_raises RuntimeError do
+        User.class_eval do
+          has_one_attached :featured_photos
+        end
+      end
+
+      assert_match(/Missing Active Storage service name. Specify Active Storage service name for config.active_storage.service in config\/environments\/test.rb/, error.message)
+    end
+  end
+
   test "raises error when misconfigured service is passed" do
     error = assert_raises ArgumentError do
       User.class_eval do


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

If `config.active_storage.service` has not been explicitly set in the respective environment's configuration file, then trying to use active storage throws a vague error message, which makes it harder to debug. This was the following error I had gotten:

```
Failed to replace attachments_attachments because one or more of the new records could not be saved.
```

Turned out I had forgotten to explicitly specify `config.active_storage.service` in my configuration file. Specifying it resolved the issue.

I had spent a considerable amount of time trying to debug this, and I would have immediately known what the fix was if the error message had been clearer. So, I'm turning in this PR so that anyone facing this in the future will know what to do at a quick glance.

Thanks 😁!
### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
