### PR TITLE
Upgrade to sdoc 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.3.0"
+  gem "sdoc", ">= 2.3.1"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
-    sdoc (2.3.0)
+    sdoc (2.3.1)
       rdoc (>= 5.0, < 6.4.0)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -632,7 +632,7 @@ DEPENDENCIES
   rubocop-packaging
   rubocop-performance
   rubocop-rails
-  sdoc (>= 2.3.0)
+  sdoc (>= 2.3.1)
   selenium-webdriver (>= 4.0.0)
   sequel
   sidekiq


### PR DESCRIPTION
### Summary

Fixes the following error in Firefox/Linux:

    Ctrl-C broken (Uncaught TypeError: $.browser is undefined)

https://github.com/zzak/sdoc/issues/173