### PR TITLE
Allow open transactions to be restored upon DB reconnect

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -330,8 +330,24 @@ module ActiveRecord
         current_transaction.open?
       end
 
-      def reset_transaction # :nodoc:
+      def reset_transaction(restore: false) # :nodoc:
+        # Store the existing transaction state to the side
+        old_state = @transaction_manager if restore && @transaction_manager&.restorable?
+
         @transaction_manager = ConnectionAdapters::TransactionManager.new(self)
+
+        if block_given?
+          # Reconfigure the connection without any transaction state in the way
+          result = yield
+
+          # Now the connection's fully established, we can swap back
+          if old_state
+            @transaction_manager = old_state
+            @transaction_manager.restore_transactions
+          end
+
+          result
+        end
       end
 
       # Register a record with the current transaction so that its after_commit and after_rollback callbacks

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -140,6 +140,10 @@ module ActiveRecord
         @materialized
       end
 
+      def restore!
+        @materialized = false
+      end
+
       def rollback_records
         return unless records
         ite = records.uniq(&:__id__)
@@ -346,6 +350,20 @@ module ActiveRecord
 
       def dirty_current_transaction
         current_transaction.dirty!
+      end
+
+      def restore_transactions
+        return false unless restorable?
+
+        @stack.each(&:restore!)
+
+        materialize_transactions unless @lazy_transactions_enabled
+
+        true
+      end
+
+      def restorable?
+        @stack.none?(&:dirty?)
       end
 
       def materialize_transactions

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -123,9 +123,9 @@ module ActiveRecord
         @raw_connection.ping
       end
 
-      def reconnect!
+      def reconnect!(restore_transactions: false)
         @lock.synchronize do
-          disconnect!
+          @raw_connection.close
           connect
           super
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -322,7 +322,7 @@ module ActiveRecord
       end
 
       # Close then reopen the connection.
-      def reconnect!
+      def reconnect!(restore_transactions: false)
         @lock.synchronize do
           begin
             @raw_connection.reset

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -163,7 +163,7 @@ module ActiveRecord
         !@raw_connection.closed?
       end
 
-      def reconnect!
+      def reconnect!(restore_transactions: false)
         @lock.synchronize do
           if active?
             @raw_connection.rollback rescue nil


### PR DESCRIPTION
If we know that any open transactions had not been queried (and `raw_connection` has not been used), then it's safe for us to pick up with a new database connection mid-request.

This doesn't yet affect any default behaviour -- it's just adding a `restore_transactions:` kwarg option to `reconnect!`.