### PR TITLE
Apply `:nodoc:` to nested classes and modules [ci-skip]

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/async.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/async.rb
@@ -10,7 +10,7 @@ module ActionCable
           AsyncSubscriberMap.new(server.event_loop)
         end
 
-        class AsyncSubscriberMap < SubscriberMap
+        class AsyncSubscriberMap < SubscriberMap # :nodoc:
           def initialize(event_loop)
             @event_loop = event_loop
             super()

--- a/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/postgresql.rb
@@ -71,7 +71,7 @@ module ActionCable
           end
         end
 
-        class Listener < SubscriberMap
+        class Listener < SubscriberMap # :nodoc:
           def initialize(adapter, event_loop)
             super()
 

--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -59,7 +59,7 @@ module ActionCable
           self.class.redis_connector.call(@server.config.cable.merge(id: identifier))
         end
 
-        class Listener < SubscriberMap
+        class Listener < SubscriberMap # :nodoc:
           def initialize(adapter, event_loop)
             super()
 

--- a/actionpack/lib/action_controller/metal/live.rb
+++ b/actionpack/lib/action_controller/metal/live.rb
@@ -230,7 +230,7 @@ module ActionController
         end
     end
 
-    class Response < ActionDispatch::Response # :nodoc: all
+    class Response < ActionDispatch::Response # :nodoc:
       private
         def before_committed
           super

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -472,7 +472,7 @@ module ActionDispatch # :nodoc:
                        ct.charset || self.class.default_charset)
     end
 
-    class RackBody
+    class RackBody # :nodoc:
       def initialize(response)
         @response = response
       end

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -133,8 +133,8 @@ module ActionDispatch
         end
     end
 
-    module ConsoleFormatter
-      class Base
+    module ConsoleFormatter # :nodoc:
+      class Base # :nodoc:
         def initialize
           @buffer = []
         end
@@ -170,7 +170,7 @@ module ActionDispatch
         end
       end
 
-      class Sheet < Base
+      class Sheet < Base # :nodoc:
         def section_title(title)
           @buffer << "\n#{title}:"
         end
@@ -206,7 +206,7 @@ module ActionDispatch
           end
       end
 
-      class Expanded < Base
+      class Expanded < Base # :nodoc:
         def initialize(width: IO.console_size[1])
           @width = width
           super()
@@ -239,7 +239,7 @@ module ActionDispatch
       end
     end
 
-    class HtmlTableFormatter
+    class HtmlTableFormatter # :nodoc:
       def initialize(view)
         @view = view
         @buffer = []

--- a/actionpack/lib/action_dispatch/testing/request_encoder.rb
+++ b/actionpack/lib/action_dispatch/testing/request_encoder.rb
@@ -2,7 +2,7 @@
 
 module ActionDispatch
   class RequestEncoder # :nodoc:
-    class IdentityEncoder
+    class IdentityEncoder # :nodoc:
       def content_type; end
       def accept_header; end
       def encode_params(params); params; end

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -127,7 +127,7 @@ module ActionView
         rendered_templates.first.format
       end
 
-      class EmptyCollection
+      class EmptyCollection # :nodoc:
         attr_reader :format
 
         def initialize(format)

--- a/actionview/lib/action_view/template/handlers/erb/erubi.rb
+++ b/actionview/lib/action_view/template/handlers/erb/erubi.rb
@@ -6,8 +6,7 @@ module ActionView
   class Template
     module Handlers
       class ERB
-        class Erubi < ::Erubi::Engine
-          # :nodoc: all
+        class Erubi < ::Erubi::Engine # :nodoc:
           def initialize(input, properties = {})
             @newline_pending = 0
 

--- a/actionview/lib/action_view/template/types.rb
+++ b/actionview/lib/action_view/template/types.rb
@@ -4,8 +4,8 @@ require "active_support/core_ext/module/attribute_accessors"
 
 module ActionView
   class Template # :nodoc:
-    module Types
-      class Type
+    module Types # :nodoc:
+      class Type # :nodoc:
         SET = Struct.new(:symbols).new([ :html, :text, :js, :css, :xml, :json ])
 
         def self.[](type)

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -2,7 +2,7 @@
 
 module ActionView
   class TemplateDetails # :nodoc:
-    class Requested
+    class Requested # :nodoc:
       attr_reader :locale, :handlers, :formats, :variants
       attr_reader :locale_idx, :handlers_idx, :formats_idx, :variants_idx
 

