### PR TITLE
Bumps nokogiri to >= 1.13.2 for security reasons in actiontext

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,7 +130,7 @@ group :test do
 end
 
 platforms :ruby, :mswin, :mswin64, :mingw, :x64_mingw do
-  gem "nokogiri", ">= 1.8.1", "!= 1.11.0"
+  gem "nokogiri", ">= 1.13.2"
 
   # Needed for compiling the ActionDispatch::Journey parser.
   gem "racc", ">=1.4.6", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ PATH
       activestorage (= 7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       globalid (>= 0.6.0)
-      nokogiri (>= 1.8.5)
+      nokogiri (>= 1.13.2)
     actionview (7.1.0.alpha)
       activesupport (= 7.1.0.alpha)
       builder (~> 3.1)
@@ -602,7 +602,7 @@ DEPENDENCIES
   minitest-ci
   minitest-retry
   mysql2 (~> 0.5)!
-  nokogiri (>= 1.8.1, != 1.11.0)
+  nokogiri (>= 1.13.2)
   pg (~> 1.3)
   propshaft (>= 0.1.7)
   psych (~> 3.0)

--- a/actiontext/actiontext.gemspec
+++ b/actiontext/actiontext.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activestorage", version
   s.add_dependency "actionpack",    version
 
-  s.add_dependency "nokogiri", ">= 1.8.5"
+  s.add_dependency "nokogiri", ">= 1.13.2"
   s.add_dependency "globalid", ">= 0.6.0"
 end


### PR DESCRIPTION
### Summary

There are `high severity` vulnerable dependencies present in `nokogiri` as published
in GitHub Security Advisory here https://github.com/advisories/GHSA-fq42-c5rg-92c2. From versions `>= 1.13.2`,
this vulnerability seems to have been patched. This PR introduces this version in the
Gemfile and actiontext's gemspec.


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->