### PR TITLE
Silence uninitialized instance var warning in tests

### DIFF
--- a/actionpack/test/controller/test_case_test.rb
+++ b/actionpack/test/controller/test_case_test.rb
@@ -1003,8 +1003,10 @@ XML
     assert_equal "1", response.body
   end
 
-  def test_can_read_instance_variables_before_or_after_request
-    assert_nil @controller.instance_variable_get(:@counter)
+  def test_can_read_instance_variables_before_and_after_request
+    silence_warnings do
+      assert_nil @controller.instance_variable_get(:@counter)
+    end
 
     get :increment_count
     assert_equal "1", response.body


### PR DESCRIPTION
### Summary

Running the Action Pack tests outputs a warning:

    ./actionpack/test/controller/test_case_test.rb:1007: warning: instance variable @counter not initialized

Surrounding the line with a `silence_warnings` block cleans up the output.