### PR TITLE
Simplify adapter construction; defer connect until first use

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -390,7 +390,7 @@ module ActiveRecord
       def rollback_db_transaction
         exec_rollback_db_transaction
       rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::ConnectionFailed
-        reconnect!
+        # Connection's gone; that counts as a rollback
       end
 
       def exec_rollback_db_transaction() end # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -414,13 +414,6 @@ module ActiveRecord
             @has_unmaterialized_transactions = false
           end
         end
-
-        # As a logical simplification for now, we assume anything that requests
-        # materialization is about to dirty the transaction. Note this is just
-        # an assumption about the caller, not a direct property of this method.
-        # It can go away later when callers are able to handle dirtiness for
-        # themselves.
-        dirty_current_transaction
       end
 
       def commit_transaction

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -439,8 +439,12 @@ module ActiveRecord
 
       def rollback_transaction(transaction = nil)
         @connection.lock.synchronize do
-          transaction ||= @stack.pop
-          transaction.rollback
+          transaction ||= @stack.last
+          begin
+            transaction.rollback
+          ensure
+            @stack.pop if @stack.last == transaction
+          end
           transaction.rollback_records
         end
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -495,6 +495,9 @@ module ActiveRecord
 
                 begin
                   commit_transaction
+                rescue ActiveRecord::ConnectionFailed
+                  transaction.state.invalidate! unless transaction.state.completed?
+                  raise
                 rescue Exception
                   rollback_transaction(transaction) unless transaction.state.completed?
                   raise

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -166,7 +166,7 @@ module ActiveRecord
       end
 
       def connection_retries
-        (@config[:connection_retries] || 3).to_i
+        (@config[:connection_retries] || 1).to_i
       end
 
       def default_timezone

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -100,7 +100,7 @@ module ActiveRecord
           @logger = ActiveRecord::Base.logger
 
           if deprecated_logger || deprecated_connection_options || deprecated_config
-            raise ArgumentError, "new API accepts just one config hash"
+            raise ArgumentError, "when initializing an ActiveRecord adapter with a config hash, that should be the only argument"
           end
         else
           # Soft-deprecated for now; we'll probably warn in future.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -958,9 +958,10 @@ module ActiveRecord
                 end
               end
 
-              if retryable_connection_error?(translated_exception)
-                # There's a problem with the connection, but we couldn't attempt to
-                # reconnect. The connection is going to stay broken, so un-verify it.
+              unless retryable_query_error?(translated_exception)
+                # Barring a known-retryable error inside the query (regardless of
+                # whether we were in a _position_ to retry it), we should infer that
+                # there's likely a real problem with the connection.
                 @verified = false
               end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -941,6 +941,12 @@ module ActiveRecord
                 end
               end
 
+              if retryable_connection_error?(translated_exception)
+                # There's a problem with the connection, but we couldn't attempt to
+                # reconnect. The connection is going to stay broken, so un-verify it.
+                @verified = false
+              end
+
               raise translated_exception
             ensure
               dirty_current_transaction if uses_transaction

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -51,10 +51,6 @@ module ActiveRecord
           end
       end
 
-      def initialize(connection, logger, connection_options, config)
-        super(connection, logger, config)
-      end
-
       def get_database_version # :nodoc:
         full_version_string = get_full_version
         version_string = version_string(full_version_string)

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -645,8 +645,9 @@ module ActiveRecord
 
         assert_equal 1, invocations # the whole transaction block is not retried
 
-        # After the (outermost) transaction block failed, it reconnected
-        assert_predicate @connection, :active?
+        # After the (outermost) transaction block failed, the connection is
+        # ready to reconnect on next use, but hasn't done so yet
+        assert_not_predicate @connection, :active?
         assert_operator Post.count, :>, 0
       end
 

--- a/activerecord/test/cases/adapters/mysql2/connection_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/connection_test.rb
@@ -52,21 +52,16 @@ class Mysql2ConnectionTest < ActiveRecord::Mysql2TestCase
     assert_predicate @connection, :active?
   end
 
-  def test_execute_after_disconnect
+  def test_execute_after_disconnect_reconnects
     @connection.disconnect!
 
-    error = assert_raise(ActiveRecord::ConnectionNotEstablished) do
-      @connection.execute("SELECT 1")
-    end
-    assert_kind_of Mysql2::Error, error.cause
+    assert_equal 3, @connection.select_value("SELECT 1+2")
   end
 
-  def test_quote_after_disconnect
+  def test_quote_after_disconnect_reconnects
     @connection.disconnect!
 
-    assert_raise(ActiveRecord::ConnectionNotEstablished) do
-      @connection.quote("string")
-    end
+    assert_equal "'string'", @connection.quote("string")
   end
 
   def test_active_after_disconnect

