### PR TITLE
Add missing ruby2_keywords in RoutingAssertions

### DIFF
--- a/actionpack/lib/action_dispatch/testing/assertions/routing.rb
+++ b/actionpack/lib/action_dispatch/testing/assertions/routing.rb
@@ -187,6 +187,7 @@ module ActionDispatch
           super
         end
       end
+      ruby2_keywords(:method_missing)
 
       private
         # Recognizes the route for a given path.


### PR DESCRIPTION
It likely wasn't noticed until now because Rails itself doesn't have any method missing based test helpers using keyword args.

But I tried to introduce one into our app, and this turned out to block me.