### PR TITLE
Syntax highlight ruby code in multi db guide

### DIFF
--- a/guides/source/active_record_multiple_databases.md
+++ b/guides/source/active_record_multiple_databases.md
@@ -129,7 +129,7 @@ If you use a differently named class for your application record you need to
 set `primary_abstract_class` instead, so that Rails knows which class `ActiveRecord::Base`
 should share a connection with.
 
-```
+```ruby
 class PrimaryApplicationRecord < ActiveRecord::Base
   self.primary_abstract_class = true
 end


### PR DESCRIPTION
### Summary
Syntax highlighting is missing in [Multiple Databases with Active Record](https://guides.rubyonrails.org/active_record_multiple_databases.html). So added it.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information
Consulted [Contributing to the Rails Documentation](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation). Let me know if I'm missing something!
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
