### PR TITLE
Reduce calls to singularize from where

### DIFF
--- a/activerecord/lib/active_record/reflection.rb
+++ b/activerecord/lib/active_record/reflection.rb
@@ -9,6 +9,7 @@ module ActiveRecord
 
     included do
       class_attribute :_reflections, instance_writer: false, default: {}
+      class_attribute :_plural_reflections, instance_writer: false, default: {}
       class_attribute :aggregate_reflections, instance_writer: false, default: {}
       class_attribute :automatic_scope_inversing, instance_writer: false, default: false
     end
@@ -23,6 +24,7 @@ module ActiveRecord
         ar.clear_reflections_cache
         name = -name.to_s
         ar._reflections = ar._reflections.except(name).merge!(name => reflection)
+        ar._plural_reflections = ar._plural_reflections.except(name).merge!(reflection.plural_name => reflection)
       end
 
       def add_aggregate_reflection(ar, name, reflection)
@@ -118,6 +120,10 @@ module ActiveRecord
 
       def _reflect_on_association(association) # :nodoc:
         _reflections[association.to_s]
+      end
+
+      def _reflect_on_association_with_plurals(association) # :nodoc:
+        _reflections[association.to_s] || _plural_reflections[association.to_s]
       end
 
       # Returns an array of AssociationReflection objects for all associations which have <tt>:autosave</tt> enabled.

--- a/activerecord/lib/active_record/table_metadata.rb
+++ b/activerecord/lib/active_record/table_metadata.rb
@@ -23,11 +23,11 @@ module ActiveRecord
     end
 
     def associated_with?(table_name)
-      klass&._reflect_on_association(table_name) || klass&._reflect_on_association(table_name.singularize)
+      klass&._reflect_on_association_with_plurals(table_name)
     end
 
     def associated_table(table_name)
-      reflection = klass._reflect_on_association(table_name) || klass._reflect_on_association(table_name.singularize)
+      reflection = klass._reflect_on_association_with_plurals(table_name)
 
       if !reflection && table_name == arel_table.name
         return self

--- a/activerecord/test/cases/relation/where_test.rb
+++ b/activerecord/test/cases/relation/where_test.rb
@@ -405,6 +405,11 @@ module ActiveRecord
       assert_equal author_addresses(:david_address), author_address
     end
 
+    def test_has_many_with_plural_association_name
+      author_address = AuthorAddress.where(authors: Author.where(name: "David")).first
+      assert_equal author_addresses(:david_address), author_address
+    end
+
     def test_where_on_association_with_select_relation
       essay = Essay.where(author: Author.where(name: "David").select(:name)).take
       assert_equal essays(:david_modest_proposal), essay


### PR DESCRIPTION
Co-authored-by: John Hawthorn <jhawthorn@github.com>

### Summary

We can reduce the number of calls to singularize from `where` queries by first checking if it is a column name.

benchmark:

<details>

```ruby
require "active_record"
require "logger"
require "stackprof"
require "benchmark/ips"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
  end
  create_table :comments, force: true do |t|
    t.belongs_to :post
    t.string :title
    t.text :body
    t.integer :likes
    t.datetime :posted_at
  end
end

class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

Benchmark.ips do |x|
  x.report "Comment.where" do
    Comment.where(title: "something", post: 5)
  end
end
```

</details>

before:

```
Warming up --------------------------------------
       Comment.where     1.427k i/100ms
Calculating -------------------------------------
       Comment.where     14.231k (± 2.4%) i/s -     71.350k in   5.016623s
```

after:

```
Warming up --------------------------------------
       Comment.where     3.273k i/100ms
Calculating -------------------------------------
       Comment.where     31.912k (± 2.4%) i/s -    160.377k in   5.028667s
```

which is a nice ~2.2 times faster `where` queries.

### Other Information

This could be considered a change in behavior since if you have an association with the same name as your column, we now prefer the column to the association. It seems to me that would be more correct behavior than preferring the the association.
