### PR TITLE
Support `nil` and `false` as a `:dependent` option for `has_one_attached` and `has_many_attached`

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Support `nil` and `false` as a `:dependent` option for `has_one_attached` and `has_many_attached`.
+
+    Previously, when `nil` or `false` were set, attachments were destroyed when the associated
+    record was destroyed. Now, attachments are preserved when the record is destroyed.
+    For this to work, you need to make `active_storage_attachments.record_id` and
+    `active_storage_attachments.record_type` columns to accept `NULL`s.
+
+    Fixes #44362
+
+    *fatkodima*
+
 *   Raise an exception if `config.active_storage.service` is not set.
 
     If Active Storage is configured and `config.active_storage.service` is not

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -18,7 +18,7 @@ require "active_support/core_ext/module/delegation"
 class ActiveStorage::Attachment < ActiveStorage::Record
   self.table_name = "active_storage_attachments"
 
-  belongs_to :record, polymorphic: true, touch: true
+  belongs_to :record, polymorphic: true, touch: true, optional: true
   belongs_to :blob, class_name: "ActiveStorage::Blob", autosave: true
 
   delegate_missing_to :blob

--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -32,6 +32,8 @@ module ActiveStorage
       #
       # If the +:dependent+ option isn't set, the attachment will be purged
       # (i.e. destroyed) whenever the record is destroyed.
+      # To skip destroying attachments, you need to pass `nil` or `false` as a +:dependent+ value and make
+      # `active_storage_attachments.record_id` and `active_storage_attachments.record_type` columns to accept `NULL`s.
       #
       # If you need the attachment to use a service which differs from the globally configured one,
       # pass the +:service+ option. For instance:
@@ -67,7 +69,8 @@ module ActiveStorage
           end
         CODE
 
-        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record, inverse_of: :record, dependent: :destroy, strict_loading: strict_loading
+        has_one :"#{name}_attachment", -> { where(name: name) }, class_name: "ActiveStorage::Attachment", as: :record,
+            inverse_of: :record, dependent: (:destroy if dependent), strict_loading: strict_loading
         has_one :"#{name}_blob", through: :"#{name}_attachment", class_name: "ActiveStorage::Blob", source: :blob, strict_loading: strict_loading
 
         scope :"with_attached_#{name}", -> { includes("#{name}_attachment": :blob) }
@@ -111,6 +114,8 @@ module ActiveStorage
       #
       # If the +:dependent+ option isn't set, all the attachments will be purged
       # (i.e. destroyed) whenever the record is destroyed.
+      # To skip destroying attachments, you need to pass `nil` or `false` as a +:dependent+ value and make
+      # `active_storage_attachments.record_id` and `active_storage_attachments.record_type` columns to accept `NULL`s.
       #
       # If you need the attachment to use a service which differs from the globally configured one,
       # pass the +:service+ option. For instance:
@@ -161,7 +166,8 @@ module ActiveStorage
           end
         CODE
 
-        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment", inverse_of: :record, dependent: :destroy, strict_loading: strict_loading do
+        has_many :"#{name}_attachments", -> { where(name: name) }, as: :record, class_name: "ActiveStorage::Attachment",
+            inverse_of: :record, dependent: (:destroy if dependent), strict_loading: strict_loading do
           def purge
             deprecate(:purge)
             each(&:purge)

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -153,6 +153,15 @@ class ActiveSupport::TestCase
       ActiveStorage::Blob.service = old_service
     end
 
+    def with_optional_record_columns
+      connection = ActiveRecord::Base.connection
+      connection.change_column_null(:active_storage_attachments, :record_id, true)
+      connection.change_column_null(:active_storage_attachments, :record_type, true)
+    ensure
+      connection.change_column_null(:active_storage_attachments, :record_id, false)
+      connection.change_column_null(:active_storage_attachments, :record_type, false)
+    end
+
     def subscribe_events_from(name)
       events = []
       ActiveSupport::Notifications.subscribe(name) do |*args|


### PR DESCRIPTION
Closes #44362

Originally, `dependent: false` was supported. Now this can be also done as `dependent: nil` (as supported on `has_one`/`has_many`).
 
cc @rafaelfranca 