### PR TITLE
`Pathname.blank?` only returns true for `Pathname.new("")`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   `Pathname.blank?` only returns true for `Pathname.new("")`
+
+    Previously it would end up calling `Pathname#empty?` which returned true
+    if the path existed and was an empty directory or file.
+
+    That behavior was unlikely to be expected.
+
+    *Jean Boussier*
+
 *   Deprecate `Notification::Event`'s `#children` and `#parent_of?`
 
 *   Change default serialization format of `MessageEncryptor` from `Marshal` to `JSON` for Rails 7.1.

--- a/activesupport/lib/active_support/core_ext/pathname.rb
+++ b/activesupport/lib/active_support/core_ext/pathname.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/pathname/blank"
 require "active_support/core_ext/pathname/existence"

--- a/activesupport/lib/active_support/core_ext/pathname/blank.rb
+++ b/activesupport/lib/active_support/core_ext/pathname/blank.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+class Pathname
+  # An Pathname is blank if it's empty:
+  #
+  #   Pathname.new("").blank?      # => true
+  #   Pathname.new(" ").blank?     # => false
+  #   Pathname.new("test).blank?  # => false
+  #
+  # @return [true, false]
+  def blank?
+    to_s.empty?
+  end
+end

--- a/activesupport/lib/active_support/core_ext/pathname/existence.rb
+++ b/activesupport/lib/active_support/core_ext/pathname/existence.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 class Pathname
   # Returns the receiver if the named file exists otherwise returns +nil+.
   # <tt>pathname.existence</tt> is equivalent to

--- a/activesupport/test/core_ext/pathname/blank_test.rb
+++ b/activesupport/test/core_ext/pathname/blank_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/pathname/blank"
+
+class PathnameBlankTest < ActiveSupport::TestCase
+  def test_blank
+    assert_predicate Pathname.new(""), :blank?
+    assert_not_predicate Pathname.new("test"), :blank?
+    assert_not_predicate Pathname.new(" "), :blank?
+  end
+end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/44452

We don't ignore blank path strings because as surprising as it is, they
are valid paths:

```ruby
>> path = Pathname.new(" ")
=> #<Pathname: >
>> path.write("test")
=> 4
>> path.exist?
=> true
```

Previously it would end up calling `Pathname#empty?` which returned true
if the path existed and was an empty directory or file.

That behavior was unlikely to be expected.
