### PR TITLE
Deprecate quoting ActiveSupport::Duration as an integer (#44341)

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Deprecate quoting `ActiveSupport::Duration` as an integer
+
+    Using ActiveSupport::Duration as an interpolated bind parameter in a SQL
+    string template is deprecated. To avoid this warning, you should explicitly
+    convert the duration to a more specific database type. For example, if you
+    want to use a duration as an integer number of seconds:
+    ```
+    Record.where("duration = ?", 1.hour.to_i)
+    ```
+    If you want to use a duration as an ISO 8601 string:
+    ```
+    Record.where("duration = ?", 1.hour.iso8601)
+    ```
+
+    *Aram Greenman*
+
 *   Add `drop_enum` migration command for PostgreSQL
 
     This does the inverse of `create_enum`. Before dropping an enum, ensure you have

--- a/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb
@@ -10,7 +10,7 @@ module ActiveRecord
           case value
           when Rational
             quote(value.to_f.to_s)
-          when Numeric, ActiveSupport::Duration
+          when Numeric
             quote(value.to_s)
           when BigDecimal
             quote(value.to_s("F"))
@@ -18,6 +18,9 @@ module ActiveRecord
             "'1'"
           when false
             "'0'"
+          when ActiveSupport::Duration
+            warn_quote_duration_deprecated
+            quote(value.to_s)
           else
             quote(value)
           end

--- a/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/bind_parameter_test.rb
@@ -79,7 +79,7 @@ module ActiveRecord
         end
 
         def test_where_with_duration_for_string_column_using_bind_parameters
-          count = Post.where("title = ?", 0.seconds).count
+          count = assert_deprecated { Post.where("title = ?", 0.seconds).count }
           assert_equal 0, count
         end
       end

--- a/activerecord/test/cases/adapters/mysql2/quoting_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/quoting_test.rb
@@ -21,7 +21,8 @@ class Mysql2QuotingTest < ActiveRecord::Mysql2TestCase
   end
 
   def test_quote_bound_duration
-    assert_equal "'42'", @conn.quote_bound_value(42.seconds)
+    expected = assert_deprecated { @conn.quote_bound_value(42.seconds) }
+    assert_equal "'42'", expected
   end
 
   def test_quote_bound_true

--- a/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
@@ -46,7 +46,7 @@ module ActiveRecord
 
         def test_where_with_duration_for_string_column_using_bind_parameters
           assert_raises ActiveRecord::StatementInvalid do
-            Post.where("title = ?", 0.seconds).count
+            assert_deprecated { Post.where("title = ?", 0.seconds).count }
           end
         end
       end

--- a/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/bind_parameter_test.rb
@@ -40,7 +40,7 @@ module ActiveRecord
         end
 
         def test_where_with_duration_for_string_column_using_bind_parameters
-          count = Post.where("title = ?", 0.seconds).count
+          count = assert_deprecated { Post.where("title = ?", 0.seconds).count }
           assert_equal 0, count
         end
       end

--- a/activerecord/test/cases/quoting_test.rb
+++ b/activerecord/test/cases/quoting_test.rb
@@ -191,7 +191,8 @@ module ActiveRecord
       end
 
       def test_quote_duration
-        assert_equal "1800", @quoter.quote(30.minutes)
+        expected = assert_deprecated { @quoter.quote(30.minutes) }
+        assert_equal "1800", expected
       end
     end
 
@@ -236,6 +237,10 @@ module ActiveRecord
       def test_type_cast_unknown_should_raise_error
         obj = Class.new.new
         assert_raise(TypeError) { @conn.type_cast(obj) }
+      end
+
+      def test_type_cast_duration_should_raise_error
+        assert_raise(TypeError) { @conn.type_cast(1.hour) }
       end
     end
 


### PR DESCRIPTION
### Summary

Deprecates passing `ActiveSupport::Duration` as an interpolated bind parameter in a SQL string template, which currently casts duration to an integer on all adapters. To avoid this warning, you should explicitly convert the duration to a more specific database type. 

For example, if you want to use a duration as an integer number of seconds:

```rb
Record.where("duration = ?", 1.hour.to_i)
```
If you want to use a duration as an ISO 8601 string:
```rb
Record.where("duration = ?", 1.hour.iso8601)
```

EDIT: this PR originally would have modified the behavior when quoting an duration, but per discussion we need a deprecation cycle first.
 <strike>

When passing an `ActiveSupport::Duration` as a bind in an array condition, the postgres adapter will now cast it to an ISO 8601 string. Previously it would be cast to an integer, which can't be used as an interval input.~~

```rb
Video.where('duration = ?', 1.hour) # ... WHERE duration = 'PT1H'
```

Note that this will break any code that depends on the previous behavior of a duration being cast to an integer number of seconds, for example assuming `duration_seconds` is an integer column:
```rb
# previous behavior
Video.where('duration_seconds = ?', 1.hour) # ... WHERE duration_seconds = 3600

# new behavior
Video.where('duration_seconds = ?', 1.hour) # ... WHERE duration_seconds = 'PT1H'
# ActiveRecord::StatementInvalid (PG::InvalidTextRepresentation: ERROR:  invalid input syntax for integer: "PT1H")

```
</strike>