### PR TITLE
remove extra core_ext/object/blank requires

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/column.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/object/blank"
-
 module ActiveRecord
   module ConnectionAdapters
     module PostgreSQL

--- a/activesupport/lib/active_support/duration/iso8601_serializer.rb
+++ b/activesupport/lib/active_support/duration/iso8601_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/object/blank"
-
 module ActiveSupport
   class Duration
     # Serializes duration to string according to ISO 8601 Duration format.

--- a/activesupport/lib/active_support/number_helper/number_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_converter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/big_decimal/conversions"
-require "active_support/core_ext/object/blank"
 require "active_support/core_ext/hash/keys"
 require "active_support/i18n"
 require "active_support/core_ext/class/attribute"

--- a/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
+++ b/activesupport/lib/active_support/number_helper/number_to_phone_converter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/blank"
 require "active_support/number_helper/number_converter"
 
 module ActiveSupport

--- a/railties/lib/rails/rack/logger.rb
+++ b/railties/lib/rails/rack/logger.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/time/conversions"
-require "active_support/core_ext/object/blank"
 require "active_support/log_subscriber"
 require "rack/body_proxy"
 


### PR DESCRIPTION
### Summary

`activerecord/lib/active_record/connection_adapters/postgresql/column.rb`
- usage added in 64fd666
- unneeded because of active_support/rails: 8f58d6e

`railties/lib/rails/rack/logger.rb`
- usage added in c83d9a1
- usage removed in c131211

`activesupport/lib/active_support/number_helper/number_converter.rb`
- the NumberHelper was split into multiple classes in 2da9d67, however
  the require was left in NumberConverter even though
  NumberToPhoneConverter is the only class where it's used

`activesupport/lib/active_support/duration/iso8601_serializer.rb`
- usage added in 04c512d
- usage removed in 51e991f
