### PR TITLE
Change the Action Mailbox AS::Notification payload to include the mailbox instance

### DIFF
--- a/actionmailbox/lib/action_mailbox/base.rb
+++ b/actionmailbox/lib/action_mailbox/base.rb
@@ -108,7 +108,7 @@ module ActionMailbox
     private
       def instrumentation_payload
         {
-          mailbox: self.class.name,
+          mailbox: self,
           inbound_email: inbound_email.instrumentation_payload
         }
       end

--- a/actionmailbox/test/unit/mailbox/notifications_test.rb
+++ b/actionmailbox/test/unit/mailbox/notifications_test.rb
@@ -12,13 +12,14 @@ class ActionMailbox::Base::NotificationsTest < ActiveSupport::TestCase
       events << ActiveSupport::Notifications::Event.new(*args)
     end
 
-    RepliesMailbox.receive create_inbound_email_from_fixture("welcome.eml")
+    mailbox = RepliesMailbox.new(create_inbound_email_from_fixture("welcome.eml"))
+    mailbox.perform_processing
 
     assert_equal 1, events.length
     assert_equal "process.action_mailbox", events[0].name
     assert_equal(
       {
-        mailbox: "RepliesMailbox",
+        mailbox: mailbox,
         inbound_email: {
           id: 1,
           message_id: "0CB459E0-0336-41DA-BC88-E6E28C697DDB@37signals.com",


### PR DESCRIPTION
### Summary

Follows https://github.com/rails/rails/pull/44643

Change the AS::Notification payload to include the mailbox instance, rather than just the name.

This will supprt a greater range of use cases and is consistent with Active Job and ActionDispatch instrumentation which include the Job and Request objects respectively.

cc @packagethief 