### PR TITLE
Remove unnecessary note for primary_key in the guide

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -352,10 +352,10 @@ end
 which creates a `products` table with a column called `name`.
 
 By default, `create_table` will create a primary key called `id`. You can change
-the name of the primary key with the `:primary_key` option (don't forget to
-update the corresponding model) or, if you don't want a primary key at all, you
-can pass the option `id: false`. If you need to pass database specific options
-you can place an SQL fragment in the `:options` option. For example:
+the name of the primary key with the `:primary_key` option  or, if you don't
+want a primary key at all, you can pass the option `id: false`. If you need to
+pass database specific options you can place an SQL fragment in the `:options`
+option. For example:
 
 ```ruby
 create_table :products, options: "ENGINE=BLACKHOLE" do |t|


### PR DESCRIPTION
### Summary

This PR removes an unnecessary note for primary_key in the AR migration guide.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

The removed note is the following:

> (don't forget to update the corresponding model)

I think this note is unnecessary because updating the model is not required.

I guess the "update" means adding `self.primary_key = 'myid'` into the model file. However, it is not required. Active Record set `self.primary_key` from RBDMS, so the user doesn't need to set it explicitly.
https://github.com/rails/rails/blob/70a0754e5d16d4bdb705f67425866938654ef801/activerecord/lib/active_record/attribute_methods/primary_key.rb#L96
Therefore we can remove the note.










<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
