### PR TITLE
[ActiveStorage] Skip integrity check when checksum is not available

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Skip integrity check when checksum is not available in blob object.
+
+    If `ActiveStorage::Blob#checksum` is `blank?`, skip integrity check
+    and `ActiveStorage::IntegrityError` won't be raised anymore.
+
+    That is supposed to help with migration from other storage solutions
+    like Paperclip/CarrierWave. Records for previously uploaded files with
+    no checksum will skip integrity check and trust the storage service.
+    New files uploaded via ActiveStorage continue having its `checksum`
+    populated and its integrity verified as before.
+
+    *Lucas Fais*
+
 *   Fixes multiple `attach` calls within transaction not uploading files correctly.
 
     In the following example, the code failed to upload all but the last file to the configured service.

--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -301,7 +301,6 @@ class ActiveStorage::Blob < ActiveStorage::Record
     service.open(
       key,
       checksum: checksum,
-      verify: !composed,
       name: [ "ActiveStorage-#{id}-", filename.extension_with_delimiter ],
       tmpdir: tmpdir,
       &block

--- a/activestorage/lib/active_storage/downloader.rb
+++ b/activestorage/lib/active_storage/downloader.rb
@@ -8,10 +8,10 @@ module ActiveStorage
       @service = service
     end
 
-    def open(key, checksum: nil, verify: true, name: "ActiveStorage-", tmpdir: nil)
+    def open(key, checksum:, name: "ActiveStorage-", tmpdir: nil)
       open_tempfile(name, tmpdir) do |file|
         download key, file
-        verify_integrity_of(file, checksum: checksum) if verify
+        verify_integrity_of(file, checksum: checksum)
         yield file
       end
     end
@@ -34,8 +34,9 @@ module ActiveStorage
         file.rewind
       end
 
+      # If checksum is not available (due to compose, data migration, etc), skip integrity check
       def verify_integrity_of(file, checksum:)
-        unless OpenSSL::Digest::MD5.file(file).base64digest == checksum
+        if checksum.present? && OpenSSL::Digest::MD5.file(file).base64digest != checksum
           raise ActiveStorage::IntegrityError
         end
       end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -157,6 +157,17 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     end
   end
 
+  test "open when checksum is not available, skip integrity check" do
+    create_blob(data: "Hello, world!").tap do |blob|
+      blob.update_attribute(:checksum, nil)
+      assert blob.checksum.blank?
+
+      assert_nothing_raised do
+        blob.open { |file| assert file }
+      end
+    end
+  end
+
   test "open in a custom tmpdir" do
     create_file_blob(filename: "racecar.jpg").open(tmpdir: tmpdir = Dir.mktmpdir) do |file|
       assert file.binmode?


### PR DESCRIPTION
### Summary

As per @gmcgibbon's work in #41544, `checksum` field in `active_storage_blobs` now accepts `NULL` values for composed files.

There is at least one other scenario that makes sense for `blob.checksum` not to be available: migration from legacy storage solutions like Paperclip/CarrierWave.

Ideally, when migrating from Paperclip/CarrierWave, previous files must be re-uploaded via ActiveStorage to make sure `checksum` and `metadata` are populated, however that could be a huge pain for applications with a large amount of data. 

This PR makes ActiveStorage skip integrity check when `blob.checksum` is `blank?`. 

That makes it possible migrating data from Paperclip/CarrierWave just by populating ActiveStorage tables based on old information, without having to actually download and re-upload all files. A file copy might still be necessary for the new file structure, but that could happen within the service without the need for download/upload. 

New files uploaded via ActiveStorage will continue having its checksum populated and its integrity checked, but old records with no checksum would simply "trust" the storage service. Of course, it would be advisable to populate `checksum` and `metadata` later, but that could be done gradually in a background process, which is much easier to deal with and it might also help with transfer quota, etc.

@gmcgibbon: Since composed blobs also don't have a checksum, they would be granted the same exemption, so I took the liberty to remove that `verify` parameter just to keep the code as simple as possible. In case you prefer to keep it, we just have to revert commit `b77e631a3114dd9d9a68f59fdf626629478416d4`.
