### PR TITLE
Allow nested access to keys loaded as custom config via `config_for`

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Allow nested access to keys loaded as custom config via `config_for`
+
+    Previously only top level keys loaded as custom config could be accessed
+    with method calls. Now any key loaded via `config_for` can be accessed
+    with method calls.
+
+    If the following config is loaded:
+
+    ```ruby
+      config.custom_config = config_for(:custom)
+    ```
+
+    ```yml
+    # config/custom.yml
+    development:
+      payment_options:
+        gateway: stripe
+    ```
+
+    `Rails.application.config.custom_config.payment_options.gateway` will now return the same thing as `Rails.application.config.custom_config[:payment_options][:gateway]`
+
+    *Ghouse Mohamed*
+
 *   Add JavaScript dependencies installation on bin/setup
 
     Add  `yarn install` to bin/setup when using esbuild, webpack, or rollout.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -239,7 +239,7 @@ module Rails
           config = ActiveSupport::OrderedOptions.new.update(config)
         end
 
-        config
+        deep_transform(config)
       else
         raise "Could not load configuration. No such file - #{yaml}"
       end
@@ -612,6 +612,16 @@ module Rails
 
       def coerce_same_site_protection(protection)
         protection.respond_to?(:call) ? protection : proc { protection }
+      end
+
+      def deep_transform(hash)
+        return hash unless hash.is_a?(Hash)
+
+        h = ActiveSupport::OrderedOptions.new
+        hash.each do |k, v|
+          h[k] = deep_transform(v)
+        end
+        h
       end
   end
 end

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1985,6 +1985,20 @@ module ApplicationTests
       assert_equal 1, Rails.application.config.my_custom_config[:foo][:bar][:baz]
     end
 
+    test "config_for loads custom configuration from yaml accessible as methods" do
+      set_custom_config <<~RUBY
+        development:
+          foo: "bar"
+          nested:
+            foo: "bar"
+      RUBY
+
+      app "development"
+
+      assert_equal "bar", Rails.application.config.my_custom_config.foo
+      assert_equal "bar", Rails.application.config.my_custom_config.nested.foo
+    end
+
     test "config_for makes all hash methods available" do
       set_custom_config <<~RUBY
         development:


### PR DESCRIPTION
### Summary

Allow nested access to keys loaded as custom config via `config_for`.

Previously only top-level keys loaded as custom config could be accessed
with method calls. Now any key loaded via `config_for` can be accessed
with method calls.

If the following config is loaded:

```ruby
  config.custom_config = config_for(:custom)
```

```yml
# config/custom.yml
development:
  payment_options:
    gateway: stripe
```

`Rails.application.config.custom_config.payment_options.gateway` will now return the same thing as `Rails.application.config.custom_config[:payment_options][:gateway]`

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->