### PR TITLE
Allow setting some Active Support settings via initializers

### DIFF
--- a/activesupport/lib/active_support/railtie.rb
+++ b/activesupport/lib/active_support/railtie.rb
@@ -11,8 +11,10 @@ module ActiveSupport
     config.eager_load_namespaces << ActiveSupport
 
     initializer "active_support.isolation_level" do |app|
-      if level = app.config.active_support.delete(:isolation_level)
-        ActiveSupport::IsolatedExecutionState.isolation_level = level
+      config.after_initialize do
+        if level = app.config.active_support.delete(:isolation_level)
+          ActiveSupport::IsolatedExecutionState.isolation_level = level
+        end
       end
     end
 
@@ -41,14 +43,12 @@ module ActiveSupport
     end
 
     initializer "active_support.reset_all_current_attributes_instances" do |app|
-      executor_around_test_case = app.config.active_support.executor_around_test_case
-
       app.reloader.before_class_unload { ActiveSupport::CurrentAttributes.clear_all }
       app.executor.to_run              { ActiveSupport::CurrentAttributes.reset_all }
       app.executor.to_complete         { ActiveSupport::CurrentAttributes.reset_all }
 
       ActiveSupport.on_load(:active_support_test_case) do
-        if executor_around_test_case
+        if app.config.active_support.executor_around_test_case
           require "active_support/executor/test_helper"
           include ActiveSupport::Executor::TestHelper
         else

--- a/railties/test/application/configuration_test.rb
+++ b/railties/test/application/configuration_test.rb
@@ -3748,6 +3748,27 @@ module ApplicationTests
       assert_equal true, ActionController::Base.raise_on_missing_callback_actions
     end
 
+    test "isolation_level is :thread by default" do
+      app "development"
+      assert_equal :thread, ActiveSupport::IsolatedExecutionState.isolation_level
+    end
+
+    test "isolation_level can be set in app config" do
+      add_to_config "config.active_support.isolation_level = :fiber"
+
+      app "development"
+      assert_equal :fiber, ActiveSupport::IsolatedExecutionState.isolation_level
+    end
+
+    test "isolation_level can be set in initializer" do
+      app_file "config/initializers/new_framework_defaults_7_0.rb", <<-RUBY
+        Rails.application.config.active_support.isolation_level = :fiber
+      RUBY
+
+      app "development"
+      assert_equal :fiber, ActiveSupport::IsolatedExecutionState.isolation_level
+    end
+
     private
       def set_custom_config(contents, config_source = "custom".inspect)
         app_file "config/custom.yml", contents


### PR DESCRIPTION
Through investigating https://github.com/rails/rails/pull/43596#discussion_r860540140 I noticed a few settings can't be configured through initializers. This PR fixes it for these, to match how most other settings in the Active Support railtie work.

- `isolation_level`
- ~~`report_deprecations`~~
- `executor_around_test_case`

**Pros of this change**: you can now set these settings in initializers, such as the new framework defaults initializer created when upgrading Rails.

**Cons of this change**: the changes won't apply while application initializers are running. So for example you might still report deprecations during application initializers, even if they get silenced later.

**Should we merge this?** Yes, I think so - currently new framework defaults suggests configs that don't work. But in future it's probably worth looking more into the configuration architecture.

cc @byroot 
