### PR TITLE
Bumps rubocop version to 1.25.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "terser", ">= 1.1.4", require: false
 gem "json", ">= 2.0.0"
 
 group :rubocop do
-  gem "rubocop", ">= 0.90", require: false
+  gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false
   gem "rubocop-packaging", require: false
   gem "rubocop-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
       racc (~> 1.4)
     os (1.1.4)
     parallel (1.21.0)
-    parser (3.1.0.0)
+    parser (3.1.1.0)
       ast (~> 2.4.1)
     path_expander (1.1.0)
     pg (1.3.0)
@@ -412,7 +412,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -423,7 +423,7 @@ GEM
     redis (4.5.1)
     redis-namespace (1.8.1)
       redis (>= 3.0.4)
-    regexp_parser (2.2.0)
+    regexp_parser (2.2.1)
     reline (0.3.1)
       io-console (~> 0.5)
     representable (3.1.1)
@@ -444,17 +444,17 @@ GEM
     retriable (3.1.2)
     rexml (3.2.5)
     rouge (3.27.0)
-    rubocop (1.24.1)
+    rubocop (1.25.1)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
       rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
+    rubocop-ast (1.16.0)
+      parser (>= 3.1.1.0)
     rubocop-minitest (0.17.0)
       rubocop (>= 0.90, < 2.0)
     rubocop-packaging (0.5.1)
@@ -627,7 +627,7 @@ DEPENDENCIES
   resque-scheduler
   rexml
   rouge
-  rubocop (>= 0.90)
+  rubocop (>= 1.25.1)
   rubocop-minitest
   rubocop-packaging
   rubocop-performance


### PR DESCRIPTION
### Summary

Bumped `rubocop` version to 1.25.1 as it fixes various false positive bugs as mentioned in their release notes for versions [1.25.0](https://github.com/rubocop/rubocop/blob/master/relnotes/v1.25.0.md) and [1.25.1](https://github.com/rubocop/rubocop/blob/master/relnotes/v1.25.1.md)

Thanks!

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->