### PR TITLE
Highlight booleans which are set to config in docs [ci-skip]

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -212,7 +212,7 @@ end
 
 #### `config.disable_sandbox`
 
-Controls whether or not someone can start a console in sandbox mode. This is helpful to avoid a long running session of sandbox console, that could lead a database server to run out of memory. Defaults to false.
+Controls whether or not someone can start a console in sandbox mode. This is helpful to avoid a long running session of sandbox console, that could lead a database server to run out of memory. Defaults to `false`.
 
 #### `config.eager_load`
 
@@ -228,7 +228,7 @@ Accepts an array of paths from which Rails will eager load on boot if `config.ca
 
 #### `config.enable_dependency_loading`
 
-When true, enables autoloading, even if the application is eager loaded and `config.cache_classes` is set to `true`. Defaults to false.
+When `true`, enables autoloading, even if the application is eager loaded and `config.cache_classes` is set to `true`. Defaults to `false`.
 
 #### `config.encoding`
 
@@ -734,7 +734,7 @@ Lets you set an array of names of environments where destructive actions should 
 
 #### `config.active_record.pluralize_table_names`
 
-Specifies whether Rails will look for singular or plural table names in the database. If set to `true` (the default), then the Customer class will use the `customers` table. If set to false, then the Customer class will use the `customer` table.
+Specifies whether Rails will look for singular or plural table names in the database. If set to `true` (the default), then the Customer class will use the `customers` table. If set to `false`, then the Customer class will use the `customer` table.
 
 #### `config.active_record.default_timezone`
 
@@ -912,7 +912,7 @@ Allows specifying the Active Job queue to use for destroy jobs. When this option
 
 #### `config.active_record.enumerate_columns_in_select_statements`
 
-When true, will always include column names in `SELECT` statements, and avoid wildcard `SELECT * FROM ...` queries. This avoids prepared statement cache errors when adding columns to a PostgreSQL database for example. Defaults to `false`.
+When `true`, will always include column names in `SELECT` statements, and avoid wildcard `SELECT * FROM ...` queries. This avoids prepared statement cache errors when adding columns to a PostgreSQL database for example. Defaults to `false`.
 
 #### `config.active_record.verify_foreign_keys_for_fixtures`
 
@@ -1614,7 +1614,7 @@ Defines the delivery method and defaults to `:smtp`. See the [configuration sect
 
 #### `config.action_mailer.perform_deliveries`
 
-Specifies whether mail will actually be delivered and is true by default. It can be convenient to set it to `false` for testing.
+Specifies whether mail will actually be delivered and is `true` by default. It can be convenient to set it to `false` for testing.
 
 #### `config.action_mailer.default_options`
 
@@ -1908,7 +1908,7 @@ Defaults to `true`.
 
 Specifies if the `ActiveSupport::JsonWithMarshalFallback` class will use `Marshal` to serialize payloads.
 
-If this is set to false, it will use `JSON` to serialize payloads.
+If this is set to `false`, it will use `JSON` to serialize payloads.
 
 Used to help migrate apps from `Marshal` to `JSON` as the default serializer for the `MessageEncryptor` class.
 


### PR DESCRIPTION
### Summary

Values that can be set in the config as booleans are highlighted in most places in the configuration doc.
This PR highlights the remaining booleans which are left out.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
