### PR TITLE
Fix typos [ci skip]

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 *   Fix `ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate` for Ruby 2.6.
 
-    Ruby 2.6 and 2.7 have slightly different implementations of the `String#@-` method.
-    In Ruby 2.6, the receiver of the `String#@-` method is modified under certain circumstances.
+    Ruby 2.6 and 2.7 have slightly different implementations of the `String#-@` method.
+    In Ruby 2.6, the receiver of the `String#-@` method is modified under certain circumstances.
     This was later identified as a bug (https://bugs.ruby-lang.org/issues/15926) and only
     fixed in Ruby 2.7.
 
     Before the changes in this commit, the
     `ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate` method, which internally
-    calls the `String#@-` method, could also modify an input string argument in Ruby 2.6 --
+    calls the `String#-@` method, could also modify an input string argument in Ruby 2.6 --
     changing a tainted, unfrozen string into a tainted, frozen string.
 
     Fixes #43056

--- a/activerecord/lib/active_record/connection_adapters/schema_cache.rb
+++ b/activerecord/lib/active_record/connection_adapters/schema_cache.rb
@@ -207,8 +207,8 @@ module ActiveRecord
               value.map { |i| deep_deduplicate(i) }
             when String
               if value.tainted?
-                # Ruby 2.6 and 2.7 have slightly different implementations of the String#@- method.
-                # In Ruby 2.6, the receiver of the String#@- method is modified under certain
+                # Ruby 2.6 and 2.7 have slightly different implementations of the String#-@ method.
+                # In Ruby 2.6, the receiver of the String#-@ method is modified under certain
                 # circumstances, and this was later identified as a bug
                 # (https://bugs.ruby-lang.org/issues/15926) and only fixed in Ruby 2.7.
                 value = value.dup


### PR DESCRIPTION
### Summary

This PR just fixes typos.

`String#@-` ->
`String#-@`