### PR TITLE
Fixes ActiveStorage proxy downloads of files over 5mb in S3-like storages

### DIFF
--- a/activestorage/CHANGELOG.md
+++ b/activestorage/CHANGELOG.md
@@ -1,3 +1,15 @@
+*   Fixes proxy downloads of files over 5mb 
+
+    Previously, trying to view and/or download files larger than 5mb stored in
+    services like S3 via proxy mode could return corrupted files at around
+    5.2mb or cause random halts in the download. Now,
+    `ActiveStorage::Blobs::ProxyController` correctly handles streaming these
+    larger files from the service to the client without any issues.
+
+    Fixes #44679
+
+    *Felipe Raul*
+
 *   Saving attachment(s) to a record returns the blob/blobs object
 
     Previously, saving attachments did not return the blob/blobs that

--- a/activestorage/app/controllers/concerns/active_storage/streaming.rb
+++ b/activestorage/app/controllers/concerns/active_storage/streaming.rb
@@ -3,6 +3,7 @@
 require "securerandom"
 
 module ActiveStorage::Streaming
+  extend ActiveSupport::Concern
   DEFAULT_BLOB_STREAMING_DISPOSITION = "inline"
 
   include ActionController::DataStreaming

--- a/activestorage/test/controllers/blobs/proxy_controller_test.rb
+++ b/activestorage/test/controllers/blobs/proxy_controller_test.rb
@@ -85,6 +85,14 @@ class ActiveStorage::Blobs::ProxyControllerTest < ActionDispatch::IntegrationTes
       )
     end
   end
+
+  test "uses a Live::Response" do
+    # This tests for a regression of #45102. If the controller doesn't respond
+    # with a ActionController::Live::Response, it will serve corrupted files
+    # over 5mb when using S3 services.
+    request = ActionController::TestRequest.create({})
+    assert_instance_of ActionController::Live::Response, ActiveStorage::Blobs::ProxyController.make_response!(request)
+  end
 end
 
 class ActiveStorage::Blobs::ExpiringProxyControllerTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
### Summary

This PR fixes the issue described in another PR (#44679), that makes it impossible to download files larger than 5mb stored in S3-like services using the proxy mode. The proposed PR in #44679 didn't solve the issue for me, so this is why I'm opening a new one. 

As described in greater detail in my comment [here](https://github.com/rails/rails/pull/44679#issuecomment-1126960722), Rails's `ActiveStorage::Blobs::ProxyController` uses `#send_blob_stream`, which in turn uses `#send_stream`, which is provided by the `ActionController::Live` concern.

`ActiveStorage::Blobs::ProxyController` doesn't include `ActionController::Live` directly; it does however include `ActiveStorage::Streaming`, which in turns includes `ActionController::Live`, so that's how `#send_blob_stream` can use  `#send_stream`.

However, downloads over 5mb in size were being truncated at ~ 5mb, and/or halting, when using S3-like storage services.

The cause is that `ActiveStorage::Streaming` is a regular module, and not a Rails concern. So even tough it includes `ActionController::Live`, the fact it is not a concern made so that `ActionController::Live`'s `module ClassMethods` was not being extended, and that's essential to wrap the response in a `Live::Response` instance that makes the streaming response > 5mb work without a glitch.

Btw, the fact that `ActiveStorage::Streaming` is located in a `/concerns` subfolder and it's not a concern is also telling that the intention was to make it a concern.

This PR is a one-liner that makes `ActiveStorage::Streaming` a concern, so it has proper concern dependency resolution, making so that `ActionController::Live` that it includes has it's class method installed. 

In the PR #44679, it was proposed to remove the `Content-Length` header, but as per my [comment](https://github.com/rails/rails/pull/44679#issuecomment-1126796327) in that issue, that didn't solve the issues for me, while this does. 