### PR TITLE
Make ActionView::Helpers::Tags::CheckBox convert object's array values to strings so it works the same way as ActionView::Helpers::Tags::CollectionSelect.

### DIFF
--- a/actionview/CHANGELOG.md
+++ b/actionview/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make `ActionView::Helpers::Tags::CheckBox` convert object's array values to strings so it works the same way as `ActionView::Helpers::Tags::CollectionSelect`
+
+    *Vasiliy Ermolovich*
+
 *   Ensure models passed to `form_for` attempt to call `to_model`.
 
     *Sean Doyle*

--- a/actionview/lib/action_view/helpers/tags/check_box.rb
+++ b/actionview/lib/action_view/helpers/tags/check_box.rb
@@ -49,7 +49,7 @@ module ActionView
               value == @checked_value
             else
               if value.respond_to?(:include?)
-                value.include?(@checked_value)
+                value.map(&:to_s).include?(@checked_value.to_s)
               else
                 value.to_i == @checked_value.to_i
               end

--- a/actionview/test/template/form_helper_test.rb
+++ b/actionview/test/template/form_helper_test.rb
@@ -696,6 +696,12 @@ class FormHelperTest < ActionView::TestCase
       check_box("post", "secret")
     )
 
+    @post.secret = [1]
+    assert_dom_equal(
+      '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',
+      check_box("post", "secret")
+    )
+
     @post.secret = Set.new(["1"])
     assert_dom_equal(
       '<input name="post[secret]" type="hidden" value="0" autocomplete="off" /><input checked="checked" id="post_secret" name="post[secret]" type="checkbox" value="1" />',


### PR DESCRIPTION
### Summary

So something like this

```ruby
@user.date = [Date.parse('2018-01-01')]

<%= form_with model: @user do |f| %>
  <%= f.check_box :date, {}, checked: '2018-01-01' %>
<% end %>
```
works. 

### Other Information

That's how CollectionSelect works https://github.com/rails/rails/blob/cece8077d4a6add9857013bd6463cf0797bdf3fa/actionview/lib/action_view/helpers/form_options_helper.rb#L361
