### PR TITLE
Let `add_flash_types` define method on helper instead of controller

### DIFF
--- a/actionpack/lib/action_controller/metal/flash.rb
+++ b/actionpack/lib/action_controller/metal/flash.rb
@@ -33,17 +33,14 @@ module ActionController # :nodoc:
         types.each do |type|
           next if _flash_types.include?(type)
 
-          define_method(type) do
-            request.flash[type]
+          if respond_to?(:_helpers) && !_helpers.method_defined?(type)
+            _helpers.define_method(type) do
+              request.flash[type]
+            end
           end
-          helper_method(type) if respond_to?(:helper_method)
 
           self._flash_types += [type]
         end
-      end
-
-      def action_methods # :nodoc:
-        @action_methods ||= super - _flash_types.map(&:to_s).to_set
       end
     end
 

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -274,7 +274,7 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
     def set_bar
       flash[:bar] = "for great justice"
-      head :ok
+      render inline: "<%= bar %>"
     end
 
     def set_flash_optionally
@@ -322,11 +322,11 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def test_added_flash_types_method
+  def test_add_flash_types_defines_helper_method
     with_test_route_set do
       get "/set_bar"
       assert_response :success
-      assert_equal "for great justice", @controller.bar
+      assert_equal "for great justice", response.body
     end
   end
 
@@ -350,21 +350,6 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
 
       assert_not_equal another_hello_flash_etag, goodbye_flash_etag
     end
-  end
-
-  def test_flash_usable_in_metal_without_helper
-    controller_class = nil
-
-    assert_nothing_raised do
-      controller_class = Class.new(ActionController::Metal) do
-        include ActionController::Flash
-      end
-    end
-
-    controller = controller_class.new
-
-    assert_respond_to controller, :alert
-    assert_respond_to controller, :notice
   end
 
   private

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -37,7 +37,7 @@ class JustMeController < ActionController::Base
   clear_helpers
 
   def flash
-    render inline: "<h1><%= notice %></h1>"
+    render inline: "<h1><%= request.flash[:notice] %></h1>"
   end
 
   def lib


### PR DESCRIPTION
To resolve https://github.com/rails/rails/issues/44867, I propose to change `#add_flash_types` so that it defines only helper methods instead of controller methods.

Since the documentation comment only mentions that the method can be called in view as follows, I think it is probably safe to change it this way for general use. 

https://github.com/rails/rails/blob/8f39fbe18a57ae74513edc8561c00a369fe10f08/actionpack/lib/action_controller/metal/flash.rb#L27-L32

However, it might be better to keep controller methods as is and add deprecation warnings since the controller methods that have been usable up to now will no longer be usable due to this change.