### PR TITLE
Add `:nodoc:` to `ActiveRecord::Relation#where_values_hash`

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -736,7 +736,7 @@ module ActiveRecord
     #
     #   User.where(name: 'Oscar').where_values_hash
     #   # => {name: "Oscar"}
-    def where_values_hash(relation_table_name = klass.table_name)
+    def where_values_hash(relation_table_name = klass.table_name) # :nodoc:
       where_clause.to_h(relation_table_name)
     end
 


### PR DESCRIPTION
According to https://github.com/rails/rails/issues/33950#issuecomment-424515220 and https://github.com/rails/rails/issues/4388#issuecomment-3468958, this method is private and should not be used by applications.