### PR TITLE
Update tests and docs for ActiveRecord::Sanitization

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -5,14 +5,14 @@ module ActiveRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      # Accepts an array or string of SQL conditions and sanitizes
-      # them into a valid SQL fragment for a WHERE clause.
+      # Accepts an array or string of SQL conditions and sanitizes them into
+      # a valid SQL fragment for a WHERE clause, using the adapter of the current `connection`.
       #
       #   sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id=4"
       #
       #   sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
-      #   # => "name='foo''bar' and group_id='4'"
+      #   # => "name='foo''bar' and group_id=4"
       #
       #   sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id='4'"
@@ -29,8 +29,8 @@ module ActiveRecord
       end
       alias :sanitize_sql :sanitize_sql_for_conditions
 
-      # Accepts an array, hash, or string of SQL conditions and sanitizes
-      # them into a valid SQL fragment for a SET clause.
+      # Accepts an array, hash, or string of SQL conditions and sanitizes them into
+      # a valid SQL fragment for a SET clause, using the adapter of the current `connection`.
       #
       #   sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
       #   # => "name=NULL and group_id=4"
@@ -39,7 +39,7 @@ module ActiveRecord
       #   # => "name=NULL and group_id=4"
       #
       #   Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
-      #   # => "`posts`.`name` = NULL, `posts`.`group_id` = 4"
+      #   # => "\"name\" = NULL, \"group_id\" = 4"
       #
       #   sanitize_sql_for_assignment("name=NULL and group_id='4'")
       #   # => "name=NULL and group_id='4'"
@@ -51,10 +51,10 @@ module ActiveRecord
         end
       end
 
-      # Accepts an array, or string of SQL conditions and sanitizes
-      # them into a valid SQL fragment for an ORDER clause.
+      # Accepts an array, or string of SQL conditions and sanitizes them into
+      # a valid SQL fragment for an ORDER clause, using the adapter of the current `connection`.
       #
-      #   sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1,3,2]])
+      #   sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
       #   # => "field(id, 1,3,2)"
       #
       #   sanitize_sql_for_order("id ASC")
@@ -78,10 +78,11 @@ module ActiveRecord
         end
       end
 
-      # Sanitizes a hash of attribute/value pairs into SQL conditions for a SET clause.
+      # Sanitizes a hash of attribute/value pairs into SQL conditions for a SET
+      # clause, using the adapter of the current `connection`.
       #
       #   sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
-      #   # => "`posts`.`status` = NULL, `posts`.`group_id` = 1"
+      #   # => "\"status\" = NULL, \"group_id\" = 1"
       def sanitize_sql_hash_for_assignment(attrs, table)
         c = connection
         attrs.map do |attr, value|
@@ -114,8 +115,8 @@ module ActiveRecord
         string.gsub(/(?=[%_])/, escape_character)
       end
 
-      # Accepts an array of conditions. The array has each value
-      # sanitized and interpolated into the SQL statement.
+      # Accepts an array of conditions. The array has each value sanitized and interpolated into
+      # the SQL statement, valid for the adapter of the current `connection`
       #
       #   sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
       #   # => "name='foo''bar' and group_id=4"

--- a/activerecord/test/cases/adapters/mysql2/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/sanitize_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class Mysql2SanitizeTest < ActiveRecord::Mysql2TestCase
+  def test_sanitize_sql_for_conditions_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_assignment_from_docs
+    actual = Post.sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+    expected = "`posts`.`name` = NULL, `posts`.`group_id` = 4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment("name=NULL and group_id='4'")
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_order_from_docs
+    skip "See https://github.com/rails/rails/issues/44312"
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, 1,3,2)"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order("id ASC")
+    expected = "id ASC"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_hash_for_assignment_from_docs
+    actual = Post.sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+    expected = "`posts`.`status` = NULL, `posts`.`group_id` = 1"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_like_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_like("100%")
+    expected = "100\\%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string")
+    expected = "snake\\_cased\\_string"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("100%", "!")
+    expected = "100!%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string", "!")
+    expected = "snake!_cased!_string"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_array_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo\\'bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/sanitize_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class PostgreSQLSanitizeTest < ActiveRecord::PostgreSQLTestCase
+  def test_sanitize_sql_for_conditions_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_assignment_from_docs
+    actual = Post.sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+    expected = "\"name\" = NULL, \"group_id\" = 4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment("name=NULL and group_id='4'")
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_order_from_docs
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, 1,3,2)"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order("id ASC")
+    expected = "id ASC"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_hash_for_assignment_from_docs
+    actual = Post.sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+    expected = "\"status\" = NULL, \"group_id\" = 1"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_like_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_like("100%")
+    expected = "100\\%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string")
+    expected = "snake\\_cased\\_string"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("100%", "!")
+    expected = "100!%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string", "!")
+    expected = "snake!_cased!_string"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_array_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+end

