### PR TITLE
Keep`mail` gem version in `actionmailer` in sync with `actionmailbox`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
       actionview (= 7.1.0.alpha)
       activejob (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
-      mail (~> 2.5, >= 2.5.4)
+      mail (>= 2.7.1)
       net-imap
       net-pop
       net-smtp

--- a/actionmailer/actionmailer.gemspec
+++ b/actionmailer/actionmailer.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "actionview", version
   s.add_dependency "activejob", version
 
-  s.add_dependency "mail", ["~> 2.5", ">= 2.5.4"]
+  s.add_dependency "mail", ">= 2.7.1"
   s.add_dependency "net-imap"
   s.add_dependency "net-pop"
   s.add_dependency "net-smtp"


### PR DESCRIPTION
### Summary

This PR is just to make sure the version of `mail` in `actionmailer` is in sync with `actionmailbox` and is using the latest version.

Note: This PR will come in handy when progress is made in this PR -> https://github.com/rails/rails/pull/44638

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->