### PR TITLE
Don't regenerate unwanted initializers during Rails upgrade

### DIFF
--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Upgrading Rails apps no longer regenerate default initializers that have been previously deleted
+
+    If you have moved or deleted `assets.rb`, `inflections.rb`, `permissions_policy.rb`,
+    `filter_parameter_logging.rb`, `content_security_policy.rb`, or `cors.rb`, it will not
+    be recreated when running `rails app:update`.
+
+    *Alex Ghiculescu*
+
 *   Add Docker files by default to new apps: Dockerfile, .dockerignore, bin/docker-entrypoint.
     These files can be skipped with `--skip-docker`. They're intended as a starting point for
     a production deploy of the application. Not intended for development (see Docked Rails for that).

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -188,6 +188,71 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_file defaults_path
   end
 
+  def test_app_update_does_not_recreate_content_security_policy
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    FileUtils.rm("#{app_root}/config/initializers/content_security_policy.rb")
+
+    run_app_update app_root
+
+    assert_no_file "#{app_root}/config/initializers/content_security_policy.rb"
+  end
+
+  def test_app_update_does_not_remove_content_security_policy_if_already_present
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/content_security_policy.rb")
+
+    run_app_update app_root
+
+    assert_file "#{app_root}/config/initializers/content_security_policy.rb"
+  end
+
+  def test_app_update_does_not_recreate_filter_parameter_logging
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    FileUtils.rm("#{app_root}/config/initializers/filter_parameter_logging.rb")
+
+    run_app_update app_root
+    assert_no_file "#{app_root}/config/initializers/filter_parameter_logging.rb"
+  end
+
+  def test_app_update_does_not_remove_filter_parameter_logging_if_already_present
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/filter_parameter_logging.rb")
+
+    run_app_update app_root
+
+    assert_file "#{app_root}/config/initializers/filter_parameter_logging.rb"
+  end
+
+  def test_app_update_does_not_recreate_inflections
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    FileUtils.rm("#{app_root}/config/initializers/inflections.rb")
+
+    run_app_update app_root
+
+    assert_no_file "#{app_root}/config/initializers/inflections.rb"
+  end
+
+  def test_app_update_does_not_remove_inflections_if_already_present
+    app_root = File.join(destination_root, "myapp")
+    run_generator [app_root]
+
+    FileUtils.touch("#{app_root}/config/initializers/inflections.rb")
+
+    run_app_update app_root
+
+    assert_file "#{app_root}/config/initializers/inflections.rb"
+  end
+
   def test_app_update_does_not_create_rack_cors
     run_generator
     run_app_update


### PR DESCRIPTION
### Summary

Currently when doing a Rails upgrade, all the files [here](https://github.com/rails/rails/tree/main/railties/lib/rails/generators/rails/app/templates/config/initializers) will get recreated for you. Apart from the new framework defaults file (which you always want), the newest initializer in that folder is `permissions_policy.rb` which was added in Rails 6.1. Since you should upgrade Rails major versions one at a time, we can assume that anyone upgrading to Rails 7.1 (which this PR targets) will have already seen all of these initializers at least once and either chosen to use them, move them, or delete them.

If you use the initializers then you'll get prompted to merge in any updates, which is fine. But if you moved or deleted the initializers, then the update process recreates unwanted, potentially duplicate, config. This is annoying.

So this PR proposes that we don't recreate initializers during the app update if they didn't already exist. This way we are not bothering users with initializers they have already made a decision on. But we are still presenting them to new users.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

This is a follow up to https://github.com/rails/rails/pull/42538

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
