### PR TITLE
Add require "models/post" to address NameError: uninitialized constant

### DIFF
--- a/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
@@ -2,6 +2,7 @@
 
 require "cases/helper"
 require "models/topic"
+require "models/post"
 
 module ActiveRecord
   module ConnectionAdapters

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/post"
 
 module ActiveRecord
   module ConnectionAdapters

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cases/helper"
+require "models/post"
 
 module ActiveRecord
   module ConnectionAdapters


### PR DESCRIPTION
### Summary

Follow up #44408

This commit addresses Active Record isolated CI failures. Here is one of them.

```ruby
$ ARCONN=sqlite3 bundle exec ruby -w -Itest -Ilib -I../activesupport/lib -I../activemodel/lib test/cases/adapters/sqlite3/bind_parameter_test.rb -n test_where_with_string_for_string_column_using_bind_parameters
Using sqlite3
Run options: -n test_where_with_string_for_string_column_using_bind_parameters --seed 21170

E

Error:
ActiveRecord::ConnectionAdapters::SQLite3Adapter::BindParameterTest#test_where_with_string_for_string_column_using_bind_parameters:
NameError: uninitialized constant ActiveRecord::ConnectionAdapters::SQLite3Adapter::BindParameterTest::Post
    test/cases/adapters/sqlite3/bind_parameter_test.rb:12:in `test_where_with_string_for_string_column_using_bind_parameters'

rails test test/cases/adapters/sqlite3/bind_parameter_test.rb:11

Finished in 0.017992s, 55.5789 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```

Other isolated CI failures are also addressed.

```ruby
ARCONN=sqlite3 bundle exec ruby -w -Itest -Ilib -I../activesupport/lib -I../activemodel/lib test/cases/adapters/sqlite3/bind_parameter_test.rb
ARCONN=mysql2 bundle exec ruby -w -Itest -Ilib -I../activesupport/lib -I../activemodel/lib test/cases/adapters/mysql2/bind_parameter_test.rb
ARCONN=postgresql bundle exec ruby -w -Itest -Ilib -I../activesupport/lib -I../activemodel/lib test/cases/adapters/postgresql/bind_parameter_test.rb
```
