### PR TITLE
Cross-link API docs [ci-skip]

### DIFF
--- a/actioncable/lib/action_cable/channel/naming.rb
+++ b/actioncable/lib/action_cable/channel/naming.rb
@@ -18,7 +18,7 @@ module ActionCable
         end
       end
 
-      # Delegates to the class's <tt>channel_name</tt>.
+      # Delegates to the class's ::channel_name.
       delegate :channel_name, to: :class
     end
   end

--- a/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
+++ b/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
@@ -3,7 +3,7 @@
 module ActionCable
   module Connection
     # Allows the use of per-connection tags against the server logger. This wouldn't work using the traditional
-    # <tt>ActiveSupport::TaggedLogging</tt> enhanced Rails.logger, as that logger will reset the tags between requests.
+    # ActiveSupport::TaggedLogging enhanced Rails.logger, as that logger will reset the tags between requests.
     # The connection is long-lived, so it needs its own set of tags for its independent duration.
     class TaggedLoggerProxy
       attr_reader :tags

--- a/actioncable/lib/action_cable/subscription_adapter/test.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/test.rb
@@ -7,7 +7,7 @@ module ActionCable
     # == Test adapter for Action Cable
     #
     # The test adapter should be used only in testing. Along with
-    # <tt>ActionCable::TestHelper</tt> it makes a great tool to test your Rails application.
+    # ActionCable::TestHelper it makes a great tool to test your Rails application.
     #
     # To use the test adapter set +adapter+ value to +test+ in your +config/cable.yml+ file.
     #

--- a/actionmailbox/lib/action_mailbox/base.rb
+++ b/actionmailbox/lib/action_mailbox/base.rb
@@ -27,7 +27,7 @@ module ActionMailbox
   #     routing :all => :backstop
   #   end
   #
-  # Application mailboxes need to override the +#process+ method, which is invoked by the framework after
+  # Application mailboxes need to override the #process method, which is invoked by the framework after
   # callbacks have been run. The callbacks available are: +before_processing+, +after_processing+, and
   # +around_processing+. The primary use case is ensure certain preconditions to processing are fulfilled
   # using +before_processing+ callbacks.
@@ -35,7 +35,7 @@ module ActionMailbox
   # If a precondition fails to be met, you can halt the processing using the +#bounced!+ method,
   # which will silently prevent any further processing, but not actually send out any bounce notice. You
   # can also pair this behavior with the invocation of an Action Mailer class responsible for sending out
-  # an actual bounce email. This is done using the +#bounce_with+ method, which takes the mail object returned
+  # an actual bounce email. This is done using the #bounce_with method, which takes the mail object returned
   # by an Action Mailer method, like so:
   #
   #   class ForwardsMailbox < ApplicationMailbox
@@ -51,7 +51,7 @@ module ActionMailbox
   #
   # During the processing of the inbound email, the status will be tracked. Before processing begins,
   # the email will normally have the +pending+ status. Once processing begins, just before callbacks
-  # and the +#process+ method is called, the status is changed to +processing+. If processing is allowed to
+  # and the #process method is called, the status is changed to +processing+. If processing is allowed to
   # complete, the status is changed to +delivered+. If a bounce is triggered, then +bounced+. If an unhandled
   # exception is bubbled up, then +failed+.
   #

--- a/actionmailbox/lib/action_mailbox/router/route.rb
+++ b/actionmailbox/lib/action_mailbox/router/route.rb
@@ -2,7 +2,7 @@
 
 module ActionMailbox
   # Encapsulates a route, which can then be matched against an inbound_email and provide a lookup of the matching
-  # mailbox class. See examples for the different route addresses and how to use them in the +ActionMailbox::Base+
+  # mailbox class. See examples for the different route addresses and how to use them in the ActionMailbox::Base
   # documentation.
   class Router::Route
     attr_reader :address, :mailbox_name

--- a/actionmailbox/lib/action_mailbox/routing.rb
+++ b/actionmailbox/lib/action_mailbox/routing.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActionMailbox
-  # See +ActionMailbox::Base+ for how to specify routing.
+  # See ActionMailbox::Base for how to specify routing.
   module Routing
     extend ActiveSupport::Concern
 

--- a/actionmailbox/lib/action_mailbox/test_helper.rb
+++ b/actionmailbox/lib/action_mailbox/test_helper.rb
@@ -4,18 +4,18 @@ require "mail"
 
 module ActionMailbox
   module TestHelper
-    # Create an +InboundEmail+ record using an eml fixture in the format of message/rfc822
+    # Create an InboundEmail record using an eml fixture in the format of message/rfc822
     # referenced with +fixture_name+ located in +test/fixtures/files/fixture_name+.
     def create_inbound_email_from_fixture(fixture_name, status: :processing)
       create_inbound_email_from_source file_fixture(fixture_name).read, status: status
     end
 
-    # Creates an +InboundEmail+ by specifying through options or a block.
+    # Creates an InboundEmail by specifying through options or a block.
     #
     # ==== Options
     #
-    # * <tt>:status</tt> - The +status+ to set for the created +InboundEmail+.
-    #   For possible statuses, see {its documentation}[rdoc-ref:ActionMailbox::InboundEmail].
+    # * <tt>:status</tt> - The +status+ to set for the created InboundEmail.
+    #   For possible statuses, see its documentation.
     #
     # ==== Creating a simple email
     #
@@ -68,26 +68,25 @@ module ActionMailbox
       create_inbound_email_from_source mail.to_s, status: status
     end
 
-    # Create an +InboundEmail+ using the raw rfc822 +source+ as text.
+    # Create an InboundEmail using the raw rfc822 +source+ as text.
     def create_inbound_email_from_source(source, status: :processing)
       ActionMailbox::InboundEmail.create_and_extract_message_id! source, status: status
     end
 
 
-    # Create an +InboundEmail+ from fixture using the same arguments as +create_inbound_email_from_fixture+
+    # Create an InboundEmail from fixture using the same arguments as create_inbound_email_from_fixture
     # and immediately route it to processing.
     def receive_inbound_email_from_fixture(*args)
       create_inbound_email_from_fixture(*args).tap(&:route)
     end
 
-    # Create an +InboundEmail+ using the same options or block as
-    # {create_inbound_email_from_mail}[rdoc-ref:#create_inbound_email_from_mail],
-    # then immediately route it for processing.
+    # Create an InboundEmail using the same options or block as
+    # create_inbound_email_from_mail, then immediately route it for processing.
     def receive_inbound_email_from_mail(**kwargs, &block)
       create_inbound_email_from_mail(**kwargs, &block).tap(&:route)
     end
 
-    # Create an +InboundEmail+ using the same arguments as +create_inbound_email_from_source+ and immediately route it
+    # Create an InboundEmail using the same arguments as create_inbound_email_from_source and immediately route it
     # to processing.
     def receive_inbound_email_from_source(*args)
       create_inbound_email_from_source(*args).tap(&:route)

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -149,9 +149,9 @@ module ActionMailer
   #   mail = NotifierMailer.welcome(User.first)      # => an ActionMailer::MessageDelivery object
   #   mail.deliver_now                               # generates and sends the email now
   #
-  # The <tt>ActionMailer::MessageDelivery</tt> class is a wrapper around a delegate that will call
+  # The ActionMailer::MessageDelivery class is a wrapper around a delegate that will call
   # your method to generate the mail. If you want direct access to the delegator, or <tt>Mail::Message</tt>,
