### PR TITLE
Fix flaky Action View tests

### DIFF
--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -30,6 +30,8 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def setup
+    ActionView::LookupContext::DetailsKey.clear
+
     @controller = TestController.new
     @request  = ActionController::TestRequest.create(@controller.class)
     @response = ActionDispatch::TestResponse.new

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -52,6 +52,11 @@ class RenderPartialWithRecordIdentificationTest < ActiveRecordTestCase
   tests RenderPartialWithRecordIdentificationController
   fixtures :developers, :projects, :developers_projects, :topics, :replies, :companies, :mascots
 
+  def setup
+    super
+    ActionView::LookupContext::DetailsKey.clear
+  end
+
   def test_rendering_partial_with_has_many_and_belongs_to_association
     get :render_with_has_many_and_belongs_to_association
     assert_equal Developer.find(1).projects.map(&:name).join, @response.body

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -712,6 +712,8 @@ class FrozenStringLiteralEnabledViewRenderTest < ActiveSupport::TestCase
   include RenderTestCases
 
   def setup
+    ActionView::LookupContext::DetailsKey.clear
+
     @previous_frozen_literal = ActionView::Template.frozen_string_literal
     ActionView::Template.frozen_string_literal = true
     view_paths = ActionController::Base.view_paths


### PR DESCRIPTION
### Summary

Various Action View tests randomly fail with errors like the following:
```
ActionView::Template::Error: undefined method `__rails_actionview_test_fixtures_test__customer_erb___1906185013242363930_25680' for #<ActionView::Base:0x000000000115a8>
```
Here's an example of a failing build: https://buildkite.com/rails/rails/builds/84207#3bc8eb7f-c86d-4f6f-8932-e2e8c26cf893

A number of test classes use `ActionView::LookupContext::DetailsKey.clear` in their `setup` method to clear out a cache before executing tests, but the failing test classes do not have this. Adding it eliminates the failures. After making these changes, I ran the test suite in a loop (`while bundle exec bin/test; do :; done`) for 12 hours and did not observe any failures.

Note: I don't understand the details of the caching mechanism that's at play here, so I'm not certain that this is the best fix. I noticed some past PRs for flaky tests that could be related:

* https://github.com/rails/rails/pull/36189
* https://github.com/rails/rails/pull/39949
* https://github.com/rails/rails/pull/44269