### PR TITLE
Do not raise error in rails/welcome if forgery protection is not enabled

### DIFF
--- a/railties/lib/rails/welcome_controller.rb
+++ b/railties/lib/rails/welcome_controller.rb
@@ -3,7 +3,7 @@
 require "rails/application_controller"
 
 class Rails::WelcomeController < Rails::ApplicationController # :nodoc:
-  skip_forgery_protection
+  skip_forgery_protection raise: false
   layout false
 
   def index


### PR DESCRIPTION
### Summary

If an application is configured with
```ruby
config.load_defaults 5.1
```
or has 
```ruby
config.action_controller.default_protect_from_forgery = false
```

`rails/welcome` controller on load will raise
> ArgumentError: Before process_action callback :verify_authenticity_token has not been defined

Sure, if such config is present - chances are that the user is not a rails newbie, but he/she still might want mentioned controller to work :)

This PR fixes the error.
