### PR TITLE
Also allow Integer as AC::Parameter keys

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,6 +1,6 @@
-*   Allow only String and Symbol keys in `ActionController::Parameters`.
+*   Allow only String, Symbol and Integer keys in `ActionController::Parameters`.
     Raise `ActionController::InvalidParameterKey` when initializing Parameters
-    with keys that aren't strings or symbols.
+    with keys that aren't strings, symbols or integers.
 
     *Seva Stefkin*
 

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -70,7 +70,7 @@ module ActionController
   #   # => ActionController::InvalidParameterKey: all keys must be Strings or Symbols
   class InvalidParameterKey < ArgumentError
     def initialize # :nodoc:
-      super("all keys must be Strings or Symbols")
+      super("all keys must be strings, symbols or integers")
     end
   end
 
@@ -269,7 +269,7 @@ module ActionController
     #   params.permitted?  # => true
     #   Person.new(params) # => #<Person id: nil, name: "Francesco">
     def initialize(parameters = {}, logging_context = {})
-      raise InvalidParameterKey unless parameters.keys.all? { |key| key.is_a?(String) || key.is_a?(Symbol) }
+      raise InvalidParameterKey unless parameters.keys.all? { |key| key.is_a?(String) || key.is_a?(Symbol) || key.is_a?(Integer) }
 
       @parameters = parameters.with_indifferent_access
       @logging_context = logging_context

--- a/actionpack/test/controller/parameters/parameters_permit_test.rb
+++ b/actionpack/test/controller/parameters/parameters_permit_test.rb
@@ -520,9 +520,13 @@ class ParametersPermitTest < ActiveSupport::TestCase
     assert_equal false, params.permitted?
   end
 
-  test "only String and Symbol keys are allowed" do
+  test "only String, Symbol and Integer keys are allowed" do
     assert_raises(ActionController::InvalidParameterKey) do
       ActionController::Parameters.new({ foo: 1 } => :bar)
+    end
+
+    assert_nothing_raised do
+      ActionController::Parameters.new(4 => :bar)
     end
   end
 end


### PR DESCRIPTION
Followup: https://github.com/rails/rails/pull/44844

It's not uncommon to have parameter hashes with integer keys for endpoints accepting JSON requests.

cc @gmcgibbon, @stefkin, @tenderlove 

I tried to read on the reason for this change, but I'm not sure I quite understand it, so please advise.

Also I just added integer, but I think we should add all JSON scalars, so `Float` as well (or maybe just check for `Numeric`). Also I'm not sure wether it makes sense to even accept symbols, as that's not something you should receive as request parameters.