### PR TITLE
Update verbose_query_logs method [ci-skip]

### DIFF
--- a/guides/source/debugging_rails_applications.md
+++ b/guides/source/debugging_rails_applications.md
@@ -217,7 +217,7 @@ irb(main):001:0> Article.pamplemousse
 => #<Comment id: 2, author: "1", body: "Well, actually...", article_id: 1, created_at: "2018-10-19 00:56:10", updated_at: "2018-10-19 00:56:10">
 ```
 
-After running `ActiveRecord::Base.verbose_query_logs = true` in the `bin/rails console` session to enable verbose query logs and running the method again, it becomes obvious what single line of code is generating all these discrete database calls:
+After running `ActiveRecord.verbose_query_logs = true` in the `bin/rails console` session to enable verbose query logs and running the method again, it becomes obvious what single line of code is generating all these discrete database calls:
 
 ```
 irb(main):003:0> Article.pamplemousse


### PR DESCRIPTION
### Summary

Rails Guides: Reflect that this method was moved out of ActiveRecord::Base

### Other Information

[Commit where method was marked as deprecated](https://github.com/rails/rails/commit/c3f43075a3c70c3b11717741426ec38a8d3cd14a)