### PR TITLE
Backport #44304 to 7-0-stable

### DIFF
--- a/actioncable/app/assets/javascripts/action_cable.js
+++ b/actioncable/app/assets/javascripts/action_cable.js
@@ -166,7 +166,7 @@
       if (!allowReconnect) {
         this.monitor.stop();
       }
-      if (this.isActive()) {
+      if (this.isOpen()) {
         return this.webSocket.close();
       }
     }

--- a/actioncable/app/assets/javascripts/actioncable.esm.js
+++ b/actioncable/app/assets/javascripts/actioncable.esm.js
@@ -172,7 +172,7 @@ class Connection {
     if (!allowReconnect) {
       this.monitor.stop();
     }
-    if (this.isActive()) {
+    if (this.isOpen()) {
       return this.webSocket.close();
     }
   }

--- a/actioncable/app/assets/javascripts/actioncable.js
+++ b/actioncable/app/assets/javascripts/actioncable.js
@@ -166,7 +166,7 @@
       if (!allowReconnect) {
         this.monitor.stop();
       }
-      if (this.isActive()) {
+      if (this.isOpen()) {
         return this.webSocket.close();
       }
     }

--- a/actioncable/app/javascript/action_cable/connection.js
+++ b/actioncable/app/javascript/action_cable/connection.js
@@ -44,7 +44,8 @@ class Connection {
 
   close({allowReconnect} = {allowReconnect: true}) {
     if (!allowReconnect) { this.monitor.stop() }
-    if (this.isActive()) {
+    // Avoid closing websockets in a "connecting" state due to Safari 15.1+ bug. See: https://github.com/rails/rails/issues/43835#issuecomment-1002288478
+    if (this.isOpen()) {
       return this.webSocket.close()
     }
   }


### PR DESCRIPTION
#44304 wasn’t backported to the latest stable release line when it was merged. As a result, released Action Cable is still broken in Safari.