### PR TITLE
Fix `change_column_comment` to preserve column's AUTO_INCREMENT in the MySQL adapter

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -9,6 +9,10 @@
 
     *Nick Holden*
 
+* Fix `change_column_comment` to preserve column's AUTO_INCREMENT in the MySQL adapter
+
+    *fatkodima*
+
 *   Fix quoting of `ActiveSupport::Duration` and `Rational` numbers in the MySQL adapter.
 
     *Kevin McPhillips*

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -722,6 +722,8 @@ module ActiveRecord
             options[:comment] = column.comment
           end
 
+          options[:auto_increment] = column.auto_increment?
+
           td = create_table_definition(table_name)
           cd = td.new_column_definition(column.name, type, **options)
           schema_creation.accept(ChangeColumnDefinition.new(cd, column.name))

--- a/activerecord/test/cases/comment_test.rb
+++ b/activerecord/test/cases/comment_test.rb
@@ -178,9 +178,13 @@ if ActiveRecord::Base.connection.supports_comments?
     end
 
     def test_change_column_comment
-      @connection.change_column_comment :commenteds, :name, "Edited column comment"
-      column = Commented.columns_hash["name"]
+      @connection.change_column_comment :commenteds, :id, "Edited column comment"
+      column = Commented.columns_hash["id"]
       assert_equal "Edited column comment", column.comment
+
+      if current_adapter?(:Mysql2Adapter)
+        assert column.auto_increment?
+      end
     end
 
     def test_change_column_comment_to_nil


### PR DESCRIPTION
Closes #44461