### PR TITLE
Prefer using `<<` operator over `+=` for string concatenation for performance benefits

### DIFF
--- a/actioncable/lib/action_cable/channel/base.rb
+++ b/actioncable/lib/action_cable/channel/base.rb
@@ -210,7 +210,7 @@ module ActionCable
         # the proper channel identifier marked as the recipient.
         def transmit(data, via: nil) # :doc:
           status = "#{self.class.name} transmitting #{data.inspect.truncate(300)}"
-          status += " (via #{via})" if via
+          status << " (via #{via})" if via
           logger.debug(status)
 
           payload = { channel_class: self.class.name, data: data, via: via }

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -36,7 +36,7 @@ module ActionDispatch
       def reqs
         @reqs ||= begin
           reqs = endpoint
-          reqs += " #{constraints}" unless constraints.empty?
+          reqs << " #{constraints}" unless constraints.empty?
           reqs
         end
       end

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -824,7 +824,7 @@ module ActionDispatch
         path = route_with_params.path(method_name)
 
         if options[:trailing_slash] && !options[:format] && !path.end_with?("/")
-          path += "/"
+          path << "/"
         end
 
         params = route_with_params.params

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -232,7 +232,7 @@ module ActionDispatch
 
             if url_host = location.host
               default = Rack::Request::DEFAULT_PORTS[location.scheme]
-              url_host += ":#{location.port}" if default != location.port
+              url_host << ":#{location.port}" if default != location.port
               host! url_host
             end
           end

--- a/actionview/lib/action_view/helpers/asset_tag_helper.rb
+++ b/actionview/lib/action_view/helpers/asset_tag_helper.rb
@@ -100,9 +100,9 @@ module ActionView
           href = path_to_javascript(source, path_options)
           if preload_links_header && !options["defer"] && href.present? && !href.start_with?("data:")
             preload_link = "<#{href}>; rel=#{rel}; as=script"
-            preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
-            preload_link += "; integrity=#{integrity}" unless integrity.nil?
-            preload_link += "; nopush" if nopush
+            preload_link << "; crossorigin=#{crossorigin}" unless crossorigin.nil?
+            preload_link << "; integrity=#{integrity}" unless integrity.nil?
+            preload_link << "; nopush" if nopush
             preload_links << preload_link
           end
           tag_options = {
@@ -180,9 +180,9 @@ module ActionView
           href = path_to_stylesheet(source, path_options)
           if preload_links_header && href.present? && !href.start_with?("data:")
             preload_link = "<#{href}>; rel=preload; as=style"
-            preload_link += "; crossorigin=#{crossorigin}" unless crossorigin.nil?
-            preload_link += "; integrity=#{integrity}" unless integrity.nil?
-            preload_link += "; nopush" if nopush
+            preload_link << "; crossorigin=#{crossorigin}" unless crossorigin.nil?
+            preload_link << "; integrity=#{integrity}" unless integrity.nil?
+            preload_link << "; nopush" if nopush
             preload_links << preload_link
           end
           tag_options = {
@@ -336,10 +336,10 @@ module ActionView
         }.merge!(options.symbolize_keys))
 
         preload_link = "<#{href}>; rel=#{rel}; as=#{as_type}"
-        preload_link += "; type=#{mime_type}" if mime_type
-        preload_link += "; crossorigin=#{crossorigin}" if crossorigin
-        preload_link += "; integrity=#{integrity}" if integrity
-        preload_link += "; nopush" if nopush
+        preload_link << "; type=#{mime_type}" if mime_type
+        preload_link << "; crossorigin=#{crossorigin}" if crossorigin
+        preload_link << "; integrity=#{integrity}" if integrity
+        preload_link << "; nopush" if nopush
 
         send_preload_links_header([preload_link])
 

--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -87,7 +87,7 @@ module ActionView
               add_default_name_and_id(options)
 
               if specified_id.blank? && options["id"].present?
-                options["id"] += "_#{sanitized_value(tag_value)}"
+                options["id"] << "_#{sanitized_value(tag_value)}"
               end
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -437,7 +437,7 @@ module ActiveRecord
               AND tc.table_name = #{scope[:name]}
               AND cc.constraint_schema = #{scope[:schema]}
           SQL
-          sql += " AND cc.table_name = #{scope[:name]}" if mariadb?
+          sql << " AND cc.table_name = #{scope[:name]}" if mariadb?
 
           chk_info = exec_query(sql, "SCHEMA")
 

--- a/activerecord/lib/active_record/errors.rb
+++ b/activerecord/lib/active_record/errors.rb
@@ -378,7 +378,7 @@ module ActiveRecord
     def initialize(model = nil, description = nil)
       if model
         message = "Unknown primary key for table #{model.table_name} in model #{model}."
-        message += "\n#{description}" if description
+        message << "\n#{description}" if description
         @model = model
         super(message)
       else

--- a/activerecord/lib/arel/visitors/dot.rb
+++ b/activerecord/lib/arel/visitors/dot.rb
@@ -285,7 +285,7 @@ module Arel # :nodoc: all
               label = "<f0>#{node.name}"
 
               node.fields.each_with_index do |field, i|
-                label += "|<f#{i + 1}>#{quote field}"
+                label << "|<f#{i + 1}>#{quote field}"
               end
 
               "#{node.id} [label=\"#{label}\"];"


### PR DESCRIPTION
### Summary

Using `+=` for string concatenation creates a new string object and allocates extra memory
for that string object. Using the `<<` operator instead changes the string in place. This PR
replaces every instance where `+=` is used and replaces it with the `<<` operator instead.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->