### PR TITLE
Add Enumerable#count_by

### DIFF
--- a/activesupport/lib/active_support/core_ext/enumerable.rb
+++ b/activesupport/lib/active_support/core_ext/enumerable.rb
@@ -20,6 +20,24 @@ module Enumerable
 
   # :startdoc:
 
+  # Return a hash of counts by the evaluation of the block.
+  #
+  #  payments = [Payment.new(25), Payment.new(10), Payment.new(10)]
+  #  payments.count_by(&:price) # => { 25 => 1, 10 => 2 }
+  def count_by(&block)
+    if block_given?
+      result = {}
+      each do |elem|
+        value = yield(elem)
+        result[value] ||= 0
+        result[value] += 1
+      end
+      result
+    else
+      to_enum(:count_by) { size if respond_to?(:size) }
+    end
+  end
+
   # Calculates the minimum from the extracted elements.
   #
   #   payments = [Payment.new(5), Payment.new(15), Payment.new(10)]

--- a/activesupport/test/core_ext/enumerable_test.rb
+++ b/activesupport/test/core_ext/enumerable_test.rb
@@ -29,6 +29,11 @@ class EnumerableTests < ActiveSupport::TestCase
     assert_equal(e, v, msg)
   end
 
+  def test_count_by
+    payments = GenericEnumerable.new([Payment.new(25), Payment.new(10), Payment.new(10)])
+    assert_equal({ 25 => 1, 10 => 2 }, payments.count_by(&:price))
+  end
+
   def test_minimum
     payments = GenericEnumerable.new([ Payment.new(5), Payment.new(15), Payment.new(10) ])
     assert_equal 5, payments.minimum(:price)


### PR DESCRIPTION
### Summary

This convenience method allows easily obtaining counts of groups of objects.

```rb
payments = [Payment.new(25), Payment.new(10), Payment.new(10)]
payments.count_by(&:price) 
# => { 25 => 1, 10 => 2 }
```
