### PR TITLE
Add yarn install into bin/setup when not using importmap

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add JavaScript dependencies installation on bin/setup
+
+    Add  `yarn install` to bin/setup when using esbuild, webpack, or rollout.
+
+    *Carlos Ribeiro*
+
 *   Use `controller_class_path` in `Rails::Generators::NamedBase#route_url`
 
     The `route_url` method now returns the correct path when generating

--- a/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
+++ b/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
@@ -15,6 +15,12 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
+<% if ["webpack", "esbuild", "rollup"].include?(options.javascript) -%>
+
+  # Install JavaScript dependencies
+  system("yarn check --check-files") || system!("yarn install")
+<% end -%>
+
 <% unless options.skip_active_record? -%>
 
   # puts "\n== Copying sample files =="


### PR DESCRIPTION
Hey folks 👋
IDK if this PR is valid but Want to see a feedback from you.
After https://github.com/rails/rails/commit/af7428c4acd0fcf9eed5c7215856594a078f23b7 the yarn install
instructions was dropped from bin/setup. I created a project with
Rails 7 and I'm using esbuild and I added it again into my bin/setup
script, since I wanna it updates my dependencies again.
This commit adds yarn install into the setup script again if the user is not using importmap.