### PR TITLE
Add anchor to a link in `load_defaults`'s api guide [ci-skip]

### DIFF
--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -83,7 +83,7 @@ module Rails
 
       # Loads default configuration values for a target version. This includes
       # defaults for versions prior to the target version. See the
-      # {configuration guide}[https://guides.rubyonrails.org/configuring.html]
+      # {configuration guide}[https://guides.rubyonrails.org/configuring.html#versioned-default-values]
       # for the default values associated with a particular version.
       def load_defaults(target_version)
         case target_version.to_s


### PR DESCRIPTION
### Summary

This PR adds an anchor to a link in `load_default`'s API guide.

The link didn't have the anchor, but the linked document has an appropriate anchor. So this PR adds the anchor to the link



### Other Information

The anchor is here: https://guides.rubyonrails.org/configuring.html#versioned-default-values

