### PR TITLE
Defer verification of database connections

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -705,7 +705,7 @@ module ActiveRecord
 
         def checkout_and_verify(c)
           c._run_checkout_callbacks do
-            c.verify!
+            c.clean!
           end
           c
         rescue

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -389,6 +389,8 @@ module ActiveRecord
       # done if the transaction block raises an exception or returns false.
       def rollback_db_transaction
         exec_rollback_db_transaction
+      rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed
+        reconnect!
       end
 
       def exec_rollback_db_transaction() end # :nodoc:
@@ -478,6 +480,10 @@ module ActiveRecord
       end
 
       private
+        def internal_execute(sql, name = "SCHEMA")
+          execute(sql, name)
+        end
+
         def execute_batch(statements, name = nil)
           statements.each do |statement|
             execute(statement, name)

--- a/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/savepoints.rb
@@ -8,15 +8,15 @@ module ActiveRecord
       end
 
       def create_savepoint(name = current_savepoint_name)
-        execute("SAVEPOINT #{name}", "TRANSACTION")
+        internal_execute("SAVEPOINT #{name}", "TRANSACTION")
       end
 
       def exec_rollback_to_savepoint(name = current_savepoint_name)
-        execute("ROLLBACK TO SAVEPOINT #{name}", "TRANSACTION")
+        internal_execute("ROLLBACK TO SAVEPOINT #{name}", "TRANSACTION")
       end
 
       def release_savepoint(name = current_savepoint_name)
-        execute("RELEASE SAVEPOINT #{name}", "TRANSACTION")
+        internal_execute("RELEASE SAVEPOINT #{name}", "TRANSACTION")
       end
     end
   end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -142,7 +142,10 @@ module ActiveRecord
       end
 
       def restore!
-        @materialized = false
+        if materialized?
+          @materialized = false
+          materialize!
+        end
       end
 
       def rollback_records
@@ -389,8 +392,6 @@ module ActiveRecord
         return false unless restorable?
 
         @stack.each(&:restore!)
-
-        materialize_transactions unless @lazy_transactions_enabled
 
         true
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -917,7 +917,7 @@ module ActiveRecord
         end
 
         def retryable_connection_error?(exception)
-          exception.is_a?(ConnectionNotEstablished)
+          exception.is_a?(ConnectionNotEstablished) || exception.is_a?(ConnectionFailed)
         end
 
         def retryable_query_error?(exception)

--- a/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/database_statements.rb
@@ -6,12 +6,15 @@ module ActiveRecord
       module DatabaseStatements
         # Returns an ActiveRecord::Result instance.
         def select_all(*, **) # :nodoc:
-          result = if ExplainRegistry.collect? && prepared_statements
-            unprepared_statement { super }
-          else
-            super
+          result = nil
+          with_raw_connection do |conn|
+            result = if ExplainRegistry.collect? && prepared_statements
+              unprepared_statement { super }
+            else
+              super
+            end
+            conn.abandon_results!
           end
-          @raw_connection.abandon_results!
           result
         end
 
@@ -69,8 +72,8 @@ module ActiveRecord
 
         def exec_delete(sql, name = nil, binds = []) # :nodoc:
           if without_prepared_statement?(binds)
-            @lock.synchronize do
-              execute_and_free(sql, name) { @raw_connection.affected_rows }
+            with_raw_connection do |conn|
+              execute_and_free(sql, name) { conn.affected_rows }
             end
           else
             exec_stmt_and_free(sql, name, binds) { |stmt| stmt.affected_rows }
@@ -99,8 +102,10 @@ module ActiveRecord
           def execute_batch(statements, name = nil)
             statements = statements.map { |sql| transform_query(sql) }
             combine_multi_statements(statements).each do |statement|
-              raw_execute(statement, name)
-              @raw_connection.abandon_results!
+              with_raw_connection do |conn|
+                raw_execute(statement, name)
+                conn.abandon_results!
+              end
             end
           end
 
@@ -109,7 +114,7 @@ module ActiveRecord
           end
 
           def last_inserted_id(result)
