### PR TITLE
Update description of working with JavaScript guide [ci-skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -211,7 +211,9 @@
       name: Working with JavaScript in Rails
       work_in_progress: true
       url: working_with_javascript_in_rails.html
-      description: This guide covers the built-in Ajax/JavaScript functionality of Rails.
+      description: >
+        This guide explains how to use import maps or jsbundling-rails to include
+        JavaScript in Rails applications, and covers the basics of working with Turbo in Rails.
     -
       name: The Rails Initialization Process
       work_in_progress: true


### PR DESCRIPTION
### Summary

https://github.com/rails/rails/pull/43957 was a complete rewrite of the working with JavaScript guide. The description of the guide on the guides index page is no longer accurate after this rewrite and probably should have been updated in the #43957 but I didn't think to check the description while working on that PR.

Happy to adjust the language as desired.

### Other Information

Current description:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/2747877/153718882-cecf79f7-af09-460a-b859-46cc99d7e759.png">

New description, after `bundle exec rake guides:generate:html` locally, to make sure I didn't mess up any formatting this time ;)

<img width="669" alt="image" src="https://user-images.githubusercontent.com/2747877/153718823-bd32be71-ccf7-4d4e-b3d6-312dda23a507.png">