-  # you can call the <tt>message</tt> method on the <tt>ActionMailer::MessageDelivery</tt> object.
+  # you can call the <tt>message</tt> method on the ActionMailer::MessageDelivery object.
   #
   #   NotifierMailer.welcome(User.first).message     # => a Mail::Message object
   #
@@ -334,9 +334,9 @@ module ActionMailer
   #   end
   #
   # Callbacks in Action Mailer are implemented using
-  # <tt>AbstractController::Callbacks</tt>, so you can define and configure
+  # AbstractController::Callbacks, so you can define and configure
   # callbacks in the same manner that you would use callbacks in classes that
-  # inherit from <tt>ActionController::Base</tt>.
+  # inherit from ActionController::Base.
   #
   # Note that unless you have a specific reason to do so, you should prefer
   # using <tt>before_action</tt> rather than <tt>after_action</tt> in your

--- a/actionmailer/lib/action_mailer/message_delivery.rb
+++ b/actionmailer/lib/action_mailer/message_delivery.rb
@@ -63,7 +63,7 @@ module ActionMailer
     # * <tt>:priority</tt> - Enqueues the email with the specified priority
     #
     # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt>. Each
-    # <tt>ActionMailer::Base</tt> class can specify the job to use by setting the class variable
+    # ActionMailer::Base class can specify the job to use by setting the class variable
     # +delivery_job+.
     #
     #   class AccountRegistrationMailer < ApplicationMailer
@@ -89,7 +89,7 @@ module ActionMailer
     # * <tt>:priority</tt> - Enqueues the email with the specified priority
     #
     # By default, the email will be enqueued using <tt>ActionMailer::MailDeliveryJob</tt>. Each
-    # <tt>ActionMailer::Base</tt> class can specify the job to use by setting the class variable
+    # ActionMailer::Base class can specify the job to use by setting the class variable
     # +delivery_job+.
     #
     #   class AccountRegistrationMailer < ApplicationMailer

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -177,7 +177,7 @@ module AbstractController
 
     # Tests if a response body is set. Used to determine if the
     # +process_action+ callback needs to be terminated in
-    # +AbstractController::Callbacks+.
+    # AbstractController::Callbacks.
     def performed?
       response_body
     end

--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -5,7 +5,7 @@ require "action_controller"
 require "action_controller/log_subscriber"
 
 module ActionController
-  # API Controller is a lightweight version of <tt>ActionController::Base</tt>,
+  # API Controller is a lightweight version of ActionController::Base,
   # created for applications that don't require all functionalities that a complete
   # \Rails controller provides, allowing you to create controllers with just the
   # features that you need for API only applications.
@@ -32,7 +32,7 @@ module ActionController
   #   end
   #
   # Request, response, and parameters objects all work the exact same way as
-  # <tt>ActionController::Base</tt>.
+  # ActionController::Base.
   #
   # == Renders
   #
@@ -51,7 +51,7 @@ module ActionController
   #
   # Redirects are used to move from one action to another. You can use the
   # <tt>redirect_to</tt> method in your controllers in the same way as in
-  # <tt>ActionController::Base</tt>. For example:
+  # ActionController::Base. For example:
   #
   #   def create
   #     redirect_to root_url and return if not_authorized?
@@ -61,7 +61,7 @@ module ActionController
   # == Adding New Behavior
   #
   # In some scenarios you may want to add back some functionality provided by
-  # <tt>ActionController::Base</tt> that is not present by default in
+  # ActionController::Base that is not present by default in
   # <tt>ActionController::API</tt>, for instance <tt>MimeResponds</tt>. This
   # module gives you the <tt>respond_to</tt> method. Adding it is quite simple,
   # you just need to include the module in a specific controller or in
@@ -83,7 +83,7 @@ module ActionController
   #     end
   #   end
   #
-  # Make sure to check the modules included in <tt>ActionController::Base</tt>
+  # Make sure to check the modules included in ActionController::Base
   # if you want to use any other functionality that is not provided
   # by <tt>ActionController::API</tt> out of the box.
   class API < Metal

--- a/actionpack/lib/action_controller/form_builder.rb
+++ b/actionpack/lib/action_controller/form_builder.rb
@@ -3,7 +3,7 @@
 module ActionController
   # Override the default form builder for all views rendered by this
   # controller and any of its descendants. Accepts a subclass of
-  # +ActionView::Helpers::FormBuilder+.
+  # ActionView::Helpers::FormBuilder.
   #
   # For example, given a form builder:
   #
@@ -36,7 +36,7 @@ module ActionController
       # in the views rendered by this controller and its subclasses.
       #
       # ==== Parameters
-      # * <tt>builder</tt> - Default form builder, an instance of +ActionView::Helpers::FormBuilder+
+      # * <tt>builder</tt> - Default form builder, an instance of ActionView::Helpers::FormBuilder
       def default_form_builder(builder)
         self._default_form_builder = builder
       end

--- a/actionpack/lib/action_controller/metal.rb
+++ b/actionpack/lib/action_controller/metal.rb
@@ -60,7 +60,7 @@ module ActionController
 
   # <tt>ActionController::Metal</tt> is the simplest possible controller, providing a
   # valid Rack interface without the additional niceties provided by
-  # <tt>ActionController::Base</tt>.
+  # ActionController::Base.
   #
   # A sample metal controller might look like this:
   #
@@ -111,7 +111,7 @@ module ActionController
   #
   # == Other Helpers
   #
-  # You can refer to the modules included in <tt>ActionController::Base</tt> to see
+  # You can refer to the modules included in ActionController::Base to see
   # other features you can bring into your metal controller.
   #
   class Metal < AbstractController::Base
@@ -137,7 +137,7 @@ module ActionController
       false
     end
 
-    # Delegates to the class's <tt>controller_name</tt>.
+    # Delegates to the class's ::controller_name.
     def controller_name
       self.class.controller_name
     end

--- a/actionpack/lib/action_controller/metal/renderers.rb
+++ b/actionpack/lib/action_controller/metal/renderers.rb
@@ -31,8 +31,7 @@ module ActionController
       class_attribute :_renderers, default: Set.new.freeze
     end
 
-    # Used in <tt>ActionController::Base</tt>
-    # and <tt>ActionController::API</tt> to include all
+    # Used in ActionController::Base and ActionController::API to include all
     # renderers by default.
     module All
       extend ActiveSupport::Concern
@@ -45,7 +44,7 @@ module ActionController
 
     # Adds a new renderer to call within controller actions.
     # A renderer is invoked by passing its name as an option to
-    # <tt>AbstractController::Rendering#render</tt>. To create a renderer
+    # AbstractController::Rendering#render. To create a renderer
     # pass it a name and a block. The block takes two arguments, the first
     # is the value paired with its key and the second is the remaining
     # hash of options passed to +render+.
@@ -96,18 +95,18 @@ module ActionController
       # Adds, by name, a renderer or renderers to the +_renderers+ available
       # to call within controller actions.
       #
-      # It is useful when rendering from an <tt>ActionController::Metal</tt> controller or
+      # It is useful when rendering from an ActionController::Metal controller or
       # otherwise to add an available renderer proc to a specific controller.
       #
-      # Both <tt>ActionController::Base</tt> and <tt>ActionController::API</tt>
-      # include <tt>ActionController::Renderers::All</tt>, making all renderers
+      # Both ActionController::Base and ActionController::API
+      # include ActionController::Renderers::All, making all renderers
       # available in the controller. See <tt>Renderers::RENDERERS</tt> and <tt>Renderers.add</tt>.
       #
