### PR TITLE
Add missing `bigdecimal` require in `ActiveJob::Arguments`

### DIFF
--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Add missing `bigdecimal` require in `ActiveJob::Arguments`
+
+    Could cause `uninitialized constant ActiveJob::Arguments::BigDecimal (NameError)`
+    when loading Active Job in isolation.
+
+    *Jean Boussier*
+
 *   Allow testing `discard_on/retry_on ActiveJob::DeserializationError`
 
     Previously in `perform_enqueued_jobs`, `deserialize_arguments_if_needed`

--- a/activejob/lib/active_job/arguments.rb
+++ b/activejob/lib/active_job/arguments.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bigdecimal"
 require "active_support/core_ext/hash"
 
 module ActiveJob


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/44399

Could cause `uninitialized constant ActiveJob::Arguments::BigDecimal (NameError)` when loading Active Job in isolation.
