### PR TITLE
Eager load controllers `view_context_class`

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -58,6 +58,10 @@ module ActionMailer
 
     require "mail"
     Mail.eager_autoload!
+
+    Base.descendants.each do |mailer|
+      mailer.eager_load! unless mailer.abstract?
+    end
   end
 end
 

--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -74,12 +74,6 @@ module ActionMailer
       end
     end
 
-    initializer "action_mailer.eager_load_actions" do
-      ActiveSupport.on_load(:after_initialize) do
-        ActionMailer::Base.descendants.each(&:action_methods) if config.eager_load
-      end
-    end
-
     config.after_initialize do |app|
       options = app.config.action_mailer
 

--- a/actionpack/lib/abstract_controller.rb
+++ b/actionpack/lib/abstract_controller.rb
@@ -24,5 +24,10 @@ module AbstractController
   def self.eager_load!
     super
     AbstractController::Caching.eager_load!
+    AbstractController::Base.descendants.each do |controller|
+      unless controller.abstract?
+        controller.eager_load!
+      end
+    end
   end
 end

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -127,6 +127,11 @@ module AbstractController
         super
         clear_action_methods!
       end
+
+      def eager_load! # :nodoc:
+        action_methods
+        nil
+      end
     end
 
     abstract!

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -14,6 +14,7 @@ module ActionController
     config.action_controller.log_query_tags_around_actions = true
     config.action_controller.wrap_parameters_by_default = false
 
+    config.eager_load_namespaces << AbstractController
     config.eager_load_namespaces << ActionController
 
     initializer "action_controller.assets_config", group: :all do |app|
@@ -96,12 +97,6 @@ module ActionController
         if app.config.action_controller.default_protect_from_forgery
           protect_from_forgery with: :exception
         end
-      end
-    end
-
-    initializer "action_controller.eager_load_actions" do
-      ActiveSupport.on_load(:after_initialize) do
-        ActionController::Metal.descendants.each(&:action_methods) if config.eager_load
       end
     end
 

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -72,6 +72,12 @@ module ActionView
         end
       end
 
+      def eager_load!
+        super
+        view_context_class
+        nil
+      end
+
       def view_context_class
         klass = ActionView::LookupContext::DetailsKey.view_context_class(ActionView::Base)
 

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -291,7 +291,7 @@ module ApplicationTests
       assert_instance_of Pathname, Rails.public_path
     end
 
-    test "does not eager load controller actions in development" do
+    test "does not eager load controllers state actions in development" do
       app_file "app/controllers/posts_controller.rb", <<-RUBY
         class PostsController < ActionController::Base
           def index;end
@@ -302,9 +302,10 @@ module ApplicationTests
       app "development"
 
       assert_nil PostsController.instance_variable_get(:@action_methods)
+      assert_nil PostsController.instance_variable_get(:@view_context_class)
     end
 
-    test "eager loads controller actions in production" do
+    test "eager loads controllers state in production" do
       app_file "app/controllers/posts_controller.rb", <<-RUBY
         class PostsController < ActionController::Base
           def index;end
@@ -320,6 +321,7 @@ module ApplicationTests
       app "production"
 
       assert_equal %w(index show).to_set, PostsController.instance_variable_get(:@action_methods)
+      assert_not_nil PostsController.instance_variable_get(:@view_context_class)
     end
 
     test "does not eager load mailer actions in development" do


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/29559

These classes are relatively small, however they include lots of modules as helpers. And if any of the included module hold constants including it cause the global constant cache to be invalidated which is really bad for performance.

So when eager loading is enabled we create all the possible classes as part of the application boot.

Here's  the backtrace I got from a modified Ruby reporting cache busts:

```
    from bundler/gems/rails-b6d4269315dc/activesupport/lib/active_support/concern.rb:134:in `append_features'
    from bundler/gems/rails-b6d4269315dc/activesupport/lib/active_support/concern.rb:134:in `append_features'
    from bundler/gems/rails-b6d4269315dc/activesupport/lib/active_support/concern.rb:133:in `include'
    from bundler/gems/rails-b6d4269315dc/activesupport/lib/active_support/concern.rb:133:in `block in append_features'
    from bundler/gems/rails-b6d4269315dc/activesupport/lib/active_support/concern.rb:133:in `each'
    from bundler/gems/rails-b6d4269315dc/activesupport/lib/active_support/concern.rb:133:in `append_features'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:65:in `include'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:65:in `block in build_view_context_class'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:63:in `initialize'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:63:in `new'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:63:in `build_view_context_class'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:78:in `view_context_class'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:89:in `view_context_class'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:103:in `view_context'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:122:in `_render_template'
    from bundler/gems/rails-b6d4269315dc/actionpack/lib/action_controller/metal/streaming.rb:216:in `_render_template'
    from bundler/gems/rails-b6d4269315dc/actionview/lib/action_view/rendering.rb:114:in `render_to_body'
    from bundler/gems/rails-b6d4269315dc/actionpack/lib/action_controller/metal/rendering.rb:46:in `render_to_body'
    from bundler/gems/rails-b6d4269315dc/actionpack/lib/action_controller/metal/renderers.rb:141:in `render_to_body'
    from bundler/gems/rails-b6d4269315dc/actionpack/lib/abstract_controller/rendering.rb:47:in `render_to_string'
    from bundler/gems/rails-b6d4269315dc/actionpack/lib/action_controller/metal/rendering.rb:35:in `render_to_string'
```