### PR TITLE
`db:fixtures:load` raises in Postgres if there are foreign key constraints in a non-`public` schema

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -45,8 +45,10 @@ Rails needs superuser privileges to disable referential integrity.
             BEGIN
             FOR r IN (
               SELECT FORMAT(
-                'UPDATE pg_constraint SET convalidated=false WHERE conname = ''%I''; ALTER TABLE %I VALIDATE CONSTRAINT %I;',
+                'UPDATE pg_constraint SET convalidated=false WHERE conname = ''%I'' AND connamespace::regnamespace = ''%I''::regnamespace; ALTER TABLE %I.%I VALIDATE CONSTRAINT %I;',
                 constraint_name,
+                table_schema,
+                table_schema,
                 table_name,
                 constraint_name
               ) AS constraint_check

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -1052,7 +1052,7 @@ class GeneratedMethodsTest < ActiveRecord::TestCase
 end
 
 class WithAnnotationsTest < ActiveRecord::TestCase
-  fixtures :pirates, :parrots
+  fixtures :pirates, :parrots, :parrots_pirates, :pirates, :treasures
 
   def test_belongs_to_with_annotation_includes_a_query_comment
     pirate = SpacePirate.where.not(parrot_id: nil).first

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -22,6 +22,7 @@ require "models/doubloon"
 require "models/essay"
 require "models/joke"
 require "models/matey"
+require "models/organization"
 require "models/other_dog"
 require "models/parrot"
 require "models/pirate"
@@ -322,9 +323,9 @@ class FixturesTest < ActiveRecord::TestCase
   end
 
   def test_create_fixtures
-    fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, "parrots")
-    assert Parrot.find_by_name("Curious George"), "George is not in the database"
-    assert fixtures.detect { |f| f.name == "parrots" }, "no fixtures named 'parrots' in #{fixtures.map(&:name).inspect}"
+    fixtures = ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, "organizations")
+    assert Organization.find_by_name("No Such Agency"), "'No Such Agency' is not in the database"
+    assert fixtures.detect { |f| f.name == "organizations" }, "no fixtures named 'organizations' in #{fixtures.map(&:name).inspect}"
   end
 
   def test_multiple_clean_fixtures
@@ -1350,12 +1351,12 @@ class FoxyFixturesTest < ActiveRecord::TestCase
 end
 
 class ActiveSupportSubclassWithFixturesTest < ActiveRecord::TestCase
-  fixtures :parrots
+  fixtures :organizations
 
   # This seemingly useless assertion catches a bug that caused the fixtures
   # setup code call nil[]
   def test_foo
-    assert_equal parrots(:louis), Parrot.find_by_name("King Louis")
+    assert_equal organizations(:nsa), Organization.find_by_name("No Such Agency")
   end
 end
 
@@ -1391,7 +1392,7 @@ class CustomNameForFixtureOrModelTest < ActiveRecord::TestCase
 end
 
 class IgnoreFixturesTest < ActiveRecord::TestCase
-  fixtures :other_books, :parrots
+  fixtures :other_books, :parrots, :parrots_pirates, :pirates, :treasures
 
   # Set to false to blow away fixtures cache and ensure our fixtures are loaded
   # without interfering with other tests that use the same `model_class`.


### PR DESCRIPTION
Hi there 👋

I think I found a tiny issue in a edgecase when loading fixtures `bin/rails db:fixtures:load` into Postgres.

### Steps to reproduce

a) Use repository

The issue can be reproduced using this repository, see its README for details:

* https://github.com/lxxxvi/rails-issue-db-fixtures-load-raises

b) Manual setup

1. Create a new rails project
2. Create a non-`public` schema and tables and at least one foreign key constraint, for example

```sql
CREATE SCHEMA other;

CREATE TABLE IF NOT EXISTS other.authors (
  id          INT       GENERATED ALWAYS AS IDENTITY,
  name        TEXT      NOT NULL,
  PRIMARY KEY(id)
);

CREATE TABLE IF NOT EXISTS other.books (
  id          INT       GENERATED ALWAYS AS IDENTITY,
  author_id   INT       NOT NULL,
  name        TEXT      NOT NULL,
  PRIMARY KEY(id),
  CONSTRAINT fk_authors FOREIGN KEY(author_id)
                        REFERENCES other.authors(id)
);
```

3. Create a common (`public`) Rails model with a fixture

```sh
bin/rails g model Cat name:string
```

4. Run `bin/rails db:fixtures:load`

### Expected behavior

`bin/rails db:fixtures:load` should load without an error.

### Actual behavior

```
rails aborted!
Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations.

Tasks: TOP => db:fixtures:load
(See full trace by running task with --trace)
```

There's only one fixture (`cats.yml`) and it does not reference anything.

Under the hood I found this problem:

```
ERROR:  relation "books" does not exist (PG::UndefinedTable)
CONTEXT:  SQL statement "UPDATE pg_constraint SET convalidated=false WHERE conname = 'fk_authors'; ALTER TABLE books VALIDATE CONSTRAINT fk_authors;"
```

### System configuration

**Rails version**: 7.0.2.3

**Ruby version**: ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [arm64-darwin21]

**Postgres version**: `14.2`