### PR TITLE
Support UTC+14/Line Islands Time

### DIFF
--- a/activesupport/lib/active_support/values/time_zone.rb
+++ b/activesupport/lib/active_support/values/time_zone.rb
@@ -179,7 +179,8 @@ module ActiveSupport
       "Nuku'alofa"                   => "Pacific/Tongatapu",
       "Tokelau Is."                  => "Pacific/Fakaofo",
       "Chatham Is."                  => "Pacific/Chatham",
-      "Samoa"                        => "Pacific/Apia"
+      "Samoa"                        => "Pacific/Apia",
+      "Kiritimati Is."               => "Pacific/Kiritimati"
     }
 
     UTC_OFFSET_WITH_COLON = "%s%02d:%02d" # :nodoc:
@@ -240,7 +241,7 @@ module ActiveSupport
         when TZInfo::Timezone
           @lazy_zones_map[arg.name] ||= create(arg.name, nil, arg)
         when Numeric, ActiveSupport::Duration
-          arg *= 3600 if arg.abs <= 13
+          arg *= 3600 if arg.abs <= 60
           all.find { |z| z.utc_offset == arg.to_i }
         else
           raise ArgumentError, "invalid argument to TimeZone[]: #{arg.inspect}"

--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -402,7 +402,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_parse_string_with_timezone
-    (-11..13).each do |timezone_offset|
+    (-12..14).each do |timezone_offset|
       zone = ActiveSupport::TimeZone[timezone_offset]
       twz = zone.parse("1999-12-31 19:00:00")
       assert_equal twz, zone.parse(twz.to_s)


### PR DESCRIPTION
### Summary

This adds support for the [UTC+14](https://www.timeanddate.com/time/zone/timezone/utc14) time offset, which is used for [Line Islands Time](https://www.timeanddate.com/time/zones/lint) ([Pacific/Kiritimati](https://www.timeanddate.com/time/zone/kiribati/kiritimati)).

Before:

```ruby
ActiveSupport::TimeZone[14]
#=> nil
```

After:

```ruby
ActiveSupport::TimeZone[14]
#=> #<ActiveSupport::TimeZone:0x00007fd79cb00060 @name="Kiritimati Is.", @tzinfo=#<TZInfo::DataTimezone: Pacific/Kiritimati>, @utc_offset=nil>
```