### PR TITLE
Restore application/problem+json after tests

### DIFF
--- a/actionpack/test/dispatch/request/json_params_parsing_test.rb
+++ b/actionpack/test/dispatch/request/json_params_parsing_test.rb
@@ -154,6 +154,13 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "parses json params for application problem+json" do
+    assert_parses(
+      { "user" => { "username" => "sikachu" }, "username" => "sikachu" },
+      "{\"username\": \"sikachu\"}", "CONTENT_TYPE" => "application/problem+json"
+    )
+  end
+
   test "parses json with non-object JSON content" do
     assert_parses(
       { "user" => { "_json" => "string content" }, "_json" => "string content" },
@@ -170,7 +177,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   ensure
     Mime::Type.unregister :json
-    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json )
   end
 
   test "parses json params after custom json mime type registered with synonym" do
@@ -182,7 +189,7 @@ class RootLessJSONParamsParsingTest < ActionDispatch::IntegrationTest
     )
   ensure
     Mime::Type.unregister :json
-    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest )
+    Mime::Type.register "application/json", :json, %w( text/x-json application/jsonrequest application/problem+json )
   end
 
   private


### PR DESCRIPTION
In #44608 the application/problem+json content type was added as a default alias for json but as the test only fails intermittently it wasn't picked up during PR review. It also restores the rootless test that was reverted due to it failing for the same reason.
