### PR TITLE
Add missing require to activerecord base_test.rb

### DIFF
--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -30,6 +30,7 @@ require "models/pet"
 require "models/owner"
 require "concurrent/atomic/count_down_latch"
 require "active_support/core_ext/enumerable"
+require "active_support/core_ext/kernel/reporting"
 
 class FirstAbstractClass < ActiveRecord::Base
   self.abstract_class = true


### PR DESCRIPTION
as  silence_warnings  is used.

### Summary

When running without Bundler, this needs to be required manually.

### Other Information

We're running tests in Fedora (packaging), for integration with OS, without Bundler, as the repositories are handled on the OS level. Tests are run as follows:
```
 ruby -Itest:lib -e 'Dir.glob("./test/cases/**/*_test.rb").sort.each{ |f| require f }'
```