### PR TITLE
Stop capturing subdomain in `HostAuthorization` middleware

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Use non-capturing group for subdomain matching in `ActionDispatch::HostAuthorization`
+
+    Since we do nothing with the captured subdomain group, we can use a non-capturing group instead.
+
+    *Sam Bostock*
+
 *   Fix `ActionController::Live` to copy the IsolatedExecutionState in the ephemeral thread.
 
     Since its inception `ActionController::Live` has been copying thread local variables

--- a/actionpack/lib/action_dispatch/middleware/host_authorization.rb
+++ b/actionpack/lib/action_dispatch/middleware/host_authorization.rb
@@ -18,6 +18,7 @@ module ActionDispatch
   class HostAuthorization
     ALLOWED_HOSTS_IN_DEVELOPMENT = [".localhost", IPAddr.new("0.0.0.0/0"), IPAddr.new("::/0")]
     PORT_REGEX = /(?::\d+)/ # :nodoc:
+    SUBDOMAIN_REGEX = /(?:[a-z0-9-]+\.)/i # :nodoc:
     IPV4_HOSTNAME = /(?<host>\d+\.\d+\.\d+\.\d+)#{PORT_REGEX}?/ # :nodoc:
     IPV6_HOSTNAME = /(?<host>[a-f0-9]*:[a-f0-9.:]+)/i # :nodoc:
     IPV6_HOSTNAME_WITH_PORT = /\[#{IPV6_HOSTNAME}\]#{PORT_REGEX}/i # :nodoc:
@@ -69,7 +70,7 @@ module ActionDispatch
 
         def sanitize_string(host)
           if host.start_with?(".")
-            /\A([a-z0-9-]+\.)?#{Regexp.escape(host[1..-1])}#{PORT_REGEX}?\z/i
+            /\A#{SUBDOMAIN_REGEX}?#{Regexp.escape(host[1..-1])}#{PORT_REGEX}?\z/i
           else
             /\A#{Regexp.escape host}#{PORT_REGEX}?\z/i
           end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

I noticed `HostAuthorization` uses a capturing group to match the optional subdomain in the ".domain.tld" special case.

Since we do nothing with the captured host, we can use a non-capturing group instead.

I also noticed that the inline pattern for the subdomain match is effectively a "magic regex" (like a "magic number"), so I gave it a name by extracting it as `SUBDOMAIN_REGEX` (with `:nodoc:` to match `PORT_REGEX`).

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

The difference between the capturing and non-capturing group in a benchmark is tiny, but it matches `PORT_REGEX`'s non-capturing group, and I think the real value is the name being extracted.

While making my `CHANGELOG` entry, I noticed a couple typos from #44499, so I fixed them.
cc. @byroot