### PR TITLE
Update MemCacheStore#increment + decrement to initialize missing keys to 0

### DIFF
--- a/activesupport/lib/active_support/cache/mem_cache_store.rb
+++ b/activesupport/lib/active_support/cache/mem_cache_store.rb
@@ -137,7 +137,7 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:increment, name, amount: amount) do
           rescue_error_with nil do
-            @data.with { |c| c.incr(normalize_key(name, options), amount, options[:expires_in]) }
+            @data.with { |c| c.incr(normalize_key(name, options), amount, options[:expires_in], options[:default]) }
           end
         end
       end
@@ -150,7 +150,7 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:decrement, name, amount: amount) do
           rescue_error_with nil do
-            @data.with { |c| c.decr(normalize_key(name, options), amount, options[:expires_in]) }
+            @data.with { |c| c.decr(normalize_key(name, options), amount, options[:expires_in], options[:default]) }
           end
         end
       end

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -139,16 +139,40 @@ class MemCacheStoreTest < ActiveSupport::TestCase
 
   def test_increment_expires_in
     cache = lookup_store(raw: true, namespace: nil)
-    assert_called_with client(cache), :incr, [ "foo", 1, 60 ] do
+    assert_called_with client(cache), :incr, [ "foo", 1, 60, nil ] do
       cache.increment("foo", 1, expires_in: 60)
     end
   end
 
   def test_decrement_expires_in
     cache = lookup_store(raw: true, namespace: nil)
-    assert_called_with client(cache), :decr, [ "foo", 1, 60 ] do
+    assert_called_with client(cache), :decr, [ "foo", 1, 60, nil ] do
       cache.decrement("foo", 1, expires_in: 60)
     end
+  end
+
+  def test_increment_without_preexisting_value
+    cache = lookup_store(raw: true, namespace: nil)
+    key = SecureRandom.uuid
+
+    assert_nil cache.increment(key)
+    assert_nil cache.read(key, raw: true)
+    assert_equal 3, cache.increment(key, default: 3)
+    assert_equal 3, cache.read(key, raw: true).to_i
+    assert_equal 4, cache.increment(key, default: 3)
+    assert_equal 4, cache.read(key, raw: true).to_i
+  end
+
+  def test_decrement_without_preexisting_value
+    cache = lookup_store(raw: true, namespace: nil)
+    key = SecureRandom.uuid
+
+    assert_nil cache.decrement(key)
+    assert_nil cache.read(key, raw: true)
+    assert_equal 3, cache.decrement(key, default: 3)
+    assert_equal 3, cache.read(key, raw: true).to_i
+    assert_equal 2, cache.decrement(key, default: 3)
+    assert_equal 2, cache.read(key, raw: true).to_i
   end
 
   def test_dalli_cache_nils


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

Currently, for the `MemCacheStore` store, `Rails.cache.increment("foo", 1)` does not do anything if the `foo` key doesn't exist.

The documentation for the method says it should initialize it to zero (and then presumably increment it by 1), and memcached has support for that. It's also the behaviour of the `RedisCacheStore`.

I'm not changing the default behaviour in this PR, since it's presumably breaking for many users, and the behaviour for `decrement` is surprising, in that memcached only operates on uint32 values, so decrement can't go below 0.

Apps can work around that by doing `Redis.cache.write(key, 1, raw: true) if Redis.cache.increment(key).nil?`, but that's 2 calls for the initial case, and a bit surprising.

This PR adds an option, `default`. If the key doesn't exist, that's the value that is set. So, `Redis.cache.increment(key, default: 1)` will set key to 1 if key doesn't exist. (For `RedisCacheStore`, that's the behaviour already for `Rails.cache.increment(key)`.

I'm calling the option `default` since [that's what Dalli calls it](https://github.com/petergoldstein/dalli/blob/8ad238df762b5bccf1b19343f712c8d1e23656cb/lib/dalli/client.rb#L270). But it could be called `missing` or `fallback` or similar too.

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->


Should this new option be documented? The current `expires_in` isn't, so not sure here.