### PR TITLE
Modernize ActiveSupport::Autoload

### DIFF
--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -26,11 +26,13 @@ module ActiveSupport
   #   MyLib.eager_load!
   module Autoload
     def self.extended(base) # :nodoc:
-      base.class_eval do
-        @_autoloads = {}
-        @_under_path = nil
-        @_at_path = nil
-        @_eager_autoload = false
+      if RUBY_VERSION < "3"
+        base.class_eval do
+          @_autoloads = nil
+          @_under_path = nil
+          @_at_path = nil
+          @_eager_autoload = false
+        end
       end
     end
 
@@ -41,7 +43,8 @@ module ActiveSupport
       end
 
       if @_eager_autoload
-        @_autoloads[const_name] = path
+        @_eagerloaded_constants ||= []
+        @_eagerloaded_constants << const_name
       end
 
       super const_name, path
@@ -69,11 +72,10 @@ module ActiveSupport
     end
 
     def eager_load!
-      @_autoloads.each_value { |file| require file }
-    end
-
-    def autoloads
-      @_autoloads
+      if @_eagerloaded_constants
+        @_eagerloaded_constants.each { |const_name| const_get(const_name) }
+        @_eagerloaded_constants = nil
+      end
     end
   end
 end


### PR DESCRIPTION
We no longer need to define instance variables to avoid uninitialized instance variable warnings.

Also rather than to keep a hash of `constant -> path` forever, we can simply keep a list of constants and call `const_get` for each of them.

And finally we can clear the list we kept, as it's just wasted memory.
