### PR TITLE
Use `ActiveModel::AttributeRegistration` in AR

### DIFF
--- a/activerecord/lib/active_record/attribute_methods/serialization.rb
+++ b/activerecord/lib/active_record/attribute_methods/serialization.rb
@@ -214,7 +214,9 @@ module ActiveRecord
 
           column_serializer = build_column_serializer(attr_name, coder, type, yaml)
 
-          attribute(attr_name, **options) do |cast_type|
+          attribute(attr_name, **options)
+
+          decorate_attributes([attr_name]) do |attr_name, cast_type|
             if type_incompatible_with_serialize?(cast_type, coder, type)
               raise ColumnNotSerializableError.new(attr_name, cast_type)
             end

--- a/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
+++ b/activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb
@@ -69,14 +69,14 @@ module ActiveRecord
       end
 
       module ClassMethods # :nodoc:
-        def define_attribute(name, cast_type, **)
-          if create_time_zone_conversion_attribute?(name, cast_type)
-            cast_type = TimeZoneConverter.new(cast_type)
-          end
-          super
-        end
-
         private
+          def hook_attribute_type(name, cast_type)
+            if create_time_zone_conversion_attribute?(name, cast_type)
+              cast_type = TimeZoneConverter.new(cast_type)
+            end
+            super
+          end
+
           def create_time_zone_conversion_attribute?(name, cast_type)
             enabled_for_column = time_zone_aware_attributes &&
               !skip_time_zone_conversion_for_attributes.include?(name.to_sym)

--- a/activerecord/lib/active_record/attributes.rb
+++ b/activerecord/lib/active_record/attributes.rb
@@ -6,12 +6,13 @@ module ActiveRecord
   # See ActiveRecord::Attributes::ClassMethods for documentation
   module Attributes
     extend ActiveSupport::Concern
+    include ActiveModel::AttributeRegistration
 
-    included do
-      class_attribute :attributes_to_define_after_schema_loads, instance_accessor: false, default: {} # :internal:
-    end
     # = Active Record \Attributes
     module ClassMethods
+      # :method: attribute
+      # :call-seq: attribute(name, cast_type = nil, **options)
+      #
       # Defines an attribute with a type on this model. It will override the
       # type of existing attributes if needed. This allows control over how
       # values are converted to and from SQL when assigned to a model. It also
@@ -205,37 +206,13 @@ module ActiveRecord
       # tracking is performed. The methods +changed?+ and +changed_in_place?+
       # will be called from ActiveModel::Dirty. See the documentation for those
       # methods in ActiveModel::Type::Value for more details.
-      def attribute(name, cast_type = nil, default: NO_DEFAULT_PROVIDED, **options)
-        name = name.to_s
-        name = attribute_aliases[name] || name
-
-        reload_schema_from_cache
-
-        case cast_type
-        when Symbol
-          cast_type = Type.lookup(cast_type, **options, adapter: Type.adapter_name_from(self))
-        when nil
-          if (prev_cast_type, prev_default = attributes_to_define_after_schema_loads[name])
-            default = prev_default if default == NO_DEFAULT_PROVIDED
-          else
-            prev_cast_type = -> subtype { subtype }
-          end
-
-          cast_type = if block_given?
-            -> subtype { yield Proc === prev_cast_type ? prev_cast_type[subtype] : prev_cast_type }
-          else
-            prev_cast_type
-          end
-        end
-
-        self.attributes_to_define_after_schema_loads =
-          attributes_to_define_after_schema_loads.merge(name => [cast_type, default])
-      end
+      #
+      #--
+      # Implemented by ActiveModel::AttributeRegistration#attribute.
 
       # This is the low level API which sits beneath +attribute+. It only
       # accepts type objects, and will do its work immediately instead of
-      # waiting for the schema to load. Automatic schema detection and
-      # ClassMethods#attribute both call this under the hood. While this method
+      # waiting for the schema to load. While this method
       # is provided so it can be used by plugin authors, application code
       # should probably use ClassMethods#attribute.
       #
@@ -260,13 +237,24 @@ module ActiveRecord
         define_default_attribute(name, default, cast_type, from_user: user_provided_default)
       end
 
-      def load_schema! # :nodoc:
-        super
-        attributes_to_define_after_schema_loads.each do |name, (cast_type, default)|
-          cast_type = cast_type[type_for_attribute(name)] if Proc === cast_type
-          define_attribute(name, cast_type, default: default)
+      def _default_attributes # :nodoc:
+        @default_attributes ||= begin
+          attributes_hash = columns_hash.transform_values do |column|
+            ActiveModel::Attribute.from_database(column.name, column.default, type_for_column(column))
+          end
+
+          attribute_set = ActiveModel::AttributeSet.new(attributes_hash)
+          apply_pending_attribute_modifications(attribute_set)
+          attribute_set
         end
       end
+
+      def reload_schema_from_cache(*)
+        reset_default_attributes!
+        super
+      end
+
+      alias :reset_default_attributes :reload_schema_from_cache
 
       private
         NO_DEFAULT_PROVIDED = Object.new # :nodoc:
@@ -286,6 +274,14 @@ module ActiveRecord
             default_attribute = ActiveModel::Attribute.from_database(name, value, type)
           end
           _default_attributes[name] = default_attribute
