### PR TITLE
Allow using aliased attributes with `insert_all`/`upsert_all`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Allow using aliased attributes with `insert_all`/`upsert_all`.
+
+    ```ruby
+    class Book < ApplicationRecord
+      alias_attribute :title, :name
+    end
+
+    Book.insert_all [{ title: "Remote", author_id: 1 }], returning: :title
+    ```
+
+    *fatkodima*
+
 *   Support encrypted attributes on columns with default db values.
 
 This adds support for encrypted attributes defined on columns with default values. 

--- a/activerecord/test/cases/insert_all_test.rb
+++ b/activerecord/test/cases/insert_all_test.rb
@@ -263,6 +263,25 @@ class InsertAllTest < ActiveRecord::TestCase
     end
   end
 
+  def test_insert_all_and_upsert_all_with_aliased_attributes
+    if supports_insert_returning?
+      assert_difference "Book.count" do
+        result = Book.insert_all [{ title: "Remote", author_id: 1 }], returning: :title
+        assert_includes result.columns, "title"
+      end
+    end
+
+    if supports_insert_on_duplicate_update?
+      Book.upsert_all [{ id: 101, title: "Perelandra", author_id: 7, isbn: "1974522598" }]
+      Book.upsert_all [{ id: 101, title: "Perelandra 2", author_id: 6, isbn: "111111" }], update_only: %i[ title isbn ]
+
+      book = Book.find(101)
+      assert_equal "Perelandra 2", book.title, "Should have updated the title"
+      assert_equal "111111", book.isbn, "Should have updated the isbn"
+      assert_equal 7, book.author_id, "Should not have updated the author_id"
+    end
+  end
+
   def test_upsert_logs_message_including_model_name
     skip unless supports_insert_on_duplicate_update?
 

--- a/activerecord/test/models/book.rb
+++ b/activerecord/test/models/book.rb
@@ -11,6 +11,8 @@ class Book < ActiveRecord::Base
 
   has_one :essay
 
+  alias_attribute :title, :name
+
   enum status: [:proposed, :written, :published]
   enum last_read: { unread: 0, reading: 2, read: 3, forgotten: nil }
   enum nullable_status: [:single, :married]


### PR DESCRIPTION
```ruby
class Book < ApplicationRecord
  alias_attribute :title, :name
end

Book.insert_all [{ title: "Remote", author_id: 1 }], returning: :title
```

Small convenience. Currently, it raises `unknown attribute 'title' for Book. (ActiveModel::UnknownAttributeError)`