### PR TITLE
Update parameter filter logging guides [ci-skip]

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1166,13 +1166,19 @@ Rails keeps a log file for each environment in the `log` folder. These are extre
 
 ### Parameters Filtering
 
-You can filter out sensitive request parameters from your log files by appending them to `config.filter_parameters` in the application configuration. These parameters will be marked [FILTERED] in the log.
+You can filter out sensitive request parameters from your log files by
+appending them to `config.filter_parameters` in the application configuration.
+These parameters will be marked [FILTERED] in the log.
 
 ```ruby
 config.filter_parameters << :password
 ```
 
-NOTE: Provided parameters will be filtered out by partial matching regular expression. Rails adds default `:password` in the appropriate initializer (`initializers/filter_parameter_logging.rb`) and cares about typical application parameters `password` and `password_confirmation`.
+NOTE: Provided parameters will be filtered out by partial matching regular
+expression. Rails adds a list of default filters, including `:passw`,
+`:secret`, and `:token`, in the appropriate
+initializer(`initializers/filter_parameter_logging.rb`), to handle typical
+application parameters like `password`, `password_confirmation` and `my_token`.
 
 ### Redirects Filtering
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -247,8 +247,19 @@ Is the class used to detect file updates in the file system when `config.reload_
 
 #### `config.filter_parameters`
 
-Used for filtering out the parameters that you don't want shown in the logs, such as passwords or credit card
-numbers. It also filters out sensitive values of database columns when calling `#inspect` on an Active Record object. By default, Rails filters out passwords by adding `Rails.application.config.filter_parameters += [:password]` in `config/initializers/filter_parameter_logging.rb`. Parameters filter works by partial matching regular expression.
+Used for filtering out the parameters that you don't want shown in the logs,
+such as passwords or credit card numbers. It also filters out sensitive values
+of database columns when calling `#inspect` on an Active Record object. By
+default, Rails filters out passwords by adding the following filters in
+`config/initializers/filter_parameter_logging.rb`.
+
+```ruby
+Rails.application.config.filter_parameters += [
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+]
+```
+
+Parameters filter works by partial matching regular expression.
 
 #### `config.force_ssl`
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -510,7 +510,11 @@ By default, Rails logs all requests being made to the web application. But log f
 config.filter_parameters << :password
 ```
 
-NOTE: Provided parameters will be filtered out by partial matching regular expression. Rails adds default `:password` in the appropriate initializer (`initializers/filter_parameter_logging.rb`) and cares about typical application parameters `password` and `password_confirmation`.
+NOTE: Provided parameters will be filtered out by partial matching regular
+expression. Rails adds a list of default filters, including `:passw`,
+`:secret`, and `:token`, in the appropriate
+initializer(`initializers/filter_parameter_logging.rb`), to handle typical
+application parameters like `password`, `password_confirmation` and `my_token`.
 
 ### Regular Expressions
 


### PR DESCRIPTION
### Summary

Instead of just `[:password]`, the `filter_parameters` configuration includes
a list of filters in the latest `filter_parameter_logging` initializer template.
This updates the guides to reflect those changes.

-----------------------

### Before
<img width="674" alt="image" src="https://user-images.githubusercontent.com/28561/153430417-e40cb591-4999-496d-892a-72991af4f3f9.png">

### After
<img width="662" alt="image" src="https://user-images.githubusercontent.com/28561/153430344-04a0619f-d52b-4125-9881-cbb3655e4330.png">

---------------

### Before
<img width="665" alt="image" src="https://user-images.githubusercontent.com/28561/153429077-38110e09-1109-4227-9b5d-1269adb3a7a2.png">

### After
<img width="677" alt="image" src="https://user-images.githubusercontent.com/28561/153402599-78111224-a96a-4812-8891-eb551faa93b4.png">