### PR TITLE
fix rubocop errors

### DIFF
--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -340,7 +340,7 @@ module ActiveStorage
         end
 
         def validate_transformation(name, argument)
-          method_name = name.to_s.gsub("-","_")
+          method_name = name.to_s.tr("-", "_")
 
           unless SUPPORTED_IMAGE_PROCESSING_METHODS.any? { |method| method_name == method }
             raise UnsupportedImageProcessingMethod, <<~ERROR.squish

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -237,7 +237,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
       end
 
       assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
-        blob.variant(resize: [123, {"-write /tmp/file.erb": "something"}, "/tmp/file.erb"]).processed
+        blob.variant(resize: [123, { "-write /tmp/file.erb": "something" }, "/tmp/file.erb"]).processed
       end
     end
   end
@@ -246,7 +246,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     process_variants_with :mini_magick do
       blob = create_file_blob(filename: "racecar.jpg")
       assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
-        blob.variant(saver: {"-write": "/tmp/file.erb"}).processed
+        blob.variant(saver: { "-write": "/tmp/file.erb" }).processed
       end
     end
   end
@@ -255,11 +255,11 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
     process_variants_with :mini_magick do
       blob = create_file_blob(filename: "racecar.jpg")
       assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
-        blob.variant(saver: {"something": {"-write": "/tmp/file.erb"}}).processed
+        blob.variant(saver: { "something": { "-write": "/tmp/file.erb" } }).processed
       end
 
       assert_raise(ActiveStorage::Transformers::ImageProcessingTransformer::UnsupportedImageProcessingArgument) do
-        blob.variant(saver: {"something": ["-write", "/tmp/file.erb"]}).processed
+        blob.variant(saver: { "something": ["-write", "/tmp/file.erb"] }).processed
       end
     end
   end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3136,7 +3136,7 @@ module ApplicationTests
       app "development"
 
       assert ActiveStorage.unsupported_image_processing_arguments.include?("-danger")
-      refute ActiveStorage.unsupported_image_processing_arguments.include?("-set")
+      assert_not ActiveStorage.unsupported_image_processing_arguments.include?("-set")
     end
 
     test "hosts include .localhost in development" do


### PR DESCRIPTION
### Summary

Using `bundle exec rubocop -a` and visually verified