### PR TITLE
Fix MemoryStore#write(name, val, unless_exist: true) with expired entry

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,8 @@
+*   `ActiveSupport::Cache::MemoryStore#write(name, val, unless_exist:true)` now
+    correctly writes expired keys.
+
+    *Alan Savage*
+
 *   `ActiveSupport::ErrorReporter` now accepts and forward a `source:` parameter.
 
     This allow libraries to signal the origin of the errors, and reporters

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -166,7 +166,7 @@ module ActiveSupport
         def write_entry(key, entry, **options)
           payload = serialize_entry(entry, **options)
           synchronize do
-            return false if options[:unless_exist] && @data.key?(key)
+            return false if options[:unless_exist] && exist?(key)
 
             old_payload = @data[key]
             if old_payload

--- a/activesupport/test/cache/stores/memory_store_test.rb
+++ b/activesupport/test/cache/stores/memory_store_test.rb
@@ -156,4 +156,10 @@ class MemoryStorePruningTest < ActiveSupport::TestCase
     @cache.write(1, nil)
     assert_equal false, @cache.write(1, "aaaaaaaaaa", unless_exist: true)
   end
+
+  def test_write_expired_value_with_unless_exist
+    assert_equal true, @cache.write(1, "aaaa", expires_in: 1.second)
+    travel 2.seconds
+    assert_equal true, @cache.write(1, "bbbb", expires_in: 1.second, unless_exist: true)
+  end
 end


### PR DESCRIPTION
### Summary

Fixes `ActiveSupport::Cache::MemoryStore#write(key, val, unless_exist: true)` when the key is expired. `#write_serialized_entry` incorrectly checked for key existence using `@data.key?` instead of `exist?` which bypassed expiration.