### PR TITLE
Eager load ActionDispatch::Routing::RoutesProxy

### DIFF
--- a/actionpack/lib/action_dispatch/routing.rb
+++ b/actionpack/lib/action_dispatch/routing.rb
@@ -250,7 +250,9 @@ module ActionDispatch
 
     autoload :Mapper
     autoload :RouteSet
-    autoload :RoutesProxy
+    eager_autoload do
+      autoload :RoutesProxy
+    end
     autoload :UrlFor
     autoload :PolymorphicRoutes
 


### PR DESCRIPTION
Otherwise it might only be loaded once `url_for` is called:

```
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/routes_proxy.rb:7:in `<module:Routing>'
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/routes_proxy.rb:6:in `<module:ActionDispatch>'
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/routes_proxy.rb:5:in `<main>'
    from gems/bootsnap-1.10.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
    from gems/bootsnap-1.10.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
    from gems/zeitwerk-2.5.4/lib/zeitwerk/kernel.rb:35:in `require'
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb:214:in `polymorphic_method'
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb:116:in `polymorphic_url'
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/url_for.rb:187:in `full_url_for'
    from bundler/gems/rails-5772ecd7d568/actionpack/lib/action_dispatch/routing/url_for.rb:170:in `url_for'
```

