### PR TITLE
Correct CSP initializer copy

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/content_security_policy.rb.tt
@@ -1,8 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.
-# For further information see the following documentation:
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+# See the Securing Rails Applications Guide for more information:
+# https://guides.rubyonrails.org/security.html#content-security-policy-header
 
 # Rails.application.configure do
 #   config.content_security_policy do |policy|
@@ -20,7 +20,6 @@
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
 #   config.content_security_policy_nonce_directives = %w(script-src)
 #
-#   # Report CSP violations to a specified URI. See:
-#   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+#   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true
 # end


### PR DESCRIPTION
### Summary

The `content_security_policy_report_only` config option does not 
"Report CSP violations to a specified URI".
It makes sure the policy isn't enforced, only reported.

Also link to the guide instead of external documentation, just as we do
for the new_framework_defaults_7_1.rb initializer:
https://github.com/rails/rails/blob/13d75c40fd477c189964429daca9b71045a49665/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt#L9-L10