### PR TITLE
Remove confusing validations comments [ci-skip]

### DIFF
--- a/activemodel/lib/active_model/validations/absence.rb
+++ b/activemodel/lib/active_model/validations/absence.rb
@@ -11,7 +11,7 @@ module ActiveModel
 
     module HelperMethods
       # Validates that the specified attributes are blank (as defined by
-      # Object#present?). Happens by default on save.
+      # Object#present?).
       #
       #   class Person < ActiveRecord::Base
       #     validates_absence_of :first_name

--- a/activemodel/lib/active_model/validations/acceptance.rb
+++ b/activemodel/lib/active_model/validations/acceptance.rb
@@ -90,7 +90,7 @@ module ActiveModel
       #
       # If the database column does not exist, the +terms_of_service+ attribute
       # is entirely virtual. This check is performed only if +terms_of_service+
-      # is not +nil+ and by default on save.
+      # is not +nil+.
       #
       # Configuration options:
       # * <tt>:message</tt> - A custom error message (default is: "must be

--- a/activemodel/lib/active_model/validations/presence.rb
+++ b/activemodel/lib/active_model/validations/presence.rb
@@ -10,7 +10,7 @@ module ActiveModel
 
     module HelperMethods
       # Validates that the specified attributes are not blank (as defined by
-      # Object#blank?). Happens by default on save.
+      # Object#blank?).
       #
       #   class Person < ActiveRecord::Base
       #     validates_presence_of :first_name

--- a/activerecord/lib/active_record/validations.rb
+++ b/activerecord/lib/active_record/validations.rb
@@ -30,10 +30,12 @@ module ActiveRecord
 
   # = Active Record \Validations
   #
-  # Active Record includes the majority of its validations from ActiveModel::Validations
-  # all of which accept the <tt>:on</tt> argument to define the context where the
-  # validations are active. Active Record will always supply either the context of
-  # <tt>:create</tt> or <tt>:update</tt> dependent on whether the model is a
+  # Active Record includes the majority of its validations from ActiveModel::Validations.
+  #
+  # In Active Record, all validations are performed on save by default.
+  # Validations accept the <tt>:on</tt> argument to define the context where
+  # the validations are active. Active Record will pass either the context of
+  # <tt>:create</tt> or <tt>:update</tt> depending on whether the model is a
   # {new_record?}[rdoc-ref:Persistence#new_record?].
   module Validations
     extend ActiveSupport::Concern


### PR DESCRIPTION
### Summary
All validations are called on `#save` by default.
The Absence, Acceptance, Presence validators don't do anything special,
so there is no reason to mention they are called on `#save` by default.