### PR TITLE
Quote ActiveSupport::Duration in mysql2 adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       module Quoting # :nodoc:
         def quote_bound_value(value)
           case value
-          when Numeric
+          when Numeric, ActiveSupport::Duration
             quote(value.to_s)
           when BigDecimal
             quote(value.to_s("F"))

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -16,6 +16,10 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
     assert_equal "'4.2'", @conn.quote_bound_value(BigDecimal("4.2"))
   end
 
+  def test_quote_bound_duration
+    assert_equal "'42'", @conn.quote_bound_value(42.seconds)
+  end
+
   def test_quote_bound_true
     assert_equal "'1'", @conn.quote_bound_value(true)
   end

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      class BindParameterTest < ActiveRecord::PostgreSQLTestCase
+        fixtures :posts
+
+        def test_where_with_string_for_string_column_using_bind_parameters
+          count = Post.where("title = ?", "Welcome to the weblog").count
+          assert_equal 1, count
+        end
+
+        def test_where_with_integer_for_string_column_using_bind_parameters
+          assert_raises ActiveRecord::StatementInvalid do
+            Post.where("title = ?", 0).count
+          end
+        end
+
+        def test_where_with_float_for_string_column_using_bind_parameters
+          assert_raises ActiveRecord::StatementInvalid do
+            Post.where("title = ?", 0.0).count
+          end
+        end
+
+        def test_where_with_boolean_for_string_column_using_bind_parameters
+          assert_raises ActiveRecord::StatementInvalid do
+            Post.where("title = ?", false).count
+          end
+        end
+
+        def test_where_with_decimal_for_string_column_using_bind_parameters
+          assert_raises ActiveRecord::StatementInvalid do
+            Post.where("title = ?", BigDecimal(0)).count
+          end
+        end
+
+        def test_where_with_duration_for_string_column_using_bind_parameters
+          assert_raises ActiveRecord::StatementInvalid do
+            Post.where("title = ?", 0.seconds).count
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -1,51 +1,12 @@
 # frozen_string_literal: true
 
 require "cases/helper"
-require "models/topic"
 
 module ActiveRecord
   module ConnectionAdapters
-    class Mysql2Adapter
-      class BindParameterTest < ActiveRecord::Mysql2TestCase
-        fixtures :topics, :posts
-
-        def test_update_question_marks
-          str       = "foo?bar"
-          x         = Topic.first
-          x.title   = str
-          x.content = str
-          x.save!
-          x.reload
-          assert_equal str, x.title
-          assert_equal str, x.content
-        end
-
-        def test_create_question_marks
-          str = "foo?bar"
-          x   = Topic.create!(title: str, content: str)
-          x.reload
-          assert_equal str, x.title
-          assert_equal str, x.content
-        end
-
-        def test_update_null_bytes
-          str       = "foo\0bar"
-          x         = Topic.first
-          x.title   = str
-          x.content = str
-          x.save!
-          x.reload
-          assert_equal str, x.title
-          assert_equal str, x.content
-        end
-
-        def test_create_null_bytes
-          str = "foo\0bar"
-          x   = Topic.create!(title: str, content: str)
-          x.reload
-          assert_equal str, x.title
-          assert_equal str, x.content
-        end
+    class SQLite3Adapter
+      class BindParameterTest < ActiveRecord::SQLite3TestCase
+        fixtures :posts
 
         def test_where_with_string_for_string_column_using_bind_parameters
           count = Post.where("title = ?", "Welcome to the weblog").count


### PR DESCRIPTION
## Summary

In working through #44404 I was trying to expand test coverage and found that `ActiveSupport::Duration` objects need to be handled and quoted in the MySQL adapter as well. This expands upon This is a followup on #42440 and https://github.com/rails/rails/pull/16069 as mitigation for [Potential Query Manipulation with Common Rails Practices and MySQL](https://groups.google.com/g/rubyonrails-security/c/ZOdH5GH5jCU).

In this case, `ActiveSupport::Duration` objects when called `.to_s` return the integer number of sections. If they are not handled in the MySQL quoting they are passed up to the [abstract connection adapter](https://github.com/rails/rails/blob/97d5716f3733a91bfa9cebd3bbaca294ea81ce2a/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L20) where they are treated as a numeric and not a string.

This is technically a security fix, but seems like a hard vector to target. I don't have a PoC.

@byroot @casperisfine @rafaelfranca 
