### PR TITLE
Remove override of ActiveModel#attribute_names

### DIFF
--- a/activemodel/lib/active_model/serialization.rb
+++ b/activemodel/lib/active_model/serialization.rb
@@ -123,7 +123,7 @@ module ActiveModel
     #   user.serializable_hash(include: { notes: { only: 'title' }})
     #   # => {"name" => "Napoleon", "notes" => [{"title"=>"Battle of Austerlitz"}]}
     def serializable_hash(options = nil)
-      attribute_names = self.attribute_names
+      attribute_names = attribute_names_for_serialization
 
       return serializable_attributes(attribute_names) if options.blank?
 
@@ -148,12 +148,11 @@ module ActiveModel
       hash
     end
 
-    # Returns an array of attribute names as strings
-    def attribute_names # :nodoc:
-      attributes.keys
-    end
-
     private
+      def attribute_names_for_serialization
+        attributes.keys
+      end
+
       # Hook method defining how an attribute value should be retrieved for
       # serialization. By default this is assumed to be an instance named after
       # the attribute. Override this method in subclasses should you need to

--- a/activerecord/lib/active_record/serialization.rb
+++ b/activerecord/lib/active_record/serialization.rb
@@ -20,5 +20,10 @@ module ActiveRecord # :nodoc:
 
       super(options)
     end
+
+    private
+      def attribute_names_for_serialization
+        attribute_names
+      end
   end
 end


### PR DESCRIPTION
### Summary

This replaces an optimisation introduced in https://github.com/rails/rails/pull/43036 which doesn't seem to have the desired affect and instead, in our case, caused a significant performance issue by causing N+1 queries for collections. This change achieves the intended optimisation of the first PR while resolving the problem it caused.

### Other Information

In https://github.com/rails/rails/pull/43036 an optimisation was applied to `ActiveModel#Serialization` to speed up the generation of `#serialized_hash` by avoiding loading the subjects attributes by using an attribute_names method. A fallback method, `ActiveModel::Serialization#attribute_names` was added as `#attribute_names` isn't part of the public API of ActiveModel.

Unfortunately, this fallback method happens to override the [`ActiveRecord#attribute_names`](https://github.com/rails/rails/blob/eeb2cfb6864169d7b9cb78744d44b7da17b2b288/activerecord/lib/active_record/attribute_methods.rb#L244-L254) method (as `ActiveModel::Serialization` is a later mixin than `ActiveRecord::AttributeMethods`), so this change didn't actually provide an optimisation - the full attribute data was loaded as per [`ActiveModel::Serialization#attribute_names`](https://github.com/rails/rails/blob/eeb2cfb6864169d7b9cb78744d44b7da17b2b288/activemodel/lib/active_model/serialization.rb#L151-L154).

This change also, in our case, produced some severe performance issues as it introduced an N+1 query in a situation where we had one gem, [Globalize](https://github.com/globalize/globalize), which adds in dynamic attributes that are loaded by a query;
and another gem, [Transitions](https://github.com/troessner/transitions), that checks attribute names at initialization. The combination of these meant that for every model that was initialized an extra query would run - no matter what includes or eager_load steps were in place. This rapidly hindered our applications' performance and meant we had to rollback the Rails 7 upgrade.

Following [rafaelfranca's suggestion](https://github.com/rails/rails/pull/44770#pullrequestreview-922209612) this adds a `attribute_names_for_serialization` method to Serialization modules in ActiveRecord and ActiveModel. This allows the ActiveRecord one to override the ActiveModel fallback and thus be optimised.

Some basic benchmarks of this follow - they use code from https://github.com/ollietreend/rails-demo and have some [pretty large arrays set as serialized attributes](https://github.com/ollietreend/rails-demo/blob/525f88887bb1605a72f7b944b59b0d0e204f92aa/db/seeds.rb) to demonstrate impacts.

#### Loading attribute names:

Rails 7.0.2.3

```
> Benchmark.ms { Widget.all.map(&:attribute_names) }
  Widget Load (131.1ms)  SELECT "widgets".* FROM "widgets"
=> 20108.852999983355
```

This patch

```
> Benchmark.ms { Widget.all.map(&:attribute_names) }
  Widget Load (144.0ms)  SELECT "widgets".* FROM "widgets"
=> 237.96699999365956
```

#### Using `serializable_hash`:

Rails 7.0.2.3

```
> widgets = Widget.all.to_a; Benchmark.ms { widgets.map { |w| w.serializable_hash(only: []) } }
  Widget Load (133.3ms)  SELECT "widgets".* FROM "widgets"
=> 22071.45000001765
```

This patch

```
> widgets = Widget.all.to_a; Benchmark.ms { widgets.map { |w| w.serializable_hash(only: []) } }
  Widget Load (86.4ms)  SELECT "widgets".* FROM "widgets"
=> 90.2289999939967
```
