### PR TITLE
ActiveSupport::Deprecation fallback to singleton disallowed_behavior

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fall back on globally configured `disallowed_behavior` in custom `ActiveSupport::Deprecator` instances.
+
+    *grncdr*
+
 *   `default` option of `thread_mattr_accessor` now applies through inheritance and
     also across new threads.
 

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -19,7 +19,7 @@ module ActiveSupport
 
       stderr: ->(message, callstack, deprecation_horizon, gem_name) {
         $stderr.puts(message)
-        $stderr.puts callstack.join("\n  ") if debug
+        $stderr.puts callstack.join("\n  ") if ActiveSupport::Deprecation.debug
       },
 
       log: ->(message, callstack, deprecation_horizon, gem_name) {
@@ -31,7 +31,7 @@ module ActiveSupport
               ActiveSupport::Logger.new($stderr)
             end
         logger.warn message
-        logger.debug callstack.join("\n  ") if debug
+        logger.debug callstack.join("\n  ") if ActiveSupport::Deprecation.debug
       },
 
       notify: ->(message, callstack, deprecation_horizon, gem_name) {
@@ -59,17 +59,22 @@ module ActiveSupport
     # Setting behaviors only affects deprecations that happen after boot time.
     # For more information you can read the documentation of the +behavior=+ method.
     module Behavior
-      # Whether to print a backtrace along with the warning.
-      attr_accessor :debug
+      attr_writer :debug
 
-      # Returns the current behavior or if one isn't set, defaults to +:stderr+.
-      def behavior
-        @behavior ||= self == Deprecation.instance ? [DEFAULT_BEHAVIORS[:stderr]] : Deprecation.behavior
+      # Whether to print a backtrace along with the warning.
+      def debug
+        defined?(@debug) ? @debug : self.class.debug
       end
 
-      # Returns the current behavior for disallowed deprecations or if one isn't set, defaults to +:raise+.
+      # Returns the current behavior. Defaults to +ActiveSupport::Deprecation.behavior+.
+      def behavior
+        @behavior || self.class.behavior
+      end
+
+      # Returns the current behavior for disallowed deprecations. Defaults to
+      # +ActiveSupport::Deprecation.disallowed_behavior+.
       def disallowed_behavior
-        @disallowed_behavior ||= self == Deprecation.instance ? [DEFAULT_BEHAVIORS[:raise]] : Deprecation.disallowed_behavior
+        @disallowed_behavior || self.class.disallowed_behavior
       end
 
       # Sets the behavior to the specified value. Can be a single value, array,

--- a/activesupport/lib/active_support/deprecation/behaviors.rb
+++ b/activesupport/lib/active_support/deprecation/behaviors.rb
@@ -64,12 +64,12 @@ module ActiveSupport
 
       # Returns the current behavior or if one isn't set, defaults to +:stderr+.
       def behavior
-        @behavior ||= [DEFAULT_BEHAVIORS[:stderr]]
+        @behavior ||= self == Deprecation.instance ? [DEFAULT_BEHAVIORS[:stderr]] : Deprecation.behavior
       end
 
       # Returns the current behavior for disallowed deprecations or if one isn't set, defaults to +:raise+.
       def disallowed_behavior
-        @disallowed_behavior ||= [DEFAULT_BEHAVIORS[:raise]]
+        @disallowed_behavior ||= self == Deprecation.instance ? [DEFAULT_BEHAVIORS[:raise]] : Deprecation.disallowed_behavior
       end
 
       # Sets the behavior to the specified value. Can be a single value, array,

--- a/activesupport/lib/active_support/deprecation/disallowed.rb
+++ b/activesupport/lib/active_support/deprecation/disallowed.rb
@@ -12,22 +12,64 @@ module ActiveSupport
       # deprecations as disallowed.
       #
       # Deprecations matching a substring or regular expression will be handled
-      # using the configured +ActiveSupport::Deprecation.disallowed_behavior+
-      # rather than +ActiveSupport::Deprecation.behavior+
+      # using the configured ActiveSupport::Deprecation#disallowed_behavior
+      # rather than ActiveSupport::Deprecation#behavior.
       attr_writer :disallowed_warnings
 
       # Returns the configured criteria used to identify deprecation messages
-      # which should be treated as disallowed.
+      # which should be treated as disallowed. Defaults to
+      # +ActiveSupport::Deprecation.disallowed_warnings+.
       def disallowed_warnings
-        @disallowed_warnings ||= []
+        @disallowed_warnings || self.class.disallowed_warnings
+      end
+
+      # Allow previously disallowed deprecation warnings within the block.
+      # <tt>allowed_warnings</tt> can be an array containing strings, symbols, or regular
+      # expressions. (Symbols are treated as strings). These are compared against
+      # the text of deprecation warning messages generated within the block.
+      # Matching warnings will be exempt from the rules set by
+      # +ActiveSupport::Deprecation.disallowed_warnings+
+      #
+      # The optional <tt>if:</tt> argument accepts a truthy/falsy value or an object that
+      # responds to <tt>.call</tt>. If truthy, then matching warnings will be allowed.
+      # If falsey then the method yields to the block without allowing the warning.
+      #
+      #   ActiveSupport::Deprecation.disallowed_behavior = :raise
+      #   ActiveSupport::Deprecation.disallowed_warnings = [
+      #     "something broke"
+      #   ]
+      #
+      #   ActiveSupport::Deprecation.warn('something broke!')
+      #   # => ActiveSupport::DeprecationException
+      #
+      #   ActiveSupport::Deprecation.allow ['something broke'] do
+      #     ActiveSupport::Deprecation.warn('something broke!')
+      #   end
+      #   # => nil
+      #
+      #   ActiveSupport::Deprecation.allow ['something broke'], if: Rails.env.production? do
+      #     ActiveSupport::Deprecation.warn('something broke!')
+      #   end
+      #   # => ActiveSupport::DeprecationException for dev/test, nil for production
+      def allow(allowed_warnings = :all, if: true, &block)
+        conditional = binding.local_variable_get(:if)
+        conditional = conditional.call if conditional.respond_to?(:call)
+        if conditional
+          @explicitly_allowed_warnings.bind(allowed_warnings, &block)
+        else
+          yield
+        end
+      end
+
+      def explicitly_allowed_warnings # :nodoc:
+        @explicitly_allowed_warnings.value || self.class.explicitly_allowed_warnings
       end
 
       private
         def deprecation_disallowed?(message)
-          disallowed = ActiveSupport::Deprecation.disallowed_warnings
           return false if explicitly_allowed?(message)
-          return true if disallowed == :all
-          disallowed.any? do |rule|
+          return true if disallowed_warnings == :all
+          disallowed_warnings.any? do |rule|
             case rule
             when String, Symbol
               message.include?(rule.to_s)
@@ -38,11 +80,8 @@ module ActiveSupport
         end
 
         def explicitly_allowed?(message)
-          allowances = @explicitly_allowed_warnings.value
-          return false unless allowances
-          return true if allowances == :all
-          allowances = [allowances] unless allowances.kind_of?(Array)
-          allowances.any? do |rule|
+          return true if explicitly_allowed_warnings == :all
+          Array(explicitly_allowed_warnings).any? do |rule|
             case rule
             when String, Symbol
               message.include?(rule.to_s)


### PR DESCRIPTION
### Summary

This addresses the issue described in https://github.com/rails/rails/issues/44553 by causing custom ActiveSupport::Deprecation instances to fall back to the `disallowed_behavior` of the global singleton instance if they don't have their own explicitly configured `disallowed_behavior`.

I feel like this approach gives developers the least-surprising results: any global configuration of deprecation behavior behavior will automatically be respected, but can still be explicitly overridden on a per-deprecator basis (and there are tests for that).

