### PR TITLE
Introduce `RemoveColumnDefinition` and use `AlterTable` to remove columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_creation.rb
@@ -22,6 +22,7 @@ module ActiveRecord
         def visit_AlterTable(o)
           sql = +"ALTER TABLE #{quote_table_name(o.name)} "
           sql << o.adds.map { |col| accept col }.join(" ")
+          sql << o.removes.map { |remove_col| accept remove_col }.join(", ")
           sql << o.foreign_key_adds.map { |fk| visit_AddForeignKey fk }.join(" ")
           sql << o.foreign_key_drops.map { |fk| visit_DropForeignKey fk }.join(" ")
           sql << o.check_constraint_adds.map { |con| visit_AddCheckConstraint con }.join(" ")
@@ -37,6 +38,10 @@ module ActiveRecord
 
         def visit_AddColumnDefinition(o)
           +"ADD #{accept(o.column)}"
+        end
+
+        def visit_RemoveColumnDefinition(o)
+          +"DROP COLUMN #{quote_column_name(o.name)}"
         end
 
         def visit_TableDefinition(o)

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb
@@ -79,6 +79,8 @@ module ActiveRecord
 
     AddColumnDefinition = Struct.new(:column) # :nodoc:
 
+    RemoveColumnDefinition = Struct.new(:name) # :nodoc:
+
     ChangeColumnDefinition = Struct.new(:column, :name) # :nodoc:
 
     CreateIndexDefinition = Struct.new(:index, :algorithm, :if_not_exists) # :nodoc:
@@ -546,13 +548,14 @@ module ActiveRecord
     end
 
     class AlterTable # :nodoc:
-      attr_reader :adds
+      attr_reader :adds, :removes
       attr_reader :foreign_key_adds, :foreign_key_drops
       attr_reader :check_constraint_adds, :check_constraint_drops
 
       def initialize(td)
         @td   = td
         @adds = []
+        @removes = []
         @foreign_key_adds = []
         @foreign_key_drops = []
         @check_constraint_adds = []
@@ -581,6 +584,16 @@ module ActiveRecord
         name = name.to_s
         type = type.to_sym
         @adds << AddColumnDefinition.new(@td.new_column_definition(name, type, **options))
+      end
+
+      def remove_column(name)
+        @removes << RemoveColumnDefinition.new(name)
+      end
+
+      def remove_columns(*names)
+        names.each do |name|
+          @removes << RemoveColumnDefinition.new(name)
+        end
       end
     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -640,8 +640,9 @@ module ActiveRecord
           raise ArgumentError.new("You must specify at least one column name. Example: remove_columns(:people, :first_name)")
         end
 
-        remove_column_fragments = remove_columns_for_alter(table_name, *column_names, type: type, **options)
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{remove_column_fragments.join(', ')}"
+        at = create_alter_table(table_name)
+        at.remove_columns(*column_names)
+        execute schema_creation.accept(at)
       end
 
       # Removes the column from the table definition.
@@ -662,7 +663,9 @@ module ActiveRecord
       def remove_column(table_name, column_name, type = nil, **options)
         return if options[:if_exists] == true && !column_exists?(table_name, column_name)
 
-        execute "ALTER TABLE #{quote_table_name(table_name)} #{remove_column_for_alter(table_name, column_name, type, **options)}"
+        at = create_alter_table(table_name)
+        at.remove_column(column_name)
+        execute schema_creation.accept(at)
       end
 
       # Changes the column's definition according to the new options.


### PR DESCRIPTION
Uses `AlterTable Definition` to handle schema statements for `#remove_column`
and #remove_columns.

### Summary

This PR is part of a larger effort to refactor the Rails migration workflow. The goal is to decouple the production of DDL from its execution, which will eventually allow applications to customize the objects responsible for producing and executing DDL.

The first step in this refactor is to ensure that all schema alterations can be represented by a schema definition, and that SchemaCreation objects can visit these definitions to produce SQL / DDL. Some operations (like `#create_table`) are already doing this. The intent here is to refactor all operations to follow this pattern.

This PR introduces a schema definition, `RemoveColumnDefinition`, for removing a column from a table. Schema operations `remove_column` and `remove_columns` use `AlterTable` definitions to represent their changes, with new methods `remove_column` and `remove_columns` added to `AlterTable` for defining columns to be removed.

We could use an entirely separate schema definition for removing columns (ie. separate from `AlterTable`), but since the underlying SQL is an `ALTER TABLE` and since `add_column` goes through `AlterTable`, I felt it made sense for the behaviour to live in `AlterTable`.

I'm relying on existing test coverage to validate that this refactor works as expected.