### PR TITLE
Rename the raw connection ivar to `@raw_connection`

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -92,7 +92,7 @@ module ActiveRecord
       def initialize(connection, logger = nil, config = {}) # :nodoc:
         super()
 
-        @connection          = connection
+        @raw_connection      = connection
         @owner               = nil
         @instrumenter        = ActiveSupport::Notifications.instrumenter
         @logger              = logger
@@ -569,7 +569,7 @@ module ActiveRecord
       def discard!
         # This should be overridden by concrete adapters.
         #
-        # Prevent @connection's finalizer from touching the socket, or
+        # Prevent @raw_connection's finalizer from touching the socket, or
         # otherwise communicating with its server, when it is collected.
         if schema_cache.connection == self
           schema_cache.connection = nil
@@ -625,7 +625,7 @@ module ActiveRecord
       # PostgreSQL's lo_* methods.
       def raw_connection
         disable_lazy_transactions!
-        @connection
+        @raw_connection
       end
 
       def default_uniqueness_comparison(attribute, value) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -639,7 +639,7 @@ module ActiveRecord
 
           log(sql, name, async: async) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.query(sql)
+              @raw_connection.query(sql)
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -11,7 +11,7 @@ module ActiveRecord
           else
             super
           end
-          @connection.abandon_results!
+          @raw_connection.abandon_results!
           result
         end
 
@@ -70,7 +70,7 @@ module ActiveRecord
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
           if without_prepared_statement?(binds)
             @lock.synchronize do
-              execute_and_free(sql, name) { @connection.affected_rows }
+              execute_and_free(sql, name) { @raw_connection.affected_rows }
             end
           else
             exec_stmt_and_free(sql, name, binds) { |stmt| stmt.affected_rows }
@@ -91,7 +91,7 @@ module ActiveRecord
           def raw_execute(sql, name, async: false)
             # make sure we carry over any changes to ActiveRecord.default_timezone that have been
             # made since we established the connection
-            @connection.query_options[:database_timezone] = default_timezone
+            @raw_connection.query_options[:database_timezone] = default_timezone
 
             super
           end
@@ -100,7 +100,7 @@ module ActiveRecord
             statements = statements.map { |sql| transform_query(sql) }
             combine_multi_statements(statements).each do |statement|
               raw_execute(statement, name)
-              @connection.abandon_results!
+              @raw_connection.abandon_results!
             end
           end
 
@@ -109,7 +109,7 @@ module ActiveRecord
           end
 
           def last_inserted_id(result)
-            @connection.last_id
+            @raw_connection.last_id
           end
 
           def multi_statements_enabled?
@@ -126,13 +126,13 @@ module ActiveRecord
             multi_statements_was = multi_statements_enabled?
 
             unless multi_statements_was
-              @connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
+              @raw_connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
             end
 
             yield
           ensure
             unless multi_statements_was
-              @connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
+              @raw_connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
             end
           end
 
@@ -171,15 +171,15 @@ module ActiveRecord
 
             # make sure we carry over any changes to ActiveRecord.default_timezone that have been
             # made since we established the connection
-            @connection.query_options[:database_timezone] = default_timezone
+            @raw_connection.query_options[:database_timezone] = default_timezone
 
             type_casted_binds = type_casted_binds(binds)
 
             log(sql, name, binds, type_casted_binds, async: async) do
               if cache_stmt
-                stmt = @statements[sql] ||= @connection.prepare(sql)
+                stmt = @statements[sql] ||= @raw_connection.prepare(sql)
               else
-                stmt = @connection.prepare(sql)
+                stmt = @raw_connection.prepare(sql)
               end
 
               begin

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -111,7 +111,7 @@ module ActiveRecord
       #++
 
       def quote_string(string)
-        @connection.escape(string)
+        @raw_connection.escape(string)
       rescue Mysql2::Error => error
         raise translate_exception(error, message: error.message, sql: "<escape>", binds: [])
       end
@@ -121,7 +121,7 @@ module ActiveRecord
       #++
 
       def active?
-        @connection.ping
+        @raw_connection.ping
       end
 
       def reconnect!
@@ -135,13 +135,13 @@ module ActiveRecord
       # Otherwise, this method does nothing.
       def disconnect!
         super
-        @connection.close
+        @raw_connection.close
       end
 
       def discard! # :nodoc:
         super
-        @connection.automatic_close = false
-        @connection = nil
+        @raw_connection.automatic_close = false
+        @raw_connection = nil
       end
 
       private
