### PR TITLE
Add ability to set the `tags_format` for `QueryLogs`

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Add configurable formatter on query log tags to support sqlcommenter. See #45139
+
+    It is now possible to opt into sqlcommenter-formatted query log tags with `config.active_record.query_log_tags_format = :sqlcommenter`.
+
+    *Modulitos and Iheanyi*
+
 *   Allow any ERB in the database.yml when creating rake tasks.
 
     Any ERB can be used in `database.yml` even if it accesses environment

--- a/activerecord/lib/active_record/query_logs_formatter.rb
+++ b/activerecord/lib/active_record/query_logs_formatter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module QueryLogs
+    class Formatter # :nodoc:
+      attr_reader :key_value_separator
+
+      # @param [String] key_value_separator: indicates the string used for
+      # separating keys and values.
+      #
+      # @param [Symbol] quote_values: indicates how values will be formatted (eg:
+      # in single quotes, not quoted at all, etc)
+      def initialize(key_value_separator:)
+        @key_value_separator = key_value_separator
+      end
+
+      # @param [String-coercible] value
+      # @return [String] The formatted value that will be used in our key-value
+      # pairs.
+      def format_value(value)
+        value
+      end
+    end
+
+    class QuotingFormatter < Formatter # :nodoc:
+      def format_value(value)
+        "'#{value.to_s.gsub("'", "\\\\'")}'"
+      end
+    end
+
+    class FormatterFactory # :nodoc:
+      # @param [Symbol] formatter: the kind of formatter we're building.
+      # @return [Formatter]
+      def self.from_symbol(formatter)
+        case formatter
+        when :legacy
+          Formatter.new(key_value_separator: ":")
+        when :sqlcommenter
+          QuotingFormatter.new(key_value_separator: "=")
+        else
+          raise ArgumentError, "Formatter is unsupported: #{formatter}"
+        end
+      end
+    end
+  end
+end

--- a/activerecord/lib/active_record/railtie.rb
+++ b/activerecord/lib/active_record/railtie.rb
@@ -34,6 +34,7 @@ module ActiveRecord
     config.active_record.sqlite3_production_warning = true
     config.active_record.query_log_tags_enabled = false
     config.active_record.query_log_tags = [ :application ]
+    config.active_record.query_log_tags_format = :legacy
     config.active_record.cache_query_log_tags = false
 
     config.active_record.queues = ActiveSupport::InheritableOptions.new
@@ -244,6 +245,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           :shard_resolver,
           :query_log_tags_enabled,
           :query_log_tags,
+          :query_log_tags_format,
           :cache_query_log_tags,
           :sqlite3_production_warning,
           :sqlite3_adapter_strict_strings_by_default,
@@ -384,7 +386,7 @@ To keep using the current cache store, you can turn off cache versioning entirel
           ActiveRecord.query_transformers << ActiveRecord::QueryLogs
           ActiveRecord::QueryLogs.taggings.merge!(
             application:  Rails.application.class.name.split("::").first,
-            pid:          -> { Process.pid },
+            pid:          -> { Process.pid.to_s },
             socket:       -> { ActiveRecord::Base.connection_db_config.socket },
             db_host:      -> { ActiveRecord::Base.connection_db_config.host },
             database:     -> { ActiveRecord::Base.connection_db_config.database }
@@ -392,6 +394,10 @@ To keep using the current cache store, you can turn off cache versioning entirel
 
           if app.config.active_record.query_log_tags.present?
             ActiveRecord::QueryLogs.tags = app.config.active_record.query_log_tags
+          end
+
+          if app.config.active_record.query_log_tags_format.present?
+            ActiveRecord::QueryLogs.update_formatter(app.config.active_record.query_log_tags_format)
           end
 
           if app.config.active_record.cache_query_log_tags

--- a/activerecord/test/cases/query_logs_formatter_test.rb
+++ b/activerecord/test/cases/query_logs_formatter_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+
+class QueryLogsFormatter < ActiveRecord::TestCase
+  def test_factory_invalid_formatter
+    assert_raises(ArgumentError) do
+      ActiveRecord::QueryLogs::FormatterFactory.from_symbol(:non_existing_formatter)
+    end
+    end
+
+  def test_sqlcommenter_key_value_separator
+    formatter = ActiveRecord::QueryLogs::FormatterFactory.from_symbol(:sqlcommenter)
+    assert_equal("=", formatter.key_value_separator)
+  end
+
+  def test_sqlcommenter_format_value
+    formatter = ActiveRecord::QueryLogs::FormatterFactory.from_symbol(:sqlcommenter)
+    assert_equal("'Joe\\'s Crab Shack'", formatter.format_value("Joe's Crab Shack"))
+  end
+
+  def test_sqlcommenter_format_value_string_coercible
+    formatter = ActiveRecord::QueryLogs::FormatterFactory.from_symbol(:sqlcommenter)
+    assert_equal("'1234'", formatter.format_value(1234))
+  end
+end

--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -1125,6 +1125,10 @@ Define an `Array` specifying the key/value tags to be inserted in an SQL
 comment. Defaults to `[ :application ]`, a predefined tag returning the
 application name.
 
+#### `config.active_record.query_log_tags_format`
+
+A `Symbol` specifying the formatter to use for tags. Valid values are `:sqlcommenter` and `:legacy`.  Defaults to `:legacy`.
+
 #### `config.active_record.cache_query_log_tags`
 
 Specifies whether or not to enable caching of query log tags. For applications

--- a/railties/test/application/query_logs_test.rb
+++ b/railties/test/application/query_logs_test.rb
@@ -22,7 +22,7 @@ module ApplicationTests
           end
 
           def dynamic_content
-            Time.now.to_f
+            Time.now.to_f.to_s
           end
         end
       RUBY
@@ -34,7 +34,7 @@ module ApplicationTests
           end
 
           def dynamic_content
-            Time.now.to_f
+            Time.now.to_f.to_s
           end
         end
       RUBY
@@ -85,6 +85,21 @@ module ApplicationTests
       comment = last_response.body.strip
 
       assert_includes comment, "controller:users"
+    end
+
+    test "sqlcommenter formatting works when specified" do
+      add_to_config "config.active_record.query_log_tags_enabled = true"
+      add_to_config "config.active_record.query_log_tags_format = :sqlcommenter"
+
+      add_to_config "config.active_record.query_log_tags = [ :pid ]"
+
+      boot_app
+
+      get "/"
+      comment = last_response.body.strip
+
+      assert_match(/pid='\d+'/, comment)
+      assert_includes comment, "controller='users'"
     end
 
     test "controller actions tagging filters can be disabled" do


### PR DESCRIPTION
### Summary

This pull request adds a new option called `tags_format` to `ActiveRecord::QueryLogs`. In some cases, we may not want to use a `:` as the separator for the key-value pairs, like in the case of [`sqlcommenter`](https://cloud.google.com/blog/topics/developers-practitioners/introducing-sqlcommenter-open-source-orm-auto-instrumentation-library), which uses `=` as separator and single quotes around values.. Therefore, we can set a new `tags_format` option that lets users specify if they want to use the `:default` functionality or `:sqlcommenter`.

### Other Information

This was literally copied from this [pull request ](https://github.com/basecamp/marginalia/pull/130)for Marginalia, credits to @modulitos for the original implementation.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
