### PR TITLE
Removed options method argument from application tests in railties

### DIFF
--- a/railties/test/application/test_test.rb
+++ b/railties/test/application/test_test.rb
@@ -101,7 +101,7 @@ module ApplicationTests
         end
       RUBY
 
-      output = run_test_file("unit/failing_test.rb", env: { "BACKTRACE" => "1" })
+      output = run_test_file("unit/failing_test.rb")
       assert_match %r{test/unit/failing_test\.rb}, output
       assert_match %r{test/unit/failing_test\.rb:4}, output
     end
@@ -331,7 +331,7 @@ Expected: ["id", "name"]
         result
       end
 
-      def run_test_file(name, options = {})
+      def run_test_file(name)
         rails "test", "#{app_path}/test/#{name}", allow_failure: true
       end
   end


### PR DESCRIPTION
### Summary

This PR removes the unused argument in method from application tests in railties. If this option was added for a particular reason but has not yet been used in an implementation, I'd be happy to extend upon the usage of the `options` argument.


Thanks

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
