### PR TITLE
Show better error messages when libvips is missing

### DIFF
--- a/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
+++ b/activestorage/lib/active_storage/analyzer/image_analyzer/vips.rb
@@ -24,8 +24,13 @@ module ActiveStorage
             {}
           end
         end
-      rescue LoadError
-        logger.info "Skipping image analysis because the ruby-vips gem isn't installed"
+      rescue LoadError => error
+        if error.message.match?(/libvips/)
+          logger.info "Skipping image analysis because libvips isn't installed"
+        else
+          logger.info "Skipping image analysis because the ruby-vips gem isn't installed"
+        end
+
         {}
       rescue ::Vips::Error => error
         logger.error "Skipping image analysis due to an Vips error: #{error.message}"

--- a/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
+++ b/activestorage/lib/active_storage/transformers/image_processing_transformer.rb
@@ -27,6 +27,15 @@ module ActiveStorage
 
         def processor
           ImageProcessing.const_get(ActiveStorage.variant_processor.to_s.camelize)
+        rescue LoadError => error
+          if error.message.match?(/libvips/)
+            raise LoadError, <<~ERROR.squish
+              Your application is configured to use vips to process variants,
+              but libvips isn't installed
+            ERROR
+          end
+
+          raise
         end
 
         def operations


### PR DESCRIPTION
### Summary

The previous error would look something like this:

```
/usr/local/bundle/gems/ffi-1.15.5/lib/ffi/library.rb:145:in `block in
ffi_lib': Could not open library 'vips.so.42': vips.so.42: cannot open
shared object file: No such file or directory. (LoadError)

Could not open library 'libvips.so.42': libvips.so.42: cannot open
shared object file: No such file or directory
```

Now the LoadError is rescued and a more helpful error message is
displayed directing users to install libvips

### Other Information

The difference can be seen by switching between the two repos in this script (on a system missing libvips):

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # gem "rails, github: "rails/rails", branch: "main"
  gem "rails", github: "skipkayhil/rails", branch: "better-libvips-error"
  gem "sqlite3"
  gem "image_processing"
end

require "active_record/railtie"
require "active_storage/engine"
require "tmpdir"

class TestApp < Rails::Application
    config.root = __dir__
    config.hosts << "example.org"
    config.eager_load = false
    config.session_store :cookie_store, key: "cookie_store_key"
    secrets.secret_key_base = "secret_key_base"

    config.logger = Logger.new($stdout)
    Rails.logger  = config.logger

    config.active_storage.service = :local
    config.active_storage.service_configurations = {
      local: {
        root: Dir.tmpdir,
        service: "Disk"
      }
    }
    config.active_storage.variant_processor = :vips
end

ENV["DATABASE_URL"] = "sqlite3::memory:"

Rails.application.initialize!

require ActiveStorage::Engine.root.join("db/migrate/20170806125915_create_active_storage_tables.rb").to_s

ActiveRecord::Schema.define do
  CreateActiveStorageTables.new.change

  create_table :users, force: true
end

class User < ActiveRecord::Base
  has_one_attached :profile
end

require "minitest/autorun"

class BugTest < Minitest::Test
  def test_upload_and_download
    ActiveStorage::Transformers::ImageProcessingTransformer.new(0).send(:processor)
  end
end
```

Closes #43976