### PR TITLE
Remove no-longer-relevant `activerecord` locale namespace in example in guides [ci-skip]

### DIFF
--- a/guides/source/i18n.md
+++ b/guides/source/i18n.md
@@ -675,7 +675,7 @@ I18n.t [:odd, :even], scope: 'errors.messages'
 Also, a key can translate to a (potentially nested) hash of grouped translations. E.g., one can receive _all_ Active Record error messages as a Hash with:
 
 ```ruby
-I18n.t 'activerecord.errors.messages'
+I18n.t 'errors.messages'
 # => {:inclusion=>"is not included in the list", :exclusion=> ... }
 ```
 


### PR DESCRIPTION
### Summary

The `activerecord.errors.messages` namespace was renamed to simply `errors.messages` in Rails 3.0 ([commit](https://github.com/rails/rails/commit/190ce3ab37966957997cd18772d1260bf121c2e0), [release notes](https://guides.rubyonrails.org/3_0_release_notes.html#patches-and-deprecations)); this change brings the guides up to date.