### PR TITLE
Removed freenode link from support resources [ci-skip]

### DIFF
--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -2090,7 +2090,6 @@ resources:
 
 * The [Ruby on Rails Guides](index.html)
 * The [Ruby on Rails mailing list](https://discuss.rubyonrails.org/c/rubyonrails-talk)
-* The [#rubyonrails](irc://irc.freenode.net/#rubyonrails) channel on irc.freenode.net
 
 
 Configuration Gotchas


### PR DESCRIPTION
### Summary

Removed irc.freenode.net as a resource from the listed support resources in the Getting Started Guide. I believe this is not being used actively as a support resource. I might be wrong, in any case, I've removed it. If it is still being used, then the link has to be updated I believe.

Thank you 😄!

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->