### PR TITLE
Adds test coverage for the `#attach` method behaviour in activestorage

### DIFF
--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -746,6 +746,21 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "attaching blobs to a record returns the attachments" do
+    @user.highlights.attach create_blob(filename: "racecar.jpg")
+    highlights = @user.highlights.attach create_blob(filename: "funky.jpg"), create_blob(filename: "town.jpg")
+    assert_instance_of ActiveStorage::Attached::Many, highlights
+    assert_equal 3, @user.highlights.count
+    assert_equal 3, highlights.count
+    assert_equal highlights.name.to_s, @user.highlights.name.to_s
+    assert_equal highlights.first.key.to_s, @user.highlights.first.key.to_s
+    assert_equal highlights.first.filename.to_s, @user.highlights.first.filename.to_s
+    assert_equal highlights.second.key.to_s, @user.highlights.second.key.to_s
+    assert_equal highlights.second.filename.to_s, @user.highlights.second.filename.to_s
+    assert_equal highlights.third.key.to_s, @user.highlights.third.key.to_s
+    assert_equal highlights.third.filename.to_s, @user.highlights.third.filename.to_s
+  end
+
   test "raises error when misconfigured service is passed" do
     error = assert_raises ArgumentError do
       User.class_eval do

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -68,6 +68,14 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     end
   end
 
+  test "attaching a blob to a record returns the attachment" do
+    avatar = @user.avatar.attach create_blob(filename: "funky.jpg")
+    assert_instance_of ActiveStorage::Attached::One, avatar
+    assert_equal avatar.key, @user.avatar.key
+    assert_equal avatar.name.to_s, @user.avatar.name.to_s
+    assert_equal avatar.filename.to_s, @user.avatar.filename.to_s
+  end
+
   test "attaching an existing blob to an existing, changed record" do
     @user.name = "Tina"
     assert @user.changed?


### PR DESCRIPTION
### Summary

This PR adds test coverage for the PR https://github.com/rails/rails/pull/44439 which modified the behavior of the `#attach` method.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
