### PR TITLE
Add support for `:include` index option

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -81,6 +81,24 @@
 
     *Leonardo Luarte*
 
+*   Add `:include` index option
+
+    Add support for including non-key columns in indexes for PostgreSQL
+    with the `INCLUDE` parameter.
+
+    ```ruby
+    add_index(:users, :email, include: [:id, :created_at])
+    ```
+
+    will result in:
+
+    ```sql
+    CREATE INDEX index_users_on_email USING btree (email) INCLUDE (id,
+    created_at)
+    ```
+
+    *Steve Abrams*
+
 *   `ActiveRecord::Relation`’s `#any?`, `#none?`, and `#one?` methods take an optional pattern
     argument, more closely matching their `Enumerable` equivalents.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -6,7 +6,7 @@ module ActiveRecord
     # this type are typically created and returned by methods in database
     # adapters. e.g. ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#indexes
     class IndexDefinition # :nodoc:
-      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :comment, :valid
+      attr_reader :table, :name, :unique, :columns, :lengths, :orders, :opclasses, :where, :type, :using, :include, :comment, :valid
 
       def initialize(
         table, name,
@@ -18,6 +18,7 @@ module ActiveRecord
         where: nil,
         type: nil,
         using: nil,
+        include: nil,
         comment: nil,
         valid: true
       )
@@ -31,6 +32,7 @@ module ActiveRecord
         @where = where
         @type = type
         @using = using
+        @include = include
         @comment = comment
         @valid = valid
       end
@@ -47,12 +49,13 @@ module ActiveRecord
         }
       end
 
-      def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, **options)
+      def defined_for?(columns = nil, name: nil, unique: nil, valid: nil, include: nil, **options)
         columns = options[:column] if columns.blank?
         (columns.nil? || Array(self.columns) == Array(columns).map(&:to_s)) &&
           (name.nil? || self.name == name.to_s) &&
           (unique.nil? || self.unique == unique) &&
-          (valid.nil? || self.valid == valid)
+          (valid.nil? || self.valid == valid) &&
+          (include.nil? || Array(self.include) == Array(include))
       end
 
       private

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -828,6 +828,16 @@ module ActiveRecord
       #
       # Note: Partial indexes are only supported for PostgreSQL and SQLite.
       #
+      # ====== Creating an index that includes additional columns
+      #
+      #   add_index(:accounts, :branch_id,  include: :party_id)
+      #
+      # generates:
+      #
+      #   CREATE INDEX index_accounts_on_branch_id ON accounts USING btree(branch_id) INCLUDE (party_id)
+      #
+      # Note: only supported by PostgreSQL.
+      #
       # ====== Creating an index with a specific method
       #
       #   add_index(:developers, :name, using: 'btree')
@@ -1385,7 +1395,7 @@ module ActiveRecord
       end
 
       def add_index_options(table_name, column_name, name: nil, if_not_exists: false, internal: false, **options) # :nodoc:
-        options.assert_valid_keys(:unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm)
+        options.assert_valid_keys(:unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include)
 
         column_names = index_column_names(column_name)
 
@@ -1404,6 +1414,7 @@ module ActiveRecord
           where: options[:where],
           type: options[:type],
           using: options[:using],
+          include: options[:include],
           comment: options[:comment]
         )
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -444,6 +444,11 @@ module ActiveRecord
         false
       end
 
+      # Does this adapter support including non-key columns?
+      def supports_index_include?
+        false
+      end
+
       # Does this adapter support expression indices?
       def supports_expression_index?
         false

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -200,6 +200,10 @@ module ActiveRecord
         true
       end
 
+      def supports_index_include?
+        database_version >= 11_00_00 # >= 11.0
+      end
+
       def supports_expression_index?
         true
       end

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -230,6 +230,7 @@ module ActiveRecord
         index_parts << "opclass: #{format_index_parts(index.opclasses)}" if index.opclasses.present?
         index_parts << "where: #{index.where.inspect}" if index.where
         index_parts << "using: #{index.using.inspect}" if !@connection.default_index_type?(index)
+        index_parts << "include: #{index.include.inspect}" if index.include
         index_parts << "type: #{index.type.inspect}" if index.type
         index_parts << "comment: #{index.comment.inspect}" if index.comment
         index_parts

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -315,6 +315,22 @@ module ActiveRecord
         end
       end
 
