### PR TITLE
Remove autoload to unused constant

### DIFF
--- a/activejob/lib/active_job.rb
+++ b/activejob/lib/active_job.rb
@@ -41,5 +41,4 @@ module ActiveJob
 
   autoload :TestCase
   autoload :TestHelper
-  autoload :QueryTags
 end


### PR DESCRIPTION
### Summary

I found a very small problem by the following code.

```rb
ActiveJob.constants.each { |c| ActiveJob.const_get(c) }
#=> <internal:/Users/ksss/.rbenv/versions/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- active_job/query_tags (LoadError)
```

### Other Information

`activejob/lib/active_job/query_tags.rb` has been removed from https://github.com/rails/rails/pull/43598