### PR TITLE
remove workarounds for old Rails/Psych combination

### DIFF
--- a/actionpack/test/controller/parameters/serialization_test.rb
+++ b/actionpack/test/controller/parameters/serialization_test.rb
@@ -29,29 +29,4 @@ class ParametersSerializationTest < ActiveSupport::TestCase
     assert_equal params, roundtripped
     assert_not_predicate roundtripped, :permitted?
   end
-
-  test "yaml backwardscompatible with psych 2.0.8 format" do
-    payload = <<~end_of_yaml
-      --- !ruby/hash:ActionController::Parameters
-      key: :value
-    end_of_yaml
-    params = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
-
-    assert_equal :value, params[:key]
-    assert_not_predicate params, :permitted?
-  end
-
-  test "yaml backwardscompatible with psych 2.0.9+ format" do
-    payload = <<~end_of_yaml
-      --- !ruby/hash-with-ivars:ActionController::Parameters
-      elements:
-        key: :value
-      ivars:
-        :@permitted: false
-    end_of_yaml
-    params = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(payload) : YAML.load(payload)
-
-    assert_equal :value, params[:key]
-    assert_not_predicate params, :permitted?
-  end
 end


### PR DESCRIPTION
### Summary

`ActionController::Parameters#init_with` was added in 31448f2b7fa6f3920485229e5710d9fcf87f190d to 
support loading yaml serialized `Parameters` from Rails 4.2 because the 
superclass changed from Hash to Object. Another workaround was added in 
6eb978234cdce57e75c36a096fa76a634705c7c8 because Psych added instance variables to serialized hashes in 2.0.9.

Neither of these workarounds should be necessary now that Parameters have
been serialized as Objects since Rails 5.

### Other Information

If `init_with` should be deprecated first before removing, I can update to do that instead
