### PR TITLE
Do not remove assets initializer when using propshaft

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -239,6 +239,10 @@ module Rails
         options[:skip_asset_pipeline] || options[:asset_pipeline] != "sprockets"
       end
 
+      def skip_propshaft?
+        options[:skip_asset_pipeline] || options[:asset_pipeline] != "propshaft"
+      end
+
 
       class GemfileEntry < Struct.new(:name, :version, :comment, :options, :commented_out)
         def initialize(name, version, comment, options = {}, commented_out = false)

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -135,7 +135,7 @@ module Rails
         template "config/storage.yml"
       end
 
-      if skip_sprockets? && !assets_config_exist
+      if skip_sprockets? && skip_propshaft? && !assets_config_exist
         remove_file "config/initializers/assets.rb"
       end
 
@@ -436,9 +436,12 @@ module Rails
         end
       end
 
-      def delete_assets_initializer_skipping_sprockets
-        if skip_sprockets?
+      def delete_assets_initializer_skipping_sprockets_and_propshaft
+        if skip_sprockets? && skip_propshaft?
           remove_file "config/initializers/assets.rb"
+        end
+
+        if skip_sprockets?
           remove_file "app/assets/config/manifest.js"
           remove_dir  "app/assets/config"
           remove_file "app/assets/stylesheets/application.css"

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -230,7 +230,7 @@ class AppGeneratorTest < Rails::Generators::TestCase
     end
   end
 
-  def test_app_update_does_not_generate_assets_initializer_when_sprockets_is_not_used
+  def test_app_update_does_not_generate_assets_initializer_when_sprockets_and_propshaft_are_not_used
     app_root = File.join(destination_root, "myapp")
     run_generator [app_root, "-a", "none"]
 
@@ -240,6 +240,20 @@ class AppGeneratorTest < Rails::Generators::TestCase
       quietly { generator.update_config_files }
 
       assert_no_file "#{app_root}/config/initializers/assets.rb"
+      assert_no_file "#{app_root}/app/assets/config/manifest.js"
+    end
+  end
+
+  def test_app_update_does_not_generate_manifest_config_when_propshaft_is_used
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root, "-a", "propshaft"]
+
+    stub_rails_application(app_root) do
+      generator = Rails::Generators::AppGenerator.new ["rails"], { update: true, asset_pipeline: "propshaft" }, { destination_root: app_root, shell: @shell }
+      generator.send(:app_const)
+      quietly { generator.update_config_files }
+
+      assert_file "#{app_root}/config/initializers/assets.rb"
       assert_no_file "#{app_root}/app/assets/config/manifest.js"
     end
   end

--- a/railties/test/generators/plugin_generator_test.rb
+++ b/railties/test/generators/plugin_generator_test.rb
@@ -666,7 +666,7 @@ class PluginGeneratorTest < Rails::Generators::TestCase
 
     assert_gem "propshaft"
     assert_no_gem "sprockets-rails"
-    assert_no_file "test/dummy/config/initializers/assets.rb"
+    assert_file "test/dummy/config/initializers/assets.rb"
     assert_file "test/dummy/config/environments/development.rb" do |content|
       assert_no_match "config.assets", content
     end


### PR DESCRIPTION
As of https://github.com/rails/propshaft/pull/65 Propshaft can use `version`. Also fixes a bug that prevent creating a new app with propshaft and bootstrap:

```
rails new example \
--javascript esbuild \
--css bootstrap \
-a propshaft
```