### PR TITLE
Instrument Action Mailbox processing

### DIFF
--- a/actionmailbox/app/models/action_mailbox/inbound_email.rb
+++ b/actionmailbox/app/models/action_mailbox/inbound_email.rb
@@ -43,6 +43,14 @@ module ActionMailbox
     def processed?
       delivered? || failed? || bounced?
     end
+
+    def instrumentation_payload # :nodoc:
+      {
+        id: id,
+        message_id: message_id,
+        status: status
+      }
+    end
   end
 end
 

--- a/actionmailbox/test/unit/mailbox/notifications_test.rb
+++ b/actionmailbox/test/unit/mailbox/notifications_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+class RepliesMailbox < ActionMailbox::Base
+end
+
+class ActionMailbox::Base::NotificationsTest < ActiveSupport::TestCase
+  test "instruments processing" do
+    events = []
+    ActiveSupport::Notifications.subscribe("process.action_mailbox") do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    RepliesMailbox.receive create_inbound_email_from_fixture("welcome.eml")
+
+    assert_equal 1, events.length
+    assert_equal "process.action_mailbox", events[0].name
+    assert_equal(
+      {
+        mailbox: "RepliesMailbox",
+        inbound_email: {
+          id: 1,
+          message_id: "0CB459E0-0336-41DA-BC88-E6E28C697DDB@37signals.com",
+          status: "processing"
+        }
+      },
+      events[0].payload
+    )
+  ensure
+    ActiveSupport::Notifications.unsubscribe("process.action_mailbox")
+  end
+end


### PR DESCRIPTION
### Summary

Use ActiveSupport::Notifications to instrument Action Mailbox for logging or performance monitoring.

cc @packagethief 