### PR TITLE
Remove LIMIT and OFFSET on relations when batch iterating

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Remove `LIMIT` and `OFFSET` on relations when batch iterating
+
+    When using `find_each`, `find_in_batches`, or `in_batches` on a relation
+    with a specified limit or offset, the batch relation yielded no longer
+    propagates those values.
+
+    Other than being being useless or potentially problematic, the removal also
+    eliminates a subquery under certain conditions when using `JOIN` with MySQL.
+
+    *Alex Coomans*
+
 *   Include current character length in error messages for index and table name length validations.
 
     *Joshua Young*


### PR DESCRIPTION
When using `find_each`, `find_in_batches`, or `in_batches` on a relation with a specified limit, the batch relation yielded no longer propagates those values.

Other than being being useless or potentially problematic, the removal also eliminates a subquery under certain conditions when using `JOIN` with MySQL.

In the test cases I added, the queries executed go from: 

```sql
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL ORDER BY `posts`.`id` ASC LIMIT 3
DELETE FROM `posts` WHERE `posts`.`id` IN (SELECT `id` FROM (SELECT `posts`.`id` FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` IN (3, 6, 8) LIMIT 5) AS __active_record_temp)
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` > 8 ORDER BY `posts`.`id` ASC LIMIT 2
DELETE FROM `posts` WHERE `posts`.`id` IN (SELECT `id` FROM (SELECT `posts`.`id` FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` IN (9, 10) LIMIT 5) AS __active_record_temp)
```

To:

```sql
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL ORDER BY `posts`.`id` ASC LIMIT 3
DELETE `posts` FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` IN (3, 6, 8)
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` > 8 ORDER BY `posts`.`id` ASC LIMIT 2
DELETE `posts` FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` IN (9, 10).
```

And from:

```sql
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL ORDER BY `posts`.`id` ASC LIMIT 3 OFFSET 2
UPDATE `posts` SET `posts`.`legacy_comments_count` = 0 WHERE `posts`.`id` IN (SELECT `id` FROM (SELECT `posts`.`id` FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` IN (8, 9, 10) LIMIT 18446744073709551615 OFFSET 2) AS __active_record_temp)
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` > 10 ORDER BY `posts`.`id` ASC LIMIT 3 OFFSET 2
```

To: 

```sql
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL ORDER BY `posts`.`id` ASC LIMIT 3 OFFSET 2
UPDATE `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` SET `posts`.`legacy_comments_count` = 0 WHERE `comments`.`id` IS NULL AND `posts`.`id` IN (8, 9, 10)
SELECT `posts`.* FROM `posts` LEFT OUTER JOIN `comments` ON `comments`.`post_id` = `posts`.`id` WHERE `comments`.`id` IS NULL AND `posts`.`id` > 10 ORDER BY `posts`.`id` ASC LIMIT 3 OFFSET 2.
```

While both can cause improper query execution, the test cases shows the usage of `OFFSET` is much easier to trigger this issue compared to `LIMIT`.

I believe the subquery behavior with Postgres and SQLite is as expected, but I'm not as familiar with their internals.