### PR TITLE
Remove fixed TODO ActionController::Metal::ContentSecurityPolicy [ci-skip]

### DIFF
--- a/actionpack/lib/action_controller/metal/content_security_policy.rb
+++ b/actionpack/lib/action_controller/metal/content_security_policy.rb
@@ -2,7 +2,6 @@
 
 module ActionController # :nodoc:
   module ContentSecurityPolicy
-    # TODO: Documentation
     extend ActiveSupport::Concern
 
     include AbstractController::Helpers


### PR DESCRIPTION
### Summary

The ActionController::Metal::ContentSecurityPolicy has documentation so
the TODO for documentation can be removed.