### PR TITLE
Add spacing to curly braces

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1292,7 +1292,7 @@ Or, in English: "return all books that have a review by a customer."
 ##### Joining Nested Associations (Multiple Level)
 
 ```ruby
-Author.joins(books: [{reviews: { customer: :orders} }, :supplier] )
+Author.joins(books: [{ reviews: { customer: :orders } }, :supplier] )
 ```
 
 This produces:


### PR DESCRIPTION
### Summary

Adding whitespaces between curly braces in the guides documentation.

### Other Information

Very small styling change on documentation
