### PR TITLE
Fix: Do not load_target if record is present

### DIFF
--- a/activerecord/lib/active_record/associations/has_one_association.rb
+++ b/activerecord/lib/active_record/associations/has_one_association.rb
@@ -54,7 +54,7 @@ module ActiveRecord
         def replace(record, save = true)
           raise_on_type_mismatch!(record) if record
 
-          return target unless load_target || record
+          return target unless record || load_target
 
           assigning_another_record = target != record
           if assigning_another_record || record.has_changes_to_save?


### PR DESCRIPTION
### Summary

Bug: When writing the target of an association, it's possible for the association to load the target (again)

### Conditions

 IF `find_target?` (https://github.com/hrdwdmrbl/rails/blob/main/activerecord/lib/active_record/associations/association.rb#L274) is true. `find_target?` will be true IF 

1. The association isn't already loaded <- will be false when assigning the association
2. The owner isn't new OR the owner does already have the has_one association foreign_key already set. <- This is important. The issue requires that the assignment of the foreign key happen before the association is assigned.
3. `klass`, which I think just means that the association's class is known.

### Work around

The caller can assign the association before assigning the foreign_key attribute.

### Fix

I fix the problem by putting the `record` condition first so that the condition evaluation halts because the association target is already present (it is being written at that moment).
