### PR TITLE
Fix ChatRelayJob definition in Testing Guide

### DIFF
--- a/guides/source/testing.md
+++ b/guides/source/testing.md
@@ -1950,7 +1950,7 @@ If you want to test the broadcasting made with `Channel.broadcast_to`, you shoul
 ```ruby
 # app/jobs/chat_relay_job.rb
 class ChatRelayJob < ApplicationJob
-  def perform_later(room, message)
+  def perform(room, message)
     ChatChannel.broadcast_to room, text: message
   end
 end


### PR DESCRIPTION
### Summary

The `ChatRelayJob` under "14.3 Custom Assertions And Testing Broadcasts Inside Other Components" defined a `perform_later` method, which I think should just be `perform`.