### PR TITLE
Show reason for referential integrity failure

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   Show reason for referential integrity failure
+
+    Previously, if there were any referential integrity errors in your fixtures,
+    the underlying Postgres and SQLite adapters would throw an error. However,
+    the original error message is swallowed in `all_foreign_keys_valid?` and
+    return false. This gave the developer very little information on where to
+    start debugging.
+
+    This replaces `all_foreign_keys_valid?` with `check_all_foreign_keys_valid`
+    to raise more useful errors instead of just returning false
+
+    *Danielle Smith*
+
 *   Add `timestamptz` as a time zone aware type for PostgreSQL
 
     This is required for correctly parsing `timestamp with time zone` values in your database.

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -540,8 +540,17 @@ module ActiveRecord
       end
 
       # Override to check all foreign key constraints in a database.
+      # DEPRECATED: Override
+      # <tt>ActiveRecord::ConnectionAdapters#check_all_foreign_keys_valid</tt>
+      # to raise a useful error message instead
       def all_foreign_keys_valid?
         true
+      end
+      deprecate :all_foreign_keys_valid?
+
+      # Override to check all foreign key constraints in a database.
+      # This should raise an error if there are any foreign key violations.
+      def check_all_foreign_keys_valid
       end
 
       # CONNECTION MANAGEMENT ====================================

--- a/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/referential_integrity.rb
@@ -38,7 +38,7 @@ Rails needs superuser privileges to disable referential integrity.
           end
         end
 
-        def all_foreign_keys_valid? # :nodoc:
+        def check_all_foreign_keys_valid # :nodoc:
           sql = <<~SQL
             do $$
               declare r record;
@@ -59,15 +59,11 @@ Rails needs superuser privileges to disable referential integrity.
             $$;
           SQL
 
-          begin
-            transaction(requires_new: true) do
-              execute(sql)
-            end
-
-            true
-          rescue ActiveRecord::StatementInvalid
-            false
+          transaction(requires_new: true) do
+            execute(sql)
           end
+
+          true
         end
       end
     end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -231,8 +231,13 @@ module ActiveRecord
         end
       end
 
-      def all_foreign_keys_valid? # :nodoc:
-        execute("PRAGMA foreign_key_check").blank?
+      def check_all_foreign_keys_valid # :nodoc:
+        sql = "PRAGMA foreign_key_check"
+        result = execute(sql)
+        return true if result.blank?
+
+        tables = result.map { |row| row["table"] }
+        raise ActiveRecord::StatementInvalid.new("Foreign key violations found: #{tables.join(", ")}", sql: sql)
       end
 
       # SCHEMA STATEMENTS ========================================

--- a/activerecord/lib/active_record/fixtures.rb
+++ b/activerecord/lib/active_record/fixtures.rb
@@ -629,8 +629,12 @@ module ActiveRecord
 
             conn.insert_fixtures_set(table_rows_for_connection, table_rows_for_connection.keys)
 
-            if ActiveRecord.verify_foreign_keys_for_fixtures && !conn.all_foreign_keys_valid?
-              raise "Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations."
+            if ActiveRecord.verify_foreign_keys_for_fixtures
+              begin
+                conn.check_all_foreign_keys_valid
+              rescue => err
+                raise "Foreign key violations found in your fixture data. Ensure you aren't referring to labels that don't exist on associations.\n#{err}"
+              end
             end
 
             # Cap primary key sequences to max(pk).

--- a/activerecord/test/cases/adapter_test.rb
+++ b/activerecord/test/cases/adapter_test.rb
@@ -530,6 +530,12 @@ module ActiveRecord
       @connection.disable_query_cache!
     end
 
+    def test_all_foreign_keys_valid_is_deprecated
+      assert_deprecated do
+        @connection.all_foreign_keys_valid?
+      end
+    end
+
     # test resetting sequences in odd tables in PostgreSQL
     if ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
       require "models/movie"

--- a/activerecord/test/cases/fixtures_test.rb
+++ b/activerecord/test/cases/fixtures_test.rb
@@ -818,9 +818,10 @@ class FixturesWithForeignKeyViolationsTest < ActiveRecord::TestCase
 
     with_verify_foreign_keys_for_fixtures do
       if current_adapter?(:SQLite3Adapter, :PostgreSQLAdapter)
-        assert_raise RuntimeError do
+        error = assert_raises RuntimeError do
           ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])
         end
+        assert_match(/fk_pointing_to_non_existent_objects/, error.message)
       else
         assert_nothing_raised do
           ActiveRecord::FixtureSet.create_fixtures(FIXTURES_ROOT, ["fk_pointing_to_non_existent_object"])


### PR DESCRIPTION
### Summary

Currently, if there is a referential integrity error in your fixtures, it will throw an error. However, the original error message from postgres is swallowed in `all_foreign_keys_valid?` and returns false. This gives the developer very little information on where to start debugging.

My proposed solution is to raise the original exception from the underlying adapter for postgres, and raise a similar error from the SQLite adapter.

### Other Information

Stack overflow explaining the issue: https://stackoverflow.com/questions/71054865/tips-for-debugging-fixture-foreign-key-errors-in-rails