### PR TITLE
Fixed rdoc typo highlighting for ActiveSupport::KeyGenerator class [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -33,17 +33,17 @@ module ActiveSupport
       @hash_digest_class = options[:hash_digest_class] || self.class.hash_digest_class
     end
 
-    # Returns a derived key suitable for use.  The default key_size is chosen
+    # Returns a derived key suitable for use.  The default +key_size+ is chosen
     # to be compatible with the default settings of ActiveSupport::MessageVerifier.
-    # i.e. OpenSSL::Digest::SHA1#block_length
+    # i.e. <tt>OpenSSL::Digest::SHA1#block_length</tt>
     def generate_key(salt, key_size = 64)
       OpenSSL::PKCS5.pbkdf2_hmac(@secret, salt, @iterations, key_size, @hash_digest_class.new)
     end
   end
 
   # CachingKeyGenerator is a wrapper around KeyGenerator which allows users to avoid
-  # re-executing the key generation process when it's called using the same salt and
-  # key_size.
+  # re-executing the key generation process when it's called using the same +salt+ and
+  # +key_size+.
   class CachingKeyGenerator
     def initialize(key_generator)
       @key_generator = key_generator


### PR DESCRIPTION
### Summary

`key_size` and `salt` in the KeyGenerator class doc should be highlighted.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
