### PR TITLE
Treat `image/bmp` as a valid content type

### DIFF
--- a/activestorage/app/models/active_storage/blob.rb
+++ b/activestorage/app/models/active_storage/blob.rb
@@ -362,7 +362,7 @@ class ActiveStorage::Blob < ActiveStorage::Record
     super
   end
 
-  INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 = ["image/jpg", "image/pjpeg", "image/bmp"]
+  INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 = ["image/jpg", "image/pjpeg"]
   INVALID_VARIABLE_CONTENT_TYPES_TO_SERVE_AS_BINARY_DEPRECATED_IN_RAILS_7 = ["text/javascript"]
 
   private

--- a/activestorage/test/engine_test.rb
+++ b/activestorage/test/engine_test.rb
@@ -5,30 +5,36 @@ require "database/setup"
 
 class ActiveStorage::EngineTest < ActiveSupport::TestCase
   test "all default content types are recognized by mini_mime" do
-    exceptions = ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 + ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_TO_SERVE_AS_BINARY_DEPRECATED_IN_RAILS_7
+    exceptions = ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_DEPRECATED_IN_RAILS_7 +
+                  ActiveStorage::Blob::INVALID_VARIABLE_CONTENT_TYPES_TO_SERVE_AS_BINARY_DEPRECATED_IN_RAILS_7 +
+                  ["image/bmp"] # see https://github.com/discourse/mini_mime/pull/45, once mini_mime is updated this can be removed
 
     ActiveStorage.variable_content_types.each do |content_type|
       next if exceptions.include?(content_type) # remove this line in Rails 7.1
 
-      assert_equal content_type, MiniMime.lookup_by_content_type(content_type).content_type
+      assert_equal content_type, MiniMime.lookup_by_content_type(content_type)&.content_type
     end
 
     ActiveStorage.web_image_content_types.each do |content_type|
       next if exceptions.include?(content_type) # remove this line in Rails 7.1
 
-      assert_equal content_type, MiniMime.lookup_by_content_type(content_type).content_type
+      assert_equal content_type, MiniMime.lookup_by_content_type(content_type)&.content_type
     end
 
     ActiveStorage.content_types_to_serve_as_binary.each do |content_type|
       next if exceptions.include?(content_type) # remove this line in Rails 7.1
 
-      assert_equal content_type, MiniMime.lookup_by_content_type(content_type).content_type
+      assert_equal content_type, MiniMime.lookup_by_content_type(content_type)&.content_type
     end
 
     ActiveStorage.content_types_allowed_inline.each do |content_type|
       next if exceptions.include?(content_type) # remove this line in Rails 7.1
 
-      assert_equal content_type, MiniMime.lookup_by_content_type(content_type).content_type
+      assert_equal content_type, MiniMime.lookup_by_content_type(content_type)&.content_type
     end
+  end
+
+  test "image/bmp is a default content type" do
+    assert_includes ActiveStorage.variable_content_types, "image/bmp"
   end
 end

--- a/activestorage/test/models/blob_test.rb
+++ b/activestorage/test/models/blob_test.rb
@@ -339,6 +339,10 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
     assert_not_deprecated do
       create_blob(filename: "funky.jpg", content_type: "image/jpeg")
     end
+
+    assert_not_deprecated do
+      create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
+    end
   end
 
   test "warning if blob is created with invalid mime type can be disabled" do
@@ -351,6 +355,10 @@ class ActiveStorage::BlobTest < ActiveSupport::TestCase
 
     assert_not_deprecated do
       create_blob(filename: "funky.jpg", content_type: "image/jpeg")
+    end
+
+    assert_not_deprecated do
+      create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
     end
 
   ensure

--- a/activestorage/test/models/variant_test.rb
+++ b/activestorage/test/models/variant_test.rb
@@ -104,7 +104,7 @@ class ActiveStorage::VariantTest < ActiveSupport::TestCase
   end
 
   test "resized variation of BMP blob" do
-    blob = create_file_blob(filename: "colors.bmp", content_type: "image/x-bmp")
+    blob = create_file_blob(filename: "colors.bmp", content_type: "image/bmp")
     variant = blob.variant(resize_to_limit: [15, 15]).processed
     assert_match(/colors\.png/, variant.url)
 

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -2107,7 +2107,7 @@ can transform through ImageMagick.
 By default, this is defined as:
 
 ```ruby
-config.active_storage.variable_content_types = %w(image/png image/gif image/jpeg image/tiff image/vnd.adobe.photoshop image/vnd.microsoft.icon image/webp image/avif image/heic image/heif)
+config.active_storage.variable_content_types = %w(image/png image/gif image/jpeg image/tiff image/bmp image/vnd.adobe.photoshop image/vnd.microsoft.icon image/webp image/avif image/heic image/heif)
 ```
 
 #### `config.active_storage.web_image_content_types`


### PR DESCRIPTION
This is a follow up to https://github.com/rails/rails/pull/42227#issuecomment-1100927828

The mime types database was incorrect regarding `image/bmp`. It has been fixed in https://github.com/mime-types/mime-types-data/issues/48 and in https://github.com/discourse/mini_mime/pull/45

Since a new version of `mini_mime` hasn't been cut yet, some of the tests in this PR look a bit off. But the core issue of not warning users if they use `image/bmp` is resolved.
