### PR TITLE
Return the Rails versions as an instance of `Gem::Version`

### DIFF
--- a/railties/lib/rails/version.rb
+++ b/railties/lib/rails/version.rb
@@ -3,8 +3,8 @@
 require_relative "gem_version"
 
 module Rails
-  # Returns the version of the currently loaded Rails as a string.
+  # Returns the version of the currently loaded Rails as a <tt>Gem::Version</tt>.
   def self.version
-    VERSION::STRING
+    gem_version
   end
 end


### PR DESCRIPTION
### Summary

Returns the rails version in railties gem as an instance of `Gem::Version` as all other gems part of rails follow the same pattern.

Eg:

Active Storage:

https://github.com/rails/rails/blob/f01fee7fc49371c28a1a59ed406f7ee00fcda3bf/activestorage/lib/active_storage/version.rb#L5-L10

Active Record:

https://github.com/rails/rails/blob/f01fee7fc49371c28a1a59ed406f7ee00fcda3bf/activerecord/lib/active_record/version.rb#L5-L10

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->