### PR TITLE
Update ActiveModel::AttributeSet::Builder to use Concurrent::Map

### DIFF
--- a/activemodel/lib/active_model/attribute_set/builder.rb
+++ b/activemodel/lib/active_model/attribute_set/builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_model/attribute"
+require "concurrent/map"
 
 module ActiveModel
   class AttributeSet # :nodoc:
@@ -25,7 +26,7 @@ module ActiveModel
       @types = types
       @additional_types = additional_types
       @default_attributes = default_attributes
-      @casted_values = {}
+      @casted_values = Concurrent::Map.new
       @materialized = false
     end
 


### PR DESCRIPTION


### Summary

While using rails  in a multi-threaded Ruby implementation and server (TruffleRuby/Puma), errors are produced by the unsafe hash usage in `AttributeSet::Builder`.  This resolves the issue by using `Concurrent::Map` for `@casted_values`.


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
