### PR TITLE
Register the interlock hook only if reloading

### DIFF
--- a/railties/lib/rails/application/finisher.rb
+++ b/railties/lib/rails/application/finisher.rb
@@ -125,7 +125,7 @@ module Rails
         else
           # Default concurrency setting: enabled, but safe
 
-          if config.reloading_enabled? || !config.eager_load
+          if config.reloading_enabled?
             app.executor.register_hook(InterlockHook, outer: true)
           end
         end


### PR DESCRIPTION
If reloading is enabled, we need the interlock to synchronize reloads.

If reloading is disabled and so is eager loading, in the past you still needed to synchronize autoloads because `classic` was not thread-safe. With Zeitwerk, this is no longer needed.


