### PR TITLE
Fix `ActiveModel::EachValidator` options hash handling

### DIFF
--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -136,6 +136,7 @@ module ActiveModel
     # +options+ reader, however the <tt>:attributes</tt> option will be removed
     # and instead be made available through the +attributes+ reader.
     def initialize(options)
+      options = options.dup
       @attributes = Array(options.delete(:attributes))
       raise ArgumentError, ":attributes cannot be blank" if @attributes.empty?
       super

--- a/activemodel/test/cases/validations/with_validation_test.rb
+++ b/activemodel/test/cases/validations/with_validation_test.rb
@@ -145,4 +145,12 @@ class ValidatesWithTest < ActiveModel::TestCase
     assert_empty topic.errors[:title]
     assert_equal ["is missing"], topic.errors[:content]
   end
+
+  test "validates_with can use multiple 'ActiveModel::EachValidator's" do
+    Topic.validates_with(ValidatorPerEachAttribute, ValidatorPerEachAttribute, attributes: [:title])
+    topic = Topic.new
+    assert_not_predicate topic, :valid?
+    assert_not_empty topic.errors[:title]
+    assert_equal ["Value is ", "Value is "], topic.errors[:title]
+  end
 end


### PR DESCRIPTION
### Summary

This PR is relates to https://github.com/rails/rails/issues/44460.
It changes `ActiveModel::EachValidator` options hash handling in order to work better with `validates_with`.

Until now the `:attributes` key was directly deleted from the underlying options hash.
This did raise a ArgumentError when multiple `ActiveModel::EachValidator` have been
chained within a `validates_with` call.
    
Now the options hash gets duplicated.