-            @raw_connection.last_id
+            @raw_connection&.last_id
           end
 
           def multi_statements_enabled?
@@ -123,16 +128,16 @@ module ActiveRecord
           end
 
           def with_multi_statements
-            multi_statements_was = multi_statements_enabled?
-
-            unless multi_statements_was
-              @raw_connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
+            if multi_statements_enabled?
+              return yield
             end
 
-            yield
-          ensure
-            unless multi_statements_was
-              @raw_connection.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
+            with_raw_connection do |conn|
+              conn.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
+
+              yield
+            ensure
+              conn.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)
             end
           end
 
@@ -167,39 +172,40 @@ module ActiveRecord
             sql = transform_query(sql)
             check_if_write_query(sql)
 
-            materialize_transactions
             mark_transaction_written_if_write(sql)
-
-            # make sure we carry over any changes to ActiveRecord.default_timezone that have been
-            # made since we established the connection
-            @raw_connection.query_options[:database_timezone] = default_timezone
 
             type_casted_binds = type_casted_binds(binds)
 
             log(sql, name, binds, type_casted_binds, async: async) do
-              if cache_stmt
-                stmt = @statements[sql] ||= @raw_connection.prepare(sql)
-              else
-                stmt = @raw_connection.prepare(sql)
-              end
+              with_raw_connection do |conn|
+                # make sure we carry over any changes to ActiveRecord.default_timezone that have been
+                # made since we established the connection
+                conn.query_options[:database_timezone] = default_timezone
 
-              begin
-                result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                  stmt.execute(*type_casted_binds)
-                end
-              rescue Mysql2::Error => e
                 if cache_stmt
-                  @statements.delete(sql)
+                  stmt = @statements[sql] ||= conn.prepare(sql)
                 else
-                  stmt.close
+                  stmt = conn.prepare(sql)
                 end
-                raise e
-              end
 
-              ret = yield stmt, result
-              result.free if result
-              stmt.close unless cache_stmt
-              ret
+                begin
+                  result = ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                    stmt.execute(*type_casted_binds)
+                  end
+                rescue Mysql2::Error => e
+                  if cache_stmt
+                    @statements.delete(sql)
+                  else
+                    stmt.close
+                  end
+                  raise e
+                end
+
+                ret = yield stmt, result
+                result.free if result
+                stmt.close unless cache_stmt
+                ret
+              end
             end
           end
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -110,7 +110,7 @@ module ActiveRecord
       #++
 
       def quote_string(string)
-        @raw_connection.escape(string)
+        any_raw_connection.escape(string)
       rescue Mysql2::Error => error
         raise translate_exception(error, message: error.message, sql: "<escape>", binds: [])
       end
@@ -160,6 +160,7 @@ module ActiveRecord
 
         def configure_connection
           @raw_connection.query_options[:as] = :array
+          @raw_connection.query_options[:database_timezone] = default_timezone
           super
         end
 
@@ -168,7 +169,7 @@ module ActiveRecord
         end
 
         def get_full_version
-          @raw_connection.server_info[:version]
+          any_raw_connection.server_info[:version]
         end
 
         def translate_exception(exception, message:, sql:, binds:)

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -123,13 +123,6 @@ module ActiveRecord
         @raw_connection.ping
       end
 
-      def reconnect!(restore_transactions: false)
-        @lock.synchronize do
-          @raw_connection.close
-          connect
-          super
-        end
-      end
       alias :reset! :reconnect!
 
       # Disconnects from the database if already connected.
@@ -156,6 +149,11 @@ module ActiveRecord
 
         def connect
           @raw_connection = self.class.new_client(@config)
+        end
+
+        def reconnect
+          @raw_connection.close
+          connect
         end
 
         def configure_connection

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -173,6 +173,12 @@ module ActiveRecord
         def translate_exception(exception, message:, sql:, binds:)
           if exception.is_a?(Mysql2::Error::TimeoutError) && !exception.error_number
             ActiveRecord::AdapterTimeout.new(message, sql: sql, binds: binds)
