### PR TITLE
Avoid escaping paths when editing credentials

### DIFF
--- a/railties/lib/rails/commands/credentials/credentials_command.rb
+++ b/railties/lib/rails/commands/credentials/credentials_command.rb
@@ -92,7 +92,7 @@ module Rails
 
         def change_credentials_in_system_editor
           credentials.change do |tmp_path|
-            system("#{ENV["EDITOR"]} #{Shellwords.escape(tmp_path)}")
+            system(*Shellwords.split(ENV["EDITOR"]), tmp_path.to_s)
           end
         end
 

--- a/railties/test/commands/credentials_test.rb
+++ b/railties/test/commands/credentials_test.rb
@@ -36,7 +36,7 @@ class Rails::Command::CredentialsCommandTest < ActiveSupport::TestCase
   end
 
   test "edit command does not overwrite by default if credentials already exists" do
-    run_edit_command(editor: "eval echo api_key: abc >")
+    run_edit_command(editor: 'ruby -e "File.write ARGV[0], %(api_key: abc)"')
     assert_match(/api_key: abc/, run_show_command)
 
     run_edit_command


### PR DESCRIPTION
`Shellwords.escape` escapes unquoted spaces with a backslash, but Windows does not treat backslash as an escape character.  Escaping is also a problem when paths are expressed in shortened 8.3 format (e.g. `C:\Users\RubyOn~1\AppData\Local\Temp\...`) because a backslash will be erroneously added before the `~`.

We can avoid the need to escape by using `system(command_name, *args)` instead of `system(command_line)`, but we must still support `ENV["EDITOR"]` values that embed command line arguments, such as `subl -w`.

This commit changes to `system(command_name, *args)`, but uses `Shellwords.split` to extract any embedded arguments from `ENV["EDITOR"]`.  This requires that Windows users put quotes around the entire path of their editor if it contains spaces, such as:

```
SET EDITOR="C:\Program Files\Microsoft VS Code\Code.exe" -w
```

In other words, the following are **not** supported on Windows:

```
SET "EDITOR=C:\Program Files\Microsoft VS Code\Code.exe"
SET EDITOR=C:\Program Files\Microsoft VS Code\Code.exe
SET EDITOR=C:\"Program Files"\"Microsoft VS Code"\Code.exe -w
SET EDITOR=C:\Program^ Files\Microsoft^ VS^ Code\Code.exe -w
SET EDITOR=C:\Program` Files\Microsoft` VS` Code\Code.exe -w
```

Fixes #41617 (again).
Closes #44890.

---

This is based on my suggestion in https://github.com/rails/rails/pull/42728#discussion_r666287484, with a fix for the test I mentioned in https://github.com/rails/rails/pull/42728#issuecomment-876585266.

/cc @ariccio @joshleblanc Would it be possible for you to test this change locally, and verify that it solves your issue?
