### PR TITLE
Add `acts_like_symbol?` method to the `Symbol` class

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `acts_like_symbol?` method to the `Symbol` core extension.
+
+    *Ghouse Mohamed*
+
 *   `Pathname.blank?` only returns true for `Pathname.new("")`
 
     Previously it would end up calling `Pathname#empty?` which returned true

--- a/activesupport/lib/active_support/core_ext/object/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/object/acts_like.rb
@@ -38,6 +38,8 @@ class Object
       respond_to? :acts_like_date?
     when :string
       respond_to? :acts_like_string?
+    when :symbol
+      respond_to? :acts_like_symbol?
     else
       respond_to? :"acts_like_#{duck}?"
     end

--- a/activesupport/lib/active_support/core_ext/symbol.rb
+++ b/activesupport/lib/active_support/core_ext/symbol.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/symbol/acts_like"
 require "active_support/core_ext/symbol/starts_ends_with"

--- a/activesupport/lib/active_support/core_ext/symbol/acts_like.rb
+++ b/activesupport/lib/active_support/core_ext/symbol/acts_like.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/object/acts_like"
+
+class Symbol
+  # Duck-types as a Symbol-like class. See Object#acts_like?.
+  def acts_like_symbol?
+    true
+  end
+end

--- a/activesupport/test/core_ext/symbol_ext_test.rb
+++ b/activesupport/test/core_ext/symbol_ext_test.rb
@@ -19,3 +19,9 @@ class SymbolStartsEndsWithTest < ActiveSupport::TestCase
     assert_not s.ends_with?("he", "ll")
   end
 end
+
+class SymbolActsLikeTest < ActiveSupport::TestCase
+  def test_acts_like_symbol
+    assert_predicate :symbol, :acts_like_symbol?
+  end
+end


### PR DESCRIPTION
### Summary

This PR adds the `acts_like_symbol?` method to the the `Symbol` core extension in
Active Support.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->