### PR TITLE
Remove Rack::Sendfile from the default middleware stack

### DIFF
--- a/actionmailbox/test/dummy/config/environments/production.rb
+++ b/actionmailbox/test/dummy/config/environments/production.rb
@@ -32,10 +32,6 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
-  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
-
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/actionpack/lib/action_controller/metal/data_streaming.rb
+++ b/actionpack/lib/action_controller/metal/data_streaming.rb
@@ -19,14 +19,8 @@ module ActionController # :nodoc:
     DEFAULT_SEND_FILE_DISPOSITION = "attachment" # :nodoc:
 
     private
-      # Sends the file. This uses a server-appropriate method (such as `X-Sendfile`)
-      # via the `Rack::Sendfile` middleware. The header to use is set via
-      # `config.action_dispatch.x_sendfile_header`. Your server can also configure
-      # this for you by setting the `X-Sendfile-Type` header.
-      #
-      # Be careful to sanitize the path parameter if it is coming from a web page.
-      # `send_file(params[:path])` allows a malicious user to download any file on
-      # your server.
+      # Sends the file. Be careful to sanitize the path parameter if it is coming from a web page.
+      # `send_file(params[:path])` allows a malicious user to download any file on your server.
       #
       # #### Options:
       #

--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -396,9 +396,7 @@ module ActionDispatch # :nodoc:
       end
     end
 
-    # Avoid having to pass an open file handle as the response body. Rack::Sendfile
-    # will usually intercept the response and uses the path directly, so there is no
-    # reason to open the file.
+    # Avoid having to pass an open file handle as the response body.
     class FileBody # :nodoc:
       attr_reader :to_path
 
@@ -410,7 +408,7 @@ module ActionDispatch # :nodoc:
         File.binread(to_path)
       end
 
-      # Stream the file's contents if Rack::Sendfile isn't present.
+      # Stream the file's contents.
       def each
         File.open(to_path, "rb") do |file|
           while chunk = file.read(16384)

--- a/actionpack/lib/action_dispatch/middleware/debug_locks.rb
+++ b/actionpack/lib/action_dispatch/middleware/debug_locks.rb
@@ -10,7 +10,7 @@ module ActionDispatch
   # To use it, insert it near the top of the middleware stack, using
   # `config/application.rb`:
   #
-  #     config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
+  #     config.middleware.insert_before ActionDispatch::Static, ActionDispatch::DebugLocks
   #
   # After restarting the application and re-triggering the deadlock condition, the
   # route `/rails/locks` will show a summary of all threads currently known to the

--- a/actionpack/lib/action_dispatch/railtie.rb
+++ b/actionpack/lib/action_dispatch/railtie.rb
@@ -11,7 +11,12 @@ require "rails/railtie"
 module ActionDispatch
   class Railtie < Rails::Railtie # :nodoc:
     config.action_dispatch = ActiveSupport::OrderedOptions.new
-    config.action_dispatch.x_sendfile_header = nil
+    config.action_dispatch.singleton_class.define_method(:x_sendfile_header=) do |val|
+      ActionDispatch.deprecator.warn(<<-MSG.squish)
+        `config.action_dispatch.x_sendfile_header` is deprecated
+        since Rack::Sendfile was removed from the default middleware stack in Rails.
+      MSG
+    end
     config.action_dispatch.ip_spoofing_check = true
     config.action_dispatch.show_exceptions = :all
     config.action_dispatch.tld_length = 1

--- a/actionpack/test/dispatch/middleware_stack_test.rb
+++ b/actionpack/test/dispatch/middleware_stack_test.rb
@@ -214,4 +214,74 @@ class MiddlewareStackTest < ActiveSupport::TestCase
   test "includes a middleware" do
     assert_equal true, @stack.include?(ActionDispatch::MiddlewareStack::Middleware.new(BarMiddleware, nil, nil))
   end
