### PR TITLE
Remove sanitize_limit method since ActiveModel::Attribute alerady use…

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -439,20 +439,6 @@ module ActiveRecord
         "DEFAULT VALUES"
       end
 
-      # Sanitizes the given LIMIT parameter in order to prevent SQL injection.
-      #
-      # The +limit+ may be anything that can evaluate to a string via #to_s. It
-      # should look like an integer, or an Arel SQL literal.
-      #
-      # Returns Integer and Arel::Nodes::SqlLiteral limits as is.
-      def sanitize_limit(limit)
-        if limit.is_a?(Integer) || limit.is_a?(Arel::Nodes::SqlLiteral)
-          limit
-        else
-          Integer(limit)
-        end
-      end
-
       # Fixture value is quoted by Arel, however scalar values
       # are not quotable. In this case we want to convert
       # the column value to YAML.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1351,7 +1351,7 @@ module ActiveRecord
 
         arel.where(where_clause.ast) unless where_clause.empty?
         arel.having(having_clause.ast) unless having_clause.empty?
-        arel.take(build_cast_value("LIMIT", connection.sanitize_limit(limit_value))) if limit_value
+        arel.take(build_cast_value("LIMIT", limit_value.to_i)) if limit_value
         arel.skip(build_cast_value("OFFSET", offset_value.to_i)) if offset_value
         arel.group(*arel_columns(group_values.uniq)) unless group_values.empty?
 

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -166,24 +166,6 @@ class BasicsTest < ActiveRecord::TestCase
     assert_equal 1, Topic.limit(2).limit(1).to_a.length
   end
 
-  def test_invalid_limit
-    assert_raises(ArgumentError) do
-      Topic.limit("asdfadf").to_a
-    end
-  end
-
-  def test_limit_should_sanitize_sql_injection_for_limit_without_commas
-    assert_raises(ArgumentError) do
-      Topic.limit("1 select * from schema").to_a
-    end
-  end
-
-  def test_limit_should_sanitize_sql_injection_for_limit_with_commas
-    assert_raises(ArgumentError) do
-      Topic.limit("1, 7 procedure help()").to_a
-    end
-  end
-
   def test_select_symbol
     topic_ids = Topic.select(:id).map(&:id).sort
     assert_equal Topic.pluck(:id).sort, topic_ids


### PR DESCRIPTION
…s BindParam

### Summary

Remove sanitize_limit method since ActiveModel::Attribute already uses BindParam.

Issue [44489](https://github.com/rails/rails/issues/44489) has covered the topic.

### Other Information

NA

