### PR TITLE
Correctly get name of middleware when a it is Module 

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/stack.rb
+++ b/actionpack/lib/action_dispatch/middleware/stack.rb
@@ -20,13 +20,13 @@ module ActionDispatch
         case middleware
         when Middleware
           klass == middleware.klass
-        when Class
+        when Module
           klass == middleware
         end
       end
 
       def inspect
-        if klass.is_a?(Class)
+        if klass.is_a?(Module)
           klass.to_s
         else
           klass.class.to_s


### PR DESCRIPTION
### Summary

This is a super simple update to the `#inspect` to check for type `Module`, as well as `Class`, to get the name of the middleware.  Without this, the middleware's name is set as `Module`.

You can reproduce this issue with the `rack-cache` gem by installing and running `rake middleware`. Example output:
```use Rack::Sendfile
use Rack::Deflater
use ActionDispatch::Static
use Module
use ActionDispatch::Executor
use Rack::Runtime
use ActionDispatch::RequestId
use RequestStore::Middleware
use ActionDispatch::RemoteIp
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::ActionableExceptions
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use ActiveRecord::Migration::CheckPending
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
```

note: `use Module`


