### PR TITLE
Fixes NoMethodError in Rails::Conductor::ActionMailbox::InboundEmailsController#create

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,7 +22,8 @@ module Rails
       def new_mail
         Mail.new(mail_params.except(:attachments).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
-          mail_params[:attachments].to_a.each do |attachment|
+          mail_params[:attachments]&.each do |attachment|
+            next if attachment.blank?
             mail.add_file(filename: attachment.original_filename, content: attachment.read)
           end
         end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -72,6 +72,27 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
     end
   end
 
+  test "create inbound email without attachments" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_emails_path, params: {
+          mail: {
+            from: "Jason Fried <jason@37signals.com>",
+            to: "Replies <replies@example.com>",
+            subject: "There is no attachment",
+            body: "There is no attachment this time.",
+            attachments: [ "" ]
+          }
+        }
+      end
+
+      mail = ActionMailbox::InboundEmail.last.mail
+      assert_equal "There is no attachment this time.", mail.body.decoded
+      assert_equal 0, mail.attachments.count
+      assert_equal [], mail.attachments.collect(&:filename)
+    end
+  end
+
   private
     def with_rails_env(env)
       old_rails_env = Rails.env


### PR DESCRIPTION
### Summary

If you generate a new application and enable ActionMailbox, when accessing `http://localhost:3000/rails/conductor/action_mailbox/inbound_emails` to test emails locally, and try to send an email (including attachments or not), it raises the following error: 

```
NoMethodError in Rails::Conductor::ActionMailbox::InboundEmailsController#create

undefined method `original_filename' for "":String
```

It turns out, when we are sending files from a multiple file input, even if there is no file, the `file` params will always have an empty string as the first element of the files param. Something like:

```
#<ActionController::Parameters {"title"=>"post 2", "body"=>"post number 2", "images"=>["", #<ActionDispatch::Http::UploadedFile:0x00007fe35eef0be8 ...">, ....]} permitted: true>
```

This PR is my attempt to fix that. I am not sure if this is the right approach, so feel free to guide me in the right direction. 