+          elsif exception.is_a?(Mysql2::Error::ConnectionError)
+            if exception.message.match?(/MySQL client is not connected/i)
+              ActiveRecord::ConnectionNotEstablished.new(exception)
+            else
+              ActiveRecord::ConnectionFailed.new(message, sql: sql, binds: binds)
+            end
           else
             super
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb
@@ -11,12 +11,11 @@ module ActiveRecord
 
         # Queries the database and returns the results in an Array-like object
         def query(sql, name = nil) # :nodoc:
-          materialize_transactions
           mark_transaction_written_if_write(sql)
 
           log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @raw_connection.async_exec(sql).map_types!(@type_map_for_results).values
+            with_raw_connection do |conn|
+              conn.async_exec(sql).map_types!(@type_map_for_results).values
             end
           end
         end
@@ -40,12 +39,11 @@ module ActiveRecord
           sql = transform_query(sql)
           check_if_write_query(sql)
 
-          materialize_transactions
           mark_transaction_written_if_write(sql)
 
-          log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @raw_connection.async_exec(sql)
+          with_raw_connection do |conn|
+            log(sql, name) do
+              conn.async_exec(sql)
             end
           end
         end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -6,14 +6,14 @@ module ActiveRecord
       module Quoting
         # Escapes binary strings for bytea input to the database.
         def escape_bytea(value)
-          @raw_connection.escape_bytea(value) if value
+          valid_raw_connection.escape_bytea(value) if value
         end
 
         # Unescapes bytea output from a database to the binary string it represents.
         # NOTE: This is NOT an inverse of escape_bytea! This is only to be used
         # on escaped binary output from database drive.
         def unescape_bytea(value)
-          @raw_connection.unescape_bytea(value) if value
+          valid_raw_connection.unescape_bytea(value) if value
         end
 
         def quote(value) # :nodoc:
@@ -43,7 +43,7 @@ module ActiveRecord
 
         # Quotes strings for use in SQL input.
         def quote_string(s) # :nodoc:
-          @raw_connection.escape(s)
+          valid_raw_connection.escape(s)
         end
 
         # Checks the following cases:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -693,6 +693,8 @@ module ActiveRecord
           when nil
             if exception.message.match?(/connection is closed/i)
               ConnectionNotEstablished.new(exception)
+            elsif exception.is_a?(PG::ConnectionBad) && !exception.message.end_with?("\n")
+              ConnectionNotEstablished.new(exception)
             else
               super
             end
@@ -721,7 +723,10 @@ module ActiveRecord
           end
         end
 
-        def retryable_error?(exception)
+        def retryable_query_error?(exception)
+        end
+
+        def retryable_connection_error?(exception)
           case exception
           when PG::ConnectionBad; !exception.message.end_with?("\n")
           end

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -325,19 +325,6 @@ module ActiveRecord
         end
       end
 
-      # Close then reopen the connection.
-      def reconnect!(restore_transactions: false)
-        @lock.synchronize do
-          begin
-            @raw_connection.reset
-          rescue PG::ConnectionBad
-            connect
-          end
-
-          super
-        end
-      end
-
       def reset!
         @lock.synchronize do
           unless @raw_connection.transaction_status == ::PG::PQTRANS_IDLE
@@ -883,6 +870,12 @@ module ActiveRecord
         # connected server's characteristics.
         def connect
           @raw_connection = self.class.new_client(@connection_parameters)
+        end
+
+        def reconnect
+          @raw_connection.reset
+        rescue PG::ConnectionBad
+          connect
         end
 
         # Configures the encoding, verbosity, schema search path, and time zone of the connection.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -377,7 +377,7 @@ module ActiveRecord
       end
 
       def set_standard_conforming_strings
-        execute("SET standard_conforming_strings = on", "SCHEMA")
+        internal_execute("SET standard_conforming_strings = on")
       end
 
       def supports_ddl_transactions?
@@ -458,7 +458,7 @@ module ActiveRecord
       end
 
       def extensions
-        exec_query("SELECT extname FROM pg_extension", "SCHEMA").cast_values
+        exec_query("SELECT extname FROM pg_extension", "SCHEMA", allow_retry: true, uses_transaction: false).cast_values
       end
 
       # Returns a list of defined enum types, and their values.
