### PR TITLE
Raise StrictLoadingViolationError with polymorphic relation violations

### DIFF
--- a/activerecord/lib/active_record/core.rb
+++ b/activerecord/lib/active_record/core.rb
@@ -213,7 +213,7 @@ module ActiveRecord
       def self.strict_loading_violation!(owner:, reflection:) # :nodoc:
         case ActiveRecord.action_on_strict_loading_violation
         when :raise
-          message = "`#{owner}` is marked for strict_loading. The `#{reflection.klass}` association named `:#{reflection.name}` cannot be lazily loaded."
+          message = reflection.strict_loading_violation_message(owner)
           raise ActiveRecord::StrictLoadingViolationError.new(message)
         when :log
           name = "strict_loading_violation.active_record"

--- a/activerecord/lib/active_record/log_subscriber.rb
+++ b/activerecord/lib/active_record/log_subscriber.rb
@@ -22,10 +22,8 @@ module ActiveRecord
     def strict_loading_violation(event)
       debug do
         owner = event.payload[:owner]
-        association = event.payload[:reflection].klass
-        name = event.payload[:reflection].name
-
-        color("Strict loading violation: #{owner} is marked for strict loading. The #{association} association named :#{name} cannot be lazily loaded.", RED)
+        reflection = event.payload[:reflection]
+        color(reflection.strict_loading_violation_message(owner), RED)
       end
     end
 

--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -297,6 +297,12 @@ module ActiveRecord
         options[:strict_loading]
       end
 
+      def strict_loading_violation_message(owner)
+        message = +"`#{owner}` is marked for strict_loading."
+        message << " The #{polymorphic? ? "polymorphic association" : "#{klass} association"}"
+        message << " named `:#{name}` cannot be lazily loaded."
+      end
+
       protected
         def actual_source_reflection # FIXME: this is a horrible name
           self

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -549,8 +549,55 @@ class StrictLoadingTest < ActiveRecord::TestCase
     developer.strict_loading!
     assert_predicate developer, :strict_loading?
 
-    assert_logged("Strict loading violation: Developer is marked for strict loading. The AuditLog association named :audit_logs cannot be lazily loaded.") do
+    expected_log = <<-MSG.squish
+      `Developer` is marked for strict_loading.
+      The AuditLog association named `:audit_logs` cannot be lazily loaded.
+    MSG
+    assert_logged(expected_log) do
       developer.audit_logs.to_a
+    end
+  ensure
+    ActiveRecord.action_on_strict_loading_violation = old_value
+  end
+
+  def test_strict_loading_violation_on_polymorphic_relation
+    pirate = Pirate.create!(catchphrase: "Arrr!")
+    Treasure.create!(looter: pirate)
+
+    treasure = Treasure.last
+    treasure.strict_loading!
+    assert_predicate treasure, :strict_loading?
+
+    error = assert_raises ActiveRecord::StrictLoadingViolationError do
+      treasure.looter
+    end
+
+    expected_error_message = <<-MSG.squish
+      `Treasure` is marked for strict_loading.
+      The polymorphic association named `:looter` cannot be lazily loaded.
+    MSG
+
+    assert_equal(expected_error_message, error.message)
+  end
+
+  def test_strict_loading_violation_logs_on_polymorphic_relation
+    old_value = ActiveRecord.action_on_strict_loading_violation
+    ActiveRecord.action_on_strict_loading_violation = :log
+    assert_equal :log, ActiveRecord.action_on_strict_loading_violation
+
+    pirate = Pirate.create!(catchphrase: "Arrr!")
+    Treasure.create!(looter: pirate)
+
+    treasure = Treasure.last
+    treasure.strict_loading!
+    assert_predicate treasure, :strict_loading?
+
+    expected_log = <<-MSG.squish
+      `Treasure` is marked for strict_loading.
+      The polymorphic association named `:looter` cannot be lazily loaded.
+    MSG
+    assert_logged(expected_log) do
+      treasure.looter
     end
   ensure
     ActiveRecord.action_on_strict_loading_violation = old_value


### PR DESCRIPTION
### Summary

Closes: https://github.com/rails/rails/issues/44906

Performing `strict_loading!` on a model with a polymorphic association currently raises an `ArgumentError` because it attempts to look up the klass for the association, which is not possible. The error message for `StrictLoadingViolationError` on models with polymorphic relationships should omit the klass for the association.