### PR TITLE
Add bin/dev and Procfile.dev to new Rails apps

### DIFF
--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -96,6 +96,7 @@ If you wish to skip some files or components from being generated, you can appen
 | ----------------------- | ----------------------------------------------------------- |
 | `--skip-git`            | Skip .gitignore file                                        |
 | `--skip-keeps`          | Skip source control .keep files                             |
+| `--skip-bin-dev`        | Skip bin/dev and Procfile.dev files                         |
 | `--skip-action-mailer`  | Skip Action Mailer files                                    |
 | `--skip-action-mailbox` | Skip Action Mailbox gem                                     |
 | `--skip-action-text`    | Skip Action Text gem                                        |
@@ -111,27 +112,35 @@ If you wish to skip some files or components from being generated, you can appen
 | `--skip-system-test`    | Skip system test files                                      |
 | `--skip-bootsnap`       | Skip bootsnap gem                                           |
 
-### `bin/rails server`
+### `bin/dev`
 
-The `bin/rails server` command launches a web server named Puma which comes bundled with Rails. You'll use this any time you want to access your application through a web browser.
+The `bin/dev` command launches a web server named Puma which comes bundled with Rails. You'll use this any time you want to access your application through a web browser as well as start up any auxilary processes such as for background jobs or frontend bundlers.
 
