### PR TITLE
Allow nested access for secrets.yml via method calls

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,22 @@
+*   Allow nested access to `secrets.yml` keys via method calls
+
+    Previously only top level keys loaded in `secrets.yml` were accessible
+    with method calls. Now any key, however nested, can be accessed with
+    method calls.
+
+    If the following `secrets.yml` file is loaded:
+
+    ```yml
+    # config/secrets.yml
+    development:
+      payment_options:
+        gateway: stripe
+    ```
+
+    `Rails.application.secrets.payment_options.gateway` will now return the same thing as `Rails.application.config.secrets.payment_options[:gateway]`
+
+    *Ghouse Mohamed*
+
 *   Add JavaScript dependencies installation on bin/setup
 
     Add  `yarn install` to bin/setup when using esbuild, webpack, or rollout.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -396,7 +396,7 @@ module Rails
         # Fallback to config.secret_key_base if secrets.secret_key_base isn't set
         secrets.secret_key_base ||= config.secret_key_base
 
-        secrets
+        deep_transform(secrets)
       end
     end
 
@@ -612,6 +612,16 @@ module Rails
 
       def coerce_same_site_protection(protection)
         protection.respond_to?(:call) ? protection : proc { protection }
+      end
+
+      def deep_transform(hash)
+        return hash unless hash.is_a?(Hash)
+
+        h = ActiveSupport::OrderedOptions.new
+        hash.each do |k, v|
+          h[k] = deep_transform(v)
+        end
+        h
       end
   end
 end

--- a/railties/test/secrets_test.rb
+++ b/railties/test/secrets_test.rb
@@ -141,6 +141,22 @@ class Rails::SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "can read keys loaded as methods" do
+    run_secrets_generator do
+      Rails::Secrets.write(<<-end_of_yaml)
+        production:
+          some_secret: yeah yeah
+          nested:
+            value: nested value
+      end_of_yaml
+
+      app("production")
+
+      assert_equal "yeah yeah", Rails.application.secrets.some_secret
+      assert_equal "nested value", Rails.application.secrets.nested.value
+    end
+  end
+
   test "can read secrets written in non-binary" do
     run_secrets_generator do
       secrets = <<-end_of_secrets


### PR DESCRIPTION
### Summary

Extension of PR https://github.com/rails/rails/pull/44758

In the production applications I'm working on, I find myself having to do something like
`Rails.application.secrets.routes[:remote_login_path]` many a times. It would be useful if nested
values could be accessed via method calls as well.

This PR introduces the same `deep_transform` method as used in https://github.com/rails/rails/pull/44758, so in case the other
https://github.com/rails/rails/pull/44758 gets merged, it would be reusing the same `deep_transform` method.

https://github.com/rails/rails/blob/353f0b917b15380d7d54900e3d83dd2f3b9d7196/railties/lib/rails/application.rb#L617-L625

In this PR, I'm just calling it on `secrets` like so:

https://github.com/rails/rails/blob/fecd2c829cd5df79533df32cd98b3e75611d8b0a/railties/lib/rails/application.rb#L399
