### PR TITLE
retain Ruby 2.2 compatibility for Rails 5.2

### DIFF
--- a/actionview/lib/action_view/helpers/tag_helper.rb
+++ b/actionview/lib/action_view/helpers/tag_helper.rb
@@ -122,7 +122,7 @@ module ActionView
             escape_attributes_option_provided = options.has_key?(:escape_attributes)
 
             if escape_attributes_option_provided
-              ActiveSupport::Deprecation.warn(<<~MSG)
+              ActiveSupport::Deprecation.warn(<<-MSG.strip_heredoc)
                 Use of the option :escape_attributes is deprecated. It currently \
                 escapes both names and values of tags and attributes and it is \
                 equivalent to :escape. If any of them are enabled, the escaping \


### PR DESCRIPTION
### Summary

ActionView::Helpers::TagHelper - use `<<-MSG` style heredoc to retain Ruby 2.2 compatibility

### Other Information

RubyGems still lists Rails 5.2 as supporting Ruby 2.2, but without this change it no longer does.