### PR TITLE
Prefer Active Support's autoload method over ruby's autoload method

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -35,7 +35,7 @@ require "active_support/core_ext/string/inflections"
 require "active_support/lazy_load_hooks"
 
 module ActionMailer
-  extend ::ActiveSupport::Autoload
+  extend ActiveSupport::Autoload
 
   eager_autoload do
     autoload :Collector

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -89,11 +89,13 @@ module ActionDispatch
   end
 
   module Session
-    autoload :AbstractStore,       "action_dispatch/middleware/session/abstract_store"
+    extend ActiveSupport::Autoload
+
+    autoload :AbstractStore
     autoload :AbstractSecureStore, "action_dispatch/middleware/session/abstract_store"
-    autoload :CookieStore,         "action_dispatch/middleware/session/cookie_store"
-    autoload :MemCacheStore,       "action_dispatch/middleware/session/mem_cache_store"
-    autoload :CacheStore,          "action_dispatch/middleware/session/cache_store"
+    autoload :CookieStore
+    autoload :MemCacheStore
+    autoload :CacheStore
   end
 
   mattr_accessor :test_app

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -16,6 +16,8 @@ require "active_support/core_ext/array/conversions"
 
 module ActionDispatch
   class Request
+    extend ActiveSupport::Autoload
+
     include Rack::Request::Helpers
     include ActionDispatch::Http::Cache::Request
     include ActionDispatch::Http::MimeNegotiation
@@ -26,8 +28,8 @@ module ActionDispatch
     include ActionDispatch::PermissionsPolicy::Request
     include Rack::Request::Env
 
-    autoload :Session, "action_dispatch/request/session"
-    autoload :Utils,   "action_dispatch/request/utils"
+    autoload :Session
+    autoload :Utils
 
     LOCALHOST   = Regexp.union [/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, /^::1$/, /^0:0:0:0:0:0:0:1(%.*)?$/]
 

--- a/actionview/lib/action_view/template/handlers.rb
+++ b/actionview/lib/action_view/template/handlers.rb
@@ -4,10 +4,12 @@ module ActionView # :nodoc:
   # = Action View Template Handlers
   class Template # :nodoc:
     module Handlers # :nodoc:
-      autoload :Raw, "action_view/template/handlers/raw"
+      extend ActiveSupport::Autoload
+
+      autoload :Raw
       autoload :ERB, "action_view/template/handlers/erb"
-      autoload :Html, "action_view/template/handlers/html"
-      autoload :Builder, "action_view/template/handlers/builder"
+      autoload :Html
+      autoload :Builder
 
       def self.extended(base)
         base.register_default_template_handler :raw, Raw.new

--- a/activerecord/lib/active_record/associations.rb
+++ b/activerecord/lib/active_record/associations.rb
@@ -262,14 +262,16 @@ module ActiveRecord
     autoload :ThroughAssociation
 
     module Builder # :nodoc:
-      autoload :Association,           "active_record/associations/builder/association"
-      autoload :SingularAssociation,   "active_record/associations/builder/singular_association"
-      autoload :CollectionAssociation, "active_record/associations/builder/collection_association"
+      extend ActiveSupport::Autoload
 
-      autoload :BelongsTo,           "active_record/associations/builder/belongs_to"
-      autoload :HasOne,              "active_record/associations/builder/has_one"
-      autoload :HasMany,             "active_record/associations/builder/has_many"
-      autoload :HasAndBelongsToMany, "active_record/associations/builder/has_and_belongs_to_many"
+      autoload :association
+      autoload :SingularAssociation
+      autoload :CollectionAssociation
+
+      autoload :BelongsTo
+      autoload :HasOne
+      autoload :HasMany
+      autoload :HasAndBelongsToMany
     end
 
     eager_autoload do

--- a/activerecord/lib/active_record/associations/preloader.rb
+++ b/activerecord/lib/active_record/associations/preloader.rb
@@ -45,10 +45,10 @@ module ActiveRecord
       extend ActiveSupport::Autoload
 
       eager_autoload do
-        autoload :Association,        "active_record/associations/preloader/association"
-        autoload :Batch,              "active_record/associations/preloader/batch"
-        autoload :Branch,             "active_record/associations/preloader/branch"
-        autoload :ThroughAssociation, "active_record/associations/preloader/through_association"
+        autoload :Association
+        autoload :Batch
+        autoload :Branch
+        autoload :ThroughAssociation
       end
 
       attr_reader :records, :associations, :scope, :associate_by_default

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -545,9 +545,11 @@ module ActiveRecord
   # Remember that you can still open your own transactions, even if you
   # are in a Migration with <tt>self.disable_ddl_transaction!</tt>.
   class Migration
-    autoload :CommandRecorder, "active_record/migration/command_recorder"
-    autoload :Compatibility, "active_record/migration/compatibility"
-    autoload :JoinTable, "active_record/migration/join_table"
+    extend ActiveSupport::Autoload
+
+    autoload :CommandRecorder
+    autoload :Compatibility
+    autoload :JoinTable
 
     # This must be defined before the inherited hook, below
     class Current < Migration # :nodoc:

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -12,11 +12,13 @@ require "active_support/core_ext/string/inflections"
 module ActiveSupport
   # See ActiveSupport::Cache::Store for documentation.
   module Cache
