### PR TITLE
Add API doc for the `same_site` option of the `cookie` [skip ci]

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -176,6 +176,10 @@ module ActionDispatch
   #   Default is +false+.
   # * <tt>:httponly</tt> - Whether this cookie is accessible via scripting or
   #   only HTTP. Defaults to +false+.
+  # * <tt>:same_site</tt> - The value of the +SameSite+ cookie attribute, which
+  #   determines how this cookie should be restricted in cross-site contexts.
+  #   Possible values are +nil+, +:none+, +:lax+, and +:strict+. Defaults to
+  #   +:lax+.
   class Cookies
     HTTP_HEADER   = "Set-Cookie"
     GENERATOR_KEY = "action_dispatch.key_generator"

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -44,8 +44,8 @@ module ActionDispatch
     #   Rails.application.config.session_store :cookie_store, expire_after: 14.days
     #
     # would set the session cookie to expire automatically 14 days after creation.
-    # Other useful options include <tt>:key</tt>, <tt>:secure</tt> and
-    # <tt>:httponly</tt>.
+    # Other useful options include <tt>:key</tt>, <tt>:secure</tt>,
+    # <tt>:httponly</tt>, and <tt>:same_site</tt>.
     class CookieStore < AbstractSecureStore
       class SessionId < DelegateClass(Rack::Session::SessionId)
         attr_reader :cookie_value


### PR DESCRIPTION
### Summary

The edge version of the [API docs](https://edgeapi.rubyonrails.org/classes/ActionDispatch/Cookies.html) didn't mention the `same_site` option of `Cookie`.

However, I've updated the documentation as the implementation allows you to specify options as follows:

https://github.com/rails/rails/blob/c9e5057de4be7e0f4365ff9c2d411cffc39c3746/actionpack/lib/action_dispatch/middleware/cookies.rb#L453

The explanation of `same_site` of　`Cookie` is based on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).