### PR TITLE
Add a way to opt into unbounded IN queries

### DIFF
--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -198,6 +198,9 @@ module ActiveRecord
   singleton_class.attr_accessor :reading_role
   self.reading_role = :reading
 
+  singleton_class.attr_accessor :require_bounded_enumerables
+  self.require_bounded_enumerables = false
+
   # Sets the async_query_executor for an application. By default the thread pool executor
   # set to +nil+ which will not run queries in the background. Applications must configure
   # a thread pool executor to use this feature. Options are:

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -8,6 +8,7 @@ module ActiveRecord
     require "active_record/relation/predicate_builder/relation_handler"
     require "active_record/relation/predicate_builder/association_query_value"
     require "active_record/relation/predicate_builder/polymorphic_array_value"
+    require "active_support/bounded_enumerable"
 
     def initialize(table)
       @table = table
@@ -18,6 +19,7 @@ module ActiveRecord
       register_handler(Relation, RelationHandler.new)
       register_handler(Array, ArrayHandler.new(self))
       register_handler(Set, ArrayHandler.new(self))
+      register_handler(ActiveSupport::BoundedEnumerable, ArrayHandler.new(self))
     end
 
     def build_from_hash(attributes, &block)

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -36,6 +36,7 @@ module ActiveSupport
   autoload :Concern
   autoload :CodeGenerator
   autoload :ActionableError
+  autoload :BoundedEnumerable
   autoload :ConfigurationFile
   autoload :CurrentAttributes
   autoload :Dependencies

--- a/activesupport/lib/active_support/bounded_enumerable.rb
+++ b/activesupport/lib/active_support/bounded_enumerable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveSupport
+  class BoundedEnumerable # :nodoc:
+    def initialize(collection, max_count)
+      @collection = collection
+      @max_count = max_count
+    end
+
+    def enumerable
+      return @collection if @collection.count <= @max_count
+      @collection.to_a.first(@max_count)
+    end
+  end
+end

--- a/activesupport/lib/active_support/core_ext/array.rb
+++ b/activesupport/lib/active_support/core_ext/array.rb
@@ -2,6 +2,7 @@
 
 require "active_support/core_ext/array/wrap"
 require "active_support/core_ext/array/access"
+require "active_support/core_ext/array/bounded"
 require "active_support/core_ext/array/conversions"
 require "active_support/core_ext/array/deprecated_conversions" unless ENV["RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION"]
 require "active_support/core_ext/array/extract"

--- a/activesupport/lib/active_support/core_ext/array/bounded.rb
+++ b/activesupport/lib/active_support/core_ext/array/bounded.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "active_support/bounded_enumerable"
+
+class Array
+  def bound_at(n)
+    ActiveSupport::BoundedEnumerable.new(self, n)
+  end
+end

--- a/activesupport/lib/active_support/core_ext/set.rb
+++ b/activesupport/lib/active_support/core_ext/set.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/set/bounded"

--- a/activesupport/lib/active_support/core_ext/set/bounded.rb
+++ b/activesupport/lib/active_support/core_ext/set/bounded.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "active_support/bounded_enumerable"
+
+class Set
+  def bound_at(n)
+    ActiveSupport::BoundedEnumerable.new(self, n)
+  end
+end


### PR DESCRIPTION
__NOTE: This is just an experiment. Please DO NOT merge.__

It's currently really easy to create unbounded `IN` queries that grow
really large without the application developer accounting for the size.

This commit introduces a setting which requires the application
developer to state up front the maximum size of a given `IN`.

When this setting is on, rather than a traditional `where`, they'll need
to specify the maximum size of the `IN` portion:

``` ruby
Article.where(id: selected_ids.bound_at(5))
```

With this, if the amount of `ids` is more than `5`, the application
would only send the first `5` forward to the `IN` query.

While the setting is on, making the same call without specifying the
upper bound would result in an exception

``` ruby
Article.where(id: selected_ids) # raise
```

Fundamentally, the idea here is about making application developers
aware of the queries that they are making rather than making it
easy to introduce these unbounded `IN`s.

Feedback on the concept & approach more than welcome.
