### PR TITLE
docs: Reformat code in Placeholder Conditions [ci-skip]

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -587,7 +587,7 @@ Similar to the `(?)` replacement style of params, you can also specify keys in y
 
 ```ruby
 Book.where("created_at >= :start_date AND created_at <= :end_date",
-  {start_date: params[:start_date], end_date: params[:end_date]})
+  { start_date: params[:start_date], end_date: params[:end_date] })
 ```
 
 This makes for clearer readability if you have a large number of variable conditions.


### PR DESCRIPTION
### Summary

This PR inserts spaces inside curly brackets in Placeholder Conditions in Active Record Query Interface to follow the coding conventions.

I chose

```diff
  Book.where("created_at >= :start_date AND created_at <= :end_date",
-   {start_date: params[:start_date], end_date: params[:end_date]})
+   { start_date: params[:start_date], end_date: params[:end_date] })
```

instead of

```diff
  Book.where("created_at >= :start_date AND created_at <= :end_date",
-   {start_date: params[:start_date], end_date: params[:end_date]})
+   start_date: params[:start_date], end_date: params[:end_date])
```

to match with the docs in `activerecord/lib/active_record/relation/query_methods.rb`. But I think the later is also good because the docs uses parenthesis in array but the rails guides doesn't.

I would appreciate if you could review this.

---

(*) `{ a: 1 }` is prefferd than `{a:1}`.
https://github.com/rails/rails/blob/v7.0.2.4/.rubocop.yml#L174-L176

(*) `where` description in `activerecord/lib/active_record/relation/query_methods.rb`:
https://github.com/rails/rails/blob/v7.0.2.4/activerecord/lib/active_record/relation/query_methods.rb#L635-L640
