### PR TITLE
Pattern matching APIs for records and relations.

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,26 @@
+*   Define pattern matching APIs for records and relations.
+
+    This provides the Ruby 2.7+ pattern matching interface for Active Record
+    records and relations. It allows the user to pattern match against
+    attributes and associations on records through a hash pattern. It also
+    allows the user to pattern match against relations through an array pattern.
+
+    ```ruby
+    class Post < ActiveRecord::Base
+      has_many :comments
+    end
+
+    class Comment < ActiveRecord::Base
+      belongs_to :post
+    end
+
+    post = Post.new(title: "Welcome!", comments: [Comment.new(body: "Thanks!")])
+    post => { title: "Welcome!", comments: [Comment[body:]] }
+    body # => "Thanks!"
+    ```
+
+    *Kevin Newton*
+
 *   Avoid queries when performing calculations on contradictory relations.
 
     Previously calculations would make a query even when passed a

--- a/activerecord/lib/active_record/base.rb
+++ b/activerecord/lib/active_record/base.rb
@@ -11,6 +11,7 @@ require "active_record/relation/delegation"
 require "active_record/attributes"
 require "active_record/type_caster"
 require "active_record/database_configurations"
+require "active_record/pattern_matching"
 
 module ActiveRecord # :nodoc:
   # = Active Record
@@ -328,6 +329,7 @@ module ActiveRecord # :nodoc:
     include SignedId
     include Suppressor
     include Encryption::EncryptableRecord
+    include PatternMatching::Record
   end
 
   ActiveSupport.run_load_hooks(:active_record, Base)

--- a/activerecord/lib/active_record/pattern_matching.rb
+++ b/activerecord/lib/active_record/pattern_matching.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  # = Active Record Pattern Matching
+  module PatternMatching
+    # Provides the pattern matching interface for an Active Record model.
+    module Record
+      # Returns a hash of attributes for the given keys. Provides the pattern
+      # matching interface for matching against hash patterns. For example:
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   def greeting_for(person)
+      #     case person
+      #     in { name: "Mary" }
+      #       "Welcome back, Mary!"
+      #     in { name: }
+      #       "Welcome, stranger!"
+      #     end
+      #   end
+      #
+      #   person = Person.new
+      #   person.name = "Mary"
+      #   greeting_for(person) # => "Welcome back, Mary!"
+      #
+      #   person = Person.new
+      #   person.name = "Bob"
+      #   greeting_for(person) # => "Welcome, stranger!"
+      def deconstruct_keys(keys)
+        deconstructed = {}
+
+        keys.each do |key|
+          method = key.to_s
+
+          if attribute_method?(method)
+            # Here we're pattern matching against an attribute method. We're
+            # going to use the [] method so that we either get the value or
+            # raise an error for a missing attribute in case it wasn't loaded.
+            deconstructed[key] = self[method]
+          elsif self.class.reflect_on_association(method)
+            # Here we're going to pattern match against an association. We're
+            # going to use the main interface for that association which can be
+            # further pattern matched later.
+            deconstructed[key] = public_send(method)
+          end
+        end
+
+        deconstructed
+      end
+    end
+
+    # Provides the pattern matching interface for an Active Record relation.
+    module Relation
+      # Returns a hash of attributes for the given keys. Provides the pattern
+      # matching interface for matching against array patterns. For example:
+      #
+      #   class Person < ActiveRecord::Base
+      #   end
+      #
+      #   case Person.all
+      #   in []
+      #     "No one is here"
+      #   in [{ name: "Mary" }]
+      #     "Only Mary is here"
+      #   in [_]
+      #     "Only one person is here"
+      #   in [_, _, *]
+      #     "More than one person is here"
+      #   end
+      #
+      # Be wary when using this method with a large number of records, as it
+      # will load everything into memory.
+      def deconstruct
+        records
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -17,6 +17,7 @@ module ActiveRecord
 
     include Enumerable
     include FinderMethods, Calculations, SpawnMethods, QueryMethods, Batches, Explain, Delegation
+    include PatternMatching::Relation
 
     attr_reader :table, :klass, :loaded, :predicate_builder
     attr_accessor :skip_preloading_value

--- a/activerecord/test/cases/pattern_matching_test.rb
+++ b/activerecord/test/cases/pattern_matching_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/comment"
+require "models/post"
+
+class PatternMatchingTest < ActiveRecord::TestCase
+  fixtures :posts, :comments
+
+  def test_matching_attributes
+    case posts(:welcome)
+    in { title: "Welcome to the weblog", body: }
+      assert_equal("Such a lovely day", body)
+    else
+      flunk("Unable to pattern match")
+    end
+  end
+
+  def test_matching_relations
+    case posts(:welcome)
+    in { title: "Welcome to the weblog", comments: }
+      assert_equal(2, comments.size)
+    else
+      flunk("Unable to pattern match")
+    end
+  end
+
+  def test_matching_relations_attributes
+    case posts(:thinking)
+    in { title: "So I was thinking", body:, comments: [{ body: "Don't think too hard" }] }
+      assert_equal("Like I hopefully always am", body)
+    else
+      flunk("Unable to pattern match")
+    end
+  end
+
+  def test_matching_relations_classes
+    case posts(:thinking)
+    in { title: "So I was thinking", comments: [Comment[body:]] }
+      assert_equal("Don't think too hard", body)
+    else
+      flunk("Unable to pattern match")
+    end
+  end
+end


### PR DESCRIPTION
This provides the Ruby 2.7+ pattern matching interface for Active Record
records and relations. It allows the user to pattern match against
attributes and associations on records through a hash pattern. It also
allows the user to pattern match against relations through an array pattern.

```ruby
class Post < ActiveRecord::Base
  has_many :comments
end

class Comment < ActiveRecord::Base
  belongs_to :post
end

post = Post.new(title: "Welcome!", comments: [Comment.new(body: "Thanks!")])
post => { title: "Welcome!", comments: [Comment[body:]] }
body # => "Thanks!"
```