### PR TITLE
Expanded windows 8.3 filenames

### DIFF
--- a/activesupport/lib/active_support/encrypted_file.rb
+++ b/activesupport/lib/active_support/encrypted_file.rb
@@ -70,7 +70,12 @@ module ActiveSupport
     private
       def writing(contents)
         tmp_file = "#{Process.pid}.#{content_path.basename.to_s.chomp('.enc')}"
-        tmp_path = Pathname.new File.join(Dir.tmpdir, tmp_file)
+
+        # Windows paths can contained shortened forms, for example MyLongName can become MyLo~1
+        # This translate that shortened path into the absolute path
+        tmp_dir = Dir.glob(Dir.tmpdir)[0]
+
+        tmp_path = Pathname.new File.join(tmp_dir, tmp_file)
         tmp_path.binwrite contents
 
         yield tmp_path


### PR DESCRIPTION
### Summary

When running the credentials:edit rake task on windows, the temp directory can resolve as an [8.3 filename](https://en.wikipedia.org/wiki/8.3_filename). This causes the editor to fail to find the resulting temp file, because we escape the path with `Shellwords.escape` [here](https://github.com/rails/rails/blob/51b4370bb371a0f1d0823c57cad3a1557bf1e6fe/railties/lib/rails/commands/credentials/credentials_command.rb#L95), which also escapes the `~` in the 8.3 filename.

This pull request expands the shortened path to the absolute path.

For example, a failing path on my system was 

```
C:/Users/JOSH~1.OMI/AppData/Local/Temp/27512.production.yml
```

The file was successfully created, but the subsequent call to `vim <the_file>` failed to find the file. Likewise for VS Code, notepad, etc, due to the escaped ~

![image](https://user-images.githubusercontent.com/1729810/163237145-0dd7afdb-7d90-4b41-a407-d1c25ef37a70.png)

The correct path is 

```
C:/Users/josh.OMICS1/AppData/Local/Temp/27512.production.yml
```

Running `Dir.glob` on the resulting path resolves the shortened name to the absolute path.


For reference, the convesation about escaping paths was done here: https://github.com/rails/rails/pull/42728, I feel like replacing Shellwords.escape is a more harazardous than fixing the path being sent. 