### PR TITLE
Group `validates_associated` guide with `validates_*` [ci-skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -320,30 +320,6 @@ don't have a field for it, the helper will create a virtual attribute. If
 the field does exist in your database, the `accept` option must be set to
 or include `true` or else the validation will not run.
 
-### `validates_associated`
-
-You should use this helper when your model has associations with other models
-and they also need to be validated. When you try to save your object, `valid?`
-will be called upon each one of the associated objects.
-
-```ruby
-class Library < ApplicationRecord
-  has_many :books
-  validates_associated :books
-end
-```
-
-This validation will work with all of the association types.
-
-CAUTION: Don't use `validates_associated` on both ends of your associations.
-They would call each other in an infinite loop.
-
-The default error message for [`validates_associated`][] is _"is invalid"_. Note
-that each associated object will contain its own `errors` collection; errors do
-not bubble up to the calling model.
-
-[`validates_associated`]: https://api.rubyonrails.org/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_associated
-
 ### `confirmation`
 
 You should use this helper when you have two text fields that should receive
@@ -701,6 +677,30 @@ WARNING. Note that some databases are configured to perform case-insensitive
 searches anyway.
 
 The default error message is _"has already been taken"_.
+
+### `validates_associated`
+
+You should use this helper when your model has associations that always need to
+be validated. Every time you try to save your object, `valid?` will be called
+on each one of the associated objects.
+
+```ruby
+class Library < ApplicationRecord
+  has_many :books
+  validates_associated :books
+end
+```
+
+This validation will work with all of the association types.
+
+CAUTION: Don't use `validates_associated` on both ends of your associations.
+They would call each other in an infinite loop.
+
+The default error message for [`validates_associated`][] is _"is invalid"_. Note
+that each associated object will contain its own `errors` collection; errors do
+not bubble up to the calling model.
+
+[`validates_associated`]: https://api.rubyonrails.org/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_associated
 
 ### `validates_with`
 


### PR DESCRIPTION
### Summary

`validates_associated` makes sure that passed associations are validated
every time the record is saved. This is unlike other validations that
validate an attribute/association has a certain value.
Typically you won't call the following:

    validates :books, associated: true

... as books aren't validated as associated.

By grouping `validates_associated` with `validates_with` and
`validates_each` it's made clearer `validates_associated` is a bit
different.

With this change the validations are sorted alphabetically.

## Before
<img width="253" alt="image" src="https://user-images.githubusercontent.com/28561/160678970-9a722aa6-98e6-4e2f-bac3-aeb5565ea0dd.png">

## After
<img width="256" alt="image" src="https://user-images.githubusercontent.com/28561/160679190-87d7d781-db5b-4b37-87a8-b73a8bc3ae09.png">
