### PR TITLE
Fix creating records having encrypted attributes with defaults

### DIFF
--- a/activerecord/lib/active_record/encryption/encryptable_record.rb
+++ b/activerecord/lib/active_record/encryption/encryptable_record.rb
@@ -83,7 +83,8 @@ module ActiveRecord
             encrypted_attributes << name.to_sym
 
             attribute name do |cast_type|
-              ActiveRecord::Encryption::EncryptedAttributeType.new scheme: attribute_scheme, cast_type: cast_type
+              ActiveRecord::Encryption::EncryptedAttributeType.new(scheme: attribute_scheme, cast_type: cast_type,
+                                                                   default: -> { columns_hash[name.to_s].default })
             end
 
             preserve_original_encrypted(name) if attribute_scheme.ignore_case?

--- a/activerecord/test/cases/encryption/encryptable_record_test.rb
+++ b/activerecord/test/cases/encryption/encryptable_record_test.rb
@@ -41,6 +41,10 @@ class ActiveRecord::Encryption::EncryptableRecordTest < ActiveRecord::Encryption
     assert_equal "", EncryptedBook.create!(name: "").name
   end
 
+  test "works with default values" do
+    assert_equal "", EncryptedBook.create!.name
+  end
+
   test "encrypts serialized attributes" do
     states = %i[ green red ]
     traffic_light = EncryptedTrafficLight.create!(state: states, long_state: states)

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -141,7 +141,7 @@ ActiveRecord::Schema.define do
   create_table :encrypted_books, id: :integer, force: true do |t|
     t.references :author
     t.string :format
-    t.column :name, :string
+    t.column :name, :string, default: ""
     t.column :original_name, :string
 
     t.datetime :created_at


### PR DESCRIPTION
I'm not sure this is the best approach. I used a proc for default to avoid loading model's schema, like was already done in this class with the length validation. 

Closes #44314
Closes #43664
