### PR TITLE
PG: Schema cache with TypeMap

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -11,7 +11,7 @@ module ActiveRecord
   module ConnectionAdapters
     module AbstractPool # :nodoc:
       def get_schema_cache(connection)
-        self.schema_cache ||= SchemaCache.new(connection)
+        self.schema_cache ||= connection.init_schema_cache
         schema_cache.connection = connection
         schema_cache
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -184,6 +184,10 @@ module ActiveRecord
         end
       end
 
+      def init_schema_cache
+        SchemaCache.new(self)
+      end
+
       def check_if_write_query(sql) # :nodoc:
         if preventing_writes? && write_query?(sql)
           raise ActiveRecord::ReadOnlyError, "Write query attempted while in readonly mode: #{sql}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_cache.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaCache < ActiveRecord::ConnectionAdapters::SchemaCache
+        cattr_accessor :additional_type_records, default: []
+        cattr_accessor :known_coder_type_records, default: []
+
+        def encode_with(coder)
+          super
+
+          coder["additional_type_records"] = self.additional_type_records
+          coder["known_coder_type_records"] = self.known_coder_type_records
+        end
+
+        def init_with(coder)
+          self.additional_type_records = coder["additional_type_records"]
+          self.known_coder_type_records = coder["known_coder_type_records"]
+
+          super
+        end
+
+        def marshal_dump
+          reset_version!
+
+          [@version, @columns, {}, @primary_keys, @data_sources, @indexes, database_version, self.known_coder_type_records, self.additional_type_records]
+        end
+
+        def marshal_load(array)
+          @version, @columns, _columns_hash, @primary_keys, @data_sources, @indexes, @database_version, self.known_coder_type_records, self.additional_type_records = array
+          @indexes ||= {}
+
+          derive_columns_hash_and_deduplicate_values
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -12,6 +12,7 @@ require "active_record/connection_adapters/postgresql/explain_pretty_printer"
 require "active_record/connection_adapters/postgresql/oid"
 require "active_record/connection_adapters/postgresql/quoting"
 require "active_record/connection_adapters/postgresql/referential_integrity"
+require "active_record/connection_adapters/postgresql/schema_cache"
 require "active_record/connection_adapters/postgresql/schema_creation"
 require "active_record/connection_adapters/postgresql/schema_definitions"
 require "active_record/connection_adapters/postgresql/schema_dumper"
@@ -654,6 +655,10 @@ module ActiveRecord
         end
       end
 
+      def init_schema_cache
+        PostgreSQL::SchemaCache.new(self)
+      end
+
       private
         def type_map
           @type_map ||= Type::HashLookupTypeMap.new
@@ -784,9 +789,17 @@ module ActiveRecord
 
         def load_additional_types(oids = nil)
           initializer = OID::TypeMapInitializer.new(type_map)
