### PR TITLE
Allow to use pre-defined variants for previews

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,18 @@
+*   Add ability to use pre-defined variants when calling `preview` or
+    `representation` on an attachment.
+
+    ```ruby
+    class User < ActiveRecord::Base
+      has_one_attached :file do |attachable|
+        attachable.variant :thumb, resize_to_limit: [100, 100]
+      end
+    end
+
+    <%= image_tag user.file.representation(:thumb) %>
+    ```
+
+    *Richard Böhme*
+
 *   Method `attach` always returns the attachments except when the record
     is persisted, unchanged, and saving it fails, in which case it returns `nil`.
 

--- a/activestorage/app/models/active_storage/attachment.rb
+++ b/activestorage/app/models/active_storage/attachment.rb
@@ -54,16 +54,30 @@ class ActiveStorage::Attachment < ActiveStorage::Record
   # Raises an +ArgumentError+ if +transformations+ is a +Symbol+ which is an
   # unknown pre-defined variant of the attachment.
   def variant(transformations)
-    case transformations
-    when Symbol
-      variant_name = transformations
-      transformations = variants.fetch(variant_name) do
-        record_model_name = record.to_model.model_name.name
-        raise ArgumentError, "Cannot find variant :#{variant_name} for #{record_model_name}##{name}"
-      end
-    end
-
+    transformations = transformations_by_name(transformations)
     blob.variant(transformations)
+  end
+
+  # Returns an ActiveStorage::Preview instance for the attachment with the set
+  # of +transformations+ provided.
+  # See ActiveStorage::Blob::Representable#preview for more information.
+  #
+  # Raises an +ArgumentError+ if +transformations+ is a +Symbol+ which is an
+  # unknown pre-defined variant of the attachment.
+  def preview(transformations)
+    transformations = transformations_by_name(transformations)
+    blob.preview(transformations)
+  end
+
+  # Returns an ActiveStorage::Preview or an ActiveStorage::Variant for the
+  # attachment with set of +transformations+ provided.
+  # See ActiveStorage::Blob::Representable#representation for more information.
+  #
+  # Raises an +ArgumentError+ if +transformations+ is a +Symbol+ which is an
+  # unknown pre-defined variant of the attachment.
+  def representation(transformations)
+    transformations = transformations_by_name(transformations)
+    blob.representation(transformations)
   end
 
   private
@@ -85,6 +99,19 @@ class ActiveStorage::Attachment < ActiveStorage::Record
 
     def variants
       record.attachment_reflections[name]&.variants
+    end
+
+    def transformations_by_name(transformations)
+      case transformations
+      when Symbol
+        variant_name = transformations
+        variants.fetch(variant_name) do
+          record_model_name = record.to_model.model_name.name
+          raise ArgumentError, "Cannot find variant :#{variant_name} for #{record_model_name}##{name}"
+        end
+      else
+        transformations
+      end
     end
 end
 

--- a/activestorage/test/models/attached/many_test.rb
+++ b/activestorage/test/models/attached/many_test.rb
@@ -907,11 +907,51 @@ class ActiveStorage::ManyAttachedTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
-  test "raises error when unknown variant name is used" do
+  test "raises error when unknown variant name is used to generate variant" do
     @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
 
     error = assert_raises ArgumentError do
       @user.highlights_with_variants.first.variant(:unknown).processed
