### PR TITLE
Fix typo

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -227,7 +227,7 @@ Outputs:
 </form>
 ```
 
-The are several things to notice here:
+There are several things to notice here:
 
 * The form `action` is automatically filled with an appropriate value for `@article`.
 * The form fields are automatically filled with the corresponding values from `@article`.


### PR DESCRIPTION
### Summary

Fix typo in Rails Guides.