### PR TITLE
Document that `data-remote` and `data-method` are deprecated

### DIFF
--- a/actionview/lib/action_view/helpers/url_helper.rb
+++ b/actionview/lib/action_view/helpers/url_helper.rb
@@ -89,21 +89,6 @@ module ActionView
       #
       # ==== Options
       # * <tt>:data</tt> - This option can be used to add custom data attributes.
-      # * <tt>method: symbol of HTTP verb</tt> - This modifier will dynamically
-      #   create an HTML form and immediately submit the form for processing using
-      #   the HTTP verb specified. Useful for having links perform a POST operation
-      #   in dangerous actions like deleting a record (which search bots can follow
-      #   while spidering your site). Supported verbs are <tt>:post</tt>, <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>.
-      #   Note that if the user has JavaScript disabled, the request will fall back
-      #   to using GET. If <tt>href: '#'</tt> is used and the user has JavaScript
-      #   disabled clicking the link will have no effect. If you are relying on the
-      #   POST behavior, you should check for it in your controller's action by using
-      #   the request object's methods for <tt>post?</tt>, <tt>delete?</tt>, <tt>patch?</tt>, or <tt>put?</tt>.
-      # * <tt>remote: true</tt> - This will allow the unobtrusive JavaScript
-      #   driver to make an Ajax request to the URL in question instead of following
-      #   the link. The drivers each provide mechanisms for listening for the
-      #   completion of the Ajax request and performing JavaScript operations once
-      #   they're complete
       #
       # ==== Examples
       #
@@ -180,12 +165,7 @@ module ActionView
       #   link_to "Nonsense search", searches_path(foo: "bar", baz: "quux")
       #   # => <a href="/searches?foo=bar&baz=quux">Nonsense search</a>
       #
-      # The only option specific to +link_to+ (<tt>:method</tt>) is used as follows:
-      #
-      #   link_to("Destroy", "http://www.example.com", method: :delete)
-      #   # => <a href='http://www.example.com' rel="nofollow" data-method="delete">Destroy</a>
-      #
-      # Also you can set any link attributes such as <tt>target</tt>, <tt>rel</tt>, <tt>type</tt>:
+      # You can set any link attributes such as <tt>target</tt>, <tt>rel</tt>, <tt>type</tt>:
       #
       #   link_to "External link", "http://www.rubyonrails.org/", target: "_blank", rel: "nofollow"
       #   # => <a href="http://www.rubyonrails.org/" target="_blank" rel="nofollow">External link</a>
@@ -195,6 +175,30 @@ module ActionView
       # Prior to Rails 7, Rails shipped with a JavaScript library called @rails/ujs on by default. Following Rails 7,
       # this library is no longer on by default. This library integrated with the following options:
       #
+      # * <tt>remote: true</tt> - This will allow @rails/ujs
+      #   to make an Ajax request to the URL in question instead of following
+      #   the link. The drivers each provide mechanisms for listening for the
+      #   completion of the Ajax request and performing JavaScript operations once
+      #   they're complete
+      # * <tt>method: symbol of HTTP verb</tt> - This modifier will dynamically
+      #   create an HTML form and immediately submit the form for processing using
+      #   the HTTP verb specified. Useful for having links perform a POST operation
+      #   in dangerous actions like deleting a record (which search bots can follow
+      #   while spidering your site). Supported verbs are <tt>:post</tt>, <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>.
+      #   Note that if the user has JavaScript disabled, the request will fall back
+      #   to using GET. If <tt>href: '#'</tt> is used and the user has JavaScript
+      #   disabled clicking the link will have no effect. If you are relying on the
+      #   POST behavior, you should check for it in your controller's action by using
+      #   the request object's methods for <tt>post?</tt>, <tt>delete?</tt>, <tt>patch?</tt>, or <tt>put?</tt>.
+      #
+      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
+      #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
+      #
+      #   link_to("Destroy", "http://www.example.com", method: :delete)
+      #   # => <a href='http://www.example.com' rel="nofollow" data-method="delete">Destroy</a>
+      #
+      # @rails/ujs also integrated with the following +:data+ options:
+      #
       # * <tt>confirm: 'question?'</tt> - This will allow the unobtrusive JavaScript
       #   driver to prompt with the question specified (in this case, the
       #   resulting text would be <tt>question?</tt>). If the user accepts, the
