### PR TITLE
Fix: PG.connect keyword arguments deprecation warning on ruby 2.7

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Fix PG.connect keyword arguments deprecation warning on ruby 2.7
+
+    Fixes #44307.
+
+    *Nikita Vasilevsky*
+
 ## Rails 6.1.6 (May 09, 2022) ##
 
 *   No changes.

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -75,7 +75,7 @@ module ActiveRecord
 
       class << self
         def new_client(conn_params)
-          PG.connect(conn_params)
+          PG.connect(**conn_params)
         rescue ::PG::Error => error
           if conn_params && conn_params[:dbname] && error.message.include?(conn_params[:dbname])
             raise ActiveRecord::NoDatabaseError
@@ -247,7 +247,7 @@ module ActiveRecord
       def initialize(connection, logger, connection_parameters, config)
         super(connection, logger, config)
 
-        @connection_parameters = connection_parameters
+        @connection_parameters = connection_parameters || {}
 
         # @local_tz is initialized as nil to avoid warnings when connect tries to use it
         @local_tz = nil

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -39,7 +39,7 @@ module ActiveRecord
           end
 
           def reset
-            raise PG::ConnectionBad
+            raise PG::ConnectionBad, "I'll be rescued by the reconnect method"
           end
 
           def close
@@ -53,8 +53,13 @@ module ActiveRecord
           { host: File::NULL }
         )
 
-        assert_raises ActiveRecord::ConnectionNotEstablished do
-          @conn.reconnect!
+        connect_raises_error = proc { |_conn_params| raise(PG::ConnectionBad, "actual bad connection error") }
+        PG.stub(:connect, connect_raises_error) do
+          error = assert_raises ActiveRecord::ConnectionNotEstablished do
+            @conn.reconnect!
+          end
+
+          assert_equal("actual bad connection error", error.message)
         end
       end
 


### PR DESCRIPTION
### Summary

Backport the Rails 7.0 fix #44346 to Rails 6.1.

Resolves outstanding comments on #44307
