### PR TITLE
AzureStorage needs version >= 2 of azure-storage-blob

### DIFF
--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -220,7 +220,7 @@ azure:
 Add the [`azure-storage-blob`](https://github.com/Azure/azure-storage-ruby) gem to your `Gemfile`:
 
 ```ruby
-gem "azure-storage-blob", require: false
+gem "azure-storage-blob", "~> 2.0", require: false
 ```
 
 ### Google Cloud Storage Service


### PR DESCRIPTION
### Summary

`active_storage_service`  needs version `"~> 2.0"`  of `azure-storage-blob`   because version 1.x of the gem doesn't support Ruby > 2.5 , more info: https://github.com/rails/rails/commit/0920b02c1d8abfddc6a611eb4f933a24af8eb2bd

So I feel it's worth mentioning it in https://edgeguides.rubyonrails.org/active_storage_overview.html#microsoft-azure-storage-service

![](https://user-images.githubusercontent.com/721990/165374689-3bbacf89-5acf-4bc7-849d-c919e5d7c479.png)


Credit for this  goes to   @SkipKayhil  for spotting  this  in issue I raised https://github.com/rails/rails/issues/44960
big thanks ! #legend 