### PR TITLE
Add `to_email_attachment_partial_path` to render `ActionText::Attachable` in mailers

### DIFF
--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -2,7 +2,7 @@
 
         class VideoEmbed < ApplicationRecord
           include ActionText::Attachable
-          
+
           # VideoEmbed records will be rendered with this partial in mailers
           def to_email_attachment_partial_path
             "video_embeds/email_preview"

--- a/actiontext/CHANGELOG.md
+++ b/actiontext/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Add `to_email_attachment_partial_path` to render `ActionText::Attachable` records in mailers.
+
+        class VideoEmbed < ApplicationRecord
+          include ActionText::Attachable
+          
+          # VideoEmbed records will be rendered with this partial in mailers
+          def to_email_attachment_partial_path
+            "video_embeds/email_preview"
+          end
+        end
+
+    *Julian Foo*
+
 *   Update bundled Trix version from `1.3.1` to `2.0.4`.
 
     *Sean Doyle*

--- a/actiontext/app/helpers/action_text/content_helper.rb
+++ b/actiontext/app/helpers/action_text/content_helper.rb
@@ -39,7 +39,11 @@ module ActionText
       options = { locals: locals, object: attachment, partial: attachment }
 
       if attachment.respond_to?(:to_attachable_partial_path)
-        options[:partial] = attachment.to_attachable_partial_path
+        if controller.kind_of?(ActionMailer::Base) && attachment.respond_to?(:to_email_attachment_partial_path)
+          options[:partial] = attachment.to_email_attachment_partial_path
+        else
+          options[:partial] = attachment.to_attachable_partial_path
+        end
       end
 
       if attachment.respond_to?(:model_name)

--- a/actiontext/lib/action_text/attachable.rb
+++ b/actiontext/lib/action_text/attachable.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module ActionText
+  # Provides the methods required to render the mixed-in class as an Action Text attachment.
   module Attachable
     extend ActiveSupport::Concern
 
@@ -67,10 +68,56 @@ module ActionText
       super.merge(attachable_sgid: attachable_sgid)
     end
 
+    # Returns the partial path used to render the Attachable in the Trix editor.
+    #
+    # Calls +to_partial_path+ by default.
+    #
+    # Can be overridden to provide a custom partial.
+    #
+    #   # Providing a custom partial
+    #   class VideoEmbed < ApplicationRecord
+    #     include ActionText::Attachable
+    #
+    #     def to_trix_content_attachment_partial_path
+    #       "video_embeds/trix_preview"
+    #     end
+    #   end
     def to_trix_content_attachment_partial_path
       to_partial_path
     end
 
+    # Returns the partial path used to render the Attachable in mailers.
+    #
+    # Calls +to_partial_path+ by default.
+    #
+    # Can be overridden to provide a custom partial.
+    #
+    #   # Providing a custom partial
+    #   class VideoEmbed < ApplicationRecord
+    #     include ActionText::Attachable
+    #
+    #     def to_email_attachment_partial_path
+    #       "video_embeds/email_preview"
+    #     end
+    #   end
+    def to_email_attachment_partial_path
+      to_partial_path
+    end
+
+    # Returns the partial path used to render the Attachable.
+    #
+    # Calls +to_partial_path+ by default.
+    #
+    # Can be overridden to provide a custom partial.
+    #
+    #   # Providing a custom partial
+    #   class VideoEmbed < ApplicationRecord
+    #     include ActionText::Attachable
+    #
+    #     def to_attachable_partial_path
+    #       "video_embeds/custom_preview"
+    #     end
+    #   end
     def to_attachable_partial_path
       to_partial_path
     end

--- a/actiontext/lib/action_text/attachables/remote_image.rb
+++ b/actiontext/lib/action_text/attachables/remote_image.rb
@@ -41,6 +41,10 @@ module ActionText
       def to_partial_path
         "action_text/attachables/remote_image"
       end
+
+      def to_email_attachment_partial_path
+        to_partial_path
+      end
     end
   end
 end

--- a/actiontext/test/dummy/app/models/person.rb
+++ b/actiontext/test/dummy/app/models/person.rb
@@ -1,6 +1,10 @@
 class Person < ApplicationRecord
   include ActionText::Attachable
 
+  def to_email_attachment_partial_path
+    "people/email_attachment"
+  end
+
   def to_trix_content_attachment_partial_path
     "people/trix_content_attachment"
   end

