### PR TITLE
Fix typo in guide for scopes for has_and_belongs_to_many association

### DIFF
--- a/guides/source/association_basics.md
+++ b/guides/source/association_basics.md
@@ -2492,7 +2492,7 @@ class Parts < ApplicationRecord
 end
 ```
 
-If you use a hash-style `where`, then record creation via this association will be automatically scoped using the hash. In this case, using `@parts.assemblies.create` or `@parts.assemblies.build` will create orders where the `factory` column has the value "Seattle".
+If you use a hash-style `where`, then record creation via this association will be automatically scoped using the hash. In this case, using `@parts.assemblies.create` or `@parts.assemblies.build` will create assemblies where the `factory` column has the value "Seattle".
 
 ##### `extending`
 


### PR DESCRIPTION
### Summary

Fixed small typo in "Active Record Associations" guide 
--> 4. Detailed Association Reference 
--> 4.4 has_and_belongs_to_many Association Reference
--> 4.4.3 Scopes for has_and_belongs_to_many
--> 4.4.3.1 where