-          load_types_queries(initializer, oids) do |query|
-            execute_and_clear(query, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |records|
-              initializer.run(records)
+          # Will not work when dumping, a dump file should be recreated on each
+          # schema_cache:dump
+          if should_load_types_from_cache?(oids)
+            records = schema_cache.additional_type_records
+            initializer.run(records)
+          else
+            load_types_queries(initializer, oids) do |query|
+              execute_and_clear(query, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |records|
+                schema_cache.additional_type_records |= records.to_a
+                initializer.run(records)
+              end
             end
           end
         end
@@ -1096,14 +1109,24 @@ module ActiveRecord
             "timestamptz" => PG::TextDecoder::TimestampWithTimeZone,
           }
 
-          known_coder_types = coders_by_name.keys.map { |n| quote(n) }
-          query = <<~SQL % known_coder_types.join(", ")
-            SELECT t.oid, t.typname
-            FROM pg_type as t
-            WHERE t.typname IN (%s)
-          SQL
-          coders = execute_and_clear(query, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |result|
-            result.filter_map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
+          if schema_cache.known_coder_type_records.present?
+            coders = schema_cache
+              .known_coder_type_records
+              .filter_map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
+          else
+            known_coder_types = coders_by_name.keys.map { |n| quote(n) }
+
+            query = <<~SQL % known_coder_types.join(", ")
+              SELECT t.oid, t.typname
+              FROM pg_type as t
+              WHERE t.typname IN (%s)
+            SQL
+
+            coders = execute_and_clear(query, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |result|
+              schema_cache.known_coder_type_records |= result.to_a
+
+              result.filter_map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
+            end
           end
 
           map = PG::TypeMapByOid.new
@@ -1123,6 +1146,15 @@ module ActiveRecord
         def construct_coder(row, coder_class)
           return unless coder_class
           coder_class.new(oid: row["oid"].to_i, name: row["typname"])
+        end
+
+        def should_load_types_from_cache?(oids)
+          if oids.blank?
+            schema_cache.additional_type_records.present?
+          else
+            cached_oids = schema_cache.additional_type_records.map { |oid| oid["oid"] }
+            (oids - cached_oids).empty?
+          end
         end
 
         class MoneyDecoder < PG::SimpleDecoder # :nodoc:

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -143,7 +143,12 @@ To keep using the current cache store, you can turn off cache versioning entirel
               schema_cache_path: db_config.schema_cache_path
             )
 
-            cache = ActiveRecord::ConnectionAdapters::SchemaCache.load_from(filename)
+            cache = if connection_pool.db_config.configuration_hash[:adapter] == "postgresql"
+              ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCache.load_from(filename)
+            else
+              ActiveRecord::ConnectionAdapters::SchemaCache.load_from(filename)
+            end
+
             next if cache.nil?
 
             if check_schema_cache_dump_version

--- a/activerecord/test/cases/adapters/postgresql/array_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/array_test.rb
@@ -12,6 +12,9 @@ class PostgresqlArrayTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def setup
+    ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCache.additional_type_records = []
+    ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCache.known_coder_type_records = []
+
     @connection = ActiveRecord::Base.connection
 
     enable_extension!("hstore", @connection)

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -23,14 +23,13 @@ module ActiveRecord
 
       def test_reconnection_error
         fake_connection = Class.new do
+          attr_accessor :type_map_for_results
+
           def async_exec(*)
             [{}]
           end
 
           def type_map_for_queries=(_)
-          end
-
-          def type_map_for_results=(_)
           end
 
           def exec_params(*)
@@ -407,6 +406,10 @@ module ActiveRecord
 
       def test_only_reload_type_map_once_for_every_unrecognized_type
         reset_connection
+
+        ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCache.additional_type_records = []
+        ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaCache.known_coder_type_records = []
+
         connection = ActiveRecord::Base.connection
 
         silence_warnings do

--- a/activerecord/test/cases/connection_adapters/postgresql/schema_cache_test.rb
+++ b/activerecord/test/cases/connection_adapters/postgresql/schema_cache_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveRecord
+  module ConnectionAdapters
+    module PostgreSQL
+      class SchemaCacheTest < ActiveRecord::TestCase
+        if current_adapter?(:PostgreSQLAdapter)
+          def setup
+            @connection = ActiveRecord::Base.connection
+          end
+
+          def test_type_map_existence_in_schema_cache
+            assert_not(@connection.schema_cache.additional_type_records.empty?)
+            assert_not(@connection.schema_cache.known_coder_type_records.empty?)
+          end
+
+          def test_type_map_queries_when_initialize_connection
+            db_config = ActiveRecord::Base.configurations.configs_for(
+              env_name: "arunit",
+              name: "primary"
+            )
+
+            assert_no_sql("SELECT t.oid, t.typname") do
+              ActiveRecord::Base.postgresql_connection(db_config.configuration_hash)
+            end
+          end
+
+          def test_type_map_queries_with_custom_types
+            cache = SchemaCache.new(@connection)
+            tempfile = Tempfile.new(["schema_cache-", ".yml"])
+
+            assert_no_sql("SELECT t.oid, t.typname") do
+              cache.dump_to(tempfile.path)
+            end
+
+            cache = SchemaCache.load_from(tempfile.path)
+            cache.connection = @connection
+
+            assert_sql(/SELECT t.oid, t.typname, t.typelem/) do
+              @connection.execute("CREATE TYPE account_status AS ENUM ('new', 'open', 'closed');")
+              @connection.execute("ALTER TABLE accounts ADD status account_status NOT NULL DEFAULT 'new';")
+              cache.dump_to(tempfile.path)
+            end
+          ensure
+            @connection.execute("DELETE FROM accounts; ALTER TABLE accounts DROP COLUMN status;DROP TYPE IF EXISTS account_status;")
+          end
+        end
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/test_case.rb
+++ b/activerecord/test/cases/test_case.rb
@@ -68,6 +68,18 @@ module ActiveRecord
       assert_queries(0, options, &block)
     end
 
+    def assert_no_sql(query_string)
+      ActiveRecord::Base.connection.materialize_transactions
+      SQLCounter.clear_log
+
+      yield
+      query_log = SQLCounter.log_all
+
+      query_existence = query_log.join('\n') =~ /#{query_string}/
+
+      assert(query_existence.nil?, "The query '#{query_string}' has been executed while it should not be")
+    end
+
     def assert_column(model, column_name, msg = nil)
       model.reset_column_information
       assert_includes model.column_names, column_name.to_s, msg


### PR DESCRIPTION
### Summary

In our project, we are using PG and Resque.
Right now, for every Resque job processed and new connection spawned, we are executing this method in Rails that run a costly query :

```ruby
def load_additional_types(oids = nil)
  initializer = OID::TypeMapInitializer.new(type_map)

  query = <<~SQL
    SELECT t.oid, t.typname, t.typelem, t.typdelim, t.typinput, r.rngsubtype, t.typtype, t.typbasetype
    FROM pg_type as t
    LEFT JOIN pg_range as r ON oid = rngtypid
  SQL
     
  if oids
    query += "WHERE t.oid IN (%s)" % oids.join(", ")
  else
    query += initializer.query_conditions_for_initial_load
  end
      
  execute_and_clear(query, "SCHEMA", []) do |records|
    initializer.run(records)
  end
end
```

To fix this issue we have done a monkey patch, basically, the connection pool stores a cache of the `type_map`, and a new connection will inherit from this cache, instead of querying it.

```ruby
module ActiveRecord
  module ConnectionAdapters
    class PoolManager
      attr_accessor :type_map
    end
  end

  class ConnectionAdapters::ConnectionPool
    def adopt_connection(conn)
      ....
      pool_manager = ConnectionAdapters::ConnectionPool.get_pool_manager

      pool_manager.type_map ||= conn.type_map
      ....
    end
  end

  class ConnectionAdapters::PostgreSQLAdapter
    attr_reader :type_map

    def initialize(connection, logger, connection_parameters, config)
      ....

      pool_manager = ConnectionAdapters::ConnectionPool.get_pool_manager
      type_map = pool_manager.type_map

      if type_map
        @type_map = type_map
      else
        @type_map = Type::HashLookupTypeMap.new
        initialize_type_map
      end
 
      ....
    end
  end
end
```

In order not to have monkey patches we want to solve it on a Rails side which could be useful for other developers too.

It also affects every Rails upgrade.

* First of all, we have dug in relevant PRs done in Rails and took some ideas.
* The solutions to deal with issues maybe:
    * Store `TypeMap` into `SchemaCache` (relevant for PG only)
    * Switch off `TypeMap` if there is no usage of PG custom types
    * Introduce the monkey patch as the solution for Rails
* We have selected the first one and would like to have feedback from Rails maintainers and complete this topic.
* If there is something we have missed we are also ready to fix it shortly.

Base PRs for this PR:

https://github.com/rails/rails/issues/35311
https://github.com/rails/rails/pull/39821/files
https://github.com/rails/rails/pull/39077/files
https://github.com/rails/rails/pull/41288/files

I would like to tag also @piecehealth and @ted-hanson