--- a/actiontext/test/dummy/app/views/people/_email_attachment.html.erb
+++ b/actiontext/test/dummy/app/views/people/_email_attachment.html.erb
@@ -1,0 +1,1 @@
+<span class="mentioned-person"><%= mail_to "#{person.name.downcase}@example.com" %></span>

--- a/actiontext/test/integration/mailer_render_test.rb
+++ b/actiontext/test/integration/mailer_render_test.rb
@@ -20,4 +20,16 @@ class ActionText::MailerRenderTest < ActionMailer::TestCase
   ensure
     ActionMailer::Base.default_url_options = original_default_url_options
   end
+
+  test "resolves ActionText::Attachable based on their to_email_attachment_partial_path" do
+    alice = people(:alice)
+
+    message = Message.new(content: ActionText::Content.new.append_attachables(alice))
+
+    MessagesMailer.with(recipient: "test", message: message).notification.deliver_now
+
+    assert_select_email do
+      assert_select "a", "#{alice.name.downcase}@example.com"
+    end
+  end
 end

--- a/actiontext/test/unit/attachment_test.rb
+++ b/actiontext/test/unit/attachment_test.rb
@@ -79,9 +79,20 @@ class ActionText::AttachmentTest < ActiveSupport::TestCase
     end
   end
 
+  test "returns email partial" do
+    attachable = Person.create! name: "Javan"
+
+    assert_equal "people/email_attachment", attachable.to_email_attachment_partial_path
+  end
+
   test "defaults trix partial to model partial" do
     attachable = Page.create! title: "Homepage"
     assert_equal "pages/page", attachable.to_trix_content_attachment_partial_path
+  end
+
+  test "defaults email partial to model partial" do
+    attachable = Page.create! title: "Homepage"
+    assert_equal "pages/page", attachable.to_email_attachment_partial_path
   end
 
   private

--- a/guides/source/action_text_overview.md
+++ b/guides/source/action_text_overview.md
@@ -205,6 +205,31 @@ partial-local variable:
 <span><%= image_tag user.avatar %> <%= user.name %></span>
 ```
 
+You can also render different partials for emails and the Trix editor with `to_email_attachment_partial_path`
+and `to_trix_content_attachment_partial_path` respectively:
+
+```ruby
+class User < ApplicationRecord
+  def to_email_attachment_partial_path
+    "users/email_attachable"
+  end
+
+  def to_trix_content_attachment_partial_path
+    "users/trix_content_attachable"
+  end
+end
+```
+
+```html+erb
+<%# app/views/users/_email_attachable.html.erb %>
+<%# Partial used when the attachment is rendered in emails %>
+<span><%= user.name %></span>
+
+<%# app/views/users/_trix_content_attachable.html.erb %>
+<%# Partial used when the attachment is rendered in the Trix editor %>
+<span><%= image_tag user.avatar %> <%= user.name %></span>
+```
+
 To integrate with Action Text `<action-text-attachment>` element rendering, a
 class must:
 


### PR DESCRIPTION

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.

Create a pull request when it is ready for review and feedback
from the Rails team :).

If your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background

I use `ActionText` to render video embeds, [similar to how Chris from Gorails does it in this video.](https://www.youtube.com/watch?v=2iGBuLQ3S0c) Often, I need to show a different video preview in mailers. 

Since `ActionText::Attachable` calls `#to_partial_path` by default, I need to add a conditional to the view to decide what to render based on the calling controller (i.e. checking if it's called from regular controllers or `ActionMailer::Base`). Something like:

```ruby
# video_embeds/_video_embed.html.erb

<% if controller.kind_of? ActionMailer::Base %>
  <%= render "video_embeds/email_preview" >
<% else %>
  <%= render "video_embeds/video_embed" >
<% end %>
```

This works but is pretty ugly to be put in the view or helper.

### Detail

In this PR, I've added `#to_email_attachment_partial_path` to `ActionText::Attachable` for this purpose. Instead of the approach above, we can now do this in the model:

```ruby
class VideoEmbeds < ApplicationRecord
  include ActionText::Attachable

  def to_email_attachment_partial_path
    "video_embeds/email_preview"
  end
end
```

The `Attachable` will then call `#to_email_attachment_partial_path` whenever it's rendered in mailers.

### Additional information

This logic:

```ruby
if controller.kind_of?(ActionMailer::Base) && attachment.respond_to?(:to_email_attachment_partial_path)
```

may not be the best or optimal way to check if the view is in a regular or mailer view. Happy to receive feedback on this and change the approach if necessary. Thank you!

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.