### PR TITLE
Convert lib and frameworks to bulleted list-README [ci-skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,16 @@ are bundled together in [Action Pack](actionpack/README.rdoc).
 ## Frameworks and libraries
 
 [Active Record](activerecord/README.rdoc), [Active Model](activemodel/README.rdoc), [Action Pack](actionpack/README.rdoc), and [Action View](actionview/README.rdoc) can each be used independently outside Rails.
-In addition to that, Rails also comes with [Action Mailer](actionmailer/README.rdoc), a library
-to generate and send emails; [Action Mailbox](actionmailbox/README.md), a library to receive emails within a Rails application;
-[Active Job](activejob/README.md), a framework for declaring jobs and making them run on a variety of queuing
-backends; [Action Cable](actioncable/README.md), a framework to
-integrate WebSockets with a Rails application; [Active Storage](activestorage/README.md), a library to attach cloud
-and local files to Rails applications; [Action Text](actiontext/README.md), a library to handle rich text content;
-and [Active Support](activesupport/README.rdoc), a collection
-of utility classes and standard library extensions that are useful for Rails,
-and may also be used independently outside Rails.
+
+In addition to that, Rails also comes with:
+
+- [Action Mailer](actionmailer/README.rdoc), a library to generate and send emails
+- [Action Mailbox](actionmailbox/README.md), a library to receive emails within a Rails application
+- [Active Job](activejob/README.md), a framework for declaring jobs and making them run on a variety of queuing backends
+- [Action Cable](actioncable/README.md), a framework to integrate WebSockets with a Rails application
+- [Active Storage](activestorage/README.md), a library to attach cloud and local files to Rails applications
+- [Action Text](actiontext/README.md), a library to handle rich text content
+- [Active Support](activesupport/README.rdoc), a collection of utility classes and standard library extensions that are useful for Rails, and may also be used independently outside Rails
 
 ## Getting Started
 


### PR DESCRIPTION
### Summary

Currently in the README.md, libraries and frameworks are listed in one line. It's harder to read. It'll look better if we convert it to a bulleted list. So readability will improve.
