### PR TITLE
Fix usage of “all_queries” flag when using multiple default scopes

### DIFF
--- a/activerecord/lib/active_record/scoping/default.rb
+++ b/activerecord/lib/active_record/scoping/default.rb
@@ -150,11 +150,13 @@ module ActiveRecord
               end
             elsif default_scopes.any?
               evaluate_default_scope do
-                default_scopes.inject(relation) do |default_scope, scope_obj|
+                default_scopes.inject(relation) do |combined_scope, scope_obj|
                   if execute_scope?(all_queries, scope_obj)
                     scope = scope_obj.scope.respond_to?(:to_proc) ? scope_obj.scope : scope_obj.scope.method(:call)
 
-                    default_scope.instance_exec(&scope) || default_scope
+                    combined_scope.instance_exec(&scope) || combined_scope
+                  else
+                    combined_scope
                   end
                 end
               end

--- a/activerecord/test/cases/scoping/default_scoping_test.rb
+++ b/activerecord/test/cases/scoping/default_scoping_test.rb
@@ -80,6 +80,23 @@ class DefaultScopingTest < ActiveRecord::TestCase
     assert_equal 50000,   wheres["salary"]
   end
 
+  def test_combined_default_scope_without_and_with_all_queries_works
+    Mentor.create!
+    klass = DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries
+
+    create_sql = capture_sql { klass.create!(name: "Steve") }.first
+
+    assert_match(/mentor_id/, create_sql)
+    assert_match(/firm_id/, create_sql)
+
+    developer = klass.find_by!(name: "Steve")
+
+    update_sql = capture_sql { developer.update(name: "Stephen") }.first
+
+    assert_no_match(/mentor_id/, update_sql)
+    assert_match(/firm_id/, update_sql)
+  end
+
   def test_default_scope_runs_on_create
     Mentor.create!
     create_sql = capture_sql { DeveloperwithDefaultMentorScopeNot.create!(name: "Eileen") }.first

--- a/activerecord/test/models/developer.rb
+++ b/activerecord/test/models/developer.rb
@@ -164,7 +164,20 @@ end
 
 class DeveloperWithDefaultNilableMentorScopeAllQueries < ActiveRecord::Base
   self.table_name = "developers"
-  firm_id = nil # Could be something like Current.mentor_id
+  firm_id = nil # Could be something like Current.firm_id
+  default_scope -> { where(firm_id: firm_id) if firm_id }, all_queries: true
+end
+
+module MentorDefaultScopeNotAllQueries
+  extend ActiveSupport::Concern
+
+  included { default_scope { where(mentor_id: 1) } }
+end
+
+class DeveloperWithIncludedMentorDefaultScopeNotAllQueriesAndDefaultScopeFirmWithAllQueries < ActiveRecord::Base
+  include MentorDefaultScopeNotAllQueries
+  self.table_name = "developers"
+  firm_id = 10 # Could be something like Current.firm_id
   default_scope -> { where(firm_id: firm_id) if firm_id }, all_queries: true
 end
 


### PR DESCRIPTION
### Summary

In our use case - we have a base model that has a default scope that we
want enabled for all queries, ex:

```ruby
class Developer < ApplicationRecord
  default_scope -> { where(firm_id: Current.firm_id) }, all_queries: true
end
```

We're also leveraging a module that will add a default scope to only
find soft-deleted records.

```ruby
module SoftDeletable
  extend ActiveSupport::Concern

  included do
    default_scope { where(deleted_at: nil) }
  end
```

Through this, we've found that when using default scopes in combination,
*specifically in the use case where the _non_ all queries scope is
declared first*, that we would get an error when calling `.update`:

```ruby
class Developer < ApplicationRecord
  include SoftDeletable

  default_scope -> { where(firm_id: Current.firm_id) }, all_queries: true
```

```ruby
Current.firm_id = 5

developer = Developer.new(name: "Steve")

developer.update(name: "Stephen")

NoMethodError: undefined method `where' for nil:NilClass
```

In digging into the code, this was due to there not being an `else` case
for the `inject` used to combine `default_scopes` together (`inject`
  uses the return value of the block as the memoizer).

Without the `else` case, if the block returned `nil`, `nil` was passed
to the evaluation of the next `default_scope`.

This commit adds the `else`, and also makes a minor adjustment in
variable naming (`default_scope` to `combined_scope`) in an effort to
add a little more readability, as we're iterating over an array of
default scopes, but what we're building is _the_ default scope to be
used in the query, etc.

### Other Information

If you want to test this out in a script, here is one you can run.

Note - to test against my intended fix - comment out the usage of `rails`’s main branch, and use mine instead.

```ruby

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  # Broken
  gem "rails", github: "rails/rails", branch: "main"

  # With Fix
  # gem "rails", github: "thewatts/rails", branch: "nw-fix-default-scope-all-queries"

  gem "sqlite3"
end

require "active_record"
require "minitest/autorun"
require "logger"

class Current < ActiveSupport::CurrentAttributes
  attribute :firm_id
end

# This connection will do for database-independent bug reports.
ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)

ActiveRecord::Schema.define do
  create_table :developers, force: true do |t|
    t.string :name
    t.integer :firm_id
    t.datetime :deleted_at
  end
end

class Developer < ActiveRecord::Base
  default_scope { where(deleted_at: nil) }
  default_scope -> { where(firm_id: Current.firm_id) }, all_queries: true
end


class BugTest < Minitest::Test
  def test_with_combined_default_scopes_first_being_not_all_queries
    Current.firm_id = 5

    developer = Developer.create!(name: "Steve")

    developer.update!(name: "Stephen")

    assert developer.name, "Stephen"
  end
end
```
