### PR TITLE
Extend json_serilization test in Active Model for the `as_json` method

### DIFF
--- a/activemodel/test/cases/serializers/json_serialization_test.rb
+++ b/activemodel/test/cases/serializers/json_serialization_test.rb
@@ -2,12 +2,14 @@
 
 require "cases/helper"
 require "models/contact"
+require "models/address"
 require "active_support/core_ext/object/instance_variables"
 
 class JsonSerializationTest < ActiveModel::TestCase
   def setup
     @contact = Contact.new
     @contact.name = "Konata Izumi"
+    @contact.address = Address.new(address_line: "Cantonment Road", city: "Trichy", state: "Tamil Nadu", country: "India")
     @contact.age = 16
     @contact.created_at = Time.utc(2006, 8, 1)
     @contact.awesome = true
@@ -143,6 +145,82 @@ class JsonSerializationTest < ActiveModel::TestCase
     end
   ensure
     Contact.include_root_in_json = original_include_root_in_json
+  end
+
+  test "as_json should work with root option set to true" do
+    json = @contact.as_json(root: true)
+
+    assert_kind_of Hash, json
+    assert_kind_of Hash, json["contact"]
+    %w(name age created_at awesome preferences).each do |field|
+      assert_equal @contact.public_send(field).as_json, json["contact"][field]
+    end
+  end
+
+  test "as_json should work with root option set to string" do
+    json = @contact.as_json(root: "connection")
+
+    assert_kind_of Hash, json
+    assert_kind_of Hash, json["connection"]
+    %w(name age created_at awesome preferences).each do |field|
+      assert_equal @contact.public_send(field).as_json, json["connection"][field]
+    end
+  end
+
+  test "as_json should allow attribute filtering with except" do
+    json = @contact.as_json(except: [:age, :created_at, :awesome, :preferences])
+
+    assert_kind_of Hash, json
+    assert_equal json, { "name" => "Konata Izumi" }
+  end
+
+  test "as_json should allow attribute filtering with only" do
+    json = @contact.as_json(only: :name)
+
+    assert_kind_of Hash, json
+    assert_equal json, { "name" => "Konata Izumi" }
+  end
+
+  test "as_json should work with methods options" do
+    json = @contact.as_json(methods: :social)
+
+    assert_kind_of Hash, json
+    %w(name age created_at awesome preferences social).each do |field|
+      assert_equal @contact.public_send(field).as_json, json[field]
+    end
+  end
+
+  test "as_json should work with include option" do
+    json = @contact.as_json(include: :address)
+
+    assert_kind_of Hash, json
+    assert_kind_of Hash, json["address"]
+    %w(name age created_at awesome preferences).each do |field|
+      assert_equal @contact.public_send(field).as_json, json[field]
+    end
+    %w(address_line city state country).each do |field|
+      assert_equal @contact.address.public_send(field).as_json, json["address"][field]
+    end
+  end
+
+  test "as_json should work with include option paired with only filter" do
+    json = @contact.as_json(include: { address: { only: :city } })
+
+    assert_kind_of Hash, json
+    %w(name age created_at awesome preferences).each do |field|
+      assert_equal @contact.public_send(field).as_json, json[field]
+    end
+    assert_equal json["address"], { "city" => "Trichy" }
+  end
+
+  test "as_json should work with include option paired with except filter" do
+    json = @contact.as_json(include: { address: { except: [:address_line, :state, :country] } })
+
+    assert_kind_of Hash, json
+    %w(name age created_at awesome preferences).each do |field|
+      assert_equal @contact.public_send(field).as_json, json[field]
+    end
+    assert_equal json["address"], { "city" => "Trichy" }
   end
 
   test "from_json should work without a root (class attribute)" do

--- a/activemodel/test/models/address.rb
+++ b/activemodel/test/models/address.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Address
+  include ActiveModel::Serializers::JSON
+
+  attr_accessor :address_line, :city, :state, :country
+
+  def initialize(options = {})
+    options.each { |name, value| public_send("#{name}=", value) }
+  end
+
+  def attributes
+    instance_values
+  end
+end


### PR DESCRIPTION
### Summary

Extended test cases for the `as_json` method in AM. The `as_json` method has a number
of options, namely: `root`, `except`, `only`, `methods`, and `include`. Test cases that
test for these options are missing from the test suite. I've added test cases for these options
in this PR.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->