-      # Since <tt>ActionController::Metal</tt> controllers cannot render, the controller
-      # must include <tt>AbstractController::Rendering</tt>, <tt>ActionController::Rendering</tt>,
-      # and <tt>ActionController::Renderers</tt>, and have at least one renderer.
+      # Since ActionController::Metal controllers cannot render, the controller
+      # must include AbstractController::Rendering, ActionController::Rendering,
+      # and ActionController::Renderers, and have at least one renderer.
       #
-      # Rather than including <tt>ActionController::Renderers::All</tt> and including all renderers,
+      # Rather than including ActionController::Renderers::All and including all renderers,
       # you may specify which renderers to include by passing the renderer name or names to
       # +use_renderers+. For example, a controller that includes only the <tt>:json</tt> renderer
       # (+_render_with_renderer_json+) might look like:
@@ -133,7 +132,7 @@ module ActionController
       alias use_renderer use_renderers
     end
 
-    # Called by +render+ in <tt>AbstractController::Rendering</tt>
+    # Called by +render+ in AbstractController::Rendering
     # which sets the return value as the +response_body+.
     #
     # If no renderer is found, +super+ returns control to

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -32,7 +32,7 @@ module ActionController # :nodoc:
   # response may be extracted. To prevent this, only XmlHttpRequest (known as XHR or
   # Ajax) requests are allowed to make requests for JavaScript responses.
   #
-  # Subclasses of <tt>ActionController::Base</tt> are protected by default with the
+  # Subclasses of ActionController::Base are protected by default with the
   # <tt>:exception</tt> strategy, which raises an
   # <tt>ActionController::InvalidAuthenticityToken</tt> error on unverified requests.
   #

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -778,7 +778,7 @@ module ActionController
 
     # Deletes a key-value pair from +Parameters+ and returns the value. If
     # +key+ is not found, returns +nil+ (or, with optional code block, yields
-    # +key+ and returns the result). Cf. +#extract!+, which returns the
+    # +key+ and returns the result). Cf. #extract!, which returns the
     # corresponding +ActionController::Parameters+ object.
     def delete(key, &block)
       convert_value_to_parameters(@parameters.delete(key, &block))

--- a/actionpack/lib/action_controller/metal/url_for.rb
+++ b/actionpack/lib/action_controller/metal/url_for.rb
@@ -4,10 +4,10 @@ module ActionController
   # Includes +url_for+ into the host class. The class has to provide a +RouteSet+ by implementing
   # the <tt>_routes</tt> method. Otherwise, an exception will be raised.
   #
-  # In addition to <tt>AbstractController::UrlFor</tt>, this module accesses the HTTP layer to define
+  # In addition to AbstractController::UrlFor, this module accesses the HTTP layer to define
   # URL options like the +host+. In order to do so, this module requires the host class
   # to implement +env+ which needs to be Rack-compatible and +request+
-  # which is either an instance of +ActionDispatch::Request+ or an object
+  # which is either an instance of ActionDispatch::Request or an object
   # that responds to the +host+, +optional_port+, +protocol+, and
   # +symbolized_path_parameter+ methods.
   #

--- a/actionpack/lib/action_controller/renderer.rb
+++ b/actionpack/lib/action_controller/renderer.rb
@@ -71,7 +71,7 @@ module ActionController
     # Render templates with any options from ActionController::Base#render_to_string.
     #
     # The primary options are:
-    # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt> for details.
+    # * <tt>:partial</tt> - See ActionView::PartialRenderer for details.
     # * <tt>:file</tt> - Renders an explicit template file. Add <tt>:locals</tt> to pass in, if so desired.
     #   It shouldn’t be used directly with unsanitized user input due to lack of validation.
     # * <tt>:inline</tt> - Renders an ERB template string.

--- a/actionpack/lib/action_dispatch/middleware/request_id.rb
+++ b/actionpack/lib/action_dispatch/middleware/request_id.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/string/access"
 
 module ActionDispatch
   # Makes a unique request id available to the +action_dispatch.request_id+ env variable (which is then accessible
-  # through <tt>ActionDispatch::Request#request_id</tt> or the alias <tt>ActionDispatch::Request#uuid</tt>) and sends
+  # through ActionDispatch::Request#request_id or the alias ActionDispatch::Request#uuid) and sends
   # the same id to the client via the X-Request-Id header.
   #
   # The unique request id is either based on the X-Request-Id header in the request, which would typically be generated

--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -65,9 +65,8 @@ module ActionDispatch
   #     resources :posts, :comments
   #   end
   #
-  # For more, see <tt>Routing::Mapper::Resources#resources</tt>,
-  # <tt>Routing::Mapper::Scoping#namespace</tt>, and
-  # <tt>Routing::Mapper::Scoping#scope</tt>.
+  # For more, see Routing::Mapper::Resources#resources,
+  # Routing::Mapper::Scoping#namespace, and Routing::Mapper::Scoping#scope.
   #
   # == Non-resourceful routes
   #

--- a/actiontext/lib/action_text/fixture_set.rb
+++ b/actiontext/lib/action_text/fixture_set.rb
@@ -25,7 +25,7 @@ module ActionText
   #   first:
   #     title: An Article
   #
-  # Then declare the <tt>ActionText::RichText</tt> fixture data in
+  # Then declare the ActionText::RichText fixture data in
   # <tt>test/fixtures/action_text/rich_texts.yml</tt>, making sure to declare
   # each entry's <tt>record:</tt> key as a polymorphic relationship:
   #

--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -2290,7 +2290,7 @@ module ActionView
         @template.fields_for(record_name, record_object, fields_options, &block)
       end
 
-      # See the docs for the <tt>ActionView::FormHelper.fields</tt> helper method.
+      # See the docs for the ActionView::Helpers::FormHelper#fields helper method.
       def fields(scope = nil, model: nil, **options, &block)
         options[:allow_method_names_outside_object] = true
         options[:skip_default_ids] = !FormHelper.form_with_generates_ids

--- a/actionview/lib/action_view/helpers/rendering_helper.rb
+++ b/actionview/lib/action_view/helpers/rendering_helper.rb
@@ -10,7 +10,7 @@ module ActionView
     module RenderingHelper
       # Returns the result of a render that's dictated by the options hash. The primary options are:
       #
-      # * <tt>:partial</tt> - See <tt>ActionView::PartialRenderer</tt>.
+      # * <tt>:partial</tt> - See ActionView::PartialRenderer.
       # * <tt>:file</tt> - Renders an explicit template file (this used to be the old default), add +:locals+ to pass in those.
       # * <tt>:inline</tt> - Renders an inline template similar to how it's done in the controller.
       # * <tt>:plain</tt> - Renders the text passed in out. Setting the content
@@ -19,8 +19,7 @@ module ActionView
       #   performs HTML escape on the string first. Setting the content type as
       #   <tt>text/html</tt>.
       # * <tt>:body</tt> - Renders the text passed in, and inherits the content
-      #   type of <tt>text/plain</tt> from <tt>ActionDispatch::Response</tt>
-      #   object.
+      #   type of <tt>text/plain</tt> from ActionDispatch::Response object.
       #
       # If no <tt>options</tt> hash is passed or if <tt>:update</tt> is specified, then:
       #

--- a/actionview/lib/action_view/view_paths.rb
+++ b/actionview/lib/action_view/view_paths.rb
@@ -91,9 +91,9 @@ module ActionView
       self.class._prefixes
     end
 
