### PR TITLE
Update sdoc to 2.3.2 to support latest rdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :rubocop do
 end
 
 group :doc do
-  gem "sdoc", ">= 2.3.1"
+  gem "sdoc", ">= 2.3.2"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators", "~> 1.3.6"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,8 +461,8 @@ GEM
     rubyzip (2.3.2)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
-    sdoc (2.3.1)
-      rdoc (>= 5.0, < 6.4.0)
+    sdoc (2.3.2)
+      rdoc (>= 5.0)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -618,7 +618,7 @@ DEPENDENCIES
   rubocop-packaging
   rubocop-performance
   rubocop-rails
-  sdoc (>= 2.3.1)
+  sdoc (>= 2.3.2)
   selenium-webdriver (>= 4.0.0)
   sequel
   sidekiq


### PR DESCRIPTION
This removes the upper constraint for rdoc 6.4.0