### PR TITLE
Document `:inline` option for `rails_command` [ci-skip]

### DIFF
--- a/guides/source/rails_application_templates.md
+++ b/guides/source/rails_application_templates.md
@@ -201,6 +201,12 @@ You can also run commands that should abort application generation if they fail:
 rails_command "db:migrate", abort_on_failure: true
 ```
 
+You can also run commands with the `inline` option. This will run the command directly, instead of shelling out.
+
+```ruby
+rails_command "db:migrate", inline: true
+```
+
 ### route(routing_code)
 
 Adds a routing entry to the `config/routes.rb` file. In the steps above, we generated a person scaffold and also removed `README.rdoc`. Now, to make `PeopleController#index` the default page for the application:


### PR DESCRIPTION
### Summary

The doc for `rails_command` does not provide information about the `:inline` option which can
be passed to the method. This PR adds basic info about this option.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->
