### PR TITLE
Use connection_class to check in connected_to

### DIFF
--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -139,7 +139,7 @@ module ActiveRecord
         raise NotImplementedError, "calling `connected_to` is only allowed on ActiveRecord::Base or abstract classes."
       end
 
-      if name != connection_specification_name && !primary_class?
+      if !connection_class? && !primary_class?
         raise NotImplementedError, "calling `connected_to` is only allowed on the abstract class that established the connection."
       end
 


### PR DESCRIPTION
Rather than check the `connection_specification_name` when determining
if we need to stop the user from calling `connected_to`, we can just
check the `connection_class?` method which should be `true` for any
class which has called `connects_to`.