### PR TITLE
ActiveSupport::OrderedOptions handle custom #dig

### DIFF
--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -40,6 +40,10 @@ module ActiveSupport
       super(key.to_sym)
     end
 
+    def dig(*keys)
+      super(*keys.flatten.map(&:to_sym))
+    end
+
     def method_missing(name, *args)
       name_string = +name.to_s
       if name_string.chomp!("=")

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -36,6 +36,16 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     end
   end
 
+  def test_string_dig
+    a = ActiveSupport::OrderedOptions.new
+
+    a[:test_key] = 56
+    assert_equal 56, a.test_key
+    assert_equal 56, a['test_key']
+    assert_equal 56, a.dig(:test_key)
+    assert_equal 56, a.dig('test_key')
+  end
+
   def test_method_access
     a = ActiveSupport::OrderedOptions.new
 


### PR DESCRIPTION
### Summary

Common access via `#[](arg)` is being casted to symbol, same behavior should be provided on using #dig in order be consistent
