### PR TITLE
Support dalli 3.2.1

### DIFF
--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -314,7 +314,11 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
 
     def servers(cache = @cache)
-      client(cache).instance_variable_get(:@servers)
+      if client(cache).instance_variable_defined?(:@normalized_servers)
+        client(cache).instance_variable_get(:@normalized_servers)
+      else
+        client(cache).instance_variable_get(:@servers)
+      end
     end
 
     def client(cache = @cache)


### PR DESCRIPTION
### Summary

This commit addresses these failures which reproduce at Rails CI
at https://buildkite.com/rails/rails/builds/84688#59b6e442-d63a-463e-acfa-222f66113378

This change has been made to dalli 3.2.1
https://github.com/petergoldstein/dalli/pull/899

```ruby
$ bundle update dalli --conservative
$ git diff
diff --git a/Gemfile.lock b/Gemfile.lock
index 172339f7d2..cb5a0dc9c6 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       railties (>= 6.0.0)
     curses (1.4.3)
     daemons (1.4.1)
-    dalli (3.2.0)
+    dalli (3.2.1)
     dante (0.2.0)
     debug (1.4.0)
       irb (>= 1.3.6)
$ bin/test test/cache/stores/mem_cache_store_test.rb
Run options: --seed 5584

................................F

Failure:
OptimizedMemCacheStoreTest#test_falls_back_to_localhost_if_address_provided_as_nil [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:231]:
Expected: ["127.0.0.1:11211"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:227

..................................................................F

Failure:
OptimizedMemCacheStoreTest#test_falls_back_to_localhost_if_no_address_provided_and_memcache_servers_undefined [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:223]:
Expected: ["127.0.0.1:11211"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:219

.............................................................................................................................F

Failure:
OptimizedMemCacheStoreTest#test_forwards_string_addresses_if_present [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:216]:
Expected: ["first", "second"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:212

..SF

Failure:
OptimizedMemCacheStoreTest#test_uses_provided_dalli_client_if_present [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:209]:
Expected: ["custom_host"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:206

.............S..F

Failure:
OptimizedMemCacheStoreTest#test_falls_back_to_localhost_if_no_address_provided_and_memcache_servers_defined [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:239]:
Expected: ["custom_host"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:235

..........................................................................S.......................................................................F

Failure:
MemCacheStoreTest#test_falls_back_to_localhost_if_no_address_provided_and_memcache_servers_defined [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:239]:
Expected: ["custom_host"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:235

F

Failure:
MemCacheStoreTest#test_forwards_string_addresses_if_present [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:216]:
Expected: ["first", "second"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:212

............S.....F

Failure:
MemCacheStoreTest#test_falls_back_to_localhost_if_no_address_provided_and_memcache_servers_undefined [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:223]:
Expected: ["127.0.0.1:11211"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:219

............F

Failure:
MemCacheStoreTest#test_falls_back_to_localhost_if_address_provided_as_nil [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:231]:
Expected: ["127.0.0.1:11211"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:227

...................................................................F

Failure:
MemCacheStoreTest#test_uses_provided_dalli_client_if_present [/home/yahonda/src/github.com/rails/rails/activesupport/test/cache/stores/mem_cache_store_test.rb:209]:
Expected: ["custom_host"]
  Actual: nil

bin/test test/cache/stores/mem_cache_store_test.rb:206

.........................

Finished in 8.884504s, 58.5289 runs/s, 241.3191 assertions/s.
520 runs, 2144 assertions, 10 failures, 0 errors, 4 skips

You have skipped tests. Run with --verbose for details.
$
```
