### PR TITLE
Add `redirect_through` for multi-redirect workflows

### DIFF
--- a/actionpack/lib/action_controller/metal/redirecting.rb
+++ b/actionpack/lib/action_controller/metal/redirecting.rb
@@ -11,6 +11,7 @@ module ActionController
 
     included do
       mattr_accessor :raise_on_open_redirects, default: false
+      helper_method(:onward_url) if respond_to?(:helper_method)
     end
 
     # Redirects the browser to the target specified in +options+. This parameter can be any one of:
@@ -127,6 +128,43 @@ module ActionController
       end
     end
 
+    # Appends an +onward+ query param to a given +intermediate_url+, and
+    # redirects the browser to the resulting URL. The value of the +onward+
+    # param defaults to the full path of the current request, and can be
+    # overridden with the +:to+ option.
+    #
+    # When responding to an intermediate request, the value of the +onward+
+    # query param can be safely accessed with #onward_url.
+    #
+    # ==== Options
+    #
+    # * <tt>:to</tt> - The value of the +onward+ query param appended to
+    #   +intermediate_url+. Defaults to the full path of the current request.
+    #
+    # All #redirect_to options are also supported.
+    #
+    # ==== Examples
+    #
+    #   # Responding to `GET /posts/1/edit`:
+    #
+    #   redirect_through sign_in_path
+    #   # => redirects to "/sign_in?onward=%2Fposts%2F1%2Fedit"
+    #
+    #   redirect_through sign_in_path(lang: "en")
+    #   # => redirects to "/sign_in?lang=en&onward=%2Fposts%2F1%2Fedit"
+    #
+    #   redirect_through sign_in_path, alert: "You must sign in first."
+    #   # => redirects to "/sign_in?onward=%2Fposts%2F1%2Fedit" with a flash alert
+    #
+    #   redirect_through sign_in_path, to: dashboard_path
+    #   # => redirects to "/sign_in?onward=%2Fdashboard"
+    #
+    def redirect_through(intermediate_url, to: request.fullpath, **options)
+      uri = URI(intermediate_url)
+      uri.query = "#{uri.query}#{"&" if uri.query}#{Rack::Utils.build_query(onward: to)}"
+      redirect_to uri.to_s, options
+    end
+
     def _compute_redirect_to_location(request, options) # :nodoc:
       case options
       # The scheme name consist of a letter followed by any combination of
@@ -169,6 +207,26 @@ module ActionController
     def url_from(location)
       location = location.presence
       location if location && _url_host_allowed?(location)
+    end
+
+    # Returns the value of the +onward+ query param if it is an internal URL or
+    # path. Otherwise returns +nil+.
+    #
+    # This method is also exposed as a view helper.
+    #
+    # ==== Examples
+    #
+    #   # Responding to `GET /sign_in?onward=%2Fposts%2F1%2Fedit`:
+    #   onward_url # => "/posts/1/edit"
+    #
+    #   # Responding to `GET /sign_in`:
+    #   onward_url # => nil
+    #
+    #   # Responding to `GET /sign_in?onward=http%3A%2F%2Fevil.com`:
+    #   onward_url # => nil
+    #
+    def onward_url
+      url_from(params[:onward])
     end
 
     private

--- a/actionpack/test/controller/redirect_test.rb
+++ b/actionpack/test/controller/redirect_test.rb
@@ -183,6 +183,22 @@ class RedirectController < ActionController::Base
     redirect_to "\000/lol\r\nwat"
   end
 
+  def redirect_through_url
+    redirect_through "/sign_in"
+  end
+
+  def redirect_through_url_with_query_string
+    redirect_through "/sign_in?foo=bar"
+  end
+
+  def redirect_through_url_to_given_url
+    redirect_through "/sign_in", to: "/posts/1/edit"
+  end
+
+  def redirect_to_onward_url_or_fallback
+    redirect_to onward_url || "/fallback"
+  end
+
   def rescue_errors(e) raise e end
 
   private
@@ -512,6 +528,21 @@ class RedirectTest < ActionController::TestCase
     end
   end
 
