### PR TITLE
Fixed MariaDB default function

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Fixed MariaDB default function support.
+
+    Defaults would be written wrong in "db/schema.rb" and not work correctly
+    if using `db:schema:load`. Further more the function name would be
+    added as string content when saving new records.
+
+    *kaspernj*
+
 *   Add `active_record.destroy_association_async_batch_size` configuration
 
     This allows applications to specify the maximum number of records that will

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -1347,6 +1347,32 @@ if ActiveRecord::Base.connection.supports_bulk_alter?
       assert_equal "This is a comment", column(:birthdate).comment
     end
 
+    if supports_text_column_with_default?
+      def test_default_functions_on_columns
+        with_bulk_change_table do |t|
+          if current_adapter?(:PostgreSQLAdapter)
+            t.string :name, default: -> { "gen_random_uuid()" }
+          else
+            t.string :name, default: -> { "UUID()" }
+          end
+        end
+
+        assert_nil column(:name).default
+
+        if current_adapter?(:PostgreSQLAdapter)
+          assert_equal "gen_random_uuid()", column(:name).default_function
+          Person.connection.execute("INSERT INTO delete_me DEFAULT VALUES")
+          person_data = Person.connection.execute("SELECT * FROM delete_me ORDER BY id DESC").to_a.first
+        else
+          assert_equal "uuid()", column(:name).default_function
+          Person.connection.execute("INSERT INTO delete_me () VALUES ()")
+          person_data = Person.connection.execute("SELECT * FROM delete_me ORDER BY id DESC").to_a(as: :hash).first
+        end
+
+        assert_match(/\A(.+)-(.+)-(.+)-(.+)\Z/, person_data.fetch("name"))
+      end
+    end
+
     if current_adapter?(:Mysql2Adapter)
       def test_updating_auto_increment
         with_bulk_change_table do |t|

--- a/activerecord/test/cases/schema_dumper_test.rb
+++ b/activerecord/test/cases/schema_dumper_test.rb
@@ -825,7 +825,16 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
       t.datetime :datetime_with_default, default: "2014-06-05 07:17:04"
       t.time     :time_with_default,     default: "07:17:04"
       t.decimal  :decimal_with_default,  default: "1234567890.0123456789", precision: 20, scale: 10
-      t.text :text_with_default, default: "John' Doe" if supports_text_column_with_default?
+
+      if supports_text_column_with_default?
+        t.text :text_with_default, default: "John' Doe"
+
+        if current_adapter?(:PostgreSQLAdapter)
+          t.text :uuid, default: -> { "gen_random_uuid()" }
+        else
+          t.text :uuid, default: -> { "uuid()" }
+        end
+      end
     end
 
     if current_adapter?(:PostgreSQLAdapter)
@@ -864,6 +873,12 @@ class SchemaDumperDefaultsTest < ActiveRecord::TestCase
     output = dump_table_schema("dump_defaults")
 
     assert_match %r{t\.text\s+"text_with_default",.*?default: "John' Doe"}, output
+
+    if current_adapter?(:PostgreSQLAdapter)
+      assert_match %r{t\.text\s+"uuid",.*?default: -> \{ "gen_random_uuid\(\)" \}}, output
+    else
+      assert_match %r{t\.text\s+"uuid",.*?default: -> \{ "uuid\(\)" \}}, output
+    end
   end if supports_text_column_with_default?
 
   def test_schema_dump_with_column_infinity_default


### PR DESCRIPTION
### Summary

Schema doesn't dump default functions correctly when using MariaDB, making them read as strings instead of functions. This can be a problem if you have a column that should get a UUID set automatically using a default function.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
