### PR TITLE
Fix `where.missing` and `where.associated` for parent/child associations

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -77,7 +77,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.joins!(association)
-          self.not(reflection.table_name => { reflection.association_primary_key => nil })
+          self.not(association => { reflection.association_primary_key => nil })
         end
 
         @scope
@@ -105,7 +105,7 @@ module ActiveRecord
         associations.each do |association|
           reflection = scope_association_reflection(association)
           @scope.left_outer_joins!(association)
-          @scope.where!(reflection.table_name => { reflection.association_primary_key => nil })
+          @scope.where!(association => { reflection.association_primary_key => nil })
         end
 
         @scope

--- a/activerecord/test/cases/relation/where_chain_test.rb
+++ b/activerecord/test/cases/relation/where_chain_test.rb
@@ -20,6 +20,13 @@ module ActiveRecord
       end
     end
 
+    def test_associated_with_child_association
+      Comment.where.associated(:children).tap do |relation|
+        assert_includes     relation, comments(:greetings)
+        assert_not_includes relation, comments(:more_greetings)
+      end
+    end
+
     def test_associated_with_multiple_associations
       Post.where.associated(:author, :comments).tap do |relation|
         assert_includes     relation, posts(:welcome)
@@ -39,6 +46,13 @@ module ActiveRecord
     def test_missing_with_association
       assert posts(:authorless).author.blank?
       assert_equal [posts(:authorless)], Post.where.missing(:author).to_a
+    end
+
+    def test_missing_with_child_association
+      Comment.where.missing(:children).tap do |relation|
+        assert_includes     relation, comments(:more_greetings)
+        assert_not_includes relation, comments(:greetings)
+      end
     end
 
     def test_missing_with_invalid_association_name

--- a/activerecord/test/fixtures/comments.yml
+++ b/activerecord/test/fixtures/comments.yml
@@ -7,6 +7,7 @@ greetings:
 more_greetings:
   id: 2
   post_id: 1
+  parent_id: 1
   body: Thank you again for the welcome
   type: Comment
 


### PR DESCRIPTION
Closes #44964