+
+  test "referencing Rack::Sendfile via #insert_before is deprecated but still valid" do
+    @stack.use ActionDispatch::MiddlewareStack::FakeSendfile
+
+    msg = /Rack::Sendfile is removed from the default middleware stack in Rails/
+    assert_deprecated(msg, ActionController.deprecator) do
+      @stack.insert_before(Rack::Sendfile, BazMiddleware)
+    end
+    assert_equal BazMiddleware, @stack[2].klass
+  end
+
+  test "referencing Rack::Sendfile via #insert_after is deprecated but still valid" do
+    @stack.use ActionDispatch::MiddlewareStack::FakeSendfile
+
+    msg = /Rack::Sendfile is removed from the default middleware stack in Rails/
+    assert_deprecated(msg, ActionController.deprecator) do
+      @stack.insert_after(Rack::Sendfile, BazMiddleware)
+    end
+    assert_equal BazMiddleware, @stack[3].klass
+  end
+
+  test "referencing Rack::Sendfile via #swap is deprecated but still valid" do
+    @stack.use ActionDispatch::MiddlewareStack::FakeSendfile
+
+    assert_equal ActionDispatch::MiddlewareStack::FakeSendfile, @stack[2].klass
+    msg = /Rack::Sendfile is removed from the default middleware stack in Rails/
+    assert_deprecated(msg, ActionController.deprecator) do
+      @stack.swap(Rack::Sendfile, BazMiddleware)
+    end
+    assert_equal BazMiddleware, @stack[2].klass
+  end
+
+  test "referencing Rack::Sendfile via #move_before is deprecated but still valid" do
+    @stack.use ActionDispatch::MiddlewareStack::FakeSendfile
+
+    msg = /Rack::Sendfile is removed from the default middleware stack in Rails/
+    assert_deprecated(msg, ActionController.deprecator) do
+      @stack.move_before(Rack::Sendfile, FooMiddleware)
+    end
+    assert_equal BarMiddleware, @stack[0].klass
+    assert_equal FooMiddleware, @stack[1].klass
+    assert_equal ActionDispatch::MiddlewareStack::FakeSendfile, @stack[2].klass
+  end
+
+  test "referencing Rack::Sendfile via #move_after is deprecated but still valid" do
+    @stack.insert_after(FooMiddleware, ActionDispatch::MiddlewareStack::FakeSendfile)
+
+    msg = /Rack::Sendfile is removed from the default middleware stack in Rails/
+    assert_deprecated(msg, ActionController.deprecator) do
+      @stack.move_after(Rack::Sendfile, FooMiddleware)
+    end
+    assert_equal ActionDispatch::MiddlewareStack::FakeSendfile, @stack[0].klass
+    assert_equal FooMiddleware, @stack[1].klass
+    assert_equal BarMiddleware, @stack[2].klass
+  end
+
+  test "referencing Rack::Sendfile is not deprecated when added explicitly" do
+    assert_not_deprecated(ActionController.deprecator) do
+      @stack.use Rack::Sendfile
+      @stack.insert_before(Rack::Sendfile, BazMiddleware)
+    end
+  end
+
+  test "referencing FakeSendfile throws an error" do
+    @stack.use ActionDispatch::MiddlewareStack::FakeSendfile
+
+    assert_raises RuntimeError do
+      @stack.insert_after ActionDispatch::MiddlewareStack::FakeSendfile, BazMiddleware
+    end
+  end
 end

--- a/actiontext/test/dummy/config/environments/production.rb
+++ b/actiontext/test/dummy/config/environments/production.rb
@@ -32,10 +32,6 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
-  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
-
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/activestorage/test/dummy/config/environments/production.rb
+++ b/activestorage/test/dummy/config/environments/production.rb
@@ -32,10 +32,6 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
-  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
-
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/guides/source/api_app.md
+++ b/guides/source/api_app.md
@@ -293,7 +293,6 @@ Choosing Middleware
 An API application comes with the following middleware by default:
 
 - `ActionDispatch::HostAuthorization`
-- `Rack::Sendfile`
 - `ActionDispatch::Static`
 - `ActionDispatch::Executor`
 - `ActionDispatch::ServerTiming`
@@ -371,40 +370,6 @@ subsequent inbound requests for the same URL.
 
 Think of it as page caching using HTTP semantics.
 
