### PR TITLE
Update ActiveJob `QueAdapter` for future compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
-    que (1.0.0)
+    que (1.3.1)
     queue_classic (4.0.0.pre.beta1)
       pg (>= 0.17, < 2.0)
     raabro (1.4.0)

--- a/activejob/CHANGELOG.md
+++ b/activejob/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Update `ActiveJob::QueueAdapters::QueAdapter` te remove deprecation warning
+
+    Remove a deprecation warning introduced in que 1.2 to prepare for changes in
+    que 2.0 necessary for Ruby 3 compatibility.
+
+    *Damir Zekic* and *Adis Hasovic*
+
 *   Add missing `bigdecimal` require in `ActiveJob::Arguments`
 
     Could cause `uninitialized constant ActiveJob::Arguments::BigDecimal (NameError)`


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

que 1.2 [deprecated passing job options directly to `#enqueue`](https://github.com/que-rb/que/pull/336). From que 1.2, job options need to be provided as a hash in the `job_options` keyword argument.

que 1.x is not compatible with Ruby 3 yet. que 2 will be, so this is a necessary step for Ruby 3 upgrade in apps that use que.

We changed `QueAdapter` to check if `Que::Job#enqueue` has the `job_options` kwarg and pass arguments accordingly.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

The que version was updated in `Gemfile.lock` to verify that the deprecation warning doesn't show up when running integration tests.

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