--- a/activerecord/test/cases/adapters/sqlite3/sanitize_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sanitize_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/post"
+
+class SQLite3SanitizeTest < ActiveRecord::SQLite3TestCase
+  def test_sanitize_sql_for_conditions_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_for_conditions("name='foo''bar' and group_id='4'")
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_assignment_from_docs
+    actual = Post.sanitize_sql_for_assignment(["name=? and group_id=?", nil, 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment(["name=:name and group_id=:group_id", name: nil, group_id: 4])
+    expected = "name=NULL and group_id=4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment({ name: nil, group_id: 4 })
+    expected = "\"name\" = NULL, \"group_id\" = 4"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_assignment("name=NULL and group_id='4'")
+    expected = "name=NULL and group_id='4'"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_for_order_from_docs
+    actual = Post.sanitize_sql_for_order([Arel.sql("field(id, ?)"), [1, 3, 2]])
+    expected = "field(id, 1,3,2)"
+    assert_equal expected, actual
+
+    actual = Post.sanitize_sql_for_order("id ASC")
+    expected = "id ASC"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_hash_for_assignment_from_docs
+    actual = Post.sanitize_sql_hash_for_assignment({ status: nil, group_id: 1 }, "posts")
+    expected = "\"status\" = NULL, \"group_id\" = 1"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_like_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_like("100%")
+    expected = "100\\%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string")
+    expected = "snake\\_cased\\_string"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("100%", "!")
+    expected = "100!%"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_like("snake_cased_string", "!")
+    expected = "snake!_cased!_string"
+    assert_equal expected, actual
+  end
+
+  def test_sanitize_sql_array_from_docs
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=? and group_id=?", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name=:name and group_id=:group_id", name: "foo'bar", group_id: 4])
+    expected = "name='foo''bar' and group_id=4"
+    assert_equal expected, actual
+
+    actual = ActiveRecord::Base.sanitize_sql_array(["name='%s' and group_id='%s'", "foo'bar", 4])
+    expected = "name='foo''bar' and group_id='4'"
+    assert_equal expected, actual
+  end
+end


### PR DESCRIPTION
## Summary

In trying to write some failing test cases for #44312, I found that most of [`ActiveRecord::Sanitization`](https://github.com/rails/rails/blob/7ac90d9ad75c50129850572ed6c7dcd42fecbf3b/activerecord/lib/active_record/sanitization.rb) is untested. [Only a subset of it has test coverage](https://github.com/rails/rails/blob/7ac90d9ad75c50129850572ed6c7dcd42fecbf3b/activerecord/test/cases/sanitize_test.rb), and much of that coverage is agnostic to the underlying connection adapter.

And that last part is the interesting part. The result of all but one of the public sanitization methods in this module **depend on the current `ActiveRecord::Base.connection` to decide how to escape the string**, and that is not reflected in docs or in tests.

I have added comprehensive test coverage local to each adapter. The tests use all the examples in the inline docs, many of which were wrong. 

Next, I will use the tests to work on #44404, and they also would have caught the regression in #44312. I updated the docs to reflect the connection dependent behaviour, and updated the cases where the output shown was not what is actually output. I have opted to use the SQLite3/PostgreSQL behaviour in docs as they are both (currently) the same, and presumably SQLite3 is the simplest use case.

I understand that typically PRs of just tests are not merged. Feedback welcome.

@rafaelfranca @byroot 