### PR TITLE
Fix `remove_foreign_key` with `:if_exists` option when foreign key actually exists

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `remove_foreign_key` with `:if_exists` option when foreign key actually exists.
+
+    *fatkodima*
+
 *   Remove `--no-comments` flag in structure dumps for PostgreSQL
 
     This broke some apps that used custom schema comments. If you don't want

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1127,7 +1127,7 @@ module ActiveRecord
       #   The name of the table that contains the referenced primary key.
       def remove_foreign_key(from_table, to_table = nil, **options)
         return unless supports_foreign_keys?
-        return if options[:if_exists] == true && !foreign_key_exists?(from_table, to_table)
+        return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table)
 
         fk_name_to_delete = foreign_key_for!(from_table, to_table: to_table, **options).name
 

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -60,7 +60,7 @@ module ActiveRecord
         end
 
         def remove_foreign_key(from_table, to_table = nil, **options)
-          return if options[:if_exists] == true && !foreign_key_exists?(from_table, to_table)
+          return if options.delete(:if_exists) == true && !foreign_key_exists?(from_table, to_table)
 
           to_table ||= options[:to_table]
           options = options.except(:name, :to_table, :validate)

--- a/activerecord/test/cases/migration/foreign_key_test.rb
+++ b/activerecord/test/cases/migration/foreign_key_test.rb
@@ -668,7 +668,7 @@ if ActiveRecord::Base.connection.supports_foreign_keys?
           @connection.add_foreign_key :astronauts, :rockets
           assert_equal 1, @connection.foreign_keys("astronauts").size
 
-          @connection.remove_foreign_key :astronauts, :rockets
+          @connection.remove_foreign_key :astronauts, :rockets, if_exists: true
           assert_equal [], @connection.foreign_keys("astronauts")
 
           assert_nothing_raised do


### PR DESCRIPTION
Closes #44636