### PR TITLE
Fix the example for using a CDN with ActiveStorage

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -645,15 +645,17 @@ You should also make sure that the generated URLs use the CDN host instead of yo
 ```ruby
 # config/routes.rb
 direct :cdn_image do |model, options|
+  expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
+
   if model.respond_to?(:signed_id)
     route_for(
       :rails_service_blob_proxy,
-      model.signed_id,
+      model.signed_id(expires_in: expires_in),
       model.filename,
       options.merge(host: ENV['CDN_HOST'])
     )
   else
-    signed_blob_id = model.blob.signed_id
+    signed_blob_id = model.blob.signed_id(expires_in: expires_in)
     variation_key  = model.variation.key
     filename       = model.blob.filename
 


### PR DESCRIPTION
### Summary

The code example relies on proper code being extracted from the Rails source code. This bears the risk of the code being  extracted becoming outdated after a change to Rails' source.

This change fixes such an inconsistency that was introduced in the past.

### Other Information

There was a PR in the past that would have made such a deviation between docs and code impossible (by adding a config option for a CDN): https://github.com/rails/rails/pull/42305

That PR was eventually closed, because the solution may not be ideal. My PR is just putting a new patch on the issue, by updating the docs to the latest state. To avoid the problem in the future we should either:
* add a config option like the one proposed in https://github.com/rails/rails/pull/42305
* update the documentation to propose an entirely different course of action (e.g. [this one](https://github.com/rails/rails/pull/42305#issuecomment-869921967), which was the trigger for closing the initial PR)