@@ -154,12 +154,12 @@ module ActiveRecord
         end
 
         def connect
-          @connection = self.class.new_client(@config)
+          @raw_connection = self.class.new_client(@config)
           configure_connection
         end
 
         def configure_connection
-          @connection.query_options[:as] = :array
+          @raw_connection.query_options[:as] = :array
           super
         end
 
@@ -168,7 +168,7 @@ module ActiveRecord
         end
 
         def get_full_version
-          @connection.server_info[:version]
+          @raw_connection.server_info[:version]
         end
 
         def translate_exception(exception, message:, sql:, binds:)

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -15,7 +15,7 @@ module ActiveRecord
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.async_exec(sql).map_types!(@type_map_for_results).values
+              @raw_connection.async_exec(sql).map_types!(@type_map_for_results).values
             end
           end
         end
@@ -43,7 +43,7 @@ module ActiveRecord
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.async_exec(sql)
+              @raw_connection.async_exec(sql)
             end
           end
         end
@@ -120,8 +120,8 @@ module ActiveRecord
 
         # Aborts a transaction.
         def exec_rollback_db_transaction # :nodoc:
-          @connection.cancel unless @connection.transaction_status == PG::PQTRANS_IDLE
-          @connection.block
+          @raw_connection.cancel unless @raw_connection.transaction_status == PG::PQTRANS_IDLE
+          @raw_connection.block
           execute("ROLLBACK", "TRANSACTION")
         end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -6,14 +6,14 @@ module ActiveRecord
       module Quoting
         # Escapes binary strings for bytea input to the database.
         def escape_bytea(value)
-          @connection.escape_bytea(value) if value
+          @raw_connection.escape_bytea(value) if value
         end
 
         # Unescapes bytea output from a database to the binary string it represents.
         # NOTE: This is NOT an inverse of escape_bytea! This is only to be used
         # on escaped binary output from database drive.
         def unescape_bytea(value)
-          @connection.unescape_bytea(value) if value
+          @raw_connection.unescape_bytea(value) if value
         end
 
         def quote(value) # :nodoc:
@@ -43,7 +43,7 @@ module ActiveRecord
 
         # Quotes strings for use in SQL input.
         def quote_string(s) # :nodoc:
-          @connection.escape(s)
+          @raw_connection.escape(s)
         end
 
         # Checks the following cases:

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @connection.execute(sql)
+              @raw_connection.execute(sql)
             end
           end
         end
@@ -45,7 +45,7 @@ module ActiveRecord
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
               # Don't cache statements if they are not prepared
               unless prepare
-                stmt = @connection.prepare(sql)
+                stmt = @raw_connection.prepare(sql)
                 begin
                   cols = stmt.columns
                   unless without_prepared_statement?(binds)
@@ -56,7 +56,7 @@ module ActiveRecord
                   stmt.close
                 end
               else
-                stmt = @statements[sql] ||= @connection.prepare(sql)
+                stmt = @statements[sql] ||= @raw_connection.prepare(sql)
                 cols = stmt.columns
                 stmt.reset!
                 stmt.bind_params(type_casted_binds)
@@ -70,7 +70,7 @@ module ActiveRecord
 
         def exec_delete(sql, name = "SQL", binds = []) # :nodoc:
           exec_query(sql, name, binds)
-          @connection.changes
+          @raw_connection.changes
         end
         alias :exec_update :exec_delete
 
@@ -78,22 +78,22 @@ module ActiveRecord
           raise TransactionIsolationError, "SQLite3 only supports the `read_uncommitted` transaction isolation level" if isolation != :read_uncommitted
           raise StandardError, "You need to enable the shared-cache mode in SQLite mode before attempting to change the transaction isolation level" unless shared_cache?
 
-          ActiveSupport::IsolatedExecutionState[:active_record_read_uncommitted] = @connection.get_first_value("PRAGMA read_uncommitted")
-          @connection.read_uncommitted = true
+          ActiveSupport::IsolatedExecutionState[:active_record_read_uncommitted] = @raw_connection.get_first_value("PRAGMA read_uncommitted")
+          @raw_connection.read_uncommitted = true
           begin_db_transaction
         end
 
         def begin_db_transaction # :nodoc:
-          log("begin transaction", "TRANSACTION") { @connection.transaction }
+          log("begin transaction", "TRANSACTION") { @raw_connection.transaction }
         end
 
         def commit_db_transaction # :nodoc:
