### PR TITLE
Perform a full reconnect on PG::UnableToSend during reconnect!

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -326,7 +326,7 @@ module ActiveRecord
         @lock.synchronize do
           begin
             @raw_connection.reset
-          rescue PG::ConnectionBad
+          rescue PG::ConnectionBad, PG::UnableToSend
             connect
           end
 


### PR DESCRIPTION
### Summary

On our setup, on some cases (when a PG reader crash for example), we receive a `PG::UnableToSend: no connection to the server` exception during `reconnect!` triggered by a `verify!`, not a `PG::ConnectionBad`.

We should consider doing a full reconnect in both cases.

