### PR TITLE
[guide] Enable syntax highlight for a code in AR validation guide [ci-skip]

### DIFF
--- a/guides/source/active_record_validations.md
+++ b/guides/source/active_record_validations.md
@@ -190,7 +190,7 @@ Note that an object instantiated with `new` will not report errors
 even if it's technically invalid, because validations are automatically run
 only when the object is saved, such as with the `create` or `save` methods.
 
-```
+```ruby
 class Person < ApplicationRecord
   validates :name, presence: true
 end


### PR DESCRIPTION
### Summary

This PR enables syntax highlight for a code block in AR validation guide

### Other Information

I've confirmed all other code blocks have language name in `active_record_validations.md`, but I haven't confirm it for other files. 