### PR TITLE
fix hash from_xml missing tag error

### DIFF
--- a/activesupport/lib/active_support/core_ext/hash/conversions.rb
+++ b/activesupport/lib/active_support/core_ext/hash/conversions.rb
@@ -216,7 +216,7 @@ module ActiveSupport
       end
 
       def become_content?(value)
-        value["type"] == "file" || (value["__content__"] && (value.keys.size == 1 || value["__content__"].present?))
+        value["type"] == "file" || (value["__content__"] && (value.keys.size == 1 || value["type"].present?))
       end
 
       def become_array?(value)

--- a/activesupport/test/core_ext/hash_ext_test.rb
+++ b/activesupport/test/core_ext/hash_ext_test.rb
@@ -868,6 +868,17 @@ class HashToXmlTest < ActiveSupport::TestCase
     assert_equal "application/octet-stream", file.content_type
   end
 
+  def test_tag_with_attrs
+    xml = <<-XML
+      <blog name="bacon is the best">
+        "Have a nice day"
+      </blog>
+    XML
+    hash = Hash.from_xml(xml)
+    assert_equal "bacon is the best", hash["blog"]["name"]
+    assert_match "Have a nice day", hash["blog"]["__content__"]
+  end
+
   def test_tag_with_attrs_and_whitespace
     xml = <<-XML
       <blog name="bacon is the best">


### PR DESCRIPTION
### Summary

Sometimes the XML has tag and content, there will missing tag when using Hash.from_xml
the XML like this:
```ruby
xml = <<-XML
      <blog name="bacon is the best">
        "Have a nice day"
      </blog>
    XML

hash = Hash.from_xml(xml)
puts hash
```

the result is below:
before:
```
{"blog"=>"\n        \"Have a nice day\"\n      "}
```
after:
```
{"blog"=>{"name"=>"bacon is the best", "__content__"=>"\n        \"Have a nice day\"\n      "}}
```

