### PR TITLE
Prevent Active Record instances from being used as params in test requests

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Prevent Active Record instances from being used as params in test requests
+
+    Integration tests will now raise an `ActionDispatch::IntegrationTest::InvalidParamError`
+    when an Active Record instance is used as a param. This prevents common test mistakes like:
+
+    ```ruby
+    post comments_path, params: { comment: comment } # should be comment.id
+    ```
+
+    This check only occurs when using the default params encoder.
+
+    *Alex Ghiculescu*
+
 *   Allow relative redirects when `raise_on_open_redirects` is enabled
 
     *Tom Hughes*

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -631,6 +631,8 @@ module ActionDispatch
   class IntegrationTest < ActiveSupport::TestCase
     include TestProcess::FixtureFile
 
+    InvalidParamError = Class.new(ArgumentError)
+
     module UrlOptions
       extend ActiveSupport::Concern
       def url_options

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -1199,6 +1199,34 @@ class IntegrationRequestEncodersTest < ActionDispatch::IntegrationTest
     end
 end
 
+module ActiveRecord
+  class Base; end
+end
+
+class IntegrationInvalidParamsTest < ActionDispatch::IntegrationTest
+  class Foo < ActiveRecord::Base; end
+
+  class FooController < ActionController::Base
+    def foos
+      render plain: "ok"
+    end
+  end
+
+  def test_prevents_ar_objects_as_params
+    with_routing do |routes|
+      routes.draw do
+        ActiveSupport::Deprecation.silence do
+          post ":action" => FooController
+        end
+      end
+
+      assert_raise(ActionDispatch::IntegrationTest::InvalidParamError) do
+        post "/foos", params: { foo: Foo.new }
+      end
+    end
+  end
+end
+
 class IntegrationFileUploadTest < ActionDispatch::IntegrationTest
   class IntegrationController < ActionController::Base
     def test_file_upload


### PR DESCRIPTION
This upstreams a runtime check we have to prevent invalid params in test requests that could lead to false positives in testing. We check for a variety of things, some of which are domain specific. Something that is *not* domain specific is Active Record instances - there's no scenario I can think of where `params[:key]` should be an AR instance, as opposed to its ID.

An example of the sort of test code this is meant to prevent:

```ruby
delete comments_path, params: { comment: comment } # should be comment.id
```

With this PR, tests that have incorrect params will raise an `ActionDispatch::IntegrationTest::InvalidParamError`.