-          log("commit transaction", "TRANSACTION") { @connection.commit }
+          log("commit transaction", "TRANSACTION") { @raw_connection.commit }
           reset_read_uncommitted
         end
 
         def exec_rollback_db_transaction # :nodoc:
-          log("rollback transaction", "TRANSACTION") { @connection.rollback }
+          log("rollback transaction", "TRANSACTION") { @raw_connection.rollback }
           reset_read_uncommitted
         end
 
@@ -111,7 +111,7 @@ module ActiveRecord
             read_uncommitted = ActiveSupport::IsolatedExecutionState[:active_record_read_uncommitted]
             return unless read_uncommitted
 
-            @connection.read_uncommitted = read_uncommitted
+            @raw_connection.read_uncommitted = read_uncommitted
           end
 
           def execute_batch(statements, name = nil)
@@ -124,13 +124,13 @@ module ActiveRecord
 
             log(sql, name) do
               ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                @connection.execute_batch2(sql)
+                @raw_connection.execute_batch2(sql)
               end
             end
           end
 
           def last_inserted_id(result)
-            @connection.last_insert_row_id
+            @raw_connection.last_insert_row_id
           end
 
           def build_fixture_statements(fixture_set)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/quoting.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module SQLite3
       module Quoting # :nodoc:
         def quote_string(s)
-          @connection.class.quote(s)
+          ::SQLite3::Database.quote(s)
         end
 
         def quote_table_name_for_assignment(table, attr)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -161,19 +161,19 @@ module ActiveRecord
       end
 
       def active?
-        !@connection.closed?
+        !@raw_connection.closed?
       end
 
       def reconnect!
         super
-        connect if @connection.closed?
+        connect if @raw_connection.closed?
       end
 
       # Disconnects from the database if already connected. Otherwise, this
       # method does nothing.
       def disconnect!
         super
-        @connection.close rescue nil
+        @raw_connection.close rescue nil
       end
 
       def supports_index_sort_order?
@@ -186,7 +186,7 @@ module ActiveRecord
 
       # Returns the current database encoding format as a string, e.g. 'UTF-8'
       def encoding
-        @connection.encoding.to_s
+        @raw_connection.encoding.to_s
       end
 
       def supports_explain?
@@ -601,7 +601,7 @@ module ActiveRecord
         end
 
         def connect
-          @connection = ::SQLite3::Database.new(
+          @raw_connection = ::SQLite3::Database.new(
             @config[:database].to_s,
             @config.merge(results_as_hash: true)
           )
@@ -609,7 +609,7 @@ module ActiveRecord
         end
 
         def configure_connection
-          @connection.busy_timeout(self.class.type_cast_config_to_integer(@config[:timeout])) if @config[:timeout]
+          @raw_connection.busy_timeout(self.class.type_cast_config_to_integer(@config[:timeout])) if @config[:timeout]
 
           execute("PRAGMA foreign_keys = ON", "SCHEMA")
         end

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         end
 
         def test_prepared_statements_do_not_get_stuck_on_query_interruption
-          pg_connection = ActiveRecord::Base.connection.instance_variable_get(:@connection)
+          pg_connection = ActiveRecord::Base.connection.instance_variable_get(:@raw_connection)
           pg_connection.stub(:get_last_result, -> { raise "random error" }) do
             assert_raises(RuntimeError) do
               Developer.where(name: "David").last

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -86,7 +86,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
   test "set the read_uncommitted PRAGMA to its previous value" do
     with_connection(flags: shared_cache_flags) do |conn|
       conn.transaction(joinable: false, isolation: :read_uncommitted) do
-        conn.instance_variable_get(:@connection).read_uncommitted = true
+        conn.instance_variable_get(:@raw_connection).read_uncommitted = true
         assert(read_uncommitted?(conn))
         conn.transaction_manager.materialize_transactions
         assert(read_uncommitted?(conn))
@@ -98,7 +98,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
 
   private
     def read_uncommitted?(conn)
-      conn.instance_variable_get(:@connection).get_first_value("PRAGMA read_uncommitted") != 0
+      conn.instance_variable_get(:@raw_connection).get_first_value("PRAGMA read_uncommitted") != 0
     end
 
     def shared_cache_flags


### PR DESCRIPTION
This is unfortunately going to force a change into all external adapter subclasses, but I'm going to be making other changes too, so it's not the worst of them... and it's just so confusing at the moment to have `@connection` sometimes mean the AR adapter and sometimes the inner connection, depending on exactly which class we're in.

A follow-up change is going to move most of these to use a private method instead of direct access, but that will be easier to reason about with this name separation in place.