-    # <tt>LookupContext</tt> is the object responsible for holding all
+    # LookupContext is the object responsible for holding all
     # information required for looking up templates, i.e. view paths and
-    # details. Check <tt>ActionView::LookupContext</tt> for more information.
+    # details. Check ActionView::LookupContext for more information.
     def lookup_context
       @_lookup_context ||=
         ActionView::LookupContext.new(self.class._view_paths, details_for_lookup, _prefixes)
@@ -103,7 +103,7 @@ module ActionView
       {}
     end
 
-    # Append a path to the list of view paths for the current <tt>LookupContext</tt>.
+    # Append a path to the list of view paths for the current LookupContext.
     #
     # ==== Parameters
     # * <tt>path</tt> - If a String is provided, it gets converted into
@@ -113,7 +113,7 @@ module ActionView
       lookup_context.view_paths.push(*path)
     end
 
-    # Prepend a path to the list of view paths for the current <tt>LookupContext</tt>.
+    # Prepend a path to the list of view paths for the current LookupContext.
     #
     # ==== Parameters
     # * <tt>path</tt> - If a String is provided, it gets converted into

--- a/activejob/lib/active_job/queue_adapters/test_adapter.rb
+++ b/activejob/lib/active_job/queue_adapters/test_adapter.rb
@@ -5,7 +5,7 @@ module ActiveJob
     # == Test adapter for Active Job
     #
     # The test adapter should be used only in testing. Along with
-    # <tt>ActiveJob::TestCase</tt> and <tt>ActiveJob::TestHelper</tt>
+    # ActiveJob::TestCase and ActiveJob::TestHelper
     # it makes a great tool to test your Rails application.
     #
     # To use the test adapter set +queue_adapter+ config to +:test+.

--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -57,12 +57,12 @@ module ActiveJob
     # Specifies the queue adapter to use with all Active Job test helpers.
     #
     # Returns an instance of the queue adapter and defaults to
-    # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
+    # ActiveJob::QueueAdapters::TestAdapter.
     #
     # Note: The adapter provided by this method must provide some additional
-    # methods from those expected of a standard <tt>ActiveJob::QueueAdapter</tt>
+    # methods from those expected of a standard ActiveJob::QueueAdapter
     # in order to be used with the active job test helpers. Refer to
-    # <tt>ActiveJob::QueueAdapters::TestAdapter</tt>.
+    # ActiveJob::QueueAdapters::TestAdapter.
     def queue_adapter_for_test
       ActiveJob::QueueAdapters::TestAdapter.new
     end

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -48,9 +48,9 @@ module ActiveModel
   #
   # The last three methods are required in your object for +Errors+ to be
   # able to generate error messages correctly and also handle multiple
-  # languages. Of course, if you extend your object with <tt>ActiveModel::Translation</tt>
+  # languages. Of course, if you extend your object with ActiveModel::Translation
   # you will not need to implement the last two. Likewise, using
-  # <tt>ActiveModel::Validations</tt> will handle the validation related methods
+  # ActiveModel::Validations will handle the validation related methods
   # for you.
   #
   # The above allows you to do:
@@ -136,7 +136,7 @@ module ActiveModel
     end
 
     # Merges the errors from <tt>other</tt>,
-    # each <tt>Error</tt> wrapped as <tt>NestedError</tt>.
+    # each Error wrapped as NestedError.
     #
     # ==== Parameters
     #

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -3,8 +3,8 @@
 module ActiveModel
   # == Active \Model \Basic \Model
   #
-  # Allows implementing models similar to <tt>ActiveRecord::Base</tt>.
-  # Includes <tt>ActiveModel::API</tt> for the required interface for an
+  # Allows implementing models similar to ActiveRecord::Base.
+  # Includes ActiveModel::API for the required interface for an
   # object to interact with Action Pack and Action View, but can be
   # extended with other functionalities.
   #

--- a/activemodel/lib/active_model/validations.rb
+++ b/activemodel/lib/active_model/validations.rb
@@ -32,7 +32,7 @@ module ActiveModel
   #   person.errors.messages          # => {first_name:["starts with z."]}
   #
   # Note that <tt>ActiveModel::Validations</tt> automatically adds an +errors+
-  # method to your instances initialized with a new <tt>ActiveModel::Errors</tt>
+  # method to your instances initialized with a new ActiveModel::Errors
   # object, so there is no need for you to do this manually.
   module Validations
     extend ActiveSupport::Concern

--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -24,7 +24,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_absence_of(*attr_names)
         validates_with AbsenceValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -104,7 +104,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_acceptance_of(*attr_names)
         validates_with AcceptanceValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/comparison.rb
+++ b/activemodel/lib/active_model/validations/comparison.rb
@@ -56,7 +56,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       #
       # The validator requires at least one of the following checks to be supplied.
       # Each will accept a proc, value, or a symbol which corresponds to a method:

--- a/activemodel/lib/active_model/validations/confirmation.rb
+++ b/activemodel/lib/active_model/validations/confirmation.rb
@@ -71,7 +71,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_confirmation_of(*attr_names)
         validates_with ConfirmationValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/exclusion.rb
+++ b/activemodel/lib/active_model/validations/exclusion.rb
@@ -40,7 +40,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_exclusion_of(*attr_names)
         validates_with ExclusionValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/format.rb
+++ b/activemodel/lib/active_model/validations/format.rb
@@ -104,7 +104,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_format_of(*attr_names)
         validates_with FormatValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/inclusion.rb
+++ b/activemodel/lib/active_model/validations/inclusion.rb
@@ -38,7 +38,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_inclusion_of(*attr_names)
         validates_with InclusionValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -118,7 +118,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_length_of(*attr_names)
         validates_with LengthValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validations/numericality.rb
+++ b/activemodel/lib/active_model/validations/numericality.rb
@@ -190,7 +190,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+ .
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       #
       # The following checks can also be supplied with a proc or a symbol which
       # corresponds to a method:

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -30,7 +30,7 @@ module ActiveModel
       #
       # There is also a list of default options supported by every validator:
       # +:if+, +:unless+, +:on+, +:allow_nil+, +:allow_blank+, and +:strict+.
-      # See <tt>ActiveModel::Validations#validates</tt> for more information.
+      # See ActiveModel::Validations::ClassMethods#validates for more information.
       def validates_presence_of(*attr_names)
         validates_with PresenceValidator, _merge_attributes(attr_names)
       end

--- a/activemodel/lib/active_model/validator.rb
+++ b/activemodel/lib/active_model/validator.rb
@@ -65,7 +65,7 @@ module ActiveModel
   # life cycle, and not on each validation run.
   #
   # The easiest way to add custom validators for validating individual attributes
-  # is with the convenient <tt>ActiveModel::EachValidator</tt>.
+  # is with the convenient ActiveModel::EachValidator.
   #
   #   class TitleValidator < ActiveModel::EachValidator
   #     def validate_each(record, attribute, value)
@@ -74,7 +74,7 @@ module ActiveModel
   #   end
   #
   # This can now be used in combination with the +validates+ method
-  # (see <tt>ActiveModel::Validations::ClassMethods.validates</tt> for more on this).
+  # (see ActiveModel::Validations::ClassMethods#validates for more on this).
   #
   #   class Person
   #     include ActiveModel::Validations

--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Encryption
-    # Configuration API for +ActiveRecord::Encryption+
+    # Configuration API for ActiveRecord::Encryption
     module Configurable
       extend ActiveSupport::Concern
 

