### PR TITLE
Allow overriding of Que and QC urls in integration tests

### DIFF
--- a/activejob/test/support/integration/adapters/que.rb
+++ b/activejob/test/support/integration/adapters/que.rb
@@ -13,11 +13,22 @@ module QueJobsManager
   def start_workers
     que_url = ENV["QUE_DATABASE_URL"] || "postgres:///active_jobs_que_int_test"
     uri = URI.parse(que_url)
+    host = uri.host
+    port = uri.port
     user = uri.user || ENV["USER"]
     pass = uri.password
     db   = uri.path[1..-1]
-    %x{#{"PGPASSWORD=\"#{pass}\"" if pass} psql -X -c 'drop database if exists "#{db}"' -U #{user} -t template1}
-    %x{#{"PGPASSWORD=\"#{pass}\"" if pass} psql -X -c 'create database "#{db}"' -U #{user} -t template1}
+
+    psql = [].tap do |args|
+      args << "PGPASSWORD=\"#{pass}\"" if pass
+      args << "psql -X -U #{user} -t template1"
+      args << "-h #{host}" if host
+      args << "-p #{port}" if port
+    end.join(" ")
+
+    %x{#{psql} -c 'drop database if exists "#{db}"'}
+    %x{#{psql} -c 'create database "#{db}"'}
+
     Que.connection = Sequel.connect(que_url)
     Que.migrate!(version: Que::Migrations::CURRENT_VERSION)
 


### PR DESCRIPTION
The Active Job integration tests for Que and Queue Classic assume a connection to a PostgreSQL database running on localhost:5432 since the psql command to create the databases does not pass the -h and -p options. This change assumes that the respective urls always include a host and port so the default urls are changed to reflect that assumption.
