### PR TITLE
Include encrypted attributes in Active Record filter attributes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Include encrypted attributes in model-level filter attributes.
+
+    Encrypted attributes would not be added to the model class `filter_attributes` due
+    to the auto-filtered-parameters hook only being applied when Action Controller is
+    loaded.
+
+    *Alex Robbin*
+
 *   Fixed MariaDB default function support.
 
     Defaults would be written wrong in "db/schema.rb" and not work correctly

--- a/activerecord/lib/active_record/encryption/configurable.rb
+++ b/activerecord/lib/active_record/encryption/configurable.rb
@@ -51,7 +51,11 @@ module ActiveRecord
         def install_auto_filtered_parameters_hook(application) # :nodoc:
           ActiveRecord::Encryption.on_encrypted_attribute_declared do |klass, encrypted_attribute_name|
             filter_parameter = [("#{klass.model_name.element}" if klass.name), encrypted_attribute_name.to_s].compact.join(".")
-            application.config.filter_parameters << filter_parameter unless excluded_from_filter_parameters?(filter_parameter)
+
+            unless excluded_from_filter_parameters?(filter_parameter)
+              application.config.filter_parameters << filter_parameter
+              klass.filter_attributes += [encrypted_attribute_name.to_s]
+            end
           end
         end
 

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -360,10 +360,8 @@ To keep using the current cache store, you can turn off cache versioning entirel
       end
 
       # Filtered params
-      ActiveSupport.on_load(:action_controller, run_once: true) do
-        if ActiveRecord::Encryption.config.add_to_filter_parameters
-          ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
-        end
+      if ActiveRecord::Encryption.config.add_to_filter_parameters
+        ActiveRecord::Encryption.install_auto_filtered_parameters_hook(app)
       end
     end
 

--- a/activerecord/test/cases/encryption/configurable_test.rb
+++ b/activerecord/test/cases/encryption/configurable_test.rb
@@ -51,18 +51,22 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
     NamedPirate.encrypts :catchphrase
 
     assert_includes application.config.filter_parameters, "named_pirate.catchphrase"
+    assert_includes NamedPirate.filter_attributes, "catchphrase"
+    assert_not_includes ActiveRecord::Base.filter_attributes, "catchphrase"
   end
 
   test "installing autofiltered parameters will work with unnamed classes" do
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
     ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
 
-    Class.new(Pirate) do
+    unnamed_class = Class.new(Pirate) do
       self.table_name = "pirates"
       encrypts :catchphrase
     end
 
     assert_includes application.config.filter_parameters, "catchphrase"
+    assert_includes unnamed_class.filter_attributes, "catchphrase"
+    assert_not_includes ActiveRecord::Base.filter_attributes, "catchphrase"
   end
 
   test "exclude the installation of autofiltered params" do
@@ -71,12 +75,14 @@ class ActiveRecord::Encryption::ConfigurableTest < ActiveRecord::EncryptionTestC
     application = OpenStruct.new(config: OpenStruct.new(filter_parameters: []))
     ActiveRecord::Encryption.install_auto_filtered_parameters_hook(application)
 
-    Class.new(Pirate) do
+    unnamed_class = Class.new(Pirate) do
       self.table_name = "pirates"
+      self.filter_attributes = []
       encrypts :catchphrase
     end
 
     assert_equal application.config.filter_parameters, []
+    assert_equal unnamed_class.filter_attributes, []
 
     ActiveRecord::Encryption.config.excluded_from_filter_parameters = []
   end


### PR DESCRIPTION
Encrypted attributes would not be added to the Active Record class `filter_attributes` due to the auto-filtered-parameters hook only being applied when Action Controller is loaded.

Consider this model:

```ruby
class Foo < ApplicationRecord
  encrypts :api_key
  encrypts :client_id
end
```

When you interact with the model in a console, you'll see this:

```ruby
Foo.new(api_key: 'foo', client_id: 'bar')
# => #<Foo id: nil, api_key: "[FILTERED]", client_id: "bar", created_at: nil, updated_at: nil>
```

`api_key` is filtered because it includes `_key`, which is included in the default `Rails.application.config.filter_parameters` configuration. However, unfortunately `client_id` is not filtered, which seems inconsistent.

Now, the filtered parameter config hook is applied regardless of Action Controller being loaded, resulting in this:

```ruby
Foo.new(api_key: 'foo', client_id: 'bar')
# => #<Foo id: nil, api_key: "[FILTERED]", client_id: "[FILTERED]", created_at: nil, updated_at: nil>
```