### PR TITLE
`simple_format` with blank `wrapper_tag` option fallback to p tag

### DIFF
--- a/actionview/lib/action_view/helpers/text_helper.rb
+++ b/actionview/lib/action_view/helpers/text_helper.rb
@@ -304,7 +304,7 @@ module ActionView
       #   simple_format("<blink>Blinkable!</blink> It's true.", {}, sanitize: false)
       #   # => "<p><blink>Blinkable!</blink> It's true.</p>"
       def simple_format(text, html_options = {}, options = {})
-        wrapper_tag = options.fetch(:wrapper_tag, :p)
+        wrapper_tag = options.fetch(:wrapper_tag, :p).presence || :p
 
         text = sanitize(text) if options.fetch(:sanitize, true)
         paragraphs = split_paragraphs(text)

--- a/actionview/test/template/text_helper_test.rb
+++ b/actionview/test/template/text_helper_test.rb
@@ -86,6 +86,12 @@ class TextHelperTest < ActionView::TestCase
     assert_equal options, passed_options
   end
 
+  def test_simple_format_with_blank_wrapper_tag
+    assert_equal "<p></p>", simple_format(nil, {}, { wrapper_tag: "" })
+    assert_equal "<p></p>", simple_format(nil, {}, { wrapper_tag: :"" })
+    assert_equal "<p></p>", simple_format(nil, {}, { wrapper_tag: nil })
+  end
+
   def test_truncate
     assert_equal "Hello World!", truncate("Hello World!", length: 12)
     assert_equal "Hello Wor...", truncate("Hello World!!", length: 12)


### PR DESCRIPTION
### Summary

This PR fixes https://github.com/rails/rails/issues/44948

#### Before

```ruby
simple_format(nil, {}, { wrapper_tag: "" })
#=> "<></>"
```

### After

```ruby
simple_format(nil, {}, { wrapper_tag: "" })
#=> "<p></p>"
```
