### PR TITLE
Make invert generate null predicates with nullable columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Make `invert` generate null predicates with nullable columns
+
+    Original `invert` didn't generate the appropriate null predicates for
+    nullable columns.
+
+    Now, `invert` detects nullable columns and non-null expressions, generates
+    the appropriate null predicates, so `where.not` have a more consistent
+    behavior.
+
+    *vy0b0x*
+
 *   Reduce the memory footprint of fixtures accessors.
 
     Until now fixtures accessors were eagerly defined using `define_method`.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -31,15 +31,21 @@ module ActiveRecord
       #
       #    User.where.not(name: "Jon")
       #    # SELECT * FROM users WHERE name != 'Jon'
+      #    # If the column is nullable
+      #    # SELECT * FROM users WHERE (name != 'Jon' OR name IS NULL)
       #
       #    User.where.not(name: nil)
       #    # SELECT * FROM users WHERE name IS NOT NULL
       #
       #    User.where.not(name: %w(Ko1 Nobu))
       #    # SELECT * FROM users WHERE name NOT IN ('Ko1', 'Nobu')
+      #    # If the column is nullable
+      #    # SELECT * FROM users WHERE (name NOT IN ('Ko1', 'Nobu') OR name IS NULL)
       #
       #    User.where.not(name: "Jon", role: "admin")
       #    # SELECT * FROM users WHERE NOT (name == 'Jon' AND role == 'admin')
+      #    # If name is nullable
+      #    # SELECT * FROM users WHERE NOT (name == 'Jon' AND role == 'admin' AND name IS NOT NULL)
       def not(opts, *rest)
         where_clause = @scope.send(:build_where_clause, opts, rest)
 

--- a/activerecord/lib/arel/table.rb
+++ b/activerecord/lib/arel/table.rb
@@ -8,6 +8,7 @@ module Arel # :nodoc: all
     @engine = nil
     class << self; attr_accessor :engine; end
 
+    attr_reader :klass
     attr_accessor :name, :table_alias
 
     # TableAlias and Table both have a #table_name which is the name of the underlying table


### PR DESCRIPTION
### Summary

Fix #44360.
Currently, the behavior of where.not with nullable columns is confusing many people. When most people call `where.not(t: '1')` on the nullable column, they are expecting the result that contains the rows with {t: nil}.
This PR fixes it by detecting nullable columns and generating the appropriate null predicates in where_clause#invert.