### PR TITLE
removed list of gems rails 7 specified in the Rails initialization guide [ci-skip]

### DIFF
--- a/guides/source/initialization.md
+++ b/guides/source/initialization.md
@@ -63,35 +63,6 @@ dependencies of the application. `config/boot.rb` sets
 exists, then `bundler/setup` is required. The require is used by Bundler to
 configure the load path for your Gemfile's dependencies.
 
-A standard Rails application depends on several gems, specifically:
-
-* actioncable
-* actionmailer
-* actionpack
-* actionview
-* activejob
-* activemodel
-* activerecord
-* activestorage
-* activesupport
-* actionmailbox
-* actiontext
-* arel
-* builder
-* bundler
-* erubi
-* i18n
-* mail
-* mime-types
-* rack
-* rack-test
-* rails
-* railties
-* rake
-* sqlite3
-* thor
-* tzinfo
-
 ### `rails/commands.rb`
 
 Once `config/boot.rb` has finished, the next file that is required is


### PR DESCRIPTION
### Summary

In the [Rails Initialization Guide](https://guides.rubyonrails.org/initialization.html), the list of gems which are said to be present in a standard rails application does not reflect the current state of a standard Rails 7 application. Here's what I've updated:

1. Removed, `arel` gem from the list, since it has now been moved to `activerecord` gem
2. Added the following gems which are missing: `bootsnap`, `importmap-rails`, `jbuilder`, `puma`, `redis`, `sprockets-rails`, `stimulus-rails`, `turbo-rails`

Thanks!

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