--- a/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb
+++ b/activemodel/lib/active_model/type/helpers/accepts_multiparameter_time.rb
@@ -2,9 +2,9 @@
 
 module ActiveModel
   module Type
-    module Helpers # :nodoc: all
-      class AcceptsMultiparameterTime < Module
-        module InstanceMethods
+    module Helpers # :nodoc:
+      class AcceptsMultiparameterTime < Module # :nodoc:
+        module InstanceMethods # :nodoc:
           def serialize(value)
             super(cast(value))
           end

--- a/activemodel/lib/active_model/type/helpers/mutable.rb
+++ b/activemodel/lib/active_model/type/helpers/mutable.rb
@@ -2,8 +2,8 @@
 
 module ActiveModel
   module Type
-    module Helpers # :nodoc: all
-      module Mutable
+    module Helpers # :nodoc:
+      module Mutable # :nodoc:
         def cast(value)
           deserialize(serialize(value))
         end

--- a/activemodel/lib/active_model/type/helpers/numeric.rb
+++ b/activemodel/lib/active_model/type/helpers/numeric.rb
@@ -2,8 +2,8 @@
 
 module ActiveModel
   module Type
-    module Helpers # :nodoc: all
-      module Numeric
+    module Helpers # :nodoc:
+      module Numeric # :nodoc:
         def serialize(value)
           cast(value)
         end

--- a/activemodel/lib/active_model/type/helpers/time_value.rb
+++ b/activemodel/lib/active_model/type/helpers/time_value.rb
@@ -5,8 +5,8 @@ require "active_support/core_ext/time/zones"
 
 module ActiveModel
   module Type
-    module Helpers # :nodoc: all
-      module TimeValue
+    module Helpers # :nodoc:
+      module TimeValue # :nodoc:
         def serialize(value)
           value = apply_seconds_precision(value)
 

--- a/activemodel/lib/active_model/type/helpers/timezone.rb
+++ b/activemodel/lib/active_model/type/helpers/timezone.rb
@@ -4,8 +4,8 @@ require "active_support/core_ext/time/zones"
 
 module ActiveModel
   module Type
-    module Helpers # :nodoc: all
-      module Timezone
+    module Helpers # :nodoc:
+      module Timezone # :nodoc:
         def is_utc?
           ::Time.zone_default.nil? || ::Time.zone_default.match?("UTC")
         end

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -24,7 +24,7 @@ module ActiveModel
           Array(options[:accept]).include?(value)
         end
 
-        class LazilyDefineAttributes < Module
+        class LazilyDefineAttributes < Module # :nodoc:
           def initialize(attributes)
             @attributes = attributes.map(&:to_s)
           end

--- a/activerecord/lib/active_record/associations/preloader/association.rb
+++ b/activerecord/lib/active_record/associations/preloader/association.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Associations
     class Preloader
       class Association # :nodoc:
-        class LoaderQuery
+        class LoaderQuery # :nodoc:
           attr_reader :scope, :association_key_name
 
           def initialize(scope, association_key_name)
@@ -40,7 +40,7 @@ module ActiveRecord
           end
         end
 
-        class LoaderRecords
+        class LoaderRecords # :nodoc:
           def initialize(loaders, loader_query)
             @loader_query = loader_query
             @loaders = loaders

--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/bit.rb
@@ -26,7 +26,7 @@ module ActiveRecord
             Data.new(super) if value
           end
 
-          class Data
+          class Data # :nodoc:
             def initialize(value)
               @value = value
             end

--- a/activerecord/lib/active_record/dynamic_matchers.rb
+++ b/activerecord/lib/active_record/dynamic_matchers.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         end
       end
 
-      class Method
+      class Method # :nodoc:
         @matchers = []
 
         class << self
@@ -90,7 +90,7 @@ module ActiveRecord
           end
       end
 
-      class FindBy < Method
+      class FindBy < Method # :nodoc:
         Method.matchers << self
 
         def self.prefix
@@ -102,7 +102,7 @@ module ActiveRecord
         end
       end
 
-      class FindByBang < Method
+      class FindByBang < Method # :nodoc:
         Method.matchers << self
 
         def self.prefix

--- a/activerecord/lib/active_record/statement_cache.rb
+++ b/activerecord/lib/active_record/statement_cache.rb
@@ -61,7 +61,7 @@ module ActiveRecord
       end
     end
 
-    class PartialQueryCollector
+    class PartialQueryCollector # :nodoc:
       attr_accessor :preparable
 
       def initialize

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -840,7 +840,7 @@ module ActiveSupport
         end
       end
 