+    end
+
+    assert_match(/Cannot find variant :unknown for User#highlights_with_variants/, error.message)
+  end
+
+  test "creating preview by variation name" do
+    @user.highlights_with_variants.attach fixture_file_upload("report.pdf")
+    preview = @user.highlights_with_variants.first.preview(:thumb).processed
+
+    image = read_image(preview.send(:variant))
+    assert_equal "PNG", image.type
+    assert_equal 77, image.width
+    assert_equal 100, image.height
+  end
+
+  test "raises error when unknown variant name is used to generate preview" do
+    @user.highlights_with_variants.attach fixture_file_upload("report.pdf")
+
+    error = assert_raises ArgumentError do
+      @user.highlights_with_variants.first.preview(:unknown).processed
+    end
+
+    assert_match(/Cannot find variant :unknown for User#highlights_with_variants/, error.message)
+  end
+
+  test "creating representation by variation name" do
+    @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
+    variant = @user.highlights_with_variants.first.representation(:thumb).processed
+
+    image = read_image(variant)
+    assert_equal "JPEG", image.type
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  end
+
+  test "raises error when unknown variant name is used to generate representation" do
+    @user.highlights_with_variants.attach fixture_file_upload("racecar.jpg")
+
+    error = assert_raises ArgumentError do
+      @user.highlights_with_variants.first.representation(:unknown).processed
     end
 
     assert_match(/Cannot find variant :unknown for User#highlights_with_variants/, error.message)

--- a/activestorage/test/models/attached/one_test.rb
+++ b/activestorage/test/models/attached/one_test.rb
@@ -716,11 +716,51 @@ class ActiveStorage::OneAttachedTest < ActiveSupport::TestCase
     assert_equal 67, image.height
   end
 
-  test "raises error when unknown variant name is used" do
+  test "raises error when unknown variant name is used to generate variant" do
     @user.avatar_with_variants.attach fixture_file_upload("racecar.jpg")
 
     error = assert_raises ArgumentError do
       @user.avatar_with_variants.variant(:unknown).processed
+    end
+
+    assert_match(/Cannot find variant :unknown for User#avatar_with_variants/, error.message)
+  end
+
+  test "creating preview by variation name" do
+    @user.avatar_with_variants.attach fixture_file_upload("report.pdf")
+    preview = @user.avatar_with_variants.preview(:thumb).processed
+
+    image = read_image(preview.send(:variant))
+    assert_equal "PNG", image.type
+    assert_equal 77, image.width
+    assert_equal 100, image.height
+  end
+
+  test "raises error when unknown variant name is used to generate preview" do
+    @user.avatar_with_variants.attach fixture_file_upload("report.pdf")
+
+    error = assert_raises ArgumentError do
+      @user.avatar_with_variants.preview(:unknown).processed
+    end
+
+    assert_match(/Cannot find variant :unknown for User#avatar_with_variants/, error.message)
+  end
+
+  test "creating representation by variation name" do
+    @user.avatar_with_variants.attach fixture_file_upload("racecar.jpg")
+    variant = @user.avatar_with_variants.representation(:thumb).processed
+
+    image = read_image(variant)
+    assert_equal "JPEG", image.type
+    assert_equal 100, image.width
+    assert_equal 67, image.height
+  end
+
+  test "raises error when unknown variant name is used to generate representation" do
+    @user.avatar_with_variants.attach fixture_file_upload("racecar.jpg")
+
+    error = assert_raises ArgumentError do
+      @user.avatar_with_variants.representation(:unknown).processed
     end
 
     assert_match(/Cannot find variant :unknown for User#avatar_with_variants/, error.message)

--- a/guides/source/active_storage_overview.md
+++ b/guides/source/active_storage_overview.md
@@ -441,6 +441,20 @@ Call `avatar.variant(:thumb)` to get a thumb variant of an avatar:
 <%= image_tag user.avatar.variant(:thumb) %>
 ```
 
+You can use specific variants for previews as well:
+
+```ruby
+class User < ApplicationRecord
+  has_one_attached :video do |attachable|
+    attachable.variant :thumb, resize_to_limit: [100, 100]
+  end
+end
+```
+
+```erb
+<%= image_tag user.video.preview(:thumb) %>
+```
+
 [`has_one_attached`]: https://api.rubyonrails.org/classes/ActiveStorage/Attached/Model.html#method-i-has_one_attached
 [Attached::One#attach]: https://api.rubyonrails.org/classes/ActiveStorage/Attached/One.html#method-i-attach
 [Attached::One#attached?]: https://api.rubyonrails.org/classes/ActiveStorage/Attached/One.html#method-i-attached-3F


### PR DESCRIPTION
### Summary

Previously, named variants could only be used when calling the `variant` method on an attachment. For files that are not `variable?` but `previewable?` those pre-defined variants could not be used.

With this patch, the methods `preview` and `representation` also allow to be passed a variation name as a symbol.

```ruby
class User < ActiveRecord::Base
  has_one_attached :file do |attachable|
    attachable.variant :thumb, resize_to_limit: [100, 100]
  end
end

<%= image_tag user.file.representation(:thumb) %>
```