-With no further work, `bin/rails server` will run our new shiny Rails app:
+With no further work, `bin/dev` will run our new shiny Rails app:
 
 ```bash
 $ cd commandsapp
-$ bin/rails server
-=> Booting Puma
-=> Rails 7.0.0 application starting in development
-=> Run `bin/rails server --help` for more startup options
-Puma starting in single mode...
-* Version 3.12.1 (ruby 2.5.7-p206), codename: Llamas in Pajamas
-* Min threads: 5, max threads: 5
-* Environment: development
-* Listening on tcp://localhost:3000
-Use Ctrl-C to stop
+$ bin/dev
+19:34:25 web.1  | started with pid 16429
+19:34:25 web.1  | => Booting Puma
+19:34:25 web.1  | => Rails 7.0.0 application starting in development
+19:34:25 web.1  | => Run `bin/rails server --help` for more startup options
+19:34:26 web.1  | Puma starting in single mode...
+19:34:26 web.1  | * Puma version: 5.6.2 (ruby 3.0.2-p107) ("Birdie's Version")
+19:34:26 web.1  | *  Min threads: 5
+19:34:26 web.1  | *  Max threads: 5
+19:34:26 web.1  | *  Environment: development
+19:34:26 web.1  | *          PID: 16429
+19:34:26 web.1  | * Listening on http://127.0.0.1:3000
+19:34:26 web.1  | * Listening on http://[::1]:3000
+19:34:26 web.1  | Use Ctrl-C to stop
 ```
 
 With just three commands we whipped up a Rails server listening on port 3000. Go to your browser and open [http://localhost:3000](http://localhost:3000), you will see a basic Rails app running.
+
+### `bin/rails server`
+
+To start only the Rails server, use the `bin/rails server` command.
 
 INFO: You can also use the alias "s" to start the server: `bin/rails s`.
 

--- a/guides/source/command_line.md
+++ b/guides/source/command_line.md
@@ -114,7 +114,7 @@ If you wish to skip some files or components from being generated, you can appen
 
 ### `bin/dev`
 
-The `bin/dev` command launches a web server named Puma which comes bundled with Rails. You'll use this any time you want to access your application through a web browser as well as start up any auxilary processes such as for background jobs or frontend bundlers.
+The `bin/dev` command launches a web server named Puma which comes bundled with Rails. You'll use this any time you want to access your application through a web browser as well as start up any auxiliary processes such as for background jobs or frontend bundlers.
 
 With no further work, `bin/dev` will run our new shiny Rails app:
 

--- a/guides/source/getting_started.md
+++ b/guides/source/getting_started.md
@@ -179,6 +179,7 @@ of the files and folders that Rails creates by default:
 |Gemfile<br>Gemfile.lock|These files allow you to specify what gem dependencies are needed for your Rails application. These files are used by the Bundler gem. For more information about Bundler, see the [Bundler website](https://bundler.io).|
 |lib/|Extended modules for your application.|
 |log/|Application log files.|
+|Procfile.dev|A local procfile that `bin/dev` executes to run a local Rails server and any additional processes.|
 |public/|Contains static files and compiled assets. When your app is running, this directory will be exposed as-is.|
 |Rakefile|This file locates and loads tasks that can be run from the command line. The task definitions are defined throughout the components of Rails. Rather than changing `Rakefile`, you should add your own tasks by adding files to the `lib/tasks` directory of your application.|
 |README.md|This is a brief instruction manual for your application. You should edit this file to tell others what your application does, how to set it up, and so on.|
@@ -203,11 +204,12 @@ start a web server on your development machine. You can do this by running the
 following command in the `blog` directory:
 
 ```bash
-$ bin/rails server
+$ bin/dev
 ```
 
-TIP: If you are using Windows, you have to pass the scripts under the `bin`
-folder directly to the Ruby interpreter e.g. `ruby bin\rails server`.
+TIP: If you are using Windows, you should use the Rails server command directly
+and have to pass the scripts under the `bin` folder directly to the Ruby
+interpreter e.g. `ruby bin\rails server`.
 
 TIP: JavaScript asset compression requires you
 have a JavaScript runtime available on your system, in the absence

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   New app generator includes `Procfile.dev` and `bin/dev`.
+
+    Based off of the files provided by `jsbundling-rails` and `cssbundling-rails`, a `bin/dev` binary which executes
+    `foreman` against a `Procfile.dev` file is now part of the default Rails install. This provides a single point
+    of entry for starting up a local environment (server, frontend bundling, background job processe, etc.).
+
+    Use `--skip-bin-dev` to skip these files for new apps.
+
+    *Tony Drake*
+
 *   No longer add autoloaded paths to `$LOAD_PATH`.
 
     This means it won't be possible to load them with a manual `require` call, the class or module can be referenced instead.

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -81,6 +81,9 @@ module Rails
         class_option :skip_bootsnap,       type: :boolean, default: false,
                                            desc: "Skip bootsnap gem"
 
+        class_option :skip_bin_dev,        type: :boolean, default: false,
+                                           desc: "Skip bin/dev and Procfile.dev generation"
+
         class_option :dev,                 type: :boolean, default: false,
                                            desc: "Set up the #{name} with Gemfile pointing to your Rails checkout"
 
@@ -464,6 +467,14 @@ module Rails
         else
           rails_command "css:install:#{options[:css]}"
         end
+      end
+
+      def run_bin_dev
+        return if options[:skip_bin_dev]
+
+        copy_file "dev", "bin/dev"
+        chmod "bin/dev", 0755, verbose: false
+        copy_file "Procfile.dev", "Procfile.dev"
       end
 
       def generate_bundler_binstub

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -503,6 +503,7 @@ module Rails
 
       public_task :apply_rails_template, :run_bundle
       public_task :generate_bundler_binstub
+      public_task :run_bin_dev
       public_task :run_javascript
       public_task :run_hotwire
       public_task :run_css

--- a/railties/lib/rails/generators/rails/app/templates/Procfile.dev.tt
+++ b/railties/lib/rails/generators/rails/app/templates/Procfile.dev.tt
@@ -1,0 +1,1 @@
+web: bin/rails server -p 3000

--- a/railties/lib/rails/generators/rails/app/templates/dev.tt
+++ b/railties/lib/rails/generators/rails/app/templates/dev.tt
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev "$@"

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -86,6 +86,12 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
     assert_no_directory "app/views"
   end
 
+  def test_generator_if_skip_bin_dev_is_given
+    run_generator [destination_root, "--api", "--skip-bin-dev"]
+    assert_no_file "bin/dev"
+    assert_no_file "Procfile.dev"
+  end
+
   def test_app_update_does_not_generate_unnecessary_config_files
     run_generator
 
@@ -121,6 +127,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
         app/views/layouts
         app/views/layouts/mailer.html.erb
         app/views/layouts/mailer.text.erb
+        bin/dev
         bin/rails
         bin/rake
         bin/setup
@@ -147,6 +154,7 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
         lib
         lib/tasks
         log
+        Procfile.dev
         test/fixtures
         test/controllers
         test/integration


### PR DESCRIPTION
### Summary

`jsbundling-rails`, `cssbundling-rails`, and `tailwindcss-rails` all introduce a new bin/dev and Procfile.dev file to the app when they are installed. This is a good thing as it allows developers to run one command to execute their Rails server and frontend build tools.

However, this change in flow is not very obvious to newcomers or even Rails developers with even moderate experience. Up until this point, they've been told to simply run `rails s` and they can start developing their app. It's not clear with the introduction of the bundling gems they need to run this separate command to get everything going unless they dig into the gems' README files. They are then left wondering why none of their Javascript or CSS changes are applying because its not obvious they have to run a separate process.

This change introduces `bin/dev` and `Procfile.dev` to Rails proper as first class citizens added on the defualt app install - regardless of `--javascript` or `--css` flags. A `--skip-bin-dev` flag was added to not generate those files.

`bin/dev` is identical to the one found in the bundling gems. Their installers will see the identical file and skip it. `Procfile.dev` includes only the "web" process which is also taken from the bundling gems.

So why even have `Procfile.dev` if it only has one service in it? If the default workflow of Rails apps going forward uses `bin/dev` to start/stop the dev stack, this can result in a more smoother transition from importmaps/raw css into the bundling gems as developers would already be using `bin/dev`. The gems would append to `Procfile.dev` and no other change would be needed on the developer's part. Also, this allows for other gems such as `sidekiq`, `resque`, `shackapacker`, `goodjob`, etc (which also need their own separate process while working locally) to slide into the Rails flow easily as one would append a new service to `Procfile.dev`.

### Other Information

Added a changelog entry and did my best to modify some existing guides.
