### PR TITLE
All intermediate delegation methods should preserve kwargs flag

### DIFF
--- a/actionmailer/lib/action_mailer/base.rb
+++ b/actionmailer/lib/action_mailer/base.rb
@@ -624,6 +624,7 @@ module ActionMailer
         @_message = NullMail.new unless @_mail_was_called
       end
     end
+    ruby2_keywords(:process)
 
     class NullMail # :nodoc:
       def body; "" end

--- a/actionmailer/lib/action_mailer/rescuable.rb
+++ b/actionmailer/lib/action_mailer/rescuable.rb
@@ -20,7 +20,7 @@ module ActionMailer # :nodoc:
     end
 
     private
-      def process(*)
+      def process(...)
         handle_exceptions do
           super
         end

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -155,6 +155,7 @@ module AbstractController
 
       process_action(action_name, *args)
     end
+    ruby2_keywords(:process)
 
     # Delegates to the class's ::controller_path.
     def controller_path
@@ -215,8 +216,8 @@ module AbstractController
       #
       # Notice that the first argument is the method to be dispatched
       # which is *not* necessarily the same as the action name.
-      def process_action(method_name, *args)
-        send_action(method_name, *args)
+      def process_action(...)
+        send_action(...)
       end
 
       # Actually call the method associated with the action. Override

--- a/actionpack/lib/abstract_controller/callbacks.rb
+++ b/actionpack/lib/abstract_controller/callbacks.rb
@@ -244,7 +244,7 @@ module AbstractController
     private
       # Override <tt>AbstractController::Base#process_action</tt> to run the
       # <tt>process_action</tt> callbacks around the normal behavior.
-      def process_action(*)
+      def process_action(...)
         run_callbacks(:process_action) do
           super
         end

--- a/actionview/lib/action_view/rendering.rb
+++ b/actionview/lib/action_view/rendering.rb
@@ -34,7 +34,7 @@ module ActionView
     end
 
     # Override process to set up I18n proxy.
-    def process(*) # :nodoc:
+    def process(...) # :nodoc:
       old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
       super
     ensure

--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -471,6 +471,7 @@ module ActiveModel
     def attribute_missing(match, *args, &block)
       __send__(match.proxy_target, match.attr_name, *args, &block)
     end
+    ruby2_keywords(:attribute_missing)
 
     # A +Person+ instance with a +name+ attribute can ask
     # <tt>person.respond_to?(:name)</tt>, <tt>person.respond_to?(:name=)</tt>,

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -429,10 +429,10 @@ module ActiveRecord
       end
     end
 
-    def _exec_scope(*args, &block) # :nodoc:
+    def _exec_scope(...) # :nodoc:
       @delegate_to_klass = true
       registry = klass.scope_registry
-      _scoping(nil, registry) { instance_exec(*args, &block) || self }
+      _scoping(nil, registry) { instance_exec(...) || self }
     ensure
       @delegate_to_klass = false
     end


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/0456826180a0c9c3a5b33542ad4b4fc250c2f13d,
`foo(*caller_args)` method call delegation no longer preserve kwargs
flag.

Fixes #44846.
