### PR TITLE
Removed `core_ext/uri.rb` since starting Rails 7.1 uri.rb is supposed to removed

### DIFF
--- a/activesupport/lib/active_support/core_ext.rb
+++ b/activesupport/lib/active_support/core_ext.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 Dir.glob(File.expand_path("core_ext/*.rb", __dir__)).sort.each do |path|
-  next if path.end_with?("core_ext/uri.rb")
   require path
 end

--- a/activesupport/lib/active_support/core_ext/uri.rb
+++ b/activesupport/lib/active_support/core_ext/uri.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-ActiveSupport::Deprecation.warn(<<-MSG.squish)
-  `active_support/core_ext/uri` is deprecated and will be removed in Rails 7.1.
-MSG


### PR DESCRIPTION
### Summary

Removed `activesupport/core_ext/uri.rb` file since it is not needed in Rails 7.1 onwards

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->