### PR TITLE
Fix rdoc for session_store documentation [ci-skip]

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -375,8 +375,8 @@ module Rails
       end
 
       # Specifies what class to use to store the session. Possible values
-      # are `:cookie_store`, `:mem_cache_store`, a custom store, or
-      # `:disabled`. `:disabled` tells Rails not to deal with sessions.
+      # are +:cookie_store+, +:mem_cache_store+, a custom store, or
+      # +:disabled+. +:disabled+ tells Rails not to deal with sessions.
       #
       # Additional options will be set as +session_options+:
       #


### PR DESCRIPTION
### Summary

Use + instead of ` for values to pass.

Sorry @jonathanhefner, this got lost in ##44448