### PR TITLE
Make ActiveRecord::Rollback bubble to outer transactions

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -202,58 +202,18 @@ module ActiveRecord
       # Runs the given block in a database transaction, and returns the result
       # of the block.
       #
+      # Options are:
+      # * <tt>:requires_new</tt> - Uses savepoints to emulate a real nested transaction. The default is +nil+
+      # * <tt>:isolation</tt> - See Isolation below. The default is +nil+.
+      # * <tt>:joinable</tt> - A non-joinable transaction creates a savepoint. The default is +nil+.
+      # * <tt>:join_existing</tt> - Will join existing transactions, so ActiveRecord::Rollback will rollback
+      #   the whole transaction see ActiveRecord::Transactions.  The default is +nil+ but in future versions of Rails the default will be +true+.
+      #
       # == Nested transactions support
       #
       # #transaction calls can be nested. By default, this makes all database
       # statements in the nested transaction block become part of the parent
-      # transaction. For example, the following behavior may be surprising:
-      #
-      #   ActiveRecord::Base.transaction do
-      #     Post.create(title: 'first')
-      #     ActiveRecord::Base.transaction do
-      #       Post.create(title: 'second')
-      #       raise ActiveRecord::Rollback
-      #     end
-      #   end
-      #
-      # This creates both "first" and "second" posts. Reason is the
-      # ActiveRecord::Rollback exception in the nested block does not issue a
-      # ROLLBACK. Since these exceptions are captured in transaction blocks,
-      # the parent block does not see it and the real transaction is committed.
-      #
-      # Most databases don't support true nested transactions. At the time of
-      # writing, the only database that supports true nested transactions that
-      # we're aware of, is MS-SQL.
-      #
-      # In order to get around this problem, #transaction will emulate the effect
-      # of nested transactions, by using savepoints:
-      # https://dev.mysql.com/doc/refman/en/savepoint.html.
-      #
-      # It is safe to call this method if a database transaction is already open,
-      # i.e. if #transaction is called within another #transaction block. In case
-      # of a nested call, #transaction will behave as follows:
-      #
-      # - The block will be run without doing anything. All database statements
-      #   that happen within the block are effectively appended to the already
-      #   open database transaction.
-      # - However, if +:requires_new+ is set, the block will be wrapped in a
-      #   database savepoint acting as a sub-transaction.
-      #
-      # In order to get a ROLLBACK for the nested transaction you may ask for a
-      # real sub-transaction by passing <tt>requires_new: true</tt>.
-      # If anything goes wrong, the database rolls back to the beginning of
-      # the sub-transaction without rolling back the parent transaction.
-      # If we add it to the previous example:
-      #
-      #   ActiveRecord::Base.transaction do
-      #     Post.create(title: 'first')
-      #     ActiveRecord::Base.transaction(requires_new: true) do
-      #       Post.create(title: 'second')
-      #       raise ActiveRecord::Rollback
-      #     end
-      #   end
-      #
-      # only post with title "first" is created.
+      # transaction.
       #
       # See ActiveRecord::Transactions to learn more.
       #
@@ -276,7 +236,7 @@ module ActiveRecord
       #     end  # RELEASE SAVEPOINT active_record_1  <--- BOOM! database error!
       #   end
       #
-      # == Transaction isolation
+      # == Isolation
       #
       # If your database supports setting the isolation level for a transaction, you can set
       # it like so:

--- a/activerecord/test/activejob/destroy_association_async_test.rb
+++ b/activerecord/test/activejob/destroy_association_async_test.rb
@@ -196,7 +196,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
 
     parent.save!
     assert_no_enqueued_jobs do
-      DestroyAsyncParent.transaction do
+      DestroyAsyncParent.transaction(join_existing: true) do
         parent.destroy
         raise ActiveRecord::Rollback
       end
@@ -293,7 +293,7 @@ class DestroyAssociationAsyncTest < ActiveRecord::TestCase
     book = BookDestroyAsync.create!
     book.tags << [tag, tag2]
     book.save!
-    ActiveRecord::Base.transaction do
+    ActiveRecord::Base.transaction(join_existing: true) do
       book.destroy
       raise ActiveRecord::Rollback
     end

--- a/activerecord/test/cases/adapters/postgresql/citext_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/citext_test.rb
@@ -39,7 +39,7 @@ class PostgresqlCitextTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_change_table_supports_json
-    @connection.transaction do
+    @connection.transaction(join_existing: true) do
       @connection.change_table("citexts") do |t|
         t.citext "username"
       end

