### PR TITLE
rails new: inform user about Rails-chosen git branch name

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -488,6 +488,20 @@ module Rails
       def git_init_command
         return "git init" if user_default_branch.strip.present?
 
+        warn <<~INFO
+          [Warning] You didn't explicitly set your default git branch, so Rails take the
+          liberty to force you into a branch named 'main'. If you don't want this, run:
+
+          git config --global init.defaultBranch <your default branch name>
+
+          to set a default. To rename the branch in the generated application, run:
+
+          git branch -m <new branch name>
+
+          For more information, see the related discussion on Github:
+          https://github.com/rails/rails/pull/40254
+        INFO
+
         git_version = `git --version`[/\d+\.\d+\.\d+/]
 
         if Gem::Version.new(git_version) >= Gem::Version.new("2.28.0")


### PR DESCRIPTION
### Summary

This PR tries to avoid confusion caused by PR #40254 when calling `rails new` (i.e., enforcement of `main` git branch when the user didn’t explicitly make a choice, i.e., behaving differently than `git init`) by providing the information and context.

### Other Information

The current behaviour is a surprise behaviour, violating [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment) (Principle of least astonishment). Given rafaelfranca’s comment in the related PR, I don’t fix that, just add a necessary piece of information to save other people from surprises and wasted time in attempts to figure out what the heck is happening.

Given the scope of this PR, I don’t add a record to the changelog. If you think this PR deserves a record there, I’ll add it.