### PR TITLE
Apply content security policy mapping when generated dynamically:

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Fix `content_security_policy` returning invalid directives.
+
+    Directives such as `self`, `unsafe-eval` and few others were not
+    single quoted when the directive was the result of calling a lambda
+    returning an array.
+
+    ```ruby
+    content_security_policy do |policy|
+      policy.frame_ancestors lambda { [:self, "https://example.com"] }
+    end
+    ```
+
+    With this fix the policy generated from above will now be valid.
+
+    *Edouard Chin*
+
 *   Fix `skip_forgery_protection` to run without raising an error if forgery
     protection has not been enabled / `verify_authenticity_token` is not a
     defined callback.

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/object/deep_dup"
+require "active_support/core_ext/array/wrap"
 
 module ActionDispatch # :nodoc:
   # Configures the HTTP
@@ -345,7 +346,7 @@ module ActionDispatch # :nodoc:
             raise RuntimeError, "Missing context for the dynamic content security policy source: #{source.inspect}"
           else
             resolved = context.instance_exec(&source)
-            resolved.is_a?(Symbol) ? apply_mapping(resolved) : resolved
+            apply_mappings(Array.wrap(resolved))
           end
         else
           raise RuntimeError, "Unexpected content security policy source: #{source.inspect}"

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -255,6 +255,14 @@ class ContentSecurityPolicyTest < ActiveSupport::TestCase
     assert_equal "script-src www.example.com", @policy.build(controller)
   end
 
+  def test_multiple_and_dynamic_directives
+    request = ActionDispatch::Request.new("HTTP_HOST" => "www.example.com")
+    controller = Struct.new(:request).new(request)
+
+    @policy.frame_ancestors -> { [:self, "https://example.com"] }
+    assert_equal "frame-ancestors 'self' https://example.com", @policy.build(controller)
+  end
+
   def test_mixed_static_and_dynamic_directives
     @policy.script_src :self, -> { "foo.com" }, "bar.com"
     request = ActionDispatch::Request.new({})


### PR DESCRIPTION
Apply content security policy mapping when generated dynamically:

- Fix #44536

