### PR TITLE
Fix typo: libaries -> libraries [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/middleware/database_selector.rb
+++ b/activerecord/lib/active_record/middleware/database_selector.rb
@@ -44,7 +44,7 @@ module ActiveRecord
     #   config.active_record.database_resolver_context = MyResolver::MySession
     #
     # Note: If you are using `rails new my_app --minimal` you will need to call
-    # `require "active_support/core_ext/integer/time"` to load the libaries
+    # `require "active_support/core_ext/integer/time"` to load the libraries
     # for +Time+.
     class DatabaseSelector
       def initialize(app, resolver_klass = nil, context_klass = nil, options = {})


### PR DESCRIPTION
### Summary

Fixed typo. So that spellcheck does not fail for other PRs.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
