### PR TITLE
Bump strscan to 3.0.2 to address bug_report_templates/action_controller_gem.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,7 @@ GEM
     stackprof (0.2.17)
     stimulus-rails (1.0.2)
       railties (>= 6.0.0)
-    strscan (3.0.1)
+    strscan (3.0.2)
     sucker_punch (3.0.1)
       concurrent-ruby (~> 1.0)
     tailwindcss-rails (2.0.3)


### PR DESCRIPTION
### Summary

This commit addresses the following error.

```ruby
% ruby -v
ruby 2.7.6p219 (2022-04-12 revision c9c2245c0a) [arm64-darwin21]
% cd guides/bug_report_templates
% ruby action_controller_gem.rb
Fetching gem metadata from https://rubygems.org/...........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
... snip ...
Fetching strscan 3.0.2
Installing strscan 3.0.2 with native extensions
Traceback (most recent call last):
	9: from action_controller_gem.rb:5:in `<main>'
	8: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/inline.rb:54:in `gemfile'
	7: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/settings.rb:124:in `temporary'
	6: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/inline.rb:70:in `block in gemfile'
	5: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/runtime.rb:26:in `setup'
	4: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/runtime.rb:26:in `map'
	3: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/spec_set.rb:147:in `each'
	2: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/spec_set.rb:147:in `each'
	1: from /Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/runtime.rb:31:in `block in setup'
/Users/yahonda/.rbenv/versions/2.7.6/lib/ruby/2.7.0/bundler/runtime.rb:312:in `check_for_activated_spec!': You have already activated strscan 3.0.1, but your Gemfile requires strscan 3.0.2. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
%
```

Background:

- It has been failing since this build
https://buildkite.com/rails/rails/builds/86305#9be4d24a-2944-4660-b5f0-03aac7992131

- strscan 3.0.2 has been released on May 9, 2022
https://rubygems.org/gems/strscan/versions/3.0.2

