### PR TITLE
ActiveStorage::Blobs::ProxyController breaks http1.x chunked responses by setting Content-Length Header

### DIFF
--- a/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/activestorage/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -16,7 +16,6 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
     else
       http_cache_forever public: true do
         response.headers["Accept-Ranges"] = "bytes"
-        response.headers["Content-Length"] = @blob.byte_size.to_s
 
         send_blob_stream @blob, disposition: params[:disposition]
       end

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -45,8 +45,13 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
   end
 
   test "Chunked responses don't set content length header" do
-    blob = create_blob data: "a" * 6.0625.megabytes # Large enough to start chunking
-    Rack::Response.prepend(Module.new { def chunked?; true; end}) # Bug in Rack::Response
+    blob = create_blob data: "a" * 5.0625.megabytes # Large enough to start chunking
+    # NOTE: Bug in Rack::Response prevents tests from passing, 
+    #       Rack Response sets Content-Length if chunked isn't set, however chunked middleware was depreciated
+    #       and setting that header isn't an application level concern.
+    #
+    # To emulate fix in Rack::Response uncomment below
+    # Rack::Response.prepend(Module.new { def chunked?; true; end}) 
     get rails_storage_proxy_url(blob)
     assert_nil response.headers["Content-Length"] # Forbidden by rfc2616 4.4 (chunked responses)
   end


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Any Downloads larger than 5MB fail in proxy mode for some Http 1.x clients.

ActiveStorage when configured with `resolve_model_to_route = :rails_storage_proxy` will break http 1.x clients due to the additional  "Content-Length" header that is forbidden by [rfc2616 section.4.4](https://datatracker.ietf.org/doc/html/rfc2616#section-4.4).

> ... The Content-Length header field MUST NOT be sent if these two lengths are different (i.e., if a Transfer-Encoding header field is present). ...

**Expected**: A request for a file larger than max chunksize (5MB in the case of ActiveStorage S3) will download successfully on all clients.

**Actual**: Curl, Fastly and other clients hang waiting for the full payload to be received. Eventually the web server persistent connection timeout occurs and download fails. 

### Other Information


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

The commit that introduced this behavior: https://github.com/rails/rails/pull/41437

Note: Some advanced clients and browsers seem to work intermittently depending their implementation. Chrome for example reports an error on PDFs > 5MB but on retry will complete the download.

There is also a potential issue with `Rack::Response` setting content length on responses that don't have the `Transfer-Encoding = chunked` header. Given this is a protocol dependent decision it doesn't seem like it belongs in Rails, it also may not belong in Rack given `Rack::Chunked` middleware is deprecated. Currently Puma sets the header for you if it detects a missing content-length and the appropriate protocol.

https://github.com/rack/rack/blob/main/lib/rack/response.rb#L334-L342


<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->

@tomify I saw your comments on 41437 and I think you might have been experiencing something similar with curl but might not have gotten to the bottom of it before the patch was merged. 