### PR TITLE
Complete check for custom CSRF storage strategies

### DIFF
--- a/actionpack/lib/action_controller/metal/request_forgery_protection.rb
+++ b/actionpack/lib/action_controller/metal/request_forgery_protection.rb
@@ -221,7 +221,7 @@ module ActionController # :nodoc:
         end
 
         def is_storage_strategy?(object)
-          object.respond_to?(:fetch) && object.respond_to?(:store)
+          object.respond_to?(:fetch) && object.respond_to?(:store) && object.respond_to?(:reset)
         end
     end
 


### PR DESCRIPTION
### Summary

As the `reset` method is called without further conditionals in [line 342](https://github.com/rails/rails/blob/7883100e0f1e6a31b2bbd6377eef9272abb792ca/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L342), all custom strategies must implement this method as well.

### Other Information

This may have been an oversight in one of the many iterations of #44283.