### PR TITLE
Fix MemCacheStoreTest flaky tests

### DIFF
--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -85,7 +85,9 @@ class MemCacheStoreTest < ActiveSupport::TestCase
   def test_clear_also_clears_local_cache
     key = SecureRandom.uuid
     cache = lookup_store(raw: true)
-    client.stub(:flush_all, -> { client.delete(key) }) do
+    stub_called = false
+
+    client(cache).stub(:flush_all, -> { stub_called = true; client.delete("#{@namespace}:#{key}") }) do
       cache.with_local_cache do
         cache.write(key, SecureRandom.alphanumeric)
         cache.clear
@@ -93,6 +95,7 @@ class MemCacheStoreTest < ActiveSupport::TestCase
       end
       assert_nil cache.read(key)
     end
+    assert stub_called
   end
 
   def test_raw_values


### PR DESCRIPTION
The stub wasn't called because it was defined on the `@cache` client rather than on `cache`'s client.

This should reduce `MemCacheStoreTest` flakiness a bit (but I think there are other sources of flakiness).
