### PR TITLE
Refer to number_field_tag in range_field documentation

### DIFF
--- a/actionview/lib/action_view/helpers/form_helper.rb
+++ b/actionview/lib/action_view/helpers/form_helper.rb
@@ -1565,7 +1565,7 @@ module ActionView
       # Returns an input tag of type "range".
       #
       # ==== Options
-      # * Accepts same options as range_field_tag
+      # * Accepts same options as number_field_tag
       def range_field(object_name, method, options = {})
         Tags::RangeField.new(object_name, method, self, options).render
       end


### PR DESCRIPTION
### Summary

When a user is looking for the options of range_field, they are referred to range_field_tag, which then refers them to number_field_tag. Referring the user directly to number_field_tag is better.

### Other Information

Before:
![before](https://user-images.githubusercontent.com/1102934/157065579-b4ed7ce5-7fc0-40a2-ba8e-63ff0f2f290f.png)

After:
![after](https://user-images.githubusercontent.com/1102934/157065576-7b5b8db5-278d-44cd-9485-7e8c7fbd1493.png)