+  def test_redirect_through_url
+    get :redirect_through_url
+    assert_redirected_to "/sign_in?onward=#{Rack::Utils.escape "/redirect/redirect_through_url"}"
+  end
+
+  def test_redirect_through_url_with_query_string
+    get :redirect_through_url_with_query_string
+    assert_redirected_to "/sign_in?foo=bar&onward=#{Rack::Utils.escape "/redirect/redirect_through_url_with_query_string"}"
+  end
+
+  def test_redirect_through_url_to_given_url
+    get :redirect_through_url_to_given_url
+    assert_redirected_to "/sign_in?onward=#{Rack::Utils.escape "/posts/1/edit"}"
+  end
+
   def test_url_from
     with_raise_on_open_redirects do
       get :safe_redirect_with_fallback, params: { redirect_url: "http://test.host/app" }
@@ -529,6 +560,27 @@ class RedirectTest < ActionController::TestCase
       get :safe_redirect_with_fallback, params: { redirect_url: "" }
       assert_response :redirect
       assert_redirected_to "http://test.host/fallback"
+    end
+  end
+
+  def test_onward_url
+    get :redirect_to_onward_url_or_fallback, params: { onward: "http://test.host/destination" }
+    assert_redirected_to "/destination"
+
+    get :redirect_to_onward_url_or_fallback, params: { onward: "/destination" }
+    assert_redirected_to "/destination"
+
+    get :redirect_to_onward_url_or_fallback, params: { onward: "" }
+    assert_redirected_to "/fallback"
+
+    get :redirect_to_onward_url_or_fallback
+    assert_redirected_to "/fallback"
+  end
+
+  def test_onward_url_with_open_redirect
+    with_raise_on_open_redirects do
+      get :redirect_to_onward_url_or_fallback, params: { onward: "http://www.rubyonrails.org/" }
+      assert_redirected_to "/fallback"
     end
   end
 


### PR DESCRIPTION
`redirect_through` provides syntactic sugar for redirecting to an intermediate page while tracking a final destination using an `onward` query param.  The final destination defaults to the current request path.  For example, if user authentication is required, you could write something like:

```ruby
before_action do
  redirect_through sign_in_path unless signed_in?
end
```

An `onward_url` method is also provided to fetch the `onward` param while providing open-redirect protection.  It is exposed as a view helper, so you can propagate the `onward` value via a "Sign in" form:

```erb
<%= form_with ... do |form| %>
  <%= hidden_field_tag :onward, onward_url %>
  ...
<% end %>
```

Then, in your "Sign in" controller, you could write something like:

```ruby
if self.current_user = User.authenticate_by(sign_in_params)
  redirect_to onward_url || root_url
else
  render :new, status: :unauthorized
end
```

**Why not use `request.referer` for the intermediate request?**

Redirects preserve the original `Referer` header.  Thus intermediate pages will not see the location that redirected.  For example:

1. Visit `/posts/1` while signed out.
2. Click `/posts/1/edit` link.  `Referer` will be `/posts/1`.
3. Require authentication: redirect from `/posts/1/edit` to `/sign_in`.
4. Serve `/sign_in`.  `Referer` is `/posts/1`, *not* `/posts/1/edit`.

Additionally, some browsers (e.g. Firefox) have privacy settings to spoof the `Referer` header, so it may not be reliable.

**Why not store `onward` in a session variable / cookie?**

As shared state, session variables / cookies can be a problem when using multiple browser tabs.  For example:

1. Visit `/posts` while signed out.
2. Open `/posts/1/edit`, `/posts/2/edit`, etc links in new tabs.
3. Each tab is redirected to `/sign_in`.  The final tab "wins" at setting the session variable.
4. Assume forms are autofilled by a password manager.  User submits each tab's form because it is easier than reopening each tab.
5. Each tab is redirected to the final tab's location; *OR*, if the session variable is discarded after use, the first tab is redirected to the final tab's intended location, and all other tabs are redirected to a fallback (or error due to `redirect_to nil`).

Additionally, session variables can erroneously "follow" the user.  For example:

1. Visit `/posts/1` while signed out.
2. Click `/posts/1/edit` link.
3. Require authentication: store `"/posts/1/edit"` in a session variable, and redirect to `/sign_in`.
4. Navigate to a page that doesn't require authentication, e.g. `/`.
5. Click `/sign_in` link in the page navbar.  Sign in.
6. Redirected to `/posts/1/edit` despite starting a new navigation sequence, because nothing triggered the session variable to change.
