### PR TITLE
Document `uses_transaction` [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/test_fixtures.rb
+++ b/activerecord/lib/active_record/test_fixtures.rb
@@ -67,6 +67,9 @@ module ActiveRecord
         end
       end
 
+      # Prevents automatically wrapping each specified test in a transaction,
+      # to allow application logic transactions to be tested in a top-level
+      # (non-nested) context.
       def uses_transaction(*methods)
         @uses_transaction = [] unless defined?(@uses_transaction)
         @uses_transaction.concat methods.map(&:to_s)


### PR DESCRIPTION
### Summary
This method has been undocumented, but is named as "a well known public API" in https://github.com/rails/rails/pull/19251#issuecomment-77791447. Adding documentation had also been encouraged in there but was apparently forgotten. Can we add this so it does not look like private from now on?
<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
