### PR TITLE
`#create_or_find_by`: `find_first` option

### DIFF
--- a/activerecord/test/cases/relations_test.rb
+++ b/activerecord/test/cases/relations_test.rb
@@ -1519,6 +1519,22 @@ class RelationTest < ActiveRecord::TestCase
     assert_not_equal subscriber, Subscriber.create_or_find_by(nick: "cat")
   end
 
+  def test_create_or_find_by_with_find_first_option
+    assert_nil Subscriber.find_by(nick: "bob")
+
+    subscriber = Subscriber.create!(nick: "bob")
+
+    options = { find_first: true }
+
+    assert_not_called(Subscriber, :create) do
+      assert_equal subscriber, Subscriber.create_or_find_by(nick: "bob", options: options)
+    end
+
+    assert_called(Subscriber, :create) do
+      assert_not_equal subscriber, Subscriber.create_or_find_by(nick: "cat", options: options)
+    end
+  end
+
   def test_create_or_find_by_with_block
     assert_nil Subscriber.find_by(nick: "bob")
 
@@ -1566,6 +1582,22 @@ class RelationTest < ActiveRecord::TestCase
 
     assert_equal subscriber, Subscriber.create_or_find_by!(nick: "bob")
     assert_not_equal subscriber, Subscriber.create_or_find_by!(nick: "cat")
+  end
+
+  def test_create_or_find_by_with_bang_and_find_first_option
+    assert_nil Subscriber.find_by(nick: "bob")
+
+    subscriber = Subscriber.create!(nick: "bob")
+
+    options = { find_first: true }
+
+    assert_not_called(Subscriber, :create!) do
+      assert_equal subscriber, Subscriber.create_or_find_by!(nick: "bob", options: options)
+    end
+
+    assert_called(Subscriber, :create!) do
+      assert_not_equal subscriber, Subscriber.create_or_find_by!(nick: "cat", options: options)
+    end
   end
 
   def test_create_or_find_by_with_bang_should_raise_due_to_validation_errors


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Updates `#create_or_find_by` to accept an optional `options` key to
house a new `find_first` flag. This flag specifies that the method runs
a `#find_by` before attempting the create.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

This can help mitigate a few potential issues:
* (Impact) Description
* (Medium) Reduces write load. In most cases, this method is useful to
  create a record once with all subsequent calls using `#find_by` as a
fallback. The proactive `#find_by` can skip the create/rescue loop and
mostly rely on the initial fetch.
* (Low) Reduces the risk of unneccesary PK increments when an existing record
  exists (ie. some versions of MySQL increment the PK on INSERT,
regardless of whether or not it succeeds). References https://github.com/rails/rails/issues/35543

[Previous implementation / inspiration](https://github.com/rails/rails/pull/35633)

### Open questions for reviewers

* Is there a better pattern for "options" in AR relation methods? 
  * The methods already accept kwargs by default and Ruby doesn't easily allow for multiple hashes as args
  (ie. `def method(hash_one, hash_two)`
* Should there be validations against options? ie. `options: { foo: :bar}` raises an error. 

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
