### PR TITLE
Factor out `ActiveModel::AttributeRegistration`

### DIFF
--- a/activemodel/lib/active_model.rb
+++ b/activemodel/lib/active_model.rb
@@ -36,6 +36,7 @@ module ActiveModel
   autoload :Attributes
   autoload :AttributeAssignment
   autoload :AttributeMethods
+  autoload :AttributeRegistration
   autoload :BlockValidator, "active_model/validator"
   autoload :Callbacks
   autoload :Conversion

--- a/activemodel/lib/active_model/attribute/user_provided_default.rb
+++ b/activemodel/lib/active_model/attribute/user_provided_default.rb
@@ -4,6 +4,10 @@ require "active_model/attribute"
 
 module ActiveModel
   class Attribute # :nodoc:
+    def with_user_default(value)
+      UserProvidedDefault.new(name, value, type, self.is_a?(FromDatabase) ? self : original_attribute)
+    end
+
     class UserProvidedDefault < FromUser # :nodoc:
       def initialize(name, value, type, database_default)
         @user_provided_value = value

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -358,6 +358,10 @@ module ActiveModel
       end
 
       private
+        def resolve_attribute_name(name)
+          attribute_aliases.fetch(super, &:itself)
+        end
+
         def generated_attribute_methods
           @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
         end

--- a/activemodel/lib/active_model/attribute_registration.rb
+++ b/activemodel/lib/active_model/attribute_registration.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/class/subclasses"
+require "active_model/attribute_set"
+require "active_model/attribute/user_provided_default"
+
+module ActiveModel
+  module AttributeRegistration # :nodoc:
+    extend ActiveSupport::Concern
+
+    module ClassMethods # :nodoc:
+      def attribute(name, type = nil, default: (no_default = true), **options)
+        type = resolve_type_name(type, **options) if type.is_a?(Symbol)
+
+        pending = pending_attribute(name)
+        pending.type = type if type
+        pending.default = default unless no_default
+
+        reset_default_attributes
+      end
+
+      def _default_attributes # :nodoc:
+        @default_attributes ||= build_default_attributes
+      end
+
+      def attribute_types # :nodoc:
+        @attribute_types ||= _default_attributes.cast_types.tap do |hash|
+          hash.default = Type.default_value
+        end
+      end
+
+      private
+        class PendingAttribute # :nodoc:
+          attr_accessor :type, :default
+
+          def apply_to(attribute)
+            attribute = attribute.with_type(type || attribute.type)
+            attribute = attribute.with_user_default(default) if defined?(@default)
+            attribute
+          end
+        end
+
+        def pending_attribute(name)
+          @pending_attributes ||= {}
+          @pending_attributes[resolve_attribute_name(name)] ||= PendingAttribute.new
+        end
+
+        def apply_pending_attributes(attribute_set)
+          superclass.send(__method__, attribute_set) if superclass.respond_to?(__method__, true)
+
+          defined?(@pending_attributes) && @pending_attributes.each do |name, pending|
+            attribute_set[name] = pending.apply_to(attribute_set[name])
+          end
+
+          attribute_set
+        end
+
+        def build_default_attributes
+          apply_pending_attributes(AttributeSet.new({}))
+        end
+
+        def reset_default_attributes
+          @default_attributes = nil
+          @attribute_types = nil
+          subclasses.each { |subclass| subclass.send(__method__) }
+        end
+
+        def resolve_attribute_name(name)
+          name.to_s
+        end
+
+        def resolve_type_name(name, **options)
+          Type.lookup(name, **options)
+        end
+    end
+  end
+end

--- a/activemodel/lib/active_model/attribute_set.rb
+++ b/activemodel/lib/active_model/attribute_set.rb
@@ -21,6 +21,10 @@ module ActiveModel
       @attributes[name] = value
     end
 
+    def cast_types
+      attributes.transform_values(&:type)
+    end
+
     def values_before_type_cast
       attributes.transform_values(&:value_before_type_cast)
     end
@@ -37,6 +41,7 @@ module ActiveModel
     def key?(name)
       attributes.key?(name) && self[name].initialized?
     end
+    alias :include? :key?
 
     def keys
       attributes.each_key.select { |name| self[name].initialized? }

