### PR TITLE
Receive a block to ActionController::Parameters.to_h

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Allow `ActionController::Parameters#to_h` to receive a block.
+
+    *Bob Farrell*
+
 *   Allow relative redirects when `raise_on_open_redirects` is enabled
 
     *Tom Hughes*

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -297,9 +297,9 @@ module ActionController
     #
     #   safe_params = params.permit(:name)
     #   safe_params.to_h # => {"name"=>"Senjougahara Hitagi"}
-    def to_h
+    def to_h(&block)
       if permitted?
-        convert_parameters_to_hashes(@parameters, :to_h)
+        convert_parameters_to_hashes(@parameters, :to_h, &block)
       else
         raise UnfilteredParameters
       end
@@ -941,14 +941,15 @@ module ActionController
         end
       end
 
-      def convert_parameters_to_hashes(value, using)
+      def convert_parameters_to_hashes(value, using, &block)
         case value
         when Array
           value.map { |v| convert_parameters_to_hashes(v, using) }
         when Hash
-          value.transform_values do |v|
+          transformed = value.transform_values do |v|
             convert_parameters_to_hashes(v, using)
-          end.with_indifferent_access
+          end
+          (block_given? ? transformed.to_h(&block) : transformed).with_indifferent_access
         when Parameters
           value.send(using)
         else


### PR DESCRIPTION
### Summary

Allow `ActionController::Parameters.to_h` to receive a block to provide parity with `Hash#to_h`. The provided block receives `key, value` and yields a two-element array/keypair which can be transformed in the resulting Hash.

### Other Information

https://ruby-doc.org/core-2.7.5/Hash.html#method-i-to_h

```
to_h → hsh or new_hashc
to_h {|key, value| block } → new_hash
Returns self. If called on a subclass of Hash, converts the receiver to a Hash object.

If a block is given, the results of the block on each pair of the receiver will be used as pairs.
```