### PR TITLE
Stop explicitly setting sql_auto_is_null

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -787,8 +787,8 @@ module ActiveRecord
         def configure_connection
           variables = @config.fetch(:variables, {}).stringify_keys
 
-          # By default, MySQL 'where id is null' selects the last inserted id; Turn this off.
-          variables["sql_auto_is_null"] = 0
+          # Since MySQL 5.5 sql_auto_is_null is off by default, but if it is set for any reason, we need to turn it off.
+          variables["sql_auto_is_null"] = 0 unless query_value("select @@sql_auto_is_null") == 0
 
           # Increase timeout so the server doesn't disconnect us.
           wait_timeout = self.class.type_cast_config_to_integer(@config[:wait_timeout])


### PR DESCRIPTION
Fixes: https://github.com/rails/rails/issues/44667

Since version 5.5 the default has been off which is the minimum supported mysql version.