--- a/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/mysql2_adapter_test.rb
@@ -12,7 +12,7 @@ class Mysql2AdapterTest < ActiveRecord::Mysql2TestCase
 
   def test_connection_error
     assert_raises ActiveRecord::ConnectionNotEstablished do
-      ActiveRecord::Base.mysql2_connection(socket: File::NULL)
+      ActiveRecord::Base.mysql2_connection(socket: File::NULL, prepared_statements: false).connect!
     end
   end
 

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
       def test_connection_error
         assert_raises ActiveRecord::ConnectionNotEstablished do
-          ActiveRecord::Base.postgresql_connection(host: File::NULL)
+          ActiveRecord::Base.postgresql_connection(host: File::NULL).connect!
         end
       end
 

--- a/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/statement_pool_test.rb
@@ -43,7 +43,7 @@ module ActiveRecord
         end
 
         def test_prepared_statements_do_not_get_stuck_on_query_interruption
-          pg_connection = ActiveRecord::Base.connection.instance_variable_get(:@raw_connection)
+          pg_connection = ActiveRecord::Base.connection.connect!.instance_variable_get(:@raw_connection)
           pg_connection.stub(:get_last_result, -> { raise "random error" }) do
             assert_raises(RuntimeError) do
               Developer.where(name: "David").last

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_create_folder_test.rb
@@ -12,6 +12,7 @@ module ActiveRecord
           @conn = Base.sqlite3_connection database: dir.join("db/foo.sqlite3"),
                                adapter: "sqlite3",
                                timeout: 100
+          @conn.connect!
 
           assert Dir.exist? dir.join("db")
           assert File.exist? dir.join("db/foo.sqlite3")

--- a/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/transaction_test.rb
@@ -59,6 +59,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
 
   test "reset the read_uncommitted PRAGMA when a transaction is rolled back" do
     with_connection(flags: shared_cache_flags) do |conn|
+      conn.connect!
       conn.transaction(joinable: false, isolation: :read_uncommitted) do
         assert_not(read_uncommitted?(conn))
         conn.transaction_manager.materialize_transactions
@@ -73,6 +74,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
 
   test "reset the read_uncommitted PRAGMA when a transaction is committed" do
     with_connection(flags: shared_cache_flags) do |conn|
+      conn.connect!
       conn.transaction(joinable: false, isolation: :read_uncommitted) do
         assert_not(read_uncommitted?(conn))
         conn.transaction_manager.materialize_transactions
@@ -85,6 +87,7 @@ class SQLite3TransactionTest < ActiveRecord::SQLite3TestCase
 
   test "set the read_uncommitted PRAGMA to its previous value" do
     with_connection(flags: shared_cache_flags) do |conn|
+      conn.connect!
       conn.transaction(joinable: false, isolation: :read_uncommitted) do
         conn.instance_variable_get(:@raw_connection).read_uncommitted = true
         assert(read_uncommitted?(conn))

--- a/activerecord/test/cases/disconnected_test.rb
+++ b/activerecord/test/cases/disconnected_test.rb
@@ -20,12 +20,17 @@ class TestDisconnectedAdapter < ActiveRecord::TestCase
   end
 
   unless in_memory_db?
-    test "can't execute statements while disconnected" do
+    test "reconnects to execute statements when disconnected" do
       @connection.execute "SELECT count(*) from products"
+      first_connection = @connection.instance_variable_get(:@raw_connection).__id__
+
       @connection.disconnect!
-      assert_raises(ActiveRecord::ConnectionNotEstablished) do
-        @connection.execute "SELECT count(*) from products"
-      end
+      assert_nil @connection.instance_variable_get(:@raw_connection)
+
+      @connection.execute "SELECT count(*) from products"
+      second_connection = @connection.instance_variable_get(:@raw_connection).__id__
+
+      assert_not_equal second_connection, first_connection
     end
   end
 end

--- a/activerecord/test/cases/view_test.rb
+++ b/activerecord/test/cases/view_test.rb
@@ -114,7 +114,7 @@ if ActiveRecord::Base.connection.supports_views?
     end
 
     teardown do
-      @connection.execute "DROP VIEW paperbacks" if @connection.view_exists? "paperbacks"
+      @connection.execute "DROP VIEW paperbacks" if @connection&.view_exists? "paperbacks"
     end
 
     def test_reading


### PR DESCRIPTION
Building on from #44576, we no longer need to connect to the database in order to construct an adapter instance: we instead supply just the config hash, and it will connect on demand, in the same way it already knows to handle later reconnections.

This cleans up a weird API overlap, where we previously needed to know how to connect in two different places.