### PR TITLE
Allow configuring if Postgres structure dumps include comments

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Allow configuring if Postgres structure dumps include comments
+
+    Introduces `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.comments_in_structure_dump`
+    to allow users to determine if `structure.sql` will include custom comments on tables or
+    columns.
+
+    The default is true, meaning comments will be included.
+
+    *Alex Ghiculescu*
+    
 *   Reduce the memory footprint of fixtures accessors.
 
     Until now fixtures accessors were eagerly defined using `define_method`.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -120,6 +120,14 @@ module ActiveRecord
       # setting, you should immediately run <tt>bin/rails db:migrate</tt> to update the types in your schema.rb.
       class_attribute :datetime_type, default: :timestamp
 
+      ##
+      # :singleton-method:
+      # Should comments on tables and columns be included in structure.sql?
+      #
+      # If false and a supported Postgres version is used, the `--no-comment` flag will be passed to `pg_dump`.
+      # The default is true.
+      class_attribute :comments_in_structure_dump, default: true
+
       NATIVE_DATABASE_TYPES = {
         primary_key: "bigserial primary key",
         string:      { name: "character varying" },

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -58,7 +58,8 @@ module ActiveRecord
           end
 
         args = ["--schema-only", "--no-privileges", "--no-owner"]
-        args << "--no-comments" if connection.database_version >= 110_000
+        remove_comments = !ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.comments_in_structure_dump && connection.database_version >= 110_000
+        args << "--no-comments" if remove_comments
         args.concat(["--file", filename])
 
         args.concat(Array(extra_flags)) if extra_flags

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -976,7 +976,7 @@ should be large enough to accommodate both the foreground threads (.e.g web serv
 
 Controls whether the Active Record MySQL adapter will consider all `tinyint(1)` columns as booleans. Defaults to `true`.
 
-#### `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_table`
+#### `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.create_unlogged_tables`
 
 Controls whether database tables created by PostgreSQL should be "unlogged", which can speed
 up performance but adds a risk of data loss if the database crashes. It is
@@ -992,6 +992,12 @@ configured `NATIVE_DATABASE_TYPES`. The default is `:timestamp`, meaning
 To use "timestamp with time zone", change this to `:timestamptz` in an
 initializer. You should run `bin/rails db:migrate` to rebuild your schema.rb
 if you change this.
+
+#### `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.comments_in_structure_dump`
+
+Controls whether the `structure.sql` file includes custom comments on tables
+and columns. If `false`, the `--no-comments` flag will be passed to `pg_dump`.
+Defaults to `true`.
 
 #### `ActiveRecord::SchemaDumper.ignore_tables`
 


### PR DESCRIPTION
Introduces `ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.comments_in_structure_dump` to allow users to determine if `structure.sql` will include custom comments on tables or columns.

The default is true, meaning comments will be included. This is because prior to https://github.com/rails/rails/pull/43216, comments were included (and there were other features like `add_column comment:` that rely on this), and I think now we have a configuration option that is the more correct default.

Fixes https://github.com/rails/rails/issues/44498
