### PR TITLE
Respect auto increment setting in abstract mysql adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -722,7 +722,9 @@ module ActiveRecord
             options[:comment] = column.comment
           end
 
-          options[:auto_increment] = column.auto_increment?
+          unless options.key?(:auto_increment)
+            options[:auto_increment] = column.auto_increment?
+          end
 
           td = create_table_definition(table_name)
           cd = td.new_column_definition(column.name, type, **options)

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1347,6 +1347,21 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_equal "This is a comment", column(:birthdate).comment
     end
 
+    if current_adapter?(:Mysql2Adapter)
+      def test_updating_auto_increment
+        with_bulk_change_table do |t|
+          t.change :id, :bigint, auto_increment: true
+        end
+
+        assert column(:id).auto_increment?
+
+        with_bulk_change_table do |t|
+          t.change :id, :bigint, auto_increment: false
+        end
+        assert_not column(:id).auto_increment?
+      end
+    end
+
     def test_changing_index
       with_bulk_change_table do |t|
         t.string :username


### PR DESCRIPTION
Following a recent change to active_mysql_adapter, updating `auto_increment: false` in a migration resulted in `auto_increment: true` annotations. This PR updates abstract mysql adapter to respect the setting.