### PR TITLE
Fix `ActiveRecord::QueryMethods#in_order_of` when passing an out-of-range Integer.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix `ActiveRecord::QueryMethods#in_order_of` when passing an out-of-range Integer
+
+    To match the behavior of the `Enumerable` version, `in_order_of` now ignores an out-of-range Integer.
+
+    *tejanium*
+
 *   Revert alphabetical sorting of table columns inside `schema.rb`.
 
     Alphabetical sorting of table columns inside the schema creates improper production tables when using `db:prepare`.

--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -721,8 +721,16 @@ module ActiveRecord
       references = column_references([column])
       self.references_values |= references unless references.empty?
 
-      values = values.map { |value| model.type_caster.type_cast_for_database(column, value) }
-      arel_column = column.is_a?(Arel::Nodes::SqlLiteral) ? column : order_column(column.to_s)
+      if column.is_a?(Arel::Nodes::SqlLiteral)
+        arel_column = column
+      else
+        arel_column = order_column(column.to_s)
+
+        caster = arel_column.type_caster
+        values = values.map do |value|
+          caster.serialize(value) if caster.serializable?(value)
+        end
+      end
 
       scope = spawn.order!(build_case_for_value_position(arel_column, values, filter: filter))
 

--- a/activerecord/test/cases/relation/field_ordered_values_test.rb
+++ b/activerecord/test/cases/relation/field_ordered_values_test.rb
@@ -117,4 +117,12 @@ class FieldOrderedValuesTest < ActiveRecord::TestCase
     assert_equal(order, posts.limit(3).map(&:id))
     assert_equal(11, posts.count)
   end
+
+  def test_in_order_of_with_out_of_bound_integer
+    max_integer = Post.type_for_attribute(:id).send(:max_value)
+    order = [max_integer, 1]
+    posts = Post.where(type: "Post").order(:type).in_order_of(:id, order)
+
+    assert_equal([1], posts.map(&:id))
+  end
 end


### PR DESCRIPTION
### Summary

Closes https://github.com/rails/rails/issues/44745

Fix an `ActiveModel::RangeError` error when passing an out-of-range integer to `in_order_of`.

```ruby
[1] pry(main)> Post.in_order_of(:id, [1, 9999999999999])
ActiveModel::RangeError: 9999999999999 is out of range for ActiveModel::Type::Integer with limit 4 bytes

[2] pry(main)> Post.in_order_of(:id, ["1", "9999999999999"])
ActiveModel::RangeError: 9999999999999 is out of range for ActiveModel::Type::Integer with limit 4 bytes
```

### Other Information

After https://github.com/rails/rails/pull/43322 it will cast all values, even unsupported ones. This PR replace the usage of `type_cast_for_database` with conditional `caster.serialize(value) if caster.serializable?(value)`

A similar approach done by 

https://github.com/rails/rails/blob/61d6eb119fc53678d8f5028bd73ae77e69b91fb6/activerecord/lib/arel/nodes/homogeneous_in.rb#L47-L56
https://github.com/rails/rails/blob/61d6eb119fc53678d8f5028bd73ae77e69b91fb6/activerecord/lib/arel/visitors/to_sql.rb#L579-L593

An added value by doing this approach is that we ignore invalid values to simplify the `order` statement