### PR TITLE
Fix a typo in Active Record Encryption guide

### DIFF
--- a/guides/source/active_record_encryption.md
+++ b/guides/source/active_record_encryption.md
@@ -221,7 +221,7 @@ class Person
 end
 ```
 
-They will also work when combining encrypted and unencrypted data,git and when configuring previous encryption schemes.
+They will also work when combining encrypted and unencrypted data, and when configuring previous encryption schemes.
 
 NOTE: If you want to ignore case, make sure to use `downcase:` or `ignore_case:` in the `encrypts` declaration. Using the `case_sensitive:` option in the validation won't work.
 


### PR DESCRIPTION
### Summary

When I read the guide I faced an unclear sentence, so I reached an author @jorgemanrubia in https://github.com/rails/rails/pull/43694#pullrequestreview-965463431, he confirmed it was a typo.