--- a/activerecord/lib/active_record/encryption/contexts.rb
+++ b/activerecord/lib/active_record/encryption/contexts.rb
@@ -2,14 +2,14 @@
 
 module ActiveRecord
   module Encryption
-    # +ActiveRecord::Encryption+ uses encryption contexts to configure the different entities used to
+    # ActiveRecord::Encryption uses encryption contexts to configure the different entities used to
     # encrypt/decrypt at a given moment in time.
     #
-    # By default, the library uses a default encryption context. This is the +Context+ that gets configured
+    # By default, the library uses a default encryption context. This is the Context that gets configured
     # initially via +config.active_record.encryption+ options. Library users can define nested encryption contexts
     # when running blocks of code.
     #
-    # See +Context+.
+    # See Context.
     module Contexts
       extend ActiveSupport::Concern
 

--- a/activerecord/lib/active_record/encryption/derived_secret_key_provider.rb
+++ b/activerecord/lib/active_record/encryption/derived_secret_key_provider.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Encryption
-    # A +KeyProvider+ that derives keys from passwords.
+    # A KeyProvider that derives keys from passwords.
     class DerivedSecretKeyProvider < KeyProvider
       def initialize(passwords)
         super(Array(passwords).collect { |password| Key.derive_from(password) })

--- a/activerecord/lib/active_record/encryption/deterministic_key_provider.rb
+++ b/activerecord/lib/active_record/encryption/deterministic_key_provider.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Encryption
-    # A +KeyProvider+ that derives keys from passwords.
+    # A KeyProvider that derives keys from passwords.
     class DeterministicKeyProvider < DerivedSecretKeyProvider
       def initialize(password)
         passwords = Array(password)

--- a/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
+++ b/activerecord/lib/active_record/encryption/encrypted_attribute_type.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   module Encryption
-    # An +ActiveModel::Type+ that encrypts/decrypts strings of text.
+    # An ActiveModel::Type::Value that encrypts/decrypts strings of text.
     #
     # This is the central piece that connects the encryption system with +encrypts+ declarations in the
     # model classes. Whenever you declare an attribute as encrypted, it configures an +EncryptedAttributeType+
@@ -19,7 +19,7 @@ module ActiveRecord
       #
       # * <tt>:scheme</tt> - A +Scheme+ with the encryption properties for this attribute.
       # * <tt>:cast_type</tt> - A type that will be used to serialize (before encrypting) and deserialize
-      #   (after decrypting). +ActiveModel::Type::String+ by default.
+      #   (after decrypting). ActiveModel::Type::String by default.
       def initialize(scheme:, cast_type: ActiveModel::Type::String.new, previous_type: false)
         super()
         @scheme = scheme

--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -6,17 +6,17 @@ require "active_support/core_ext/numeric"
 
 module ActiveRecord
   module Encryption
-    # An encryptor exposes the encryption API that +ActiveRecord::Encryption::EncryptedAttributeType+
+    # An encryptor exposes the encryption API that ActiveRecord::Encryption::EncryptedAttributeType
     # uses for encrypting and decrypting attribute values.
     #
-    # It interacts with a +KeyProvider+ for getting the keys, and delegate to
-    # +ActiveRecord::Encryption::Cipher+ the actual encryption algorithm.
+    # It interacts with a KeyProvider for getting the keys, and delegate to
+    # ActiveRecord::Encryption::Cipher the actual encryption algorithm.
     class Encryptor
       # Encrypts +clean_text+ and returns the encrypted result
       #
       # Internally, it will:
       #
-      # 1. Create a new +ActiveRecord::Encryption::Message+
+      # 1. Create a new ActiveRecord::Encryption::Message
       # 2. Compress and encrypt +clean_text+ as the message payload
       # 3. Serialize it with +ActiveRecord::Encryption.message_serializer+ (+ActiveRecord::Encryption::SafeMarshal+
       #    by default)
@@ -29,7 +29,7 @@ module ActiveRecord
       #   +ActiveRecord::Encryption.key_provider+ when not provided.
       #
       # [:cipher_options]
-      #   +Cipher+-specific options that will be passed to the Cipher configured in
+      #   Cipher-specific options that will be passed to the Cipher configured in
       #   +ActiveRecord::Encryption.cipher+
       def encrypt(clear_text, key_provider: default_key_provider, cipher_options: {})
         clear_text = force_encoding_if_needed(clear_text) if cipher_options[:deterministic]
@@ -47,7 +47,7 @@ module ActiveRecord
       #   +ActiveRecord::Encryption.key_provider+ when not provided
       #
       # [:cipher_options]
-      #   +Cipher+-specific options that will be passed to the Cipher configured in
+      #   Cipher-specific options that will be passed to the Cipher configured in
       #   +ActiveRecord::Encryption.cipher+
       def decrypt(encrypted_text, key_provider: default_key_provider, cipher_options: {})
         message = deserialize_message(encrypted_text)

--- a/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
+++ b/activerecord/lib/active_record/encryption/extended_deterministic_queries.rb
@@ -16,10 +16,10 @@ module ActiveRecord
     #
     # This patches ActiveRecord to support this automatically. It addresses both:
     #
-    # * ActiveRecord::Base: Used in <tt>Contact.find_by_email_address(...)</tt>
-    # * ActiveRecord::Relation: Used in <tt>Contact.internal.find_by_email_address(...)</tt>
+    # * ActiveRecord::Base - Used in <tt>Contact.find_by_email_address(...)</tt>
+    # * ActiveRecord::Relation - Used in <tt>Contact.internal.find_by_email_address(...)</tt>
     #
-    # +ActiveRecord::Base+ relies on +ActiveRecord::Relation+ (+ActiveRecord::QueryMethods+) but it does
+    # ActiveRecord::Base relies on ActiveRecord::Relation (ActiveRecord::QueryMethods) but it does
     # some prepared statements caching. That's why we need to intercept +ActiveRecord::Base+ as soon
     # as it's invoked (so that the proper prepared statement is cached).
     #

--- a/activerecord/lib/active_record/encryption/scheme.rb
+++ b/activerecord/lib/active_record/encryption/scheme.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     #
     # It validates and serves attribute encryption options.
     #
-    # See +EncryptedAttributeType+, +Context+
+    # See EncryptedAttributeType, Context
     class Scheme
       attr_accessor :previous_schemes
 

--- a/activerecord/lib/active_record/enum.rb
+++ b/activerecord/lib/active_record/enum.rb
@@ -83,7 +83,7 @@ module ActiveRecord
   #
   # In rare circumstances you might need to access the mapping directly.
   # The mappings are exposed through a class method with the pluralized attribute
-  # name, which return the mapping in a +HashWithIndifferentAccess+:
+  # name, which return the mapping in a ActiveSupport::HashWithIndifferentAccess :
   #
   #   Conversation.statuses[:active]    # => 0
   #   Conversation.statuses["archived"] # => 1

--- a/activerecord/lib/active_record/locking/pessimistic.rb
+++ b/activerecord/lib/active_record/locking/pessimistic.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # Locking::Pessimistic provides support for row-level locking using
     # SELECT ... FOR UPDATE and other lock types.
     #
-    # Chain <tt>ActiveRecord::Base#find</tt> to <tt>ActiveRecord::QueryMethods#lock</tt> to obtain an exclusive
+    # Chain <tt>ActiveRecord::Base#find</tt> to ActiveRecord::QueryMethods#lock to obtain an exclusive
     # lock on the selected rows:
     #   # select * from accounts where id=1 for update
     #   Account.lock.find(1)
