### PR TITLE
Make `update` and `save` behave the same in tests where transactions are rolled back

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Make `update` and `save` behave the same in tests where transactions are rolled back
+
+    Fixes a bug in transactional tests where if a save is attempted using `update`
+    but is rolled back, the record's mutation state could be lost.
+
+    See [#44713](https://github.com/rails/rails/issues/44713) for more information.
+
+    *Alex Ghiculescu*
+    
 *   Fix `ciphertext_for` for yet-to-be-encrypted values.
 
     Previously, `ciphertext_for` returned the cleartext of values that had not

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb
@@ -361,7 +361,7 @@ module ActiveRecord
       # Register a record with the current transaction so that its after_commit and after_rollback callbacks
       # can be called.
       def add_transaction_record(record, ensure_finalize = true)
-        current_transaction.add_record(record, ensure_finalize)
+        current_transaction.uniquely_add_record(record, ensure_finalize)
       end
 
       # Begins the transaction (and turns off auto-committing).

--- a/activerecord/lib/active_record/transactions.rb
+++ b/activerecord/lib/active_record/transactions.rb
@@ -350,8 +350,9 @@ module ActiveRecord
       ensure_finalize = !connection.transaction_open?
 
       connection.transaction do
-        add_to_transaction(ensure_finalize || has_transactional_callbacks?)
-        remember_transaction_record_state
+        if add_to_transaction(ensure_finalize || has_transactional_callbacks?)
+          remember_transaction_record_state
+        end
 
         status = yield
         raise ActiveRecord::Rollback unless status


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/44713

An issue exists in tests (and maybe other situations where a savepoint transaction is used) where an `update` attempt is rolled back. The record's mutation state could be lost and not correctly reset, the way it is if you call `save`.

cc @richardboehme, could you please test your repro / app against this.