-      module Loader
+      module Loader # :nodoc:
         extend self
 
         def load(payload)
@@ -863,7 +863,7 @@ module ActiveSupport
         end
       end
 
-      module Rails61Coder
+      module Rails61Coder # :nodoc:
         include Loader
         extend self
 
@@ -876,7 +876,7 @@ module ActiveSupport
         end
       end
 
-      module Rails70Coder
+      module Rails70Coder # :nodoc:
         include Loader
         extend self
 

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -180,7 +180,7 @@ module ActiveSupport
             end
           end
 
-          module Loader
+          module Loader # :nodoc:
             def load(payload)
               if payload.is_a?(Entry)
                 payload
@@ -190,7 +190,7 @@ module ActiveSupport
             end
           end
 
-          module Rails61Coder
+          module Rails61Coder # :nodoc:
             include Loader
             extend self
 
@@ -203,7 +203,7 @@ module ActiveSupport
             end
           end
 
-          module Rails70Coder
+          module Rails70Coder # :nodoc:
             include Cache::Coders::Rails70Coder
             include Loader
             extend self

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -148,7 +148,7 @@ module ActiveSupport
       end
 
       module Conditionals # :nodoc:
-        class Value
+        class Value # :nodoc:
           def initialize(&block)
             @block = block
           end
@@ -156,10 +156,10 @@ module ActiveSupport
         end
       end
 
-      module Filters
+      module Filters # :nodoc:
         Environment = Struct.new(:target, :halted, :value)
 
-        class Before
+        class Before # :nodoc:
           def self.build(callback_sequence, user_callback, user_conditions, chain_config, filter, name)
             halted_lambda = chain_config[:terminator]
 
@@ -209,7 +209,7 @@ module ActiveSupport
           private_class_method :halting
         end
 
-        class After
+        class After # :nodoc:
           def self.build(callback_sequence, user_callback, user_conditions, chain_config)
             if chain_config[:skip_after_callbacks_if_terminated]
               if user_conditions.any?
@@ -373,7 +373,7 @@ module ActiveSupport
       # A future invocation of user-supplied code (either as a callback,
       # or a condition filter).
       module CallTemplate # :nodoc:
-        class MethodCall
+        class MethodCall # :nodoc:
           def initialize(method)
             @method_name = method
           end
@@ -408,7 +408,7 @@ module ActiveSupport
           end
         end
 
-        class ObjectCall
+        class ObjectCall # :nodoc:
           def initialize(target, method)
             @override_target = target
             @method_name = method
@@ -431,7 +431,7 @@ module ActiveSupport
           end
         end
 
-        class InstanceExec0
+        class InstanceExec0 # :nodoc:
           def initialize(block)
             @override_block = block
           end
@@ -453,7 +453,7 @@ module ActiveSupport
           end
         end
 
-        class InstanceExec1
+        class InstanceExec1 # :nodoc:
           def initialize(block)
             @override_block = block
           end
@@ -475,7 +475,7 @@ module ActiveSupport
           end
         end
 
-        class InstanceExec2
+        class InstanceExec2 # :nodoc:
           def initialize(block)
             @override_block = block
           end
@@ -500,7 +500,7 @@ module ActiveSupport
           end
         end
 
-        class ProcCall
+        class ProcCall # :nodoc:
           def initialize(target)
             @override_target = target
           end

--- a/activesupport/lib/active_support/code_generator.rb
+++ b/activesupport/lib/active_support/code_generator.rb
@@ -2,7 +2,7 @@
 
 module ActiveSupport
   class CodeGenerator # :nodoc:
-    class MethodSet
+    class MethodSet # :nodoc:
       METHOD_CACHES = Hash.new { |h, k| h[k] = Module.new }
 
       def initialize(namespace)

--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -32,7 +32,7 @@ module ActiveSupport
   #     checker.execute_if_updated
   #     # => "changed"
   #
-  class EventedFileUpdateChecker # :nodoc: all
+  class EventedFileUpdateChecker # :nodoc:
     def initialize(files, dirs = {}, &block)
       unless block
         raise ArgumentError, "A block is required to initialize an EventedFileUpdateChecker"
@@ -65,7 +65,7 @@ module ActiveSupport
       end
     end
 
-    class Core
+    class Core # :nodoc:
       attr_reader :updated
 
       def initialize(files, dirs)

--- a/activesupport/lib/active_support/fork_tracker.rb
+++ b/activesupport/lib/active_support/fork_tracker.rb
@@ -2,7 +2,7 @@
 
 module ActiveSupport
   module ForkTracker # :nodoc:
