### PR TITLE
Remove to_ary from RackBody

### DIFF
--- a/actionpack/lib/action_dispatch/http/response.rb
+++ b/actionpack/lib/action_dispatch/http/response.rb
@@ -502,10 +502,6 @@ module ActionDispatch # :nodoc:
       def to_path
         @response.stream.to_path
       end
-
-      def to_ary
-        nil
-      end
     end
 
     def handle_no_content!


### PR DESCRIPTION
### Summary

It was added in 66f8997 to be compatible with `Rack::ContentLength`.
However, `to_ary` was removed from `Rack::Response` in 2.1.0, and
`Rack::ContentLength` stopped checking for response bodies to define
`to_ary` in 2.2.0. In addition, Rack 3 will eventually require response
bodies that define `to_ary` to have a proper return value.

Since the minimum supported Rack version is already 2.2.0, `to_ary` can
be safely removed now.

### Other Information

- Added in #16793
- `to_ary` removed from `Rack::Response` in rack/rack#1453
- `to_ary` check removed from `Rack::ContentLength` in rack/rack#1509
- Rack 3 change: https://github.com/rack/rack/pull/1748#issuecomment-827147490
- See also: rack/rack#1876