### PR TITLE
Don't delegate ActionController::Parameters#values to hash

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Make ActionController::Parameters#values cast nested hashes into parameters.
+
+    *Gannon McGibbon*
+
 *   Introduce `html:` and `screenshot:` kwargs for system test screenshot helper
 
     Use these as an alternative to the already-available environment variables.
@@ -26,7 +30,7 @@
 *   Fix `authenticate_with_http_basic` to allow for missing password.
 
     Before Rails 7.0 it was possible to handle basic authentication with only a username.
-    
+
     ```ruby
     authenticate_with_http_basic do |token, _|
       ApiClient.authenticate(token)

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -222,15 +222,7 @@ module ActionController
     #   value?(value)
     #
     # Returns true if the given value is present for some key in the parameters.
-
-    ##
-    # :method: values
-    #
-    # :call-seq:
-    #   values()
-    #
-    # Returns a new array of the values of the parameters.
-    delegate :keys, :key?, :has_key?, :member?, :values, :has_value?, :value?, :empty?, :include?,
+    delegate :keys, :key?, :has_key?, :member?, :has_value?, :value?, :empty?, :include?,
       :as_json, :to_s, :each_key, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
@@ -401,6 +393,11 @@ module ActionController
       end
 
       self
+    end
+
+    # Returns a new array of the values of the parameters.
+    def values
+      to_enum(:each_value).to_a
     end
 
     # Attribute that keeps track of converted arrays, if any, to avoid double

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -312,8 +312,8 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
   end
 
   test "values returns an array of the values of the params" do
-    params = ActionController::Parameters.new(city: "Chicago", state: "Illinois")
-    assert_equal ["Chicago", "Illinois"], params.values
+    params = ActionController::Parameters.new(city: "Chicago", state: "Illinois", person: ActionController::Parameters.new(first_name: "David"))
+    assert_equal ["Chicago", "Illinois", ActionController::Parameters.new(first_name: "David")], params.values
   end
 
   test "values_at retains permitted status" do

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -72,7 +72,7 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
 
   test "each without a block returns an enumerator" do
     assert_kind_of Enumerator, @params.each
-    assert_equal @params, @params.each.to_h
+    assert_equal @params, ActionController::Parameters.new(@params.each.to_h)
   end
 
   test "each_pair carries permitted status" do


### PR DESCRIPTION
https://github.com/rails/rails/issues/44813

Makes `ActionController::Parameters#values` cast nested hash values to `ActionController::Parameters`. Also a commit to fix the deprecation warning in the test suite introduced by https://github.com/rails/rails/commit/8af86c997c7bfbb05afa7dbde8847cf9b55a7b47