-    autoload :FileStore,        "active_support/cache/file_store"
-    autoload :MemoryStore,      "active_support/cache/memory_store"
-    autoload :MemCacheStore,    "active_support/cache/mem_cache_store"
-    autoload :NullStore,        "active_support/cache/null_store"
-    autoload :RedisCacheStore,  "active_support/cache/redis_cache_store"
+    extend ActiveSupport::Autoload
+
+    autoload :FileStore
+    autoload :MemoryStore
+    autoload :MemCacheStore
+    autoload :NullStore
+    autoload :RedisCacheStore
 
     # These options mean something to all cache implementations. Individual cache
     # implementations may support additional options.
@@ -30,7 +32,9 @@ module ActiveSupport
     }.freeze
 
     module Strategy
-      autoload :LocalCache, "active_support/cache/strategy/local_cache"
+      extend ActiveSupport::Autoload
+
+      autoload :LocalCache
     end
 
     @format_version = 6.1

--- a/activesupport/lib/active_support/multibyte.rb
+++ b/activesupport/lib/active_support/multibyte.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require "active_support/dependencies/autoload"
+
 module ActiveSupport # :nodoc:
   module Multibyte
-    autoload :Chars, "active_support/multibyte/chars"
-    autoload :Unicode, "active_support/multibyte/unicode"
+    extend ActiveSupport::Autoload
+
+    autoload :Chars
+    autoload :Unicode
 
     # The proxy class returned when calling mb_chars. You can use this accessor
     # to configure your own proxy class so you can support other encodings. See

--- a/activesupport/lib/active_support/time.rb
+++ b/activesupport/lib/active_support/time.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  autoload :Duration, "active_support/duration"
-  autoload :TimeWithZone, "active_support/time_with_zone"
-  autoload :TimeZone, "active_support/values/time_zone"
+  extend ActiveSupport::Autoload
+
+  autoload :Duration
+  autoload :TimeWithZone
+  autoload :TimeZone
 end
 
 require "date"

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -59,12 +59,14 @@ module Rails
   # 10. Run +config.before_eager_load+ and +eager_load!+ if +eager_load+ is +true+.
   # 11. Run +config.after_initialize+ callbacks.
   class Application < Engine
-    autoload :Bootstrap,              "rails/application/bootstrap"
-    autoload :Configuration,          "rails/application/configuration"
-    autoload :DefaultMiddlewareStack, "rails/application/default_middleware_stack"
-    autoload :Finisher,               "rails/application/finisher"
-    autoload :Railties,               "rails/engine/railties"
-    autoload :RoutesReloader,         "rails/application/routes_reloader"
+    extend ActiveSupport::Autoload
+
+    autoload :Bootstrap
+    autoload :Configuration
+    autoload :DefaultMiddlewareStack
+    autoload :Finisher
+    autoload :Railties
+    autoload :RoutesReloader
 
     class << self
       def inherited(base)

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -347,7 +347,9 @@ module Rails
   #   # load Blog::Engine with highest priority, followed by application and other railties
   #   config.railties_order = [Blog::Engine, :main_app, :all]
   class Engine < Railtie
-    autoload :Configuration, "rails/engine/configuration"
+    extend ActiveSupport::Autoload
+
+    autoload :Configuration
 
     class << self
       attr_accessor :called_from, :isolated

--- a/railties/lib/rails/generators.rb
+++ b/railties/lib/rails/generators.rb
@@ -15,17 +15,18 @@ require "active_support/core_ext/string/inflections"
 
 module Rails
   module Generators
+    extend ActiveSupport::Autoload
     include Rails::Command::Behavior
 
-    autoload :Actions,         "rails/generators/actions"
-    autoload :ActiveModel,     "rails/generators/active_model"
-    autoload :Base,            "rails/generators/base"
-    autoload :Migration,       "rails/generators/migration"
-    autoload :Database,        "rails/generators/database"
-    autoload :AppName,         "rails/generators/app_name"
-    autoload :NamedBase,       "rails/generators/named_base"
-    autoload :ResourceHelpers, "rails/generators/resource_helpers"
-    autoload :TestCase,        "rails/generators/test_case"
+    autoload :Actions
+    autoload :ActiveModel
+    autoload :Base
+    autoload :Migration
+    autoload :Database
+    autoload :AppName
+    autoload :NamedBase
+    autoload :ResourceHelpers
+    autoload :TestCase
 
     mattr_accessor :namespace
 

--- a/railties/lib/rails/rack.rb
+++ b/railties/lib/rails/rack.rb
@@ -2,6 +2,8 @@
 
 module Rails
   module Rack
-    autoload :Logger, "rails/rack/logger"
+    extend ActiveSupport::Autoload
+
+    autoload :Logger
   end
 end

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -134,7 +134,9 @@ module Rails
   #
   # Be sure to look at the documentation of those specific classes for more information.
   class Railtie
-    autoload :Configuration, "rails/railtie/configuration"
+    extend ActiveSupport::Autoload
+
+    autoload :Configuration
 
     extend ActiveSupport::DescendantsTracker
     include Initializable


### PR DESCRIPTION
### Summary

Prefer Active Support's autoload over ruby's autoload method. Replaced throughout the repository where Active Support's autoload method can be used.