### PR TITLE
Fix typo in engines guide for reopening existing classes using concern [ci-skip]

### DIFF
--- a/guides/source/engines.md
+++ b/guides/source/engines.md
@@ -1163,9 +1163,9 @@ end
 module Blorgh::Concerns::Models::Article
   extend ActiveSupport::Concern
 
-  # 'included do' causes the included code to be evaluated in the
-  # context where it is included (article.rb), rather than being
-  # executed in the module's context (blorgh/concerns/models/article).
+  # `included do` causes the block to be evaluated in the context
+  # in which the module is included (i.e. Blorgh::Article),
+  # rather than in the module itself.
   included do
     attr_accessor :author_name
     belongs_to :author, class_name: "User"


### PR DESCRIPTION
### Summary

Fixed small typo in path to file in "Getting Started with Engines" guide
--> 6 Improving Engine Functionality
--> 6.1 Overriding Models and Controllers
--> 6.1.2 Reopening existing classes using ActiveSupport::Concern

Having
https://github.com/duffuniverse/rails/blob/main/guides/source/engines.md#reopening-existing-classes-using-activesupportconcern
```
# ---> Blorgh/lib/concerns/models/article.rb

module Blorgh::Concerns::Models::Article
  extend ActiveSupport::Concern

  ... 
  included do
    ...
  end
  ...
end
```

