### PR TITLE
Fix deprecation warnings in Action Text tests

### DIFF
--- a/actiontext/test/integration/controller_render_test.rb
+++ b/actiontext/test/integration/controller_render_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
   test "uses current request environment" do
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     message = Message.create!(content: ActionText::Content.new.append_attachables(blob))
 
     host! "loocalhoost"
@@ -15,7 +15,7 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
   end
 
   test "renders as HTML when the request format is not HTML" do
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     message = Message.create!(content: ActionText::Content.new.append_attachables(blob))
 
     host! "loocalhoost"
@@ -34,7 +34,7 @@ class ActionText::ControllerRenderTest < ActionDispatch::IntegrationTest
   end
 
   test "resolves partials when controller is namespaced" do
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     message = Message.create!(content: ActionText::Content.new.append_attachables(blob))
 
     get admin_message_path(message)

--- a/actiontext/test/integration/mailer_render_test.rb
+++ b/actiontext/test/integration/mailer_render_test.rb
@@ -7,7 +7,7 @@ class ActionText::MailerRenderTest < ActionMailer::TestCase
     original_default_url_options = ActionMailer::Base.default_url_options
     ActionMailer::Base.default_url_options = { host: "hoost" }
 
-    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpg")
+    blob = create_file_blob(filename: "racecar.jpg", content_type: "image/jpeg")
     message = Message.new(content: ActionText::Content.new.append_attachables(blob))
 
     MessagesMailer.with(recipient: "test", message: message).notification.deliver_now


### PR DESCRIPTION
Support for the `image/jpg` content type will be removed in Rails 7.1 and the use of it within the Action Text tests appears to be a typo.
