### PR TITLE
Safely remove core_ext/integer/time require from generated app config/environments

### DIFF
--- a/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/development.rb.tt
@@ -1,5 +1,3 @@
-require "active_support/core_ext/integer/time"
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt
@@ -1,5 +1,3 @@
-require "active_support/core_ext/integer/time"
-
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/environments/test.rb.tt
@@ -1,5 +1,3 @@
-require "active_support/core_ext/integer/time"
-
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped


### PR DESCRIPTION
`require "active_support/core_ext/integer/time"` in default generated rails app config/environments/*.rb is not need, as rails lib has already required it.

* Since activejob gem's dependency globalid lib/global_id/railtie.rb already required it. https://github.com/rails/globalid/commit/1aec708b98d8657ef241d02813960e8af8ebd952#diff-a70635094e6998f28c96dfddc2e3d73fecc9606357e3fe755e1f2f577e79d8edR8
* activesupport Cache module has already required it.  https://github.com/rails/rails/blob/c21c4139e1ceae0289a7ae2cd597b4705a24a71b/activesupport/lib/active_support/cache.rb#L9

