### PR TITLE
Be explicit every time we invoke 'rails'

### DIFF
--- a/railties/lib/rails/generators/actions.rb
+++ b/railties/lib/rails/generators/actions.rb
@@ -340,16 +340,7 @@ module Rails
             abort_on_failure: options[:abort_on_failure],
           }
 
-          in_root { run("#{sudo}#{extify(executor)} #{command}", config) }
-        end
-
-        # Add an extension to the given name based on the platform.
-        def extify(name) # :doc:
-          if Gem.win_platform?
-            "#{name}.bat"
-          else
-            name
-          end
+          in_root { run("#{sudo}#{Shellwords.escape Gem.ruby} bin/#{executor} #{command}", config) }
         end
 
         # Always returns value in double quotes.

--- a/railties/test/generators/actions_test.rb
+++ b/railties/test/generators/actions_test.rb
@@ -734,7 +734,11 @@ class ActionsTest < Rails::Generators::TestCase
       config_matcher = ->(actual_config) do
         assert_equal config, actual_config.slice(*config.keys)
       end if config
-      args = Array(commands).map { |command| [command, *config_matcher] }
+      args = Array(commands).map do |command|
+        command_matcher = Regexp.escape(command)
+        command_matcher = command_matcher.sub(/^sudo\\ /, '\A\1.*')
+        [/#{command_matcher}\z/, *config_matcher]
+      end
 
       assert_called_with(generator, :run, args) do
         block.call

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -125,7 +125,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_application_new_exits_with_non_zero_code_on_invalid_application_name
-    quietly { system "rails new test --no-rc" }
+    quietly { system "#{File.expand_path("../../exe/rails", __dir__)} new test --no-rc" }
     assert_equal false, $?.success?
   end
 
@@ -134,7 +134,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     run_generator [app_root]
     output = nil
     Dir.chdir(app_root) do
-      output = `rails new mysecondapp`
+      output = `#{File.expand_path("../../exe/rails", __dir__)} new mysecondapp`
     end
     assert_equal "Can't initialize a new Rails application within the directory of another, please change to a non-Rails directory first.\nType 'rails' for help.\n", output
     assert_equal false, $?.success?
@@ -144,7 +144,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     app_root = File.join(destination_root, "myfirstapp")
     run_generator [app_root]
     output = Dir.chdir(app_root) do
-      `rails new --help`
+      `#{File.expand_path("../../exe/rails", __dir__)} new --help`
     end
     assert_match(/rails new APP_PATH \[options\]/, output)
     assert_equal true, $?.success?


### PR DESCRIPTION
This almost never matters, but if the path-global 'rake' or 'rails' points to a specific (and wrong) ruby version, (or, possible in CI, there is no installed 'rails' executable), things get confused.

Instead, any time we mean "run a global 'rails', as for 'new'", use a fully-qualified path to our in-tree copy. And any time we're working inside an application, use the bin/rails script directly. It would be equivalently valid to always use the one in exe/, because that handles searching for bin/rails internally... but it's uglier to fully-qualify, plus 'rake' would then be more complicated.

---

I noticed this after having reset my local machine's ruby binstubs: I didn't have an installed Rails, so `rails` was hitting the (macOS-supplied?) "Rails is not currently installed on this system" script in `/usr/bin/rails`... which is also stuck pointing at `/usr/bin/ruby`, which is _not_ the version I intended to be running.