### PR TITLE
Preserve original application configs when configuring ActionMailer

### DIFF
--- a/actionmailer/lib/action_mailer/railtie.rb
+++ b/actionmailer/lib/action_mailer/railtie.rb
@@ -37,11 +37,11 @@ module ActionMailer
         extend ::AbstractController::Railties::RoutesHelpers.with(app.routes, false)
         include app.routes.mounted_helpers
 
-        register_interceptors(options.delete(:interceptors))
-        register_preview_interceptors(options.delete(:preview_interceptors))
-        register_observers(options.delete(:observers))
+        register_interceptors(options.interceptors)
+        register_preview_interceptors(options.preview_interceptors)
+        register_observers(options.observers)
 
-        if delivery_job = options.delete(:delivery_job)
+        if delivery_job = options.delivery_job
           self.delivery_job = delivery_job.constantize
         end
 
@@ -49,12 +49,14 @@ module ActionMailer
           self.smtp_settings = options.smtp_settings
         end
 
-        smtp_timeout = options.delete(:smtp_timeout)
+        smtp_timeout = options.smtp_timeout
 
         if self.smtp_settings && smtp_timeout
           self.smtp_settings[:open_timeout] ||= smtp_timeout
           self.smtp_settings[:read_timeout] ||= smtp_timeout
         end
+
+        options = options.except(:interceptors, :preview_interceptors, :observers, :delivery_job, :smtp_timeout)
 
         options.each { |k, v| send("#{k}=", v) }
       end


### PR DESCRIPTION
I have seen basically only one of all rails railties and engines also mutates original configs - https://github.com/rails/rails/blob/main/actionview/lib/action_view/railtie.rb. So maybe worth fixing too. 

Is there a reason not to leave original values? It will be easier for a user to find a config name in the `Configuring.md` guide and to check in the console, for example, what the configured value is without dropping to the internals and to find which other global config it sets.

Closes https://github.com/rails/rails/issues/44134