### PR TITLE
`rails db:schema:{dump,load}` now checks `ENV["SCHEMA_FORMAT"]` before config

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   `rails db:schema:{dump,load}` now checks `ENV["SCHEMA_FORMAT"]` before config
+
+    Since `rails db:structure:{dump,load}` was deprecated there wasn't a simple
+    way to dump a schema to both SQL and Ruby formats. You can now do this with
+    an environment variable. For example:
+
+    ```
+    SCHEMA_FORMAT=sql rake db:schema:dump
+    ```
+
+    *Alex Ghiculescu*
+
 *   Fixed MariaDB default function support.
 
     Defaults would be written wrong in "db/schema.rb" and not work correctly


### PR DESCRIPTION
Since `rails db:structure:{dump,load}` was deprecated there wasn't a simple way to dump a schema to both SQL and Ruby formats. This PR implements @jeremy's suggestion @ https://github.com/rails/rails/pull/39470#pullrequestreview-483599714, so you can now do this with an environment variable. For example:

```
SCHEMA_FORMAT=sql rake db:schema:dump
```
