### PR TITLE
Allow to reset cache counters for multiple records

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Allow to reset cache counters for multiple records.
+
+    ```
+    Aircraft.reset_counters([1, 2, 3], :wheels_count)
+    ```
+
+    It produces much fewer queries compared to the custom implementation using looping over ids.
+    Previously: `O(ids.size * counters.size)` queries, now: `O(ids.size + counters.size)` queries.
+
+    *fatkodima*
+
 *   Add `affected_rows` to `sql.active_record` Notification.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/counter_cache.rb
+++ b/activerecord/lib/active_record/counter_cache.rb
@@ -17,7 +17,7 @@ module ActiveRecord
       #
       # ==== Parameters
       #
-      # * +id+ - The id of the object you wish to reset a counter on.
+      # * +id+ - The id of the object you wish to reset a counter on or an array of ids.
       # * +counters+ - One or more association counters to reset. Association name or counter name can be given.
       # * <tt>:touch</tt> - Touch timestamp columns when updating.
       #   Pass +true+ to touch +updated_at+ and/or +updated_on+. Pass a symbol to
@@ -28,13 +28,25 @@ module ActiveRecord
       #   # For the Post with id #1, reset the comments_count
       #   Post.reset_counters(1, :comments)
       #
+      #   # For posts with ids #1 and #2, reset the comments_count
+      #   Post.reset_counters([1, 2], :comments)
+      #
       #   # Like above, but also touch the +updated_at+ and/or +updated_on+
       #   # attributes.
       #   Post.reset_counters(1, :comments, touch: true)
       def reset_counters(id, *counters, touch: nil)
-        object = find(id)
+        ids = if composite_primary_key?
+          if id.first.is_a?(Array)
+            id
+          else
+            [id]
+          end
+        else
+          Array(id)
+        end
 
-        updates = {}
+        updates = Hash.new { |h, k| h[k] = {} }
+
         counters.each do |counter_association|
           has_many_association = _reflect_on_association(counter_association)
           unless has_many_association
@@ -48,14 +60,22 @@ module ActiveRecord
             has_many_association = has_many_association.through_reflection
           end
 
+          counter_association = counter_association.to_sym
           foreign_key  = has_many_association.foreign_key.to_s
           child_class  = has_many_association.klass
           reflection   = child_class._reflections.values.find { |e| e.belongs_to? && e.foreign_key.to_s == foreign_key && e.options[:counter_cache].present? }
           counter_name = reflection.counter_cache_column
 
-          count_was = object.send(counter_name)
-          count = object.send(counter_association).count(:all)
-          updates[counter_name] = count if count != count_was
+          counts =
+            unscoped
+              .joins(counter_association)
+              .where(primary_key => ids)
+              .group(primary_key)
+              .count(:all)
+
+          ids.each do |id|
+            updates[id].merge!(counter_name => counts[id] || 0)
+          end
         end
 
         if touch
@@ -63,10 +83,15 @@ module ActiveRecord
           names = Array.wrap(names)
           options = names.extract_options!
           touch_updates = touch_attributes_with_time(*names, **options)
-          updates.merge!(touch_updates)
+
+          updates.each_value do |record_updates|
+            record_updates.merge!(touch_updates)
+          end
         end
 
-        unscoped.where(primary_key => [object.id]).update_all(updates) if updates.any?
+        updates.each do |id, record_updates|
+          unscoped.where(primary_key => [id]).update_all(record_updates)
+        end
 
         true
       end

--- a/activerecord/test/cases/counter_cache_test.rb
+++ b/activerecord/test/cases/counter_cache_test.rb
@@ -103,6 +103,15 @@ class CounterCacheTest < ActiveRecord::TestCase
     end
   end
 
+  test "reset counters for multiple records" do
+    t1, t2 = topics(:first, :second)
+    Topic.increment_counter(:replies_count, [t1.id, t2.id])
+
+    assert_difference ["t1.reload.replies_count", "t2.reload.replies_count"], -1 do
+      Topic.reset_counters([t1.id, t2.id], :replies_count)
+    end
+  end
+
   test "reset multiple counters" do
     Topic.update_counters @topic.id, replies_count: 1, unique_replies_count: 1
     assert_difference ["@topic.reload.replies_count", "@topic.reload.unique_replies_count"], -1 do
@@ -164,10 +173,9 @@ class CounterCacheTest < ActiveRecord::TestCase
   test "reset counter performs query for correct counter with touch: true" do
     Topic.reset_counters(@topic.id, :replies_count)
 
-    # SELECT "topics".* FROM "topics" WHERE "topics"."id" = ? LIMIT ?
     # SELECT COUNT(*) FROM "topics" WHERE "topics"."type" IN (?, ?, ?, ?, ?) AND "topics"."parent_id" = ?
     # UPDATE "topics" SET "updated_at" = ? WHERE "topics"."id" = ?
-    assert_queries_count(3) do
+    assert_queries_count(2) do
       Topic.reset_counters(@topic.id, :replies_count, touch: true)
     end
   end


### PR DESCRIPTION
There is often a need to reset counter caches for multiple records. Achieving this before will generate many extra queries. 

### Before

```ruby
[1,2,...,10].each do |id|
  Aircraft.reset_counters(id, :wheels, :engines)
end
```

`reset_counters` creates 4 queries:
1. to get a record by id
2. to calculate a counter for `:wheels`
3. to calculate a counter for `:engines`
4. to update the record

So, to update 10 records, this will create 10x4=**40 queries**.

### After

```ruby
Aircraft.reset_counters([1,2,...,10], :wheels, :engines)
```

1 query to get `:wheels` counts for all records
1 query to get `:engines` counts for all records
1 query for each record to update counters

Total: **12 queries**.

**Note**: Currently, [all](http://edgeapi.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-decrement_counter), [other](http://edgeapi.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-increment_counter), [methods](http://edgeapi.rubyonrails.org/classes/ActiveRecord/CounterCache/ClassMethods.html#method-i-update_counters) from `CounterCache` module accept multiple ids.