### PR TITLE
Add API docs for `run_load_hooks` [ci-skip]

### DIFF
--- a/activesupport/lib/active_support/lazy_load_hooks.rb
+++ b/activesupport/lib/active_support/lazy_load_hooks.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module ActiveSupport
-  # lazy_load_hooks allows Rails to lazily load a lot of components and thus
+  # LazyLoadHooks allows Rails to lazily load a lot of components and thus
   # making the app boot faster. Because of this feature now there is no need to
   # require <tt>ActiveRecord::Base</tt> at boot time purely to apply
   # configuration. Instead a hook is registered that applies configuration once
   # <tt>ActiveRecord::Base</tt> is loaded. Here <tt>ActiveRecord::Base</tt> is
   # used as example but this feature can be applied elsewhere too.
   #
-  # Here is an example where +on_load+ method is called to register a hook.
+  # Here is an example where on_load method is called to register a hook.
   #
   #   initializer 'active_record.initialize_timezone' do
   #     ActiveSupport.on_load(:active_record) do
@@ -18,10 +18,14 @@ module ActiveSupport
   #   end
   #
   # When the entirety of +ActiveRecord::Base+ has been
-  # evaluated then +run_load_hooks+ is invoked. The very last line of
+  # evaluated then run_load_hooks is invoked. The very last line of
   # +ActiveRecord::Base+ is:
   #
   #   ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+  #
+  # run_load_hooks will then execute all the hooks that were registered
+  # with the on_load method. In the case of the above example, it will
+  # execute the block of code that is in the +initializer+.
   module LazyLoadHooks
     def self.extended(base) # :nodoc:
       base.class_eval do
@@ -46,6 +50,13 @@ module ActiveSupport
       @load_hooks[name] << [block, options]
     end
 
+    # Executes all blocks registered to +name+ via on_load, using +base+ as the
+    # evaluation context.
+    #
+    #  ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+    #
+    # In the case of the above example, it will execute all hooks registered
+    # for +:active_record+ within the class +ActiveRecord::Base+.
     def run_load_hooks(name, base = Object)
       @loaded[name] << base
       @load_hooks[name].each do |hook, options|


### PR DESCRIPTION
### Summary

The API docs for `run_load_hooks` are not present, and the behavior of this method is not
clearly explained in the context of lazy loading. This PR extends the docs for this method and
describes the behavior.

<img width="1057" alt="Screenshot 2022-04-14 at 9 44 34 PM" src="https://user-images.githubusercontent.com/56545288/163430753-aabb27de-6145-444e-84a3-8a6dc1fcf3ba.png">

<img width="1059" alt="Screenshot 2022-04-14 at 9 45 44 PM" src="https://user-images.githubusercontent.com/56545288/163430909-b2a01c75-0767-41f9-9933-bbc2b9af422f.png">


<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
