### PR TITLE
Rails Guides - Fix incorrect generator example [ci-skip]

### DIFF
--- a/guides/source/generators.md
+++ b/guides/source/generators.md
@@ -215,6 +215,7 @@ config.generators do |g|
   g.orm             :active_record
   g.template_engine :erb
   g.test_framework  :test_unit, fixture: false
+  g.stylesheets     false
 end
 ```
 


### PR DESCRIPTION
Description says "stop generating stylesheet and test fixtures" but example doesn't stop stylesheet generation.
(we can also change the description instead of the example, but it's reused a few lines below)
