### PR TITLE
Fix `Range#overlaps?` for beginless ranges

### DIFF
--- a/activesupport/lib/active_support/core_ext/range/overlaps.rb
+++ b/activesupport/lib/active_support/core_ext/range/overlaps.rb
@@ -5,6 +5,6 @@ class Range
   #  (1..5).overlaps?(4..6) # => true
   #  (1..5).overlaps?(7..9) # => false
   def overlaps?(other)
-    cover?(other.first) || other.cover?(first)
+    other.begin == self.begin || cover?(other.begin) || other.cover?(self.begin)
   end
 end

--- a/activesupport/test/core_ext/range_ext_test.rb
+++ b/activesupport/test/core_ext/range_ext_test.rb
@@ -65,6 +65,14 @@ class RangeTest < ActiveSupport::TestCase
     assert_not (5..10).overlaps?(1...5)
   end
 
+  def test_overlaps_with_beginless_range
+    assert((1..5).overlaps?(..10))
+  end
+
+  def test_overlaps_with_two_beginless_ranges
+    assert((..5).overlaps?(..10))
+  end
+
   def test_should_include_identical_inclusive
     assert((1..10).include?(1..10))
   end


### PR DESCRIPTION
### Summary
Related issue https://github.com/rails/rails/issues/44755

Using `Range#begin` to get the first element of the range. `Range#first` raises an error when called on a beginless range.

Adding additional equality condition to cover the case when both ranges are beginless.