--- a/activemodel/test/cases/attribute_registration_test.rb
+++ b/activemodel/test/cases/attribute_registration_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+module ActiveModel
+  class AttributeRegistrationTest < ActiveModel::TestCase
+    MyType = Class.new(Type::Value)
+    Type.register(MyType.name.to_sym, MyType)
+    TYPE_1 = MyType.new(precision: 1)
+    TYPE_2 = MyType.new(precision: 2)
+
+    test "attributes can be registered" do
+      attributes = default_attributes_for { attribute :foo, TYPE_1 }
+      assert_same TYPE_1, attributes["foo"].type
+    end
+
+    test "the default type is used when type is omitted" do
+      attributes = default_attributes_for { attribute :foo }
+      assert_equal Type::Value.new, attributes["foo"].type
+    end
+
+    test "type is resolved when specified by name" do
+      attributes = default_attributes_for { attribute :foo, MyType.name.to_sym }
+      assert_instance_of MyType, attributes["foo"].type
+    end
+
+    test "type options are forwarded when type is specified by name" do
+      attributes = default_attributes_for { attribute :foo, MyType.name.to_sym, precision: 123 }
+      assert_equal 123, attributes["foo"].type.precision
+    end
+
+    test "default value can be specified" do
+      attributes = default_attributes_for do
+        attribute :foo, TYPE_1, default: 123
+        attribute :bar, TYPE_2
+        attribute :bar, default: 456
+      end
+
+      assert_same TYPE_1, attributes["foo"].type
+      assert_equal 123, attributes["foo"].value
+      assert_same TYPE_2, attributes["bar"].type
+      assert_equal 456, attributes["bar"].value
+    end
+
+    test "default value can be nil" do
+      attributes = default_attributes_for do
+        attribute :foo, default: nil
+        attribute :bar
+      end
+
+      assert_predicate attributes["foo"], :came_from_user?
+      assert_not_predicate attributes["bar"], :came_from_user?
+    end
+
+    test "attribute_types reflects registered attribute types" do
+      klass = class_with { attribute :foo, TYPE_1 }
+      assert_same TYPE_1, klass.attribute_types["foo"]
+    end
+
+    test "attribute_types returns the default type when key is missing" do
+      klass = class_with { attribute :foo, TYPE_1 }
+      assert_equal Type::Value.new, klass.attribute_types["bar"]
+    end
+
+    test "new attributes can be registered at any time" do
+      klass = class_with { attribute :foo, TYPE_1 }
+      assert_includes klass._default_attributes, "foo"
+      assert_not_includes klass._default_attributes, "bar"
+      assert_same TYPE_1, klass.attribute_types["foo"]
+
+      klass.attribute :bar, TYPE_2
+      assert_includes klass._default_attributes, "foo"
+      assert_includes klass._default_attributes, "bar"
+      assert_same TYPE_1, klass.attribute_types["foo"]
+      assert_same TYPE_2, klass.attribute_types["bar"]
+    end
+
+    test "attributes are inherited" do
+      parent = class_with do
+        attribute :foo, TYPE_1, default: 123
+      end
+
+      child = Class.new(parent)
+
+      assert_same parent._default_attributes["foo"].type, child._default_attributes["foo"].type
+      assert_same parent._default_attributes["foo"].value, child._default_attributes["foo"].value
+    end
+
+    test "subclass attributes do not affect superclass" do
+      parent = class_with { attribute :foo }
+      child = class_with(parent) { attribute :bar }
+
+      assert_not_includes parent._default_attributes, "bar"
+      assert_includes child._default_attributes, "bar"
+    end
+
+    test "new superclass attributes are inherited even after subclass attributes are registered" do
+      parent = class_with { attribute :foo }
+      child = class_with(parent) { attribute :bar }
+      parent.attribute :qux
+
+      assert_includes child._default_attributes, "qux"
+    end
+
+    test "new superclass attributes do not override subclass attributes" do
+      parent = class_with { attribute :bar }
+      child = class_with(parent) { attribute :foo, TYPE_1 }
+      parent.attribute :foo, TYPE_2
+
+      assert_same TYPE_1, child._default_attributes["foo"].type
+    end
+
+    test "superclass attributes can be overridden" do
+      parent = class_with { attribute :foo, TYPE_1 }
+      child = class_with(parent) { attribute :foo, TYPE_2 }
+
+      assert_same TYPE_2, child._default_attributes["foo"].type
+      assert_same TYPE_1, parent._default_attributes["foo"].type
+    end
+
+    test "superclass default values can be overridden" do
+      parent = class_with do
+        attribute :foo, TYPE_1, default: 123
+        attribute :bar, TYPE_2
+      end
+
+      child = class_with(parent) do
+        attribute :foo, default: 456
+        attribute :bar, default: 789
+      end
+
+      assert_same TYPE_1, child._default_attributes["foo"].type
+      assert_same TYPE_2, child._default_attributes["bar"].type
+      assert_equal 456, child._default_attributes["foo"].value
+      assert_equal 789, child._default_attributes["bar"].value
+      assert_equal 123, parent._default_attributes["foo"].value
+      assert_nil parent._default_attributes["bar"].value
+    end
+
+    private
+      def class_with(base_class = nil, &block)
+        Class.new(*base_class) do
+          include AttributeRegistration
+          instance_eval(&block)
+        end
+      end
+
+      def default_attributes_for(&block)
+        class_with(&block)._default_attributes
+      end
+  end
+end


### PR DESCRIPTION
As a step toward sharing more code between Active Model and Active Record, this commit factors an `ActiveModel::AttributeRegistration` module out of `ActiveModel::Attributes`.  This module is marked as `nodoc` and is for internal use only.

Additionally, this commit adds thorough test coverage of attribute registration and inheritance.  (`activemodel/test/cases/attributes_test.rb` does already test some of this behavior, but it is focused on high-level functionality.)

---

For some next steps, see #44665 and #44666.
