### PR TITLE
Fix javascript example code block [ci-skip]

### DIFF
--- a/guides/source/working_with_javascript_in_rails.md
+++ b/guides/source/working_with_javascript_in_rails.md
@@ -42,6 +42,7 @@ $ bin/importmap pin react react-dom
 ```
 
 Then, import the package into `application.js` as usual:
+
 ```javascript
 import React from "react"
 import ReactDOM from "react-dom"
@@ -57,7 +58,8 @@ bundling, you can create new Rails applications with your choice of
 
 To use a bundler instead of import maps in a new Rails application, pass the `—javascript` or `-j`
 option to `rails new`:
-```
+
+```bash
 $ rails new my_new_app --javascript=webpack
 OR
 $ rails new my_new_app -j webpack


### PR DESCRIPTION
Linebreaks are required before code blocks.

### Before

<img width="513" alt="image" src="https://user-images.githubusercontent.com/28561/153662613-2ea435dd-156c-48ba-9b26-9818da819314.png">

<img width="674" alt="image" src="https://user-images.githubusercontent.com/28561/153662980-1afa5ce0-7432-422c-8eb9-376190324b21.png">


### After

<img width="668" alt="image" src="https://user-images.githubusercontent.com/28561/153662806-75e76dd3-70f7-49c5-b666-6c6f323fb4f5.png">

<img width="657" alt="image" src="https://user-images.githubusercontent.com/28561/153663125-4efcd4e3-9e65-490c-8ed7-4c5b84a16ce6.png">
