### PR TITLE
Make block work for existing record when calling `find_or_initialize_by` as well

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,20 @@
+*   Blocks work for existing record when calling `find_or_initialize_by` as well.
+
+    Previously if `find_or_initialize_by` returned an existing record, the block
+    was not being executed for the particular record which is being queried.
+    After this change, the block is executed for the record being queried.
+
+    ```ruby
+    bird = Bird.find_or_initialize_by(name: "bob") do |record|
+      record.name = "alice"
+      record.color = "red"
+    end
+    bird.name # => "alice"
+    bird.color # => "red"
+    ```
+
+    *Ghouse Mohamed*
+
 *   Fixed MariaDB default function support.
 
     Defaults would be written wrong in "db/schema.rb" and not work correctly

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -224,7 +224,15 @@ module ActiveRecord
     # Like #find_or_create_by, but calls {new}[rdoc-ref:Core#new]
     # instead of {create}[rdoc-ref:Persistence::ClassMethods#create].
     def find_or_initialize_by(attributes, &block)
-      find_by(attributes) || new(attributes, &block)
+      record = find_by(attributes)
+      if record
+        if block_given?
+          yield record
+        end
+        record
+      else
+        new(attributes, &block)
+      end
     end
 
     # Runs EXPLAIN on the query or queries triggered by this relation and

--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1562,6 +1562,36 @@ class RelationTest < ActiveRecord::TestCase
     assert_equal bird, Bird.find_or_initialize_by(name: "bob")
   end
 
+  def test_find_or_initialize_by_with_block_for_new_record
+    assert_nil Bird.find_by(name: "bob")
+
+    bird = Bird.find_or_initialize_by(name: "bob") do |record|
+      record.color = "blue"
+    end
+    assert_predicate bird, :new_record?
+    assert_equal bird.color, "blue"
+    bird.save!
+
+    assert_equal bird, Bird.find_or_initialize_by(name: "bob")
+  end
+
+  def test_find_or_initialize_by_with_block_for_existing_record
+    old_bird = Bird.create!(name: "bob", color: "blue")
+    assert_equal old_bird.name, "bob"
+    assert_equal old_bird.color, "blue"
+
+    new_bird = Bird.find_or_initialize_by(name: "bob") do |record|
+      record.name = "alice"
+      record.color = "red"
+    end
+    assert_not new_bird.new_record?
+    assert_equal new_bird.name, "alice"
+    assert_equal new_bird.color, "red"
+    new_bird.save!
+
+    assert_equal new_bird, Bird.find_or_initialize_by(name: "alice")
+  end
+
   def test_explicit_create_with
     hens = Bird.where(name: "hen")
     assert_equal "hen", hens.new.name


### PR DESCRIPTION
### Summary

Previously, the `find_or_initialize_by` method only executed the block against a record only
for *new* records. For an already existing record queried via `find_or_initialize_by` the block was
ignored. With this change, something like this should also work:

```ruby
Bird.create!(name: "bob")

bird = Bird.find_or_initialize_by(name: "bob") do |record|
   record.name = "alice"
   record.color = "red"
end

bird.name # => "alice"
bird.color # => "red"
```

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->