### PR TITLE
Re-raise unexpected errors in MemCacheStore tests

### DIFF
--- a/activesupport/test/cache/behaviors/failure_raising_behavior.rb
+++ b/activesupport/test/cache/behaviors/failure_raising_behavior.rb
@@ -5,7 +5,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.fetch(key)
       end
@@ -17,7 +17,7 @@ module FailureRaisingBehavior
     value = SecureRandom.alphanumeric
     @cache.write(key, value)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.fetch(key) { SecureRandom.alphanumeric }
       end
@@ -30,7 +30,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.read(key)
       end
@@ -45,7 +45,7 @@ module FailureRaisingBehavior
       other_key => SecureRandom.alphanumeric
     )
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.read_multi(key, other_key)
       end
@@ -53,7 +53,7 @@ module FailureRaisingBehavior
   end
 
   def test_write_failure_raises
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.write(SecureRandom.uuid, SecureRandom.alphanumeric)
       end
@@ -61,7 +61,7 @@ module FailureRaisingBehavior
   end
 
   def test_write_multi_failure_raises
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.write_multi(
           SecureRandom.uuid => SecureRandom.alphanumeric,
@@ -79,7 +79,7 @@ module FailureRaisingBehavior
       other_key => SecureRandom.alphanumeric
     )
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.fetch_multi(key, other_key) { |k| "unavailable" }
       end
@@ -90,7 +90,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.delete(key)
       end
@@ -101,7 +101,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, SecureRandom.alphanumeric)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.exist?(key)
       end
@@ -112,7 +112,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, 1, raw: true)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.increment(key)
       end
@@ -123,7 +123,7 @@ module FailureRaisingBehavior
     key = SecureRandom.uuid
     @cache.write(key, 1, raw: true)
 
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.decrement(key)
       end
@@ -131,7 +131,7 @@ module FailureRaisingBehavior
   end
 
   def test_clear_failure_returns_nil
-    assert_raise Redis::BaseError do
+    assert_raise expected_exception do
       emulating_unavailability do |cache|
         cache.clear
       end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -46,7 +46,13 @@ module MemCacheStoreTest
 
   class StoreTest < ActiveSupport::TestCase
     def lookup_store(options = {})
-      cache = ActiveSupport::Cache.lookup_store(*store, { namespace: @namespace }.merge(options))
+      cache = ActiveSupport::Cache.lookup_store(
+        *store,
+        {
+          namespace: @namespace,
+          error_handler: -> (method:, returning:, exception:) { raise exception },
+        }.merge(options)
+      )
       (@_stores ||= []) << cache
       cache
     end

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -307,6 +307,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include FailureRaisingBehavior
 
     private
+      def expected_exception
+        Redis::BaseError
+      end
+
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, UnavailableRedisClient)
@@ -323,6 +327,10 @@ module ActiveSupport::Cache::RedisCacheStoreTests
     include FailureRaisingBehavior
 
     private
+      def expected_exception
+        Redis::BaseError
+      end
+
       def emulating_unavailability
         old_client = Redis.send(:remove_const, :Client)
         Redis.const_set(:Client, MaxClientsReachedRedisClient)


### PR DESCRIPTION
We've been seeing a lot of MemCacheStore test failures lately in CI.

This isn't going to change that, but at least will mean that whatever intermittent memcached issues we're experiencing get reported as the actual exception, rather than being silently swallowed into nil (which is of course the correct default "broken cache shouldn't break the app" behaviour).