### PR TITLE
Use #attribute_names in ActiveRecord::Core#inspect

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -685,7 +685,7 @@ module ActiveRecord
       # We check defined?(@attributes) not to issue warnings if the object is
       # allocated but not initialized.
       inspection = if defined?(@attributes) && @attributes
-        self.class.attribute_names.filter_map do |name|
+        attribute_names.filter_map do |name|
           if _has_attribute?(name)
             "#{name}: #{attribute_for_inspect(name)}"
           end

--- a/activerecord/test/cases/core_test.rb
+++ b/activerecord/test/cases/core_test.rb
@@ -50,6 +50,11 @@ class CoreTest < ActiveRecord::TestCase
     assert_equal "NonExistentTable(Table doesn't exist)", NonExistentTable.inspect
   end
 
+  def test_inspect_relation_with_virtual_field
+    relation = Topic.limit(1).select("1 as virtual_field")
+    assert_match(/virtual_field: 1/, relation.inspect)
+  end
+
   def test_pretty_print_new
     topic = Topic.new
     actual = +""


### PR DESCRIPTION
This ensures that any attributes on an object in a serialized field that are not on the model schema are still reported via `inspect`

### Summary

Resolves https://github.com/rails/rails/issues/37211
Reproducible bug: https://gist.github.com/fractaledmind/5e7aecb4693ed2d0268c395b63711577

In short, the bug can be seen by following these steps:
1. Use serialize to store an ActiveRecord object in a database field.
2. Remove a column via migration from that object's table
3. Access that serialized object via the getter

You will observe that the attribute is present in the database but not reported via `inspect`

Or, you can simply note that `Model.select("1 as virtual_field").inspect` won't report `virtual_field: 1`

