### PR TITLE
Allow relative redirects when `raise_on_open_redirects` is enabled

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow relative redirects when `raise_on_open_redirects` is enabled
+
+    *Tom Hughes*
+
 *   Allow Content Security Policy DSL to generate for API responses.
 
     *Tim Wade*

--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -195,7 +195,7 @@ module ActionController
       end
 
       def _url_host_allowed?(url)
-        URI(url.to_s).host == request.host
+        [request.host, nil].include?(URI(url.to_s).host)
       rescue ArgumentError, URI::Error
         false
       end

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -88,6 +88,10 @@ class RedirectController < ActionController::Base
     redirect_back_or_to "http://www.rubyonrails.org/"
   end
 
+  def only_path_redirect
+    redirect_to action: "other_host", only_path: true
+  end
+
   def safe_redirect_with_fallback
     redirect_to url_from(params[:redirect_url]) || "/fallback"
   end
@@ -497,6 +501,14 @@ class RedirectTest < ActionController::TestCase
       end
 
       assert_equal "Unsafe redirect to \"http://www.rubyonrails.org/\", pass allow_other_host: true to redirect anyway.", error.message
+    end
+  end
+
+  def test_only_path_redirect
+    with_raise_on_open_redirects do
+      get :only_path_redirect
+      assert_response :redirect
+      assert_redirected_to "/redirect/other_host"
     end
   end
 


### PR DESCRIPTION
### Summary

Redirecting to a URL generated with `only_path: true` should be allowed when open redirect protection is enabled because a relative URL with no host refers to the same host.