### PR TITLE
Add the Active Job Test Adapter to QueueAdapter documentation [ci-skip]

### DIFF
--- a/activejob/lib/active_job/queue_adapters.rb
+++ b/activejob/lib/active_job/queue_adapters.rb
@@ -13,9 +13,13 @@ module ActiveJob
   # * {Sidekiq}[https://sidekiq.org]
   # * {Sneakers}[https://github.com/jondot/sneakers]
   # * {Sucker Punch}[https://github.com/brandonhilkert/sucker_punch]
-  # * {Active Job Async Job}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html]
-  # * {Active Job Inline}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html]
   # * Please Note: We are not accepting pull requests for new adapters. See the {README}[link:files/activejob/README_md.html] for more details.
+  #
+  # For testing and development Active Job has three built-in adapters:
+  #
+  # * {Active Job Async}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/AsyncAdapter.html]
+  # * {Active Job Inline}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/InlineAdapter.html]
+  # * {Active Job Test}[https://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html]
   #
   # === Backends Features
   #
@@ -31,6 +35,7 @@ module ActiveJob
   #   | Sucker Punch      | Yes   | Yes    | Yes        | No         | No      | No      |
   #   | Active Job Async  | Yes   | Yes    | Yes        | No         | No      | No      |
   #   | Active Job Inline | No    | Yes    | N/A        | N/A        | N/A     | N/A     |
+  #   | Active Job Test   | No    | Yes    | N/A        | N/A        | N/A     | N/A     |
   #
   # ==== Async
   #
@@ -106,10 +111,6 @@ module ActiveJob
   # N/A: The adapter does not run in a separate process, and therefore doesn't
   # support retries.
   #
-  # === Async and Inline Queue Adapters
-  #
-  # Active Job has two built-in queue adapters intended for development and
-  # testing: +:async+ and +:inline+.
   module QueueAdapters
     extend ActiveSupport::Autoload
 


### PR DESCRIPTION
The test adapter wasn't documented in the QueueAdapter overview.