### PR TITLE
Generate content security policy for non-HTML responses

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,4 +1,5 @@
 *   Allow Content Security Policy DSL to generate for API responses.
+
     *Tim Wade*
 
 *   Fix `authenticate_with_http_basic` to allow for missing password.

--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,6 @@
+*   Allow Content Security Policy DSL to generate for API responses.
+    *Tim Wade*
+
 *   Fix `authenticate_with_http_basic` to allow for missing password.
 
     Before Rails 7.0 it was possible to handle basic authentication with only a username.

--- a/actionpack/lib/action_dispatch/http/content_security_policy.rb
+++ b/actionpack/lib/action_dispatch/http/content_security_policy.rb
@@ -35,7 +35,6 @@ module ActionDispatch # :nodoc:
         request = ActionDispatch::Request.new env
         _, headers, _ = response = @app.call(env)
 
-        return response unless html_response?(headers)
         return response if policy_present?(headers)
 
         if policy = request.content_security_policy
@@ -49,12 +48,6 @@ module ActionDispatch # :nodoc:
       end
 
       private
-        def html_response?(headers)
-          if content_type = headers[CONTENT_TYPE]
-            /html/.match?(content_type)
-          end
-        end
-
         def header_name(request)
           if request.content_security_policy_report_only
             POLICY_REPORT_ONLY

--- a/actionpack/test/dispatch/content_security_policy_test.rb
+++ b/actionpack/test/dispatch/content_security_policy_test.rb
@@ -403,6 +403,11 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
 
     content_security_policy_report_only only: :report_only
 
+    content_security_policy only: :api do |p|
+      p.default_src :none
+      p.frame_ancestors :none
+    end
+
     def index
       head :ok
     end
@@ -431,6 +436,10 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def api
+      render json: {}
+    end
+
     private
       def condition?
         params[:condition] == "true"
@@ -447,6 +456,7 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
       get "/script-src", to: "policy#script_src"
       get "/style-src", to: "policy#style_src"
       get "/no-policy", to: "policy#no_policy"
+      get "/api", to: "policy#api"
     end
   end
 
@@ -516,6 +526,11 @@ class ContentSecurityPolicyIntegrationTest < ActionDispatch::IntegrationTest
 
     assert_nil response.headers["Content-Security-Policy"]
     assert_nil response.headers["Content-Security-Policy-Report-Only"]
+  end
+
+  def test_generates_api_security_policy
+    get "/api"
+    assert_policy "default-src 'none'; frame-ancestors 'none'"
   end
 
   private


### PR DESCRIPTION
### Summary

One feature of the content security policy DSL, though undocumented,
is that it will not generate headers for non-HTML responses, even if a
configuration is explicitly provided. While it may not seem obvious
that anyone would want to send this header in an API response, Mozilla
Observatory, for instance, recommends the following for API responses:

`Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`

(source: https://observatory.mozilla.org/faq/)

The Secure Headers gem also makes recommendations about the content
security policy for API responses: https://github.com/github/secure_headers#api-configurations

As such, this removes the HTML guard clause from the
`ContentSecurityPolicy` middleware.

### Other Information

Pulled out of https://github.com/rails/rails/pull/39398 based on https://github.com/rails/rails/pull/39398#issuecomment-1028501715


