### PR TITLE
Prefetch primary key when default is UUID function

### DIFF
--- a/activerecord/test/cases/primary_keys_test.rb
+++ b/activerecord/test/cases/primary_keys_test.rb
@@ -480,36 +480,38 @@ if current_adapter?(:PostgreSQLAdapter, :Mysql2Adapter)
     end
   end
 
-  class PrimaryKeyUuidDefaultTest < ActiveRecord::TestCase
-    self.use_transactional_tests = false
+  if supports_text_column_with_default?
+    class PrimaryKeyUuidDefaultTest < ActiveRecord::TestCase
+      self.use_transactional_tests = false
 
-    class Thing < ActiveRecord::Base; end
+      class Thing < ActiveRecord::Base; end
 
-    def setup
-      super
+      def setup
+        super
 
-      uuid_function = if current_adapter?(:PostgreSQLAdapter)
-        "gen_random_uuid()"
-      else
-        "uuid()"
+        uuid_function = if current_adapter?(:PostgreSQLAdapter)
+          "gen_random_uuid()"
+        else
+          "uuid()"
+        end
+
+        Thing.connection.create_table :things, id: { type: :string, limit: 36, default: -> { uuid_function } }, force: true do |t|
+          t.string :name
+        end
+
+        Thing.reset_column_information
+        ActiveRecord::Base.connection.schema_cache.clear!
       end
 
-      Thing.connection.create_table :things, id: { type: :string, limit: 36, default: -> { uuid_function } }, force: true do |t|
-        t.string :name
+      teardown do
+        Thing.connection.drop_table(:things) if Thing.connection.table_exists?(:things)
+        Thing.reset_column_information
       end
 
-      Thing.reset_column_information
-      ActiveRecord::Base.connection.schema_cache.clear!
-    end
-
-    teardown do
-      Thing.connection.drop_table(:things) if Thing.connection.table_exists?(:things)
-      Thing.reset_column_information
-    end
-
-    def test_primary_key_uuid_default
-      thing = Thing.create!(name: "test")
-      assert_match(/\A(.+)-(.+)-(.+)-(.+)\Z/, thing.id)
+      def test_primary_key_uuid_default
+        thing = Thing.create!(name: "test")
+        assert_match(/\A(.+)-(.+)-(.+)-(.+)\Z/, thing.id)
+      end
     end
   end
 end


### PR DESCRIPTION
### Summary

Prefetch primary key as UUID when the primary key defaults to a UUID function. Otherwise it will call last inserted ID which will be zero (because it reads from the sequence that didn't get used in the insert) and the returned model will have an ID of zero which isn't correct and messes all kinds of stuff up.

### Other Information

I really wanted to put all of this in the MySQL adapter, but that doesn't have access to all of the nice helpers methods like `columns`, `primary_key` etc. without doing additional callbacks? (at least as far as I could understand)