### PR TITLE
Fixed: MemCacheStore#read_multi_entries NoMethodError: undefined method `expired?` for nil:NilClass

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -255,7 +255,7 @@ module ActiveSupport
           raw_values.each do |key, value|
             entry = deserialize_entry(value, raw: options[:raw])
 
-            unless entry.expired? || entry.mismatched?(normalize_version(keys_to_names[key], options))
+            unless entry.nil? || entry.expired? || entry.mismatched?(normalize_version(keys_to_names[key], options))
               values[keys_to_names[key]] = entry.value
             end
           end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -287,6 +287,13 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     end
   end
 
+  def test_can_read_multi_entries_raw_values_from_dalli_store
+    key = "test-with-nil-value-the-way-the-dalli-store-did"
+
+    @cache.instance_variable_get(:@data).with { |c| c.set(@cache.send(:normalize_key, key, nil), nil, 0, compress: false) }
+    assert_equal({}, @cache.send(:read_multi_entries, [key]))
+  end
+
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join


### PR DESCRIPTION
### Summary

- While using the `dalli_store`, you set any value in the Rails cache.
- You change to the `mem_cache_store`.
- You use `Rails.cache.read_multi(key)`
- `Error: NoMethodError: undefined method expired? for nil:NilClass`

Added entry.nil? Like [RedisCacheStore](https://github.com/rails/rails/blob/89471b2d7d3e6df631b1c236573c6674ac7f2502/activesupport/lib/active_support/cache/redis_cache_store.rb#L356) to avoid error