### PR TITLE
Add a flag to disable deprecated AC::Parameters comparison

### DIFF
--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -234,6 +234,8 @@ module ActionController
     #    config.action_controller.always_permitted_parameters = %w( controller action format )
     cattr_accessor :always_permitted_parameters, default: %w( controller action )
 
+    cattr_accessor :allow_deprecated_parameters_hash_equality, default: true, instance_accessor: false
+
     class << self
       def nested_attribute?(key, value) # :nodoc:
         /\A-?\d+\z/.match?(key) && (value.is_a?(Hash) || value.is_a?(Parameters))
@@ -268,13 +270,15 @@ module ActionController
       if other.respond_to?(:permitted?)
         permitted? == other.permitted? && parameters == other.parameters
       else
-        if Hash === other
+        if self.class.allow_deprecated_parameters_hash_equality && Hash === other
           ActiveSupport::Deprecation.warn <<-WARNING.squish
             Comparing equality between `ActionController::Parameters` and a
             `Hash` is deprecated and will be removed in Rails 7.1. Please only do
             comparisons between instances of `ActionController::Parameters`. If
             you need to compare to a hash, first convert it using
             `ActionController::Parameters#new`.
+            To disable the deprecated behaviour set
+            `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false`.
           WARNING
           @parameters == other
         else

--- a/actionpack/lib/action_controller/railtie.rb
+++ b/actionpack/lib/action_controller/railtie.rb
@@ -42,6 +42,11 @@ module ActionController
         end
 
         ActionController::Parameters.action_on_unpermitted_parameters = action_on_unpermitted_parameters
+
+        unless options.allow_deprecated_parameters_hash_equality.nil?
+          ActionController::Parameters.allow_deprecated_parameters_hash_equality =
+            options.allow_deprecated_parameters_hash_equality
+        end
       end
     end
 
@@ -72,7 +77,8 @@ module ActionController
           :permit_all_parameters,
           :action_on_unpermitted_parameters,
           :always_permitted_parameters,
-          :wrap_parameters_by_default
+          :wrap_parameters_by_default,
+          :allow_deprecated_parameters_hash_equality
         )
 
         filtered_options.each do |k, v|

--- a/actionpack/test/controller/parameters/accessors_test.rb
+++ b/actionpack/test/controller/parameters/accessors_test.rb
@@ -6,6 +6,7 @@ require "action_controller/metal/strong_parameters"
 class ParametersAccessorsTest < ActiveSupport::TestCase
   setup do
     ActionController::Parameters.permit_all_parameters = false
+    ActionController::Parameters.allow_deprecated_parameters_hash_equality = true
 
     @params = ActionController::Parameters.new(
       person: {
@@ -101,6 +102,15 @@ class ParametersAccessorsTest < ActiveSupport::TestCase
     assert_kind_of Enumerator, @params.each_pair
     assert_deprecated do
       assert_equal @params, @params.each_pair.to_h
+    end
+  end
+
+  test "deprecated comparison disabled" do
+    ActionController::Parameters.allow_deprecated_parameters_hash_equality = false
+
+    assert_kind_of Enumerator, @params.each_pair
+    assert_not_deprecated do
+      assert_not_equal @params, @params.each_pair.to_h
     end
   end
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -64,6 +64,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.add_autoload_paths_to_load_path`](#config-add-autoload-paths-to-load-path): `false`
 - [`config.active_support.default_message_encryptor_serializer`](#config-active-support-default-message-encryptor-serializer): `:json`
 - [`config.active_support.default_message_verifier_serializer`](#config-active-support-default-message-verifier-serializer): `:json`
+- [`config.action_controller.allow_deprecated_parameters_hash_equality`](#config-action-controller-allow-deprecated-parameters-hash-equality): `false`
 
 #### Default Values for Target Version 7.0
 
@@ -1154,6 +1155,18 @@ The default value depends on the `config.load_defaults` target version:
 
 Configures the [`ParamsWrapper`](https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html). This can be called at
 the top level, or on individual controllers.
+
+#### `config.action_controller.allow_deprecated_parameters_hash_equality`
+
+Controls behaviour of `ActionController::Parameters#==` with `Hash` arguments.
+Value of the setting determines whether an `ActionController::Parameters` instance is equal to an equivalent `Hash`.
+
+The default value depends on the `config.load_defaults` target version:
+
+| Starting with version | The default value is |
+| --------------------- | -------------------- |
+| (original)            | `true`               |
+| 7.1                   | `false`              |
 
 ### Configuring Action Dispatch
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -272,6 +272,10 @@ module Rails
             active_support.default_message_encryptor_serializer = :json
             active_support.default_message_verifier_serializer = :json
           end
+
+          if respond_to?(:action_controller)
+            action_controller.allow_deprecated_parameters_hash_equality = false
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -24,3 +24,7 @@
 #   "X-Permitted-Cross-Domain-Policies" => "none",
 #   "Referrer-Policy" => "strict-origin-when-cross-origin"
 # }
+
+# Do not treat an `ActionController::Parameters` instance
+# as equal to an equivalent `Hash` by default.
+# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false


### PR DESCRIPTION
### Summary

The PR https://github.com/rails/rails/pull/44812 added a deprecation for the comparison of AC::Params with Hashes.

The existing implementation can sometimes lead to the following bug:

Given a process where hashes of `AC::Parameters` and equivalent `Hash` collide
```
hash = { "bar" => [{"foo" => 1}]}
acp = ActionController::Parameters.new(hash)
h = {}
h[acp] = true
h[hash] # => true
```
the following happens:
```
hash = { "bar" => [{"foo" => 1}]}
acp = ActionController::Parameters.new(hash)
acp.fetch("bar")
acp["bar"] # => [{"foo"=>1}]
```

Reads of the key with fetch (also delete, values_at) lead to all subsequent read operations of the key to return an array of raw Hashes.

The addition of the flag is going to allow affected users to turn off the deprecated implementation and avoid the bug without waiting for the next release cycle.

