### PR TITLE
Refactor ActionDispatch::Journey::Path::Pattern#offsets method to avoid race condition

### DIFF
--- a/actionpack/lib/action_dispatch/journey/path/pattern.rb
+++ b/actionpack/lib/action_dispatch/journey/path/pattern.rb
@@ -183,22 +183,22 @@ module ActionDispatch
           end
 
           def offsets
-            return @offsets if @offsets
+            @offsets ||= begin
+              offsets = [0]
 
-            @offsets = [0]
+              spec.find_all(&:symbol?).each do |node|
+                node = node.to_sym
 
-            spec.find_all(&:symbol?).each do |node|
-              node = node.to_sym
-
-              if @requirements.key?(node)
-                re = /#{Regexp.union(@requirements[node])}|/
-                @offsets.push((re.match("").length - 1) + @offsets.last)
-              else
-                @offsets << @offsets.last
+                if @requirements.key?(node)
+                  re = /#{Regexp.union(@requirements[node])}|/
+                  offsets.push((re.match("").length - 1) + offsets.last)
+                else
+                  offsets << offsets.last
+                end
               end
-            end
 
-            @offsets
+              offsets
+            end
           end
       end
     end


### PR DESCRIPTION
In environments where the routes aren't eager loaded such as development or test a race condition could occur where two requests would trigger the `offsets` method in `ActionDispatch::Journey::Path::Pattern` and the early return for `@offsets` would be triggered by the initialisation of the instance variable to `[0]` before the rest of the method had completed.

Fixes #43431.
