### PR TITLE
Really deprecate comparing AC::Parameters with a hash

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -276,7 +276,18 @@ module ActionController
       if other.respond_to?(:permitted?)
         permitted? == other.permitted? && parameters == other.parameters
       else
-        @parameters == other
+        if Hash === other
+          ActiveSupport::Deprecation.warn <<-WARNING.squish
+            Comparing equality between `ActionController::Parameters` and a
+            `Hash` is deprecated and will be removed in Rails 7.1. Please only do
+            comparisons between instances of `ActionController::Parameters`. If
+            you need to compare to a hash, first convert it using
+            `ActionController::Parameters#new`.
+          WARNING
+          @parameters == other
+        else
+          super
+        end
       end
     end
     alias eql? ==

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -94,7 +94,14 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each_pair without a block returns an enumerator" do
     assert_kind_of Enumerator, @params.each_pair
-    assert_equal @params, @params.each_pair.to_h
+    assert_equal @params, ActionController::Parameters.new(@params.each_pair.to_h)
+  end
+
+  test "deprecated comparison works" do
+    assert_kind_of Enumerator, @params.each_pair
+    assert_deprecated do
+      assert_equal @params, @params.each_pair.to_h
+    end
   end
 
   test "each_value carries permitted status" do


### PR DESCRIPTION
PR #23733 was supposed to deprecate and remove the ability to compare
Hash objects with AC::Parameters objects.  Unfortunately it seems that
we still accidentally support that.

This PR adds a deprecation warning so that we can remove it in the
future.

Unfortunately the deprecation message is showing for a few tests and I'm not 100% sure how we should proceed.

We are [delegating some methods to the underlying hash](https://github.com/rails/rails/blob/8af86c997c7bfbb05afa7dbde8847cf9b55a7b47/actionpack/lib/action_controller/metal/strong_parameters.rb#L233-L234), but other methods [have their own implementation](https://github.com/rails/rails/blob/8af86c997c7bfbb05afa7dbde8847cf9b55a7b47/actionpack/lib/action_controller/metal/strong_parameters.rb#L397-L404).

One specific example is `ActionController::Parameters#values` vs `ActionController::Parameters#each_value`.  These two methods can hand back different objects:

```ruby
require "minitest/autorun"
require "active_support/all"
require "action_controller/metal/strong_parameters"

class ParametersMemberTest < Minitest::Test
  def test_ok
    hash = { "foo" => { "bar" => :baz } }
    params = ActionController::Parameters.new(hash)
    p params.values
    p params.each_value.to_a
  end
end
```

Output is:

```
$ bundle exec ruby -I activesupport/lib/:actionpack/lib thing.rb
Run options: --seed 23907

# Running:

[{"bar"=>:baz}]
[#<ActionController::Parameters {"bar"=>:baz} permitted: false>]
.

Finished in 0.000400s, 2499.9999 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

The above behavior leads to an odd case where `params.values` doesn't equal `params.each_value.to_a` and we have a test for that [here](https://github.com/rails/rails/blob/8af86c997c7bfbb05afa7dbde8847cf9b55a7b47/actionpack/test/controller/parameters/accessors_test.rb#L120-L123).

IMO we need to stop delegating any methods to the underlying hash, or at least drastically restrict them, but I'm somewhat worried about compatibility.