### PR TITLE
Clarified requirements for keys in nested structures

### DIFF
--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -985,7 +985,7 @@ The `fields_for` yields a form builder. The parameters' name will be what
 }
 ```
 
-The keys of the `:addresses_attributes` hash are unimportant; they need to be integers and different for each address.
+The actual values of the keys in the `:addresses_attributes` hash are unimportant; however they need to be strings of integers and different for each address.
 
 If the associated object is already saved, `fields_for` autogenerates a hidden input with the `id` of the saved record. You can disable this by passing `include_id: false` to `fields_for`.
 

--- a/guides/source/form_helpers.md
+++ b/guides/source/form_helpers.md
@@ -985,7 +985,7 @@ The `fields_for` yields a form builder. The parameters' name will be what
 }
 ```
 
-The keys of the `:addresses_attributes` hash are unimportant, they need merely be different for each address.
+The keys of the `:addresses_attributes` hash are unimportant; they need to be integers and different for each address.
 
 If the associated object is already saved, `fields_for` autogenerates a hidden input with the `id` of the saved record. You can disable this by passing `include_id: false` to `fields_for`.
 


### PR DESCRIPTION
"The keys of the ... hash are unimportant" is a little bit misleading since non numeric keys are ignored:

https://github.com/rails/rails/blob/6bb0e0efb2bea8b22c4b22c60bc776c8760d41bd/actionpack/test/controller/parameters/nested_parameters_permit_test.rb#L169

