### PR TITLE
Add ability to ignore tables by regexp for SQL schema dumps

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add ability to ignore tables by regexp for SQL schema dumps.
+
+    ```ruby
+    ActiveRecord::SchemaDumper.ignore_tables = [/^_/]
+    ```
+
+    *fatkodima*
+
 *   Avoid queries when performing calculations on contradictory relations.
 
     Previously calculations would make a query even when passed a

--- a/activerecord/lib/active_record/schema_dumper.rb
+++ b/activerecord/lib/active_record/schema_dumper.rb
@@ -13,8 +13,7 @@ module ActiveRecord
     ##
     # :singleton-method:
     # A list of tables which should not be dumped to the schema.
-    # Acceptable values are strings as well as regexp if ActiveRecord.schema_format == :ruby.
-    # Only strings are accepted if ActiveRecord.schema_format == :sql.
+    # Acceptable values are strings and regexps.
     cattr_accessor :ignore_tables, default: []
 
     ##

--- a/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/mysql_database_tasks.rb
@@ -49,6 +49,7 @@ module ActiveRecord
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
+          ignore_tables = connection.data_sources.select { |table| ignore_tables.any? { |pattern| pattern === table } }
           args += ignore_tables.map { |table| "--ignore-table=#{db_config.database}.#{table}" }
         end
 

--- a/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
@@ -70,6 +70,7 @@ module ActiveRecord
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
+          ignore_tables = connection.data_sources.select { |table| ignore_tables.any? { |pattern| pattern === table } }
           args += ignore_tables.flat_map { |table| ["-T", table] }
         end
 

--- a/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
+++ b/activerecord/lib/active_record/tasks/sqlite_database_tasks.rb
@@ -49,6 +49,7 @@ module ActiveRecord
 
         ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
         if ignore_tables.any?
+          ignore_tables = connection.data_sources.select { |table| ignore_tables.any? { |pattern| pattern === table } }
           condition = ignore_tables.map { |table| connection.quote(table) }.join(", ")
           args << "SELECT sql FROM sqlite_master WHERE tbl_name NOT IN (#{condition}) ORDER BY tbl_name, type DESC, name"
         else


### PR DESCRIPTION
`SchemaDumper.ignore_tables` already supports regexps for `schema.rb`. This also adds support for regexps when using `structure.sql`. For example, this is useful when using zero-downtime migration tools and they create temporary tables when migrating.

When regexps are provided, I fetch all tables/views, select those that needs to be ignored and explicitly ignore them in the built adapter-specific command. Does anyone see problems with this approach?

Fixes #35220