### PR TITLE
Fix ruby 2.7 keyword args warning for postgresql reconnection_error test

### DIFF
--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -53,7 +53,7 @@ module ActiveRecord
           { host: File::NULL }
         )
 
-        connect_raises_error = proc { |_conn_params| raise(PG::ConnectionBad, "actual bad connection error") }
+        connect_raises_error = proc { |**_conn_params| raise(PG::ConnectionBad, "actual bad connection error") }
         PG.stub(:connect, connect_raises_error) do
           error = assert_raises ActiveRecord::ConnectionNotEstablished do
             @conn.reconnect!


### PR DESCRIPTION
### Summary

Similar to https://github.com/rails/rails/pull/44346 but now it tests
My bad because I was the one who introduced the test.

Not causing any issues but a little bit annoying:
![image](https://user-images.githubusercontent.com/5512772/153315719-86c8d219-7434-4ee8-8d86-ce6f8c92bb91.png)
 


