### PR TITLE
Replace execute statement with DRY call to rename_index

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -385,9 +385,9 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"
           pk, seq = pk_and_sequence_for(new_name)
           if pk
-            idx = "#{table_name}_pkey"
+            old_idx = "#{table_name}_pkey"
             new_idx = "#{new_name}_pkey"
-            execute "ALTER INDEX #{quote_table_name(idx)} RENAME TO #{quote_table_name(new_idx)}"
+            rename_index(table_name, old_idx, new_idx)
             if seq && seq.identifier == "#{table_name}_#{pk}_seq"
               new_seq = "#{new_name}_#{pk}_seq"
               execute "ALTER TABLE #{seq.quoted} RENAME TO #{quote_table_name(new_seq)}"

--- a/activerecord/test/cases/migration/compatibility_test.rb
+++ b/activerecord/test/cases/migration/compatibility_test.rb
@@ -585,6 +585,11 @@ module ActiveRecord
           else
             assert_match(/Identifier name '#{long_table_name}' is too long/i, error.message)
           end
+        elsif current_adapter?(:PostgreSQLAdapter)
+          error = assert_raises(StandardError) do
+            ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
+          end
+          assert_match(/Index name '#{long_table_name}_pkey' on table 'more_testings' is too long/i, error.message)
         else
           ActiveRecord::Migrator.new(:up, [migration], @schema_migration).migrate
           assert connection.table_exists?(long_table_name)


### PR DESCRIPTION
### Summary

DRY SQL command `ALTER INDEX #{quote_table_name(idx)} RENAME TO #{quote_table_name(new_idx)}` with existing method `rename_index`, which also contains index name length validation `def validate_index_length`