### PR TITLE
Fixes development Action Mailbox new mail form

### DIFF
--- a/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
+++ b/actionmailbox/app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb
@@ -22,7 +22,7 @@ module Rails
       def new_mail
         Mail.new(mail_params.except(:attachments).to_h).tap do |mail|
           mail[:bcc]&.include_in_headers = true
-          mail_params[:attachments].to_a.each do |attachment|
+          mail_params[:attachments]&.select(&:present?)&.each do |attachment|
             mail.add_file(filename: attachment.original_filename, content: attachment.read)
           end
         end

--- a/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
+++ b/actionmailbox/test/controllers/rails/action_mailbox/inbound_emails_controller_test.rb
@@ -72,6 +72,29 @@ class Rails::Conductor::ActionMailbox::InboundEmailsControllerTest < ActionDispa
     end
   end
 
+  test "create inbound email with empty attachment" do
+    with_rails_env("development") do
+      assert_difference -> { ActionMailbox::InboundEmail.count }, +1 do
+        post rails_conductor_inbound_emails_path, params: {
+          mail: {
+            from: "",
+            to: "",
+            cc: "",
+            bcc: "",
+            x_original_to: "",
+            subject: "",
+            in_reply_to: "",
+            body: "",
+            attachments: [ "" ],
+          }
+        }
+      end
+
+      mail = ActionMailbox::InboundEmail.last.mail
+      assert_equal 0, mail.attachments.count
+    end
+  end
+
   private
     def with_rails_env(env)
       old_rails_env = Rails.env


### PR DESCRIPTION
I wanted to add a test for sending an attachment that is an empty string
and a file but got this error:

```
NoMethodError: undefined method `original_filename' for "#<Rack::Test::UploadedFile:0x000000010840d388>":String
```

Related: #44702

Fixes #45088

-----

```
Started POST "/rails/conductor/action_mailbox/inbound_emails" for ::1 at 2022-05-14 07:34:19 +0200
Processing by Rails::Conductor::ActionMailbox::InboundEmailsController#create as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]", "mail"=>{"from"=>"", "to"=>"", "cc"=>"", "bcc"=>"", "x_original_to"=>"", "in_reply_to"=>"", "subject"=>"", "body"=>"", "attachments"=>[""]}, "commit"=>"Deliver inbound email"}
Completed 500 Internal Server Error in 7ms (ActiveRecord: 0.0ms | Allocations: 2600)

NoMethodError (undefined method `original_filename' for "":String

            mail.add_file(filename: attachment.original_filename, content: attachment.read)
                                              ^^^^^^^^^^^^^^^^^^):

actionmailbox (7.0.3) app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:26:in `block (2 levels) in new_mail'
actionmailbox (7.0.3) app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:25:in `each'
actionmailbox (7.0.3) app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:25:in `block in new_mail'
<internal:kernel>:90:in `tap'
actionmailbox (7.0.3) app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:23:in `new_mail'
actionmailbox (7.0.3) app/controllers/rails/conductor/action_mailbox/inbound_emails_controller.rb:17:in `create'
```