@@ -474,7 +474,7 @@ module ActiveRecord
           GROUP BY type.OID, type.typname;
         SQL
 
-        exec_query(query, "SCHEMA").cast_values.each_with_object({}) do |row, memo|
+        exec_query(query, "SCHEMA", allow_retry: true, uses_transaction: false).cast_values.each_with_object({}) do |row, memo|
           memo[row.first] = row.last
         end.to_a
       end
@@ -516,7 +516,7 @@ module ActiveRecord
       # Set the authorized user for this session
       def session_auth=(user)
         clear_cache!
-        execute("SET SESSION AUTHORIZATION #{user}")
+        internal_execute("SET SESSION AUTHORIZATION #{user}", nil, uses_transaction: true)
       end
 
       def use_insert_returning?
@@ -743,7 +743,7 @@ module ActiveRecord
         def load_additional_types(oids = nil)
           initializer = OID::TypeMapInitializer.new(type_map)
           load_types_queries(initializer, oids) do |query|
-            execute_and_clear(query, "SCHEMA", []) do |records|
+            execute_and_clear(query, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |records|
               initializer.run(records)
             end
           end
@@ -766,14 +766,14 @@ module ActiveRecord
 
         FEATURE_NOT_SUPPORTED = "0A000" # :nodoc:
 
-        def execute_and_clear(sql, name, binds, prepare: false, async: false)
+        def execute_and_clear(sql, name, binds, prepare: false, async: false, allow_retry: false, uses_transaction: true)
           sql = transform_query(sql)
           check_if_write_query(sql)
 
           if !prepare || without_prepared_statement?(binds)
-            result = exec_no_cache(sql, name, binds, async: async)
+            result = exec_no_cache(sql, name, binds, async: async, allow_retry: allow_retry, uses_transaction: uses_transaction)
           else
-            result = exec_cache(sql, name, binds, async: async)
+            result = exec_cache(sql, name, binds, async: async, allow_retry: allow_retry, uses_transaction: uses_transaction)
           end
           begin
             ret = yield result
@@ -783,8 +783,7 @@ module ActiveRecord
           ret
         end
 
-        def exec_no_cache(sql, name, binds, async: false)
-          materialize_transactions
+        def exec_no_cache(sql, name, binds, async:, allow_retry:, uses_transaction:)
           mark_transaction_written_if_write(sql)
 
           # make sure we carry over any changes to ActiveRecord.default_timezone that have been
@@ -799,9 +798,9 @@ module ActiveRecord
           end
         end
 
-        def exec_cache(sql, name, binds, async: false)
-          materialize_transactions
+        def exec_cache(sql, name, binds, async:, allow_retry:, uses_transaction:)
           mark_transaction_written_if_write(sql)
+
           update_typemap_for_default_timezone
 
           stmt_key = prepare_statement(sql, binds)
@@ -896,16 +895,16 @@ module ActiveRecord
           variables = @config.fetch(:variables, {}).stringify_keys
 
           # Set interval output format to ISO 8601 for ease of parsing by ActiveSupport::Duration.parse
-          execute("SET intervalstyle = iso_8601", "SCHEMA")
+          internal_execute("SET intervalstyle = iso_8601")
 
           # SET statements from :variables config hash
           # https://www.postgresql.org/docs/current/static/sql-set.html
           variables.map do |k, v|
             if v == ":default" || v == :default
               # Sets the value to the global or compile default
-              execute("SET SESSION #{k} TO DEFAULT", "SCHEMA")
+              internal_execute("SET SESSION #{k} TO DEFAULT")
             elsif !v.nil?
-              execute("SET SESSION #{k} TO #{quote(v)}", "SCHEMA")
+              internal_execute("SET SESSION #{k} TO #{quote(v)}")
             end
           end
 
@@ -926,9 +925,9 @@ module ActiveRecord
           # If using Active Record's time zone support configure the connection
           # to return TIMESTAMP WITH ZONE types in UTC.
           if default_timezone == :utc
-            execute("SET SESSION timezone TO 'UTC'", "SCHEMA")
+            internal_execute("SET SESSION timezone TO 'UTC'")
           else
-            execute("SET SESSION timezone TO DEFAULT", "SCHEMA")
+            internal_execute("SET SESSION timezone TO DEFAULT")
           end
         end
 
@@ -995,7 +994,7 @@ module ActiveRecord
                   AND castsource = #{quote column.sql_type}::regtype
               )
             SQL
