### PR TITLE
Add option to configure digest algorithm in Active Record Encryption

### DIFF
--- a/activerecord/lib/active_record/encryption/config.rb
+++ b/activerecord/lib/active_record/encryption/config.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Encryption
     # Container of configuration options
     class Config
-      attr_accessor :primary_key, :deterministic_key, :store_key_references, :key_derivation_salt,
+      attr_accessor :primary_key, :deterministic_key, :store_key_references, :key_derivation_salt, :hash_digest_class,
                     :support_unencrypted_data, :encrypt_fixtures, :validate_column_size, :add_to_filter_parameters,
                     :excluded_from_filter_parameters, :extend_queries, :previous_schemes, :forced_encoding_for_deterministic_encryption
 
@@ -39,6 +39,7 @@ module ActiveRecord
           self.excluded_from_filter_parameters = []
           self.previous_schemes = []
           self.forced_encoding_for_deterministic_encryption = Encoding::UTF_8
+          self.hash_digest_class = OpenSSL::Digest::SHA1
 
           # TODO: Setting to false for now as the implementation is a bit experimental
           self.extend_queries = false

--- a/activerecord/lib/active_record/encryption/key_generator.rb
+++ b/activerecord/lib/active_record/encryption/key_generator.rb
@@ -30,7 +30,8 @@ module ActiveRecord
       #
       # The generated key will be salted with the value of +ActiveRecord::Encryption.key_derivation_salt+
       def derive_key_from(password, length: key_length)
-        ActiveSupport::KeyGenerator.new(password).generate_key(key_derivation_salt, length)
+        ActiveSupport::KeyGenerator.new(password, hash_digest_class: ActiveRecord::Encryption.config.hash_digest_class)
+          .generate_key(key_derivation_salt, length)
       end
 
       private

--- a/activerecord/test/cases/encryption/helper.rb
+++ b/activerecord/test/cases/encryption/helper.rb
@@ -156,7 +156,7 @@ class ActiveRecord::EncryptionTestCase < ActiveRecord::TestCase
   include ActiveRecord::Encryption::EncryptionHelpers, ActiveRecord::Encryption::PerformanceHelpers
 
   ENCRYPTION_PROPERTIES_TO_RESET = {
-    config: %i[ primary_key deterministic_key key_derivation_salt store_key_references
+    config: %i[ primary_key deterministic_key key_derivation_salt store_key_references hash_digest_class
       key_derivation_salt support_unencrypted_data encrypt_fixtures
       forced_encoding_for_deterministic_encryption ],
     context: %i[ key_provider ]

--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -475,6 +475,10 @@ The salt used when deriving keys. It's preferred to configure it via the `active
 
 The default encoding for attributes encrypted deterministically. You can disable forced encoding by setting this option to `nil`. It's `Encoding::UTF_8` by default.
 
+#### `config.active_record.encryption.hash_digest_class`
+
+The digest algorithm used to derive keys. `OpenSSL::Digest::SHA1` by default.
+
 ### Encryption Contexts
 
 An encryption context defines the encryption components that are used in a given moment. There is a default encryption context based on your global configuration, but you can configure a custom context for a given attribute or when running a specific block of code.

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -67,6 +67,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_record.before_committed_on_all_records`](#config-active-record-before-committed-on-all-records): `true`
 - [`config.active_record.belongs_to_required_validates_foreign_key`](#config-active-record-belongs-to-required-validates-foreign-key): `false`
 - [`config.active_record.default_column_serializer`](#config-active-record-default-column-serializer): `nil`
+- [`config.active_record.encryption.hash_digest_class`](#config-active-record-encryption-hash-digest-class): `OpenSSL::Digest::SHA256`
 - [`config.active_record.query_log_tags_format`](#config-active-record-query-log-tags-format): `:sqlcommenter`
 - [`config.active_record.raise_on_assign_to_attr_readonly`](#config-active-record-raise-on-assign-to-attr-readonly): `true`
 - [`config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction`](#config-active-record-run-commit-callbacks-on-first-saved-instances-in-transaction): `false`
@@ -1461,6 +1462,17 @@ Allows setting a different regular expression that will be used to decide
 whether a foreign key's name should be dumped to db/schema.rb or not. By
 default, foreign key names starting with `fk_rails_` are not exported to the
 database schema dump. Defaults to `/^fk_rails_[0-9a-f]{10}$/`.
+
+ #### `config.active_record.encryption.hash_digest_class`
+
+ Sets the digest algorithm used by Active Record Encryption.
+
+ The default value depends on the `config.load_defaults` target version:
+
+ | Starting with version | The default value is      |
+ |-----------------------|---------------------------|
+ | (original)            | `OpenSSL::Digest::SHA1`   |
+ | 7.1                   | `OpenSSL::Digest::SHA256` |
 
 ### Configuring Action Controller
 

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -314,6 +314,10 @@ module Rails
           if respond_to?(:action_controller)
             action_controller.allow_deprecated_parameters_hash_equality = false
           end
+
+          if respond_to?(:active_record)
+            active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+          end
         else
           raise "Unknown version #{target_version.to_s.inspect}"
         end

--- a/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_1.rb.tt
@@ -29,6 +29,15 @@
 # as equal to an equivalent `Hash` by default.
 # Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
+# Active Record Encryption now uses SHA-256 as its hash digest algorithm. Important: If you have
+# data encrypted with previous versions, you should not set the new default or the existing data
+# will fail to decrypt. In this case, if you load the new 7.1 defaults, you need to configure the
+# previous algorithm SHA-1:
+# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
+# Alternatively, if you don't have data encrypted previously, you can configure the new digest for
+# Active Record Encryption with:
+# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::256
+
 # No longer run after_commit callbacks on the first of multiple Active Record
 # instances to save changes to the same database row within a transaction.
 # Instead, run these callbacks on the instance most likely to have internal


### PR DESCRIPTION
This adds a new option to configure the digest algorithm in Active Record Encryption. It sets SHA-256 as the new default starting in 7.1 and SHA-1 for previous versions.

This is a second take on this problem (see https://github.com/rails/rails/pull/42929). I forgot about the first PR and it went unmerged 🙄. 

Rails 7 uses `SHA256` as the [new default digest](https://github.com/rails/rails/pull/41043). However, due to [this bug](https://github.com/rails/rails/issues/42922)  , Active Record Encryption kept using SHA-1 until it was unintentionally fixed by [this change](https://github.com/rails/rails/pull/44540). Because that fix is recent, I think setting SHA-1 as the pre-7.1 default makes sense.

This shows why a mechanism to fix the digest algorithm in AR encryption is positive. Changing the digest prevents existing encrypted contents from decrypting, so we don't want the digest to change inadvertently when picking a new one in Rails.

To configure the new option:

```ruby
config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
```

Hat tip to @boomer196 for the original report, to @georgeclaghorn for the [great troubleshooting here](https://github.com/rails/rails/pull/44540#issuecomment-1063571641), and to @matthewd for the [change that exposed this bug](https://github.com/rails/rails/pull/44540).

cc @matthewd 