### PR TITLE
Raise ActiveRecord::RecordNotSaved when saving an object with a missing record

### DIFF
--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1107,7 +1107,7 @@ module ActiveRecord
 
       yield(self) if block_given?
 
-      affected_rows
+      attribute_names.empty? ? true : affected_rows == 1
     end
 
     # Creates a record with values matching those of the instance attributes

--- a/activerecord/test/cases/persistence_test.rb
+++ b/activerecord/test/cases/persistence_test.rb
@@ -428,6 +428,16 @@ class PersistenceTest < ActiveRecord::TestCase
     assert_equal "Failed to save the record", error.message
   end
 
+  def test_save_missing_record_from_database
+    topic = Topic.create!(title: "Some Title")
+    Topic.find(topic.id).delete
+    topic.title = "Another Title"
+
+    error = assert_raise(ActiveRecord::RecordNotSaved) { topic.save! }
+
+    assert_equal "Failed to save the record", error.message
+  end
+
   def test_save_null_string_attributes
     topic = Topic.find(1)
     topic.attributes = { "title" => "null", "author_name" => "null" }


### PR DESCRIPTION
### Summary

`ActiveRecord::Base#save!` does not raise an `ActiveRecord::RecordNotSaved` when saving an object where the record cannot be found on the database. For example:

```
topic = Topic.create(name: "New Title")
Topic.find(topic.id).delete
topic.title = "Another Title"
topic.save! #=> true
```

I believe this should raise an exception instead of failing silently. This PR makes it so that:

```
topic = Topic.create(name: "New Title")
Topic.find(topic.id).delete
topic.title = "Another Title"
topic.save! #=> raises ActiveRecord::RecordNotSaved
```