### PR TITLE
Wrap rails runner in executor

### DIFF
--- a/actioncable/lib/action_cable/engine.rb
+++ b/actioncable/lib/action_cable/engine.rb
@@ -60,7 +60,7 @@ module ActionCable
     initializer "action_cable.set_work_hooks" do |app|
       ActiveSupport.on_load(:action_cable) do
         ActionCable::Server::Worker.set_callback :work, :around, prepend: true do |_, inner|
-          app.executor.wrap do
+          app.executor.wrap(source: "application.action_cable") do
             # If we took a while to get the lock, we may have been halted
             # in the meantime. As we haven't started doing any real work
             # yet, we should pretend that we never made it off the queue.
@@ -71,7 +71,7 @@ module ActionCable
         end
 
         wrap = lambda do |_, inner|
-          app.executor.wrap(&inner)
+          app.executor.wrap(source: "application.action_cable", &inner)
         end
         ActionCable::Channel::Base.set_callback :subscribe, :around, prepend: true, &wrap
         ActionCable::Channel::Base.set_callback :unsubscribe, :around, prepend: true, &wrap

--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -14,7 +14,7 @@ module ActionDispatch
         response = @app.call(env)
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }
       rescue => error
-        @executor.error_reporter.report(error, handled: false)
+        @executor.error_reporter.report(error, handled: false, source: "application.action_dispatch")
         raise
       ensure
         state.complete! unless returned

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -84,14 +84,14 @@ module ActiveSupport
     end
 
     # Perform the work in the supplied block as an execution.
-    def self.wrap
+    def self.wrap(source: "application.active_support")
       return yield if active?
 
       instance = run!
       begin
         yield
       rescue => error
-        error_reporter.report(error, handled: false, source: "unhandled_error.active_support")
+        error_reporter.report(error, handled: false, source: source)
         raise
       ensure
         instance.complete!

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -67,8 +67,8 @@ module ActiveSupport
     end
 
     # Run the supplied block as a work unit, reloading code as needed
-    def self.wrap
-      executor.wrap do
+    def self.wrap(**kwargs)
+      executor.wrap(**kwargs) do
         super
       end
     end

--- a/activesupport/test/executor_test.rb
+++ b/activesupport/test/executor_test.rb
@@ -27,7 +27,14 @@ class ExecutorTest < ActiveSupport::TestCase
         raise error
       end
     end
-    assert_equal [[error, false, :error, "unhandled_error.active_support", {}]], subscriber.events
+    assert_equal [error, false, :error, "application.active_support", {}], subscriber.events.last
+
+    assert_raises DummyError do
+      executor.wrap(source: "custom") do
+        raise error
+      end
+    end
+    assert_equal [error, false, :error, "custom", {}], subscriber.events.last
   end
 
   def test_wrap_invokes_callbacks

--- a/railties/CHANGELOG.md
+++ b/railties/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Execute `rails runner` scripts inside the executor.
+
+    Enables error reporting, query cache, etc.
+
+    *Jean Boussier*
+
 *   Avoid booting in development then test for test tasks.
 
     Running one of the rails test subtasks (e.g. test:system, test:models) would

--- a/railties/lib/rails/commands/runner/runner_command.rb
+++ b/railties/lib/rails/commands/runner/runner_command.rb
@@ -36,14 +36,20 @@ module Rails
         ARGV.replace(command_argv)
 
         if code_or_file == "-"
-          eval($stdin.read, TOPLEVEL_BINDING, "stdin")
+          Rails.application.executor.wrap(source: "application.runner.railties") do
+            eval($stdin.read, TOPLEVEL_BINDING, "stdin")
+          end
         elsif File.exist?(code_or_file)
           expanded_file_path = File.expand_path code_or_file
           $0 = expanded_file_path
-          Kernel.load expanded_file_path
+          Rails.application.executor.wrap(source: "application.runner.railties") do
+            Kernel.load expanded_file_path
+          end
         else
           begin
-            eval(code_or_file, TOPLEVEL_BINDING, __FILE__, __LINE__)
+            Rails.application.executor.wrap(source: "application.runner.railties") do
+              eval(code_or_file, TOPLEVEL_BINDING, __FILE__, __LINE__)
+            end
           rescue SyntaxError, NameError => e
             error "Please specify a valid ruby command or the path of a script to run."
             error "Run '#{self.class.executable} -h' for help."


### PR DESCRIPTION
The main reason is to automatically report uncaught exceptions since `rails runner` is often used for cron tasks and such.

cc @st0012 