### PR TITLE
Fix MySQL warning when creating Active Record's test databases

### DIFF
--- a/activerecord/Rakefile
+++ b/activerecord/Rakefile
@@ -198,7 +198,7 @@ namespace :db do
   namespace :mysql do
     connection_arguments = lambda do |connection_name|
       config = ARTest.config["connections"]["mysql2"][connection_name]
-      ["--user=#{config["username"]}", "--password=#{config["password"]}", ("--host=#{config["host"]}" if config["host"]), ("--socket=#{config["socket"]}" if config["socket"])].join(" ")
+      ["--user=#{config["username"]}", ("--password=#{config["password"]}" if config["password"]), ("--host=#{config["host"]}" if config["host"]), ("--socket=#{config["socket"]}" if config["socket"])].join(" ")
     end
 
     desc "Create the MySQL Rails User"


### PR DESCRIPTION
An empty password argument was passed by default and would produce
warnings when doing `rake db:create` in `activerecord/`

    mysql: [Warning] Using a password on the command line interface can be insecure.
    mysql: [Warning] Using a password on the command line interface can be insecure.

By default the password is empty so not passing the password argument
prevents the warning from appearing.

Tested on "mysql  Ver 8.0.29 for macos12.2 on arm64 (Homebrew)"

### Summary

I was setting up my local rails development environment and when doing `rake db:create` in the `activerecord/` directory I got some warnings from mysql so I looked into it and it seems like an empty password argument was passed so
I tried without it and it doesn't produce warnings.

### Other Information

As this is just a local mysql installation I don't think the warning matter too much and I think it's probably to prevent having mysql user's password in the command line history or in clear text.

I didn't add a test as this is the local setup for hacking on rails itself.