### PR TITLE
Use the through_reflection class to open transactions

### DIFF
--- a/activerecord/lib/active_record/associations/through_association.rb
+++ b/activerecord/lib/active_record/associations/through_association.rb
@@ -7,6 +7,10 @@ module ActiveRecord
       delegate :source_reflection, to: :reflection
 
       private
+        def transaction(&block)
+          through_reflection.klass.transaction(&block)
+        end
+
         def through_reflection
           @through_reflection ||= begin
             refl = reflection.through_reflection

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -892,6 +892,16 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     end
   end
 
+  def test_has_many_through_uses_the_through_model_to_create_transactions
+    post   = posts(:thinking)
+    person = people(:david)
+    other_person = people(:michael)
+
+    assert_called(Reader, :transaction) do
+      post.people = [person, other_person]
+    end
+  end
+
   def test_has_many_association_through_a_belongs_to_association_where_the_association_doesnt_exist
     post = Post.create!(title: "TITLE", body: "BODY")
     assert_equal [], post.author_favorites


### PR DESCRIPTION
Co-authored-by: matthewd <matthewd@github.com>

### Summary

Imagine the `has_many :through` Rails Guide [example](https://guides.rubyonrails.org/association_basics.html#the-has-many-through-association). Both the `Physician` and  the `Appointment` models are stored in `Database A` while the `Patient` model is stored in `Database B`. 

When we assign two `Patient`s to a `Physician` record we'd expect a single transaction that wrapps the creation of `Appointment` records. We recently found that this is not the current behavior. Instead we see one transaction per through record creation. 

This led to an unexpected invocation of `after_commit` callbacks in our system.

![image](https://user-images.githubusercontent.com/1753524/161712346-bee3d659-18b3-4245-aeca-f9bdf3852a3e.png)

Please refer to this [repository](https://github.com/schlubbi/has_many_through_connection_test) for the code used to generate the test cases.

**Before**

Executing the following snippet:

```ruby
Patient.create name: "patenient 1"
Patient.create name: "patenient 2"
Physician.create name: "physician"
Physician.first.patients = Patient.all
```

Would generate the following:

```ruby
irb(main):001:0> load "transaction_test.rb"
...
  TRANSACTION (0.0ms)  begin transaction
  Appointment Create (0.1ms)  INSERT INTO "appointments" ("patient_id", "physician_id", "appointment_date", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?)  [["patient_id", 1], ["physician_id", 1], ["appointment_date", nil], ["created_at", "2022-04-05 11:43:40.445492"], ["updated_at", "2022-04-05 11:43:40.445492"]]
  TRANSACTION (4.6ms)  commit transaction
  TRANSACTION (0.0ms)  begin transaction
  Appointment Create (0.1ms)  INSERT INTO "appointments" ("patient_id", "physician_id", "appointment_date", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?)  [["patient_id", 2], ["physician_id", 1], ["appointment_date", nil], ["created_at", "2022-04-05 11:43:40.451175"], ["updated_at", "2022-04-05 11:43:40.451175"]]
  TRANSACTION (4.8ms)  commit transaction
=> true
```

We can see one transaction for each `Appointment` record where there should only be one transaction wrapping the creation of both.
 
**After**

With the change proposed in this PR in place the execution of the snippet above would produce the following:

```ruby
Loading development environment (Rails 7.1.0.alpha)
irb(main):001:0> load "transaction_test.rb"
...
  TRANSACTION (0.0ms)  begin transaction
  Appointment Create (0.1ms)  INSERT INTO "appointments" ("patient_id", "physician_id", "appointment_date", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?)  [["patient_id", 1], ["physician_id", 1], ["appointment_date", nil], ["created_at", "2022-04-05 11:56:40.497366"], ["updated_at", "2022-04-05 11:56:40.497366"]]
  Appointment Create (0.0ms)  INSERT INTO "appointments" ("patient_id", "physician_id", "appointment_date", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?)  [["patient_id", 2], ["physician_id", 1], ["appointment_date", nil], ["created_at", "2022-04-05 11:56:40.498085"], ["updated_at", "2022-04-05 11:56:40.498085"]]
  TRANSACTION (4.8ms)  commit transaction
=> true
```

As expected we see on transaction wrapping the creation both `Appointment` records.

This [branch](https://github.com/schlubbi/has_many_through_connection_test/tree/with-fix-in-place) was used to generate the above.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
