### PR TITLE
Fix some guide spacing and wrapping introduced in e3beba127b

### DIFF
--- a/guides/source/action_controller_overview.md
+++ b/guides/source/action_controller_overview.md
@@ -1176,9 +1176,9 @@ config.filter_parameters << :password
 
 NOTE: Provided parameters will be filtered out by partial matching regular
 expression. Rails adds a list of default filters, including `:passw`,
-`:secret`, and `:token`, in the appropriate
-initializer(`initializers/filter_parameter_logging.rb`), to handle typical
-application parameters like `password`, `password_confirmation` and `my_token`.
+`:secret`, and `:token`, in the appropriate initializer
+(`initializers/filter_parameter_logging.rb`), to handle typical application
+parameters like `password`, `password_confirmation` and `my_token`.
 
 ### Redirects Filtering
 

--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -512,9 +512,9 @@ config.filter_parameters << :password
 
 NOTE: Provided parameters will be filtered out by partial matching regular
 expression. Rails adds a list of default filters, including `:passw`,
-`:secret`, and `:token`, in the appropriate
-initializer(`initializers/filter_parameter_logging.rb`), to handle typical
-application parameters like `password`, `password_confirmation` and `my_token`.
+`:secret`, and `:token`, in the appropriate initializer
+(`initializers/filter_parameter_logging.rb`), to handle typical application
+parameters like `password`, `password_confirmation` and `my_token`.
 
 ### Regular Expressions
 


### PR DESCRIPTION
In e3beba127b a space character was removed between "initializer"
and "(`initializers/filter_parameter_logging.rb`)".

