### PR TITLE
ActiveStorage Audio previewer via ffmpeg

### DIFF
--- a/activestorage/lib/active_storage/previewer/audio_previewer.rb
+++ b/activestorage/lib/active_storage/previewer/audio_previewer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "shellwords"
+module ActiveStorage
+  class Previewer::AudioPreviewer < Previewer
+    class << self
+      def accept?(blob)
+        blob.audio? && ffmpeg_exists?
+      end
+
+      def ffmpeg_exists?
+        return @ffmpeg_exists if defined?(@ffmpeg_exists)
+
+        @ffmpeg_exists = system(ffmpeg_path, "-version", out: File::NULL, err: File::NULL)
+      end
+
+      def ffmpeg_path
+        ActiveStorage.paths[:ffmpeg] || "ffmpeg"
+      end
+
+      def ffprobe_path
+        ActiveStorage.paths[:ffprobe] || "ffprobe"
+      end
+    end
+
+    def preview(**options)
+      download_blob_to_tempfile do |input|
+        draw_image_waveform_from input, options do |output|
+          yield io: output, filename: "#{blob.filename.base}.jpg", content_type: "image/jpeg", **options
+        end
+      end
+    end
+
+    private
+      def draw_image_waveform_from(file, options, &block)
+        default_filter = "color=c=blue[color];aformat=channel_layouts=mono,showwavespic=s=1280x720:colors=white[wave];[color][wave]scale2ref[bg][fg];[bg][fg]overlay=format=auto"
+        filter_options = options[:filter_options] || default_filter
+        draw self.class.ffmpeg_path, "-i", file.path, *Shellwords.split("-filter_complex \"#{filter_options}\" -frames:v 1 -f image2"), "-", &block
+      end
+  end
+end

--- a/activestorage/test/previewer/audio_previewer_test.rb
+++ b/activestorage/test/previewer/audio_previewer_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "database/setup"
+
+require "active_storage/previewer/audio_previewer"
+
+class ActiveStorage::Previewer::AudioPreviewerTest < ActiveSupport::TestCase
+  test "previewing an MP3 audio" do
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+
+    ActiveStorage::Previewer::AudioPreviewer.new(blob).preview do |attachable|
+      assert_equal "image/jpeg", attachable[:content_type]
+      assert_equal "audio.jpg", attachable[:filename]
+
+      image = MiniMagick::Image.read(attachable[:io])
+      assert_equal 1280, image.width
+      assert_equal 720, image.height
+      assert_equal "image/jpeg", image.mime_type
+    end
+  end
+
+  test "previewing an MP3 audio with options" do
+    blob = create_file_blob(filename: "audio.mp3", content_type: "audio/mp3")
+
+    filter_options = "color=c=blue[color];aformat=channel_layouts=mono,showwavespic=s=640x480:colors=white[wave];[color][wave]scale2ref[bg][fg];[bg][fg]overlay=format=auto"
+
+    ActiveStorage::Previewer::AudioPreviewer.new(blob).preview(filter_options: filter_options) do |attachable|
+      assert_equal "image/jpeg", attachable[:content_type]
+      assert_equal "audio.jpg", attachable[:filename]
+
+      image = MiniMagick::Image.read(attachable[:io])
+      assert_equal 640, image.width
+      assert_equal 480, image.height
+      assert_equal "image/jpeg", image.mime_type
+    end
+  end
+
+  test "previewing a audio that can't be previewed" do
+    blob = create_file_blob(filename: "report.pdf", content_type: "audio/mp4")
+
+    assert_raises ActiveStorage::PreviewError do
+      ActiveStorage::Previewer::VideoPreviewer.new(blob).preview
+    end
+  end
+end


### PR DESCRIPTION
### ActiveStorage AudioPreviewer

This PR allows to generate an audio preview via FFmpeg, also allows passing raw FFmpeg options in order to customize the  preview image

![image](https://user-images.githubusercontent.com/11976/163660543-ecee86cb-8dba-46c4-b96f-596e4537270a.png)

### Other ideas for (maybe) another PR.

I'm wondering if also could be a good idea to add a variant for audio in order to provide a "preview" of the audio something like a 5 seconds version of large audio. This could be useful for music-sharing platforms.

Last but not least, it might be a good idea to generate a JSON metadata for the audio? for example, if you need to draw the audio via canvas or SVG then we could extract the frames via frame tags as JSON data. 

