### PR TITLE
Set a default value for ActiveSupport::ErrorReporter#report handled kwarg

### DIFF
--- a/activesupport/lib/active_support/error_reporter.rb
+++ b/activesupport/lib/active_support/error_reporter.rb
@@ -91,8 +91,8 @@ module ActiveSupport
 
     # When the block based +handle+ and +record+ methods are not suitable, you can directly use +report+
     #
-    #   Rails.error.report(error, handled: true)
-    def report(error, handled:, severity: handled ? :warning : :error, context: {})
+    #   Rails.error.report(error)
+    def report(error, handled: true, severity: handled ? :warning : :error, context: {})
       unless SEVERITIES.include?(severity)
         raise ArgumentError, "severity must be one of #{SEVERITIES.map(&:inspect).join(", ")}, got: #{severity.inspect}"
       end


### PR DESCRIPTION
### Summary

While recently migrating to use the new ErrorReporter interface, I noticed that where we currently report errors we almost always are handling them gracefully. The method signature of `Rails.error.report(exception, handled: true)` is frequently called and so I think it's desirable to shorten it for the majority of use cases by simply setting a default value for the `handled` kwarg.

cc @jorgemanrubia 