@@ -82,11 +82,11 @@ module ActiveRecord
 
       # Wraps the passed block in a transaction, locking the object
       # before yielding. You can pass the SQL locking clause
-      # as an optional argument (see <tt>#lock!</tt>).
+      # as an optional argument (see #lock!).
       #
       # You can also pass options like <tt>requires_new:</tt>, <tt>isolation:</tt>,
       # and <tt>joinable:</tt> to the wrapping transaction (see
-      # <tt>ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction</tt>).
+      # ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction).
       def with_lock(*args)
         transaction_opts = args.extract_options!
         lock = args.present? ? args.first : true

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       # Active Record callbacks or validations. Though passed values
       # go through Active Record's type casting and serialization.
       #
-      # See <tt>ActiveRecord::Persistence#insert_all</tt> for documentation.
+      # See #insert_all for documentation.
       def insert(attributes, returning: nil, unique_by: nil, record_timestamps: nil)
         insert_all([ attributes ], returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
       end
@@ -79,7 +79,7 @@ module ActiveRecord
       # duplicate rows are skipped.
       # Override with <tt>:unique_by</tt> (see below).
       #
-      # Returns an <tt>ActiveRecord::Result</tt> with its contents based on
+      # Returns an ActiveRecord::Result with its contents based on
       # <tt>:returning</tt> (see below).
       #
       # ==== Options
@@ -151,7 +151,7 @@ module ActiveRecord
       # Active Record callbacks or validations. Though passed values
       # go through Active Record's type casting and serialization.
       #
-      # See <tt>ActiveRecord::Persistence#insert_all!</tt> for more.
+      # See #insert_all! for more.
       def insert!(attributes, returning: nil, record_timestamps: nil)
         insert_all!([ attributes ], returning: returning, record_timestamps: record_timestamps)
       end
@@ -167,10 +167,9 @@ module ActiveRecord
       # Raises <tt>ActiveRecord::RecordNotUnique</tt> if any rows violate a
       # unique index on the table. In that case, no rows are inserted.
       #
-      # To skip duplicate rows, see <tt>ActiveRecord::Persistence#insert_all</tt>.
-      # To replace them, see <tt>ActiveRecord::Persistence#upsert_all</tt>.
+      # To skip duplicate rows, see #insert_all. To replace them, see #upsert_all.
       #
-      # Returns an <tt>ActiveRecord::Result</tt> with its contents based on
+      # Returns an ActiveRecord::Result with its contents based on
       # <tt>:returning</tt> (see below).
       #
       # ==== Options
@@ -219,7 +218,7 @@ module ActiveRecord
       # it trigger Active Record callbacks or validations. Though passed values
       # go through Active Record's type casting and serialization.
       #
-      # See <tt>ActiveRecord::Persistence#upsert_all</tt> for documentation.
+      # See #upsert_all for documentation.
       def upsert(attributes, on_duplicate: :update, returning: nil, unique_by: nil, record_timestamps: nil)
         upsert_all([ attributes ], on_duplicate: on_duplicate, returning: returning, unique_by: unique_by, record_timestamps: record_timestamps)
       end
@@ -232,7 +231,7 @@ module ActiveRecord
       # The +attributes+ parameter is an Array of Hashes. Every Hash determines
       # the attributes for a single row and must have the same keys.
       #
-      # Returns an <tt>ActiveRecord::Result</tt> with its contents based on
+      # Returns an ActiveRecord::Result with its contents based on
       # <tt>:returning</tt> (see below).
       #
       # By default, +upsert_all+ will update all the columns that can be updated when

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -39,7 +39,7 @@ module ActiveRecord
     #   Post.find_by_sql "SELECT p.title, c.author FROM posts p, comments c WHERE p.id = c.post_id"
     #   # => [#<Post:0x36bff9c @attributes={"title"=>"Ruby Meetup", "author"=>"Quentin"}>, ...]
     #
-    # You can use the same string replacement techniques as you can with <tt>ActiveRecord::QueryMethods#where</tt>:
+    # You can use the same string replacement techniques as you can with ActiveRecord::QueryMethods#where :
     #
     #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
     #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]

--- a/activerecord/lib/active_record/signed_id.rb
+++ b/activerecord/lib/active_record/signed_id.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         end
       end
 
-      # Works like +find_signed+, but will raise an +ActiveSupport::MessageVerifier::InvalidSignature+
+      # Works like find_signed, but will raise an +ActiveSupport::MessageVerifier::InvalidSignature+
       # exception if the +signed_id+ has either expired, has a purpose mismatch, is for another record,
       # or has been tampered with. It will also raise an +ActiveRecord::RecordNotFound+ exception if
       # the valid signed id can't find a record.

--- a/activesupport/lib/active_support/backtrace_cleaner.rb
+++ b/activesupport/lib/active_support/backtrace_cleaner.rb
@@ -21,10 +21,10 @@ module ActiveSupport
   #
   # To reconfigure an existing BacktraceCleaner (like the default one in Rails)
   # and show as much data as possible, you can always call
-  # <tt>BacktraceCleaner#remove_silencers!</tt>, which will restore the
+  # BacktraceCleaner#remove_silencers!, which will restore the
   # backtrace to a pristine state. If you need to reconfigure an existing
   # BacktraceCleaner so that it does not filter or modify the paths of any lines
-  # of the backtrace, you can call <tt>BacktraceCleaner#remove_filters!</tt>
+  # of the backtrace, you can call BacktraceCleaner#remove_filters!
   # These two methods will give you a completely untouched backtrace.
   #
   # Inspired by the Quiet Backtrace gem by thoughtbot.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -139,7 +139,7 @@ module ActiveSupport
       #
       # Race condition TTL is not set by default. This can be used to avoid
       # "thundering herd" cache writes when hot cache entries are expired.
-      # See <tt>ActiveSupport::Cache::Store#fetch</tt> for more.
+      # See ActiveSupport::Cache::Store#fetch for more.
       def initialize(namespace: nil, compress: true, compress_threshold: 1.kilobyte, coder: default_coder, expires_in: nil, race_condition_ttl: nil, error_handler: DEFAULT_ERROR_HANDLER, **redis_options)
         @redis_options = redis_options
 

--- a/activesupport/lib/active_support/callbacks.rb
+++ b/activesupport/lib/active_support/callbacks.rb
@@ -16,19 +16,19 @@ module ActiveSupport
   # needing to override or redefine methods of the base class.
   #
   # Mixing in this module allows you to define the events in the object's
-  # life cycle that will support callbacks (via +ClassMethods.define_callbacks+),
+  # life cycle that will support callbacks (via ClassMethods#define_callbacks),
   # set the instance methods, procs, or callback objects to be called (via
-  # +ClassMethods.set_callback+), and run the installed callbacks at the
+  # ClassMethods#set_callback), and run the installed callbacks at the
   # appropriate times (via +run_callbacks+).
   #
   # By default callbacks are halted by throwing +:abort+.
-  # See +ClassMethods.define_callbacks+ for details.
+  # See ClassMethods#define_callbacks for details.
   #
   # Three kinds of callbacks are supported: before callbacks, run before a
   # certain event; after callbacks, run after the event; and around callbacks,
   # blocks that surround the event, triggering it when they yield. Callback code
   # can be contained in instance methods, procs or lambdas, or callback objects
-  # that respond to certain predetermined methods. See +ClassMethods.set_callback+
+  # that respond to certain predetermined methods. See ClassMethods#set_callback
   # for details.
   #
   #   class Record

--- a/activesupport/lib/active_support/configurable.rb
+++ b/activesupport/lib/active_support/configurable.rb
@@ -5,7 +5,7 @@ require "active_support/ordered_options"
 
 module ActiveSupport
   # Configurable provides a <tt>config</tt> method to store and retrieve
-  # configuration options as an <tt>OrderedOptions</tt>.
+  # configuration options as an OrderedOptions.
   module Configurable
     extend ActiveSupport::Concern
 
@@ -127,7 +127,7 @@ module ActiveSupport
       private :config_accessor
     end
 
-    # Reads and writes attributes from a configuration <tt>OrderedOptions</tt>.
+    # Reads and writes attributes from a configuration OrderedOptions.
     #
     #   require "active_support/configurable"
     #

--- a/activesupport/lib/active_support/core_ext/array/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/array/inquiry.rb
@@ -3,8 +3,8 @@
 require "active_support/array_inquirer"
 
 class Array
-  # Wraps the array in an +ArrayInquirer+ object, which gives a friendlier way
-  # to check its string-like contents.
+  # Wraps the array in an ActiveSupport::ArrayInquirer object, which gives a
+  # friendlier way to check its string-like contents.
   #
   #   pets = [:cat, :dog].inquiry
   #

--- a/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
+++ b/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb
@@ -3,7 +3,7 @@
 require "active_support/hash_with_indifferent_access"
 
 class Hash
-  # Returns an <tt>ActiveSupport::HashWithIndifferentAccess</tt> out of its receiver:
+  # Returns an ActiveSupport::HashWithIndifferentAccess out of its receiver:
   #
   #   { a: 1 }.with_indifferent_access['a'] # => 1
   def with_indifferent_access
@@ -14,7 +14,7 @@ class Hash
   # #with_indifferent_access. This method will be called on the current object
   # by the enclosing object and is aliased to #with_indifferent_access by
   # default. Subclasses of Hash may override this method to return +self+ if
-  # converting to an <tt>ActiveSupport::HashWithIndifferentAccess</tt> would not be
+  # converting to an ActiveSupport::HashWithIndifferentAccess would not be
   # desirable.
   #
   #   b = { b: 1 }

--- a/activesupport/lib/active_support/core_ext/string/inquiry.rb
+++ b/activesupport/lib/active_support/core_ext/string/inquiry.rb
@@ -4,7 +4,7 @@ require "active_support/string_inquirer"
 require "active_support/environment_inquirer"
 
 class String
-  # Wraps the current string in the <tt>ActiveSupport::StringInquirer</tt> class,
+  # Wraps the current string in the ActiveSupport::StringInquirer class,
   # which gives you a prettier way to test for equality.
   #
   #   env = 'production'.inquiry

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -143,7 +143,7 @@ module ActiveSupport # :nodoc:
     alias_method :original_concat, :concat
     private :original_concat
 
-    # Raised when <tt>ActiveSupport::SafeBuffer#safe_concat</tt> is called on unsafe buffers.
+    # Raised when ActiveSupport::SafeBuffer#safe_concat is called on unsafe buffers.
     class SafeConcatError < StandardError
       def initialize
         super "Could not concatenate to the buffer because it is not html safe."

--- a/activesupport/lib/active_support/core_ext/time/zones.rb
+++ b/activesupport/lib/active_support/core_ext/time/zones.rb
@@ -55,7 +55,7 @@ class Time
     #     end
     #   end
     #
-    # NOTE: This won't affect any <tt>ActiveSupport::TimeWithZone</tt>
+    # NOTE: This won't affect any ActiveSupport::TimeWithZone
     # objects that have already been created, e.g. any model timestamp
     # attributes that have been read before the block will remain in
     # the application's default timezone.

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -3,7 +3,7 @@
 require "active_support/notifications"
 
 module ActiveSupport
-  # Raised when <tt>ActiveSupport::Deprecation::Behavior#behavior</tt> is set with <tt>:raise</tt>.
+  # Raised when ActiveSupport::Deprecation::Behavior#behavior is set with <tt>:raise</tt>.
   # You would set <tt>:raise</tt>, as a behavior to raise errors and proactively report exceptions from deprecations.
   class DeprecationException < StandardError
   end

--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -6,7 +6,7 @@ require "active_support/subscriber"
 
 module ActiveSupport
   # <tt>ActiveSupport::LogSubscriber</tt> is an object set to consume
-  # <tt>ActiveSupport::Notifications</tt> with the sole purpose of logging them.
+  # ActiveSupport::Notifications with the sole purpose of logging them.
   # The log subscriber dispatches notifications to a registered object based
   # on its given namespace.
   #
@@ -36,7 +36,7 @@ module ActiveSupport
   # it will properly dispatch the event
   # (<tt>ActiveSupport::Notifications::Event</tt>) to the sql method.
   #
-  # Being an <tt>ActiveSupport::Notifications</tt> consumer,
+  # Being an ActiveSupport::Notifications consumer,
   # <tt>ActiveSupport::LogSubscriber</tt> exposes a simple interface to check if
   # instrumented code raises an exception. It is common to log a different
   # message in case of an error, and this can be achieved by extending

--- a/activesupport/lib/active_support/message_encryptor.rb
+++ b/activesupport/lib/active_support/message_encryptor.rb
@@ -13,7 +13,7 @@ module ActiveSupport
   # The cipher text and initialization vector are base64 encoded and returned
   # to you.
   #
-  # This can be used in situations similar to the <tt>MessageVerifier</tt>, but
+  # This can be used in situations similar to the MessageVerifier, but
   # where you don't want users to be able to determine the value of the payload.
   #
   #   len   = ActiveSupport::MessageEncryptor.key_len
@@ -131,10 +131,10 @@ module ActiveSupport
     # Initialize a new MessageEncryptor. +secret+ must be at least as long as
     # the cipher key size. For the default 'aes-256-gcm' cipher, this is 256
     # bits. If you are using a user-entered secret, you can generate a suitable
-    # key by using <tt>ActiveSupport::KeyGenerator</tt> or a similar key
+    # key by using ActiveSupport::KeyGenerator or a similar key
     # derivation function.
     #
-    # First additional parameter is used as the signature key for +MessageVerifier+.
+    # First additional parameter is used as the signature key for MessageVerifier.
     # This allows you to specify keys to encrypt and sign data.
     #
     #    ActiveSupport::MessageEncryptor.new('secret', 'signature_secret')

--- a/activesupport/lib/active_support/notifications.rb
+++ b/activesupport/lib/active_support/notifications.rb
@@ -84,7 +84,7 @@ module ActiveSupport
   #   event.payload[:exception]         # => ["ArgumentError", "Invalid value"]
   #   event.payload[:exception_object]  # => #<ArgumentError: Invalid value>
   #
-  # As the earlier example depicts, the class <tt>ActiveSupport::Notifications::Event</tt>
+  # As the earlier example depicts, the class ActiveSupport::Notifications::Event
   # is able to take the arguments as they come and provide an object-oriented
   # interface to that data.
   #

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -68,7 +68,7 @@ module ActiveSupport
     end
   end
 
-  # +InheritableOptions+ provides a constructor to build an +OrderedOptions+
+  # +InheritableOptions+ provides a constructor to build an OrderedOptions
   # hash inherited from another hash.
   #
   # Use this if you already have some hash and you want to create a new one based on it.

--- a/activesupport/lib/active_support/secure_compare_rotator.rb
+++ b/activesupport/lib/active_support/secure_compare_rotator.rb
@@ -4,7 +4,7 @@ require "active_support/security_utils"
 require "active_support/messages/rotator"
 
 module ActiveSupport
-  # The ActiveSupport::SecureCompareRotator is a wrapper around +ActiveSupport::SecurityUtils.secure_compare+
+  # The ActiveSupport::SecureCompareRotator is a wrapper around ActiveSupport::SecurityUtils.secure_compare
   # and allows you to rotate a previously defined value to a new one.
   #
   # It can be used as follow:

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -175,7 +175,7 @@ module Rails
     #     Rails.application.message_verifier('sensitive_data').verify(message)
     #     # => 'my sensible data'
     #
-    # See the +ActiveSupport::MessageVerifier+ documentation for more information.
+    # See the ActiveSupport::MessageVerifier documentation for more information.
     def message_verifier(verifier_name)
       @message_verifiers[verifier_name] ||= begin
         secret = key_generator.generate_key(verifier_name.to_s)
@@ -403,7 +403,8 @@ module Rails
     attr_writer :secrets, :credentials
 
     # The secret_key_base is used as the input secret to the application's key generator, which in turn
-    # is used to create all MessageVerifiers/MessageEncryptors, including the ones that sign and encrypt cookies.
+    # is used to create all ActiveSupport::MessageVerifier and ActiveSupport::MessageEncryptor instances,
+    # including the ones that sign and encrypt cookies.
     #
     # In development and test, this is randomly generated and stored in a
     # temporary file in <tt>tmp/development_secret.txt</tt>.

--- a/railties/lib/rails/console/helpers.rb
+++ b/railties/lib/rails/console/helpers.rb
@@ -4,14 +4,14 @@ module Rails
   module ConsoleMethods
     # Gets the helper methods available to the controller.
     #
-    # This method assumes an +ApplicationController+ exists, and that it extends +ActionController::Base+.
+    # This method assumes an +ApplicationController+ exists, and that it extends ActionController::Base.
     def helper
       ApplicationController.helpers
     end
 
     # Gets a new instance of a controller object.
     #
-    # This method assumes an +ApplicationController+ exists, and that it extends +ActionController::Base+.
+    # This method assumes an +ApplicationController+ exists, and that it extends ActionController::Base.
     def controller
       @controller ||= ApplicationController.new
     end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -11,10 +11,10 @@ require "thread"
 module Rails
   # <tt>Rails::Engine</tt> allows you to wrap a specific Rails application or subset of
   # functionality and share it with other applications or within a larger packaged application.
-  # Every <tt>Rails::Application</tt> is just an engine, which allows for simple
+  # Every Rails::Application is just an engine, which allows for simple
   # feature and application sharing.
   #
-  # Any <tt>Rails::Engine</tt> is also a <tt>Rails::Railtie</tt>, so the same
+  # Any <tt>Rails::Engine</tt> is also a Rails::Railtie, so the same
   # methods (like <tt>rake_tasks</tt> and +generators+) and configuration
   # options that are available in railties can also be used in engines.
   #
@@ -236,9 +236,9 @@ module Rails
   # +articles_path+, like you would do with your main application.
   #
   # To make this behavior consistent with other parts of the framework,
-  # isolated engines also have an effect on <tt>ActiveModel::Naming</tt>. In a
+  # isolated engines also have an effect on ActiveModel::Naming. In a
   # normal Rails app, when you use a namespaced model such as
-  # <tt>Namespace::Article</tt>, <tt>ActiveModel::Naming</tt> will generate
+  # <tt>Namespace::Article</tt>, ActiveModel::Naming will generate
   # names with the prefix "namespace". In an isolated engine, the prefix will
   # be omitted in URL helpers and form fields, for convenience.
   #
@@ -442,7 +442,7 @@ module Rails
     end
 
     # Load console and invoke the registered hooks.
-    # Check <tt>Rails::Railtie.console</tt> for more info.
+    # Check Rails::Railtie.console for more info.
     def load_console(app = self)
       require "rails/console/app"
       require "rails/console/helpers"
@@ -451,14 +451,14 @@ module Rails
     end
 
     # Load Rails runner and invoke the registered hooks.
-    # Check <tt>Rails::Railtie.runner</tt> for more info.
+    # Check Rails::Railtie.runner for more info.
     def load_runner(app = self)
       run_runner_blocks(app)
       self
     end
 
     # Load Rake and railties tasks, and invoke the registered hooks.
-    # Check <tt>Rails::Railtie.rake_tasks</tt> for more info.
+    # Check Rails::Railtie.rake_tasks for more info.
     def load_tasks(app = self)
       require "rake"
       run_tasks_blocks(app)
@@ -466,7 +466,7 @@ module Rails
     end
 
     # Load Rails generators and invoke the registered hooks.
-    # Check <tt>Rails::Railtie.generators</tt> for more info.
+    # Check Rails::Railtie.generators for more info.
     def load_generators(app = self)
       require "rails/generators"
       run_generators_blocks(app)
@@ -475,7 +475,7 @@ module Rails
     end
 
     # Invoke the server registered hooks.
-    # Check <tt>Rails::Railtie.server</tt> for more info.
+    # Check Rails::Railtie.server for more info.
     def load_server(app = self)
       run_server_blocks(app)
       self

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -12,7 +12,7 @@ module Rails
     #   root.add "app/controllers", eager_load: true
     #
     # The above command creates a new root object and adds "app/controllers" as a path.
-    # This means we can get a <tt>Rails::Paths::Path</tt> object back like below:
+    # This means we can get a Rails::Paths::Path object back like below:
     #
     #   path = root["app/controllers"]
     #   path.eager_load?               # => true

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -24,7 +24,7 @@ module Rails
   # * creating initializers
   # * configuring a Rails framework for the application, like setting a generator
   # * adding <tt>config.*</tt> keys to the environment
-  # * setting up a subscriber with <tt>ActiveSupport::Notifications</tt>
+  # * setting up a subscriber with ActiveSupport::Notifications
   # * adding Rake tasks
   #
   # == Creating a Railtie
@@ -129,7 +129,7 @@ module Rails
   # == Application and Engine
   #
   # An engine is nothing more than a railtie with some initializers already set. And since
-  # <tt>Rails::Application</tt> is an engine, the same configuration described here can be
+  # Rails::Application is an engine, the same configuration described here can be
   # used in both.
   #
   # Be sure to look at the documentation of those specific classes for more information.

--- a/railties/lib/rails/source_annotation_extractor.rb
+++ b/railties/lib/rails/source_annotation_extractor.rb
@@ -70,7 +70,7 @@ module Rails
     #
     # If +options+ has a <tt>:tag</tt> flag, it will be passed to each annotation's +to_s+.
     #
-    # See <tt>#find_in</tt> for a list of file extensions that will be taken into account.
+    # See SourceAnnotationExtractor#find_in for a list of file extensions that will be taken into account.
     #
     # This class method is the single entry point for the <tt>rails notes</tt> command.
     def self.enumerate(tag = nil, options = {})


### PR DESCRIPTION
RDoc will automatically format and link API references as long as they are not already marked up as inline code.

This commit removes markup from various API references so that those references will link to the relevant API docs.

| Before (example) | After (example) |
| --- | --- |
| ![cross-link-before](https://user-images.githubusercontent.com/771968/155006380-b2acd62b-170b-47c5-a3cd-172aa953129b.png) | ![cross-link-after](https://user-images.githubusercontent.com/771968/155006406-867db619-3e4d-4b09-a746-2fdd8eb90ebf.png) |
