### PR TITLE
Add `destroying_async?` method to `ActiveRecord::Persistence`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Add `destroying_async?` to `ActiveRecord::Persistence`
+
+    Allows applications to introduce `*_destroy` callbacks that only run when
+    a record is destroyed in the background due to an association with the
+    `dependent: :destroy_async` option.
+
+    ```ruby
+    class Book < ActiveRecord::Base
+      has_many :essays, dependent: :destroy_async
+    end
+
+    class Essay < ActiveRecord::Base
+      before_destroy :callback, if: :destroying_async?
+
+      private
+        def callback
+          # Do something before this `Essay` is destroyed only if it was
+          # destroyed in the background due to a `Book` destruction.
+        end
+    end
+    ```
+
+    *Nick Holden*
+
 *   Fix `config.active_record.destroy_association_async_job` configuration
 
     `config.active_record.destroy_association_async_job` should allow

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -1374,7 +1374,9 @@ module ActiveRecord
         #
         #   * <tt>nil</tt> do nothing (default).
         #   * <tt>:destroy</tt> causes all the associated objects to also be destroyed.
-        #   * <tt>:destroy_async</tt> destroys all the associated objects in a background job. <b>WARNING:</b> Do not use
+        #   * <tt>:destroy_async</tt> destroys all the associated objects in a background job. The associated
+        #     objects can have `*_destroy` callbacks that only run when they are destroyed in the background
+        #     by making the callbacks conditional on `destroying_async?`. <b>WARNING:</b> Do not use
         #     this option if the association is backed by foreign key constraints in your database. The foreign key
         #     constraint actions will occur inside the same transaction that deletes its owner.
         #   * <tt>:delete_all</tt> causes all the associated objects to be deleted directly from the database (so callbacks will not be executed).
@@ -1535,7 +1537,9 @@ module ActiveRecord
         #
         #   * <tt>nil</tt> do nothing (default).
         #   * <tt>:destroy</tt> causes the associated object to also be destroyed
-        #   * <tt>:destroy_async</tt> causes the associated object to be destroyed in a background job. <b>WARNING:</b> Do not use
+        #   * <tt>:destroy_async</tt> causes the associated object to be destroyed in a background job. The associated
+        #     object can have `*_destroy` callbacks that only run when it is destroyed in the background
+        #     by making the callbacks conditional on `destroying_async?`. <b>WARNING:</b> Do not use
         #     this option if the association is backed by foreign key constraints in your database. The foreign key
         #     constraint actions will occur inside the same transaction that deletes its owner.
         #   * <tt>:delete</tt> causes the associated object to be deleted directly from the database (so callbacks will not execute)
@@ -1717,6 +1721,8 @@ module ActiveRecord
         #   If set to <tt>:destroy</tt>, the associated object is destroyed when this object is. If set to
         #   <tt>:delete</tt>, the associated object is deleted *without* calling its destroy method. If set to
         #   <tt>:destroy_async</tt>, the associated object is scheduled to be destroyed in a background job.
+        #   The associated object can have `*_destroy` callbacks that only run when it is destroyed in
+        #   the background by making the callbacks conditional on `destroying_async?`.
         #   This option should not be specified when #belongs_to is used in conjunction with
         #   a #has_many relationship on another class because of the potential to leave
         #   orphaned records behind.

--- a/activerecord/lib/active_record/destroy_association_async_job.rb
+++ b/activerecord/lib/active_record/destroy_association_async_job.rb
@@ -24,7 +24,9 @@ module ActiveRecord
       end
 
       association_model.where(association_primary_key_column => association_ids).find_each do |r|
+        r.instance_variable_set(:@destroying_async, true)
         r.destroy
+        r.instance_variable_set(:@destroying_async, false)
       end
     end
 

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -581,6 +581,14 @@ module ActiveRecord
       @destroyed
     end
 
+    # Returns true if this object is being destroyed because an associated
+    # record with the `dependent: :destroy_async` option has been destroyed.
+    # Allows applications to introduce `*_destroy` callbacks that only run when
+    # a record is destroyed in the background.
+    def destroying_async?
+      instance_variable_defined?(:@destroying_async) && @destroying_async
+    end
+
     # Returns true if the record is persisted, i.e. it's not a new record and it was
     # not destroyed, otherwise returns false.
     def persisted?

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -1152,6 +1152,20 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal true, developer.destroyed?
   end
 
+  def test_destroying_async_returns_boolean
+    developer = Developer.first
+    assert_equal false, developer.destroying_async?
+
+    developer.instance_variable_set(:@destroying_async, true)
+    assert_equal true, developer.destroying_async?
+
+    developer.instance_variable_set(:@destroying_async, false)
+    assert_equal false, developer.destroying_async?
+
+    developer.remove_instance_variable(:@destroying_async)
+    assert_equal false, developer.destroying_async?
+  end
+
   def test_persisted_returns_boolean
     developer = Developer.new(name: "Jose")
     assert_equal false, developer.persisted?

--- a/activerecord/test/models/book_destroy_async.rb
+++ b/activerecord/test/models/book_destroy_async.rb
@@ -22,3 +22,21 @@ class BookDestroyAsyncWithScopedTags < ActiveRecord::Base
   has_many :taggings, as: :taggable, class_name: "Tagging"
   has_many :tags, -> { where name: "Der be rum" }, through: :taggings, dependent: :destroy_async
 end
+
+class BookDestroyAsyncWithDestroyingAsyncCallbackEssays < ActiveRecord::Base
+  self.table_name = "books"
+
+  has_many :essays,
+    dependent: :destroy_async,
+    class_name: "EssayWithDestroyingAsyncCallback",
+    foreign_key: "book_id"
+end
+
+class BookDestroySyncWithDestroyingAsyncCallbackEssays < ActiveRecord::Base
+  self.table_name = "books"
+
+  has_many :essays,
+    dependent: :destroy,
+    class_name: "EssayWithDestroyingAsyncCallback",
+    foreign_key: "book_id"
+end

--- a/activerecord/test/models/essay_destroy_async.rb
+++ b/activerecord/test/models/essay_destroy_async.rb
@@ -10,3 +10,16 @@ end
 
 class ShortEssayDestroyAsync < EssayDestroyAsync
 end
+
+class EssayWithDestroyingAsyncCallback < ActiveRecord::Base
+  self.table_name = "essays"
+  around_destroy :callback, if: :destroying_async?
+
+  private
+    def callback
+      before_destroying_async
+      yield
+    end
+
+    def before_destroying_async; end
+end


### PR DESCRIPTION
Allows applications to introduce `*_destroy` callbacks that only run when a record is destroyed in the background due to an association with the `dependent: :destroy_async` option.

```ruby
class Book < ActiveRecord::Base
  has_many :essays, dependent: :destroy_async
end

class Essay < ActiveRecord::Base
  before_destroy :callback, if: :destroying_async?

  private
    def callback
      # Do something before this `Essay` is destroyed only if it was
      # destroyed in the background due to a `Book` destruction.
    end
end
```

At GitHub, we have a custom method for destroying associated records in the background that we'd like to replace with `dependent: :destroy_async`. One of the requirements is that we have a way to throttle associated record destruction, which `dependent: :destroy_async` doesn't support. Having callbacks that only run when records are destroyed in the background will allow us to throttle associated record destruction and makes `dependent: :destroy_async` extensible in ways we haven't considered yet.