### PR TITLE
Extends ruby reserved keywords list in Module ext in Active Support

### DIFF
--- a/activesupport/lib/active_support/core_ext/module/delegation.rb
+++ b/activesupport/lib/active_support/core_ext/module/delegation.rb
@@ -7,9 +7,9 @@ class Module
   # option is not used.
   class DelegationError < NoMethodError; end
 
-  RUBY_RESERVED_KEYWORDS = %w(alias and BEGIN begin break case class def defined? do
-  else elsif END end ensure false for if in module next nil not or redo rescue retry
-  return self super then true undef unless until when while yield)
+  RUBY_RESERVED_KEYWORDS = %w(__ENCODING__ __LINE__ __FILE__ alias and BEGIN begin break
+  case class def defined? do else elsif END end ensure false for if in module next nil
+  not or redo rescue retry return self super then true undef unless until when while yield)
   DELEGATION_RESERVED_KEYWORDS = %w(_ arg args block)
   DELEGATION_RESERVED_METHOD_NAMES = Set.new(
     RUBY_RESERVED_KEYWORDS + DELEGATION_RESERVED_KEYWORDS


### PR DESCRIPTION
### Summary

The keywords `__ENCODING__`, `__LINE__`, and `__FILE__` seem to be missing
from the list `RUBY_RESERVED_KEYWORDS`.

https://github.com/rails/rails/blob/02ad57a46bb8450f7a4b4e15cd06c69715406881/activesupport/lib/active_support/core_ext/module/delegation.rb#L10-L12

I've added these keywords to account for the missing keywords.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->