### PR TITLE
Add 'initial' option to belongs_to association

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add `initial` option to `belongs_to` association.
+
+    Set an initial value for `belongs_to` associations that takes affect when the owner is first instantiated.
+    Differs from `default` in being set upon instantiation rather than before validation and in allowing an association
+    to be set to nil rather than setting nil associations back to the default before validation.
+
 *   Remove `ActiveRecord.legacy_connection_handling`.
 
     *Eileen M. Uchitelle*

--- a/activerecord/lib/active_record/associations/builder/belongs_to.rb
+++ b/activerecord/lib/active_record/associations/builder/belongs_to.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Associations::Builder # :nodoc:
     end
 
     def self.valid_options(options)
-      valid = super + [:polymorphic, :counter_cache, :optional, :default]
+      valid = super + [:polymorphic, :counter_cache, :optional, :default, :initial]
       valid += [:foreign_type] if options[:polymorphic]
       valid += [:ensuring_owner_was] if options[:dependent] == :destroy_async
       valid
@@ -22,6 +22,10 @@ module ActiveRecord::Associations::Builder # :nodoc:
       add_counter_cache_callbacks(model, reflection) if reflection.options[:counter_cache]
       add_touch_callbacks(model, reflection)         if reflection.options[:touch]
       add_default_callbacks(model, reflection)       if reflection.options[:default]
+      if reflection.options[:initial]
+        model.attribute(reflection.foreign_key,
+                        default: -> { reflection.options[:initial].call.send(reflection.association_primary_key) })
+      end
     end
 
     def self.add_counter_cache_callbacks(model, reflection)

--- a/activerecord/test/cases/associations/belongs_to_associations_test.rb
+++ b/activerecord/test/cases/associations/belongs_to_associations_test.rb
@@ -250,6 +250,30 @@ class BelongsToAssociationsTest < ActiveRecord::TestCase
     assert_not_equal sql, capture_sql { comment.post }
   end
 
+  def test_initial
+    david = developers(:david)
+    jamis = developers(:jamis)
+
+    model = Class.new(ActiveRecord::Base) do
+      self.table_name = "ships"
+      def self.name; "Temp"; end
+      belongs_to :developer, initial: -> { david }, optional: true
+    end
+
+    ship = model.new
+    assert_equal david, ship.developer
+
+    ship = model.new(developer: nil)
+    assert_nil ship.developer
+
+    ship = model.new(developer: jamis)
+    assert_equal jamis, ship.developer
+
+    ship = model.create!
+    ship.update!(developer: nil)
+    assert_nil model.first.developer
+  end
+
   def test_proxy_assignment
     account = Account.find(1)
     assert_nothing_raised { account.firm = account.firm }


### PR DESCRIPTION
### Summary

This adds an `initial` option to `belongs_to` associations. It's similar to the `default` option, but came about when the `default` option didn't do quite what I expected, so I'm going to compare it to that.

The `default` option is applied before every validation and prevents an association from being set to `nil`. The `initial` option behaves more like the `default` option for `attribute` (it uses that functionality under the hood and is basically a shortcut to it). It is only set once, the first time a new record is instantiated, and does not prevent the association from being set to `nil` later.

Some examples:

```ruby
class Book < ApplicationRecord
  belongs_to :genre, initial: -> { Genre.first }, optional: true
  belongs_to :author, default: -> { Author.first }, optional: true
end

b = Book.new

# Genre is already set, author is not
b.genre
=> #<Genre:0x00007fdf2c9d4578 id: 1, name: "Sci-fi", ...>
b.author
=> nil

# Author is set before validation
b.valid?
=> true
b.author
=> #<Author:0x00007fdf29726068 id: 1, name: "Booker", ...>

# Genre can be set to nil, author cannot be
b.update(genre: nil, author: nil)
=> true
b.genre
=> nil
b.author
=> #<Author:0x00007fdf2d386350 id: 1, name: "Booker", ...>
```

The two options can be used at the same time to get both behaviors:

```ruby
class Book < ApplicationRecord
  belongs_to :genre, initial: -> { Genre.first }, default: -> { Genre.first }, optional: true
  # They don't necessarily have to use the same values, but it probably often makes sense to
end

b = Book.new

b.genre
=> #<Genre:0x00007ff099ced920 id: 1, name: "Sci-fi", ...>
b.genre = nil
=> nil
b.save
=> true
b.genre
=> #<Genre:0x00007fcbb8469390 id: 1, name: "Sci-fi", ...>
```

  
