### PR TITLE
Fixed typo: Github -> GitHub [ci-skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -189,7 +189,7 @@ To move on from submitting bugs to helping resolve existing issues or contributi
 
 #### The Easiest Way
 
-Start a Github Codespace from the repository and start developing right away from the browser IDE or in your local VScode. The Codespace is initialized with all required dependencies and allows you to run all tests.
+Start a GitHub Codespace from the repository and start developing right away from the browser IDE or in your local VScode. The Codespace is initialized with all required dependencies and allows you to run all tests.
 
 #### The Easy Way
 


### PR DESCRIPTION
### Summary

Fixes typo.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->