### PR TITLE
Use `public_send` for public methods in activerecord

### DIFF
--- a/activerecord/lib/active_record/associations/has_many_through_association.rb
+++ b/activerecord/lib/active_record/associations/has_many_through_association.rb
@@ -92,9 +92,9 @@ module ActiveRecord
           inverse = source_reflection.inverse_of
           if inverse
             if inverse.collection?
-              record.send(inverse.name) << build_through_record(record)
+              record.public_send(inverse.name) << build_through_record(record)
             elsif inverse.has_one?
-              record.send("#{inverse.name}=", build_through_record(record))
+              record.public_send("#{inverse.name}=", build_through_record(record))
             end
           end
 

--- a/activerecord/lib/active_record/encryption/contexts.rb
+++ b/activerecord/lib/active_record/encryption/contexts.rb
@@ -34,7 +34,7 @@ module ActiveRecord
           self.custom_contexts ||= []
           self.custom_contexts << default_context.dup
           properties.each do |key, value|
-            self.current_custom_context.send("#{key}=", value)
+            self.current_custom_context.public_send("#{key}=", value)
           end
 
           yield


### PR DESCRIPTION
### Summary

Use `public_send` for public methods in AR. I've grepped in ActiveRecord for all instances,
these are the ones which are not using `public_send`

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->