### PR TITLE
Enable open struct cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -213,7 +213,7 @@ Lint/DuplicateMethods:
 
 Lint/ErbNewArguments:
   Enabled: true
-  
+
 Lint/EnsureReturn:
   Enabled: true
 
@@ -300,6 +300,9 @@ Performance/DeletePrefix:
   Enabled: true
 
 Performance/DeleteSuffix:
+  Enabled: true
+
+Performance/OpenStruct:
   Enabled: true
 
 Minitest/UnreachableAssertion:


### PR DESCRIPTION
In https://github.com/rails/rails/pull/44328 I noticed we don't have the `Performance/OpenStruct` cop enabled. This PR enables it, enables performance cops in tests, and corrects its use in tests. 

Enabling performance cops in tests may be controversial. Rails' test suite isn't slow, and maybe this is over-optimization. However, I think tests should default to be written with the same expectations and quality standards library code is.

I'm happy to adjust the approach to just enable `Performance/OpenStruct` for library code and leave tests out of it, or continue fixing the TODOs in another PR if we agree to keep it as-is. Let me know what you think!
