### PR TITLE
Avoid query from calculations on contradictory relation

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,14 @@
+*   Avoid queries when performing calculations on contradictory relations.
+
+    Previously calculations would make a query even when passed a
+    contradiction, such as `User.where(id: []).count`. We no longer perform a
+    query in that scenario.
+
+    This applies to the following calculations: `count`, `sum`, `average`,
+    `minimum` and `maximum`
+
+    *Luan Vieira, John Hawthorn and Daniel Colson*
+
 *   Allow using aliased attributes with `insert_all`/`upsert_all`.
 
     ```ruby

--- a/activerecord/test/cases/calculations_test.rb
+++ b/activerecord/test/cases/calculations_test.rb
@@ -717,6 +717,36 @@ class CalculationsTest < ActiveRecord::TestCase
         Account.where("credit_limit > 50").from("accounts").maximum(:credit_limit)
   end
 
+  def test_no_queries_for_empty_relation_on_count
+    assert_queries(0) do
+      assert_equal 0, Post.where(id: []).count
+    end
+  end
+
+  def test_no_queries_for_empty_relation_on_sum
+    assert_queries(0) do
+      assert_equal 0, Post.where(id: []).sum(:tags_count)
+    end
+  end
+
+  def test_no_queries_for_empty_relation_on_average
+    assert_queries(0) do
+      assert_nil Post.where(id: []).average(:tags_count)
+    end
+  end
+
+  def test_no_queries_for_empty_relation_on_minimum
+    assert_queries(0) do
+      assert_nil Account.where(id: []).minimum(:id)
+    end
+  end
+
+  def test_no_queries_for_empty_relation_on_maximum
+    assert_queries(0) do
+      assert_nil Account.where(id: []).maximum(:id)
+    end
+  end
+
   def test_maximum_with_not_auto_table_name_prefix_if_column_included
     Company.create!(name: "test", contracts: [Contract.new(developer_id: 7)])
 


### PR DESCRIPTION
### Summary

Previously, relation calculations such as `count` would make a query even when passed a contradiction, like `User.where(id: []).count`. 

@jhawthorn has worked on avoiding queries for contradictions in a couple of PRs already:
* https://github.com/rails/rails/pull/37266 addressed loading records
* https://github.com/rails/rails/pull/40387 addressed the `exists?` method

@composerinteralia , @jhawthorn and I spotted this missed optimization for relation calculations and used the previous PRs as guides

This PR avoids making a query to the database when the relation used for `count`, `sum`, `average`, `minimum` and `maximum` is a contradiction.
