### PR TITLE
fix warnings when eager loading on ruby 2.7

### DIFF
--- a/activesupport/lib/active_support/dependencies/autoload.rb
+++ b/activesupport/lib/active_support/dependencies/autoload.rb
@@ -32,6 +32,7 @@ module ActiveSupport
           @_under_path = nil
           @_at_path = nil
           @_eager_autoload = false
+          @_eagerloaded_constants = nil
         end
       end
     end


### PR DESCRIPTION
### Summary

fix warnings when eager loading on ruby 2.7

before:

```
ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/loading_test.rb

Run options: --seed 11862

............/home/hartley/dev/github.com/skipkayhil/rails/activesupport/lib/active_support/dependencies/autoload.rb:75:
warning: instance variable @_eagerloaded_constants not initialized
/home/hartley/dev/github.com/skipkayhil/rails/activesupport/lib/active_support/dependencies/autoload.rb:75:
warning: instance variable @_eagerloaded_constants not initialized
.../home/hartley/dev/github.com/skipkayhil/rails/activesupport/lib/active_support/dependencies/autoload.rb:75:
warning: instance variable @_eagerloaded_constants not initialized
/home/hartley/dev/github.com/skipkayhil/rails/activesupport/lib/active_support/dependencies/autoload.rb:75:
warning: instance variable @_eagerloaded_constants not initialized
/home/hartley/dev/github.com/skipkayhil/rails/activesupport/lib/active_support/dependencies/autoload.rb:75:
warning: instance variable @_eagerloaded_constants not initialized
...

Finished in 2.819071s, 6.3851 runs/s, 13.1249 assertions/s.
18 runs, 37 assertions, 0 failures, 0 errors, 0 skips
```

after:

```
ruby -w -Itest -Ilib -I../activesupport/lib -I../actionpack/lib -I../actionview/lib -I../activemodel/lib test/application/loading_test.rb

Run options: --seed 34841

..................

Finished in 3.407082s, 5.2831 runs/s, 10.8597 assertions/s.
18 runs, 37 assertions, 0 failures, 0 errors, 0 skips
```

### Other Information

Example warning: https://buildkite.com/rails/rails/builds/85892#37da638c-e904-4dc3-ae6f-0d769ef37c01/1101-1107
