### PR TITLE
The database server discards prepared statements when the client disconnects

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -549,14 +549,14 @@ module ActiveRecord
       # new connection with the database. Implementors should call super if they
       # override the default implementation.
       def reconnect!
-        clear_cache!
+        clear_cache!(new_connection: true)
         reset_transaction
       end
 
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
-        clear_cache!
+        clear_cache!(new_connection: true)
         reset_transaction
       end
 
@@ -593,8 +593,16 @@ module ActiveRecord
       end
 
       # Clear any caching the database adapter may be doing.
-      def clear_cache!
-        @lock.synchronize { @statements.clear } if @statements
+      def clear_cache!(new_connection: false)
+        if @statements
+          @lock.synchronize do
+            if new_connection
+              @statements.reset
+            else
+              @statements.clear
+            end
+          end
+        end
       end
 
       # Returns true if its required to reload the connection between requests for development mode.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -321,10 +321,10 @@ module ActiveRecord
       # Close then reopen the connection.
       def reconnect!
         @lock.synchronize do
-          super
           @connection.reset
           configure_connection
           reload_type_map
+          super
         rescue PG::ConnectionBad
           connect
         end
@@ -332,12 +332,12 @@ module ActiveRecord
 
       def reset!
         @lock.synchronize do
-          clear_cache!
           reset_transaction
           unless @connection.transaction_status == ::PG::PQTRANS_IDLE
             @connection.query "ROLLBACK"
           end
           @connection.query "DISCARD ALL"
+          clear_cache!(new_connection: true)
           configure_connection
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -77,6 +77,8 @@ module ActiveRecord
       }
 
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
+        alias reset clear
+
         private
           def dealloc(stmt)
             stmt.close unless stmt.closed?

--- a/activerecord/lib/active_record/connection_adapters/statement_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/statement_pool.rb
@@ -42,6 +42,13 @@ module ActiveRecord
         cache.clear
       end
 
+      # Clear the pool without deallocating; this is only safe when we
+      # know the server has independently deallocated all statements
+      # (e.g. due to a reconnect, or a DISCARD ALL)
+      def reset
+        cache.clear
+      end
+
       def delete(key)
         dealloc cache[key]
         cache.delete(key)


### PR DESCRIPTION
Knowing that, we know there's no need to try to manually deallocate them.

Most of the time this would currently be skipping deallocations because the connection is dead at the time of the call -- but instead of relying on that call sequencing (and pointlessly sending a series of deallocations in other circumstances), we can simply drop our cache if the whole connection gets reset.