### PR TITLE
Improve #configured_migrate_path logic

### DIFF
--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -40,12 +40,11 @@ module ActiveRecord
         end
 
         def configured_migrate_path
-          return unless database = options[:database]
-          config = ActiveRecord::Base.configurations.configs_for(
+          config = Array(ActiveRecord::Base.configurations.configs_for(
             env_name: Rails.env,
-            name: database
-          )
-          config&.migrations_paths
+            name: options[:database],
+          )).first
+          config&.migrations_paths&.first
         end
     end
   end

--- a/activerecord/lib/rails/generators/active_record/migration.rb
+++ b/activerecord/lib/rails/generators/active_record/migration.rb
@@ -44,7 +44,7 @@ module ActiveRecord
             env_name: Rails.env,
             name: options[:database],
           )).first
-          config&.migrations_paths&.first
+          Array(config&.migrations_paths).first
         end
     end
   end


### PR DESCRIPTION
### Summary

This solves two issues:

* `migrations_paths` is an Array, which here gets coerced to a string.
  This is fine if it's a single path, but otherwise the generated path
  is a concatenation of all the paths, which doesn't really make sense.
  Instead, pick the first one.

* If the `--database` flag is not passed in, fall back to the primary
  database's `migrations_paths` entry (if available) before falling back
  to the global default migrate path.