### PR TITLE
Add Action Cable command callbacks at the connection level

### DIFF
--- a/actioncable/CHANGELOG.md
+++ b/actioncable/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Added command callbacks to `ActionCable::Base::Connection`.
 
+    Now you can define `before_command`, `after_command`, and `around_command` to be invoked before, after or around any command received by a client respectively.
+
+    *Vladimir Dementyev*
 
 Please check [7-0-stable](https://github.com/rails/rails/blob/7-0-stable/actioncable/CHANGELOG.md) for previous changes.

--- a/actioncable/lib/action_cable/connection/callbacks.rb
+++ b/actioncable/lib/action_cable/connection/callbacks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "active_support/callbacks"
+
+module ActionCable
+  module Connection
+    module Callbacks
+      extend  ActiveSupport::Concern
+      include ActiveSupport::Callbacks
+
+      included do
+        define_callbacks :command
+      end
+
+      module ClassMethods
+        def before_command(*methods, &block)
+          set_callback(:command, :before, *methods, &block)
+        end
+
+        def after_command(*methods, &block)
+          set_callback(:command, :after, *methods, &block)
+        end
+
+        def around_command(*methods, &block)
+          set_callback(:command, :around, *methods, &block)
+        end
+      end
+    end
+  end
+end

--- a/actioncable/test/connection/callbacks_test.rb
+++ b/actioncable/test/connection/callbacks_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "stubs/test_server"
+
+class ActionCable::Connection::CallbacksTest < ActionCable::TestCase
+  class Connection < ActionCable::Connection::Base
+    identified_by :context
+
+    attr_reader :commands_counter
+
+    before_command do
+      throw :abort unless context.nil?
+    end
+
+    around_command :set_current_context
+    after_command :increment_commands_counter
+
+    def initialize(*)
+      super
+      @commands_counter = 0
+    end
+
+    private
+      def set_current_context
+        self.context = request.params["context"]
+        yield
+      ensure
+        self.context = nil
+      end
+
+      def increment_commands_counter
+        @commands_counter += 1
+      end
+  end
+
+  class ChatChannel < ActionCable::Channel::Base
+    class << self
+      attr_accessor :words_spoken, :subscribed_count
+    end
+
+    self.words_spoken = []
+    self.subscribed_count = 0
+
+    def subscribed
+      self.class.subscribed_count += 1
+    end
+
+    def speak(data)
+      self.class.words_spoken << { data: data, context: context }
+    end
+  end
+
+  setup do
+    @server = TestServer.new
+    @env = Rack::MockRequest.env_for "/test", "HTTP_HOST" => "localhost", "HTTP_CONNECTION" => "upgrade", "HTTP_UPGRADE" => "websocket"
+    @connection = Connection.new(@server, @env)
+    @identifier = { channel: "ActionCable::Connection::CallbacksTest::ChatChannel" }.to_json
+  end
+
+  attr_reader :server, :env, :connection, :identifier
+
+  test "before and after callbacks" do
+    result = assert_difference -> { ChatChannel.subscribed_count }, +1 do
+      assert_difference -> { connection.commands_counter }, +1 do
+        connection.handle_channel_command({ "identifier" => identifier, "command" => "subscribe" })
+      end
+    end
+    assert result
+  end
+
+  test "before callback halts" do
+    connection.context = "non_null"
+    result = assert_no_difference -> { ChatChannel.subscribed_count } do
+      connection.handle_channel_command({ "identifier" => identifier, "command" => "subscribe" })
+    end
+    assert_not result
+  end
+
+  test "around_command callback" do
+    env["QUERY_STRING"] = "context=test"
+    connection = Connection.new(server, env)
+
+    assert_difference -> { ChatChannel.words_spoken.size }, +1 do
+      # We need to add subscriptions first
+      connection.handle_channel_command({
+        "identifier" => identifier,
+        "command" => "subscribe"
+      })
+      connection.handle_channel_command({
+        "identifier" => identifier,
+        "command" => "message",
+        "data" =>  { "action" => "speak", "message" => "hello" }.to_json
+      })
+    end
+
+    message = ChatChannel.words_spoken.last
+    assert_equal({ data: { "action" => "speak", "message" => "hello" }, context: "test" }, message)
+  end
+end


### PR DESCRIPTION
### Summary

This PR adds support for _command_ callbacks to `ActionCable::Connection::Base`. For example, 
the `before_command` callback is invoked before a command is processed by a channel. The `after_command` and `around_command` callbacks work similarly.

### Other Information

The main motivation behind this PR is to make working with multi-tenant apps easier. Most multi-tenancy libs (apartment, acts_as_tenant to name a few) provide an API to set the current tenant for the block. To make sure that channels code is executed within a particular context, we had to either add smth like `Tenant.switch! tenant` before every action (too error-prone) or patching the `#dispatch_websocket_message` method (better, but _hacky_):

```ruby
class Connection < ActionCable::Base::Connection
  def dispatch_websocket_message(*)
    using_current_tenant { super }
  end
end
```

I believe, we need an _official API_ for that (and other similar use cases). With the proposed API, the example above could be rewritten as:

```ruby
class Connection < ActionCable::Base::Connection
  around_command :set_current_tenant

  private

  def set_current_tenant
    using_current_tenant { yield }
  end
end
```
