### PR TITLE
Eager load ActiveJob::ConfiguredJob and Serializers

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -33,8 +33,12 @@ module ActiveJob
 
   autoload :Base
   autoload :QueueAdapters
-  autoload :Serializers
-  autoload :ConfiguredJob
+
+  eager_autoload do
+    autoload :Serializers
+    autoload :ConfiguredJob
+  end
+
   autoload :TestCase
   autoload :TestHelper
   autoload :QueryTags


### PR DESCRIPTION
Otherwise they are autoloaded when the first job is enqueued which isn't good for production performance.
