### PR TITLE
Update source of `secret_key_base` in cookie rotator example

### DIFF
--- a/guides/source/upgrading_ruby_on_rails.md
+++ b/guides/source/upgrading_ruby_on_rails.md
@@ -381,7 +381,7 @@ The following is an example for rotator for the encrypted cookies.
 Rails.application.config.after_initialize do
   Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
     salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-    secret_key_base = Rails.application.secrets.secret_key_base
+    secret_key_base = Rails.application.secret_key_base
 
     key_generator = ActiveSupport::KeyGenerator.new(
       secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1


### PR DESCRIPTION
### Summary

`secrets.secret_key_base` can be one of the many different places where `secret_key_base` is set and therefore it might not work with your application.
Updating the docs to use `Rails.application.secret_key_base` fixes the issue.

Rails `secret_key_base` - [docs](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base)