### PR TITLE
Implement inspect for Notifications::Fanout

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -68,6 +68,11 @@ module ActiveSupport
         end
       end
 
+      def inspect # :nodoc:
+        total_patterns = @string_subscribers.size + @other_subscribers.size
+        "#<#{self.class} (#{total_patterns} patterns)>"
+      end
+
       def start(name, id, payload)
         iterate_guarding_exceptions(listeners_for(name)) { |s| s.start(name, id, payload) }
       end

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -231,6 +231,13 @@ module Notifications
     end
   end
 
+  class InspectTest < TestCase
+    def test_inspect_output_is_small
+      expected = "#<ActiveSupport::Notifications::Fanout (2 patterns)>"
+      assert_equal expected, @notifier.inspect
+    end
+  end
+
   class UnsubscribeTest < TestCase
     def test_unsubscribing_removes_a_subscription
       @notifier.publish :foo


### PR DESCRIPTION
A few classes hold a reference to this object (anything with a subscription, but notably the ActiveRecord connection), causing the `inspect` or pretty print output to be unreasonably large and slow.

This implements a simple representation for the `Notifications::Fanout` object as users usually don't care about its internals.

```
"#<ActiveSupport::Notifications::Fanout (155 patterns)>"
```

Suggested by @brasic 