### PR TITLE
Return false when saving an object with a missing record

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1086,8 +1086,13 @@ module ActiveRecord
     def create_or_update(**, &block)
       _raise_readonly_record_error if readonly?
       return false if destroyed?
-      result = new_record? ? _create_record(&block) : _update_record(&block)
-      result != false
+      if new_record?
+        result = _create_record(&block)
+        result != false
+      else
+        result = _update_record(&block)
+        result != 0
+      end
     end
 
     # Updates the associated record with values matching those of the instance attributes.

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -428,6 +428,16 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal "Failed to save the record", error.message
   end
 
+  def test_save_missing_record_from_database
+    topic = Topic.create!(title: "Some Title")
+    Topic.find(topic.id).delete
+    topic.title = "Another Title"
+
+    error = assert_raise(ActiveRecord::RecordNotSaved) { topic.save! }
+
+    assert_equal "Failed to save the record", error.message
+  end
+
   def test_save_null_string_attributes
     topic = Topic.find(1)
     topic.attributes = { "title" => "null", "author_name" => "null" }


### PR DESCRIPTION
### Summary

`ActiveRecord::Base#save!` does not raise an `ActiveRecord::RecordNotSaved` when saving an object with a missing record on the database. For example:

```
topic = Topic.create(name: "New Title")
Topic.find(topic.id).delete
topic.title = "Another Title"
topic.save! #=> true
```

I believe this should raise an exception instead of failing silently.