### PR TITLE
Rename "Contributions" Guides section to "Contributing"

### DIFF
--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -288,7 +288,7 @@
       description: This guide describes the considerations needed and tools available when working directly with concurrency in a Rails application.
       work_in_progress: true
 -
-  name: Contributions
+  name: Contributing
   documents:
     -
       name: Contributing to Ruby on Rails


### PR DESCRIPTION
### Summary

The Contributions section in the guides doesn't document "contributions
to Rails" but "how to Contribute to Rails".
By renaming the section title to "Contributing", it would better describe
the guides for this section.

An alternative could be "Contributing to Rails" similar to "Extending Rails", but
the first guide already uses "Contributing to Ruby on Rails".