### PR TITLE
Allow column name with COLLATE as safe SQL string

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow column name with COLLATE (e.g., title COLLATE "C") as safe SQL string
+
+    *Shugo Maeda*
+
 *   Permit underscores in the VERSION argument to database rake tasks.
 
     *Eddie Lebow*

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -97,6 +97,7 @@ module ActiveRecord
               # `table_name`.`column_name` | function(one or no argument)
               ((?:\w+\.|`\w+`\.)?(?:\w+|`\w+`)) | \w+\((?:|\g<2>)\)
             )
+            (?:\s+COLLATE\s+(?:\w+|"\w+"))?
             (?:\s+ASC|\s+DESC)?
           )
           (?:\s*,\s*\g<1>)*

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -149,6 +149,7 @@ module ActiveRecord
               # "schema_name"."table_name"."column_name"::type_name | function(one or no argument)::type_name
               ((?:\w+\.|"\w+"\.){,2}(?:\w+|"\w+")(?:::\w+)?) | \w+\((?:|\g<2>)\)(?:::\w+)?
             )
+            (?:\s+COLLATE\s+"\w+")?
             (?:\s+ASC|\s+DESC)?
             (?:\s+NULLS\s+(?:FIRST|LAST))?
           )

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -101,6 +101,7 @@ module ActiveRecord
               # "table_name"."column_name" | function(one or no argument)
               ((?:\w+\.|"\w+"\.)?(?:\w+|"\w+")) | \w+\((?:|\g<2>)\)
             )
+            (?:\s+COLLATE\s+(?:\w+|"\w+"))?
             (?:\s+ASC|\s+DESC)?
           )
           (?:\s*,\s*\g<1>)*

--- a/activerecord/test/cases/unsafe_raw_sql_test.rb
+++ b/activerecord/test/cases/unsafe_raw_sql_test.rb
@@ -166,6 +166,20 @@ class UnsafeRawSqlTest < ActiveRecord::TestCase
     assert_equal ids_expected, ids
   end
 
+  test "order: allows valid arguments with COLLATE" do
+    collation_name = {
+      "PostgreSQL" => "C",
+      "Mysql2" => "utf8mb4_bin",
+      "SQLite" => "binary"
+    }[ActiveRecord::Base.connection.adapter_name]
+
+    ids_expected = Post.order(Arel.sql(%Q'author_id, title COLLATE "#{collation_name}" DESC')).pluck(:id)
+
+    ids = Post.order(["author_id", %Q'title COLLATE "#{collation_name}" DESC']).pluck(:id)
+
+    assert_equal ids_expected, ids
+  end
+
   test "order: logs deprecation warning for unrecognized column" do
     e = assert_raises(ActiveRecord::UnknownAttributeReference) do
       Post.order("REPLACE(title, 'misc', 'zzzz')")


### PR DESCRIPTION
### Summary

Functions in the argument of ORDER BY is allowed now (#36448).
COLLATE should also be allowed.

```ruby
Post.order('title COLLATE "C"')
```

### Other Information

It seems that PostgreSQL requires quotes for collation names while MySQL and SQLite doesn't.
