### PR TITLE
Document horo variables in RDoc configuration

### DIFF
--- a/railties/lib/rails/api/task.rb
+++ b/railties/lib/rails/api/task.rb
@@ -162,7 +162,8 @@ module Rails
         end
       end
 
-      def setup_horo_variables
+      # These variables are used by the sdoc template
+      def setup_horo_variables # :nodoc:
         ENV["HORO_PROJECT_NAME"]    = "Ruby on Rails"
         ENV["HORO_PROJECT_VERSION"] = rails_version
       end


### PR DESCRIPTION
Horo was replaced by sdoc in https://github.com/rails/rails/commit/827a0fee07eff7ca35ecdf5ca650f2094ad4825a eleven years ago, but these variables are still used by the sdoc template.