### PR TITLE
Fix scoped associations with empty loaded records

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -320,7 +320,6 @@ module ActiveRecord
         #   * Otherwise, attributes should have the value found in the database
         def merge_target_lists(persisted, memory)
           return persisted if memory.empty?
-          return memory    if persisted.empty?
 
           persisted.map! do |record|
             if mem_record = memory.delete(record)

--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -32,6 +32,8 @@ require "models/discount"
 require "models/line_item"
 require "models/shipping_line"
 require "models/essay"
+require "models/member"
+require "models/membership"
 
 class AssociationsTest < ActiveRecord::TestCase
   fixtures :accounts, :companies, :developers, :projects, :developers_projects,
@@ -125,7 +127,7 @@ class AssociationsTest < ActiveRecord::TestCase
 end
 
 class AssociationProxyTest < ActiveRecord::TestCase
-  fixtures :authors, :author_addresses, :posts, :categorizations, :categories, :developers, :projects, :developers_projects
+  fixtures :authors, :author_addresses, :posts, :categorizations, :categories, :developers, :projects, :developers_projects, :members
 
   def test_push_does_not_load_target
     david = authors(:david)
@@ -298,6 +300,27 @@ class AssociationProxyTest < ActiveRecord::TestCase
 
     assert_equal 1, david.thinking_posts.size
     assert_equal 1, david.thinking_posts.to_a.size
+  end
+
+  def test_target_merging_ignores_persisted_in_memory_records_when_loaded_records_are_empty
+    member = members(:blarpy_winkup)
+    assert_empty member.favorite_memberships
+
+    membership = member.favorite_memberships.create!
+    membership.update!(favorite: false)
+
+    assert_empty member.favorite_memberships.to_a
+  end
+
+  def test_target_merging_recognizes_updated_in_memory_records
+    member = members(:blarpy_winkup)
+    membership = member.create_membership!(favorite: false)
+
+    assert_empty member.favorite_memberships
+
+    membership.update!(favorite: true)
+
+    assert_not_empty member.favorite_memberships.to_a
   end
 end
 


### PR DESCRIPTION
### Summary
This PR addresses a few bugs found while working in our Rails application. They impact associations with a scope, like so:
```ruby
class Coupon < ActiveRecord::Base
  has_many :coupon_redemptions, -> { where(expired: false) }
end
```

These bugs are caused by assuming that the list of in-memory targets have not been persisted to the database when the list of persisted records is empty.

Specifically, these are the 3 issues addressed:
```ruby
assert_empty with .to_a at the end.
coupon = Coupon.create!
coupon_redemption = coupon.coupon_redemptions.create!
coupon_redemption.update!(expired: true)
assert_empty coupon.coupon_redemptions.to_a
```

This test used to fail because [CollectionAssociation#merge_target_lists would return the in-memory records if no persisted records came back from the database](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L323). After this commit the test will pass because `merge_target_lists` will filter out any persisted records from the in-memory list.
```ruby
assert_empty without .to_a at the end.
coupon = Coupon.create!
coupon_redemption = coupon.coupon_redemptions.create!
coupon_redemption.update!(expired: true)
assert_empty coupon.coupon_redemptions
```

This test used to fail because [CollectionAssociation#empty? did not account for persisted records in memory before checking for emptiness](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/collection_association.rb#L228). This commit adds that scenario.

Calling `.size` before assert_empty
```ruby
coupon = Coupon.create!
coupon_redemption = coupon.coupon_redemptions.create!
coupon_redemption.update!(expired: true)
assert_equal 0, coupon.coupon_redemptions.size
assert_empty coupon.coupon_redemptions
```

This test used to fail through a more complex path. When asserting `coupon.coupon_redemptions.size` [the target gets marked as loaded as part of HasManyAssociation#count_records](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/has_many_association.rb#L85). This is an issue as the target value is not empty when we expect it to be. [The comment in the method above](https://github.com/rails/rails/blob/5fdbd217d18302cd277f80a9ba7fd567844ec324/activerecord/lib/active_record/associations/has_many_association.rb#L82-L84) validates that.
After this commit, the test will pass because we set the target to an empty array if target has no new records.

### Other Information

Removing this guard clause should not affect performance since persisted is empty, so the `map!` won't do anything.
```diff
def merge_target_lists(persisted, memory)
  return persisted if memory.empty?
- return memory if persisted.empty?
  
  persisted.map! do |record|
    # ...
  end
end
```