### PR TITLE
Simplify regex detecting comments in sql query

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -36,7 +36,7 @@ module ActiveRecord
       include Savepoints
 
       SIMPLE_INT = /\A\d+\z/
-      COMMENT_REGEX = %r{(?:--.*\n)*|/\*(?:[^*]|\*[^/])*\*/}m
+      COMMENT_REGEX = %r{(?:--.*\n)|/\*(?:[^*]|\*[^/])*\*/}m
 
       attr_accessor :pool
       attr_reader :visitor, :owner, :logger, :lock


### PR DESCRIPTION
This regex has extra `*` for `--`- like comments that is not needed, since `*` is also added here https://github.com/rails/rails/blob/dce43bb01d85d09c0f7423719b1052d59a6ab3b0/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L81 

Closes #45011

ping @yassenb