### PR TITLE
fix namespaced schema load ignoring protected env

### DIFF
--- a/activerecord/lib/active_record/railties/databases.rake
+++ b/activerecord/lib/active_record/railties/databases.rake
@@ -484,7 +484,7 @@ db_namespace = namespace :db do
     namespace :load do
       ActiveRecord::Tasks::DatabaseTasks.for_each(databases) do |name|
         desc "Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `config.active_record.schema_format`) into the #{name} database"
-        task name => :load_config do
+        task name => [:load_config, :check_protected_environments] do
           original_db_config = ActiveRecord::Base.connection_db_config
           db_config = ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env, name: name)
           ActiveRecord::Tasks::DatabaseTasks.load_schema(db_config)


### PR DESCRIPTION
### Summary

This makes the task requirements for db:schema:load:namespace the same
as db:schema:load (adding check_protected_environments)

### Other Information

Fixes #44630 
