### PR TITLE
Remove mark_transaction_written_if_write

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -325,13 +325,6 @@ module ActiveRecord
                :commit_transaction, :rollback_transaction, :materialize_transactions,
                :disable_lazy_transactions!, :enable_lazy_transactions!, to: :transaction_manager
 
-      def mark_transaction_written_if_write(sql) # :nodoc:
-        transaction = current_transaction
-        if transaction.open?
-          transaction.written ||= write_query?(sql)
-        end
-      end
-
       def transaction_open?
         current_transaction.open?
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -84,7 +84,6 @@ module ActiveRecord
 
     class Transaction # :nodoc:
       attr_reader :connection, :state, :savepoint_name, :isolation_level
-      attr_accessor :written
 
       def initialize(connection, isolation: nil, joinable: true, run_commit_callbacks: false)
         @connection = connection
@@ -338,7 +337,7 @@ module ActiveRecord
               # @connection still holds an open or invalid transaction, so we must not
               # put it back in the pool for reuse.
               @connection.throw_away! unless transaction.state.rolledback?
-            elsif Thread.current.status == "aborting" || (!completed && transaction.written)
+            elsif Thread.current.status == "aborting" || !completed
               # The transaction is still open but the block returned earlier.
               #
               # The block could return early because of a timeout or because the thread is aborting,

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -636,7 +636,6 @@ module ActiveRecord
 
         def raw_execute(sql, name, async: false)
           materialize_transactions
-          mark_transaction_written_if_write(sql)
 
           log(sql, name, async: async) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -168,7 +168,6 @@ module ActiveRecord
             check_if_write_query(sql)
 
             materialize_transactions
-            mark_transaction_written_if_write(sql)
 
             # make sure we carry over any changes to ActiveRecord.default_timezone that have been
             # made since we established the connection

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -12,7 +12,6 @@ module ActiveRecord
         # Queries the database and returns the results in an Array-like object
         def query(sql, name = nil) # :nodoc:
           materialize_transactions
-          mark_transaction_written_if_write(sql)
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
@@ -41,7 +40,6 @@ module ActiveRecord
           check_if_write_query(sql)
 
           materialize_transactions
-          mark_transaction_written_if_write(sql)
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -757,7 +757,6 @@ module ActiveRecord
 
         def exec_no_cache(sql, name, binds, async: false)
           materialize_transactions
-          mark_transaction_written_if_write(sql)
 
           # make sure we carry over any changes to ActiveRecord.default_timezone that have been
           # made since we established the connection
@@ -773,7 +772,6 @@ module ActiveRecord
 
         def exec_cache(sql, name, binds, async: false)
           materialize_transactions
-          mark_transaction_written_if_write(sql)
           update_typemap_for_default_timezone
 
           stmt_key = prepare_statement(sql, binds)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -25,7 +25,6 @@ module ActiveRecord
           check_if_write_query(sql)
 
           materialize_transactions
-          mark_transaction_written_if_write(sql)
 
           log(sql, name) do
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
@@ -39,7 +38,6 @@ module ActiveRecord
           check_if_write_query(sql)
 
           materialize_transactions
-          mark_transaction_written_if_write(sql)
 
           type_casted_binds = type_casted_binds(binds)
 
@@ -123,7 +121,6 @@ module ActiveRecord
             check_if_write_query(sql)
 
             materialize_transactions
-            mark_transaction_written_if_write(sql)
 
             log(sql, name) do
               ActiveSupport::Dependencies.interlock.permit_concurrent_loads do


### PR DESCRIPTION
This was only needed for the deprecation cycle for aborted/incomplete transactions committing -> rolling back (#39453).