### PR TITLE
Restart Action Cable when Redis disconnects

### DIFF
--- a/actioncable/lib/action_cable/subscription_adapter/redis.rb
+++ b/actioncable/lib/action_cable/subscription_adapter/redis.rb
@@ -150,6 +150,9 @@ module ActionCable
 
                 conn = @adapter.redis_connection_for_subscriptions
                 listen conn
+              rescue ::Redis::BaseConnectionError
+                @thread = @raw_client = nil
+                ActionCable.server.restart
               end
             end
 


### PR DESCRIPTION
### Summary

Prevents the web service process from aborting when there is a Redis
connection error. Instead, we restart Action Cable so that all clients
are disconnected and we would reconnect to Redis when the next Action
Cable request comes in.

Closes https://github.com/rails/rails/issues/27659

From https://gitlab.com/gitlab-org/gitlab/-/merge_requests/80822

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
