### PR TITLE
Improve `sanitize_sql_like` performance

### DIFF
--- a/activerecord/lib/active_record/sanitization.rb
+++ b/activerecord/lib/active_record/sanitization.rb
@@ -107,8 +107,11 @@ module ActiveRecord
       #   sanitize_sql_like("snake_cased_string", "!")
       #   # => "snake!_cased!_string"
       def sanitize_sql_like(string, escape_character = "\\")
-        pattern = Regexp.union(escape_character, "%", "_")
-        string.gsub(pattern) { |x| [escape_character, x].join }
+        if string.include?(escape_character) && escape_character != "%" && escape_character != "_"
+          string = string.gsub(escape_character, '\0\0')
+        end
+
+        string.gsub(/(?=[%_])/, escape_character)
       end
 
       # Accepts an array of conditions. The array has each value

--- a/activerecord/test/cases/sanitize_test.rb
+++ b/activerecord/test/cases/sanitize_test.rb
@@ -75,6 +75,11 @@ class SanitizeTest < ActiveRecord::TestCase
     assert_equal "normal string 42", Binary.sanitize_sql_like("normal string 42", "!")
   end
 
+  def test_sanitize_sql_like_with_wildcard_as_escape_character
+    assert_equal "1__000_%", Binary.sanitize_sql_like("1_000%", "_")
+    assert_equal "1%_000%%", Binary.sanitize_sql_like("1_000%", "%")
+  end
+
   def test_sanitize_sql_like_example_use_case
     searchable_post = Class.new(Post) do
       def self.search_as_method(term)


### PR DESCRIPTION
This improves performance and reduces memory allocations for `sanitize_sql_like` across multiple use cases.

<details>
  <summary><strong>Benchmark script</strong></summary>

  ```ruby
  require "benchmark/memory"
  require "benchmark/ips"

  def old_sanitize_sql_like(string, escape_character = "\\")
    pattern = Regexp.union(escape_character, "%", "_")
    string.gsub(pattern) { |x| [escape_character, x].join }
  end

  def new_sanitize_sql_like(string, escape_character = "\\")
    if string.include?(escape_character) && escape_character != "%" && escape_character != "_"
      string = string.gsub(escape_character, '\0\0')
    end

    string.gsub(/(?=[%_])/, escape_character)
  end

  [
    "no-special-characters",
    "one_wildcard",
    "one\\escape",
    "two_wildcards%and\\two\\escapes",
  ].each do |string|
    puts "\n= #{string.inspect} ".ljust(72, "=")

    Benchmark.memory do |x|
      # Warmup:
      old_sanitize_sql_like(string)
      new_sanitize_sql_like(string)

      x.report("old") { old_sanitize_sql_like(string) }
      x.report("new") { new_sanitize_sql_like(string) }
    end

    puts

    Benchmark.ips do |x|
      x.report("old") { old_sanitize_sql_like(string) }
      x.report("new") { new_sanitize_sql_like(string) }
      x.compare!
    end
  end
  ```
</details>

**Benchmark results:**

```
= "no-special-characters" =============================================
Calculating -------------------------------------
                 old   875.000  memsize (     0.000  retained)
                        10.000  objects (     0.000  retained)
                         5.000  strings (     0.000  retained)
                 new    40.000  memsize (     0.000  retained)
                         1.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Warming up --------------------------------------
                 old     9.483k i/100ms
                 new   119.791k i/100ms
Calculating -------------------------------------
                 old     95.694k (± 0.3%) i/s -    483.633k in   5.053985s
                 new      1.228M (± 0.5%) i/s -      6.229M in   5.072317s

Comparison:
                 new:  1228094.1 i/s
                 old:    95694.3 i/s - 12.83x  (± 0.00) slower

= "one_wildcard" ======================================================
Calculating -------------------------------------
                 old     1.395k memsize (     0.000  retained)
                        15.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
                 new   440.000  memsize (     0.000  retained)
                         3.000  objects (     0.000  retained)
                         1.000  strings (     0.000  retained)

Warming up --------------------------------------
                 old     6.527k i/100ms
                 new    30.205k i/100ms
Calculating -------------------------------------
                 old     65.255k (± 0.6%) i/s -    326.350k in   5.001318s
                 new    300.058k (± 0.5%) i/s -      1.510M in   5.033333s

Comparison:
                 new:   300057.6 i/s
                 old:    65255.2 i/s - 4.60x  (± 0.00) slower

= "one\\escape" =======================================================
Calculating -------------------------------------
                 old     1.395k memsize (     0.000  retained)
                        15.000  objects (     0.000  retained)
                         6.000  strings (     0.000  retained)
                 new   560.000  memsize (     0.000  retained)
                         6.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)

Warming up --------------------------------------
                 old     6.506k i/100ms
                 new    24.312k i/100ms
Calculating -------------------------------------
                 old     65.467k (± 0.4%) i/s -    331.806k in   5.068392s
                 new    245.704k (± 0.5%) i/s -      1.240M in   5.046485s

Comparison:
                 new:   245703.8 i/s
                 old:    65466.9 i/s - 3.75x  (± 0.00) slower

= "two_wildcards%and\\two\\escapes" ===================================
Calculating -------------------------------------
                 old     1.755k memsize (     0.000  retained)
                        24.000  objects (     0.000  retained)
                         8.000  strings (     0.000  retained)
                 new   832.000  memsize (     0.000  retained)
                         8.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)

Warming up --------------------------------------
                 old     5.265k i/100ms
                 new    12.360k i/100ms
Calculating -------------------------------------
                 old     52.698k (± 0.3%) i/s -    268.515k in   5.095425s
                 new    124.006k (± 0.3%) i/s -    630.360k in   5.083351s

Comparison:
                 new:   124006.2 i/s
                 old:    52697.9 i/s - 2.35x  (± 0.00) slower
```
