### PR TITLE
Add --name option to the app generator

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -24,6 +24,9 @@ module Rails
       end
 
       def self.add_shared_options_for(name)
+        class_option :name,                type: :string, aliases: "-n",
+                                           desc: "Name of the app"
+
         class_option :template,            type: :string, aliases: "-m",
                                            desc: "Path to some #{name} template (can be a filesystem path or URL)"
 

--- a/railties/lib/rails/generators/app_name.rb
+++ b/railties/lib/rails/generators/app_name.rb
@@ -11,7 +11,7 @@ module Rails
         end
 
         def original_app_name
-          @original_app_name ||= defined_app_const_base? ? defined_app_name : File.basename(destination_root)
+          @original_app_name ||= defined_app_const_base? ? defined_app_name : (options[:name] || File.basename(destination_root))
         end
 
         def defined_app_name

--- a/railties/test/generators/app_generator_test.rb
+++ b/railties/test/generators/app_generator_test.rb
@@ -989,6 +989,11 @@ class AppGeneratorTest < Rails::Generators::TestCase
     assert_no_gem "web-console"
   end
 
+  def test_name_option
+    run_generator [destination_root, "--name=my-app"]
+    assert_file "config/application.rb", /^module MyApp$/
+  end
+
   private
     def stub_rails_application(root = destination_root, &block)
       Rails.application.config.root = root


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

In this pull request, we are adding the option to set the name of the app when generating a new one with `rails new`.

The option `--name` will override the application name to be different from the folder name.

```
rails new my-app-folder --name=my-actual-app-name
```

The command above will generate a new Rails application in the folder `my-app-folder`, but the file `config/application.rb` will have the following structure:

```ruby
module MyActualAppName
  class Application < Rails::Application
  end
end
```

This option would be most useful when generating a Rails application in the current folder:

```
rails new . --name=my-app
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
n/a