### PR TITLE
Fix links in CSP documentation [ci-skip]

### DIFF
--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/object/deep_dup"
 
 module ActionDispatch # :nodoc:
   # Allows configuring a
-  # {Content-Security-Policy}(https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy)
+  # {Content-Security-Policy}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy]
   # to help protect against XSS and injection attacks.
   #
   # Example global policy:
@@ -224,7 +224,7 @@ module ActionDispatch # :nodoc:
       end
     end
 
-    # Enable the {report-uri}(https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri)
+    # Enable the {report-uri}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri]
     # directive. Violation reports will be sent to the specified URI:
     #
     #   policy.report_uri "/csp-violation-report-endpoint"
@@ -233,7 +233,7 @@ module ActionDispatch # :nodoc:
       @directives["report-uri"] = [uri]
     end
 
-    # Specify asset types for which {Subresource Integrity}(https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
+    # Specify asset types for which {Subresource Integrity}[https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity]
     # is required:
     #
     #   policy.require_sri_for :script, :style
@@ -250,7 +250,7 @@ module ActionDispatch # :nodoc:
       end
     end
 
-    # Specify whether a {sandbox}(https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox)
+    # Specify whether a {sandbox}[https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox]
     # should be enabled for the requested resource:
     #
     #   policy.sandbox


### PR DESCRIPTION
rdoc links use square brackets for the URL part.
Sorry @jonathanhefner  another fix 🙂 