### PR TITLE
Fix sqlite index creation for non existing columns

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -1367,7 +1367,7 @@ module ActiveRecord
 
       def quoted_columns_for_index(column_names, options) # :nodoc:
         quoted_columns = column_names.each_with_object({}) do |name, result|
-          result[name.to_sym] = quote_column_name(name).dup
+          result[name.to_sym] = quote_column_for_index(name).dup
         end
         add_options_for_index_columns(quoted_columns, **options).values.join(", ")
       end
@@ -1428,6 +1428,10 @@ module ActiveRecord
           end
 
           quoted_columns
+        end
+
+        def quote_column_for_index(name)
+          quote_column_name(name)
         end
 
         def index_name_for_remove(table_name, column_name, options)

--- a/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3/schema_statements.rb
@@ -35,7 +35,7 @@ module ActiveRecord
               # Add info on sort order for columns (only desc order is explicitly specified,
               # asc is the default)
               if index_sql # index_sql can be null in case of primary key indexes
-                index_sql.scan(/"(\w+)" DESC/).flatten.each { |order_column|
+                index_sql.scan(/(['"])(\w+)\1 DESC/).each { |_, order_column|
                   orders[order_column] = :desc
                 }
               end
@@ -124,6 +124,10 @@ module ActiveRecord
 
           def validate_index_length!(table_name, new_name, internal = false)
             super unless internal
+          end
+
+          def quote_column_for_index(name)
+            "'#{name.to_s.gsub("'", "''")}'"
           end
 
           def new_column_from_field(table_name, field)

--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -381,6 +381,15 @@ module ActiveRecord
         end
       end
 
+      def test_index_non_existent_column
+        with_example_table do
+          error = assert_raises(ActiveRecord::StatementInvalid) do
+            @conn.add_index "ex", "non_existent"
+          end
+          assert_match(/no such column: non_existent/, error.message)
+        end
+      end
+
       if ActiveRecord::Base.connection.supports_expression_index?
         def test_expression_index
           with_example_table do


### PR DESCRIPTION
In sqlite, it is possible to create an index for non existing column 😱 

```ruby
create_table :requests do |t|
  t.string :referer
end

# Some time later
add_index :requests, :referrer # successfully creates index
```

And this migration will break in production, where postgres/mysql is used.

Fixes #27782