### PR TITLE
Auto-create user and grant privs when creating dbs

### DIFF
--- a/.devcontainer/boot.sh
+++ b/.devcontainer/boot.sh
@@ -14,11 +14,5 @@ sudo su postgres -c "createdb -O vscode -E UTF8 -T template0 activerecord_unitte
 sudo su postgres -c "createdb -O vscode -E UTF8 -T template0 activerecord_unittest2"
 
 # Create MySQL database and databases
-MYSQL_PWD=root sudo mysql -uroot <<SQL
-CREATE USER 'rails'@'localhost';
-CREATE DATABASE activerecord_unittest  DEFAULT CHARACTER SET utf8mb4;
-CREATE DATABASE activerecord_unittest2 DEFAULT CHARACTER SET utf8mb4;
-GRANT ALL PRIVILEGES ON activerecord_unittest.* to 'rails'@'localhost';
-GRANT ALL PRIVILEGES ON activerecord_unittest2.* to 'rails'@'localhost';
-GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to 'rails'@'localhost';
-SQL
+cd activerecord
+MYSQL_CODESPACES=1 bundle exec rake db:mysql:build

--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -201,8 +201,24 @@ namespace :db do
       ["--user=#{config["username"]}", "--password=#{config["password"]}", ("--host=#{config["host"]}" if config["host"]), ("--socket=#{config["socket"]}" if config["socket"])].join(" ")
     end
 
+    desc "Create the MySQL Rails User"
+    task :build_user do
+      if ENV["MYSQL_CODESPACES"]
+        mysql_command = "sudo mysql -uroot -proot -e"
+      else
+        mysql_command = "mysql -uroot -e"
+      end
+
+      config = ARTest.config["connections"]["mysql2"]
+      %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit"]["username"]}'@'localhost';" )
+      %x( #{mysql_command} "CREATE USER IF NOT EXISTS '#{config["arunit2"]["username"]}'@'localhost';" )
+      %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit"]["database"]}.* to '#{config["arunit"]["username"]}'@'localhost'" )
+      %x( #{mysql_command} "GRANT ALL PRIVILEGES ON #{config["arunit2"]["database"]}.* to '#{config["arunit2"]["username"]}'@'localhost'" )
+      %x( #{mysql_command} "GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to '#{config["arunit"]["username"]}'@'localhost';" )
+    end
+
     desc "Build the MySQL test databases"
-    task :build do
+    task build: ["db:mysql:build_user"] do
       config = ARTest.config["connections"]["mysql2"]
       %x( mysql #{connection_arguments["arunit"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
       %x( mysql #{connection_arguments["arunit2"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )


### PR DESCRIPTION
Everytime I need to set up Rails locally on a new computer I have to
search for how to do this, then login to mysql, and run all these
commands.

In this change creating the rails user and running the grants is now
part of the `mysql` build rake task. This will default to using the
`root` user and no password. If this becomes problematic we can make it
configurable with env vars. I created the `rails` user twice for each
database defined even though the user is the same. This is in case we
decide to change it later on for arunit2.

I'll update the https://guides.rubyonrails.org/development_dependencies_install.html after this is merged. 