-            execute_and_clear(sql, "SCHEMA", []) do |result|
+            execute_and_clear(sql, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |result|
               result.getvalue(0, 0)
             end
           end
@@ -1049,7 +1048,7 @@ module ActiveRecord
             FROM pg_type as t
             WHERE t.typname IN (%s)
           SQL
-          coders = execute_and_clear(query, "SCHEMA", []) do |result|
+          coders = execute_and_clear(query, "SCHEMA", [], allow_retry: true, uses_transaction: false) do |result|
             result.filter_map { |row| construct_coder(row, coders_by_name[row["typname"]]) }
           end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -264,7 +264,7 @@ module ActiveRecord
       class StatementPool < ConnectionAdapters::StatementPool # :nodoc:
         def initialize(connection, max)
           super(max)
-          @raw_connection = connection
+          @connection = connection
           @counter = 0
         end
 
@@ -274,14 +274,14 @@ module ActiveRecord
 
         private
           def dealloc(key)
-            @raw_connection.query "DEALLOCATE #{key}" if connection_active?
+            # This is ugly, but safe: the statement pool is only
+            # accessed while holding the connection's lock. (And we
+            # don't need the complication of with_raw_connection because
+            # a reconnect would invalidate the entire statement pool.)
+            if conn = @connection.instance_variable_get(:@raw_connection)
+              conn.query "DEALLOCATE #{key}" if conn.status == PG::CONNECTION_OK
+            end
           rescue PG::Error
-          end
-
-          def connection_active?
-            @raw_connection.status == PG::CONNECTION_OK
-          rescue PG::Error
-            false
           end
       end
 
@@ -976,7 +976,7 @@ module ActiveRecord
         end
 
         def build_statement_pool
-          StatementPool.new(@raw_connection, self.class.type_cast_config_to_integer(@config[:statement_limit]))
+          StatementPool.new(self, self.class.type_cast_config_to_integer(@config[:statement_limit]))
         end
 
         def can_perform_case_insensitive_comparison_for?(column)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb
@@ -24,12 +24,11 @@ module ActiveRecord
           sql = transform_query(sql)
           check_if_write_query(sql)
 
-          materialize_transactions
           mark_transaction_written_if_write(sql)
 
           log(sql, name) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              @raw_connection.execute(sql)
+            with_raw_connection do |conn|
+              conn.execute(sql)
             end
           end
         end
@@ -38,16 +37,15 @@ module ActiveRecord
           sql = transform_query(sql)
           check_if_write_query(sql)
 
-          materialize_transactions
           mark_transaction_written_if_write(sql)
 
           type_casted_binds = type_casted_binds(binds)
 
           log(sql, name, binds, type_casted_binds, async: async) do
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+            with_raw_connection do |conn|
               # Don't cache statements if they are not prepared
               unless prepare
-                stmt = @raw_connection.prepare(sql)
+                stmt = conn.prepare(sql)
                 begin
                   cols = stmt.columns
                   unless without_prepared_statement?(binds)
@@ -58,7 +56,7 @@ module ActiveRecord
                   stmt.close
                 end
               else
-                stmt = @statements[sql] ||= @raw_connection.prepare(sql)
+                stmt = @statements[sql] ||= conn.prepare(sql)
                 cols = stmt.columns
                 stmt.reset!
                 stmt.bind_params(type_casted_binds)
@@ -86,16 +84,28 @@ module ActiveRecord
         end
 
         def begin_db_transaction # :nodoc:
-          log("begin transaction", "TRANSACTION") { @raw_connection.transaction }
+          log("begin transaction", "TRANSACTION") do
+            with_raw_connection do |conn|
+              conn.transaction
+            end
+          end
         end
 
         def commit_db_transaction # :nodoc:
-          log("commit transaction", "TRANSACTION") { @raw_connection.commit }
+          log("commit transaction", "TRANSACTION") do
+            with_raw_connection do |conn|
+              conn.commit
+            end
+          end
           reset_read_uncommitted
         end
 
         def exec_rollback_db_transaction # :nodoc:
-          log("rollback transaction", "TRANSACTION") { @raw_connection.rollback }
+          log("rollback transaction", "TRANSACTION") do
+            with_raw_connection do |conn|
+              conn.rollback
+            end
+          end
           reset_read_uncommitted
         end
 
@@ -121,13 +131,11 @@ module ActiveRecord
             sql = combine_multi_statements(statements)
 
             check_if_write_query(sql)
-
-            materialize_transactions
             mark_transaction_written_if_write(sql)
 
             log(sql, name) do
-              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-                @raw_connection.execute_batch2(sql)
+              with_raw_connection do |conn|
+                conn.execute_batch2(sql)
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -577,10 +577,6 @@ module ActiveRecord
           end
         end
 
-        def retryable_error?(exception)
-          exception.message.match?(/called on a closed database/i)
-        end
-
         COLLATE_REGEX = /.*"(\w+)".*collate\s+"(\w+)".*/i.freeze
 
         def table_structure_with_collation(table_name, basic_structure)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -204,7 +204,7 @@ module ActiveRecord
 
       # Returns the current database encoding format as a string, e.g. 'UTF-8'
       def encoding
-        @raw_connection.encoding.to_s
+        any_raw_connection.encoding.to_s
       end
 
       def supports_explain?
@@ -575,6 +575,10 @@ module ActiveRecord
           else
             super
           end
+        end
+
+        def retryable_error?(exception)
+          exception.message.match?(/called on a closed database/i)
         end
 
         COLLATE_REGEX = /.*"(\w+)".*collate\s+"(\w+)".*/i.freeze

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -174,17 +174,6 @@ module ActiveRecord
         !@raw_connection.closed?
       end
 
-      def reconnect!(restore_transactions: false)
-        @lock.synchronize do
-          if active?
-            @raw_connection.rollback rescue nil
-          else
-            connect
-          end
-
-          super
-        end
-      end
       alias :reset! :reconnect!
 
       # Disconnects from the database if already connected. Otherwise, this
@@ -631,6 +620,14 @@ module ActiveRecord
             @config[:database].to_s,
             @config.merge(results_as_hash: true)
           )
