### PR TITLE
Add `Model` type to Active Model attributes

### DIFF
--- a/activemodel/lib/active_model/attributes.rb
+++ b/activemodel/lib/active_model/attributes.rb
@@ -118,6 +118,11 @@ module ActiveModel
       @attributes.to_hash
     end
 
+    # Returns a hash of attributes for assignment to the database.
+    def attributes_for_database
+      @attributes.values_for_database
+    end
+
     # Returns an array of attribute names as strings.
     #
     #   class Person

--- a/activemodel/lib/active_model/type.rb
+++ b/activemodel/lib/active_model/type.rb
@@ -13,6 +13,7 @@ require "active_model/type/decimal"
 require "active_model/type/float"
 require "active_model/type/immutable_string"
 require "active_model/type/integer"
+require "active_model/type/model"
 require "active_model/type/string"
 require "active_model/type/time"
 
@@ -49,6 +50,7 @@ module ActiveModel
     register(:float, Type::Float)
     register(:immutable_string, Type::ImmutableString)
     register(:integer, Type::Integer)
+    register(:model, Type::Model)
     register(:string, Type::String)
     register(:time, Type::Time)
   end

--- a/activemodel/lib/active_model/type/model.rb
+++ b/activemodel/lib/active_model/type/model.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ActiveModel
+  module Type
+    class Model < Value # :nodoc:
+      def initialize(**args)
+        @class_name = args.delete(:class_name)
+        @serializer = args.delete(:serializer) || ActiveSupport::JSON
+        super
+      end
+
+      def changed_in_place?(raw_old_value, value)
+        old_value = deserialize(raw_old_value)
+        old_value.attributes != value.attributes
+      end
+
+      def valid_value?(value)
+        return valid_hash?(value) if value.is_a?(Hash)
+
+        value.is_a?(klass)
+      end
+
+      def type
+        :model
+      end
+
+      def serializable?(value)
+        value.is_a?(klass)
+      end
+
+      def serialize(value)
+        serializer.encode(value.attributes_for_database)
+      end
+
+      def deserialize(value)
+        attributes = serializer.decode(value)
+        klass.new(attributes)
+      end
+
+      private
+        attr_reader :serializer
+
+        def valid_hash?(value)
+          value.keys.map(&:to_s).difference(klass.attribute_names).none?
+        end
+
+        def klass
+          @_model_type_class ||= @class_name.constantize
+        end
+
+        def cast_value(value)
+          case value
+          when Hash
+            klass.new(value)
+          else
+            klass.new(value.attributes)
+          end
+        end
+    end
+  end
+end

