### PR TITLE
Restore AbstractModel#none behavior

### DIFF
--- a/activerecord/lib/active_record/null_relation.rb
+++ b/activerecord/lib/active_record/null_relation.rb
@@ -38,6 +38,14 @@ module ActiveRecord
       false
     end
 
+    def to_sql
+      if model.abstract_class?
+        ""
+      else
+        super
+      end
+    end
+
     def calculate(operation, _column_name)
       result = case operation
                when :count, :sum

--- a/activerecord/test/cases/null_relation_test.rb
+++ b/activerecord/test/cases/null_relation_test.rb
@@ -104,4 +104,15 @@ class NullRelationTest < ActiveRecord::TestCase
     assert_operator Comment.count, :>, 0 # precondition, make sure there are comments.
     assert_equal 0, Comment.where(post_id: Post.none).count
   end
+
+  class AbstractRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+
+  def test_abstract_model
+    # The following used to work on 6.1 even though it isn't documented or anything.
+    # It would be worth deprecating calling `#none` on an abstract model.
+    assert_not_equal Comment.none, AbstractRecord.none
+    assert_equal "", AbstractRecord.none.to_sql
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/44905

Using a null relation on an abstract model used to work. I believe it's misguided, and it was never documented, so we could just say it's not supported. But if we decide to do that I think it would be better to go though a deprecation cycle.

cc @Viktor-Ivliev, @fatkodima 

Also cc @eileencodes and @rafaelfranca I wonder if you have an opinion on this. I'm tempted to deprecate `.none` on abstract models for 7.1.