### PR TITLE
Remove assets.enabled from Configuring guide

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -367,11 +367,6 @@ Sets the default time zone for the application and enables time zone awareness f
 
 ### Configuring Assets
 
-#### `config.assets.enabled`
-
-A flag that controls whether the asset pipeline is enabled. It is set to `true`
-by default.
-
 #### `config.assets.css_compressor`
 
 Defines the CSS compressor to use. It is set by default by `sass-rails`. The unique alternative value at the moment is `:yui`, which uses the `yui-compressor` gem.


### PR DESCRIPTION
The option was removed in https://github.com/rails/rails/pull/18636 and didn't make the cut to the gem (since loading the gem enables the asset pipeline).

### Summary

Removes a nonexistent configuration option from the Configuring guide.

### Other Information

Should we remove the whole `assets` section since it's optional now? The configuration options are well documented in the [gem itself](https://github.com/rails/sprockets-rails#initializer-options) so we could point there.