### PR TITLE
Add `:scope` as a valid option to associations

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add `scope` as a valid option for associations
+
+    This allows models to define scopes for associations also via the `:scope` option as opposed
+    to passing it as an argument. Previously, the scope had to be the second argument and it was
+    not possible to define a scope for associations as an option. Now, it's possible to define a
+    scope as an option for associations like so:
+
+    ```ruby
+    class Topic < ActiveRecord::Base
+      has_many :categories, scope: -> { where(visible: true) }
+    end
+    ```
+
+    *Ghouse Mohamed*
+
 *   Fixed MariaDB default function support.
 
     Defaults would be written wrong in "db/schema.rb" and not work correctly


### PR DESCRIPTION
### Summary

This PR adds `:scope` as one of the valid options to pass to associations. Right now,
the way we can define the scope for associations is by passing a `Proc` or lambda as the
second argument to the association. But with this change, it now also possible to pass it as
one of the options. It makes for more a readable experience, and the associations are not bound
to define the scope as the second argument always. Now we can also define scopes for
associations like so: 

```ruby
class Topic < ActiveRecord::Base
    has_many :categories, class_name: "Category", scope: -> { where(visible: true) }
end
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

Here's why I thought this might be a good addition to Active Record:

During my development, I wanted to set the scope for one of my associations. And I was passing
the scope (Proc) at the end of options like so:

```ruby
class Topic < ActiveRecord::Base
    has_many :categories, class_name: "Category", scope: -> { where(visible: true) }
end
```

Through intuition, I expected this to work. But instead, the scope did not seem to work. Then after
going through the documentation, I realized, the scope *had* to passed as the second argument.
After this, I thought it might be a good idea to allow the `:scope` option as one of the valid options.

I might be out of my depth on this one, please let me know your thoughts.

Thanks!