### PR TITLE
[docs] Remove incorrect sprockets reference

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -542,7 +542,6 @@ require "rails"
   action_mailbox/engine
   action_text/engine
   rails/test_unit/railtie
-  sprockets/railtie
 ).each do |railtie|
   begin
     require railtie


### PR DESCRIPTION
Updated the list of engines to match current state of https://github.com/rails/rails/blob/main/railties/lib/rails/all.rb

This was mentioned in https://github.com/rails/rails/issues/44292