### PR TITLE
Adds `#interceptors` method to ActionMailer::Base

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
       actionview (= 7.1.0.alpha)
       activejob (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
-      mail (~> 2.5, >= 2.5.4)
+      mail (>= 2.8.1)
       net-imap
       net-pop
       net-smtp
@@ -279,7 +279,7 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop

--- a/actionmailer/CHANGELOG.md
+++ b/actionmailer/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Added `interceptors` method to `ActionMailer::Base`.
+
+    Calling `ActionMailer::Base.interceptors` returns the all registered
+    mail interceptors.
+
+    *Ghouse Mohamed*
+
 *   The `deliver_later_queue_name` used by the default mailer job can now be
     configured on a per-mailer basis. Previously this was only configurable
     for all mailers via `ActionMailer::Base`.

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version
 
-  s.add_dependency "mail", ["~> 2.5", ">= 2.5.4"]
+  s.add_dependency "mail", ">= 2.8.1"
   s.add_dependency "net-imap"
   s.add_dependency "net-pop"
   s.add_dependency "net-smtp"

--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -545,6 +545,11 @@ module ActionMailer
         Mail.unregister_interceptor(observer_class_for(interceptor))
       end
 
+      # Returns all the registered interceptors.
+      def interceptors
+        Mail.delivery_interceptors
+      end
+
       def observer_class_for(value) # :nodoc:
         case value
         when String, Symbol

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1190,7 +1190,7 @@ module ApplicationTests
       require "mail"
       _ = ActionMailer::Base
 
-      assert_equal [::MyMailInterceptor], ::Mail.class_variable_get(:@@delivery_interceptors)
+      assert_equal [::MyMailInterceptor], ActionMailer::Base.interceptors
     end
 
     test "registers multiple interceptors with ActionMailer" do
@@ -1203,7 +1203,7 @@ module ApplicationTests
       require "mail"
       _ = ActionMailer::Base
 
-      assert_equal [::MyMailInterceptor, ::MyOtherMailInterceptor], ::Mail.class_variable_get(:@@delivery_interceptors)
+      assert_equal [::MyMailInterceptor, ::MyOtherMailInterceptor], ActionMailer::Base.interceptors
     end
 
     test "registers preview interceptors with ActionMailer" do


### PR DESCRIPTION
### Summary

Added `interceptors` as a class attribute in ActionMailer::Base, so that `ActionMailer::Base.interceptors` returns the registered interceptors.

Also changed the test cases in railties where `::Mail.class_variable_get(:@@delivery_interceptors)` was used to verify the registered interceptors. Instead it can be done like `ActionMailer::Base.interceptors`, just like how preview interceptors are fetched like -> `ActionMailer::Base.preview_interceptors`
