### PR TITLE
Fix test case in activerecord: assert -> assert_equal

### DIFF
--- a/activerecord/test/cases/scoping/named_scoping_test.rb
+++ b/activerecord/test/cases/scoping/named_scoping_test.rb
@@ -623,7 +623,7 @@ class NamedScopingTest < ActiveRecord::TestCase
     end
 
     assert_sql(%r{/\* from-scope \*/}) do
-      assert Topic.including_annotate_in_scope.to_a, Topic.all.to_a
+      assert_equal Topic.including_annotate_in_scope.to_a, Topic.all.to_a
     end
   end
 end


### PR DESCRIPTION
### Summary

One of the test case in ActiveRecord should use `assert_equal` instead of `assert`

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->