+        end
+
+        def resolve_type_name(name, **options)
+          Type.lookup(name, **options, adapter: Type.adapter_name_from(self))
+        end
+
+        def type_for_column(column)
+          hook_attribute_type(column.name, super)
         end
     end
   end

--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -84,7 +84,7 @@ module ActiveRecord
           def encrypt_attribute(name, key_provider: nil, key: nil, deterministic: false, support_unencrypted_data: nil, downcase: false, ignore_case: false, previous: [], **context_properties)
             encrypted_attributes << name.to_sym
 
-            attribute name do |cast_type|
+            decorate_attributes([name]) do |name, cast_type|
               scheme = scheme_for key_provider: key_provider, key: key, deterministic: deterministic, support_unencrypted_data: support_unencrypted_data, \
                 downcase: downcase, ignore_case: ignore_case, previous: previous, **context_properties
 

--- a/activerecord/lib/active_record/locking/optimistic.rb
+++ b/activerecord/lib/active_record/locking/optimistic.rb
@@ -182,14 +182,14 @@ module ActiveRecord
             super
           end
 
-          def define_attribute(name, cast_type, **) # :nodoc:
-            if lock_optimistically && name == locking_column
-              cast_type = LockingType.new(cast_type)
-            end
-            super
-          end
-
           private
+            def hook_attribute_type(name, cast_type)
+              if lock_optimistically && name == locking_column
+                cast_type = LockingType.new(cast_type)
+              end
+              super
+            end
+
             def inherited(base)
               super
               base.class_eval do

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -435,11 +435,6 @@ module ActiveRecord
         end
       end
 
-      def attribute_types # :nodoc:
-        load_schema
-        @attribute_types ||= Hash.new(Type.default_value)
-      end
-
       def yaml_encoder # :nodoc:
         @yaml_encoder ||= ActiveModel::AttributeSet::YAMLEncoder.new(attribute_types)
       end
@@ -491,11 +486,6 @@ module ActiveRecord
       def column_defaults
         load_schema
         @column_defaults ||= _default_attributes.deep_dup.to_hash.freeze
-      end
-
-      def _default_attributes # :nodoc:
-        load_schema
-        @default_attributes ||= ActiveModel::AttributeSet.new({})
       end
 
       # Returns an array of column names as strings.
@@ -577,9 +567,7 @@ module ActiveRecord
           @arel_table = nil
           @column_names = nil
           @symbol_column_to_string_name_hash = nil
-          @attribute_types = nil
           @content_columns = nil
-          @default_attributes = nil
           @column_defaults = nil
           @attributes_builder = nil
           @columns = nil
@@ -616,17 +604,7 @@ module ActiveRecord
           columns_hash = connection.schema_cache.columns_hash(table_name)
           columns_hash = columns_hash.except(*ignored_columns) unless ignored_columns.empty?
           @columns_hash = columns_hash.freeze
-          @columns_hash.each do |name, column|
-            type = connection.lookup_cast_type_from_column(column)
-            type = _convert_type_from_options(type)
-            define_attribute(
-              name,
-              type,
-              default: column.default,
-              user_provided_default: false
-            )
-            alias_attribute :id_value, :id if name == "id"
-          end
+          alias_attribute :id_value, :id if @columns_hash.key?("id")
 
           super
         end
@@ -654,12 +632,12 @@ module ActiveRecord
           end
         end
 
-        def _convert_type_from_options(type)
+        def type_for_column(column)
+          type = connection.lookup_cast_type_from_column(column)
           if immutable_strings_by_default && type.respond_to?(:to_immutable_string)
-            type.to_immutable_string
-          else
-            type
+            type = type.to_immutable_string
           end
+          type
         end
     end
   end

--- a/activerecord/lib/active_record/normalization.rb
+++ b/activerecord/lib/active_record/normalization.rb
@@ -78,10 +78,8 @@ module ActiveRecord # :nodoc:
       #
       #   User.normalize_value_for(:phone, "+1 (555) 867-5309") # => "5558675309"
       def normalizes(*names, with:, apply_to_nil: false)
-        names.each do |name|
-          attribute(name) do |cast_type|
-            NormalizedValueType.new(cast_type: cast_type, normalizer: with, normalize_nil: apply_to_nil)
-          end
+        decorate_attributes(names) do |name, cast_type|
+          NormalizedValueType.new(cast_type: cast_type, normalizer: with, normalize_nil: apply_to_nil)
         end
 
         self.normalized_attributes += names.map(&:to_sym)

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -128,7 +128,7 @@ class BasicsTest < ActiveRecord::TestCase
 
     Topic.reset_column_information
 
-    Topic.connection.stub(:lookup_cast_type_from_column, ->(_) { raise "Some Error" }) do
+    Topic.connection.stub(:schema_cache, -> { raise "Some Error" }) do
       assert_raises RuntimeError do
         Topic.columns_hash
       end


### PR DESCRIPTION
This refactors the `ActiveRecord::Attributes` module to use `ActiveModel::AttributeRegistration`.  This also replaces the block form of the `attribute` method (which was support by only Active Record) with `decorate_attributes` (which is supported by both Active Model and Active Record).  The block form of the `attribute` method was a private API, so no deprecation is necessary.