### PR TITLE
Add documentation for controller CSP methods [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/content_security_policy.rb
+++ b/actionpack/lib/action_controller/metal/content_security_policy.rb
@@ -14,6 +14,29 @@ module ActionController # :nodoc:
     end
 
     module ClassMethods
+      # Overrides parts of the globally configured Content-Security-Policy
+      # header:
+      #
+      #   class PostsController < ApplicationController
+      #     content_security_policy do |policy|
+      #       policy.base_uri "https://www.example.com"
+      #     end
+      #   end
+      #
+      # Options can be passed similar to +before_action+. For example, pass
+      # <tt>only: :index</tt> to override the header on the index action only:
+      #
+      #   class PostsController < ApplicationController
+      #     content_security_policy(only: :index) do |policy|
+      #       policy.default_src :self, :https
+      #     end
+      #   end
+      #
+      # Pass +false+ to remove the Content-Security-Policy header:
+      #
+      #   class PostsController < ApplicationController
+      #     content_security_policy false, only: :index
+      #   end
       def content_security_policy(enabled = true, **options, &block)
         before_action(options) do
           if block_given?
@@ -28,6 +51,18 @@ module ActionController # :nodoc:
         end
       end
 
+      # Overrides the globally configured Content-Security-Policy-Report-Only
+      # header:
+      #
+      #   class PostsController < ApplicationController
+      #     content_security_policy_report_only only: :index
+      #   end
+      #
+      # Pass +false+ to remove the Content-Security-Policy-Report-Only header:
+      #
+      #   class PostsController < ApplicationController
+      #     content_security_policy_report_only false, only: :index
+      #   end
       def content_security_policy_report_only(report_only = true, **options)
         before_action(options) do
           request.content_security_policy_report_only = report_only


### PR DESCRIPTION
Documents the ActionController::ContentSecurityPolicy::ClassMethods.