### PR TITLE
Add module/class nesting consistency on newly generated application:

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/test/channels/application_cable/connection_test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/channels/application_cable/connection_test.rb.tt
@@ -1,11 +1,13 @@
 require "test_helper"
 
-class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
-  # test "connects with cookies" do
-  #   cookies.signed[:user_id] = 42
-  #
-  #   connect
-  #
-  #   assert_equal connection.user_id, "42"
-  # end
+module ApplicationCable
+  class ConnectionTest < ActionCable::Connection::TestCase
+    # test "connects with cookies" do
+    #   cookies.signed[:user_id] = 42
+    #
+    #   connect
+    #
+    #   assert_equal connection.user_id, "42"
+    # end
+  end
 end

--- a/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/test/test_helper.rb.tt
@@ -2,18 +2,20 @@ ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
 
-class ActiveSupport::TestCase
-  # Run tests in parallel with specified workers
+module ActiveSupport
+  class TestCase
+    # Run tests in parallel with specified workers
 <% if Process.respond_to?(:fork) && !Gem.win_platform? -%>
-  parallelize(workers: :number_of_processors)
+    parallelize(workers: :number_of_processors)
 <%- else -%>
-  parallelize(workers: :number_of_processors, with: :threads)
+    parallelize(workers: :number_of_processors, with: :threads)
 <% end -%>
 
 <% unless options[:skip_active_record] -%>
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
+    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    fixtures :all
 
 <% end -%>
-  # Add more helper methods to be used by all tests here...
+    # Add more helper methods to be used by all tests here...
+  end
 end

--- a/railties/test/application/rake_test.rb
+++ b/railties/test/application/rake_test.rb
@@ -182,7 +182,7 @@ module ApplicationTests
     end
 
     def test_code_statistics
-      assert_match "Code LOC: 62     Test LOC: 3     Code to Test Ratio: 1:0.0",
+      assert_match "Code LOC: 62     Test LOC: 5     Code to Test Ratio: 1:0.1",
         rails("stats")
     end
 


### PR DESCRIPTION
Hello 👋 , long time 😃  

Hoping to get this small change accepted even though it is style related.

- These two generated files are the only two that uses a compact style
   when defining a class, (it's not the case for their non-test
   counterpart i.e. https://github.com/rails/rails/blob/0f3642596f41bb323772fb7d160a3acdf0498650/railties/lib/rails/generators/rails/app/templates/app/channels/application_cable/connection.rb.tt#L1-L2).

  This fixes that to add some consistency and will avoid users using
  rubocop with the `Style/ClassAndModuleChildren: nested` rule to have
  to manually edit those files when generating a new app.

