### PR TITLE
Add missing skip options for Rails 7 command line documentation [ci-skip]

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -97,13 +97,16 @@ If you wish to skip some files or components from being generated, you can appen
 | `--skip-git`            | Skip .gitignore file                                        |
 | `--skip-keeps`          | Skip source control .keep files                             |
 | `--skip-action-mailer`  | Skip Action Mailer files                                    |
+| `--skip-action-mailbox` | Skip Action Mailbox gem                                     |
 | `--skip-action-text`    | Skip Action Text gem                                        |
 | `--skip-active-record`  | Skip Active Record files                                    |
+| `--skip-active-job`     | Skip Active Job                                             |
 | `--skip-active-storage` | Skip Active Storage files                                   |
 | `--skip-action-cable`   | Skip Action Cable files                                     |
 | `--skip-asset-pipeline` | Skip Asset Pipeline                                         |
 | `--skip-javascript`     | Skip JavaScript files                                       |
-| `--skip-turbolinks`     | Skip turbolinks gem                                         |
+| `--skip-hotwire`        | Skip Hotwire integration                                    |
+| `--skip-jbuilder`       | Skip jbuilder gem                                           |
 | `--skip-test`           | Skip test files                                             |
 | `--skip-system-test`    | Skip system test files                                      |
 | `--skip-bootsnap`       | Skip bootsnap gem                                           |


### PR DESCRIPTION
### Summary

In a [PR](https://github.com/rails/rails/pull/44409) I had raised earlier I had added documentation for the `skip-asset-pipeline` option.

The Rails 7 command line has more skip options than which are listed in the document. So I've added the missing skip options in the documentation for this PR.

I've also removed the `--skip-turbolinks` option since Rails 7 is not shipping with this option.

I've ordered the skip options here so that they are listed in the same order as when `rails --help` is run, along with the same description as listed.

Thanks!

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

