### PR TITLE
Remove delegation of #empty? in AC::Parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   Do not delegate `ActionController::Parameters#empty?` to underlying hash.
+    Instead, use own implementation.
+
+    *Paulo Barros*
+
 *   Allow only String and Symbol keys in `ActionController::Parameters`.
     Raise `ActionController::InvalidParameterKey` when initializing Parameters
     with keys that aren't strings or symbols.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -162,14 +162,6 @@ module ActionController
     # If no block is given, an enumerator is returned instead.
 
     ##
-    # :method: empty?
-    #
-    # :call-seq:
-    #   empty?()
-    #
-    # Returns true if the parameters have no key/value pairs.
-
-    ##
     # :method: has_key?
     #
     # :call-seq:
@@ -232,7 +224,7 @@ module ActionController
     #   value?(value)
     #
     # Returns true if the given value is present for some key in the parameters.
-    delegate :keys, :key?, :has_key?, :member?, :has_value?, :value?, :empty?, :include?,
+    delegate :keys, :key?, :has_key?, :member?, :has_value?, :value?, :include?,
       :as_json, :to_s, :each_key, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
@@ -414,6 +406,11 @@ module ActionController
     # Returns a new array of the values of the parameters.
     def values
       to_enum(:each_value).to_a
+    end
+
+    # Returns +true+ if the parameters have no key/value pairs.
+    def empty?
+      to_unsafe_h.empty?
     end
 
     # Attribute that keeps track of converted arrays, if any, to avoid double


### PR DESCRIPTION
This is part of #44813

### Summary

This PR removes `#empty?` from the list of delegated methods in `ActionController::Parameters` and adds its own implementation of said method.

The reasoning behind using `#to_unsafe_h` instead of `#to_h` is based on the fact that `#to_h` will exclude unpermitted params, which means the underlying hash is not really empty. However, one might argue that converting to `Hash` and calling `#empty?` on it is technically still delegating the method call. 😄 

No new tests were added/changed, since the [existing tests](https://github.com/rails/rails/blob/main/actionpack/test/controller/parameters/accessors_test.rb#L149-L156) already test the behavior of `#empty?`.

### Other Information

This is my first PR to rails, so bear with me if I am missing something. 😅 