-    module ModernCoreExt
+    module ModernCoreExt # :nodoc:
       def _fork
         pid = super
         if pid == 0
@@ -12,7 +12,7 @@ module ActiveSupport
       end
     end
 
-    module CoreExt
+    module CoreExt # :nodoc:
       def fork(...)
         if block_given?
           super do
@@ -28,7 +28,7 @@ module ActiveSupport
       end
     end
 
-    module CoreExtPrivate
+    module CoreExtPrivate # :nodoc:
       include CoreExt
       private :fork
     end

--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -15,7 +15,7 @@ module ActiveSupport
         @rotations << build_rotation(*secrets, @options.merge(options))
       end
 
-      module Encryptor
+      module Encryptor # :nodoc:
         include Rotator
 
         def decrypt_and_verify(*args, on_rotation: @on_rotation, **options)
@@ -30,7 +30,7 @@ module ActiveSupport
           end
       end
 
-      module Verifier
+      module Verifier # :nodoc:
         include Rotator
 
         def verified(*args, on_rotation: @on_rotation, **options)

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -173,7 +173,7 @@ module ActiveSupport
             pattern === name && !exclusions.include?(name)
           end
 
-          class AllMessages
+          class AllMessages # :nodoc:
             def ===(name)
               true
             end
@@ -259,7 +259,7 @@ module ActiveSupport
           end
         end
 
-        class EventObject < Evented
+        class EventObject < Evented # :nodoc:
           def start(name, id, payload)
             stack = IsolatedExecutionState[:_event_stack] ||= []
             event = build_event name, id, payload

--- a/activesupport/lib/active_support/testing/parallelization/server.rb
+++ b/activesupport/lib/active_support/testing/parallelization/server.rb
@@ -6,7 +6,7 @@ require "drb/unix" unless Gem.win_platform?
 module ActiveSupport
   module Testing
     class Parallelization # :nodoc:
-      class Server
+      class Server # :nodoc:
         include DRb::DRbUndumped
 
         def initialize

--- a/activesupport/lib/active_support/testing/parallelization/worker.rb
+++ b/activesupport/lib/active_support/testing/parallelization/worker.rb
@@ -3,7 +3,7 @@
 module ActiveSupport
   module Testing
     class Parallelization # :nodoc:
-      class Worker
+      class Worker # :nodoc:
         def initialize(number, url)
           @id = SecureRandom.uuid
           @number = number

--- a/activesupport/lib/active_support/xml_mini/libxmlsax.rb
+++ b/activesupport/lib/active_support/xml_mini/libxmlsax.rb
@@ -10,7 +10,7 @@ module ActiveSupport
 
     # Class that will build the hash while the XML document
     # is being parsed using SAX events.
-    class HashBuilder
+    class HashBuilder # :nodoc:
       include LibXML::XML::SaxParser::Callbacks
 
       CONTENT_KEY   = "__content__"

--- a/activesupport/lib/active_support/xml_mini/nokogirisax.rb
+++ b/activesupport/lib/active_support/xml_mini/nokogirisax.rb
@@ -15,7 +15,7 @@ module ActiveSupport
 
     # Class that will build the hash while the XML document
     # is being parsed using SAX events.
-    class HashBuilder < Nokogiri::XML::SAX::Document
+    class HashBuilder < Nokogiri::XML::SAX::Document # :nodoc:
       CONTENT_KEY   = "__content__"
       HASH_SIZE_KEY = "__hash_size__"
 

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -240,7 +240,7 @@ module Rails
       end
 
 
-      class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)
+      class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out) # :nodoc:
         def initialize(name, version, comment, options = {}, commented_out = false)
           super
         end


### PR DESCRIPTION
When `:nodoc:` is applied to a class / module, RDoc will still document nested classes / modules, unless `:nodoc:` is applied to them as well.  Additionally, if `:nodoc: all` is applied to a class / module that contains nested classes / modules, like so:

```ruby
class Foo # :nodoc: all
  def foo_method; end

  class Bar
    def bar_method; end
  end
end
```

RDoc will still include the outer class / module (e.g. `Foo`) in the doc index, albeit as an empty namespace.  Furthermore, SDoc will include both outer and inner (e.g. `Foo` and `Bar`) in the index as empty namespaces.

However, when `:nodoc:` is applied at all levels, like so:

```ruby
class Foo # :nodoc:
  def foo_method; end

  class Bar # :nodoc:
    def bar_method; end
  end
end
```

Both RDoc and SDoc include neither outer nor inner in the index.
