### PR TITLE
use `git init -b` in generator when supported

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -476,6 +476,22 @@ module Rails
       def keep_file(destination)
         create_file("#{destination}/.keep") if keeps?
       end
+
+      def user_default_branch
+        @user_default_branch ||= `git config init.defaultbranch`
+      end
+
+      def git_init_command
+        return "git init" if user_default_branch.strip.present?
+
+        git_version = `git --version`[/\d+\.\d+\.\d+/]
+
+        if Gem::Version.new(git_version) >= Gem::Version.new("2.28.0")
+          "git init -b main"
+        else
+          "git init && git symbolic-ref HEAD refs/heads/main"
+        end
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -72,10 +72,7 @@ module Rails
 
     def version_control
       if !options[:skip_git] && !options[:pretend]
-        run "git init", capture: options[:quiet], abort_on_failure: false
-        if user_default_branch.strip.empty?
-          `git symbolic-ref HEAD refs/heads/main`
-        end
+        run git_init_command, capture: options[:quiet], abort_on_failure: false
       end
     end
 
@@ -244,11 +241,6 @@ module Rails
     def config_target_version
       defined?(@config_target_version) ? @config_target_version : Rails::VERSION::STRING.to_f
     end
-
-    private
-      def user_default_branch
-        @user_default_branch ||= `git config init.defaultbranch`
-      end
   end
 
   module Generators

--- a/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
+++ b/railties/lib/rails/generators/rails/plugin/plugin_generator.rb
@@ -68,10 +68,7 @@ module Rails
 
     def version_control
       if !options[:skip_git] && !options[:pretend]
-        run "git init", capture: options[:quiet], abort_on_failure: false
-        if user_default_branch.strip.empty?
-          `git symbolic-ref HEAD refs/heads/main`
-        end
+        run git_init_command, capture: options[:quiet], abort_on_failure: false
       end
     end
 
@@ -191,11 +188,6 @@ module Rails
         append_file gemfile_in_app_path, entry
       end
     end
-
-    private
-      def user_default_branch
-        @user_default_branch ||= `git config init.defaultbranch`
-      end
   end
 
   module Generators


### PR DESCRIPTION
### Summary

This has the benefit of hiding the warning message from git when
initialBranch configuration is unset, and was a recommendation on the
original commit adding main as the default branch for generators.

Ref: eb261937ac856100b4e1c8a2dbb56aab6e5d140e
Example warning messages in test output: https://buildkite.com/rails/rails/builds/84815#bb2c86d0-143b-4f86-85b9-3abb9567bcde