### PR TITLE
Fix tag helper regression

### DIFF
--- a/actionview/test/template/tag_helper_test.rb
+++ b/actionview/test/template/tag_helper_test.rb
@@ -201,6 +201,8 @@ class TagHelperTest < ActionView::TestCase
                  content_tag(:p, "<script>evil_js</script>")
     assert_equal "<p><script>evil_js</script></p>",
                  content_tag(:p, "<script>evil_js</script>", nil, false)
+    assert_equal "<div @click=\"triggerNav()\">test</div>",
+                 content_tag(:div, "test", "@click": "triggerNav()")
   end
 
   def test_tag_builder_with_content

--- a/activesupport/lib/active_support/core_ext/string/output_safety.rb
+++ b/activesupport/lib/active_support/core_ext/string/output_safety.rb
@@ -12,7 +12,7 @@ class ERB
     JSON_ESCAPE_REGEXP = /[\u2028\u2029&><]/u
 
     # Following XML requirements: https://www.w3.org/TR/REC-xml/#NT-Name
-    TAG_NAME_START_REGEXP_SET = ":A-Z_a-z\u{C0}-\u{D6}\u{D8}-\u{F6}\u{F8}-\u{2FF}\u{370}-\u{37D}\u{37F}-\u{1FFF}" \
+    TAG_NAME_START_REGEXP_SET = "@:A-Z_a-z\u{C0}-\u{D6}\u{D8}-\u{F6}\u{F8}-\u{2FF}\u{370}-\u{37D}\u{37F}-\u{1FFF}" \
                                 "\u{200C}-\u{200D}\u{2070}-\u{218F}\u{2C00}-\u{2FEF}\u{3001}-\u{D7FF}\u{F900}-\u{FDCF}" \
                                 "\u{FDF0}-\u{FFFD}\u{10000}-\u{EFFFF}"
     TAG_NAME_START_REGEXP = /[^#{TAG_NAME_START_REGEXP_SET}]/


### PR DESCRIPTION
Vue.js, alpinejs, and potentially other JS libraries support tags
starting with `@` symbols. This was broken by the recent security release in
https://github.com/rails/rails/commit/649516ce0feb699ae06a8c5e81df75d460cc9a85

I've only added `@` to the list even though there are potentially other
safe characters. We can add more if necessary (and if safe).

Fixes:
* #45014
* #44972 

cc/ @tenderlove 