### PR TITLE
Update getting_started.md [ci-skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -308,7 +308,7 @@ and see our text displayed!
 
 ### Setting the Application Home Page
 
-At the moment, <http://localhost:3000> still displays "Yay! You're on Rails!".
+At the moment, <http://localhost:3000> still displays a page with the Ruby on Rails logo.
 Let's display our "Hello, Rails!" text at <http://localhost:3000> as well. To do
 so, we will add a route that maps the *root path* of our application to the
 appropriate controller and action.
@@ -1442,7 +1442,7 @@ controller. Again, we'll use the same generator we used before:
 $ bin/rails generate controller Comments
 ```
 
-This creates four files and one empty directory:
+This creates three files and one empty directory:
 
 | File/Directory                               | Purpose                                  |
 | -------------------------------------------- | ---------------------------------------- |
@@ -1450,7 +1450,6 @@ This creates four files and one empty directory:
 | app/views/comments/                          | Views of the controller are stored here  |
 | test/controllers/comments_controller_test.rb | The test for the controller              |
 | app/helpers/comments_helper.rb               | A view helper file                       |
-| app/assets/stylesheets/comments.scss         | Cascading style sheet for the controller |
 
 Like with any blog, our readers will create their comments directly after
 reading the article, and once they have added their comment, will be sent back


### PR DESCRIPTION
The phrase "Yay! You're on Rails!" was in versions up to 7. Now there is just a page with a logo referring to the official site.
![image](https://user-images.githubusercontent.com/62876883/154533775-bb6f3cd6-849a-444f-adc5-9fe461c65958.png)

The error is not critical, but taking into account the fact that it is at the very beginning of the documentation, which is mostly intended for beginners, this can mislead them.
Therefore, I propose to redo this proposal, a possible option in this PR.

----------------------------------------------------------------------------------------------------------------------------
app/assets/stylesheets/comments.scss is not generated in the app, so I suggest removing this line
Screenshot from my local project with rails 7
![image](https://user-images.githubusercontent.com/62876883/154534136-fbd06a24-3bb8-414b-b84c-b717896b2e64.png)
