### PR TITLE
Update ActiveSupport time zone tests for UTC-12 (International Date Line West)

### DIFF
--- a/activesupport/test/time_zone_test.rb
+++ b/activesupport/test/time_zone_test.rb
@@ -402,7 +402,7 @@ class TimeZoneTest < ActiveSupport::TestCase
   end
 
   def test_parse_string_with_timezone
-    (-11..13).each do |timezone_offset|
+    (-12..13).each do |timezone_offset|
       zone = ActiveSupport::TimeZone[timezone_offset]
       twz = zone.parse("1999-12-31 19:00:00")
       assert_equal twz, zone.parse(twz.to_s)


### PR DESCRIPTION
### Summary

The [UTC-12](https://www.timeanddate.com/time/zone/timezone/utc-12) time offset was [added in Rails 5.2](https://github.com/rails/rails/pull/29776); this change updates the tests to check for that.

See <https://github.com/rails/rails/pull/44824#issuecomment-1086708287>.