### PR TITLE
Correct spelling in docs nullbale -> nullable

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       #
       # If there is a non-nil condition on a nullable column in the hash condition, the records that have
       # nil values on the nullable column won't be returned.
-      #    User.create!(nullbale_country: nil)
+      #    User.create!(nullable_country: nil)
       #    User.where.not(nullable_country: "UK")
       #    # SELECT * FROM users WHERE NOT (nullable_country = 'UK')
       #    # => []


### PR DESCRIPTION
### Summary

Correct spelling in the documentation of `#not`