### PR TITLE
Make Notifications::Fanout faster and safer

### DIFF
--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -17,78 +17,7 @@ module ActiveSupport
       end
     end
 
-    # This is a default queue implementation that ships with Notifications.
-    # It just pushes events to all registered log subscribers.
-    #
-    # This class is thread safe. All methods are reentrant.
-    class Fanout
-      include Mutex_m
-
-      def initialize
-        @string_subscribers = Hash.new { |h, k| h[k] = [] }
-        @other_subscribers = []
-        @listeners_for = Concurrent::Map.new
-        super
-      end
-
-      def subscribe(pattern = nil, callable = nil, monotonic: false, &block)
-        subscriber = Subscribers.new(pattern, callable || block, monotonic)
-        synchronize do
-          case pattern
-          when String
-            @string_subscribers[pattern] << subscriber
-            @listeners_for.delete(pattern)
-          when NilClass, Regexp
-            @other_subscribers << subscriber
-            @listeners_for.clear
-          else
-            raise ArgumentError,  "pattern must be specified as a String, Regexp or empty"
-          end
-        end
-        subscriber
-      end
-
-      def unsubscribe(subscriber_or_name)
-        synchronize do
-          case subscriber_or_name
-          when String
-            @string_subscribers[subscriber_or_name].clear
-            @listeners_for.delete(subscriber_or_name)
-            @other_subscribers.each { |sub| sub.unsubscribe!(subscriber_or_name) }
-          else
-            pattern = subscriber_or_name.try(:pattern)
-            if String === pattern
-              @string_subscribers[pattern].delete(subscriber_or_name)
-              @listeners_for.delete(pattern)
-            else
-              @other_subscribers.delete(subscriber_or_name)
-              @listeners_for.clear
-            end
-          end
-        end
-      end
-
-      def inspect # :nodoc:
-        total_patterns = @string_subscribers.size + @other_subscribers.size
-        "#<#{self.class} (#{total_patterns} patterns)>"
-      end
-
-      def start(name, id, payload)
-        iterate_guarding_exceptions(listeners_for(name)) { |s| s.start(name, id, payload) }
-      end
-
-      def finish(name, id, payload, listeners = listeners_for(name))
-        iterate_guarding_exceptions(listeners) { |s| s.finish(name, id, payload) }
-      end
-
-      def publish(name, *args)
-        iterate_guarding_exceptions(listeners_for(name)) { |s| s.publish(name, *args) }
-      end
-
-      def publish_event(event)
-        iterate_guarding_exceptions(listeners_for(event.name)) { |s| s.publish_event(event) }
-      end
-
+    module FanoutIteration # :nodoc:
       def iterate_guarding_exceptions(listeners)
         exceptions = nil
 
@@ -108,6 +37,238 @@ module ActiveSupport
         end
 
         listeners
