### PR TITLE
Update action_text/index.js

### DIFF
--- a/actiontext/app/javascript/actiontext/index.js
+++ b/actiontext/app/javascript/actiontext/index.js
@@ -1,4 +1,4 @@
-import { AttachmentUpload } from "./attachment_upload"
+import { AttachmentUpload } from "./attachment_upload.js"
 
 addEventListener("trix-attachment-add", event => {
   const { attachment, target } = event


### PR DESCRIPTION
For webpack 6, it should be changed this way.

### Summary

I'm trying to use Shakapacker in my Webpack application. Everything works, but Actiontext collapses because of this line. 