### PR TITLE
Remove dead URL

### DIFF
--- a/railties/lib/rails/generators/app_base.rb
+++ b/railties/lib/rails/generators/app_base.rb
@@ -369,7 +369,7 @@ module Rails
         return unless defined?(Rubinius)
 
         comment = "Use Psych as the YAML engine, instead of Syck, so serialized " \
-                  "data can be read safely from different rubies (see https://github.com/rubysl/rubysl-yaml/pull/3)"
+                  "data can be read safely from different rubies"
         GemfileEntry.new("psych", "~> 2.0", comment, platforms: :rbx)
       end
 


### PR DESCRIPTION
The `rubysl/rubysl-yaml` repo and its issue tracker are gone, and there doesn't seem to be an alternative URL.

---

From a cursory search, there are a couple dozen places where we have Rubinius-specific code.  Rubinius hasn't had a commit since May 2020 (https://github.com/rubinius/rubinius/commit/b7a755c83f3dd3f0c1f5e546f0e58fb61851ea44), and we do not officially support it.  Is there interest in removing this code?
