### PR TITLE
chore: remove git.io

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install
-        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
+        run: wget -O - -q https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b .
       - name: Misspell
         run: git ls-files --empty-directory | xargs ./misspell -i 'aircrafts,devels,invertions' -error

--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -366,7 +366,7 @@ module Rails
         return unless defined?(Rubinius)
 
         comment = "Use Psych as the YAML engine, instead of Syck, so serialized " \
-                  "data can be read safely from different rubies (see http://git.io/uuLVag)"
+                  "data can be read safely from different rubies (see https://github.com/rubysl/rubysl-yaml/pull/3)"
         GemfileEntry.new("psych", "~> 2.0", comment, platforms: :rbx)
       end
 


### PR DESCRIPTION
### Summary

All links on git.io will stop redirecting after April 29, 2022.

### Other Information

- https://github.blog/changelog/2022-04-25-git-io-deprecation/