### PR TITLE
Address bug_report_templates/action_controller_gem.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,6 @@ GEM
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.5.11)
-    io-wait (0.2.1)
     irb (1.4.1)
       reline (>= 0.3.0)
     jmespath (1.4.0)
@@ -360,8 +359,7 @@ GEM
       digest
       net-protocol
       timeout
-    net-protocol (0.1.2)
-      io-wait
+    net-protocol (0.1.3)
       timeout
     net-smtp (0.3.1)
       digest


### PR DESCRIPTION
### Summary

This commit addresses the following error.

```ruby
$ ruby -v
ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux]
$ cd guides/bug_report_templates
$ ruby action_controller_gem.rb
Fetching gem metadata from https://rubygems.org/...........
... snip ...
Fetching net-protocol 0.1.3
... snip ...
/home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/runtime.rb:309:in `check_for_activated_spec!': You have already activated net-protocol 0.1.2, but your Gemfile requires net-protocol 0.1.3. Since net-protocol is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports net-protocol as a default gem. (Gem::LoadError)
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/runtime.rb:25:in `block in setup'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/spec_set.rb:136:in `each'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/spec_set.rb:136:in `each'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/runtime.rb:24:in `map'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/runtime.rb:24:in `setup'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/inline.rb:71:in `block in gemfile'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/settings.rb:131:in `temporary'
	from /home/yahonda/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/bundler-2.3.4/lib/bundler/inline.rb:55:in `gemfile'
	from action_controller_gem.rb:5:in `<main>'
$
```

Background:

- This test fails since net-protocol 0.1.3 has been released on Apr 1, 2022
https://rubygems.org/gems/net-protocol/versions/0.1.3

- Gemfile.lock specifies `net-protocol` 0.1.2, I assume it means "You
  have already activated net-protocol 0.1.2,".

  https://buildkite.com/rails/rails/builds/85716#dec4bf21-ae22-41db-8cf6-b91ab93b31b5/140-734
  ```ruby
    net-protocol (0.1.2)
  ```

- Actually, I do not know why this `action_controller_gem.rb` only fails with Ruby
  3.0 or higher, Ruby 2.7 works fine.


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
