### PR TITLE
remove unused requires in ActiveSupport::Cache

### DIFF
--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -2,11 +2,9 @@
 
 require "zlib"
 require "active_support/core_ext/array/extract_options"
-require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/attribute_accessors"
 require "active_support/core_ext/numeric/bytes"
-require "active_support/core_ext/numeric/time"
 require "active_support/core_ext/object/to_param"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"

--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -10,6 +10,7 @@ end
 require "delegate"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/array/extract_options"
+require "active_support/core_ext/numeric/time"
 
 module ActiveSupport
   module Cache

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -15,6 +15,7 @@ begin
 rescue LoadError
 end
 
+require "active_support/core_ext/numeric/time"
 require "active_support/digest"
 
 module ActiveSupport

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/numeric/time"
+
 # Tests the base functionality that should be identical across all cache stores.
 module CacheStoreBehavior
   def test_should_read_and_write_strings

--- a/activesupport/test/cache/coder_test.rb
+++ b/activesupport/test/cache/coder_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "../abstract_unit"
 require "active_support/cache"
+require "active_support/core_ext/numeric/time"
 
 class CacheCoderTest < ActiveSupport::TestCase
   def test_new_coder_can_read_legacy_payloads


### PR DESCRIPTION
### Summary

core_ext/array/wrap
- added in b1164adda12268b38bba9b0d81c0d26b7251b8bb
- usage removed in fa986ae0cac423bf1ebcb5caeccbecf00c990094

core_ext/numeric/time
- added in ee51b51b60f9e6cce9babed2c8a65a14d87790c8, but usage was only
  in mem_cache_store so moved require there
