### PR TITLE
Don't output the whole Rails::Railtie object when a NoMethodError is raised

### DIFF
--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -247,6 +247,10 @@ module Rails
       end
     end
 
+    def inspect # :nodoc:
+      "#<#{self.class.name}>"
+    end
+
     def configure(&block) # :nodoc:
       instance_eval(&block)
     end

--- a/railties/test/railties/railtie_test.rb
+++ b/railties/test/railties/railtie_test.rb
@@ -224,5 +224,18 @@ module RailtiesTest
       Rails.env = original_env
       assert_equal(original_env, Rails.env)
     end
+
+    test "Railtie object isn't output when a NoMethodError is raised" do
+      class Foo < Rails::Railtie
+        config.foo = ActiveSupport::OrderedOptions.new
+        config.foo.greetings = "hello"
+      end
+
+      error = assert_raises(NoMethodError) do
+        Foo.instance.abc
+      end
+
+      assert_equal("undefined method `abc' for #<RailtiesTest::RailtieTest::Foo>", error.original_message)
+    end
   end
 end


### PR DESCRIPTION
Don't output the whole Rails::Railtie object when a NoMethodError is raised

- ### Summary

  The terminal output on a Rails application running ruby 3 will be
  cluttered with thousands of lines if one inadventarly call a
  unexisting method.
  This happen in various places (IntegrationTest, when running a db
  migration ...).
  This is related to a change in ruby 3 when a NoMethodError is
  raised.

  ### Simple reproduction

  ```ruby
  class A
    def initialize(session)
      @A = session
    end
  end

  test = A.new("*" * 36)
  test.dsad # undefined method `dsad' for #<A:0x00007f847d8494b0 @A="************************************"> (NoMethodError)
  # Note that the "#<A:0x00007f847d8494b0 @A="************************************">" part is 65 chars long.

  test = test = A.new("*" * 37)
  test.dsad # undefined method `dsad' for #<A:0x00007fa8c38299c0> (NoMethodError)
  ```

  On Ruby < 3, the NoMethodError message (everything starting from the
  "#" char) could only be 65 characters long. If it was above that
  ruby would only output the name of the class and its address.

  On Ruby >= 3, that limitation has been removed and the message can
  be any length long.

  Change upstream was here https://github.com/ruby/ruby/commit/1258a0fb90ea63bf1ec108815cce0d552acfc726

  ### On Rails

  Anytime a method is called on a object that holds the entire
  Rails::Application, the terminal would output the entire application
  which is annoying and be can be dangerous because it will leak
  everything containing the credentials (stored inside the Application
  object).