--- a/activerecord/test/cases/adapters/postgresql/hstore_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/hstore_test.rb
@@ -69,7 +69,7 @@ class PostgresqlHstoreTest < ActiveRecord::PostgreSQLTestCase
   end
 
   def test_change_table_supports_hstore
-    @connection.transaction do
+    @connection.transaction(join_existing: true) do
       @connection.change_table("hstores") do |t|
         t.hstore "users", default: ""
       end

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -42,7 +42,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
   test "opens a `read_uncommitted` transaction" do
     with_connection(flags: shared_cache_flags) do |conn1|
       conn1.create_table(:zines) { |t| t.column(:title, :string) } if in_memory_db?
-      conn1.transaction do
+      conn1.transaction(join_existing: true) do
         conn1.transaction_manager.materialize_transactions
         conn1.execute("INSERT INTO zines (title) VALUES ('foo')")
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -720,7 +720,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::InternalMetadata.drop_table
     assert_not_predicate ActiveRecord::InternalMetadata, :table_exists?
 
-    ActiveRecord::InternalMetadata.connection.transaction do
+    ActiveRecord::InternalMetadata.connection.transaction(join_existing: true) do
       ActiveRecord::InternalMetadata.create_table
       assert_predicate ActiveRecord::InternalMetadata, :table_exists?
 
@@ -729,7 +729,7 @@ class MigrationTest < ActiveRecord::TestCase
       raise ActiveRecord::Rollback
     end
 
-    ActiveRecord::InternalMetadata.connection.transaction do
+    ActiveRecord::InternalMetadata.connection.transaction(join_existing: true) do
       ActiveRecord::InternalMetadata.create_table
       assert_predicate ActiveRecord::InternalMetadata, :table_exists?
 
@@ -745,7 +745,7 @@ class MigrationTest < ActiveRecord::TestCase
     ActiveRecord::SchemaMigration.drop_table
     assert_not_predicate ActiveRecord::SchemaMigration, :table_exists?
 
-    ActiveRecord::SchemaMigration.connection.transaction do
+    ActiveRecord::SchemaMigration.connection.transaction(join_existing: true) do
       ActiveRecord::SchemaMigration.create_table
       assert_predicate ActiveRecord::SchemaMigration, :table_exists?
 
@@ -754,7 +754,7 @@ class MigrationTest < ActiveRecord::TestCase
       raise ActiveRecord::Rollback
     end
 
-    ActiveRecord::SchemaMigration.connection.transaction do
+    ActiveRecord::SchemaMigration.connection.transaction(join_existing: true) do
       ActiveRecord::SchemaMigration.create_table
       assert_predicate ActiveRecord::SchemaMigration, :table_exists?
 

--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -574,7 +574,7 @@ class QueryCacheTest < ActiveRecord::TestCase
     ActiveRecord::Base.connection.enable_query_cache!
     post = Post.first
 
-    Post.transaction do
+    Post.transaction(join_existing: true) do
       post.update(title: "rollback")
       assert_equal 1, Post.where(title: "rollback").to_a.count
       raise ActiveRecord::Rollback

--- a/activerecord/test/cases/relation/load_async_test.rb
+++ b/activerecord/test/cases/relation/load_async_test.rb
@@ -102,7 +102,7 @@ module ActiveRecord
 
     def test_load_async_from_transaction
       posts = nil
-      Post.transaction do
+      Post.transaction(join_existing: true) do
         Post.where(author_id: 1).update_all(title: "In Transaction")
         posts = Post.where(author_id: 1).load_async
         if in_memory_db?
@@ -231,7 +231,7 @@ module ActiveRecord
 
       def test_load_async_from_transaction
         posts = nil
-        Post.transaction do
+        Post.transaction(join_existing: true) do
           Post.where(author_id: 1).update_all(title: "In Transaction")
           posts = Post.where(author_id: 1).load_async
           assert_not_predicate posts, :scheduled?
@@ -365,7 +365,7 @@ module ActiveRecord
 
       def test_load_async_from_transaction
         posts = nil
-        Post.transaction do
+        Post.transaction(join_existing: true) do
           Post.where(author_id: 1).update_all(title: "In Transaction")
           posts = Post.where(author_id: 1).load_async
           assert_predicate posts, :scheduled?


### PR DESCRIPTION
### Summary

Re-raise the error till it reaches a savepoint or the top transaction.
The reason to stop at savepoint / requires_new transactions is that
they are actual nested transactions so are the smallest unit the
database can rollback.

### Other Information

This is a breaking change but the current behaviour is documented as
being "surprising".