### PR TITLE
Refactored `EncryptedConfiguration#config` method and improved test cases

### DIFF
--- a/activesupport/lib/active_support/encrypted_configuration.rb
+++ b/activesupport/lib/active_support/encrypted_configuration.rb
@@ -8,8 +8,7 @@ require "active_support/core_ext/module/delegation"
 
 module ActiveSupport
   class EncryptedConfiguration < EncryptedFile
-    delegate :[], :fetch, to: :config
-    delegate_missing_to :options
+    delegate_missing_to :config
 
     def initialize(config_path:, key_path:, env_key:, raise_if_missing_key:)
       super content_path: config_path, key_path: key_path,
@@ -30,7 +29,7 @@ module ActiveSupport
     end
 
     def config
-      @config ||= deserialize(read).deep_symbolize_keys
+      @config ||= deep_transform(deserialize(read))
     end
 
     private
@@ -42,10 +41,6 @@ module ActiveSupport
           h[k] = deep_transform(v)
         end
         h
-      end
-
-      def options
-        @options ||= ActiveSupport::InheritableOptions.new(deep_transform(config))
       end
 
       def deserialize(config)

--- a/activesupport/test/encrypted_configuration_test.rb
+++ b/activesupport/test/encrypted_configuration_test.rb
@@ -55,6 +55,38 @@ class EncryptedConfigurationTest < ActiveSupport::TestCase
     assert_equal @credentials.config, {}
   end
 
+  test "reading config from configuration" do
+    @credentials.write({ something: { good: true, bad: false, nested: { foo: "bar" } } }.to_yaml)
+    assert_equal @credentials.config, { something: { good: true, bad: false, nested: { foo: "bar" } } }
+  end
+
+  test "reading config from configuration via methods" do
+    @credentials.write({ something: { good: true, bad: false, nested: { foo: "bar" } } }.to_yaml)
+    assert_equal @credentials.config, { something: { good: true, bad: false, nested: { foo: "bar" } } }
+    assert_equal @credentials.config.something, { good: true, bad: false, nested: { foo: "bar" } }
+    assert_equal @credentials.config.something.good, true
+    assert_equal @credentials.config.something.bad, false
+    assert_equal @credentials.config.something.nested, { foo: "bar" }
+  end
+
+  test "reading config from configuration via symbols" do
+    @credentials.write({ something: { good: true, bad: false, nested: { foo: "bar" } } }.to_yaml)
+    assert_equal @credentials.config, { something: { good: true, bad: false, nested: { foo: "bar" } } }
+    assert_equal @credentials.config[:something], { good: true, bad: false, nested: { foo: "bar" } }
+    assert_equal @credentials.config[:something][:good], true
+    assert_equal @credentials.config[:something][:bad], false
+    assert_equal @credentials.config[:something][:nested], { foo: "bar" }
+  end
+
+  test "reading config from configuration via strings" do
+    @credentials.write({ something: { good: true, bad: false, nested: { foo: "bar" } } }.to_yaml)
+    assert_equal @credentials.config, { something: { good: true, bad: false, nested: { foo: "bar" } } }
+    assert_equal @credentials.config["something"], { good: true, bad: false, nested: { foo: "bar" } }
+    assert_equal @credentials.config["something"]["good"], true
+    assert_equal @credentials.config["something"]["bad"], false
+    assert_equal @credentials.config["something"]["nested"], { foo: "bar" }
+  end
+
   test "change configuration by key file" do
     @credentials.write({ something: { good: true } }.to_yaml)
     @credentials.change do |config_file|


### PR DESCRIPTION
### Summary

There is no need to call `deep_symbolize_keys` in the `config` method, since `deep_transform`
is being called on `config` anyway. Instead, something like this can be done:

```ruby
def config
  @config ||= deep_transform(deserialize(read))
end
```

Moving the `deep_transform` to the `config` method ensures that `deep_transform` is not called
on `config` redundantly.

This PR also extends the test cases for the `config` method appropriately.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
