### PR TITLE
Handle quoting of Rational numbers for MySQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix quoting of `ActiveSupport::Duration` and `Rational` numbers in the MySQL adapter.
+
+    *Kevin McPhillips*
+
 *   Allow column name with COLLATE (e.g., title COLLATE "C") as safe SQL string
 
     *Shugo Maeda*

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -8,6 +8,8 @@ module ActiveRecord
       module Quoting # :nodoc:
         def quote_bound_value(value)
           case value
+          when Rational
+            quote(value.to_f.to_s)
           when Numeric, ActiveSupport::Duration
             quote(value.to_s)
           when BigDecimal

--- a/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
@@ -72,6 +72,11 @@ module ActiveRecord
           assert_equal 0, count
         end
 
+        def test_where_with_rational_for_string_column_using_bind_parameters
+          count = Post.where("title = ?", Rational(0)).count
+          assert_equal 0, count
+        end
+
         def test_where_with_duration_for_string_column_using_bind_parameters
           count = Post.where("title = ?", 0.seconds).count
           assert_equal 0, count

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -16,6 +16,10 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
     assert_equal "'4.2'", @conn.quote_bound_value(BigDecimal("4.2"))
   end
 
+  def test_quote_bound_rational
+    assert_equal "'0.75'", @conn.quote_bound_value(Rational(3, 4))
+  end
+
   def test_quote_bound_duration
     assert_equal "'42'", @conn.quote_bound_value(42.seconds)
   end

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -37,6 +37,12 @@ module ActiveRecord
           end
         end
 
+        def test_where_with_rational_for_string_column_using_bind_parameters
+          assert_raises ActiveRecord::StatementInvalid do
+            Post.where("title = ?", Rational(0)).count
+          end
+        end
+
         def test_where_with_duration_for_string_column_using_bind_parameters
           assert_raises ActiveRecord::StatementInvalid do
             Post.where("title = ?", 0.seconds).count

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -33,6 +33,11 @@ module ActiveRecord
           assert_equal 0, count
         end
 
+        def test_where_with_rational_for_string_column_using_bind_parameters
+          count = Post.where("title = ?", Rational(0)).count
+          assert_equal 0, count
+        end
+
         def test_where_with_duration_for_string_column_using_bind_parameters
           count = Post.where("title = ?", 0.seconds).count
           assert_equal 0, count

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -336,6 +336,11 @@ module ActiveRecord
       assert_equal 0, count
     end
 
+    def test_where_with_rational_for_string_column
+      count = Post.where(title: Rational(0)).count
+      assert_equal 0, count
+    end
+
     def test_where_with_duration_for_string_column
       count = Post.where(title: 0.seconds).count
       assert_equal 0, count


### PR DESCRIPTION
### Summary

Quoting for numbers in MySQL was added in #42440. 

In the case of `Rational` it was handled as a `Numeric` and had `.to_s` called on it and was quoted. But `.to_s` on a rational returns the fractional representation, resulting in the quoted value being `'3/5'` which did not work for MySQL.

This solution first turns the value into a float, then string and quote as normal.