### PR TITLE
Add response body change to update guide [skip ci]

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -248,6 +248,27 @@ Alternatively, you could load defaults for 7.1
 config.load_defaults 7.1
 ```
 
+### Response body content removed from redirect responses
+Rails no longer adds the "You are being redirected" text to redirect responses. If your test suit throws the following error:
+```bash
+NoMethodError: undefined method `document' for nil:NilClass
+
+              Nokogiri::XML::NodeSet.new(node.document, [node])
+```
+
+You are likely missing the follow redirect command. Locate the lines of code that are causing the error:
+```ruby
+get user_photos_path
+assert_select "h1", text: "My Photos"
+```
+
+And add the command to them:
+```ruby
+get user_photos_path
+follow_redirect!
+assert_select "h1", text: "My Photos"
+```
+
 Upgrading from Rails 6.1 to Rails 7.0
 -------------------------------------
 


### PR DESCRIPTION
PR https://github.com/rails/rails/pull/44554 removed the body content from redirect responses. This caused quite a few of the following error in our CI:
```
NoMethodError: undefined method `document' for nil:NilClass
  Nokogiri::XML::NodeSet.new(node.document, [node])
```

Aparently something in `get` or `assert_select` in integration tests was automatically following the redirects in those messages. We had to update to add `follow_redirect!` to the broken tests:
```diff
 get event_rsvps_path(events(:wedding)) do
+  follow_redirect!
   assert_select "a[title='RSVP by Whatsapp']", false
 end
```

This PR adds an entry to the upgrade guide to explain this.

EDIT: Sorry, I forgot about the skip ci