### PR TITLE
Remove unmaintained francesc/rails-translate-routes gem

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -272,7 +272,7 @@ get '/:locale' => 'dashboard#index'
 
 Do take special care about the **order of your routes**, so this route declaration does not "eat" other ones. (You may want to add it directly before the `root :to` declaration.)
 
-NOTE: Have a look at various gems which simplify working with routes: [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [rails-translate-routes](https://github.com/francesc/rails-translate-routes), [route_translator](https://github.com/enriclluelles/route_translator).
+NOTE: Have a look at various gems which simplify working with routes: [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master), [route_translator](https://github.com/enriclluelles/route_translator).
 
 #### Setting the Locale from User Preferences
 


### PR DESCRIPTION
## Summary

A docs change for i18n guides. The other two gems here are modern and kept up with modern Rails, and
this one hasn't. Last updated in 2012. So just removing it from the list of suitable gems

### Removing
https://github.com/francesc/rails-translate-routes

### Keeping
https://github.com/svenfuchs/routing-filter
https://github.com/enriclluelles/route_translator