### PR TITLE
Better handle basic authentication without a password

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Fix `authenticate_with_http_basic` to allow for missing password.
+
+    Before Rails 7.0 it was possible to handle basic authentication with only a username.
+    
+    ```ruby
+    authenticate_with_http_basic do |token, _|
+      ApiClient.authenticate(token)
+    end
+    ```
+
+    This ability is restored.
+
+    *Jean Boussier*
+
 *   Fix `content_security_policy` returning invalid directives.
 
     Directives such as `self`, `unsafe-eval` and few others were not

--- a/actionpack/lib/action_controller/metal/http_authentication.rb
+++ b/actionpack/lib/action_controller/metal/http_authentication.rb
@@ -74,6 +74,8 @@ module ActionController
           #
           # See ActionController::HttpAuthentication::Basic for example usage.
           def http_basic_authenticate_with(name:, password:, realm: nil, **options)
+            raise ArgumentError, "Expected name: to be a String, got #{name.class}" unless name.is_a?(String)
+            raise ArgumentError, "Expected password: to be a String, got #{password.class}" unless name.is_a?(String)
             before_action(options) { http_basic_authenticate_or_request_with name: name, password: password, realm: realm }
           end
         end
@@ -82,8 +84,8 @@ module ActionController
           authenticate_or_request_with_http_basic(realm, message) do |given_name, given_password|
             # This comparison uses & so that it doesn't short circuit and
             # uses `secure_compare` so that length information isn't leaked.
-            ActiveSupport::SecurityUtils.secure_compare(given_name, name) &
-              ActiveSupport::SecurityUtils.secure_compare(given_password, password)
+            ActiveSupport::SecurityUtils.secure_compare(given_name.to_s, name) &
+              ActiveSupport::SecurityUtils.secure_compare(given_password.to_s, password)
           end
         end
 
@@ -107,7 +109,7 @@ module ActionController
       end
 
       def has_basic_credentials?(request)
-        request.authorization.present? && (auth_scheme(request).downcase == "basic") && user_name_and_password(request).length == 2
+        request.authorization.present? && (auth_scheme(request).downcase == "basic")
       end
 
       def user_name_and_password(request)


### PR DESCRIPTION
https://github.com/rails/rails/pull/43209 immediately rejects the request if no password is passed, but there are legitimate uses for accepting authentication without a password.

cc @mpestov, @rafaelfranca, @p8 