+      end
+    end
+
+    # This is a default queue implementation that ships with Notifications.
+    # It just pushes events to all registered log subscribers.
+    #
+    # This class is thread safe. All methods are reentrant.
+    class Fanout
+      include Mutex_m
+
+      def initialize
+        @string_subscribers = Hash.new { |h, k| h[k] = [] }
+        @other_subscribers = []
+        @listeners_for = Concurrent::Map.new
+        @groups_for = Concurrent::Map.new
+        super
+      end
+
+      def inspect # :nodoc:
+        total_patterns = @string_subscribers.size + @other_subscribers.size
+        "#<#{self.class} (#{total_patterns} patterns)>"
+      end
+
+      def subscribe(pattern = nil, callable = nil, monotonic: false, &block)
+        subscriber = Subscribers.new(pattern, callable || block, monotonic)
+        synchronize do
+          case pattern
+          when String
+            @string_subscribers[pattern] << subscriber
+            clear_cache(pattern)
+          when NilClass, Regexp
+            @other_subscribers << subscriber
+            clear_cache
+          else
+            raise ArgumentError,  "pattern must be specified as a String, Regexp or empty"
+          end
+        end
+        subscriber
+      end
+
+      def unsubscribe(subscriber_or_name)
+        synchronize do
+          case subscriber_or_name
+          when String
+            @string_subscribers[subscriber_or_name].clear
+            clear_cache(subscriber_or_name)
+            @other_subscribers.each { |sub| sub.unsubscribe!(subscriber_or_name) }
+          else
+            pattern = subscriber_or_name.try(:pattern)
+            if String === pattern
+              @string_subscribers[pattern].delete(subscriber_or_name)
+              clear_cache(pattern)
+            else
+              @other_subscribers.delete(subscriber_or_name)
+              clear_cache
+            end
+          end
+        end
+      end
+
+      def clear_cache(key = nil) # :nodoc:
+        if key
+          @listeners_for.delete(key)
+          @groups_for.delete(key)
+        else
+          @listeners_for.clear
+          @groups_for.clear
+        end
+      end
+
+      class BaseGroup # :nodoc:
+        include FanoutIteration
+
+        def initialize(listeners, name, id, payload)
+          @listeners = listeners
+        end
+
+        def each(&block)
+          iterate_guarding_exceptions(@listeners, &block)
+        end
+      end
+
+      class BaseTimeGroup < BaseGroup # :nodoc:
+        def start(name, id, payload)
+          @start_time = now
+        end
+
+        def finish(name, id, payload)
+          stop_time = now
+          each do |listener|
+            listener.call(name, @start_time, stop_time, id, payload)
+          end
+        end
+      end
+
+      class MonotonicTimedGroup < BaseTimeGroup # :nodoc:
+        private
+          def now
+            Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          end
+      end
+
+      class TimedGroup < BaseTimeGroup # :nodoc:
+        private
+          def now
+            Time.now
+          end
+      end
+
+      class EventedGroup < BaseGroup # :nodoc:
+        def start(name, id, payload)
+          each do |s|
+            s.start(name, id, payload)
+          end
+        end
+
+        def finish(name, id, payload)
+          each do |s|
+            s.finish(name, id, payload)
+          end
+        end
+      end
+
+      class EventObjectGroup < BaseGroup # :nodoc:
+        def start(name, id, payload)
+          @event = build_event(name, id, payload)
+          @event.start!
+        end
+
+        def finish(name, id, payload)
+          @event.payload = payload
+          @event.finish!
+
+          each do |s|
+            s.call(@event)
+          end
+        end
+
+        private
+          def build_event(name, id, payload)
+            ActiveSupport::Notifications::Event.new name, nil, nil, id, payload
+          end
+      end
+
+      def groups_for(name) # :nodoc:
+        @groups_for.compute_if_absent(name) do
+          listeners_for(name).group_by(&:group_class).transform_values do |s|
+            s.map(&:delegate)
+          end
+        end
+      end
+
+      # A Handle is used to record the start and finish time of event
+      #
+      # Both `#start` and `#finish` must each be called exactly once
+      #
+      # Where possible, it's best to the block form, +ActiveSupport::Notifications.instrument+
+      # +Handle+ is a low-level API intended for cases where the block form can't be used.
+      #
+      #   handle = ActiveSupport::Notifications.instrumenter.build_handle("my.event", {})
+      #   begin
+      #     handle.start
+      #     # work to be instrumented
+      #   ensure
+      #     handle.finish
+      #   end
+      class Handle
+        def initialize(notifier, name, id, payload) # :nodoc:
+          @name = name
+          @id = id
+          @payload = payload
+          @groups = notifier.groups_for(name).map do |group_klass, grouped_listeners|
+            group_klass.new(grouped_listeners, name, id, payload)
+          end
+          @state = :initialized
+        end
+
+        def start
+          ensure_state! :initialized
+          @state = :started
+
+          @groups.each do |group|
+            group.start(@name, @id, @payload)
+          end
+        end
+
+        def finish
+          finish_with_values(@name, @id, @payload)
+        end
+
+        def finish_with_values(name, id, payload) # :nodoc:
+          ensure_state! :started
+          @state = :finished
+
+          @groups.each do |group|
+            group.finish(name, id, payload)
+          end
+        end
+
+        private
+          def ensure_state!(expected)
+            if @state != expected
+              raise ArgumentError, "expected state to be #{expected.inspect} but was #{@state.inspect}"
+            end
+          end
+      end
+
+      include FanoutIteration
+
+      def build_handle(name, id, payload)
+        Handle.new(self, name, id, payload)
+      end
+
+      def start(name, id, payload)
+        handle_stack = (IsolatedExecutionState[:_fanout_handle_stack] ||= [])
+        handle = build_handle(name, id, payload)
+        handle_stack << handle
+        handle.start
+      end
+
+      def finish(name, id, payload, listeners = nil)
+        handle_stack = IsolatedExecutionState[:_fanout_handle_stack]
+        handle = handle_stack.pop
+        handle.finish_with_values(name, id, payload)
+      end
+
+      def publish(name, *args)
+        iterate_guarding_exceptions(listeners_for(name)) { |s| s.publish(name, *args) }
+      end
+
+      def publish_event(event)
+        iterate_guarding_exceptions(listeners_for(event.name)) { |s| s.publish_event(event) }
       end
 
       def listeners_for(name)
@@ -185,13 +346,17 @@ module ActiveSupport
         end
 
         class Evented # :nodoc:
