### PR TITLE
Fix touch and update_column/s for readonly records

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -827,6 +827,7 @@ module ActiveRecord
     def update_columns(attributes)
       raise ActiveRecordError, "cannot update a new record" if new_record?
       raise ActiveRecordError, "cannot update a destroyed record" if destroyed?
+      _raise_readonly_record_error if readonly?
 
       attributes = attributes.transform_keys do |key|
         name = key.to_s
@@ -1013,6 +1014,7 @@ module ActiveRecord
     #
     def touch(*names, time: nil)
       _raise_record_not_touched_error unless persisted?
+      _raise_readonly_record_error if readonly?
 
       attribute_names = timestamp_attributes_for_update_in_model
       attribute_names |= names.map! do |name|

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -37,6 +37,39 @@ class ReadOnlyTest < ActiveRecord::TestCase
     assert_equal "Developer is marked as readonly", e.message
   end
 
+  def test_cant_touch_readonly_record
+    dev = Developer.find(1)
+    assert_not_predicate dev, :readonly?
+
+    dev.readonly!
+    assert_predicate dev, :readonly?
+
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.touch  }
+    assert_equal "Developer is marked as readonly", e.message
+  end
+
+  def test_cant_update_column_readonly_record
+    dev = Developer.find(1)
+    assert_not_predicate dev, :readonly?
+
+    dev.readonly!
+    assert_predicate dev, :readonly?
+
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.update_column(:name, "New name")  }
+    assert_equal "Developer is marked as readonly", e.message
+  end
+
+  def test_cant_update_columns_readonly_record
+    dev = Developer.find(1)
+    assert_not_predicate dev, :readonly?
+
+    dev.readonly!
+    assert_predicate dev, :readonly?
+
+    e = assert_raise(ActiveRecord::ReadOnlyRecord) { dev.update_columns(name: "New name")  }
+    assert_equal "Developer is marked as readonly", e.message
+  end
+
   def test_find_with_readonly_option
     Developer.all.each { |d| assert_not d.readonly? }
     Developer.readonly(false).each { |d| assert_not d.readonly? }


### PR DESCRIPTION
The methods `touch`, `update_column`, and `update_columns` were not
raising an error when the record was readonly.

Fixes #44839
