### PR TITLE
Delegated Type supports customizeable foreign_type column

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,10 @@
+*   Respect `foreign_type` option to `delegated_type` for `{role}_class` method.
+
+    Usage of `delegated_type` with non-conventional `{role}_type` column names can now be specified with `foreign_type` option.
+    This option is the same as `foreign_type` as forwarded to the underlying `belongs_to` association that `delegated_type` wraps.
+
+    *Jason Karns*
+
 *   Add support for unique constraints (PostgreSQL-only).
 
     ```ruby

--- a/activerecord/lib/active_record/delegated_type.rb
+++ b/activerecord/lib/active_record/delegated_type.rb
@@ -192,6 +192,11 @@ module ActiveRecord
     #   +role+ with an "_id" suffix. So a class that defines a
     #   <tt>delegated_type :entryable, types: %w[ Message Comment ]</tt> association will use "entryable_id" as
     #   the default <tt>:foreign_key</tt>.
+    # [:foreign_type]
+    #   Specify the column used to store the associated object's type. By default this is inferred to be the passed
+    #   +role+ with a "_type" suffix. A class that defines a
+    #   <tt>delegated_type :entryable, types: %w[ Message Comment ]</tt> association will use "entryable_type" as
+    #   the default <tt>:foreign_type</tt>.
     # [:primary_key]
     #   Specify the method that returns the primary key of associated object used for the convenience methods.
     #   By default this is +id+.
@@ -211,11 +216,11 @@ module ActiveRecord
     private
       def define_delegated_type_methods(role, types:, options:)
         primary_key = options[:primary_key] || "id"
-        role_type = "#{role}_type"
+        role_type = options[:foreign_type] || "#{role}_type"
         role_id   = options[:foreign_key] || "#{role}_id"
 
         define_method "#{role}_class" do
-          public_send("#{role}_type").constantize
+          public_send(role_type).constantize
         end
 
         define_method "#{role}_name" do

--- a/activerecord/test/cases/delegated_type_test.rb
+++ b/activerecord/test/cases/delegated_type_test.rb
@@ -11,11 +11,12 @@ require "models/uuid_message"
 require "models/uuid_comment"
 
 class DelegatedTypeTest < ActiveRecord::TestCase
-  fixtures :comments, :accounts
+  fixtures :comments, :accounts, :posts
 
   setup do
     @entry_with_message = Entry.create! entryable: Message.new(subject: "Hello world!"), account: accounts(:signals37)
     @entry_with_comment = Entry.create! entryable: comments(:greetings), account: accounts(:signals37)
+    @entry_with_post = Entry.create! thing: posts(:welcome), account: accounts(:signals37)
 
     if current_adapter?(:PostgreSQLAdapter)
       @uuid_entry_with_message = UuidEntry.create! uuid: SecureRandom.uuid, entryable: UuidMessage.new(uuid: SecureRandom.uuid, subject: "Hello world!")
@@ -26,6 +27,12 @@ class DelegatedTypeTest < ActiveRecord::TestCase
   test "delegated class" do
     assert_equal Message, @entry_with_message.entryable_class
     assert_equal Comment, @entry_with_comment.entryable_class
+  end
+
+  test "delegated class with custom foreign_type" do
+    assert_equal Message, @entry_with_message.thing_class
+    assert_equal Comment, @entry_with_comment.thing_class
+    assert_equal Post, @entry_with_post.thing_class
   end
 
   test "delegated type name" do
@@ -44,9 +51,19 @@ class DelegatedTypeTest < ActiveRecord::TestCase
     assert_not @entry_with_comment.message?
   end
 
+  test "delegated type predicates with custom foreign_type" do
+    assert @entry_with_post.post?
+    assert_not @entry_with_message.post?
+    assert_not @entry_with_comment.post?
+  end
+
   test "scope" do
     assert Entry.messages.first.message?
     assert Entry.comments.first.comment?
+  end
+
+  test "scope with custom foreign_type" do
+    assert Entry.posts.first.post?
   end
 
   test "accessor" do

--- a/activerecord/test/models/entry.rb
+++ b/activerecord/test/models/entry.rb
@@ -3,4 +3,8 @@
 class Entry < ActiveRecord::Base
   delegated_type :entryable, types: %w[ Message Comment ]
   belongs_to :account, touch: true
+
+  # alternate delegation for custom foreign_key/foreign_type
+  delegated_type :thing, types: %w[ Post ],
+    foreign_key: :entryable_id, foreign_type: :entryable_type
 end


### PR DESCRIPTION
Adds support for customizing `delegated_type`'s `{role}_type` column via the `foreign_type` option.

### Summary

Delegated Types leans heavily on Rails’ existing polymorphic associations. The primary association created by `delegated_type` is a polymorphic `belongs_to` association.

For apps that are using polymorphic associations but need to customize the column containing the type/class, `foreign_type` is available as an option. It would be helpful if the same customization were available for Delegated Types.

Since delegated_types already passes its options along to the underlying belongs_to association, this is a relatively straightforward change. Instead of only deriving the type column by using "#{role}_type", it can respect a `foreign_type` option. (Same option key as used by polymorphic associations.)

Example:

```rb
delegated_type :entryable, types: %w[ Message Comment ], foreign_type: :entry_class
```
