### PR TITLE
Fix deserializing infinite ranges from time-based range columns in PostgreSQL

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/oid/range.rb
@@ -25,7 +25,7 @@ module ActiveRecord
             from = type_cast_single extracted[:from]
             to = type_cast_single extracted[:to]
 
-            if !infinity?(from) && extracted[:exclude_start]
+            if from && extracted[:exclude_start]
               raise ArgumentError, "The Ruby Range object does not support excluding the beginning of a Range. (unsupported value: '#{value}')"
             end
             ::Range.new(from, to, extracted[:exclude_end])
@@ -59,18 +59,18 @@ module ActiveRecord
 
           private
             def type_cast_single(value)
-              infinity?(value) ? value : @subtype.deserialize(value)
+              infinity?(value) ? nil : @subtype.deserialize(value)
             end
 
             def type_cast_single_for_database(value)
-              infinity?(value) ? value : @subtype.serialize(@subtype.cast(value))
+              infinity?(value) ? nil : @subtype.serialize(@subtype.cast(value))
             end
 
             def extract_bounds(value)
               from, to = value[1..-2].split(",", 2)
               {
-                from:          (from == "" || from == "-infinity") ? infinity(negative: true) : unquote(from),
-                to:            (to == "" || to == "infinity") ? infinity : unquote(to),
+                from:          (from == "" || from == "-infinity") ? nil : unquote(from),
+                to:            (to == "" || to == "infinity") ? nil : unquote(to),
                 exclude_start: value.start_with?("("),
                 exclude_end:   value.end_with?(")")
               }
@@ -92,16 +92,6 @@ module ActiveRecord
                 unquoted_value
               else
                 value
-              end
-            end
-
-            def infinity(negative: false)
-              if subtype.respond_to?(:infinity)
-                subtype.infinity(negative: negative)
-              elsif negative
-                -::Float::INFINITY
-              else
-                ::Float::INFINITY
               end
             end
 

--- a/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb
@@ -194,11 +194,7 @@ module ActiveRecord
           end
 
           def type_cast_range_value(value)
-            infinity?(value) ? "" : type_cast(value)
-          end
-
-          def infinity?(value)
-            value.respond_to?(:infinite?) && value.infinite?
+            value ? type_cast(value) : ""
           end
       end
     end


### PR DESCRIPTION
Fixes #39833. See its description for context.

Ruby does not support `Time.now..Float::INFINITY`-like ranges, and since the minimum required ruby version is 2.7, we can use beginless/endless ranges. So this PR implements the use of beginless/endless ranges for all PostgreSQL `range` type columns.

Before: `thing.numeric_range # => 1..Float::INFINITY`
After: `thing.numeric_range # => 1..`

This is potentially a breaking change, since while functionally equivalent, but `1..Float::INFINITY != 1..`.