-### Using Rack::Sendfile
-
-When you use the `send_file` method inside a Rails controller, it sets the
-`X-Sendfile` header. `Rack::Sendfile` is responsible for actually sending the
-file.
-
-If your front-end server supports accelerated file sending, `Rack::Sendfile`
-will offload the actual file sending work to the front-end server.
-This enables Rails to finish request handling and free resources earlier.
-
-You can configure the name of the header that your front-end server uses for
-this purpose using [`config.action_dispatch.x_sendfile_header`][] in the appropriate
-environment's configuration file.
-
-You can learn more about how to use `Rack::Sendfile` with popular
-front-ends in [the Rack::Sendfile
-documentation](https://rack.github.io/rack/main/Rack/Sendfile.html).
-
-Here are some values for this header for some popular servers, once these servers are configured to support
-accelerated file sending:
-
-```ruby
-# Apache and lighttpd
-config.action_dispatch.x_sendfile_header = "X-Sendfile"
-
-# Nginx
-config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
-```
-
-Make sure to configure your server to support these options following the
-instructions in the `Rack::Sendfile` documentation.
-
-[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-dispatch-x-sendfile-header
-
 ### Using ActionDispatch::Request
 
 `ActionDispatch::Request#params` will take parameters from the client in the JSON
@@ -477,10 +442,10 @@ If you don't want to use a middleware that is included by default in the API-onl
 middleware set, you can remove it with:
 
 ```ruby
-config.middleware.delete ::Rack::Sendfile
+config.middleware.delete ::Rack::Runtime
 ```
 
-Keep in mind that removing these middlewares will remove support for certain
+Keep in mind that removing some of these middlewares will remove support for certain
 features in Action Controller.
 
 Choosing Controller Modules

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -836,10 +836,6 @@ Makes a unique X-Request-Id header available to the response and enables the `Ac
 
 Checks for IP spoofing attacks and gets valid `client_ip` from request headers. Configurable with the `config.action_dispatch.ip_spoofing_check`, and `config.action_dispatch.trusted_proxies` options.
 
-#### `Rack::Sendfile`
-
-Intercepts responses whose body is being served from a file and replaces it with a server specific X-Sendfile header. Configurable with `config.action_dispatch.x_sendfile_header`.
-
 #### `ActionDispatch::Callbacks`
 
 Runs the prepare callbacks before serving the request.
@@ -2256,10 +2252,6 @@ config.action_dispatch.domain_extractor = CustomDomainExtractor
 #### `config.action_dispatch.ignore_accept_header`
 
 Is used to determine whether to ignore accept headers from a request. Defaults to `false`.
-
-#### `config.action_dispatch.x_sendfile_header`
-
-Specifies server specific X-Sendfile header. This is useful for accelerated file sending from server. For example it can be set to 'X-Sendfile' for Apache.
 
 #### `config.action_dispatch.http_auth_salt`
 

--- a/guides/source/rails_on_rack.md
+++ b/guides/source/rails_on_rack.md
@@ -82,7 +82,6 @@ For a freshly generated Rails application, this might produce something like:
 
 ```ruby
 use ActionDispatch::HostAuthorization
-use Rack::Sendfile
 use ActionDispatch::Static
 use ActionDispatch::Executor
 use ActionDispatch::ServerTiming
@@ -220,12 +219,6 @@ Much of Action Controller's functionality is implemented as Middlewares. The fol
 **`ActionDispatch::HostAuthorization`**
 
 * Guards from DNS rebinding attacks by explicitly permitting the hosts a request can be sent to. See the [configuration guide](configuring.html#actiondispatch-hostauthorization) for configuration instructions.
-
-**`Rack::Sendfile`**
-
-* Sets server specific X-Sendfile header. Configure this via [`config.action_dispatch.x_sendfile_header`][] option.
-
-[`config.action_dispatch.x_sendfile_header`]: configuring.html#config-action-dispatch-x-sendfile-header
 
 **`ActionDispatch::Static`**
 

--- a/guides/source/threading_and_code_execution.md
+++ b/guides/source/threading_and_code_execution.md
@@ -324,7 +324,7 @@ involved, you can temporarily add the ActionDispatch::DebugLocks middleware to
 `config/application.rb`:
 
 ```ruby
-config.middleware.insert_before Rack::Sendfile,
+config.middleware.insert_before ActionDispatch::Static,
                                   ActionDispatch::DebugLocks
 ```
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Remove `Rack::Sendfile` from the default middleware stack and deprecate
+    referencing it in middleware operations.
+
+    Deprecate configuration option for specifying the header used for sending files:
+
+    ```
+    config.action_dispatch.x_sendfile_header = 'X-Sendfile'
+    ```
+
+    `Rack::Sendfile` instead can be explicitly added if needed:
+
+    ```
+    use Rack::SendFile, 'X-Sendfile'
+    ```
+
+    *Stanislav Valkanov*
+
 *   Do not clean directories directly under the application root with `Rails::BacktraceCleaner`
 
     Improved `Rails.backtrace_cleaner` so that most paths located directly under the application's root directory are no longer silenced.

--- a/railties/lib/rails/application/default_middleware_stack.rb
+++ b/railties/lib/rails/application/default_middleware_stack.rb
@@ -26,7 +26,7 @@ module Rails
               ssl_default_redirect_status: config.action_dispatch.ssl_default_redirect_status
           end
 
-          middleware.use ::Rack::Sendfile, config.action_dispatch.x_sendfile_header
+          middleware.use ::ActionDispatch::MiddlewareStack::FakeSendfile
 
           if config.public_file_server.enabled
             headers = config.public_file_server.headers || {}

--- a/railties/test/application/middleware/sendfile_test.rb
+++ b/railties/test/application/middleware/sendfile_test.rb
@@ -23,49 +23,21 @@ module ApplicationTests
       end
     end
 
-    # x_sendfile_header middleware
-    test "config.action_dispatch.x_sendfile_header defaults to nil" do
-      make_basic_app
+    test "config.action_dispatch.x_sendfile_header cannot be set" do
+      make_basic_app do |app|
+        msg = /`config.action_dispatch.x_sendfile_header` is deprecated/
+        assert_deprecated(msg, ActionDispatch.deprecator) do
+          app.config.action_dispatch.x_sendfile_header = "X-Sendfile"
+        end
+
+        assert_nil app.config.action_dispatch.x_sendfile_header
+      end
+
       simple_controller
 
       get "/"
       assert_not last_response.headers["X-Sendfile"]
       assert_equal File.read(__FILE__), last_response.body
-    end
-
-    test "config.action_dispatch.x_sendfile_header can be set" do
-      make_basic_app do |app|
-        app.config.action_dispatch.x_sendfile_header = "X-Sendfile"
-      end
-
-      simple_controller
-
-      get "/"
-      assert_equal File.expand_path(__FILE__), last_response.headers["X-Sendfile"]
-    end
-
-    test "config.action_dispatch.x_sendfile_header is sent to Rack::Sendfile" do
-      make_basic_app do |app|
-        app.config.action_dispatch.x_sendfile_header = "X-Lighttpd-Send-File"
-      end
-
-      simple_controller
-
-      get "/"
-      assert_equal File.expand_path(__FILE__), last_response.headers["X-Lighttpd-Send-File"]
-    end
-
-    test "files handled by ActionDispatch::Static are handled by Rack::Sendfile" do
-      make_basic_app do |app|
-        app.config.action_dispatch.x_sendfile_header = "X-Sendfile"
-        app.config.public_file_server.enabled = true
-        app.paths["public"] = File.join(rails_root, "public")
-      end
-
-      app_file "public/foo.txt", "foo"
-
-      get "/foo.txt", "HTTP_X_SENDFILE_TYPE" => "X-Sendfile"
-      assert_equal File.join(rails_root, "public/foo.txt"), last_response.headers["X-Sendfile"]
     end
   end
 end

--- a/railties/test/commands/middleware_test.rb
+++ b/railties/test/commands/middleware_test.rb
@@ -27,7 +27,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
 
     assert_equal [
       "ActionDispatch::HostAuthorization",
-      "Rack::Sendfile",
+      "ActionDispatch::MiddlewareStack::FakeSendfile",
       "ActionDispatch::Static",
       "Propshaft::Server",
       "ActionDispatch::Executor",
@@ -63,7 +63,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
 
     assert_equal [
       "ActionDispatch::HostAuthorization",
-      "Rack::Sendfile",
+      "ActionDispatch::MiddlewareStack::FakeSendfile",
       "ActionDispatch::Static",
       "Propshaft::Server",
       "ActionDispatch::Executor",
@@ -98,7 +98,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
 
     assert_equal [
       "ActionDispatch::HostAuthorization",
-      "Rack::Sendfile",
+      "ActionDispatch::MiddlewareStack::FakeSendfile",
       "ActionDispatch::Static",
       "Propshaft::Server",
       "ActionDispatch::Executor",
@@ -137,7 +137,7 @@ class Rails::Command::MiddlewareTest < ActiveSupport::TestCase
       %w(ActionDispatch::Reloader ActionDispatch::ShowExceptions ActionDispatch::DebugExceptions),
 
       # Outright dependencies
-      %w(ActionDispatch::Static Rack::Sendfile),
+      %w(ActionDispatch::Static ActionDispatch::MiddlewareStack::FakeSendfile),
       %w(ActionDispatch::Flash ActionDispatch::Session::CookieStore),
       %w(ActionDispatch::Session::CookieStore ActionDispatch::Cookies),
     ]


### PR DESCRIPTION
### Summary
Discussions: #41148, #42635 
Fixes #41148

*  `Rack::Sendfile` is replaced by a dummy `FakeSendfile` middleware, which cannot be used in middleware operations
*   Using `Rack::Sendfile` in middleware operations (`insert_after`, `insert_before`, etc.) throws a deprecation warning and uses `FakeSendfile` as asserting index instead
*   If an application adds `Rack::Sendfile` explicitly (`use`, etc.), then the deprecation warning is not raised and `FakeSendfile` is ignored
*   Deprecated configuration option for specifying the header used for sending files:
    ```
    config.action_dispatch.x_sendfile_header = 'X-Sendfile'
    ```
*   Docs are updated. Some examples are updated as well.
