### PR TITLE
make the length of error message predictable.

### DIFF
--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -23,6 +23,8 @@ module ActionCable
       rescue Exception => e
         @connection.rescue_with_handler(e)
         logger.error "Could not execute command from (#{data.inspect}) [#{e.class} - #{e.message.truncate(300)}]: #{e.backtrace.first(5).join(" | ")}"
+
+        ActiveSupport.error_reporter&.report(e, severity: :warning, handled: true, source: "action_cable")
       end
 
       def add(data)

--- a/actioncable/lib/action_cable/connection/subscriptions.rb
+++ b/actioncable/lib/action_cable/connection/subscriptions.rb
@@ -22,7 +22,7 @@ module ActionCable
         end
       rescue Exception => e
         @connection.rescue_with_handler(e)
-        logger.error "Could not execute command from (#{data.inspect}) [#{e.class} - #{e.message}]: #{e.backtrace.first(5).join(" | ")}"
+        logger.error "Could not execute command from (#{data.inspect}) [#{e.class} - #{e.message.truncate(300)}]: #{e.backtrace.first(5).join(" | ")}"
       end
 
       def add(data)


### PR DESCRIPTION
### Summary

The length of the `e.message` is unpredictable, it may inspect a large object so that the logger IO may be blocked.


#### Reproduce my issue:
I have a channel like:
```ruby
class RoomChannel < ApplicationCable::Channel
  ...

  def stop_stream
    stop_all_steams # <= typo here, should be stop_all_streams
  end
end
```

