### PR TITLE
Fix migrations compatibility for polymorphic references default index name

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -198,6 +198,10 @@ module ActiveRecord
 
         def index_options(table_name)
           index_options = as_options(index)
+
+          # legacy reference index names are used on versions 6.0 and earlier
+          return index_options if options[:_uses_legacy_reference_index_name]
+
           index_options[:name] ||= polymorphic_index_name(table_name) if polymorphic
           index_options
         end

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -22,27 +22,10 @@ module ActiveRecord
           end
         end
 
-        module SQLite3
-          module TableDefinition
-            def references(*args, **options)
-              args.each do |ref_name|
-                ReferenceDefinition.new(ref_name, type: :integer, **options).add_to(self)
-              end
-            end
-            alias :belongs_to :references
-
-            def column(name, type, index: nil, **options)
-              options[:precision] ||= nil
-              super
-            end
-          end
-        end
-
         module TableDefinition
           def references(*args, **options)
-            args.each do |ref_name|
-              ReferenceDefinition.new(ref_name, **options).add_to(self)
-            end
+            options[:_uses_legacy_reference_index_name] = true
+            super
           end
           alias :belongs_to :references
         end
@@ -73,12 +56,11 @@ module ActiveRecord
 
         def add_reference(table_name, ref_name, **options)
           if connection.adapter_name == "SQLite"
-            reference_definition = ReferenceDefinition.new(ref_name, type: :integer, **options)
-          else
-            reference_definition = ReferenceDefinition.new(ref_name, **options)
+            options[:type] = :integer
           end
 
-          reference_definition.add_to(connection.update_table_definition(table_name, self))
+          options[:_uses_legacy_reference_index_name] = true
+          super
         end
         alias :add_belongs_to :add_reference
 
@@ -86,7 +68,6 @@ module ActiveRecord
           def compatible_table_definition(t)
             class << t
               prepend TableDefinition
-              prepend SQLite3::TableDefinition
             end
             t
           end
@@ -148,7 +129,7 @@ module ActiveRecord
             class << t
               prepend TableDefinition
             end
-            t
+            super
           end
 
           def command_recorder

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -269,72 +269,6 @@ module ActiveRecord
         end
       end
 
-      def test_create_table_with_polymorphic_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            create_table :more_testings do |t|
-              t.references :widget, polymorphic: true, index: true
-              t.belongs_to :gizmo, polymorphic: true, index: true
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
-      ensure
-        connection.drop_table :more_testings rescue nil
-      end
-
-      def test_change_table_with_polymorphic_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            change_table :testings do |t|
-              t.references :widget, polymorphic: true, index: true
-              t.belongs_to :gizmo, polymorphic: true, index: true
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
-      end
-
-      def test_create_join_table_with_polymorphic_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            create_join_table :more, :testings do |t|
-              t.references :widget, polymorphic: true, index: true
-              t.belongs_to :gizmo, polymorphic: true, index: true
-            end
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
-      ensure
-        connection.drop_table :more_testings rescue nil
-      end
-
-      def test_polymorphic_add_reference_uses_all_column_names_in_index
-        migration = Class.new(ActiveRecord::Migration[6.0]) {
-          def migrate(x)
-            add_reference :testings, :widget, polymorphic: true, index: true
-            add_belongs_to :testings, :gizmo, polymorphic: true, index: true
-          end
-        }.new
-
-        ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
-
-        assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
-        assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
-      end
-
       if current_adapter?(:SQLite3Adapter)
         def test_references_stays_as_integer_column_on_create_table_with_reference_6_0
           migration = Class.new(ActiveRecord::Migration[6.0]) {
@@ -388,6 +322,132 @@ module ActiveRecord
           end
         end
     end
+  end
+end
+
+module LegacyPolymorphicReferenceIndexTestCases
+  attr_reader :connection
+
+  def setup
+    @connection = ActiveRecord::Base.connection
+    @schema_migration = @connection.schema_migration
+    @verbose_was = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+
+    connection.create_table :testings, if_not_exists: true
+  end
+
+  def teardown
+    ActiveRecord::Migration.verbose = @verbose_was
+    ActiveRecord::SchemaMigration.delete_all rescue nil
+    connection.drop_table :testings rescue nil
+  end
+
+  def test_create_table_with_polymorphic_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        create_table :more_testings do |t|
+          t.references :widget, polymorphic: true, index: true
+          t.belongs_to :gizmo, polymorphic: true, index: true
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_change_table_with_polymorphic_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        change_table :testings do |t|
+          t.references :widget, polymorphic: true, index: true
+          t.belongs_to :gizmo, polymorphic: true, index: true
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
+  end
+
+  def test_create_join_table_with_polymorphic_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        create_join_table :more, :testings do |t|
+          t.references :widget, polymorphic: true, index: true
+          t.belongs_to :gizmo, polymorphic: true, index: true
+        end
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:more_testings, [:widget_type, :widget_id], name: :index_more_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:more_testings, [:gizmo_type, :gizmo_id], name: :index_more_testings_on_gizmo_type_and_gizmo_id)
+  ensure
+    connection.drop_table :more_testings rescue nil
+  end
+
+  def test_polymorphic_add_reference_uses_all_column_names_in_index
+    migration = Class.new(migration_class) {
+      def migrate(x)
+        add_reference :testings, :widget, polymorphic: true, index: true
+        add_belongs_to :testings, :gizmo, polymorphic: true, index: true
+      end
+    }.new
+
+    ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+
+    assert connection.index_exists?(:testings, [:widget_type, :widget_id], name: :index_testings_on_widget_type_and_widget_id)
+    assert connection.index_exists?(:testings, [:gizmo_type, :gizmo_id], name: :index_testings_on_gizmo_type_and_gizmo_id)
+  end
+end
+
+module LegacyPolymorphicReferenceIndexTest
+  class V6_0 < ActiveRecord::TestCase
+    include LegacyPolymorphicReferenceIndexTestCases
+
+    self.use_transactional_tests = false
+
+    private
+      def migration_class
+        ActiveRecord::Migration[6.0]
+      end
+  end
+
+  class V5_2 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[5.2]
+      end
+  end
+
+  class V5_1 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[5.1]
+      end
+  end
+
+  class V5_0 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[5.0]
+      end
+  end
+
+  class V4_2 < V6_0
+    private
+      def migration_class
+        ActiveRecord::Migration[4.2]
+      end
   end
 end
 


### PR DESCRIPTION
Backport of https://github.com/rails/rails/pull/42350 to `6-1-stable`.

@rafaelfranca 