### PR TITLE
Fixes test cases for ActiveSupport multibyte chars

### DIFF
--- a/activesupport/test/multibyte_chars_test.rb
+++ b/activesupport/test/multibyte_chars_test.rb
@@ -111,8 +111,9 @@ class MultibyteCharsUTF8BehaviourTest < ActiveSupport::TestCase
   %w{capitalize downcase lstrip reverse rstrip swapcase upcase}.each do |method|
     class_eval(<<-EOTESTS, __FILE__, __LINE__ + 1)
       def test_#{method}_bang_should_return_self_when_modifying_wrapped_string
-        chars = ' él piDió Un bUen café '.dup
-        assert_equal chars.object_id, chars.public_send("#{method}!").object_id
+        original = ' él piDió Un bUen café '.dup
+        proxy = chars(original.dup)
+        assert_equal proxy.object_id, proxy.public_send("#{method}!").object_id
       end
 
       def test_#{method}_bang_should_change_wrapped_string


### PR DESCRIPTION
### Summary

Tests cases for `ActiveSupport::Multbyte::Chars` string methods should use the correct class as a proxy for testing, instead of relying on the `String` class itself.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->