After I perform `#stop_stream` action, I get an endless log
```
Could not execute command from ({"command"=>"message", "identifier"=>"{\"channel\":\"RoomChannel\",\"id\":\"1\"}", "data"=>"{\"action\":\"stop_stream\"}"}) [NameError - undefined local variable or method `stop_all_steams' for #<RoomChannel:0x000000010856bb08 @connection=#<ApplicationCable::Connection:0x0000000108511608 @coder=ActiveSupport::JSON, @env={"rack.version"=>[1, 6], "rack.errors"=>#<IO:<STDERR>>, "rack.multithread"=>true, "rack.multiprocess"=>false, "rack.run_once"=>false, "rack.url_scheme"=>"http", "SCRIPT_NAME"=>"/cable", "QUERY_STRING"=>"", "SERVER_PROTOCOL"=>"HTTP/1.1", "SERVER_SOFTWARE"=>"puma 5.6.2 Birdie's Version", "GATEWAY_INTERFACE"=>"CGI/1.2", "REQUEST_METHOD"=>"GET", "REQUEST_PATH"=>"/cable", "REQUEST_URI"=>"/cable", "HTTP_VERSION"=>"HTTP/1.1", "HTTP_HOST"=>"localhost:3000", "HTTP_CONNECTION"=>"Upgrade", "HTTP_PRAGMA"=>"no-cache", "HTTP_CACHE_CONTROL"=>"no-cache", "HTTP_USER_AGENT"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36", "HTTP_UPGRADE"=>"websocket", "HTTP_ORIGIN"=>"http://localhost:3000", "HTTP_SEC_WEBSOCKET_VERSION"=>"13", "HTTP_ACCEPT_ENCODING"=>"gzip, deflate, br", "HTTP_ACCEPT_LANGUAGE"=>"zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7", "HTTP_COOKIE"=>"name=lMLESKfD4fAvB%2FPuF%2BT2kRJUEWUrj4tYJyEaZzJDxNxAc6OInZKGAD0J1C53jIKGqVifOh4eyEdok6uGnMDYow%3D%3D--vDgyRzJYCkjAl9wk--FjhjfMrgVkf%2BUxbrVuZI6w%3D%3D; userName=KKK; _chat_session=3gv7Vn4ye%2BO5xbEXpd1OCTtqwGiGsp9Iv%2FcsYqPAAbzYL7mfDnBRyba3sytbsViioC%2B5ADphfWCZh4B7623GWyfXvJWZa8VDB9jtey3LXzU9qq%2BQuDAwyte9tahbxRptAEPpvBxN2LAiBub0Oy%2FvEovHD8%2BG7u%2Bt7NvPzBoDwDXMK%2BdC3sBfFWAqSQSR4M2rUYAkSp9QKNOlVYzU%2FhgPKnCr3ONmH%2FdJfAlcfdwSdXVarb7h%2BsvQRLEHTOaQ1G1E6B6VJrt%2B6%2BduXFcg1iAV6GETmYCd--3AR4M%2BeWZHqw%2BJRg--IOOAFWL2K4zp6l8NClJazw%3D%3D", "HTTP_SEC_WEBSOCKET_KEY"=>"EM1ZYal3gdcZO+bgR7u8Fg==", "HTTP_SEC_WEBSOCKET_EXTENSIONS"=>"permessage-deflate; client_max_window_bits", "HTTP_SEC_WEBSOCKET_PROTOCOL"=>"actioncable-v1-json, actioncable-unsupported", "puma.request_body_wait"=>0, "SERVER_NAME"=>"localhost", "SERVER_PORT"=>"3000", "PATH_INFO"=>"/", "REMOTE_ADDR"=>"::1", "puma.socket"=>#<TCPSocket:fd 18, AF_INET6, ::1, 3000>, "rack.hijack?"=>true, "rack.hijack"=>#<Puma::Client:0x6f7c @ready=true>, "rack.input"=>#<Puma::NullIO:0x00000001074ead38>, "rack.after_reply"=>[], "puma.config"=>#<Puma::Configuration:0x0000000107532fc0 @options=#<Puma::UserFileDefaultOptions:0x00000001075329d0 @user_options={:Port=>3000, :binds=>["tcp://localhost:3000"], :app=>#<Chat::Application:0x0000000106a45478 @_all_autoload_paths=["/rails_chat/app/channels", "/rails_chat/app/controllers", "/rails_chat/app/controllers/concerns", "/rails_chat/app/helpers", "/rails_chat/app/jobs", "/rails_chat/app/models", "/rails_chat/app/models/concerns"], @_all_load_paths=["/rails_chat/lib", "/rails_chat/vendor", "/rails_chat/app/channels", "/rails_chat/app/controllers", "/rails_chat/app/controllers/concerns", "/rails_chat/app/helpers", "/rails_chat/app/jobs", "/rails_chat/app/models", "/rails_chat/app/models/concerns"], @app=#<ActionDispatch::HostAuthorization:0x0000000107210ae0 @app=#<Rack::Sendfile:0x0000000107210bd0 @app=#<ActionDispatch::Static:0x0000000107219fa0 @app=#<ActionDispatch::Executor:0x000000010721a0b8 @app=#<ActionDispatch::ServerTiming:0x000000010721a158 @app=#<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x000000010711b450 @name="ActiveSupport::Cache::Strategy::LocalCache", @local_cache_key=:active_support_cache_null_store_local_cache_3500, @app=#<Rack::Runtime:0x000000010721a2e8 @app=#<Rack::MethodOverride:0x000000010721a388 @app=#<ActionDispatch::RequestId:0x000000010721a450 @app=#<ActionDispatch::RemoteIp:0x000000010721a568 @app=#<Sprockets::Rails::QuietAssets:0x000000010721a8b0 @app=#<Rails::Rack::Logger:0x000000010721a978 @app=#<ActionDispatch::ShowExceptions:0x000000010721aa18 @app=#<WebConsole::Middleware:0x000000010721aae0 @app=#<ActionDispatch::DebugExceptions:0x000000010721abf8 @app=#<ActionDispatch::ActionableExceptions:0x000000010721ac98 @app=#<ActionDispatch::Reloader:0x000000010721ad60 @app=#<ActionDispatch::Callbacks:0x000000010721ae50 @app=#<ActionDispatch::Cookies:0x000000010721aef0 @app=#<ActionDispatch::Session::CookieStore:0x000000010721b148 @app=#<ActionDispatch::ContentSecurityPolicy::Middleware:0x000000010721b260 @app=#<ActionDispatch::PermissionsPolicy::Middleware:0x000000010721b300 @app=#<Rack::Head:0x000000010721b3c8 @app=#<Rack::ConditionalGet:0x000000010721b490 @app=#<Rack::ETag:0x000000010721b580 @app=#<Rack::TempfileReaper:0x000000010721b648 @app=#<ActionDispatch::Routing::RouteSet:0x000000010711a6b8>>, @cache_control="max-age=0, private, must-revalidate", @no_cache_control="no-cache">>>>>, @default_options={:path=>"/", :domain=>nil, :expire_after=>nil, :secure=>false, :httponly=>true, :defer=>false, :renew=>false}, @key="_chat_session", @cookie_only=true, @same_site=nil>>>, @executor=#<Class:0x0000000106e9f8c0>>>, @routes_app=#<Chat::Application:0x0000000106a45478 ...>, @response_format=:default, @interceptors=[WebConsole::Interceptor]>>, @exceptions_app=#<ActionDispatch::PublicExceptions:0x0000000107188c08 @public_path=#<Pathname:/rails_chat/public>>>, @taggers=[]>, @assets_regex=/\A\/{0,2}\/assets/>, @check_ip=true, @proxies=[#<IPAddr: IPv4:127.0.0.0/255.0.0.0>, #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>, #<IPAddr: IPv6:fc00:0000:0000:0000:0000:0000:0000:0000/fe00:0000:0000:0000:0000:0000:0000:0000>, #<IPAddr: IPv4:10.0.0.0/255.0.0.0>, #<IPAddr: IPv4:172.16.0.0/255.240.0.0>, #<IPAddr: IPv4:192.168.0.0/255.255.0.0>]>, @header="X-Request-Id">>, @header_name="X-Runtime">>>, @executor=#<Class:0x0000000106a55800>>, @file_handler=#<ActionDispatch::FileHandler:0x0000000107219eb0 @root="/rails_chat/public
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
