### PR TITLE
Fix `has_many :through` association when through merges relation from other table

### DIFF
--- a/activerecord/lib/active_record/relation/merger.rb
+++ b/activerecord/lib/active_record/relation/merger.rb
@@ -181,6 +181,11 @@ module ActiveRecord
 
           having_clause = relation.having_clause.merge(other.having_clause)
           relation.having_clause = having_clause unless having_clause.empty?
+
+          no_clause_merged = [where_clause.empty?, having_clause.empty?, !replace_from_clause?].all?
+          unless no_clause_merged || relation.klass.base_class == other.klass.base_class
+            relation.references_values |= [*other.references_values, Arel.sql(other.table.name)]
+          end
         end
 
         def replace_from_clause?

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -1094,6 +1094,13 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_equal expected, Author.eager_load(:lazy_readers_skimmers_or_not_3).last.lazy_readers_skimmers_or_not_3
   end
 
+  def test_has_many_through_with_through_scope_with_joins_and_merge
+    expected = [readers(:michael_welcome).becomes(LazyReader)]
+    assert_equal expected, Author.first.lazy_readers_skimmers_or_not_4
+    assert_equal expected, Author.preload(:lazy_readers_skimmers_or_not_4).first.lazy_readers_skimmers_or_not_4
+    assert_equal expected, Author.eager_load(:lazy_readers_skimmers_or_not_4).first.lazy_readers_skimmers_or_not_4
+  end
+
   def test_duplicated_has_many_through_with_through_scope_with_joins
     Categorization.create!(author: authors(:david), post: posts(:thinking), category: categories(:technology))
 

--- a/activerecord/test/models/author.rb
+++ b/activerecord/test/models/author.rb
@@ -107,6 +107,7 @@ class Author < ActiveRecord::Base
   has_many :hello_post_comments, through: :hello_posts, source: :comments
   has_many :posts_with_no_comments, -> { where("comments.id" => nil).includes(:comments) }, class_name: "Post"
   has_many :posts_with_no_comments_2, -> { left_joins(:comments).where("comments.id": nil) }, class_name: "Post"
+  has_many :posts_with_thank_you_for_the_welcome_comments, -> { left_joins(:comments).merge(Comment.thank_you_for_the_welcome) }, class_name: "Post"
 
   has_many :hello_posts_with_hash_conditions, -> { where(body: "hello") }, class_name: "Post"
   has_many :hello_post_comments_with_hash_conditions, through: :hello_posts_with_hash_conditions, source: :comments
@@ -231,6 +232,7 @@ class Author < ActiveRecord::Base
   has_many :lazy_readers_skimmers_or_not, through: :posts
   has_many :lazy_readers_skimmers_or_not_2, through: :posts_with_no_comments, source: :lazy_readers_skimmers_or_not
   has_many :lazy_readers_skimmers_or_not_3, through: :posts_with_no_comments_2, source: :lazy_readers_skimmers_or_not
+  has_many :lazy_readers_skimmers_or_not_4, through: :posts_with_thank_you_for_the_welcome_comments, source: :lazy_readers_skimmers_or_not
 
   attr_accessor :post_log
   after_initialize :set_post_log

--- a/activerecord/test/models/comment.rb
+++ b/activerecord/test/models/comment.rb
@@ -7,6 +7,7 @@ class Comment < ActiveRecord::Base
   scope :limit_by, lambda { |l| limit(l) }
   scope :containing_the_letter_e, -> { where("comments.body LIKE '%e%'") }
   scope :not_again, -> { where("comments.body NOT LIKE '%again%'") }
+  scope :thank_you_for_the_welcome, -> { where(body: "Thank you for the welcome") }
   scope :for_first_post, -> { where(post_id: 1) }
   scope :for_first_author, -> { joins(:post).where("posts.author_id" => 1) }
   scope :created, -> { all }

--- a/activerecord/test/models/post.rb
+++ b/activerecord/test/models/post.rb
@@ -382,6 +382,10 @@ class FakeKlass
 
     def deterministic_encrypted_attributes
     end
+
+    def base_class
+      self
+    end
   end
 
   inherited self


### PR DESCRIPTION
### Summary

When declaring a `has_many :through` association, if the through part merges a relation from another table, the association queries fail with referenced unknown column. For example, calling `Post.first.online_users` will raise `ActiveRecord::StatementInvalid` in the following code, as the SQL that gets generated skips the joins part of the query:

```rb
class Post < ActiveRecord::Base
  has_many :online_comments, ->{ joins(:source).merge(Source.where(online: true)) }, class_name: "Comment"
  has_many :online_users, through: :online_comments, source: :user
end
```
Full reproduction script [here](https://github.com/rails/rails/issues/44806). This same association works as expected if declared as:
```rb
has_many :online_comments, ->{ joins(:source).where(sources: {online: true}) }, class_name: "Comment"
```

That works because when another table is referenced in a `where` or `order` clause, a value gets added to the relation `references_values`. The block added to `AssociationScope` [here](https://github.com/rails/rails/pull/39390) finds that reference and mantain the joins in the query.

The difference in the first case, when merging a relation from other table, is that the relation where clause gets replaced with a merged where clause, but the references values are left unchanged. Then, the block that keeps the joins gets skipped and the association queries fail.

Here I modify `Merger` to apply the missing reference unless relation base klasses are the same.

Fixes: https://github.com/rails/rails/issues/44806

### Other information

The second example was failing as well, but was reported and and fixed in https://github.com/rails/rails/pull/39390.
A similar issue was fixed in https://github.com/rails/rails/pull/41029.

EDIT: Improved description