### PR TITLE
Dynamic Includes

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,27 @@
+*   Dynamic Includes
+
+    Added a feature to automatically prefill an association on reference.
+
+    Normally this code would n+1 and happen in 9 queries, when
+    using the dynamic includes block it will prefill the association
+    on reference causing this to only create 4 database queries:
+
+    developers = Developer.where(id: [developer.id, developer2.id])
+
+        ActiveRecord.enable_dynamic_includes do
+            assert_queries(4) do
+                developers.each do |d|
+                d.ship.parts.each do |part|
+                    part.trinkets.each do |t|
+                    t
+                    end
+                end
+                end
+            end
+        end
+
+    * Cory Gwin *
+
 *   Fixed MariaDB default function support.
 
     Defaults would be written wrong in "db/schema.rb" and not work correctly

--- a/activerecord/lib/active_record.rb
+++ b/activerecord/lib/active_record.rb
@@ -44,12 +44,14 @@ module ActiveRecord
   autoload :DelegatedType
   autoload :DestroyAssociationAsyncJob
   autoload :DynamicMatchers
+  autoload :DynamicIncludes
   autoload :Encryption
   autoload :Enum
   autoload :Explain
   autoload :Inheritance
   autoload :Integration
   autoload :InternalMetadata
+  autoload :LoadTree
   autoload :Migration
   autoload :Migrator, "active_record/migration"
   autoload :ModelSchema
@@ -340,6 +342,8 @@ module ActiveRecord
 
   singleton_class.attr_accessor :query_transformers
   self.query_transformers = []
+
+  include DynamicIncludes
 
   def self.eager_load!
     super

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -321,6 +321,9 @@ module ActiveRecord
         def merge_target_lists(persisted, memory)
           return persisted if memory.empty?
           return memory    if persisted.empty?
+          # If merge target list ran in the preloader, then
+          # the in memory records will be the same array as the persisted records
+          return persisted if persisted.equal?(memory)
 
           persisted.map! do |record|
             if mem_record = memory.delete(record)

--- a/activerecord/lib/active_record/dynamic_includes.rb
+++ b/activerecord/lib/active_record/dynamic_includes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module DynamicIncludes
+    extend ActiveSupport::Concern
+
+    included do
+      def self.dynamic_includes_enabled=(value)
+        ActiveSupport::IsolatedExecutionState[:dynamic_includes_enabled] = value
+      end
+
+      def self.dynamic_includes_enabled?
+        ActiveSupport::IsolatedExecutionState[:dynamic_includes_enabled] ||= false
+      end
+
+      def self.with_dynamic_includes(enabled: true)
+        prior_value = self.dynamic_includes_enabled?
+        self.dynamic_includes_enabled = enabled
+        yield
+      ensure
+        self.dynamic_includes_enabled = prior_value
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/load_tree.rb
+++ b/activerecord/lib/active_record/load_tree.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  class LoadTree
+    attr_reader :record_class_name, :loaded_associations
+    attr_accessor :siblings, :parent, :loaded_association, :association_name
+
+    # Create a Load Tree instance representing the loaded record and its place in the overall
+    # hierarchy of the object tree. Any passed parents or sibilings should also include the load_tree
+    # instance on themselves.
+    #
+    # parent: Instance that is the parent of the loaded record.
+    # siblings: Instances that were loaded at the same time as the loaded record.
+    # association_name: The name of the association that was loaded.
+    def initialize(creator: nil, parent: nil, siblings: [], association_name: nil)
+      @parent = parent
+      @record_class_name = creator.class.name
+      @association_name = association_name
+      parent._load_tree.add_loaded_association(association_name) unless parent.nil? || association_name.nil?
+      @loaded_associations = []
+      @siblings = siblings
+    end
+
+    def set_records
+      select_allowed_siblings
+      self
+    end
+
+    # Does this load tree belong to a parent?
+    def root?
+      parent.nil?
+    end
+
+    # The full call path to the parent of this load tree. Traverses up the load tree
+    # checking if the current load tree is the the root, if it is then it returns
+    # the class name of the record for the root element, if not it returns the association
+    # name that was used to instantiate the current load tree's record. This will put together
+    # a full method chain.
+    #
+    # parent = Person.find(1)
+    # child = parent.children.first
+    # child._load_tree.full_load_call_path # => "Person.children"
+    #
+    def full_load_path
+      return record_class_name if root?
+      parent._load_tree.full_load_path + "." + association_name.to_s
+    end
+
+    # Add an association name to the list of loaded associations.
+    def add_loaded_association(association_name)
+      return if association_name.nil? || @loaded_associations.include?(association_name)
+      @loaded_associations << association_name
+    end
+
+    private
+
+    # We only want to keep sibling of the same class type as the creator
+    # This ensures we will not try to preload any associations that may not
+    # exist on some of the sibling which were loaded because of STI.
+    def select_allowed_siblings
+      @siblings = siblings.select { |s| s.class.name == @record_class_name }.compact
+    end
+  end
+end

--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -917,10 +917,19 @@ module ActiveRecord
           else
             exec_main_query
           end
-
           records = instantiate_records(rows, &block)
-          preload_associations(records) unless skip_preloading_value
 
+          # Setup the siblings and turn on auto includes
+          # when appropriate for future requests.
+          records.each do |record|
+            if null_relation? || @association.nil?
+              record._create_load_tree(siblings: records)
+            else
+              record._create_load_tree(siblings: records, parent: @association.owner, association_name: @association.reflection.name)
+            end
+          end
+
+          preload_associations(records) unless skip_preloading_value
           records.each(&:readonly!) if readonly_value
           records.each(&:strict_loading!) if strict_loading_value
 

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -754,6 +754,7 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       assert_not_nil iz
       assert_equal interest.topic, iz.topic, "Interest topics should be the same before changes to child"
       interest.topic = "Eating cheese with a spoon"
