### PR TITLE
Fix disabling strict_loading when enabled by default

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -923,7 +923,7 @@ module ActiveRecord
           preload_associations(records) unless skip_preloading_value
 
           records.each(&:readonly!) if readonly_value
-          records.each(&:strict_loading!) if strict_loading_value
+          records.each { |record| record.strict_loading!(strict_loading_value) } unless strict_loading_value.nil?
 
           records
         end

--- a/activerecord/test/cases/strict_loading_test.rb
+++ b/activerecord/test/cases/strict_loading_test.rb
@@ -86,6 +86,7 @@ class StrictLoadingTest < ActiveRecord::TestCase
   def test_strict_loading_by_default
     with_strict_loading_by_default(Developer) do
       Developer.all.each { |d| assert d.strict_loading? }
+      Developer.strict_loading(false).each { |d| assert_not d.strict_loading? }
     end
   end
 


### PR DESCRIPTION
### Summary

When `strict_loading` is enabled by default, trying to explicitly disable strict loading at the relation level doesn't work:

```rb
class Developer < ApplicationRecord
  self.strict_loading_by_default = true
end

developer = Developer.strict_loading(false).first
developer.strict_loading? # => true
```

This PR ensures that `.strict_loading(false)` results in records which don't strictly load, even when enabled by default.

### Other Information

Use-case: in an app with strict loading globally enabled (`config.active_record.strict_loading_by_default = true`), there's some contexts (noodling around in a Rails console, say) where you want a quick escape hatch.
