### PR TITLE
fix activestorage update

### DIFF
--- a/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
+++ b/activestorage/db/update_migrate/20190112182829_add_service_name_to_active_storage_blobs.rb
@@ -1,5 +1,7 @@
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   def up
+    return unless table_exists?(:active_storage_blobs)
+
     unless column_exists?(:active_storage_blobs, :service_name)
       add_column :active_storage_blobs, :service_name, :string
 
@@ -12,6 +14,8 @@ class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   end
 
   def down
+    return unless table_exists?(:active_storage_blobs)
+
     remove_column :active_storage_blobs, :service_name
   end
 end

--- a/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
+++ b/activestorage/db/update_migrate/20191206030411_create_active_storage_variant_records.rb
@@ -1,5 +1,7 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change
+    return unless table_exists?(:active_storage_blobs)
+
     # Use Active Record's configured type for primary key
     create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type

--- a/activestorage/db/update_migrate/20211119233751_remove_not_null_on_active_storage_blobs_checksum.rb
+++ b/activestorage/db/update_migrate/20211119233751_remove_not_null_on_active_storage_blobs_checksum.rb
@@ -1,5 +1,7 @@
 class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
   def change
+    return unless table_exists?(:active_storage_blobs)
+
     change_column_null(:active_storage_blobs, :checksum, true)
   end
 end


### PR DESCRIPTION
### Summary
When I run `rails app:update`, it will generate some migration files by invoking `rails active_storage:update`, but I hadn't run `rails active_storage:install` before, so of course, the newly generated migrations will fail.

Check whether `active_storage_blobs` table exists by default would make `rails app:update` more smooth.