### PR TITLE
Improve Rails 7 documentation for the command line and asset pipeline [ci-skip]

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -27,10 +27,10 @@ from other gems.
 The asset pipeline is implemented by the
 [sprockets-rails](https://github.com/rails/sprockets-rails) gem,
 and is enabled by default. You can disable it while creating a new application by
-passing the `--skip-sprockets` option.
+passing the `--skip-asset-pipeline` option.
 
 ```bash
-$ rails new appname --skip-sprockets
+$ rails new appname --skip-asset-pipeline
 ```
 
 Rails can easily work with Sass by adding the [`sassc-rails`](https://github.com/sass/sassc-rails)
@@ -444,7 +444,7 @@ which contains these lines:
 ```
 
 Rails creates `app/assets/stylesheets/application.css` regardless of whether the
-`--skip-sprockets` option is used when creating a new Rails application. This is
+`--skip-asset-pipeline` option is used when creating a new Rails application. This is
 so you can easily add asset pipelining later if you like.
 
 The directives that work in JavaScript files also work in stylesheets

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -101,7 +101,7 @@ If you wish to skip some files or components from being generated, you can appen
 | `--skip-active-record`  | Skip Active Record files                                    |
 | `--skip-active-storage` | Skip Active Storage files                                   |
 | `--skip-action-cable`   | Skip Action Cable files                                     |
-| `--skip-sprockets`      | Skip Sprockets files                                        |
+| `--skip-asset-pipeline` | Skip Asset Pipeline                                         |
 | `--skip-javascript`     | Skip JavaScript files                                       |
 | `--skip-turbolinks`     | Skip turbolinks gem                                         |
 | `--skip-test`           | Skip test files                                             |
@@ -118,7 +118,7 @@ With no further work, `bin/rails server` will run our new shiny Rails app:
 $ cd commandsapp
 $ bin/rails server
 => Booting Puma
-=> Rails 6.0.0 application starting in development
+=> Rails 7.0.0 application starting in development
 => Run `bin/rails server --help` for more startup options
 Puma starting in single mode...
 * Version 3.12.1 (ruby 2.5.7-p206), codename: Llamas in Pajamas
@@ -441,7 +441,7 @@ $ bin/rails destroy model Oops
 ```bash
 $ bin/rails about
 About your application's environment
-Rails version             6.0.0
+Rails version             7.0.0
 Ruby version              2.7.0 (x86_64-linux)
 RubyGems version          2.7.3
 Rack version              2.0.4


### PR DESCRIPTION
### Summary

This PR intends to improve the Rails 7 documentation

1. The Rails 7 documentation for the [Rails command line](https://guides.rubyonrails.org/command_line.html), mentions 6.0.0 in places where it should mention 7.0.0
2. Since Rails 7 command line does not ship with `--skip-sprockets` option, I've removed the option for the documentation here as well.

Thanks!

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->