-          attr_reader :pattern
+          attr_reader :pattern, :delegate
 
           def initialize(pattern, delegate)
             @pattern = Matcher.wrap(pattern)
             @delegate = delegate
             @can_publish = delegate.respond_to?(:publish)
             @can_publish_event = delegate.respond_to?(:publish_event)
+          end
+
+          def group_class
+            EventedGroup
           end
 
           def publish(name, *args)
@@ -208,14 +373,6 @@ module ActiveSupport
             end
           end
 
-          def start(name, id, payload)
-            @delegate.start name, id, payload
-          end
-
-          def finish(name, id, payload)
-            @delegate.finish name, id, payload
-          end
-
           def subscribed_to?(name)
             pattern === name
           end
@@ -226,63 +383,29 @@ module ActiveSupport
         end
 
         class Timed < Evented # :nodoc:
+          def group_class
+            TimedGroup
+          end
+
           def publish(name, *args)
             @delegate.call name, *args
-          end
-
-          def start(name, id, payload)
-            timestack = IsolatedExecutionState[:_timestack] ||= []
-            timestack.push Time.now
-          end
-
-          def finish(name, id, payload)
-            timestack = IsolatedExecutionState[:_timestack]
-            started = timestack.pop
-            @delegate.call(name, started, Time.now, id, payload)
           end
         end
 
-        class MonotonicTimed < Evented # :nodoc:
-          def publish(name, *args)
-            @delegate.call name, *args
-          end
-
-          def start(name, id, payload)
-            timestack = IsolatedExecutionState[:_timestack_monotonic] ||= []
-            timestack.push Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          end
-
-          def finish(name, id, payload)
-            timestack = IsolatedExecutionState[:_timestack_monotonic]
-            started = timestack.pop
-            @delegate.call(name, started, Process.clock_gettime(Process::CLOCK_MONOTONIC), id, payload)
+        class MonotonicTimed < Timed # :nodoc:
+          def group_class
+            MonotonicTimedGroup
           end
         end
 
         class EventObject < Evented
-          def start(name, id, payload)
-            stack = IsolatedExecutionState[:_event_stack] ||= []
-            event = build_event name, id, payload
-            event.start!
-            stack.push event
-          end
-
-          def finish(name, id, payload)
-            stack = IsolatedExecutionState[:_event_stack]
-            event = stack.pop
-            event.payload = payload
-            event.finish!
-            @delegate.call event
+          def group_class
+            EventObjectGroup
           end
 
           def publish_event(event)
             @delegate.call event
           end
-
-          private
-            def build_event(name, id, payload)
-              ActiveSupport::Notifications::Event.new name, nil, nil, id, payload
-            end
         end
       end
     end

--- a/activesupport/test/notifications_test.rb
+++ b/activesupport/test/notifications_test.rb
@@ -140,6 +140,66 @@ module Notifications
     end
   end
 
+  class BuildHandleTest < TestCase
+    def test_interleaved_event
+      event_name = "foo"
+      actual_times = []
+
+      ActiveSupport::Notifications.subscribe(event_name) do |name, started, finished, unique_id, data|
+        actual_times << [started, finished]
+      end
+
+      times = (1..4).map { |s| Time.new(2020, 1, 1) + s }
+
+      instrumenter = ActiveSupport::Notifications.instrumenter
+      travel_to times[0]
+      handle1 = instrumenter.build_handle(event_name, {})
+      handle2 = instrumenter.build_handle(event_name, {})
+
+      handle1.start
+      travel_to times[1]
+      handle2.start
+      travel_to times[2]
+      handle1.finish
+      travel_to times[3]
+      handle2.finish
+
+      assert_equal [
+        # from when start1 was returned, to when its state passed to finish
+        [times[0], times[2]],
+        # from when start2 was returned, to when its state passed to finish
+        [times[1], times[3]],
+      ], actual_times
+    end
+
+    def test_subscribed_interleaved_with_event
+      instrumenter = ActiveSupport::Notifications.instrumenter
+
+      name    = "foo"
+      events1 = []
+      events2 = []
+
+      callback1 = lambda { |event| events1 << event }
+      callback2 = lambda { |event| events2 << event }
+
+      ActiveSupport::Notifications.subscribed(callback1, name) do
+        handle = instrumenter.build_handle(name, {})
+        handle.start
+
+        ActiveSupport::Notifications.subscribed(callback2, name) do
+          handle.finish
+        end
+      end
+
+      assert_equal 1, events1.size
+      assert_empty events2
+
+      assert_equal name, events1[0].name
+      assert events1[0].time
+      assert events1[0].end
+    end
+  end
+
   class SubscribedTest < TestCase
     def test_subscribed
       name     = "foo"


