### PR TITLE
Return the blob/blobs when #attach is able to save the record

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Saving attachment(s) to a record returns the blob/blobs object
+
+    Previously, saving attachments did not return the blob/blobs that
+    were attached. Now, saving attachments to a record with `#attach`
+    method returns the blob or array of blobs that were attached to
+    the record. If it fails to save the attachment(s), then it returns
+    `false`.
+
+    *Ghouse Mohamed*
+
 *   Don't stream responses in redirect mode
 
     Previously, both redirect mode and proxy mode streamed their

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -49,7 +49,8 @@ module ActiveStorage
     def attach(*attachables)
       if record.persisted? && !record.changed?
         record.public_send("#{name}=", blobs + attachables.flatten)
-        record.save
+        return record.public_send("#{name}") if record.save
+        false
       else
         record.public_send("#{name}=", (change&.attachables || blobs) + attachables.flatten)
       end

--- a/activestorage/lib/active_storage/attached/many.rb
+++ b/activestorage/lib/active_storage/attached/many.rb
@@ -49,8 +49,11 @@ module ActiveStorage
     def attach(*attachables)
       if record.persisted? && !record.changed?
         record.public_send("#{name}=", blobs + attachables.flatten)
-        return record.public_send("#{name}") if record.save
-        false
+        if record.save
+          record.public_send("#{name}")
+        else
+          false
+        end
       else
         record.public_send("#{name}=", (change&.attachables || blobs) + attachables.flatten)
       end

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -56,8 +56,11 @@ module ActiveStorage
     def attach(attachable)
       if record.persisted? && !record.changed?
         record.public_send("#{name}=", attachable)
-        return record.public_send("#{name}") if record.save
-        false
+        if record.save
+          record.public_send("#{name}")
+        else
+          false
+        end
       else
         record.public_send("#{name}=", attachable)
       end

--- a/activestorage/lib/active_storage/attached/one.rb
+++ b/activestorage/lib/active_storage/attached/one.rb
@@ -56,7 +56,8 @@ module ActiveStorage
     def attach(attachable)
       if record.persisted? && !record.changed?
         record.public_send("#{name}=", attachable)
-        record.save
+        return record.public_send("#{name}") if record.save
+        false
       else
         record.public_send("#{name}=", attachable)
       end


### PR DESCRIPTION
### Summary

In the following piece of code, when an attachable is attached to a record, it returns a boolean instead of the blob that was attached.

```ruby
@user = User.create!(name: "Josh")
avatar = @user.avatar.attach(params[:avatar])
```

It is convenient to use the blob methods directly like so:

```ruby
avatar.download
avatar.url
avatar.variant(:thumb)
....
```

This PR modified the #attach method so that it returns the blob/blobs which were attached if the record was saved, otherwise it returns false.

Thanks!

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->