### PR TITLE
Make AR Presence and Absence validation docs more consistent [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/validations/absence.rb
+++ b/activerecord/lib/active_record/validations/absence.rb
@@ -14,7 +14,7 @@ module ActiveRecord
     module ClassMethods
       # Validates that the specified attributes are not present (as defined by
       # Object#present?). If the attribute is an association, the associated object
-      # is considered absent if it was marked for destruction.
+      # is also considered not present if it is marked for destruction.
       #
       # See ActiveModel::Validations::HelperMethods.validates_absence_of for more information.
       def validates_absence_of(*attr_names)

--- a/activerecord/lib/active_record/validations/presence.rb
+++ b/activerecord/lib/active_record/validations/presence.rb
@@ -13,9 +13,8 @@ module ActiveRecord
 
     module ClassMethods
       # Validates that the specified attributes are not blank (as defined by
-      # Object#blank?), and, if the attribute is an association, that the
-      # associated object is not marked for destruction. Happens by default
-      # on save.
+      # Object#blank?). If the attribute is an association, the associated object
+      # is also considered blank if it is marked for destruction.
       #
       #   class Person < ActiveRecord::Base
       #     has_one :face
@@ -25,41 +24,19 @@ module ActiveRecord
       # The face attribute must be in the object and it cannot be blank or marked
       # for destruction.
       #
-      # If you want to validate the presence of a boolean field (where the real values
-      # are true and false), you will want to use
-      # <tt>validates_inclusion_of :field_name, in: [true, false]</tt>.
-      #
-      # This is due to the way Object#blank? handles boolean values:
-      # <tt>false.blank? # => true</tt>.
-      #
       # This validator defers to the Active Model validation for presence, adding the
       # check to see that an associated object is not marked for destruction. This
       # prevents the parent object from validating successfully and saving, which then
       # deletes the associated object, thus putting the parent object into an invalid
       # state.
       #
+      # See ActiveModel::Validations::HelperMethods.validates_presence_of for
+      # more information.
+      #
       # NOTE: This validation will not fail while using it with an association
       # if the latter was assigned but not valid. If you want to ensure that
       # it is both present and valid, you also need to use
       # {validates_associated}[rdoc-ref:Validations::ClassMethods#validates_associated].
-      #
-      # Configuration options:
-      # * <tt>:message</tt> - A custom error message (default is: "can't be blank").
-      # * <tt>:on</tt> - Specifies the contexts where this validation is active.
-      #   Runs in all validation contexts by default +nil+. You can pass a symbol
-      #   or an array of symbols. (e.g. <tt>on: :create</tt> or
-      #   <tt>on: :custom_validation_context</tt> or
-      #   <tt>on: [:create, :custom_validation_context]</tt>)
-      # * <tt>:if</tt> - Specifies a method, proc, or string to call to determine if
-      #   the validation should occur (e.g. <tt>if: :allow_validation</tt>, or
-      #   <tt>if: Proc.new { |user| user.signup_step > 2 }</tt>). The method, proc
-      #   or string should return or evaluate to a +true+ or +false+ value.
-      # * <tt>:unless</tt> - Specifies a method, proc, or string to call to determine
-      #   if the validation should not occur (e.g. <tt>unless: :skip_validation</tt>,
-      #   or <tt>unless: Proc.new { |user| user.signup_step <= 2 }</tt>). The method,
-      #   proc or string should return or evaluate to a +true+ or +false+ value.
-      # * <tt>:strict</tt> - Specifies whether validation should be strict.
-      #   See ActiveModel::Validations#validates! for more information.
       def validates_presence_of(*attr_names)
         validates_with PresenceValidator, _merge_attributes(attr_names)
       end


### PR DESCRIPTION
### Summary
Make it clearer that, in the ActiveRecord AbsenceValidator, the
associated object is not _only_ absent if it is marked for destruction.

For the ActiveRecord PresenceValidator we can point to the ActiveModel
validations, like we do for other validations as well. This allows us to
remove some duplicated documentation.