### PR TITLE
Allow some tests to run serially while using parallel testing

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Allow some tests to run serially while using parallel testing
+
+    `ActiveSupport::TestCase` runs serially when [Minitest::Test.test_order](https://github.com/seattlerb/minitest/blob/master/lib/minitest/test.rb#L83) is not `:parallel` to respect default Minitest behaviour.
+
+    *Louis Boudreau*
+    
+
 *   Deprecate preserving the pre-Ruby 2.4 behavior of `to_time`
 
     With Ruby 2.4+ the default for +to_time+ changed from converting to the

--- a/activesupport/lib/active_support/test_case.rb
+++ b/activesupport/lib/active_support/test_case.rb
@@ -84,6 +84,7 @@ module ActiveSupport
         return if workers <= 1
 
         Minitest.parallel_executor = ActiveSupport::Testing::ParallelizeExecutor.new(size: workers, with: with, threshold: threshold)
+        ActiveSupport.test_order = :parallel
       end
 
       # Set up hook for parallel testing. This can be used if you have multiple


### PR DESCRIPTION
### Summary

Minitest [allows to run some tests serially and some tests in parallel](https://github.com/seattlerb/minitest/blob/master/lib/minitest.rb#L169) during the same execution. The test suite can determine how it runs by overriding the [`test_order`](https://github.com/seattlerb/minitest/blob/master/lib/minitest/test.rb#L83) method. It is currently not possible to run some tests serially while using Rails parallel testing when overriding the `test_order` method. This PR therefore aims at allowing `ActiveSupport::TestCase` to run serially when specified to while still running other test suites in parallel. 



### How it works
* The `parallelize()` method will now set `ActiveSupport.test_order = :parallel` so that by default, all `ActiveSupport::TestCase` run in parallel since test_order will return `:parallel` [here](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/test_case.rb#L44).
* If a particular test must run serially, the class can override the `self.test_order` like so:
```rb
class FooTest < ActiveSupport::TestCase
   class << self
        def test_order
            :random
        end
   end
end
```

### Other information
All the serial test suites will run serially in the same process before the parallel tests.