### PR TITLE
[Active Support] Add explicit assertions to tests with no assertions

### DIFF
--- a/activesupport/lib/active_support/testing/method_call_assertions.rb
+++ b/activesupport/lib/active_support/testing/method_call_assertions.rb
@@ -28,7 +28,7 @@ module ActiveSupport
 
           object.stub(method_name, mock, &block)
 
-          mock.verify
+          assert_mock(mock)
         end
 
         def assert_not_called(object, method_name, message = nil, &block)

--- a/activesupport/test/cache/stores/file_store_test.rb
+++ b/activesupport/test/cache/stores/file_store_test.rb
@@ -47,7 +47,7 @@ class FileStoreTest < ActiveSupport::TestCase
 
   def test_clear_without_cache_dir
     FileUtils.rm_r(cache_dir)
-    @cache.clear
+    assert_nothing_raised { @cache.clear }
   end
 
   def test_long_uri_encoded_keys

--- a/activesupport/test/cache/stores/null_store_test.rb
+++ b/activesupport/test/cache/stores/null_store_test.rb
@@ -10,11 +10,15 @@ class NullStoreTest < ActiveSupport::TestCase
   end
 
   def test_clear
+    @cache.write("name", "value")
     @cache.clear
+    assert_nil @cache.read("name")
   end
 
   def test_cleanup
+    @cache.write("name", "value")
     @cache.cleanup
+    assert_nil @cache.read("name")
   end
 
   def test_write
@@ -44,6 +48,7 @@ class NullStoreTest < ActiveSupport::TestCase
   def test_delete_matched
     @cache.write("name", "value")
     @cache.delete_matched(/name/)
+    assert_nil @cache.read("name")
   end
 
   def test_local_store_strategy

--- a/activesupport/test/core_ext/kernel_test.rb
+++ b/activesupport/test/core_ext/kernel_test.rb
@@ -45,9 +45,11 @@ class KernelSuppressTest < ActiveSupport::TestCase
   end
 
   def test_suppression
-    suppress(ArgumentError) { raise ArgumentError }
-    suppress(LoadError) { raise LoadError }
-    suppress(LoadError, ArgumentError) { raise LoadError }
-    suppress(LoadError, ArgumentError) { raise ArgumentError }
+    assert_nothing_raised do
+      suppress(ArgumentError) { raise ArgumentError }
+      suppress(LoadError) { raise LoadError }
+      suppress(LoadError, ArgumentError) { raise LoadError }
+      suppress(LoadError, ArgumentError) { raise ArgumentError }
+    end
   end
 end

--- a/activesupport/test/deprecation_test.rb
+++ b/activesupport/test/deprecation_test.rb
@@ -508,8 +508,10 @@ class DeprecationTest < ActiveSupport::TestCase
   def test_no_disallowed_behavior_with_no_disallowed_messages
     resetting_disallowed_deprecation_config do
       ActiveSupport::Deprecation.disallowed_behavior = :raise
-      @dtc.none
-      @dtc.partially
+      assert_nothing_raised do
+        @dtc.none
+        @dtc.partially
+      end
     end
   end
 
@@ -518,7 +520,7 @@ class DeprecationTest < ActiveSupport::TestCase
       ActiveSupport::Deprecation.disallowed_behavior = :raise
       ActiveSupport::Deprecation.disallowed_warnings = ["foo=nil"]
 
-      @dtc.none
+      assert_nothing_raised { @dtc.none }
     end
   end
 

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -92,10 +92,11 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_does_not_send_the_event_if_it_doesnt_match_the_class
-    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    instrument "unknown_event.my_log_subscriber"
-    wait
-    # If we get here, it means that NoMethodError was not raised.
+    assert_nothing_raised do
+      ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+      instrument "unknown_event.my_log_subscriber"
+      wait
+    end
   end
 
   def test_does_not_send_the_event_if_logger_is_nil
@@ -108,9 +109,11 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_does_not_fail_with_non_namespaced_events
-    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
-    instrument "whatever"
-    wait
+    assert_nothing_raised do
+      ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+      instrument "whatever"
+      wait
+    end
   end
 
   def test_flushes_loggers

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -43,7 +43,9 @@ class LoggerTest < ActiveSupport::TestCase
     str = +"\x80"
     str.force_encoding("ASCII-8BIT")
 
-    logger.add Logger::DEBUG, str
+    assert_nothing_raised do
+      logger.add Logger::DEBUG, str
+    end
   ensure
     logger.close
     t.close true
@@ -61,7 +63,9 @@ class LoggerTest < ActiveSupport::TestCase
     str = +"\x80"
     str.force_encoding("ASCII-8BIT")
 
-    logger.add Logger::DEBUG, str
+    assert_nothing_raised do
+      logger.add Logger::DEBUG, str
+    end
   ensure
     logger.close
     File.unlink fname

--- a/activesupport/test/metadata/shared_metadata_tests.rb
+++ b/activesupport/test/metadata/shared_metadata_tests.rb
@@ -14,10 +14,10 @@ module SharedMessageMetadataTests
   end
 
   def test_verifies_array_when_purpose_matches
-    unless null_serializing?
-      data = [ "credit_card_no: 5012-6748-9087-5678", { "card_holder" => "Donald", "issued_on" => Time.local(2017) }, 12345 ]
-      assert_equal data, parse(generate(data, purpose: :registration), purpose: :registration)
-    end
+    skip if null_serializing?
+
+    data = [ "credit_card_no: 5012-6748-9087-5678", { "card_holder" => "Donald", "issued_on" => Time.local(2017) }, 12345 ]
+    assert_equal data, parse(generate(data, purpose: :registration), purpose: :registration)
   end
 
   def test_encryption_and_decryption_with_different_purposes_returns_nil

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -185,8 +185,10 @@ module Notifications
 
       ActiveSupport::Notifications.subscribe("foo", TestSubscriber.new)
 
-      ActiveSupport::Notifications.instrument("foo") do
-        ActiveSupport::Notifications.subscribe("foo") { }
+      assert_nothing_raised do
+        ActiveSupport::Notifications.instrument("foo") do
+          ActiveSupport::Notifications.subscribe("foo") { }
+        end
       end
     ensure
       ActiveSupport::Notifications.notifier = old_notifier


### PR DESCRIPTION
### Summary

Add explicit assertions to tests that perform no assertions. The goal here is eventually to be able to introduce some tooling that makes sure that we don't introduce tests that do nothing, for example because of wrong usage of stubs/mocks.
Here are few examples of basically empty tests that were not doing anything:
https://github.com/rails/rails/pull/44345
https://github.com/rails/rails/pull/44342

Most of those tests are implicitly relying on the fact that no exception is being raised. And even though I would agree that such tests are perfectly valid tests, I think that adding explicit `assert_nothing_raised` call can't hurt and first-time readers should benefit from clearly realizing the expectation of the test 
