### PR TITLE
Rotate Default Logs on Each 100MB

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -65,6 +65,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_support.default_message_encryptor_serializer`](#config-active-support-default-message-encryptor-serializer): `:json`
 - [`config.active_support.default_message_verifier_serializer`](#config-active-support-default-message-verifier-serializer): `:json`
 - [`config.action_controller.allow_deprecated_parameters_hash_equality`](#config-action-controller-allow-deprecated-parameters-hash-equality): `false`
+- [`config.log_file_size`](#config-log-file-size): `100.megabytes`
 
 #### Default Values for Target Version 7.0
 
@@ -272,6 +273,10 @@ Forces all requests to be served over HTTPS, and sets "https://" as the default 
 #### `config.javascript_path`
 
 Sets the path where your app's JavaScript lives relative to the `app` directory. The default is `javascript`, used by [webpacker](https://github.com/rails/webpacker). An app's configured `javascript_path` will be excluded from `autoload_paths`.
+
+#### `config.log_file_size`
+
+Defines the maximum size of the Rails log file. Defaults to 100 MB in development and test, and unlimited in all other environments.
 
 #### `config.log_formatter`
 

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow configuration of logger size for local and test environments
+
+    `config.log_file_size`
+
+    Defaults to `100` megabytes.
+
+    *Bernie Chiu*
+
 *   Enroll new apps in decrypted diffs of credentials by default.  This behavior
     can be opted out of with the app generator's `--skip-decrypted-diffs` flag.
 

--- a/railties/lib/rails/application/bootstrap.rb
+++ b/railties/lib/rails/application/bootstrap.rb
@@ -35,7 +35,11 @@ module Rails
       # Initialize the logger early in the stack in case we need to log some deprecation.
       initializer :initialize_logger, group: :all do
         Rails.logger ||= config.logger || begin
-          logger = ActiveSupport::Logger.new(config.default_log_file)
+          logger = if config.log_file_size
+            ActiveSupport::Logger.new(config.default_log_file, 1, config.log_file_size)
+          else
+            ActiveSupport::Logger.new(config.default_log_file)
+          end
           logger.formatter = config.log_formatter
           logger = ActiveSupport::TaggedLogging.new(logger)
           logger

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -21,7 +21,7 @@ module Rails
                     :read_encrypted_secrets, :log_level, :content_security_policy_report_only,
                     :content_security_policy_nonce_generator, :content_security_policy_nonce_directives,
                     :require_master_key, :credentials, :disable_sandbox, :add_autoload_paths_to_load_path,
-                    :rake_eager_load, :server_timing
+                    :rake_eager_load, :server_timing, :log_file_size
 
       attr_reader :encoding, :api_only, :loaded_config_version
 
@@ -49,6 +49,7 @@ module Rails
         @time_zone                               = "UTC"
         @beginning_of_week                       = :monday
         @log_level                               = :debug
+        @log_file_size                           = nil
         @generators                              = app_generators
         @cache_store                             = [ :file_store, "#{root}/tmp/cache/" ]
         @railties_order                          = [:all]
@@ -259,6 +260,10 @@ module Rails
           load_defaults "7.0"
 
           self.add_autoload_paths_to_load_path = false
+
+          if Rails.env.development? || Rails.env.test?
+            self.log_file_size = (100 * 1024 * 1024)
+          end
 
           if respond_to?(:action_dispatch)
             action_dispatch.default_headers = {

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -1743,6 +1743,24 @@ module ApplicationTests
       assert_equal Rails.application.config.paths["log"].first, app.config.default_log_file.path
     end
 
+    test "config.log_file_size returns a 100MB size number in development" do
+      app "development"
+
+      assert_equal 100.megabytes, app.config.log_file_size
+    end
+
+    test "config.log_file_size returns a 100MB size number in test" do
+      app "test"
+
+      assert_equal 100.megabytes, app.config.log_file_size
+    end
+
+    test "config.log_file_size returns no limit in production" do
+      app "production"
+
+      assert_equal nil, app.config.log_file_size
+    end
+
     test "rake_tasks block works at instance level" do
       app_file "config/environments/development.rb", <<-RUBY
         Rails.application.configure do


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Also found that the default logs could grow quite big and left unnoticed, maybe we could set a default to 100MB which might already be enough for general usage and local development

<img width="721" alt="Screen Shot 2022-04-13 at 11 31 02 PM" src="https://user-images.githubusercontent.com/2749593/163220954-f08de706-0e99-4267-a432-4fae1fcf6b9e.png">

### Other Information

REF: https://github.com/rails/rails/pull/44887

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