+        end
+
+        def reconnect
+          if active?
+            @raw_connection.rollback rescue nil
+          else
+            connect
+          end
         end
 
         def configure_connection

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -493,6 +493,11 @@ module ActiveRecord
   class AdapterTimeout < QueryAborted
   end
 
+  # ConnectionFailed will be raised when the network connection to the
+  # database fails while sending a query or waiting for its result.
+  class ConnectionFailed < QueryAborted
+  end
+
   # UnknownAttributeReference is raised when an unknown and potentially unsafe
   # value is passed to a query method. For example, passing a non column name
   # value to a relation's #order method might cause this exception.

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -405,7 +405,7 @@ module ActiveRecord
         assert raw_transaction_open?(@connection)
         @connection.reconnect!(restore_transactions: true)
         assert_predicate @connection, :transaction_open?
-        assert_not raw_transaction_open?(@connection)
+        assert raw_transaction_open?(@connection)
       ensure
         @connection.reconnect!
         assert_not_predicate @connection, :transaction_open?

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -31,8 +31,7 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_no_automatic_reconnection_after_timeout
     assert_predicate @connection, :active?
-    @connection.update("set @@wait_timeout=1")
-    sleep 2
+    cause_server_side_disconnect
     assert_not_predicate @connection, :active?
   ensure
     # Repair all fixture connections so other tests won't break.
@@ -41,16 +40,14 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
 
   def test_successful_reconnection_after_timeout_with_manual_reconnect
     assert_predicate @connection, :active?
-    @connection.update("set @@wait_timeout=1")
-    sleep 2
+    cause_server_side_disconnect
     @connection.reconnect!
     assert_predicate @connection, :active?
   end
 
   def test_successful_reconnection_after_timeout_with_verify
     assert_predicate @connection, :active?