+      def test_include_index
+        with_example_table do
+          @connection.add_index "ex", %w{ id }, name: "include", include: :number
+          index = @connection.indexes("ex").find { |idx| idx.name == "include" }
+          assert_equal [:number], index.include
+        end
+      end
+
+      def test_include_multiple_columns_index
+        with_example_table do
+          @connection.add_index "ex", %w{ id }, name: "include", include: [:number, :data]
+          index = @connection.indexes("ex").find { |idx| idx.name == "include" }
+          assert_equal [:number, :data], index.include
+        end
+      end
+
       def test_expression_index
         with_example_table do
           expr = "mod(id, 10), abs(number)"

--- a/activerecord/test/cases/adapters/postgresql/schema_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/schema_test.rb
@@ -768,3 +768,16 @@ class SchemaJoinTablesTest < ActiveRecord::PostgreSQLTestCase
     assert_not @connection.table_exists?("test_schema.comments_posts")
   end
 end
+
+class SchemaIndexIncludeColumnsTest < ActiveRecord::PostgreSQLTestCase
+  include SchemaDumpingHelper
+
+  def test_schema_dumps_index_included_columns
+    index_definition = dump_table_schema("companies").split(/\n/).grep(/t\.index.*company_include_index/).first.strip
+    if ActiveRecord::Base.connection.supports_index_include?
+      assert_equal 't.index ["firm_id", "type"], name: "company_include_index", include: [:name, :account_id]', index_definition
+    else
+      assert_equal 't.index ["firm_ids", "type"], name: "company_include_index"', index_definition
+    end
+  end
+end

--- a/activerecord/test/cases/migration/index_test.rb
+++ b/activerecord/test/cases/migration/index_test.rb
@@ -270,6 +270,22 @@ module ActiveRecord
           connection.remove_index("testings", "last_name")
           assert_not connection.index_exists?("testings", "last_name")
         end
+
+        def test_add_index_with_included_column
+          connection.add_index("testings", "last_name", include: :foo)
+          assert connection.index_exists?("testings", "last_name", include: :foo)
+
+          connection.remove_index("testings", "last_name")
+          assert_not connection.index_exists?("testings", "last_name")
+        end
+
+        def test_add_index_with_multiple_included_columns
+          connection.add_index("testings", "last_name", include: [:foo, :bar])
+          assert connection.index_exists?("testings", "last_name", include: [:foo, :bar])
+
+          connection.remove_index("testings", "last_name")
+          assert_not connection.index_exists?("testings", "last_name")
+        end
       end
 
       private

--- a/activerecord/test/cases/migration/invalid_options_test.rb
+++ b/activerecord/test/cases/migration/invalid_options_test.rb
@@ -20,7 +20,7 @@ module ActiveRecord
       end
 
       def invalid_add_index_option_exception_message(key)
-        "Unknown key: :#{key}. Valid keys are: :unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm"
+        "Unknown key: :#{key}. Valid keys are: :unique, :length, :order, :opclass, :where, :type, :using, :comment, :algorithm, :include"
       end
 
       def invalid_create_table_option_exception_message(key)

--- a/activerecord/test/schema/postgresql_specific_schema.rb
+++ b/activerecord/test/schema/postgresql_specific_schema.rb
@@ -148,4 +148,8 @@ _SQL
     create_table(:measurements_concepcion, id: false, force: true,
                                            options: "PARTITION OF measurements FOR VALUES IN (2)")
   end
+
+  if supports_index_include?
+    add_index(:companies, [:firm_id, :type], name: "company_include_index", include: [:name, :account_id])
+  end
 end


### PR DESCRIPTION
### Summary

This adds the option `:include` to PostgreSQL btree indexes to include non-key columns in the index using the `INCLUDE` parameter.

The `INCLUDE` parameter of `CREATE INDEX` is described in the [PostgreSQL docs](https://www.postgresql.org/docs/current/sql-createindex.html):

> The optional INCLUDE clause specifies a list of columns which will be included in the index as non-key columns.

Example:

```ruby
# In a migration
def change
  add_index :users, :email, include: :id
end
```

will result in:

```sql
CREATE INDEX index_users_on_email USING btree (email) INCLUDE (id)
```

Example with multiple columns:

```ruby
# In a migration
def change
  add_index :users, :email, include: [:id, :created_at]
end
```

will result in:

```sql
CREATE INDEX index_users_on_email USING btree (email) INCLUDE (id, created_at)
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
