### PR TITLE
Fix syntax error in PrimaryApplicationRecord

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -132,7 +132,7 @@ should share a connection with.
 
 ```
 class PrimaryApplicationRecord < ActiveRecord::Base
-  self.primary_abstract_class
+  self.primary_abstract_class = true
 end
 ```
 


### PR DESCRIPTION
### Summary

The Rails guides for [Multiple Databases with Active Record](https://guides.rubyonrails.org/active_record_multiple_databases.html#setting-up-your-application) have a syntax error in one of the example codes. This fixes it.

`self.primary_abstract_class` → `self.primary_abstract_class = true`