### PR TITLE
Implicitly assert no exception is raised in `assert_queries` & al

### DIFF
--- a/actiontext/test/test_helper.rb
+++ b/actiontext/test/test_helper.rb
@@ -22,7 +22,7 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
 end
 
 class ActiveSupport::TestCase
-  def assert_queries(expected_count)
+  def assert_queries(expected_count, &block)
     ActiveRecord::Base.connection.materialize_transactions
 
     queries = []
@@ -30,9 +30,9 @@ class ActiveSupport::TestCase
       queries << payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(payload[:name])
     end
 
-    yield.tap do
-      assert_equal expected_count, queries.size, "#{queries.size} instead of #{expected_count} queries were executed. #{queries.inspect}"
-    end
+    result = _assert_nothing_raised_or_warn("assert_queries", &block)
+    assert_equal expected_count, queries.size, "#{queries.size} instead of #{expected_count} queries were executed. #{queries.inspect}"
+    result
   end
 
   def assert_no_queries(&block)

--- a/actionview/test/activerecord/relation_cache_test.rb
+++ b/actionview/test/activerecord/relation_cache_test.rb
@@ -25,7 +25,7 @@ class RelationCacheTest < ActionView::TestCase
 
   def view_cache_dependencies; []; end
 
-  def assert_queries(num)
+  def assert_queries(num, &block)
     ActiveRecord::Base.connection.materialize_transactions
     count = 0
 
@@ -33,7 +33,7 @@ class RelationCacheTest < ActionView::TestCase
       count += 1 unless ["SCHEMA", "TRANSACTION"].include? payload[:name]
     end
 
-    result = yield
+    result = _assert_nothing_raised_or_warn("assert_queries", &block)
     assert_equal num, count, "#{count} instead of #{num} queries were executed."
     result
   end

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -489,9 +489,11 @@ class QueryCacheTest < ActiveRecord::TestCase
       payload[:sql].downcase!
     end
 
-    assert_raises FrozenError do
-      ActiveRecord::Base.cache do
-        assert_queries(1) { Task.find(1); Task.find(1) }
+    ActiveRecord::Base.cache do
+      assert_queries(1) do
+        assert_raises FrozenError do
+          Task.find(1)
+        end
       end
     end
   ensure

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1121,9 +1121,9 @@ class TransactionTest < ActiveRecord::TestCase
   end
 
   def test_raising_does_not_materialize_transaction
-    assert_raise(RuntimeError) do
-      assert_no_queries do
-        Topic.transaction { raise }
+    assert_no_queries do
+      assert_raise(RuntimeError) do
+        Topic.transaction { raise "Expected" }
       end
     end
   end

--- a/activestorage/test/test_helper.rb
+++ b/activestorage/test/test_helper.rb
@@ -61,7 +61,7 @@ class ActiveSupport::TestCase
     ActiveStorage::Current.reset
   end
 
-  def assert_queries(expected_count)
+  def assert_queries(expected_count, &block)
     ActiveRecord::Base.connection.materialize_transactions
 
     queries = []
@@ -69,9 +69,9 @@ class ActiveSupport::TestCase
       queries << payload[:sql] unless %w[ SCHEMA TRANSACTION ].include?(payload[:name])
     end
 
-    yield.tap do
-      assert_equal expected_count, queries.size, "#{queries.size} instead of #{expected_count} queries were executed. #{queries.inspect}"
-    end
+    result = _assert_nothing_raised_or_warn("assert_queries", &block)
+    assert_equal expected_count, queries.size, "#{queries.size} instead of #{expected_count} queries were executed. #{queries.inspect}"
+    result
   end
 
   def assert_no_queries(&block)


### PR DESCRIPTION
Fix: https://github.com/rails/rails/pull/44397
Ref: https://github.com/rails/rails/pull/37313
Ref: https://github.com/rails/rails/pull/42459

This avoid mistakes such as:

```ruby
assert_raise Something do
  assert_queries(1) do
    raise Something
  end
end
```
