### PR TITLE
Use schema definition for `drop_table` operation

### DIFF
--- a/activerecord/lib/active_record/connection_adapters.rb
+++ b/activerecord/lib/active_record/connection_adapters.rb
@@ -21,6 +21,7 @@ module ActiveRecord
       autoload :ForeignKeyDefinition
       autoload :CheckConstraintDefinition
       autoload :TableDefinition
+      autoload :DropTableDefinition
       autoload :Table
       autoload :AlterTable
       autoload :ReferenceDefinition

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -65,6 +65,12 @@ module ActiveRecord
           create_sql
         end
 
+        def visit_DropTableDefinition(o)
+          sql = +"DROP TABLE "
+          sql << "IF EXISTS " if o.if_exists
+          sql << quote_table_name(o.name)
+        end
+
         def visit_PrimaryKeyDefinition(o)
           "PRIMARY KEY (#{o.name.map { |name| quote_column_name(name) }.join(', ')})"
         end

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -545,6 +545,16 @@ module ActiveRecord
         end
     end
 
+    class DropTableDefinition
+      attr_reader :name, :if_exists, :force
+
+      def initialize(name, if_exists: false, force: false, **options)
+        @name = name
+        @if_exists = if_exists
+        @force = force
+      end
+    end
+
     class AlterTable # :nodoc:
       attr_reader :adds
       attr_reader :foreign_key_adds, :foreign_key_drops

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -516,7 +516,8 @@ module ActiveRecord
       # In that case, +options+ and the block will be used by #create_table.
       def drop_table(table_name, **options)
         schema_cache.clear_data_source_cache!(table_name.to_s)
-        execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}"
+        drop_table_definition = DropTableDefinition.new(table_name, **options)
+        execute schema_creation.accept(drop_table_definition)
       end
 
       # Add a new +type+ column named +column_name+ to +table_name+.

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -333,7 +333,8 @@ module ActiveRecord
       # In that case, +options+ and the block will be used by create_table.
       def drop_table(table_name, **options)
         schema_cache.clear_data_source_cache!(table_name.to_s)
-        execute "DROP#{' TEMPORARY' if options[:temporary]} TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
+        drop_table_definition = MySQL::DropTableDefinition.new(table_name, **options)
+        execute schema_creation.accept(drop_table_definition)
       end
 
       def rename_index(table_name, old_name, new_name)

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_creation.rb
@@ -11,6 +11,16 @@ module ActiveRecord
             "DROP FOREIGN KEY #{name}"
           end
 
+          def visit_DropTableDefinition(o)
+            sql = +"DROP "
+            sql << "TEMPORARY " if o.temporary
+            sql << "TABLE "
+            sql << "IF EXISTS " if o.if_exists
+            sql << quote_table_name(o.name)
+            sql << " CASCADE" if o.force == :cascade
+            sql
+          end
+
           def visit_DropCheckConstraint(name)
             "DROP #{mariadb? ? 'CONSTRAINT' : 'CHECK'} #{name}"
           end

--- a/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql/schema_definitions.rb
@@ -98,6 +98,15 @@ module ActiveRecord
       class Table < ActiveRecord::ConnectionAdapters::Table
         include ColumnMethods
       end
+
+      class DropTableDefinition < ActiveRecord::ConnectionAdapters::DropTableDefinition
+        attr_reader :temporary
+
+        def initialize(name, temporary: false, **options)
+          @temporary = temporary
+          super(name, **options)
+        end
+      end
     end
   end
 end

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb
@@ -9,6 +9,14 @@ module ActiveRecord
             super << o.constraint_validations.map { |fk| visit_ValidateConstraint fk }.join(" ")
           end
 
+          def visit_DropTableDefinition(o)
+            sql = +"DROP TABLE "
+            sql << "IF EXISTS " if o.if_exists
+            sql << quote_table_name(o.name)
+            sql << " CASCADE" if o.force == :cascade
+            sql
+          end
+
           def visit_AddForeignKey(o)
             super.dup.tap do |sql|
               if o.deferrable

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -56,7 +56,8 @@ module ActiveRecord
 
         def drop_table(table_name, **options) # :nodoc:
           schema_cache.clear_data_source_cache!(table_name.to_s)
-          execute "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
+          drop_table_definition = DropTableDefinition.new(table_name, **options)
+          execute schema_creation.accept(drop_table_definition)
         end
 
         # Returns true if schema exists.


### PR DESCRIPTION
### Summary

This PR is part of a larger effort to refactor the Rails migration workflow. The goal is to decouple the production of DDL from its execution, which will eventually allow applications to customize the objects responsible for producing and executing DDL.

The first step in this refactor is to ensure that all schema alterations can be represented by a schema definition, and that `SchemaCreation` objects can visit these definitions to produce SQL / DDL. Some operations (like `#create_table`) are already doing this. The intent here is to refactor all operations to follow this pattern.

This PR introduces a schema definition, `DropTableDefinition` , for dropping a table from a database. It defines `visit_DropTableDefinition` methods on the relevant `SchemaCreation` objects, and extracts the SQL creation from the adapters to these methods.

I'm relying on existing test coverage to validate that this refactor works as expected.