### PR TITLE
Don't change the encoding of frozen parameters

### DIFF
--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -83,6 +83,9 @@ module ActionDispatch
           return params unless controller && controller.valid_encoding? && encoding_template = action_encoding_template(request, controller, action)
           params.except(:controller, :action).each do |key, value|
             ActionDispatch::Request::Utils.each_param_value(value) do |param|
+              # If `param` is frozen, it comes from the router defaults
+              next if param.frozen?
+
               if encoding_template[key.to_s]
                 param.force_encoding(encoding_template[key.to_s])
               end

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -1079,6 +1079,16 @@ class RequestParameters < BaseRequestTest
     assert_equal "Invalid path parameters: Invalid encoding for parameter: �", err.message
   end
 
+  test "path parameters don't re-encode frozen strings" do
+    request = stub_request
+
+    ActionDispatch::Request::Utils::CustomParamEncoder.stub(:action_encoding_template, Hash.new { Encoding::BINARY }) do
+      request.path_parameters = { foo: "frozen", bar: +"mutable", controller: "test_controller" }
+      assert_equal Encoding::BINARY, request.params[:bar].encoding
+      assert_equal Encoding::UTF_8, request.params[:foo].encoding
+    end
+  end
+
   test "parameters not accessible after rack parse error of invalid UTF8 character" do
     request = stub_request("QUERY_STRING" => "foo%81E=1")
     assert_raises(ActionController::BadRequest) { request.parameters }


### PR DESCRIPTION
Fix: https://github.com/rails/rails/issues/44923

The fix may seem very ad hoc, but this methods assumes all params come from Rack, hence are mutable. So checking for frozen is a decent proxy for ignoring the router defaults.

One worry I have is that frozen strings can also come from controller tests. 

cc @jason-o-matic