### PR TITLE
Add error wrapper when rich_text_area is required

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Apply `field_error_proc` to `rich_text_area` form fields.
+
+    *Kaíque Kandy Koga*
+
 *   Action Text attachment URLs rendered in a background job (a la Turbo
     Streams) now use `Rails.application.default_url_options` and
     `Rails.application.config.force_ssl` instead of `http://example.org`.

--- a/actiontext/app/helpers/action_text/tag_helper.rb
+++ b/actiontext/app/helpers/action_text/tag_helper.rb
@@ -50,7 +50,8 @@ module ActionView::Helpers
       options = @options.stringify_keys
       add_default_name_and_id(options)
       options["input"] ||= dom_id(object, [options["id"], :trix_input].compact.join("_")) if object
-      @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
+      html_tag = @template_object.rich_text_area_tag(options.delete("name"), options.fetch("value") { value }, options.except("value"))
+      error_wrapping(html_tag)
     end
   end
 

--- a/actiontext/test/template/form_helper_test.rb
+++ b/actiontext/test/template/form_helper_test.rb
@@ -69,6 +69,25 @@ class ActionText::FormHelperTest < ActionView::TestCase
       output_buffer
   end
 
+  test "form with rich text area and error wrapper" do
+    message = Message.new
+    message.errors.add(:content, :blank)
+
+    form_with model: message, scope: :message do |form|
+      form.rich_text_area :content
+    end
+
+    assert_dom_equal \
+      '<form action="/messages" accept-charset="UTF-8" method="post">' \
+        '<div class="field_with_errors">' \
+            '<input type="hidden" name="message[content]" id="message_content_trix_input_message" autocomplete="off" />' \
+            '<trix-editor id="message_content" input="message_content_trix_input_message" class="trix-content" data-direct-upload-url="http://test.host/rails/active_storage/direct_uploads" data-blob-url-template="http://test.host/rails/active_storage/blobs/redirect/:signed_id/:filename">' \
+            "</trix-editor>" \
+          "</div>" \
+      "</form>",
+      output_buffer
+  end
+
   test "form with rich text area for non-attribute" do
     form_with model: Message.new, scope: :message do |form|
       form.rich_text_area :not_an_attribute


### PR DESCRIPTION
It is wrapping trix-editor with a div like other ActionView helpers when invalid.

https://github.com/rails/rails/issues/44762