### PR TITLE
Add `timestamptz` as a time zone aware type for PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Add `timestamptz` as a time zone aware type for PostgreSQL
+
+    This is required for correctly parsing `timestamp with time zone` values in your database.
+
+    If you don't want this, you can opt out by adding this initializer:
+
+    ```ruby
+    ActiveRecord::Base.time_zone_aware_types -= [:timestamptz]
+    ```
+
+    *Alex Ghiculescu*
+    
 *   Add new `ActiveRecord::Base::generates_token_for` API.
 
     Currently, `signed_id` fulfills the role of generating tokens for e.g.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -1095,5 +1095,6 @@ module ActiveRecord
         ActiveRecord::Type.register(:vector, OID::Vector, adapter: :postgresql)
         ActiveRecord::Type.register(:xml, OID::Xml, adapter: :postgresql)
     end
+    ActiveSupport.run_load_hooks(:active_record_postgresqladapter, PostgreSQLAdapter)
   end
 end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -78,6 +78,12 @@ module ActiveRecord
       end
     end
 
+    initializer "active_record.postgresql_time_zone_aware_types" do
+      ActiveSupport.on_load(:active_record_postgresqladapter) do
+        ActiveRecord::Base.time_zone_aware_types << :timestamptz
+      end
+    end
+
     initializer "active_record.logger" do
       ActiveSupport.on_load(:active_record) { self.logger ||= ::Rails.logger }
     end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -102,6 +102,7 @@ def with_timezone_config(cfg)
 
   old_default_zone = ActiveRecord.default_timezone
   old_awareness = ActiveRecord::Base.time_zone_aware_attributes
+  old_aware_types = ActiveRecord::Base.time_zone_aware_types
   old_zone = Time.zone
 
   if cfg.has_key?(:default)
@@ -110,6 +111,9 @@ def with_timezone_config(cfg)
   if cfg.has_key?(:aware_attributes)
     ActiveRecord::Base.time_zone_aware_attributes = cfg[:aware_attributes]
   end
+  if cfg.has_key?(:aware_types)
+    ActiveRecord::Base.time_zone_aware_types = cfg[:aware_types]
+  end
   if cfg.has_key?(:zone)
     Time.zone = cfg[:zone]
   end
@@ -117,12 +121,14 @@ def with_timezone_config(cfg)
 ensure
   ActiveRecord.default_timezone = old_default_zone
   ActiveRecord::Base.time_zone_aware_attributes = old_awareness
+  ActiveRecord::Base.time_zone_aware_types = old_aware_types
   Time.zone = old_zone
 end
 
 # This method makes sure that tests don't leak global state related to time zones.
 EXPECTED_ZONE = nil
 EXPECTED_DEFAULT_TIMEZONE = :utc
+EXPECTED_AWARE_TYPES = [:datetime, :time]
 EXPECTED_TIME_ZONE_AWARE_ATTRIBUTES = false
 def verify_default_timezone_config
   if Time.zone != EXPECTED_ZONE
@@ -147,6 +153,14 @@ def verify_default_timezone_config
     Global state `ActiveRecord::Base.time_zone_aware_attributes` was leaked.
       Expected: #{EXPECTED_TIME_ZONE_AWARE_ATTRIBUTES}
       Got: #{ActiveRecord::Base.time_zone_aware_attributes}
+    MSG
+  end
+  if ActiveRecord::Base.time_zone_aware_types != EXPECTED_AWARE_TYPES
+    $stderr.puts <<-MSG
+\n#{self}
+    Global state `ActiveRecord::Base.time_zone_aware_types` was leaked.
+      Expected: #{EXPECTED_AWARE_TYPES}
+      Got: #{ActiveRecord::Base.time_zone_aware_types}
     MSG
   end
 end


### PR DESCRIPTION
https://github.com/rails/rails/pull/41395 added support for the `timestamptz` type on the Postgres adapter.

As we found [here](https://github.com/rails/rails/pull/41084#issuecomment-1056430921) this causes issues because in some scenarios the new type is not considered a time zone aware attribute, meaning values of this type in the DB are presented as a `Time`, not an `ActiveSupport::TimeWithZone`.

This PR fixes that by ensuring that `timestamptz` is always a time zone aware type, for Postgres users. A workaround is to do this in an initializer:

```ruby
ActiveRecord::Base.time_zone_aware_types << :timestamptz
```

Or if you don't want this you can opt out in an initializer:

```ruby
ActiveRecord::Base.time_zone_aware_types -= [:timestamptz]
```

I think this should be backported to `7-0-stable`.

Fixes https://github.com/rails/rails/issues/45270