### PR TITLE
Doc: fix of name attribute

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1811,7 +1811,7 @@ If you also have a `locked` field on the `Customer` model, you also get `find_by
 You can specify an exclamation point (`!`) on the end of the dynamic finders
 to get them to raise an `ActiveRecord::RecordNotFound` error if they do not return any records, like `Customer.find_by_name!("Ryan")`
 
-If you want to find both by `name` and `orders_count`, you can chain these finders together by simply typing "`and`" between the fields.
+If you want to find both by `first_name` and `orders_count`, you can chain these finders together by simply typing "`and`" between the fields.
 For example, `Customer.find_by_first_name_and_orders_count("Ryan", 5)`.
 
 Enums


### PR DESCRIPTION
### Summary
Fix of `name` attribute name to `first_name` in dynamic finders for correct use of `find_by_first_name_and_orders_count` method

