### PR TITLE
Mime Support for "problem detail"

### DIFF
--- a/actionpack/lib/action_dispatch/http/mime_types.rb
+++ b/actionpack/lib/action_dispatch/http/mime_types.rb
@@ -43,7 +43,8 @@ Mime::Type.register "application/x-www-form-urlencoded", :url_encoded_form
 
 # https://www.ietf.org/rfc/rfc4627.txt
 # http://www.json.org/JSONRequest.html
-Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+# https://www.ietf.org/rfc/rfc7807.txt
+Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json )
 
 Mime::Type.register "application/pdf", :pdf, [], %w(pdf)
 Mime::Type.register "application/zip", :zip, [], %w(zip)

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -154,13 +154,6 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
-  test "parses json params for application problem+json" do
-    assert_parses(
-      { "user" => { "username" => "sikachu" }, "username" => "sikachu" },
-      "{\"username\": \"sikachu\"}", "CONTENT_TYPE" => "application/problem+json"
-    )
-  end
-
   test "parses json with non-object JSON content" do
     assert_parses(
       { "user" => { "_json" => "string content" }, "_json" => "string content" },

--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -39,6 +39,13 @@ class JsonParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses json params for application problem+json" do
+    assert_parses(
+      { "person" => { "name" => "David" } },
+      "{\"person\": {\"name\": \"David\"}}", "CONTENT_TYPE" => "application/problem+json"
+    )
+  end
+
   test "does not parse unregistered media types such as application/vnd.api+json" do
     assert_parses(
       {},
@@ -144,6 +151,13 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     assert_parses(
       { "user" => { "username" => "sikachu" }, "username" => "sikachu" },
       "{\"username\": \"sikachu\"}", "CONTENT_TYPE" => "application/jsonrequest"
+    )
+  end
+
+  test "parses json params for application problem+json" do
+    assert_parses(
+      { "user" => { "username" => "sikachu" }, "username" => "sikachu" },
+      "{\"username\": \"sikachu\"}", "CONTENT_TYPE" => "application/problem+json"
     )
   end
 


### PR DESCRIPTION
### Summary

[RFC7807](https://datatracker.ietf.org/doc/html/rfc7807) defines a "problem detail" as
> a way to carry machine-readable details of errors in a HTTP response to avoid the need to define new error response formats for HTTP APIs

The spec is somewhat irrelevant, but due to the extended content type Rails does not recognize `application/problem+json` as JSON (particularly when parsing test Response bodies). This PR proposes adding it as an additional recognized Mime subtype for `application/json`

### Other Information

The largest counterpoint I can think of is the previous addition and removal of `application/vnd.api+json` (see https://github.com/rails/rails/pull/23712). Unlike `vnd.api+json`, `problem_json` is an RFC-specific format that is universal - not vendor-specific - and native support would add lots of value to Rails API projects.