--- a/activemodel/test/cases/type/model_test.rb
+++ b/activemodel/test/cases/type/model_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+module ActiveModel
+  module Type
+    class ModelTest < ActiveModel::TestCase
+      setup do
+        @type = Type::Model.new(class_name: "Post")
+      end
+
+      test "#cast returns a new model instance from the given hash" do
+        model = @type.cast(title: "Greeting", body: "Hello!")
+
+        assert_equal "Greeting", model.title
+        assert_equal "Hello!", model.body
+      end
+
+      test "#cast returns a new model instance from the given model instance" do
+        model = Post.new(title: "Greeting", body: "Hello!")
+
+        new_model = @type.cast(model)
+
+        assert_equal "Greeting", new_model.title
+        assert_equal "Hello!", new_model.body
+
+        assert_not_same model, new_model
+      end
+
+      test "#valid_value? returns true if the value is an object of the same class as the type" do
+        model = Post.new(title: "Greeting", body: "Hello!")
+
+        assert @type.valid_value?(model)
+      end
+
+      test "#valid_value? returns true if the value is a hash that contains only supported keys" do
+        model_hash = { title: "Greeting", body: "Hello!" }
+
+        assert @type.valid_value?(model_hash)
+      end
+
+      test "#valid_value? returns true if the value is a hash that contains only required keys" do
+        model_hash = { title: "Greeting" }
+
+        assert @type.valid_value?(model_hash)
+      end
+
+      test "#valid_value? returns false if value is a hash but with not-supported keys" do
+        model_hash = { title: "Greeting", body: "Hello!", what_am_i: "I'm not supposed to be here" }
+
+        assert_not @type.valid_value?(model_hash)
+      end
+
+      test "valid_value? returns false if value is neither a hash or an object of the type class" do
+        assert_not @type.valid_value?("Just a string")
+      end
+
+      test "#serialize serializes object as values_for_database" do
+        model = Post.new(title: "Greeting", body: "Hello!")
+        expected = "Hello! Post; serialized"
+        serializer = Minitest::Mock.new
+        type = Type::Model.new(class_name: "Post", serializer: serializer)
+
+        serializer.expect(:encode, expected, [model.attributes])
+
+        serialized = type.serialize(model)
+        assert_equal(expected, serialized)
+      end
+
+      test "#deserialize deserializes attributes set and instantiates an object of the type class" do
+        serialized = "Hello! Post; serialized"
+        attributes_set = { "title" => "Greeting", "body" => "Hello!"  }
+        serializer = Minitest::Mock.new
+        type = Type::Model.new(class_name: "Post", serializer: serializer)
+
+        serializer.expect(:decode, attributes_set, [serialized])
+        model = type.deserialize(serialized)
+
+        assert_equal "Greeting", model.title
+        assert_equal "Hello!", model.body
+      end
+
+      test "#serializable? returns true if value of the same class as the type" do
+        assert @type.serializable?(Post.new)
+      end
+
+      test "#serializable? returns false if value is not of the same class as the type" do
+        assert_not @type.serializable?("i'm not a post")
+      end
+
+      test "#changed_in_place? returns false if object attributes are the same" do
+        serialized_old_post = "#Post"
+        old_post, new_post = 2.times.map { Post.new(title: "Greeting") }
+        @type.stub(:deserialize, old_post) do
+          assert_not @type.changed_in_place?(serialized_old_post, new_post)
+        end
+      end
+
+      test "#changed_in_place? returns true if object attributes are not the same" do
+        serialized_old_post = "#Post"
+        old_post = Post.new(title: "Greeting")
+        new_post = Post.new(title: "About me")
+        @type.stub(:deserialize, old_post) do
+          assert @type.changed_in_place?(serialized_old_post, new_post)
+        end
+      end
+    end
+  end
+end

--- a/activemodel/test/models/post.rb
+++ b/activemodel/test/models/post.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Post
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :title, :string
+  attribute :body, :string
+end

--- a/activemodel/test/models/user.rb
+++ b/activemodel/test/models/user.rb
@@ -5,6 +5,10 @@ class User
   include ActiveModel::Attributes
   include ActiveModel::Dirty
   include ActiveModel::SecurePassword
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
 
   define_model_callbacks :create
 


### PR DESCRIPTION

### Summary

The new Model type handles all operations on conversion around model representations, from POROs to hashes and database string/JSON columns.

Attributes that are specified as the Model type are required to also specify a class name, which will be used to cast the given values into model instances. On the database serialization side, the model is represented as a JSON, with its `AttributeSet` being serialized by the types of each respective attribute.



### Docs:

`type`: returns the :model symbol.

`serializable?`: checks if the given value is an instance of the model class that this type was initialized with, returning false otherwise.

`serialize`: returns a string with the JSON representation of the given model attributes. It achieves that by calling values_for_database in the model’s AttributeSet, and converts the hash received into a JSON string.

`deserialize`: this method expects a JSON string, supposed to be a serialized set of attributes of a model instance. It proceeds to convert the JSON into a Ruby hash, and then instantiates a new model of the appropriate class name with the Ruby hash as its attributes. The mass assignment will allow each attribute to be deserialized accordingly and stored in the instance’s attribute set.

`cast`: receives a value that is either a hash of attributes or a model instance. It then instantiates a new model based on the class name with the given attributes. This means that if a model is passed, a new instance with the same attribute values will be returned, but not the exact same object.

`changed_in_place?`: Accepts a raw serialized attribute set, deserializes it and compares it with the given model instance. If the deserialized model’s attribute set is equal to the given model’s attribute set, returns true, or false otherwise.

`assert_valid_value`: this method checks if the given value can be cast to the model class. It takes either a model or a hash of attributes. If the model is not the same class as the type’s class name, or if the given hash contains keys that do not belong to the class's attribute set, it raises an error.

### Other Information

`attributes_for_database` was copied from 
https://github.com/rails/rails/blob/caced273937cf61c9ed2056877e0c3cd6a6b6577/activerecord/lib/active_record/attribute_methods/before_type_cast.rb#L70
with an intention to only exist in Active Model, but kept in both places for simplicity of this PR

