### PR TITLE
Fix `db:prepare` task to create/migrate test db when dev db already exists

### DIFF
--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -702,6 +702,17 @@ module ApplicationTests
         end
       end
 
+      test "db:prepare creates test database if it does not exist" do
+        Dir.chdir(app_path) do
+          use_postgresql
+          rails "db:drop", "db:create"
+          rails "runner", "ActiveRecord::Base.connection.drop_database(:railties_test)"
+
+          output = rails("db:prepare")
+          assert_match(%r{Created database 'railties_test'}, output)
+        end
+      end
+
       test "lazily loaded schema cache isn't read when reading the schema migrations table" do
         Dir.chdir(app_path) do
           app_file "config/initializers/lazy_load_schema_cache.rb", <<-RUBY

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -487,11 +487,12 @@ module TestHelpers
           default: &default
             adapter: postgresql
             pool: 5
-            database: railties_test
           development:
             <<: *default
+            database: railties_development
           test:
             <<: *default
+            database: railties_test
           YAML
         end
       end


### PR DESCRIPTION
Fixes #44815.