### PR TITLE
Pass cache options to Rails.cache.fetch's block

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,16 @@
+*   `ActiveSupport::Cache:Store#fetch` now passes cache options to the block.
+
+    It makes possible to override cache options:
+
+        Rails.cache.fetch("3rd-party-token") do |name, options|
+          fetch_token_from_remote.tap |token|
+            # set cache's TTL to match token's TTL
+            options[:expires_in] = token.expires_in
+          end
+        end
+
+    *Andrii Gladkyi*
+
 *   `ActiveSupport::Cache::MemoryStore#write(name, val, unless_exist:true)` now
     correctly writes expired keys.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -806,7 +806,7 @@ module ActiveSupport
 
         def save_block_result_to_cache(name, options)
           result = instrument(:generate, name, options) do
-            yield(name)
+            yield(name, options)
           end
 
           write(name, result, options) unless result.nil? && options[:skip_nil]

--- a/activesupport/test/cache/behaviors/cache_store_behavior.rb
+++ b/activesupport/test/cache/behaviors/cache_store_behavior.rb
@@ -85,6 +85,16 @@ module CacheStoreBehavior
     assert_equal "bar", @cache.read(key)
   end
 
+  def test_fetch_with_block_modifying_options
+    key = SecureRandom.uuid
+    assert_called_with(@cache, :write, [key, "bar", @cache.options.merge(expires_in: 10)]) do
+      @cache.fetch(key) do |name, options|
+        options[:expires_in] = 10
+        "bar"
+      end
+    end
+  end
+
   def test_should_read_and_write_hash
     key = SecureRandom.uuid
     assert @cache.write(key, a: "b")


### PR DESCRIPTION
### Summary

Our application fetches 3rd-party access tokens that expire over time. We cache them in Redis with
```ruby
Rails.cache.fetch(""3rd-party-token") { fetch_new_token }
```
but we'd like Redis entries to auto-expire once the corresponding tokens get expired. With this change we will be able to do that by dynamically setting cache's `expires_in` option to match token's TTL:

```ruby
Rails.cache.fetch("3rd-party-token") do |name, options| # cache options are passed to block
  fetch_token_from_remote.tap |token|
    options[:expires_in] = token.expires_in # set cache's TTL to match token's TTL
  end
end
```

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
