### PR TITLE
fix net-smtp load error regex in 6.1.5

### DIFF
--- a/actionmailbox/lib/action_mailbox/mail_with_error_handling.rb
+++ b/actionmailbox/lib/action_mailbox/mail_with_error_handling.rb
@@ -3,7 +3,7 @@
 begin
   require "mail"
 rescue LoadError => error
-  if error.message.match?(/net-smtp/)
+  if error.message.match?(/net\/smtp/)
     $stderr.puts "You don't have net-smtp installed in your application. Please add it to your Gemfile and run bundle install"
     raise
   end

--- a/actionmailer/lib/action_mailer/mail_with_error_handling.rb
+++ b/actionmailer/lib/action_mailer/mail_with_error_handling.rb
@@ -3,7 +3,7 @@
 begin
   require "mail"
 rescue LoadError => error
-  if error.message.match?(/net-smtp/)
+  if error.message.match?(/net\/smtp/)
     $stderr.puts "You don't have net-smtp installed in your application. Please add it to your Gemfile and run bundle install"
     raise
   end


### PR DESCRIPTION
### Summary

Currently, trying to load ActionMailer in 6.1 without adding net-smtp to
the gemfile will result in an error like this:

```
$ bin/rails zeitwerk:check
Hold on, I am eager loading the application.
rails aborted!
NameError: uninitialized constant Mail::TestMailer

      delegate :deliveries, :deliveries=, to: Mail::TestMailer
                                                  ^^^^^^^^^^^^
/Users/hmcguire/test/sixonefive/app/mailers/application_mailer.rb:1:in `<main>'
/Users/hmcguire/test/sixonefive/bin/rails:5:in `<top (required)>'
/Users/hmcguire/test/sixonefive/bin/spring:10:in `block in <top (required)>'
/Users/hmcguire/test/sixonefive/bin/spring:7:in `<top (required)>'
Tasks: TOP => zeitwerk:check
(See full trace by running task with --trace)
```

This commit fixes the regex so that requiring mail no longer fails
silently:

```
irb(main):002:1* begin
irb(main):003:1*   require "mail"
irb(main):004:1* rescue LoadError => error
irb(main):005:1*   error
irb(main):006:0> end
=> #<LoadError: cannot load such file -- net/smtp>

irb(main):010:0> error.message.match?(/net-smtp/)
=> false
irb(main):011:0> error.message.match?(/net\/smtp/)
=> true
```

### Other Information

I understand 6.1 is security fix only, however I wanted to raise this issue because the current error messaging is quite confusing.
