### PR TITLE
Fix small type in CSP guide [ci-skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1162,7 +1162,7 @@ end
 If you are considering 'unsafe-inline', consider using nonces instead. [Nonces
 provide a substantial improvement](https://www.w3.org/TR/CSP3/#security-nonces)
 over 'unsafe-inline' when implementing a Content Security Policy on top
-existing code.
+of existing code.
 
 ```ruby
 # config/initializers/content_security_policy.rb


### PR DESCRIPTION
### Summary

This fixes a small typo.