### PR TITLE
Allow skip_forgery_protection if no protection set

### DIFF
--- a/actionmailbox/app/controllers/action_mailbox/base_controller.rb
+++ b/actionmailbox/app/controllers/action_mailbox/base_controller.rb
@@ -3,7 +3,7 @@
 module ActionMailbox
   # The base class for all Action Mailbox ingress controllers.
   class BaseController < ActionController::Base
-    skip_forgery_protection if default_protect_from_forgery
+    skip_forgery_protection
 
     before_action :ensure_configured
 

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Fix `skip_forgery_protection` to run without raising an error if forgery
+    protection has not been enabled / `verify_authenticity_token` is not a
+    defined callback.
+
+    This fix prevents the Rails 7.0 Welcome Page (`/`) from raising an
+    `ArgumentError` if `default_protect_from_forgery` is false.
+
+    *Brad Trick*
+
 *   Make `redirect_to` return an empty response body.
 
     Application controllers that wish to add a response body after calling

--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -155,7 +155,7 @@ module ActionController # :nodoc:
       #
       # See +skip_before_action+ for allowed options.
       def skip_forgery_protection(options = {})
-        skip_before_action :verify_authenticity_token, options
+        skip_before_action :verify_authenticity_token, options.reverse_merge(raise: false)
       end
 
       private

--- a/actionpack/test/controller/request_forgery_protection_test.rb
+++ b/actionpack/test/controller/request_forgery_protection_test.rb
@@ -190,6 +190,11 @@ class SkipProtectionController < ActionController::Base
   attr_accessor :skip_requested
 end
 
+class SkipProtectionWhenUnprotectedController < ActionController::Base
+  include RequestForgeryProtectionActions
+  skip_forgery_protection
+end
+
 # common test methods
 module RequestForgeryProtectionTests
   def setup
@@ -1114,6 +1119,17 @@ class SkipProtectionControllerTest < ActionController::TestCase
 
   def assert_blocked(&block)
     assert_raises(ActionController::InvalidAuthenticityToken, &block)
+  end
+
+  def assert_not_blocked(&block)
+    assert_nothing_raised(&block)
+    assert_response :success
+  end
+end
+
+class SkipProtectionWhenUnprotectedControllerTest < ActionController::TestCase
+  def test_should_allow_skip_request_when_protection_is_not_set
+    assert_not_blocked { post :index }
   end
 
   def assert_not_blocked(&block)

--- a/railties/test/application/routing_test.rb
+++ b/railties/test/application/routing_test.rb
@@ -747,5 +747,17 @@ module ApplicationTests
       get "/"
       assert_equal 200, last_response.status
     end
+
+    test "request to rails/welcome is successful when default_protect_from_forgery is false" do
+      add_to_config <<-RUBY
+        config.action_dispatch.show_exceptions = false
+        config.action_controller.default_protect_from_forgery = false
+      RUBY
+
+      app "development"
+
+      get "/"
+      assert_equal 200, last_response.status
+    end
   end
 end


### PR DESCRIPTION
### Summary

Fix `skip_forgery_protection` to run without raising an error if forgery
protection has not been enabled / `verify_authenticity_token` is not a
defined callback.

This fix prevents the Rails 7.0 Welcome Page (`/`) from raising an
`ArgumentError` if `default_protect_from_forgery` is false.

-----

Calling `skip_forgery_protection` without first calling
`protect_from_forgery`--either manually or through default
settings--raises an `ArgumentError` because `verify_authenticity_token`
has not been defined as a callback.

Since Rails 7.0 adds `skip_forgery_protection` to the
`Rails::WelcomeController` (PR #42864), this behavior means that setting
`default_protect_from_forgery` to false and visiting the Rails Welcome
page (`/`) raises an error.

This behavior also created an issue for `ActionMailbox` that was
previously fixed in the Mailbox controller by running
`skip_forgery_protection` only if `default_protect_from_forgery` was
true (PR #35935).

This PR addresses the underlying issue by setting the `raise` option for
`skip_before_action` to default to false inside
`skip_forgery_protection`.

### Other Information

The fix is implemented in `request_forgery_protection.rb`. The change to
`ActionMailbox`'s `base_controller.rb` then removes the now-unnecessary
check of `default_protect_from_forgery` that was added to address this
issue.

The tests added in `request_forgery_protection_test.rb` and
`routing_test.rb` both raise an error when run against the current
codebase and pass with changes noted above.