### PR TITLE
Removed unwanted code which sets session host in console mode

### DIFF
--- a/railties/lib/rails/console/app.rb
+++ b/railties/lib/rails/console/app.rb
@@ -9,9 +9,7 @@ module Rails
     # instance, pass a non-false value as the parameter.
     def app(create = false)
       @app_integration_instance = nil if create
-      @app_integration_instance ||= new_session do |sess|
-        sess.host! "www.example.com"
-      end
+      @app_integration_instance ||= new_session
     end
 
     # create a new session. If a block is given, the new session will be yielded
@@ -19,7 +17,6 @@ module Rails
     def new_session
       app = Rails.application
       session = ActionDispatch::Integration::Session.new(app)
-      yield session if block_given?
 
       # This makes app.url_for and app.foo_path available in the console
       session.extend(app.routes.url_helpers)


### PR DESCRIPTION
### Summary

Setting the session host for the app instance in the following way for console mode is
not needed.

https://github.com/rails/rails/blob/61d6eb119fc53678d8f5028bd73ae77e69b91fb6/railties/lib/rails/console/app.rb#L12-L14

The default host is already being set in `ActionDispatch::Testing::Integration`, which is
the session class that is being used by the app instance.

https://github.com/rails/rails/blob/61d6eb119fc53678d8f5028bd73ae77e69b91fb6/actionpack/lib/action_dispatch/testing/integration.rb#L84-L86

The session class that is being used by the app instance:

https://github.com/rails/rails/blob/61d6eb119fc53678d8f5028bd73ae77e69b91fb6/railties/lib/rails/console/app.rb#L21