### PR TITLE
Bump jsbindling-rails and cssbundling-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    cssbundling-rails (1.0.0)
+    cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
     curses (1.4.3)
     daemons (1.4.1)
@@ -309,7 +309,7 @@ GEM
     irb (1.4.1)
       reline (>= 0.3.0)
     jmespath (1.4.0)
-    jsbundling-rails (1.0.0)
+    jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
     json (2.6.1)
     jwt (2.3.0)

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -774,8 +774,6 @@ class AppGeneratorTest < Rails::Generators::TestCase
   end
 
   def test_css_option_with_cssbundling_gem
-    skip if ENV["CI"]
-
     run_generator [destination_root, "--css", "postcss", "--no-skip-bundle"]
     assert_gem "cssbundling-rails"
     assert_file "app/assets/stylesheets/application.postcss.css"


### PR DESCRIPTION
### Summary

When both jsbundling-rails v1.0.1 and cssbundling-rails v1.1.0 are used at the same time, thor shows the prompt to replace `bin/dev` or not.

jsbundling-rails v1.0.2 addresses this issue.
https://github.com/rails/jsbundling-rails/releases/tag/v1.0.2
https://github.com/rails/jsbundling-rails/pull/95

Also we can run `AppGeneratorTest#test_css_option_with_cssbundling_gem` at CI.
