### PR TITLE
fix serializing Parameters as yaml

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -908,6 +908,10 @@ module ActionController
       end
     end
 
+    def encode_with(coder) # :nodoc:
+      coder.map = { "parameters" => @parameters, "permitted" => @permitted }
+    end
+
     # Returns duplicate of object including all parameters.
     def deep_dup
       self.class.new(@parameters.deep_dup, @logging_context).tap do |duplicate|

--- a/actionpack/test/controller/parameters_integration_test.rb
+++ b/actionpack/test/controller/parameters_integration_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class IntegrationController < ActionController::Base
+  def yaml_params
+    render plain: params.to_yaml
+  end
+end
+
+class ActionControllerParametersIntegrationTest < ActionController::TestCase
+  tests IntegrationController
+
+  test "parameters can be serialized as yaml" do
+    post :yaml_params, params: { person: { name: "Mjallo!" } }
+    expected = <<~YAML
+--- !ruby/object:ActionController::Parameters
+parameters: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
+  person: !ruby/hash:ActiveSupport::HashWithIndifferentAccess
+    name: Mjallo!
+  controller: integration
+  action: yaml_params
+permitted: false
+    YAML
+    assert_equal expected, response.body
+  end
+end


### PR DESCRIPTION
### Summary

This has been broken since the logging context was added in
6be9c498bccd8dbc99b4b451841fcf73c7061d48

Also added a higher level test to ensure that this isn't broken again in
the future.

### Other Information

The test isn't perfect, as the anonymous class causing the error doesn't seem to exist in the test case. (It's somewhere around `ActionDispatch::Routing::RouteSet::NamedRouteCollection` based on printing `@emitter.instance_variable_get(:@stack)` in a debugger). So instead of testing that `to_yaml` doesn't error, I tested the actual output, which I think is also reasonable (since the logging context should not be in the output)

Fixes #44743 
