### PR TITLE
Updates --skip-git option description to be more accurate

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -31,7 +31,7 @@ module Rails
                                            desc: "Preconfigure for selected database (options: #{DATABASES.join('/')})"
 
         class_option :skip_git,            type: :boolean, aliases: "-G", default: false,
-                                           desc: "Skip .gitignore file"
+                                           desc: "Skip git init, .gitignore and .gitattributes"
 
         class_option :skip_keeps,          type: :boolean, default: false,
                                            desc: "Skip source control .keep files"


### PR DESCRIPTION
It skips git init, .gitignore and .gitattributes not only .gitignore

### Summary

As [suggested by an user (Giuseppe) on rails's forum](https://discuss.rubyonrails.org/t/how-to-recommend-a-change-in-a-task-desc/80458) the `--skip-git` option description of the `rails new` command would only describe itself as skipping the `.gitignore` file while it skips `git init`, `.gitignore` and `.gitattributes`.