### PR TITLE
Only allow String and Symbol keys in ActionController::Parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Allow only String and Symbol keys in `ActionController::Parameters`.
+    Raise `ActionController::InvalidParameterKey` when initializing Parameters
+    with keys that aren't strings or symbols.
+
+    *Seva Stefkin*
+
 *   Add the ability to use custom logic for storing and retrieving CSRF tokens.
 
     By default, the token will be stored in the session.  Custom classes can be

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -64,6 +64,16 @@ module ActionController
     end
   end
 
+  # Raised when initializing Parameters with keys that aren't strings or symbols.
+  #
+  #   ActionController::Parameters.new(123 => 456)
+  #   # => ActionController::InvalidParameterKey: all keys must be Strings or Symbols
+  class InvalidParameterKey < ArgumentError
+    def initialize # :nodoc:
+      super("all keys must be Strings or Symbols")
+    end
+  end
+
   # == Action Controller \Parameters
   #
   # Allows you to choose which attributes should be permitted for mass updating
@@ -259,6 +269,8 @@ module ActionController
     #   params.permitted?  # => true
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def initialize(parameters = {}, logging_context = {})
+      raise InvalidParameterKey unless parameters.keys.all? { |key| key.is_a?(String) || key.is_a?(Symbol) }
+
       @parameters = parameters.with_indifferent_access
       @logging_context = logging_context
       @permitted = self.class.permit_all_parameters

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -519,4 +519,10 @@ class ParametersPermitTest < ActiveSupport::TestCase
 
     assert_equal false, params.permitted?
   end
+
+  test "only String and Symbol keys are allowed" do
+    assert_raises(ActionController::InvalidParameterKey) do
+      ActionController::Parameters.new({ foo: 1 } => :bar)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Only allow `Symbol` and `String` keys for `ActionController::Parameters`

this is an experiment for https://github.com/rails/rails/issues/44813


