### PR TITLE
Only materialize the new transaction if it needs it

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -326,10 +326,12 @@ module ActiveRecord
               )
             end
 
-          if @connection.supports_lazy_transactions? && lazy_transactions_enabled? && _lazy
-            @has_unmaterialized_transactions = true
-          else
-            transaction.materialize!
+          unless transaction.materialized?
+            if @connection.supports_lazy_transactions? && lazy_transactions_enabled? && _lazy
+              @has_unmaterialized_transactions = true
+            else
+              transaction.materialize!
+            end
           end
           @stack.push(transaction)
           transaction

--- a/activerecord/test/cases/transactions_test.rb
+++ b/activerecord/test/cases/transactions_test.rb
@@ -1197,6 +1197,44 @@ class TransactionTest < ActiveRecord::TestCase
     end
   end
 
+  def test_nested_transactions_after_disable_lazy_transactions
+    Topic.connection.disable_lazy_transactions!
+
+    capture_sql do
+      # RealTransaction (begin..commit)
+      Topic.transaction(requires_new: true) do
+        # ResetParentTransaction (no queries)
+        Topic.transaction(requires_new: true) do
+          Topic.delete_all
+          # SavepointTransaction (savepoint..release)
+          Topic.transaction(requires_new: true) do
+            # ResetParentTransaction (no queries)
+            Topic.transaction(requires_new: true) do
+              # no-op
+            end
+          end
+        end
+        Topic.delete_all
+      end
+    end
+
+    actual_queries = ActiveRecord::SQLCounter.log_all
+
+    expected_queries = [
+      /BEGIN/i,
+      /DELETE/i,
+      /^SAVEPOINT/i,
+      /^RELEASE/i,
+      /DELETE/i,
+      /COMMIT/i,
+    ]
+
+    assert_equal expected_queries.size, actual_queries.size
+    expected_queries.zip(actual_queries) do |expected, actual|
+      assert_match expected, actual
+    end
+  end
+
   if ActiveRecord::Base.connection.prepared_statements
     def test_prepared_statement_materializes_transaction
       Topic.first


### PR DESCRIPTION
Historically this was unnecessary, because all possible Transaction instances would start their life unmaterialized. But now (#44526), if the new transaction is a ResetParentTransaction, its materialization state relies upon its parent, so it may already be done. Indeed, if lazy transactions are disabled, the parent is almost certainly already materialized. #materialize! will happily re-run the query without question (a behaviour we rely upon elsewhere), so in this case it's up to the caller to check first.

Fixes #44955 (the double-BEGIN bug; the absence of savepoints is expected).