### PR TITLE
Rotate the debug.log on each 100MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 /doc/
 /guides/output/
 Brewfile.lock.json
-debug.log
+debug.log*
 node_modules/
 package-lock.json
 pkg/

--- a/activerecord/test/support/connection.rb
+++ b/activerecord/test/support/connection.rb
@@ -21,7 +21,7 @@ module ARTest
   def self.connect
     ActiveRecord.async_query_executor = :global_thread_pool
     puts "Using #{connection_name}"
-    ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 0, 100 * 1024 * 1024)
+    ActiveRecord::Base.logger = ActiveSupport::Logger.new("debug.log", 1, 100 * 1024 * 1024)
     ActiveRecord::Base.configurations = test_configuration_hashes
     ActiveRecord::Base.establish_connection :arunit
     ARUnit2Model.establish_connection :arunit2


### PR DESCRIPTION
Just found 1Gb+ `debug.log` file when tried up to free some space on my pc.

It was intended to rotate it in the [commit some time ago](https://github.com/rails/rails/commit/64391cd520cd8aee2c8b9ba1b95e4aae4512a6a0), but this is not working, as per [documentation](https://ruby-doc.org/stdlib-3.1.1/libdoc/logger/rdoc/Logger.html#method-c-new). 

cc @rafaelfranca