### PR TITLE
Fix ActiveSupport::XmlMini on JRuby 9.3.x.x

### DIFF
--- a/activesupport/lib/active_support/xml_mini/jdom.rb
+++ b/activesupport/lib/active_support/xml_mini/jdom.rb
@@ -20,13 +20,6 @@ module ActiveSupport
 
     CONTENT_KEY = "__content__"
 
-    NODE_TYPE_NAMES = %w{ATTRIBUTE_NODE CDATA_SECTION_NODE COMMENT_NODE DOCUMENT_FRAGMENT_NODE
-    DOCUMENT_NODE DOCUMENT_TYPE_NODE ELEMENT_NODE ENTITY_NODE ENTITY_REFERENCE_NODE NOTATION_NODE
-    PROCESSING_INSTRUCTION_NODE TEXT_NODE}
-
-    node_type_map = {}
-    NODE_TYPE_NAMES.each { |type| node_type_map[Node.send(type)] = type }
-
     # Parse an XML Document string or IO into a simple hash using Java's jdom.
     # data::
     #   XML Document string or IO to parse
@@ -80,7 +73,7 @@ module ActiveSupport
         if child_nodes.length > 0
           (0...child_nodes.length).each do |i|
             child = child_nodes.item(i)
-            merge_element!(hash, child, depth - 1) unless child.node_type == Node.TEXT_NODE
+            merge_element!(hash, child, depth - 1) unless child.node_type == Node::TEXT_NODE
           end
           merge_texts!(hash, element) unless empty_content?(element)
           hash
@@ -156,7 +149,7 @@ module ActiveSupport
         child_nodes = element.child_nodes
         (0...child_nodes.length).each do |i|
           item = child_nodes.item(i)
-          if item.node_type == Node.TEXT_NODE
+          if item.node_type == Node::TEXT_NODE
             texts << item.get_data
           end
         end
@@ -172,7 +165,7 @@ module ActiveSupport
         child_nodes = element.child_nodes
         (0...child_nodes.length).each do |i|
           item = child_nodes.item(i)
-          if item.node_type == Node.TEXT_NODE
+          if item.node_type == Node::TEXT_NODE
             text << item.get_data.strip
           end
         end


### PR DESCRIPTION
### Summary

Using ActiveSupport::XmlMini to parse XML files using JDOM does not work with JRuby 9.3.0.0 or higher because accessors are no longer bound to Java interface-based constants (see https://github.com/jruby/jruby/pull/5732) and using `Node.<method_name>` (like `Node.TEXT`) raises an `NoMethodError` exception:

```
NoMethodError: undefined method `ATTRIBUTE_NODE' for Java::OrgW3cDom::Node:Module
Did you mean?  attr_reader
    /home/andrei/.rbenv/versions/jruby-9.3.2.0/lib/ruby/gems/shared/gems/activesupport-6.1.4.4/lib/active_support/xml_mini/jdom.rb:28:in `block in XmlMini_JDOM'
    org/jruby/RubyArray.java:1865:in `each'
    /home/andrei/.rbenv/versions/jruby-9.3.2.0/lib/ruby/gems/shared/gems/activesupport-6.1.4.4/lib/active_support/xml_mini/jdom.rb:28:in `<module:XmlMini_JDOM>'
    /home/andrei/.rbenv/versions/jruby-9.3.2.0/lib/ruby/gems/shared/gems/activesupport-6.1.4.4/lib/active_support/xml_mini/jdom.rb:18:in `<module:ActiveSupport>'
    /home/andrei/.rbenv/versions/jruby-9.3.2.0/lib/ruby/gems/shared/gems/activesupport-6.1.4.4/lib/active_support/xml_mini/jdom.rb:17:in `<main>'
    org/jruby/RubyKernel.java:1017:in `require'
    /home/andrei/.rbenv/versions/jruby-9.3.2.0/lib/ruby/gems/shared/gems/activesupport-6.1.4.4/lib/active_support/xml_mini.rb:194:in `cast_backend_name_to_module'
    /home/andrei/.rbenv/versions/jruby-9.3.2.0/lib/ruby/gems/shared/gems/activesupport-6.1.4.4/lib/active_support/xml_mini.rb:101:in `backend='
    jdom.rb:19:in `test_set_jdom_backend'
```

This pull request makes the following changes:

* [Lines 23-28](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/xml_mini/jdom.rb#L23..L28) which set a `NODE_TYPE_NAMES` variable and populate a `node_type_map` hash are removed because that piece of code is not used at all
* `Node.TEXT_NODE` is replaced with `Node::TEXT_NODE` which works correctly regardless of the JRuby version

### Other Information

The PR does not include any changes to the tests because Rails 7+ requires Ruby 2.7 and the latest JRuby version is compatible with CRuby 2.5.

Closes #44073