### PR TITLE
Add Working With JavaScript guide to navigation [ci skip]

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -209,7 +209,6 @@
         CoffeeScript, Sass, and ERB.
     -
       name: Working with JavaScript in Rails
-      work_in_progress: true
       url: working_with_javascript_in_rails.html
       description: >
         This guide explains how to use import maps or jsbundling-rails to include


### PR DESCRIPTION
### Summary

The [Working With JavaScript guide](https://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html) was rewritten in https://github.com/rails/rails/pull/43957.

After the rewrite, this guide feels like it should be fairly stable moving forward. Users would benefit from it being discoverable in the navigation and from the removal of the work in progress warning.