### PR TITLE
Fix setting `trailing_slash: true` in route definition

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Fix setting `trailing_slash: true` in route definition.
+
+    ```ruby
+    get '/test' => "test#index", as: :test, trailing_slash: true
+
+    test_path() # => "/test/"
+    ```
+
+    *Jean Boussier*
+
 *   Make `Session#merge!` stringify keys.
 
     Previously `Session#update` would, but `merge!` wouldn't.

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -196,7 +196,9 @@ module ActionDispatch
             def call(t, method_name, args, inner_options, url_strategy)
               if args.size == arg_size && !inner_options && optimize_routes_generation?(t)
                 options = t.url_options.merge @options
-                options[:path] = optimized_helper(args)
+                path = optimized_helper(args)
+                path << "/" if options[:trailing_slash] && !path.end_with?("/")
+                options[:path] = path
 
                 original_script_name = options.delete(:original_script_name)
                 script_name = t._routes.find_script_name(options)

--- a/actionpack/test/dispatch/url_generation_test.rb
+++ b/actionpack/test/dispatch/url_generation_test.rb
@@ -16,12 +16,21 @@ module TestUrlGeneration
       def add_trailing_slash
         render plain: url_for(trailing_slash: true, params: request.query_parameters, format: params[:format])
       end
+
+      def trailing_slash_default
+        if params[:url]
+          render plain: trailing_slash_default_url(format: params[:url_format])
+        else
+          render plain: trailing_slash_default_path(format: params[:url_format])
+        end
+      end
     end
 
     Routes.draw do
       get "/foo", to: "my_route_generating#index", as: :foo
       get "(/optional/:optional_id)/baz", to: "my_route_generating#index", as: :baz
       get "/add_trailing_slash", to: "my_route_generating#add_trailing_slash", as: :add_trailing_slash
+      get "/trailing_slash_default", to: "my_route_generating#trailing_slash_default", as: :trailing_slash_default, trailing_slash: true
 
       resources :bars
 
@@ -174,6 +183,22 @@ module TestUrlGeneration
     test "generating the current URL with a trailing slashes and format indicator" do
       get "/add_trailing_slash.json"
       assert_equal "http://www.example.com/add_trailing_slash.json", response.body
+    end
+
+    test "generating the path with `trailing_slashes: true` default options" do
+      get "/trailing_slash_default"
+      assert_equal "/trailing_slash_default/", response.body
+
+      get "/trailing_slash_default?url=1"
+      assert_equal "http://www.example.com/trailing_slash_default/", response.body
+    end
+
+    test "generating the path with `trailing_slashes: true` default options and format" do
+      get "/trailing_slash_default?url_format=json"
+      assert_equal "/trailing_slash_default.json", response.body
+
+      get "/trailing_slash_default?url=1&url_format=json"
+      assert_equal "http://www.example.com/trailing_slash_default.json", response.body
     end
 
     test "generating URLs with trailing slashes" do


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43287
Fix: https://github.com/rails/rails/issues/44373

The `OptimizedUrlHelper` wasn't considering this option.
