### PR TITLE
Deprecate preserving the pre-Ruby 2.4 behavior of `to_time`

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Deprecate preserving the pre-Ruby 2.4 behavior of `to_time`
+
+    With Ruby 2.4+ the default for +to_time+ changed from converting to the
+    local system time to preserving the offset of the receiver. At the time Rails
+    supported older versions of Ruby so a compatibility layer was added to assist
+    in the migration process. From Rails 5.0 new applications have defaulted to 
+    the Ruby 2.4+ behavior and since Rails 7.0 now only supports Ruby 2.7+
+    this compatibility layer can be safely removed.
+    
+    To minimize any noise generated the deprecation warning only appears when the
+    setting is configured to `false` as that is the only scenario where the
+    removal of the compatibility layer has any effect.
+    
+    *Andrew White*
+
 *   `Pathname.blank?` only returns true for `Pathname.new("")`
 
     Previously it would end up calling `Pathname#empty?` which returned true

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -110,6 +110,12 @@ module ActiveSupport
   end
 
   def self.to_time_preserves_timezone=(value)
+    unless value
+      ActiveSupport::Deprecation.warn(
+        "Support for the pre-Ruby 2.4 behavior of to_time has been deprecated and will be removed in Rails 7.1."
+      )
+    end
+
     DateAndTime::Compatibility.preserve_timezone = value
   end
 

--- a/activesupport/test/abstract_unit.rb
+++ b/activesupport/test/abstract_unit.rb
@@ -21,8 +21,10 @@ Thread.abort_on_exception = true
 # Show backtraces for deprecated behavior for quicker cleanup.
 ActiveSupport::Deprecation.debug = true
 
-# Default to old to_time behavior but allow running tests with new behavior
-ActiveSupport.to_time_preserves_timezone = ENV["PRESERVE_TIMEZONES"] == "1"
+# Default to Ruby 2.4+ to_time behavior but allow running tests with old behavior
+ActiveSupport::Deprecation.silence do
+  ActiveSupport.to_time_preserves_timezone = ENV.fetch("PRESERVE_TIMEZONES", "1") == "1"
+end
 
 # Disable available locale checks to avoid warnings running the test suite.
 I18n.enforce_available_locales = false

--- a/activesupport/test/core_ext/date_and_time_compatibility_test.rb
+++ b/activesupport/test/core_ext/date_and_time_compatibility_test.rb
@@ -272,4 +272,24 @@ class DateAndTimeCompatibilityTest < ActiveSupport::TestCase
       end
     end
   end
+
+  def test_to_time_preserves_timezone_is_deprecated
+    current_preserve_tz = ActiveSupport.to_time_preserves_timezone
+
+    assert_not_deprecated do
+      ActiveSupport.to_time_preserves_timezone
+    end
+
+    assert_not_deprecated do
+      ActiveSupport.to_time_preserves_timezone = true
+    end
+
+    assert_deprecated do
+      ActiveSupport.to_time_preserves_timezone = false
+    end
+  ensure
+    ActiveSupport::Deprecation.silence do
+      ActiveSupport.to_time_preserves_timezone = current_preserve_tz
+    end
+  end
 end

--- a/activesupport/test/time_zone_test_helpers.rb
+++ b/activesupport/test/time_zone_test_helpers.rb
@@ -18,10 +18,16 @@ module TimeZoneTestHelpers
 
   def with_preserve_timezone(value)
     old_preserve_tz = ActiveSupport.to_time_preserves_timezone
-    ActiveSupport.to_time_preserves_timezone = value
+
+    ActiveSupport::Deprecation.silence do
+      ActiveSupport.to_time_preserves_timezone = value
+    end
+
     yield
   ensure
-    ActiveSupport.to_time_preserves_timezone = old_preserve_tz
+    ActiveSupport::Deprecation.silence do
+      ActiveSupport.to_time_preserves_timezone = old_preserve_tz
+    end
   end
 
   def with_tz_mappings(mappings)


### PR DESCRIPTION
With Ruby 2.4+ the default for +to_time+ changed from converting to the local system time to preserving the offset of the receiver. At the time Rails supported older versions of Ruby so a compatibility layer was added to assist in the migration process. From Rails 5.0 new applications have defaulted to the Ruby 2.4+ behavior and since Rails 7.0 now only supports Ruby 2.7+ this compatibility layer can be safely removed.

To minimize any noise generated the deprecation warning only appears when the setting is configured to `false` as that is the only scenario where the removal of the compatibility layer has any effect.
