### PR TITLE
Added missing `config.session_store` option `:cache_store` to docs [ci-skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -334,7 +334,7 @@ Configures Rails to serve static files from the public directory. This option de
 
 #### `config.session_store`
 
-Specifies what class to use to store the session. Possible values are `:cookie_store`, `:mem_cache_store`, a custom store, or `:disabled`. `:disabled` tells Rails not to deal with sessions.
+Specifies what class to use to store the session. Possible values are `:cache_store`, `:cookie_store`, `:mem_cache_store`, a custom store, or `:disabled`. `:disabled` tells Rails not to deal with sessions.
 
 This setting is configured via a regular method call, rather than a setter. This allows additional options to be passed:
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -376,8 +376,9 @@ module Rails
       end
 
       # Specifies what class to use to store the session. Possible values
-      # are +:cookie_store+, +:mem_cache_store+, a custom store, or
-      # +:disabled+. +:disabled+ tells Rails not to deal with sessions.
+      # are +:cache_store+, +:cookie_store+, +:mem_cache_store+, a custom
+      # store, or +:disabled+. +:disabled+ tells Rails not to deal with
+      # sessions.
       #
       # Additional options will be set as +session_options+:
       #


### PR DESCRIPTION
### Summary

While debugging an issue with the `:cache_store` option for `config.session_store`, I noticed
that the `:cache_store` option is a valid option for `config.session_store` and was missing
from the docs. This PR adds this as a valid option to the docs.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