### PR DESCRIPTION
@seejohnrun and I wrote this on his Twitch stream Tuesday night. Thanks those who helped us in chat 😁

This commit aims to improve `ActiveSupport::Notifications::Fanout`. There are three main goals here: backwards compatibility, safety, and performance.

## Backwards compatibility

`ActiveSupport::Notifications` is an old and well used interface. Over time it has collected a lot of features and flexibility, much of which I suspect is not used anywhere by anyone, but it is hard to know specifics and we would at minimum need a deprecation cycle to remove any of them.

For this reason this aims to fully maintain compatibility. This includes both the ability to use an alternate notification implementation instead of `Fanout`, the signatures received by all types of listeners, and the interface used on the `Instrumenter` and `Fanout` itself (including the sometimes problematic `start`/`finish`).

## Safety

There have been issues (both recent and past, ex. #44167 #21873) with the "timestacks" becoming invalid, particularly when subscribing and unsubscribing within events. This is an issue when topics are subscribed/unsubscribed to while they are in flight.

The previous implementation would record a separate timestamp or event object for each listener in a thread local stack. This meant that it was essential that the listeners to start and finish were identical.

This issue is avoided by passing the listeners used to `start` the event to `finish` (`finish_with_state` in the Instrumenter), to ensure they are the same set in `start`/`finish`.

This commit further avoids this issue. Instead of pushing individual times onto a stack, we now push a single object, `Handle`, onto the stack for an event. This object holds all the subscribers (recorded at start time) and all their associated data. This means that as long as start/stop calls are not interleaved they too are now safe. When `Instrumenter#instrument` is used we can avoid using thread-locals entirely!

This commit also exposes `build_handle` as a public interface. This returns the Handle object which can have start/stop called at any time and any order safely. The one reservation I have with making this public is that existing "evented" listeners (those receiving start/stop) may not be ready for that (ex. if they maintain an internal thread-local stack).

## Performance

This aims to be faster and make fewer allocations then the existing implementation.

For time-based and event-object-based listeners, the previous implementation created a separate object for each listener, pushing and popping it on a thread-local stack. This is slower both because we need to access the thread local repeatedly (hash lookups) and because we're allocating duplicate objects.

The new implementation works by grouping similar types of listeners together and shares either the `Event` or start/stop times between all of them. The grouping was done so that we didn't need to allocate Events or Times for topics which did have a listener of that type.

This implementation is significantly faster for all cases, except for evented, which is slower.

For topics with 10 subscriptions:

<details>
<summary>benchmark</summary>

```
# frozen_string_literal: true

require 'benchmark/ips'
require 'active_support/all'

class EventedSubscriber
  def start(name, id, payload); end
  def finish(name, id, payload); end
end

10.times do
  ActiveSupport::Notifications.subscribe("timed") do |name, started, ended, id, payload|
  end

  ActiveSupport::Notifications.monotonic_subscribe("timed_monotonic") do |name, started, ended, id, payload|
  end

  ActiveSupport::Notifications.subscribe("event_object") do |event|
  end

  ActiveSupport::Notifications.subscribe("evented", EventedSubscriber.new)
end

Benchmark.ips do |x|
  x.report("timed") do
    ActiveSupport::Notifications.instrument("timed"){}
  end
  x.report("timed_monotonic") do
    ActiveSupport::Notifications.instrument("timed_monotonic"){}
  end
  x.report("event_object") do
    ActiveSupport::Notifications.instrument("event_object"){}
  end
  x.report("evented") do
    ActiveSupport::Notifications.instrument("evented"){}
  end
  x.report("unsubscribed") do
    ActiveSupport::Notifications.instrument("unsubscribed"){}
  end
end
```

</details>

*main*:

               timed     66.739k (± 2.5%) i/s -    338.800k in   5.079883s
     timed_monotonic    138.265k (± 0.6%) i/s -    699.261k in   5.057575s
        event_object     48.650k (± 0.2%) i/s -    244.250k in   5.020614s
             evented    366.559k (± 1.0%) i/s -      1.851M in   5.049727s
        unsubscribed      3.696M (± 0.5%) i/s -     18.497M in   5.005335s

*This branch*:

               timed    259.031k (± 0.6%) i/s -      1.302M in   5.025612s
     timed_monotonic    327.439k (± 1.7%) i/s -      1.665M in   5.086815s
        event_object    228.991k (± 0.3%) i/s -      1.164M in   5.083539s
             evented    296.057k (± 0.3%) i/s -      1.501M in   5.070315s
        unsubscribed      3.670M (± 0.3%) i/s -     18.376M in   5.007095s