### PR TITLE
Implement ErrorReporter#disable

### DIFF
--- a/activesupport/test/error_reporter_test.rb
+++ b/activesupport/test/error_reporter_test.rb
@@ -41,6 +41,20 @@ class ErrorReporterTest < ActiveSupport::TestCase
     assert_equal [[error, true, :warning, { section: "public" }]], @subscriber.events
   end
 
+  test "#disable allow to skip a subscriber" do
+    @reporter.disable(@subscriber) do
+      @reporter.report(ArgumentError.new("Oops"), handled: true)
+    end
+    assert_equal [], @subscriber.events
+  end
+
+  test "#disable allow to skip a subscribers per class" do
+    @reporter.disable(ErrorSubscriber) do
+      @reporter.report(ArgumentError.new("Oops"), handled: true)
+    end
+    assert_equal [], @subscriber.events
+  end
+
   test "#handle swallow and report any unhandled error" do
     error = ArgumentError.new("Oops")
     @reporter.handle do


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/43625#discussion_r809532572

It can be used by error reporting service integration when they wish to handle the error higher in the stack.

For instance Sidekiq has its own error handling interface with a little bit of extra context information.

cc @st0012, does this work for you?