### PR TITLE
Add a boolean config to disable compression for encrypted columns.

### DIFF
--- a/activerecord/lib/active_record/encryption/config.rb
+++ b/activerecord/lib/active_record/encryption/config.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     # Container of configuration options
     class Config
       attr_accessor :primary_key, :deterministic_key, :store_key_references, :key_derivation_salt,
-                    :support_unencrypted_data, :encrypt_fixtures, :validate_column_size, :add_to_filter_parameters,
+                    :support_unencrypted_data, :encrypt_fixtures, :validate_column_size, :compress, :add_to_filter_parameters,
                     :excluded_from_filter_parameters, :extend_queries, :previous_schemes, :forced_encoding_for_deterministic_encryption
 
       def initialize
@@ -35,6 +35,7 @@ module ActiveRecord
           self.support_unencrypted_data = false
           self.encrypt_fixtures = false
           self.validate_column_size = true
+          self.compress = true
           self.add_to_filter_parameters = true
           self.excluded_from_filter_parameters = []
           self.previous_schemes = []

--- a/activerecord/lib/active_record/encryption/encryptor.rb
+++ b/activerecord/lib/active_record/encryption/encryptor.rb
@@ -112,7 +112,7 @@ module ActiveRecord
 
         # Under certain threshold, ZIP compression is actually worse that not compressing
         def compress_if_worth_it(string)
-          if string.bytesize > THRESHOLD_TO_JUSTIFY_COMPRESSION
+          if ActiveRecord::Encryption.config.compress && string.bytesize > THRESHOLD_TO_JUSTIFY_COMPRESSION
             [compress(string), true]
           else
             [string, false]

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -134,6 +134,29 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_equal "", book.name
   end
 
+  test "ciphertext length varies based on compression settings" do
+    # THRESHOLD_TO_JUSTIFY_COMPRESSION is 140 bytes
+    plaintext_under_threshold = "_" * 130
+    plaintext_over_threshold = "_" * 300
+
+    ActiveRecord::Encryption.config.compress = true
+    minimal_length = EncryptedBook.create!(name: "_").ciphertext_for(:name).length
+    under_threshold_length = EncryptedBook.create!(name: plaintext_under_threshold).ciphertext_for(:name).length
+    over_threshold_length = EncryptedBook.create!(name: plaintext_over_threshold).ciphertext_for(:name).length
+
+    ActiveRecord::Encryption.config.compress = false
+    over_threshold_uncompressed_length = EncryptedBook.create!(name: plaintext_over_threshold).ciphertext_for(:name).length
+
+    # Short plaintexts are not compressed.
+    assert_operator under_threshold_length, :>, minimal_length + 150
+
+    # A highly compressible plaintext should add very little length to the ciphertext.
+    assert_operator over_threshold_length, :<, minimal_length + 30
+
+    # 300 bytes of uncompressed plaintext should significantly lengthen the ciphertext
+    assert_operator over_threshold_uncompressed_length, :>, minimal_length + 350
+  end
+
   test "can't modify encrypted attributes when frozen_encryption is true" do
     post = posts(:welcome).becomes(EncryptedPost)
     post.title = "Some new title"

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -139,6 +139,7 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     plaintext_under_threshold = "_" * 130
     plaintext_over_threshold = "_" * 300
 
+    # Explicitly set the default
     ActiveRecord::Encryption.config.compress = true
     minimal_length = EncryptedBook.create!(name: "_").ciphertext_for(:name).length
     under_threshold_length = EncryptedBook.create!(name: plaintext_under_threshold).ciphertext_for(:name).length
@@ -146,6 +147,9 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
 
     ActiveRecord::Encryption.config.compress = false
     over_threshold_uncompressed_length = EncryptedBook.create!(name: plaintext_over_threshold).ciphertext_for(:name).length
+
+    # Change back to the default to avoid affecting other tests.
+    ActiveRecord::Encryption.config.compress = true
 
     # Short plaintexts are not compressed.
     assert_operator under_threshold_length, :>, minimal_length + 150


### PR DESCRIPTION
### Summary

Compressing data before encryption can leak information about the plaintext[^1], and can compromise the confidentiality of the data. This PR adds an `ActiveRecord::Encryption.config.compress` boolean that allows turning off compression entirely, in order to mitigate this risk.

[^1]: For example, [CRIME](https://en.wikipedia.org/wiki/CRIME)  and [BREACH](https://en.wikipedia.org/wiki/BREACH) exploit the compressibility of HTTPS requests to leak cookies. "At-rest" database encryption might seem a little harder to exploit, but I can certainly think of some "learn the remaining information" attacks that would compromise the kinds of threat models that would lead a service to consider column encryption in the first place.

To match the existing functionality of encrypted columns, this PR currently defaults the boolean to `true`. But I'd also like to ask reviewers if you're open to changing the default to `false` — I'd advocate that disabling compression is a better zero-config default, if the data is sensitive enough to encrypt in the first place. Existing services that use encrypted columns would need to be made aware of this change, but in the worst case a default of `false` would mainly cost database space, not cryptographic security.

### Other Information

Please let me know if this warrants a `CHANGELOG` entry. I'm not able to find a `CHANGELOG` entry for encrypted columns in the first place, so I'm not certain what the appropriate pattern is.
