### PR TITLE
Add missing test cases for Object in activesupport

### DIFF
--- a/activesupport/test/core_ext/object/acts_like_test.rb
+++ b/activesupport/test/core_ext/object/acts_like_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "../../abstract_unit"
 require "active_support/core_ext/date/acts_like"
+require "active_support/core_ext/string/behavior"
 require "active_support/core_ext/time/acts_like"
 require "active_support/core_ext/date_time/acts_like"
 require "active_support/core_ext/object/acts_like"
@@ -9,6 +10,15 @@ require "active_support/core_ext/object/acts_like"
 class ObjectTests < ActiveSupport::TestCase
   class DuckTime
     def acts_like_time?
+      true
+    end
+  end
+
+  class Stringish < String
+  end
+
+  class DuckString
+    def acts_like_string?
       true
     end
   end
@@ -34,5 +44,16 @@ class ObjectTests < ActiveSupport::TestCase
 
     assert duck.acts_like?(:time)
     assert_not duck.acts_like?(:date)
+  end
+
+  def test_acts_like_string
+    string = Stringish.new
+    duck_string = DuckString.new
+
+    assert string.acts_like?(:string)
+    assert_not string.acts_like?(:invalid)
+
+    assert duck_string.acts_like?(:string)
+    assert_not string.acts_like?(:invalid)
   end
 end


### PR DESCRIPTION
### Summary

The `Object` class provides a way to check whether some class acts like some other class
based on the existence of an appropriately-named marker method. For example, Active
Support extends `Date` and `Time` to define methods like `acts_like_date?`and `acts_like_time?`.
Similarly, Active Support extends `String` to define the `acts_like_string?` method. The test
coverage for this method seems to be missing. This PR just adds coverage for `acts_like?(:string)`
method.

Thanks :)

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->