-    @connection.update("set @@wait_timeout=1")
-    sleep 2
+    cause_server_side_disconnect
     @connection.verify!
     assert_predicate @connection, :active?
   end
@@ -221,6 +218,11 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
   end
 
   private
+    def cause_server_side_disconnect
+      @connection.update("set @@wait_timeout=1")
+      sleep 2
+    end
+
     def test_lock_free(lock_name)
       @connection.select_value("SELECT IS_FREE_LOCK(#{@connection.quote(lock_name)})") == 1
     end

--- a/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
+++ b/activerecord/test/cases/connection_adapters/adapter_leasing_test.rb
@@ -20,19 +20,19 @@ module ActiveRecord
 
       def test_in_use?
         assert_not @adapter.in_use?, "adapter is not in use"
-        assert @adapter.lease, "lease adapter"
+        @adapter.lease
         assert @adapter.in_use?, "adapter is in use"
       end
 
       def test_lease_twice
-        assert @adapter.lease, "should lease adapter"
+        @adapter.lease
         assert_raises(ActiveRecordError) do
           @adapter.lease
         end
       end
 
       def test_expire_mutates_in_use
-        assert @adapter.lease, "lease adapter"
+        @adapter.lease
         assert @adapter.in_use?, "adapter is in use"
         @adapter.expire
         assert_not @adapter.in_use?, "adapter is in use"

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -15,6 +15,7 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
   teardown do
     return if in_memory_db?
     db_config = ActiveRecord::Base.connection_db_config
+    ActiveRecord::Base.remove_connection
     ActiveRecord::Base.establish_connection(db_config)
   end
 

--- a/activerecord/test/cases/secure_password_test.rb
+++ b/activerecord/test/cases/secure_password_test.rb
@@ -25,6 +25,9 @@ class SecurePasswordTest < ActiveRecord::TestCase
   end
 
   test "authenticate_by takes the same amount of time regardless of whether record is found" do
+    # Warm-up (mostly to ensure the DB connection is established)
+    User.authenticate_by(token: @user.token, password: @user.password)
+
     # Benchmark.realtime returns fractional seconds.  Thus, summing over 1000
     # iterations is equivalent to averaging over 1000 iterations and then
     # multiplying by 1000 to convert to milliseconds.

--- a/activerecord/test/cases/statement_invalid_test.rb
+++ b/activerecord/test/cases/statement_invalid_test.rb
@@ -21,7 +21,9 @@ module ActiveRecord
       sql = Book.where(author_id: 96, cover: "hard").to_sql
       error = assert_raises(ActiveRecord::StatementInvalid) do
         Book.connection.send(:log, sql, Book.name) do
-          raise MockDatabaseError
+          Book.connection.send(:with_raw_connection) do
+            raise MockDatabaseError
+          end
         end
       end
       assert_not error.message.include?("SELECT")
@@ -32,7 +34,9 @@ module ActiveRecord
       binds = [Minitest::Mock.new, Minitest::Mock.new]
       error = assert_raises(ActiveRecord::StatementInvalid) do
         Book.connection.send(:log, sql, Book.name, binds) do
-          raise MockDatabaseError
+          Book.connection.send(:with_raw_connection) do
+            raise MockDatabaseError
+          end
         end
       end
       assert_equal error.sql, sql

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -739,6 +739,8 @@ class TransactionTest < ActiveRecord::TestCase
 
   def test_releasing_named_savepoints
     Topic.transaction do
+      Topic.connection.materialize_transactions
+
       Topic.connection.create_savepoint("another")
       Topic.connection.release_savepoint("another")
 


### PR DESCRIPTION
Instead of verifying upon checkout, wait until we run a query.

If the query we need to run is safely retryable (including schema inspection, and most notably `BEGIN`), we don't need to explicitly verify, and can just recover if the query fails.

By extension, we can apply the same connection-recovery logic to _every_ retryable query we run -- so e.g. the beginning of any top-level transaction is a safe transparent DB-reconnection point.