@@ -202,10 +206,6 @@ module ActionView
       # * <tt>:disable_with</tt> - Value of this parameter will be used as the
       #   name for a disabled version of the link. This feature is provided by
       #   the unobtrusive JavaScript driver.
-      #
-      #   link_to "Visit Other Site", "http://www.rubyonrails.org/", data: { confirm: "Are you sure?" }
-      #   # => <a href="http://www.rubyonrails.org/" data-confirm="Are you sure?">Visit Other Site</a>
-      #
       def link_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options, name = options, name, block if block_given?
         options ||= {}
@@ -255,8 +255,6 @@ module ActionView
       #   <tt>:delete</tt>, <tt>:patch</tt>, and <tt>:put</tt>. By default it will be <tt>:post</tt>.
       # * <tt>:disabled</tt> - If set to true, it will generate a disabled button.
       # * <tt>:data</tt> - This option can be used to add custom data attributes.
-      # * <tt>:remote</tt> -  If set to true, will allow the Unobtrusive JavaScript drivers to control the
-      #   submit behavior. By default this behavior is an ajax submit.
       # * <tt>:form</tt> - This hash will be form attributes
       # * <tt>:form_class</tt> - This controls the class of the form within which the submit button will
       #   be placed
@@ -298,8 +296,8 @@ module ActionView
       #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off"/>
       #   #    </form>"
       #
-      #   <%= button_to "Create", { action: "create" }, remote: true, form: { "data-type" => "json" } %>
-      #   # => "<form method="post" action="/images/create" class="button_to" data-remote="true" data-type="json">
+      #   <%= button_to "Create", { action: "create" }, form: { "data-type" => "json" } %>
+      #   # => "<form method="post" action="/images/create" class="button_to" data-type="json">
       #   #      <button type="submit">Create</button>
       #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off"/>
       #   #    </form>"
@@ -309,14 +307,24 @@ module ActionView
       # Prior to Rails 7, Rails shipped with a JavaScript library called @rails/ujs on by default. Following Rails 7,
       # this library is no longer on by default. This library integrated with the following options:
       #
-      # * <tt>confirm: 'question?'</tt> - This will allow the unobtrusive JavaScript
-      #   driver to prompt with the question specified (in this case, the
+      # * <tt>:remote</tt> -  If set to true, will allow @rails/ujs to control the
+      #   submit behavior. By default this behavior is an ajax submit.
+      #
+      #   <%= button_to "Create", { action: "create" }, remote: true, form: { "data-type" => "json" } %>
+      #   # => "<form method="post" action="/images/create" class="button_to" data-remote="true" data-type="json">
+      #   #      <button type="submit">Create</button>
+      #   #      <input name="authenticity_token" type="hidden" value="10f2163b45388899ad4d5ae948988266befcb6c3d1b2451cf657a0c293d605a6"  autocomplete="off"/>
+      #   #    </form>"
+      #
+      # @rails/ujs also integrated with the following +:data+ options:
+      #
+      # * <tt>confirm: 'question?'</tt> - This will allow @rails/ujs
+      #   to prompt with the question specified (in this case, the
       #   resulting text would be <tt>question?</tt>). If the user accepts, the
       #   button is processed normally, otherwise no action is taken.
       # * <tt>:disable_with</tt> - Value of this parameter will be
       #   used as the value for a disabled version of the submit
-      #   button when the form is submitted. This feature is provided
-      #   by the unobtrusive JavaScript driver.
+      #   button when the form is submitted.
       def button_to(name = nil, options = nil, html_options = nil, &block)
         html_options, options = options, name if block_given?
         html_options ||= {}


### PR DESCRIPTION
Follow up to https://github.com/rails/rails/pull/43112 and https://github.com/rails/rails/pull/44100, some more functionality that is only provided by Rails UJs, and should therefore be marked as deprecated:

- `data-remote` is deprecated on links and buttons. Turbo doesn't need it since that is the default behaviour. You use `data-turbo=false` on elements that opt out of that, but I don't think that's in scope for Rails.
- `data-method` is deprecated on links. Turbo expects [`data-turbo-method`](https://turbo.hotwired.dev/handbook/drive#performing-visits-with-a-different-method).
