### PR TITLE
Added `ActiveSupport::Enumerable#each_decreasing_slice`

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -36,6 +36,41 @@ module Enumerable
     map(&key).max
   end
 
+
+  # Without a block returns an Enumerable of Enumerables (slices).
+  # Each slice is decreased by the decrement (defaults to 1).
+  #
+  #   (1..10).each_decreasing_slice(4).to_a
+  #    # => [[1, 2, 3, 4], [5, 6, 7], [8, 9], [10]]
+  #   (1..10).each_decreasing_slice(4, 2)
+  #   # => [[1, 2, 3, 4], [5, 6], [7], [8], [9], [10]]
+  #
+  # With a block executes the block and returns an enumerable of Enumerables.
+  #   result = []
+  #   elements.each_decreasing_slice(4, 2) { |slice| result << slice.sum }
+  #   # => [[1, 2, 3, 4], [5, 6], [7], [8], [9], [10]]
+  #   p result
+  #   # => [10, 11, 7, 8, 9, 10]
+  def each_decreasing_slice(initial_slice_size, decrement = 1, &block)
+    next_slice_size = initial_slice_size
+    index = 0
+    slices = slice_after do |el|
+      if (index += 1) == next_slice_size
+        initial_slice_size = initial_slice_size > decrement ? initial_slice_size - decrement : 1
+        next_slice_size += initial_slice_size
+        true
+      end
+    end
+
+
+
+    if block_given?
+      slices.to_a.each(&block)
+    else
+      slices
+    end
+  end
+
   # Calculates a sum from the elements.
   #
   #  payments.sum { |p| p.price * p.tax_rate }

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -49,6 +49,30 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_nil payments.maximum(:price)
   end
 
+  def test_each_decreasing_slice
+    elements = GenericEnumerable.new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    assert_equal [[1, 2, 3, 4], [5, 6, 7], [8, 9], [10]], elements.each_decreasing_slice(4).to_a
+  end
+
+  def test_each_decreasing_slice_with_decrement
+    elements = GenericEnumerable.new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    assert_equal [[1, 2, 3, 4], [5, 6], [7], [8], [9], [10]], elements.each_decreasing_slice(4, 2).to_a
+  end
+
+  def test_each_decreasing_slice_with_block
+    elements = GenericEnumerable.new([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    eachstuff = elements.each { |el| el +1 }
+
+    result = []
+    elements.each_decreasing_slice(4, 2) do |slice|
+      result << slice.sum
+    end
+
+
+    assert_equal [10, 11, 7, 8, 9, 10], result
+  end
+
+
   def test_sums
     enum = GenericEnumerable.new([5, 15, 10])
     assert_equal 30, enum.sum


### PR DESCRIPTION
### Changelog entry
*   Add `ActiveSupport::Enumerable#each_decreasing_slice`
    This method will return an enumerable of decreasing enumerable sizes

    It can also be called with a block to execute the code on each Enumerable slice and return an Enumerable of Enumerables

    *Pablo Curell*

### Summary

Added functionality to the Enumerable module that permits the iteration in
decreasing slices. Similar to `Enumerable#each_slice`
with decreasing slice size.

    (1..10).each_decreasing_slice(4).to_a
    # => [[1, 2, 3, 4], [5, 6, 7], [8, 9], [10]]

    (1..10).each_decreasing_slice(4, 2)
    # => [[1, 2, 3, 4], [5, 6], [7], [8], [9], [10]]

    result = []

    (1..10).each_decreasing_slice(4, 2) { |slice| result << slice.sum }
    # => [[1, 2, 3, 4], [5, 6], [7], [8], [9], [10]]

    p result
    # => [10, 11, 7, 8, 9, 10]

