### PR TITLE
Raise when saving readonly aliased attributes

### DIFF
--- a/activemodel/lib/active_model/attribute_methods.rb
+++ b/activemodel/lib/active_model/attribute_methods.rb
@@ -208,6 +208,8 @@ module ActiveModel
       #   person.nickname_short? # => true
       def alias_attribute(new_name, old_name)
         self.attribute_aliases = attribute_aliases.merge(new_name.to_s => old_name.to_s)
+        attr_readonly(old_name) if respond_to?(:attr_readonly) && readonly_attribute?(new_name)
+
         ActiveSupport::CodeGenerator.batch(self, __FILE__, __LINE__) do |code_generator|
           attribute_method_patterns.each do |pattern|
             method_name = pattern.method_name(new_name).to_s

--- a/activerecord/lib/active_record/readonly_attributes.rb
+++ b/activerecord/lib/active_record/readonly_attributes.rb
@@ -23,7 +23,9 @@ module ActiveRecord
       #   post = Post.create!(title: "Introducing Ruby on Rails!")
       #   post.update(title: "a different title") # change to title will be ignored
       def attr_readonly(*attributes)
-        self._attr_readonly = Set.new(attributes.map(&:to_s)) + (_attr_readonly || [])
+        attributes = attributes.map(&:to_s)
+        attributes += attributes.select { |attr| attribute_alias(attr) }.compact if respond_to?(:attribute_alias)
+        self._attr_readonly = Set.new(attributes) + (_attr_readonly || [])
       end
 
       # Returns an array of all the attributes that have been specified as readonly.
@@ -32,7 +34,7 @@ module ActiveRecord
       end
 
       def readonly_attribute?(name) # :nodoc:
-        _attr_readonly.include?(name)
+        _attr_readonly.include?(name.to_s)
       end
     end
   end

--- a/activerecord/test/cases/base_test.rb
+++ b/activerecord/test/cases/base_test.rb
@@ -66,6 +66,11 @@ class ReadonlyTitlePost < Post
   attr_readonly :title
 end
 
+class ReadonlyAliasedTitlePost < Post
+  attr_readonly :name
+  alias_attribute :name, :title
+end
+
 class Weird < ActiveRecord::Base; end
 
 class LintTest < ActiveRecord::TestCase
@@ -700,6 +705,19 @@ class BasicsTest < ActiveRecord::TestCase
     post.update(title: "try to change", body: "changed")
     post.reload
     assert_equal "cannot change this", post.title
+    assert_equal "changed", post.body
+  end
+
+  def test_readonly_aliased_attributes
+    assert_equal Set.new([ "name", "title", "comments_count" ]), ReadonlyAliasedTitlePost.readonly_attributes
+
+    post = ReadonlyAliasedTitlePost.create(name: "cannot change this", body: "changeable")
+    post.reload
+    assert_equal "cannot change this", post.name
+
+    post.update(name: "try to change", body: "changed")
+    post.reload
+    assert_equal "cannot change this", post.name
     assert_equal "changed", post.body
   end
 


### PR DESCRIPTION
```ruby
class Post < ApplicationRecord
  alias_attribute :name, :title
  attr_readonly :name
end
```

`post.update(name: "Name changed")` succeeds, while should not. This PR fixes that.
