### PR TITLE
Respect the formatter keyword arg in ActiveSupport::Logger.new

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,16 +1,25 @@
+*   Respect `ActiveSupport::Logger.new`'s `:formatter` keyword argument
+
+    The stdlib `Logger::new` allows passing a `:formatter` keyword argument to
+    set the logger's formatter. Previously `ActiveSupport::Logger.new` ignored
+    that argument by always setting the formatter to an instance of
+    `ActiveSupport::Logger::SimpleFormatter`.
+
+    *Steven Harman*
+
 *   Deprecate preserving the pre-Ruby 2.4 behavior of `to_time`
 
     With Ruby 2.4+ the default for +to_time+ changed from converting to the
     local system time to preserving the offset of the receiver. At the time Rails
     supported older versions of Ruby so a compatibility layer was added to assist
-    in the migration process. From Rails 5.0 new applications have defaulted to 
+    in the migration process. From Rails 5.0 new applications have defaulted to
     the Ruby 2.4+ behavior and since Rails 7.0 now only supports Ruby 2.7+
     this compatibility layer can be safely removed.
-    
+
     To minimize any noise generated the deprecation warning only appears when the
     setting is configured to `false` as that is the only scenario where the
     removal of the compatibility layer has any effect.
-    
+
     *Andrew White*
 
 *   `Pathname.blank?` only returns true for `Pathname.new("")`

--- a/activesupport/lib/active_support/logger.rb
+++ b/activesupport/lib/active_support/logger.rb
@@ -78,7 +78,7 @@ module ActiveSupport
 
     def initialize(*args, **kwargs)
       super
-      @formatter = SimpleFormatter.new
+      @formatter ||= SimpleFormatter.new
     end
 
     # Simple formatter which only displays the message.

--- a/activesupport/test/logger_test.rb
+++ b/activesupport/test/logger_test.rb
@@ -71,6 +71,17 @@ class LoggerTest < ActiveSupport::TestCase
     File.unlink fname
   end
 
+  def test_defaults_to_simple_formatter
+    logger = Logger.new(@output)
+    assert_instance_of ActiveSupport::Logger::SimpleFormatter, logger.formatter
+  end
+
+  def test_formatter_can_be_set_via_keyword_arg
+    custom_formatter = ::Logger::Formatter.new
+    logger = Logger.new(@output, formatter: custom_formatter)
+    assert_same custom_formatter, logger.formatter
+  end
+
   def test_should_log_debugging_message_when_debugging
     @logger.level = Logger::DEBUG
     @logger.add(Logger::DEBUG, @message)


### PR DESCRIPTION
### Summary

The stdlib `Logger::new` allows passing a `:formatter` keyword argument to set the logger's formatter. `ActiveSupport::Logger.new` ignores this argument by always setting the formatter to an instance of `ActiveSupport::Logger::SimpleFormatter`. Instead, we should only set it when none is yet set.