### PR TITLE
Move `convert_to_model` call from `form_for` into `form_with`

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Move `convert_to_model` call from `form_for` into `form_with`
+
+    Now that `form_for` is implemented in terms of `form_with`, remove the
+    `convert_to_model` call from `form_for`.
+
+    *Sean Doyle*
+
 *   Fix and add protections for XSS in `ActionView::Helpers` and `ERB::Util`.
 
     Escape dangerous characters in names of tags and names of attributes in the

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -438,7 +438,7 @@ module ActionView
           model       = nil
           object_name = record
         else
-          model       = convert_to_model(record)
+          model       = record
           object      = _object_for_form_builder(record)
           raise ArgumentError, "First argument in form cannot contain nil or be empty" unless object
           object_name = options[:as] || model_name_from_record_or_class(object).param_key
@@ -763,7 +763,7 @@ module ActionView
             end
           end
 
-          model   = _object_for_form_builder(model)
+          model   = convert_to_model(_object_for_form_builder(model))
           scope ||= model_name_from_record_or_class(model).param_key
         end
 

--- a/actionview/test/template/form_helper/form_with_test.rb
+++ b/actionview/test/template/form_helper/form_with_test.rb
@@ -387,7 +387,7 @@ class FormWithActsLikeFormForTest < FormWithTest
 
     form_with(model: post_form) { }
 
-    expected = whole_form("/posts/123", method: :post) { "" }
+    expected = whole_form("/posts/123", method: :patch) { "" }
 
     assert_dom_equal expected, output_buffer
   end


### PR DESCRIPTION
### Summary

Ensure models passed to `form_with` attempt to call `to_model`.

Now that `form_for` is implemented in terms of `form_with`, this commit
also removes the `convert_to_model` call from the `form_for` implementation.

To exercise this behavior, change existing `form_with` test coverage.

Prior to this change, a call to `form_with` made with a `model:` argument 
that responds to `to_model` would not incorporate the instance's persistence 
state into the form's HTTP verb. After this change, the persistence state 
inferred from the `model:` argument's `to_model` call is incorporated into 
the `<form>` element's `[method]` attribute.

This is a separate follow-up change proposed in [rails/rails#44328][].
The original change to restore old behavior _deliberately_ excluded
applying the same logic to `form_with`, since it would be a breaking
change from how `form_with` behaved previously.

This commit proposed making that breaking change.

[rails/rails#44328]: https://github.com/rails/rails/pull/44328#discussion_r808475585
