### PR TITLE
Do not delegate #include? in AC::Parameters

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add implementation and aliases for `ActionController::Parameters#include?`.
+
+    *Paulo Barros*
+
 *   Allow only String and Symbol keys in `ActionController::Parameters`.
     Raise `ActionController::InvalidParameterKey` when initializing Parameters
     with keys that aren't strings or symbols.

--- a/actionpack/lib/action_controller/metal/strong_parameters.rb
+++ b/actionpack/lib/action_controller/metal/strong_parameters.rb
@@ -170,44 +170,12 @@ module ActionController
     # Returns true if the parameters have no key/value pairs.
 
     ##
-    # :method: has_key?
-    #
-    # :call-seq:
-    #   has_key?(key)
-    #
-    # Returns true if the given key is present in the parameters.
-
-    ##
     # :method: has_value?
     #
     # :call-seq:
     #   has_value?(value)
     #
     # Returns true if the given value is present for some key in the parameters.
-
-    ##
-    # :method: include?
-    #
-    # :call-seq:
-    #   include?(key)
-    #
-    # Returns true if the given key is present in the parameters.
-
-    ##
-    # :method: key?
-    #
-    # :call-seq:
-    #   key?(key)
-    #
-    # Returns true if the given key is present in the parameters.
-
-    ##
-    # :method: member?
-    #
-    # :call-seq:
-    #   member?(key)
-    #
-    # Returns true if the given key is present in the parameters.
 
     ##
     # :method: keys
@@ -232,8 +200,7 @@ module ActionController
     #   value?(value)
     #
     # Returns true if the given value is present for some key in the parameters.
-    delegate :keys, :key?, :has_key?, :member?, :has_value?, :value?, :empty?, :include?,
-      :as_json, :to_s, :each_key, to: :@parameters
+    delegate :keys, :has_value?, :value?, :empty?, :as_json, :to_s, :each_key, to: :@parameters
 
     # By default, never raise an UnpermittedParameters exception if these
     # params are present. The default includes both 'controller' and 'action'
@@ -415,6 +382,14 @@ module ActionController
     def values
       to_enum(:each_value).to_a
     end
+
+    # Returns +true+ if the given key is present in the parameters.
+    def include?(key)
+      to_unsafe_h.include?(key)
+    end
+    alias_method :has_key?, :include?
+    alias_method :key?, :include?
+    alias_method :member?, :include?
 
     # Attribute that keeps track of converted arrays, if any, to avoid double
     # looping in the common use case permit + mass-assignment. Defined in a


### PR DESCRIPTION
This is part of #44813

### Summary

This PR removes `#include?`, `#has_key?`, `#key?` and `#member?` from the list of delegated methods in `ActionController::Parameters` and adds its own implementation of said method. The same aliases that exist in [`Hash`](https://ruby-doc.org/core-3.1.1/Hash.html#method-i-include-3F) are reproduced here (i.e. all other methods are aliases to `#include?`).

The reasoning behind using `#to_unsafe_h` instead of `#to_h` is based on the fact that `#to_h` will exclude unpermitted params. However, one might argue that converting to `Hash` and calling `#include?` on it is technically still delegating the method call. 😄 That said, maybe the right way is to check if the result of `#keys` (which is also delegated at the moment) includes a given key.

No new tests were added/changed, since the [existing tests](https://github.com/rails/rails/blob/main/actionpack/test/controller/parameters/accessors_test.rb#L180-L220) already test the behavior of those methods.
