### PR TITLE
Use immutable URL for arbitrary code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install
-        run: wget -O - -q https://raw.githubusercontent.com/client9/misspell/master/install-misspell.sh | sh -s -- -b .
+        run: wget -O - -q https://raw.githubusercontent.com/client9/misspell/c0b55c8239520f6b5aa15a0207ca8b28027ba49e/install-misspell.sh | sh -s -- -b .
       - name: Misspell
         run: git ls-files --empty-directory | xargs ./misspell -i 'aircrafts,devels,invertions' -error


### PR DESCRIPTION
If the `client9/misspell` repo is compromised, an attacker could control the contents of `install-misspell.sh`.  Since we execute that file directly, we should use a URL that guarantees its contents will not change.

Note that, at the time of writing, the last commit to `client9/misspell` was in March 2018 (client9/misspell@c0b55c8239520f6b5aa15a0207ca8b28027ba49e), so the code appears to be stable.

Also, although using a tag would be prettier than using a hash, the repo's last commit is after its most recent tag (`v0.3.4`).