+      assert_equal interest.object_id, iz.object_id
       assert_equal interest.topic, iz.topic, "Interest topics should be the same after changes to child"
       iz.topic = "Cow tipping"
       assert_equal interest.topic, iz.topic, "Interest topics should be the same after changes to parent-owned instance"

--- a/activerecord/test/cases/dynamic_includes_test.rb
+++ b/activerecord/test/cases/dynamic_includes_test.rb
@@ -1,0 +1,419 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+require "models/contract"
+require "models/company"
+require "models/computer"
+require "models/mentor"
+require "models/project"
+require "models/ship"
+require "models/ship_part"
+require "models/strict_zine"
+require "models/interest"
+require "models/human"
+require "models/topic"
+require "models/treasure"
+require "models/pirate"
+require "models/book"
+require "models/post"
+require "models/author"
+require "models/author_encrypted"
+require "models/comment"
+require "models/member"
+require "models/member_type"
+
+require "active_support/log_subscriber/test_helper"
+
+class ShipPart
+  def expensive_method
+    trinkets.map do |t|
+      ActiveRecord.dynamic_includes_enabled?
+    end
+  end
+end
+
+class DynamicIncludesTest < ActiveRecord::TestCase
+  fixtures :developers, :developers_projects, :projects, :posts,
+           :ships, :interests, :humans, :topics, :books, :authors, :members
+
+  test "dynamic loading prevents all n+1 queries" do
+    developer = Developer.first
+    developer2 = Developer.last
+    developer3 = Developer.create!(name: "Developer 3")
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    ship2 = Ship.create!(developer_id: developer.id, name: "Ship2")
+    ShipPart.create!(name: "Stern2", ship: ship2)
+    ShipPart.create!(name: "bow2", ship: ship2)
+    bow1.trinkets.create!(name: "Bow Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+    project3 = Project.create!(name: "Apollo3", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer2.projects << project3
+    developer = Developer.find(developer.id)
+    developers = Developer.where(id: [developer.id, developer2.id, developer3.id])
+
+
+    # Preloaded has many throughs need to run 2 queries to get the data.
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      assert_queries(3) do
+        developers.each do |dev|
+          dev.projects.to_a
+        end
+      end
+
+      assert_queries(1) { developer.projects.to_a }
+      assert_queries(1) do
+        developer.projects.each do |project|
+          project.firm
+        end
+      end
+
+      assert_queries(1) { developer.ship }
+      assert_queries(1) { developer.ship.parts.to_a }
+
+      assert_queries(1) do
+        developer.ship.parts.each do |part|
+          part.trinkets.to_a
+        end
+      end
+    end
+  end
+
+  test "dynamic loading disabled does n+1" do
+    developer = Developer.first
+    ship = Ship.first
+    ShipPart.create!(name: "Stern", ship: ship)
+    ShipPart.create!(name: "bow", ship: ship)
+    ship2 = Ship.create!(developer_id: developer.id, name: "Ship2")
+    ShipPart.create!(name: "Stern2", ship: ship2)
+    ShipPart.create!(name: "bow2", ship: ship2)
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.find(developer.id)
+
+    assert_not ActiveRecord.dynamic_includes_enabled?
+
+    assert_queries(1) { developer.projects.to_a }
+    assert_queries(2) do
+      developer.projects.each do |project|
+        project.firm
+      end
+    end
+
+    assert_queries(2) { developer.ship.parts.to_a }
+
+    assert_queries(2) do
+      developer.ship.parts.each do |part|
+       part.trinkets.to_a
+       part.trinkets.each do |trinket|
+         trinket
+       end
+     end
+    end
+  end
+
+  test "dynamic loading can be disabled for a method that maybe expensive" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    ship2 = Ship.create!(developer_id: developer.id, name: "Ship2")
+    ShipPart.create!(name: "Stern2", ship: ship2)
+    ShipPart.create!(name: "bow2", ship: ship2)
+    bow1.trinkets.create!(name: "Bow Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      developer = Developer.find(developer.id)
+      assert_queries(3) do
+        developer.ship.parts.each do |part|
+          part.expensive_method # This should not n+1
+        end
+      end
+    end
+
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      developer = Developer.find(developer.id)
+
+      assert_queries(4) do
+        developer.ship.parts.each do |part|
+          ActiveRecord.with_dynamic_includes(enabled: false) do
+            part.expensive_method # This should n+1
+            assert_not ActiveRecord.dynamic_includes_enabled?
+          end
+          assert ActiveRecord.dynamic_includes_enabled?
+        end
+      end
+    end
+  end
+
+  test "when disabling dynamic loading it can be turned back on to avoid n+1 queries" do
+    developer = Developer.first
+    ship = Ship.first
+    ship.update_column(:developer_id, developer.id)
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    Ship.create!(developer_id: developer.id, name: "Ship2")
+    bow1.trinkets.create!(name: "Bow Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+
+    developer2 = Developer.last
+    ship2 = Ship.create!(developer_id: developer2.id, name: "Ship2")
+    ship2_stern = ShipPart.create!(name: "Stern2", ship: ship2)
+    ship2_bow = ShipPart.create!(name: "bow2", ship: ship2)
+    ship2_stern.trinkets.create!(name: "Stern Trinket")
+    ship2_bow.trinkets.create!(name: "Bow Trinket")
+
+    # Standard rails n+1 behavior
+    developers = Developer.where(id: [developer.id, developer2.id])
+    assert_queries(9) do
+      developers.each do |d|
+        d.ship.parts.each do |part|
+          part.trinkets.each do |t|
+            t
+          end
+        end
+      end
+    end
+
+    # Always Dynamically Include
+    developers = Developer.where(id: [developer.id, developer2.id])
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      assert_queries(4) do
+        developers.each do |d|
+          d.ship.parts.each do |part|
+            part.trinkets.each do |t|
+              t
+            end
+          end
+        end
+      end
+    end
+
+    # Toggle Dynamic Includes on and off
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      developers = Developer.where(id: [developer.id, developer2.id])
+      assert_queries(7) do
+        developers.each do |d|
+          assert ActiveRecord.dynamic_includes_enabled?
+          ActiveRecord.with_dynamic_includes(enabled: false) do
+            d.ship.parts.each do |part| # This should n+1
+              assert_not ActiveRecord.dynamic_includes_enabled?
+              ActiveRecord.with_dynamic_includes(enabled: true) do
+                part.trinkets.each do |t|
+                  assert ActiveRecord.dynamic_includes_enabled?
+                end
+              end
+              assert_not ActiveRecord.dynamic_includes_enabled?
+            end
+          end
+          assert ActiveRecord.dynamic_includes_enabled?
+        end
+      end
+    end
+  end
+
+  test "it logs when an n+1 query is avoided" do
+    old_logger = ActiveRecord::Base.logger
+    logger = ActiveSupport::LogSubscriber::TestHelper::MockLogger.new
+
+    ActiveRecord::Base.logger = logger
+
+
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    bow1.trinkets.create!(name: "Bow Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+    project3 = Project.create!(name: "Apollo3", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects.delete_all
+    developer.projects << project
+    developer.projects << project2
+    developer.projects << project3
+    developer = Developer.find(developer.id)
+
+
+    # Preloaded has many throughs need to run 2 queries to get the data.
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      expected_message = "Dynamically preloaded: Developer.projects.firm, 1 records for 3 owners"
+      assert_queries(2) do
+        developer.projects.each do |project|
+          project.firm
+          assert_equal "Developer.projects.firm", project.firm._load_tree.full_load_path
+        end
+      end
+      assert_includes(logger.logged(:debug), expected_message)
+
+      assert_queries(3) do
+        developer.ship.parts.each do |part|
+          part.trinkets.each do |t|
+            assert_equal "Developer.ship.parts.trinkets", t._load_tree.full_load_path
+          end
+        end
+      end
+    end
+
+    assert_includes(logger.logged(:debug), "Dynamically preloaded: Developer.ship.parts.trinkets, 3 records for 2 owners")
+  ensure
+    ActiveRecord::Base.logger = old_logger
+  end
+
+  def test_with_has_many_inversing_should_try_to_set_inverse_instances_when_the_inverse_is_a_has_many
+    with_has_many_inversing(Interest) do
+      ActiveRecord.with_dynamic_includes(enabled: true) do
+        interest = interests(:trainspotting)
+        human = interest.human
+        assert_not_nil human.interests
+        iz = human.interests.detect { |_iz| _iz.id == interest.id }
+        assert_not_nil iz
+        assert_equal interest.topic, iz.topic, "Interest topics should be the same before changes to child"
+        interest.topic = "Eating cheese with a spoon"
+        assert_equal interest.object_id, iz.object_id
+        assert_equal interest.topic, iz.topic, "Interest topics should be the same after changes to child"
+        iz.topic = "Cow tipping"
+        assert_equal interest.topic, iz.topic, "Interest topics should be the same after changes to parent-owned instance"
+      end
+    end
+  end
+
+  test "manually running an include should work with dynamic includes mainting an appropriate sibling tree" do
+    developer = Developer.first
+    ship = Ship.first
+    ship.update_column(:developer_id, developer.id)
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    bow1.trinkets.create!(name: "Bow Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+
+    developer2 = Developer.last
+    ship2 = Ship.create!(developer_id: developer2.id, name: "Ship2")
+    ship2_stern = ShipPart.create!(name: "Stern2", ship: ship2)
+    ship2_bow = ShipPart.create!(name: "bow2", ship: ship2)
+    ship2_stern.trinkets.create!(name: "Stern Trinket")
+    ship2_bow.trinkets.create!(name: "Bow Trinket")
+
+    developers = Developer.includes(ship: [:parts]).where(id: [developer.id, developer2.id])
+
+    assert_queries(4) do
+      developers.each do |d|
+        ActiveRecord.with_dynamic_includes(enabled: true) do
+          assert_equal d.ship._load_tree.siblings, [ship, ship2]
+          d.ship.parts.each do |part|
+            assert_equal part._load_tree.siblings, [stern1, bow1, ship2_stern, ship2_bow]
+            part.trinkets.each do |t|
+              t
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def test_works_with_polymorphic_belongs_to
+    author = Author.first
+    comment = Post.first.comments.create!(body: "Comment", author: author)
+
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      comment = Comment.find(comment.id)
+      assert_equal comment.author._load_tree.siblings, [comment.author]
+    end
+  end
+
+  test "iterating over a sub array will properly load includes for all parents" do
+    developer = Developer.first
+    firm = Firm.create(name: "Nasa")
+    firm2 = Firm.create(name: "SpaceX")
+    developer.projects.create!(name: "Apollo", firm: firm)
+    developer.projects.create!(name: "Icarus", firm: firm2)
+    developer.projects.create!(name: "no results", firm: firm2)
+
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      developer = Developer.find(developer.id)
+      scope = developer.projects
+      projects1 = scope.select { |p| p.name.start_with?("Apollo") }
+      projects2 = scope.select { |p| p.name.start_with?("Icarus") }
+      firms = (projects1 + projects2).map(&:firm)
+      firms.each do |firm|
+        assert_not_nil firm
+      end
+    end
+  end
+
+  def test_works_with_polymorphic_belongs_to_when_selecting_from_array
+    author = Author.first
+    author2 = EncryptedAuthor.last
+    post = Post.first
+    comment = post.comments.create!(body: "Comment", author: author)
+    comment1 = post.comments.create!(body: "Something", author: author2)
+    comment2 = post.comments.create!(body: "no result", author: nil)
+
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      comments = Comment.where(id: [comment.id, comment1.id, comment2.id])
+      comment1 = comments.select { |c| c.body.start_with?("Comment") }
+      comment2 = comments.select { |c| c.body.start_with?("Something") }
+      authors = (comment1 + comment2).map(&:author)
+      assert authors.length == 2
+      authors.each do |author|
+        assert_not_nil author
+      end
+    end
+  end
+
+  def test_preload_groups_queries_with_same_scope_separates_the_siblings_dynamic_includes_properly_preloads
+    book = books(:awdr)
+    book.author = authors(:david)
+    book.save
+    post = posts(:welcome)
+    post.author = authors(:mary)
+    post.save
+    member_type = MemberType.create(name: "club")
+    member = Member.create(member_type: member_type)
+    post.comments.create(body: "text", origin: member)
+
+    book = Book.find(book.id)
+    post = Post.find(post.id)
+
+    davids_posts = authors(:david).posts.to_a
+    marys_members = authors(:mary).members.to_a
+
+    assert_queries(3) do
+      ActiveRecord.with_dynamic_includes(enabled: true) do
+        preloader = ActiveRecord::Associations::Preloader.new(records: [book, post], associations: :author)
+        preloader.call
+        book.author.posts.each do |post|
+          assert_equal post._load_tree.siblings, davids_posts.select { |p| p.class.name == post.class.name }
+        end
+
+        assert_equal post.author.members.to_a.first._load_tree.siblings, marys_members
+      end
+    end
+  end
+end

--- a/activerecord/test/cases/load_tree_test.rb
+++ b/activerecord/test/cases/load_tree_test.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "models/developer"
+require "models/contract"
+require "models/company"
+require "models/computer"
+require "models/mentor"
+require "models/project"
+require "models/ship"
+require "models/ship_part"
+require "models/strict_zine"
+require "models/post"
+require "models/pirate"
+require "models/treasure"
+require "models/book"
+
+class LoadTreeTest < ActiveRecord::TestCase
+  fixtures :developers, :developers_projects, :projects, :ships, :books, :posts, :authors
+
+  test "load tree has a parent and siblings" do
+    tree = ActiveRecord::LoadTree.new(creator: Ship.first, siblings: [Ship.first, Ship.last]).set_records
+    assert_equal [Ship.first, Ship.last], tree.siblings
+  end
+
+  test "if a load tree gets a sibling that is not of the same class it ignores it" do
+    tree = ActiveRecord::LoadTree.new(creator: Ship.first, siblings: [Ship.first, Ship.last, Post.first]).set_records
+    assert_equal [Ship.first, Ship.last], tree.siblings
+  end
+
+  test "an association is able to find its siblings" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    ship_parts_array = [stern1, bow1]
+    trinket_for_parents = [
+      stern1.trinkets.create!(name: "Stern Trinket"),
+      stern1.trinkets.create!(name: "Stern Trinket 2"),
+      bow1.trinkets.create!(name: "Bow Trinket")
+    ].sort
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.find(developer.id)
+
+    ActiveRecord.with_dynamic_includes(enabled: true) do
+      developer.projects.each do |project|
+        assert_equal developer.projects.to_a, project._load_tree.siblings
+      end
+      assert_equal developer.ship._load_tree.siblings, [developer.ship]
+
+      developer.ship.parts.each do |part|
+        assert_equal ship_parts_array, part._load_tree.siblings
+        part.trinkets.each do |trinket|
+          assert_equal trinket_for_parents, trinket._load_tree.siblings
+        end
+      end
+
+      developer.ship.parts.first.trinkets.first._load_tree.siblings.each do |trinket|
+        assert_equal trinket_for_parents, trinket._load_tree.siblings
+      end
+    end
+  end
+
+  test "when a where at the top level is requested, it should have a load tree" do
+    records = Developer.where(id: [Developer.first.id, Developer.last.id])
+    records.each do |record|
+      assert_equal record._load_tree.siblings, records
+    end
+  end
+
+
+  test "when a record is duplicated it does not inherit the load tree" do
+    records = Developer.where(id: [Developer.first.id, Developer.last.id])
+    dup_records = records.map(&:dup)
+    dup_records.each do |record|
+      assert_equal record._load_tree.siblings, [record]
+    end
+  end
+
+  test "when a record is at the top level it should be a root node and not have a parent" do
+    records = Developer.where(id: [Developer.first.id, Developer.last.id])
+    records.each do |record|
+      assert record._load_tree.root?
+      assert record._load_tree.parent.nil?
+      assert_nil record._load_tree.association_name
+    end
+  end
+
+  test "when a record is not at the top level it should have a parent and the association name that loaded it" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+    bow1.trinkets.create!(name: "Bow Trinket")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.find(developer.id)
+
+    assert developer._load_tree.root?
+    assert_equal developer._load_tree.siblings, [developer]
+
+    developer.projects.each do |project|
+      assert_not project._load_tree.root?
+      assert_equal developer, project._load_tree.parent
+      assert_equal :projects, project._load_tree.association_name
+    end
+    assert_equal developer.ship._load_tree.parent, developer
+    assert_equal :ship, developer.ship._load_tree.association_name
+
+    developer.ship.parts.each do |part|
+      assert_equal developer.ship, part._load_tree.parent
+      assert_not part._load_tree.root?
+      assert_equal :parts, part._load_tree.association_name
+      part.trinkets.each do |trinket|
+        assert_equal part, trinket._load_tree.parent
+        assert_not trinket._load_tree.root?
+        assert_equal :trinkets, trinket._load_tree.association_name
+        assert_equal ship, trinket._load_tree.parent._load_tree.parent
+      end
+    end
+  end
+
+  test "when an association is loaded, it lets the parent know that it is loaded to assist with tree crawling" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    bow1 = ShipPart.create!(name: "bow", ship: ship)
+    stern1.trinkets.create!(name: "Stern Trinket")
+    stern1.trinkets.create!(name: "Stern Trinket 2")
+    bow1.trinkets.create!(name: "Bow Trinket")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+    project2 = Project.create!(name: "Apollo2", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects << project
+    developer.projects << project2
+    developer = Developer.find(developer.id)
+
+    developer.projects.each do |project|
+      assert developer._load_tree.loaded_associations.include?(:projects), "Loaded association should include :project #{developer._load_tree.loaded_associations}"
+    end
+    developer.ship
+    assert developer._load_tree.loaded_associations.include?(:ship), "Loaded association should include :ship #{developer._load_tree.loaded_associations}"
+
+    developer.ship.parts.each do |part|
+      assert developer.ship._load_tree.loaded_associations.include?(:parts), "Loaded association should include :parts #{developer.ship._load_tree.loaded_associations}"
+      part.trinkets.each do |trinket|
+        assert part._load_tree.loaded_associations.include?(:trinkets), "Loaded association should include :trinkets #{part._load_tree.loaded_associations}"
+      end
+    end
+
+    developer._load_tree.loaded_associations.each do |assoc|
+      child = developer.send(assoc)
+      if child.is_a?(Array) || child.is_a?(ActiveRecord::Associations::CollectionProxy)
+        child.each do |c|
+          assert_equal c._load_tree.parent, developer
+        end
+        last_child = child.last
+      else
+        assert_equal child._load_tree.parent, developer
+        last_child = child
+      end
+      last_child._load_tree.loaded_associations.each do |assoc2|
+        grandchild = last_child.send(assoc2).first
+        assert_equal grandchild._load_tree.parent, last_child
+      end
+    end
+  end
+
+  test "load tree can get the full method path from the tree for a particular object" do
+    developer = Developer.first
+    ship = Ship.first
+    stern1 = ShipPart.create!(name: "Stern", ship: ship)
+    stern1.trinkets.create!(name: "Stern Trinket")
+
+    firm = Firm.create!(name: "NASA")
+    project = Project.create!(name: "Apollo", firm: firm)
+
+    ship.update_column(:developer_id, developer.id)
+    developer.projects.destroy_all
+    developer.projects << project
+
+    developer = Developer.find(developer.id)
+
+    assert_equal "Developer.projects.firm", developer.projects.first.firm._load_tree.full_load_path
+    assert_equal "Developer.ship.parts.trinkets", developer.ship.parts.first.trinkets.first._load_tree.full_load_path
+  end
+
+  def test_preload_groups_queries_with_same_scope_separates_the_siblings
+    book = books(:awdr)
+    book.author = authors(:david)
+    book.save
+    book2 = books(:rfr)
+    book2.author = authors(:mary)
+    book2.save
+    post = posts(:welcome)
+    post.author = authors(:mary)
+    post.save
+
+
+    book = Book.find(book.id)
+    book2 = Book.find(book2.id)
+    post = Post.find(post.id)
+    assert_queries(1) do
+      preloader = ActiveRecord::Associations::Preloader.new(records: [book, book2, post], associations: :author)
+      preloader.call
+
+      assert_equal book.author._load_tree.siblings, [book.author, book2.author]
+      post.author
+      assert_equal post.author._load_tree.siblings, [post.author]
+    end
+  end
+end

--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1407,6 +1407,7 @@ The methods are:
 * [`includes`][]
 * [`preload`][]
 * [`eager_load`][]
+* [`dynamic_includes`][]
 
 ### includes
 
@@ -1533,6 +1534,69 @@ SELECT `books`.`id` AS t0_r0, `books`.`last_name` AS t0_r1, ...
 ```
 
 NOTE: The `eager_load` method uses an array, hash, or a nested hash of array/hash in the same way as the `includes` method to load any number of associations with a single `Model.find` call. Also, like the `includes` method, you can specify conditions for eager loaded associations.
+
+### dynamic_includes
+
+Dynamic includes will automatically fix N+1 queries that have not been preloaded using one of the above methods.
+
+Normally this code would execute in 9 queries, when enabling dynamic includes it happens in 4:
+
+```ruby
+developers = Developer.where(id: [developer.id, developer2.id])
+
+ActiveRecord.enable_dynamic_includes do
+    developers.each do |d|
+      d.ship.parts.each do |part|
+        part.trinkets.each do |t|
+          t
+        end
+      end
+    end
+  end
+end
+```
+
+The executed sql looks like this:
+```sql
+SELECT "developers"."id", "developers"."name", "developers"."salary", "developers"."firm_id", "developers"."mentor_id", "developers"."legacy_created_at", "developers"."legacy_updated_at", "developers"."legacy_created_on", "developers"."legacy_updated_on" FROM "developers" WHERE "developers"."id" IN (?, ?)  [["id", 1], ["id", 11]]
+SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" IN (?, ?)  [["developer_id", 1], ["developer_id", 11]]
+SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" IN (?, ?)  [["ship_id", 2], ["ship_id", 751016585]]
+SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_type" = ? AND "treasures"."looter_id" IN (?, ?, ?, ?)  [["looter_type", "ShipPart"], ["looter_id", 1], ["looter_id", 2], ["looter_id", 3], ["looter_id", 4]]
+```
+
+In some scenarios it is ideal to not preload all the data for a particular algorithm, if perhaps it has a very expensive database query associated or perhaps a select runs prior to loading the data to limit the selected data further in memory, you may want to turn off the dynamic includes in such a scenario. This is an exceptional case but is possible.
+
+The below example will take 7 queries:
+
+```ruby
+ActiveRecord.enable_dynamic_includes do
+  developers = Developer.where(id: [developer.id, developer2.id])
+  developers.each do |d|
+    ActiveRecord.disable_dynamic_includes do
+      d.ship.parts.each do |part| # This should n+1
+        ActiveRecord.enable_dynamic_includes do
+          part.trinkets.each do |t|
+            t
+          end
+        end
+       end
+     end
+   end
+ end
+end
+ ```
+
+The executed sql would look like this:
+
+```sql
+SELECT "developers"."id", "developers"."name", "developers"."salary", "developers"."firm_id", "developers"."mentor_id", "developers"."legacy_created_at", "developers"."legacy_updated_at", "developers"."legacy_created_on", "developers"."legacy_updated_on" FROM "developers" WHERE "developers"."id" IN (?, ?)  [["id", 1], ["id", 11]]
+SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" = ? LIMIT ?  [["developer_id", 1], ["LIMIT", 1]]
+SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" = ?  [["ship_id", 2]]
+SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_type" = ? AND "treasures"."looter_id" IN (?, ?)  [["looter_type", "ShipPart"], ["looter_id", 1], ["looter_id", 2]]
+SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" = ? LIMIT ?  [["developer_id", 11], ["LIMIT", 1]]
+SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" = ?  [["ship_id", 751016585]]
+SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_type" = ? AND "treasures"."looter_id" IN (?, ?)  [["looter_type", "ShipPart"], ["looter_id", 3], ["looter_id", 4]]
+```
 
 Scopes
 ------


### PR DESCRIPTION
### Summary

When working on a significantly large application, developers will sink many hours into setting up specific pages to preload data in the correct way across different types of database loading patterns. The complexity involved in many of these methods will have cross cutting effects to pages that do not receive the same level of effort towards optimization. When those other pages access the same data, often by developers working in other areas of the code, they may not have the requisite knowledge to properly optimize the models associations or methods causing Rails to introduce n+1 queries. 

This PR offers a few different patterns to help with these situations. The key feature being dynamic_includes, this is a proposed Rails feature which ties into the existing Preloader, lazily running it on accessed associations that are not preloaded, when the feature is enabled, preventing n+1 queries. Here is an example of what these changes enable from a developer perspective.

### Example Usage

These examples are taken from the tests added to the PR. Without dynamic includes enabled, the following implementation would execute 9 queries:

```ruby
developers = Developer.where(id: [developer.id, developer2.id])
assert_queries(9) do
  developers.each do |d|
    d.ship.parts.each do |part|
      part.trinkets.each do |t|
        t
      end
    end
  end
end
```

<details>
<summary>SQL Log</summary>

<pre>
D, [2022-05-05T16:18:46.432004 #3280] DEBUG -- :   Developer Load (0.2ms)  SELECT "developers"."id", "developers"."name", "developers"."salary", "developers"."firm_id", "developers"."mentor_id", "developers"."legacy_created_at", "developers"."legacy_updated_at", "developers"."legacy_created_on", "developers"."legacy_updated_on" FROM "developers" WHERE "developers"."id" IN (?, ?)  [["id", 1], ["id", 11]]
D, [2022-05-05T16:18:46.432893 #3280] DEBUG -- :   Ship Load (0.1ms)  SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" = ? LIMIT ?  [["developer_id", 1], ["LIMIT", 1]]
D, [2022-05-05T16:18:46.433554 #3280] DEBUG -- :   ShipPart Load (0.1ms)  SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" = ?  [["ship_id", 2]]
D, [2022-05-05T16:18:46.434335 #3280] DEBUG -- :   Treasure Load (0.1ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_id" = ? AND "treasures"."looter_type" = ?  [["looter_id", 1], ["looter_type", "ShipPart"]]
D, [2022-05-05T16:18:46.434911 #3280] DEBUG -- :   Treasure Load (0.1ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_id" = ? AND "treasures"."looter_type" = ?  [["looter_id", 2], ["looter_type", "ShipPart"]]
D, [2022-05-05T16:18:46.435559 #3280] DEBUG -- :   Ship Load (0.0ms)  SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" = ? LIMIT ?  [["developer_id", 11], ["LIMIT", 1]]
D, [2022-05-05T16:18:46.436479 #3280] DEBUG -- :   ShipPart Load (0.1ms)  SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" = ?  [["ship_id", 751016585]]
D, [2022-05-05T16:18:46.437258 #3280] DEBUG -- :   Treasure Load (0.1ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_id" = ? AND "treasures"."looter_type" = ?  [["looter_id", 3], ["looter_type", "ShipPart"]]
D, [2022-05-05T16:18:46.438098 #3280] DEBUG -- :   Treasure Load (0.1ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_id" = ? AND "treasures"."looter_type" = ?  [["looter_id", 4], ["looter_type", "ShipPart"]]
</pre>
</details>


When enabling dynamic includes it happens in 4:

```ruby
developers = Developer.where(id: [developer.id, developer2.id])

ActiveRecord.enable_dynamic_includes do
  assert_queries(4) do
    developers.each do |d|
      d.ship.parts.each do |part|
        part.trinkets.each do |t|
          t
        end
      end
    end
  end
end
```

<details>
<summary>SQL Log</summary>

<pre>
D, [2022-05-05T16:18:46.388805 #3280] DEBUG -- :   Developer Load (0.2ms)  SELECT "developers"."id", "developers"."name", "developers"."salary", "developers"."firm_id", "developers"."mentor_id", "developers"."legacy_created_at", "developers"."legacy_updated_at", "developers"."legacy_created_on", "developers"."legacy_updated_on" FROM "developers" WHERE "developers"."id" IN (?, ?)  [["id", 1], ["id", 11]]
D, [2022-05-05T16:18:46.424796 #3280] DEBUG -- :   Ship Load (0.3ms)  SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" IN (?, ?)  [["developer_id", 1], ["developer_id", 11]]
D, [2022-05-05T16:18:46.425470 #3280] DEBUG -- : Dynamically preloaded: Developer.ship
D, [2022-05-05T16:18:46.427809 #3280] DEBUG -- :   ShipPart Load (0.2ms)  SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" IN (?, ?)  [["ship_id", 2], ["ship_id", 751016585]]
D, [2022-05-05T16:18:46.428172 #3280] DEBUG -- : Dynamically preloaded: Developer.ship.parts
D, [2022-05-05T16:18:46.430243 #3280] DEBUG -- :   Treasure Load (0.2ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_type" = ? AND "treasures"."looter_id" IN (?, ?, ?, ?)  [["looter_type", "ShipPart"], ["looter_id", 1], ["looter_id", 2], ["looter_id", 3], ["looter_id", 4]]
D, [2022-05-05T16:18:46.430748 #3280] DEBUG -- : Dynamically preloaded: Developer.ship.parts.trinkets
</pre>

</details>

In some scenarios it is ideal to not preload all the data for a particular algorithm, if perhaps it has a very expensive database query associated and perhaps a select runs prior to loading the data to limit the selected data further in memory, you may want to turn off the dynamic includes in such a scenario. This is an exceptional case but is possible. 

The below example will take 7 queries:

```ruby
ActiveRecord.enable_dynamic_includes do
  developers = Developer.where(id: [developer.id, developer2.id])
  assert_queries(7) do
  developers.each do |d|
    assert ActiveRecord.dynamic_includes_enabled?
    ActiveRecord.disable_dynamic_includes do
      d.ship.parts.each do |part| # This should n+1
        assert_not ActiveRecord.dynamic_includes_enabled?
          ActiveRecord.enable_dynamic_includes do
            part.trinkets.each do |t|
              t
              assert ActiveRecord.dynamic_includes_enabled?
            end
         end
         assert_not ActiveRecord.dynamic_includes_enabled?
       end
     end
     assert ActiveRecord.dynamic_includes_enabled?
   end
 end
end
 ```

<details>
<summary>SQL Log</summary>

```
D, [2022-05-05T16:18:46.439329 #3280] DEBUG -- :   Developer Load (0.2ms)  SELECT "developers"."id", "developers"."name", "developers"."salary", "developers"."firm_id", "developers"."mentor_id", "developers"."legacy_created_at", "developers"."legacy_updated_at", "developers"."legacy_created_on", "developers"."legacy_updated_on" FROM "developers" WHERE "developers"."id" IN (?, ?)  [["id", 1], ["id", 11]]
D, [2022-05-05T16:18:46.440002 #3280] DEBUG -- :   Ship Load (0.1ms)  SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" = ? LIMIT ?  [["developer_id", 1], ["LIMIT", 1]]
D, [2022-05-05T16:18:46.440643 #3280] DEBUG -- :   ShipPart Load (0.1ms)  SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" = ?  [["ship_id", 2]]
D, [2022-05-05T16:18:46.441803 #3280] DEBUG -- :   Treasure Load (0.1ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_type" = ? AND "treasures"."looter_id" IN (?, ?)  [["looter_type", "ShipPart"], ["looter_id", 1], ["looter_id", 2]]
D, [2022-05-05T16:18:46.442134 #3280] DEBUG -- : Dynamically preloaded: Developer.ship.parts.trinkets
D, [2022-05-05T16:18:46.442986 #3280] DEBUG -- :   Ship Load (0.1ms)  SELECT "ships".* FROM "ships" WHERE "ships"."developer_id" = ? LIMIT ?  [["developer_id", 11], ["LIMIT", 1]]
D, [2022-05-05T16:18:46.443639 #3280] DEBUG -- :   ShipPart Load (0.1ms)  SELECT "ship_parts".* FROM "ship_parts" WHERE "ship_parts"."ship_id" = ?  [["ship_id", 751016585]]
D, [2022-05-05T16:18:46.445137 #3280] DEBUG -- :   Treasure Load (0.2ms)  SELECT "treasures".* FROM "treasures" WHERE "treasures"."looter_type" = ? AND "treasures"."looter_id" IN (?, ?)  [["looter_type", "ShipPart"], ["looter_id", 3], ["looter_id", 4]]
D, [2022-05-05T16:18:46.445454 #3280] DEBUG -- : Dynamically preloaded: Developer.ship.parts.trinkets
```

</details>

### Changes that enable this functionality

This is accomplished through 3 new concepts:

1. Load Tree: This class maintains a tree-like structure of the loaded Active Record objects. 
2. Dynamic Includes: A new ActiveRecord block that when enabled dynamically preloads Rails association on access (lazy) preventing n+1 queries.
3. Overfetch debug mode: A new debugging mode that stores all the loaded and used ActiveRecord objects, and expands the Load Tree to also maintain a call stack for each instantiated object so that developers can easily find where and when an object was instantiated.

These new concepts enable the following new capabilities which are key to the functionality this pr introduces:

1. Load Trees maintains a list of siblings, which are records loaded at the same time, which opens the door to a dynamic includes feature that lazy preloads associations to prevent n+1 queries.
2.  The Load Tree API is public so that other Gems such as [prelude](https://github.com/seejohnrun/prelude) can interface directly with it, expanding the use of Load Tree and allowing for tools like prelude to run a lazy dynamic preload as well. This greatly simplifies the development experience when moving between different data loading patterns, since the api for preloading is extensible. ([Here is a spike that investigated how to do this with prelude](https://github.com/seejohnrun/prelude/compare/main...gwincr11:prelude:cg-load_tree))
3. Dynamic Include blocks can be nested ensuring all method callers load database entities in the most performant way by scoping the appropriate n+1/include behavior to method scopes.
4. Storing the Load Tree allows for a walkable tree of all loaded records, providing useful debugging information and exposing valuable information to other consumers about how records are related.
5. Load Tree provides deep introspection into how each record instance was instantiated allowing developers to use graphical interfaces to reason about what objects were instantiated, how and when.
 




### Findings:

As part of my testing process I set  up the GitHub test suite with dynamic includes enabled globally. This helped me find some edge cases and also let me take a look at what sort of patterns dynamic includes frequently fixed. 

Running the GitHub test suite to completion locally is impossible, as it will eventually time out, so I turned it on for as long as it would run to see how many times the dynamic includes filled an association that was accessed but not preloaded. I was able to get through about 1800 tests and the prefill ran 671 times. I then ran just the integration tests for about 30 minutes, it timed out pretty quickly, showing that it prefilled 248 missed prefills. This was only prefilling associations, I suspect extending it to prelude and twirp calls would further increase this number as we frequently jump between patterns.

There were also a large number of tests that had assertions against how many queries were allowed. After turning on dynamic includes most of these tests were failing, the number of queries had dropped, sometimes by up to 50%. As a part of my testing, I reviewed places in the GitHub code base where query counts dropped significantly, in order to find patterns that the dynamic includes were frequently fixed. The most common fixes I found included:

Destroy_all calls with associations frequently nested multiple layers deep that utilized destroy_dependent association properties.
Update, save, creation or other active record callbacks that manipulate associations after changes occur.
Model access patterns where a method call on the parent instance had subsequent method calls more than 2 layers deep which  loaded an association.
Active Record calls on a model (x) which instantiaed other model instances (y) with ActiveRecord where or find, which was a method and not association, that then loaded an association (z) further down the method chain of the instantiated (y) object.


### Tradeoff to Dynamic Includes:

As with any preload approach there is a risk that data that is not used will be preloaded. In practice after testing on GitHub in a few places, the dynamic includes seem to provide more than enough value to offset any concern about over fetching given the quality concern where less database calls are valued over potentially more memory usage. 

The pattern in which over fetching occurs is worth noting, it is not uncommon to get an array of results back from the database and then select elements that meet some criteria out of the array in memory. In this case, the sibling tree (which is relied upon to preload associations) will not be altered, so selecting a subset of an array and then iterating through it while loading associations will load the associations on records (siblings) that are not in the current iteration (the resulting array of the selection process). 

```ruby
ActiveRecord.enable_dynamic_includes do
  devs = Developers.where(id: [some ids]) 
  staff = devs.select(&:employee?)
  staff.each do |s|
    s.association # this will load the association on all devs
  end
end
```

This can be handled in three ways (that occur to me), easiest is to disable dynamic includes and N+1, another option is to disable dynamic includes around this operation and manually preload for just the selected records.

```ruby
ActiveRecord.enable_dynamic_includes do
  devs = Developers.where(id: [some ids]) 
  staff = devs.select(&:employee?)
  ActiveRecord.disable_dynamic_includes do
    ActiveRecord::Associations::Preloader.new(records: staff, associations: [:association]).call
    staff.each do |s|
      s.association # this will load the association on all devs
    end
  end
end
```

The final option I can think of would be to manually reset the siblings on the selected records load trees. 

```ruby
ActiveRecord.enable_dynamic_includes do
  devs = Developers.where(id: [some ids]) 
  staff = devs.select(&:employee?)
  staff.each do |s|
    s._load_tree.reset_siblings(staff)
  end
  staff.each do |s|
    s.association # this will load the association on all devs
  end
end
```

This pattern, in the GitHub codebase, without dynamic includes, appears to frequently introduce an N+1 or to overfetch.  The `includes()` api that ActiveRecord expose I believe suffers this same problem since it needs to be set up prior to the select occuring, so over fetching is not uncommon with includes today. GitHub has a custom Preload tool that we use in these scenarios, but developers need to recognize this problem to avoid it. Even when overfetching happens the concern that dynamic includes focuses on, less database calls preferred to more memory usage, holds as the overfetching still incurs only 1 database call for the over fetched association.

### Alternative Syntaxes Explored

I tried out 3 different syntaxes for this and landed on the block based function calls for a few reasons. The first version I tried was the classic Rails includes, where the user lists out the includes they want to allow. This syntax was undesirable for a few reasons. It is far too easy to miss an include and introduce an N+1, especially as model interactions become more complex. It also prevents a user from toggling on and off includes, when associations are nested. For example if I have a Blog post with comments and authors and authors have posts. Suppose I want to allow the system to dynamically include comments and posts for authors but I need to do something on authors to determine when to display posts. The closest I can come is this: 
`Blogs.include([comments: [authors: [posts]]])`, which is not what I wish to acheive.

Next I tried chaining the include as part of the Model so `blogs = Blog.all.enable_dynamic_includes.posts`. This would pass the setting to all the children it created for the association `blogs.comments` comments would dynamically prefill. This allowed for the ability to enable and disable the includes in the way I wanted but keeping track of all the state was messy. It was also pretty easy to turn it off then get deep down into model calls and not realize it had been left off, as the state was not intuitive to follow from parent to child.

The block based model proved to be very flexible, easy to understand and allows for the feature to be enabled for entire sections of the codebase without lots of change to the underlying model code. It also has a really nice feature of allowing methods to define their preferred behavior and going back to the calling methods preferred setting once the scope of the called method ends. The other benefit is that it can easily be turned on for a single controller action with a before filter to slowly roll it out and try out the behavior.

```ruby
def dynamic_includes
  ActiveRecord.enable_dynamic_includes do
    yield
  end
end
```


### Debugging Tools

I have put together a template which simplifies debugging how ActiveRecord loads data, it is available on this [gist](https://gist.github.com/gwincr11/35adf30f1892beae2db86f025c340c24). Simply drop it into your Rails template and enable `ActiveRecord.enable_dynamic_includes_overfetch_debugging`, this template will show the full load tree and navigate through parent/association relationships by opening the html summaries. The template works recursively so it is possible to walk through the entire load tree for any record.

Here is a demo video of the debugging tool I created with this to help with the development of this feature, it would be very easy to develop gems or even Rails tooling to enable sophisticated ways to debug active record:

https://user-images.githubusercontent.com/289882/167911312-4da245ae-30e7-4df6-b912-207e3d4a5ce3.mov



### Other Information

Async is a thing I have not looked at very much, I am not 100% sure how this should work in that context. I think the simplest first implementation is to pass the current state of the dynamic includes setting into the thread and just let the methods called in the thread do their thing. One other consideration here is how to handle debugging when threaded, how could we get all the loaded records back to the main thread and add them correctly as loaded state?


### Thanks for the help

I got feedback and help from a number of people prior to opening this pr. Thanks to @seejohnrun, @composerinteralia, @jhawthorn, @matthewd, @mtodd, @rushtonmd and @katestud for all the help, advice and guidance.

