### PR TITLE
Removed unwanted requires of `tempfile` and fix rubocop errors

### DIFF
--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -32,7 +32,6 @@ require "models/task"
 require "models/topic"
 require "models/traffic_light"
 require "models/treasure"
-require "tempfile"
 
 class FixturesTest < ActiveRecord::TestCase
   include ConnectionHelper

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -41,9 +41,9 @@ class OrderedOptionsTest < ActiveSupport::TestCase
 
     a[:test_key] = 56
     assert_equal 56, a.test_key
-    assert_equal 56, a['test_key']
+    assert_equal 56, a["test_key"]
     assert_equal 56, a.dig(:test_key)
-    assert_equal 56, a.dig('test_key')
+    assert_equal 56, a.dig("test_key")
   end
 
   def test_method_access

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -5,7 +5,6 @@ require "env_helpers"
 require "rails/command"
 require "rails/commands/credentials/credentials_command"
 require "fileutils"
-require "tempfile"
 
 class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation, EnvHelpers


### PR DESCRIPTION
### Summary

Removed unwanted requires of `tempfile` and fixed rubocop errors from https://github.com/rails/rails/pull/44644

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->