### PR TITLE
Add `ActiveModel::Access`

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -30,6 +30,7 @@ require "active_model/version"
 module ActiveModel
   extend ActiveSupport::Autoload
 
+  autoload :Access
   autoload :API
   autoload :Attribute
   autoload :Attributes

--- a/activemodel/lib/active_model/access.rb
+++ b/activemodel/lib/active_model/access.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/enumerable"
+require "active_support/core_ext/hash/indifferent_access"
+
+module ActiveModel
+  module Access # :nodoc:
+    def slice(*methods)
+      methods.flatten.index_with { |method| public_send(method) }.with_indifferent_access
+    end
+
+    def values_at(*methods)
+      methods.flatten.map! { |method| public_send(method) }
+    end
+  end
+end

--- a/activemodel/lib/active_model/model.rb
+++ b/activemodel/lib/active_model/model.rb
@@ -42,5 +42,27 @@ module ActiveModel
   module Model
     extend ActiveSupport::Concern
     include ActiveModel::API
+    include ActiveModel::Access
+
+    ##
+    # :method: slice
+    #
+    # :call-seq: slice(*methods)
+    #
+    # Returns a hash of the given methods with their names as keys and returned
+    # values as values.
+    #
+    #--
+    # Implemented by ActiveModel::Access#slice.
+
+    ##
+    # :method: values_at
+    #
+    # :call-seq: values_at(*methods)
+    #
+    # Returns an array of the values returned by the given methods.
+    #
+    #--
+    # Implemented by ActiveModel::Access#values_at.
   end
 end

--- a/activemodel/test/cases/access_test.rb
+++ b/activemodel/test/cases/access_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "active_support/core_ext/hash/indifferent_access"
+
+class AccessTest < ActiveModel::TestCase
+  class Point
+    include ActiveModel::Access
+
+    def initialize(*vector)
+      @vector = vector
+    end
+
+    def x
+      @vector[0]
+    end
+
+    def y
+      @vector[1]
+    end
+
+    def z
+      @vector[2]
+    end
+  end
+
+  setup do
+    @point = Point.new(123, 456, 789)
+  end
+
+  test "slice" do
+    expected = { z: @point.z, x: @point.x }.with_indifferent_access
+    actual = @point.slice(:z, :x)
+
+    assert_equal expected.keys, actual.keys
+
+    expected.each do |key, value|
+      assert_equal value, actual[key.to_s]
+      assert_equal value, actual[key.to_sym]
+    end
+  end
+
+  test "slice with array" do
+    expected = { z: @point.z, x: @point.x }.with_indifferent_access
+    assert_equal expected, @point.slice([:z, :x])
+  end
+
+  test "values_at" do
+    assert_equal [@point.x, @point.z], @point.values_at(:x, :z)
+    assert_equal [@point.z, @point.x], @point.values_at(:z, :x)
+  end
+
+  test "values_at with array" do
+    assert_equal [@point.x, @point.z], @point.values_at([:x, :z])
+    assert_equal [@point.z, @point.x], @point.values_at([:z, :x])
+  end
+end

--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/enumerable"
-require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/string/filters"
 require "active_support/parameter_filter"
 require "concurrent/map"
@@ -9,6 +8,7 @@ require "concurrent/map"
 module ActiveRecord
   module Core
     extend ActiveSupport::Concern
+    include ActiveModel::Access
 
     included do
       ##
@@ -722,15 +722,26 @@ module ActiveRecord
       end
     end
 
-    # Returns a hash of the given methods with their names as keys and returned values as values.
-    def slice(*methods)
-      methods.flatten.index_with { |method| public_send(method) }.with_indifferent_access
-    end
+    ##
+    # :method: slice
+    #
+    # :call-seq: slice(*methods)
+    #
+    # Returns a hash of the given methods with their names as keys and returned
+    # values as values.
+    #
+    #--
+    # Implemented by ActiveModel::Access#slice.
 
+    ##
+    # :method: values_at
+    #
+    # :call-seq: values_at(*methods)
+    #
     # Returns an array of the values returned by the given methods.
-    def values_at(*methods)
-      methods.flatten.map! { |method| public_send(method) }
-    end
+    #
+    #--
+    # Implemented by ActiveModel::Access#values_at.
 
     private
       # +Array#flatten+ will call +#to_ary+ (recursively) on each of the elements of

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -1479,43 +1479,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 10, Topic.select("10 as tenderlove").first.tenderlove
   end
 
-  def test_slice
-    company = Company.new(rating: 1, name: "37signals", firm_name: "37signals")
-    hash = company.slice(:name, :rating, "arbitrary_method")
-    assert_equal hash[:name], company.name
-    assert_equal hash["name"], company.name
-    assert_equal hash[:rating], company.rating
-    assert_equal hash["arbitrary_method"], company.arbitrary_method
-    assert_equal hash[:arbitrary_method], company.arbitrary_method
-    assert_nil hash[:firm_name]
-    assert_nil hash["firm_name"]
-  end
-
-  def test_slice_accepts_array_argument
-    attrs = {
-      title: "slice",
-      author_name: "@Cohen-Carlisle",
-      content: "accept arrays so I don't have to splat"
-    }.with_indifferent_access
-    topic = Topic.new(attrs)
-    assert_equal attrs, topic.slice(attrs.keys)
-  end
-
-  def test_values_at
-    company = Company.new(name: "37signals", rating: 1)
-
-    assert_equal [ "37signals", 1, "I am Jack's profound disappointment" ],
-      company.values_at(:name, :rating, :arbitrary_method)
-    assert_equal [ "I am Jack's profound disappointment", 1, "37signals" ],
-      company.values_at(:arbitrary_method, :rating, :name)
-  end
-
-  def test_values_at_accepts_array_argument
-    topic = Topic.new(title: "Budget", author_name: "Jason")
-
-    assert_equal %w( Budget Jason ), topic.values_at(%w( title author_name ))
-  end
-
   def test_default_values_are_deeply_dupped
     company = Company.new
     company.description << "foo"


### PR DESCRIPTION
This ports `ActiveRecord::Base#slice` and `#values_at` to a new `ActiveModel::Access` module, which is included in `ActiveModel::Model` by default.

---

I am open to a different name.  `Access` was inspired by [`active_support/core_ext/array/access.rb`](https://github.com/rails/rails/blob/d04dbcfcbd4b8ef0a7d4c607949c5d9c7860346f/activesupport/lib/active_support/core_ext/array/access.rb).
