### PR TITLE
Add missing info for `change` column and table comment in Guides

### DIFF
--- a/guides/source/active_record_migrations.md
+++ b/guides/source/active_record_migrations.md
@@ -603,17 +603,18 @@ and
 ### Using the `change` Method
 
 The `change` method is the primary way of writing migrations. It works for the
-majority of cases, where Active Record knows how to reverse the migration
-automatically. Currently, the `change` method supports only these migration
-definitions:
+majority of cases in which Active Record knows how to reverse a migration's
+actions automatically. Below are some of the actions that `change` supports:
 
 * [`add_column`][]
 * [`add_foreign_key`][]
 * [`add_index`][]
 * [`add_reference`][]
 * [`add_timestamps`][]
+* [`change_column_comment`][] (must supply a `:from` and `:to` option)
 * [`change_column_default`][] (must supply a `:from` and `:to` option)
 * [`change_column_null`][]
+* [`change_table_comment`][] (must supply a `:from` and `:to` option)
 * [`create_join_table`][]
 * [`create_table`][]
 * `disable_extension`
@@ -645,6 +646,8 @@ or write the `up` and `down` methods instead of using the `change` method.
 
 [`add_foreign_key`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_foreign_key
 [`add_timestamps`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_timestamps
+[`change_column_comment`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_column_comment
+[`change_table_comment`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table_comment
 [`drop_join_table`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-drop_join_table
 [`drop_table`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-drop_table
 [`remove_foreign_key`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_foreign_key


### PR DESCRIPTION
### Summary

Some people (myself included) rely heavier on the guides for a quick reference more than the api docs. Thought I'd throw this one in there to see if it helps.

> You can help improve the Rails guides or the API reference by making them more coherent, consistent, or readable, **adding missing information**, correcting factual errors, fixing typos, or bringing them up to date with the latest edge Rails.

This will address the "adding missing information" suggestion from the [guide](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation).

