### PR TITLE
Deprecate ChainedCookieJar#signed_or_encrypted

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -257,6 +257,13 @@ module ActionDispatch
       # Returns the +signed+ or +encrypted+ jar, preferring +encrypted+ if +secret_key_base+ is set.
       # Used by ActionDispatch::Session::CookieStore to avoid the need to introduce new cookie stores.
       def signed_or_encrypted
+        ActiveSupport::Deprecation.warn <<~WARNING.squish
+          ChainedCookieJar#signed_or_encrypted is deprecated and will be
+          removed in Rails 7.1. Usage should be replaced with #encrypted, which
+          has been its effective behavior since Rails 6.0 when secret_key_base
+          became required
+        WARNING
+
         @signed_or_encrypted ||=
           if request.secret_key_base.present?
             encrypted

--- a/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+++ b/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
@@ -115,7 +115,7 @@ module ActionDispatch
         end
 
         def cookie_jar(request)
-          request.cookie_jar.signed_or_encrypted
+          request.cookie_jar.encrypted
         end
     end
   end

--- a/actionpack/test/controller/flash_test.rb
+++ b/actionpack/test/controller/flash_test.rb
@@ -253,7 +253,8 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
     ActiveSupport::KeyGenerator.new("b3c631c314c0bbca50c1b2843150fe33", iterations: 1000)
   )
   Rotations = ActiveSupport::Messages::RotationConfiguration.new
-  SIGNED_COOKIE_SALT = "signed cookie"
+  ENCRYPTED_COOKIE_SALT = "encrypted cookie"
+  ENCRYPTED_SIGNED_COOKIE_SALT = "encrypted signed cookie"
 
   class TestController < ActionController::Base
     add_flash_types :bar
@@ -373,7 +374,8 @@ class FlashIntegrationTest < ActionDispatch::IntegrationTest
       options[:env] ||= {}
       options[:env]["action_dispatch.key_generator"] ||= Generator
       options[:env]["action_dispatch.cookies_rotations"] = Rotations
-      options[:env]["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
+      options[:env]["action_dispatch.encrypted_cookie_salt"] = ENCRYPTED_COOKIE_SALT
+      options[:env]["action_dispatch.encrypted_signed_cookie_salt"] = ENCRYPTED_SIGNED_COOKIE_SALT
       super(path, **options)
     end
 

--- a/actionpack/test/dispatch/routing_test.rb
+++ b/actionpack/test/dispatch/routing_test.rb
@@ -5172,7 +5172,7 @@ class FlashRedirectTest < ActionDispatch::IntegrationTest
     ActiveSupport::KeyGenerator.new("b3c631c314c0bbca50c1b2843150fe33", iterations: 1000)
   )
   Rotations = ActiveSupport::Messages::RotationConfiguration.new
-  SIGNED_COOKIE_SALT = "signed cookie"
+  ENCRYPTED_COOKIE_SALT = "encrypted cookie"
   ENCRYPTED_SIGNED_COOKIE_SALT = "signed encrypted cookie"
 
   class KeyGeneratorMiddleware
@@ -5183,7 +5183,7 @@ class FlashRedirectTest < ActionDispatch::IntegrationTest
     def call(env)
       env["action_dispatch.key_generator"] ||= Generator
       env["action_dispatch.cookies_rotations"] ||= Rotations
-      env["action_dispatch.signed_cookie_salt"] = SIGNED_COOKIE_SALT
+      env["action_dispatch.encrypted_cookie_salt"] = ENCRYPTED_COOKIE_SALT
       env["action_dispatch.encrypted_signed_cookie_salt"] = ENCRYPTED_SIGNED_COOKIE_SALT
 
       @app.call(env)


### PR DESCRIPTION
### Summary

It has been effectively the same as `#encrypted` since `secret_key_base` was
made a requirement in Rails 6.0

### Other Information

If deprecating is too aggressive, I could also make it just an alias for `#encrypted`