### PR TITLE
Add Module#eager_load! to trigger the loading of autoloaded constants

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/eager_load.rb
+++ b/activesupport/lib/active_support/core_ext/module/eager_load.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Module
+  # Triggers loading of all registered `autoload` on this module or class.
+  def eager_load!
+    constants.each do |const|
+      const_get(const)
+    end
+    nil
+  end
+end

--- a/activesupport/test/core_ext/module/eager_load_test.rb
+++ b/activesupport/test/core_ext/module/eager_load_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../../abstract_unit"
+require "active_support/core_ext/module/eager_load"
+
+class EagerLoadTest < ActiveSupport::TestCase
+  module TestModule
+    autoload :DoesNotExist, "does/not/exist"
+  end
+
+  test "eager_load! trigger the load of autoloaded constants" do
+    error = assert_raises LoadError do
+      TestModule.eager_load!
+    end
+    assert_includes error.message, "does/not/exist"
+  end
+end


### PR DESCRIPTION
It's not uncommon to have gems that are largely autoloaded, which can be a problem for Rails application in production.

For instance: https://github.com/weppos/whois/pull/644

If the autoloaded constants are not referenced as part of boot the first request to actually use it will pay the loading cost. This is what tend to cause "shark fin" looking latency graphs around deploy.

Additionally to the cost of loading the code, defining constants cause the Ruby global constant cache to be busted, causing most inline caches and JITed code to be invalidated.

It also prevent this memory from being shared through the parent process in forking setups.

`Module#eager_load!` would make it easy to eagerly load some third party namespaces:

```ruby
config.eager_load_namespaces << Whois::Server::Adapters
```
