### PR TITLE
Use `controller_class_path` in `Rails::Generators::NamedBase#route_url`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,36 @@
+*   Use `controller_class_path` in `Rails::Generators::NamedBase#route_url`
+
+    The `route_url` method now returns the correct path when generating
+    a namespaced controller with a top-level model using `--model-name`.
+
+    Previously, when running this command:
+
+    ``` sh
+    bin/rails generate scaffold_controller Admin/Post --model-name Post
+    ```
+
+    the comments above the controller action would look like:
+
+    ``` ruby
+    # GET /posts
+    def index
+      @posts = Post.all
+    end
+    ```
+
+    afterwards, they now look like this:
+
+    ``` ruby
+    # GET /admin/posts
+    def index
+      @posts = Post.all
+    end
+    ```
+
+    Fixes #44662.
+
+    *Andrew White*
+
 *   No longer add autoloaded paths to `$LOAD_PATH`.
 
     This means it won't be possible to load them with a manual `require` call, the class or module can be referenced instead.

--- a/railties/lib/rails/generators/named_base.rb
+++ b/railties/lib/rails/generators/named_base.rb
@@ -127,7 +127,7 @@ module Rails
         end
 
         def route_url # :doc:
-          @route_url ||= class_path.collect { |dname| "/" + dname }.join + "/" + plural_file_name
+          @route_url ||= controller_class_path.collect { |dname| "/" + dname }.join + "/" + plural_file_name
         end
 
         def url_helper_prefix # :doc:

--- a/railties/test/generators/scaffold_controller_generator_test.rb
+++ b/railties/test/generators/scaffold_controller_generator_test.rb
@@ -207,14 +207,17 @@ class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
   def test_model_name_option
     run_generator ["Admin::User", "--model-name=User"]
     assert_file "app/controllers/admin/users_controller.rb" do |content|
+      assert_match "# GET /admin/users", content
       assert_instance_method :index, content do |m|
         assert_match("@users = User.all", m)
       end
 
+      assert_match "# POST /admin/users", content
       assert_instance_method :create, content do |m|
         assert_match("redirect_to [:admin, @user]", m)
       end
 
+      assert_match "# PATCH/PUT /admin/users/1", content
       assert_instance_method :update, content do |m|
         assert_match("redirect_to [:admin, @user]", m)
       end


### PR DESCRIPTION
The `route_url` method now returns the correct path when generating a namespaced controller with a top-level model using `--model-name`.

Previously, when running this command:

``` sh
bin/rails generate scaffold_controller Admin/Post --model-name Post
```

the comments above the controller action would look like:

``` ruby
# GET /posts
def index
  @posts = Post.all
end
```

afterwards, they now look like this:

``` ruby
# GET /admin/posts
def index
  @posts = Post.all
end
```

Fixes #44662.
