### PR TITLE
Handle net-smtp mail dependency error for Ruby 3.1

### DIFF
--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "mail"
+require "action_mailbox/mail_with_error_handling"
 
 module ActionMailbox
   # The +InboundEmail+ is an Active Record that keeps a reference to the raw email stored in Active Storage

--- a/actionmailbox/lib/action_mailbox/mail_ext.rb
+++ b/actionmailbox/lib/action_mailbox/mail_ext.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "mail"
+require "action_mailbox/mail_with_error_handling"
 
 # The hope is to upstream most of these basic additions to the Mail gem's Mail object. But until then, here they lay!
 Dir["#{File.expand_path(File.dirname(__FILE__))}/mail_ext/*"].each { |path| require "action_mailbox/mail_ext/#{File.basename(path)}" }

--- a/actionmailbox/lib/action_mailbox/mail_with_error_handling.rb
+++ b/actionmailbox/lib/action_mailbox/mail_with_error_handling.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+begin
+  require "mail"
+rescue LoadError => error
+  if error.message.match?(/net-stmp/)
+    $stderr.puts "You don't have net-stmp installed in your application. Please add it to your Gemfile and run bundle install"
+    raise
+  end
+end

--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -57,7 +57,7 @@ module ActionMailer
   def self.eager_load!
     super
 
-    require "mail"
+    require "action_mailer/mail_with_error_handling"
     Mail.eager_autoload!
   end
 end

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "mail"
+require "action_mailer/mail_with_error_handling"
 require "action_mailer/collector"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/hash/except"

--- a/actionmailer/lib/action_mailer/mail_with_error_handling.rb
+++ b/actionmailer/lib/action_mailer/mail_with_error_handling.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+begin
+  require "mail"
+rescue LoadError => error
+  if error.message.match?(/net-stmp/)
+    $stderr.puts "You don't have net-stmp installed in your application. Please add it to your Gemfile and run bundle install"
+    raise
+  end
+end


### PR DESCRIPTION
In Ruby 3.1, net-stmp is not a default gem anymore. Mail uses it as
dependency and try to loads without declaring the dependency, which
will fail unless the application have net-stmp in the gemfile.

For Rails 7 we could just make those gems dependencies of the framework.
But in Rails 6.1, which we need to support old rubies, installing those
gems can cause trouble. So instead we are intercepting the error and
telling people to add the gem to the Gemfile.
