### PR TITLE
Allow easier debugging of Action Dispatch requests

### DIFF
--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -195,9 +195,20 @@ module ActionDispatch
     # Returns the original value of the environment's REQUEST_METHOD,
     # even if it was overridden by middleware. See #request_method for
     # more information.
-    def method
-      @method ||= check_method(get_header("rack.methodoverride.original_method") || get_header("REQUEST_METHOD"))
+    #
+    # For debugging purposes, when called with arguments this method will
+    # fallback to Object#method
+    def method(*args)
+      if args.empty?
+        @method ||= check_method(
+          get_header("rack.methodoverride.original_method") ||
+          get_header("REQUEST_METHOD")
+        )
+      else
+        super
+      end
     end
+    ruby2_keywords(:method)
 
     # Returns a symbol form of the #method.
     def method_symbol

--- a/actionpack/test/dispatch/request_test.rb
+++ b/actionpack/test/dispatch/request_test.rb
@@ -783,6 +783,14 @@ class RequestMethod < BaseRequestTest
       end
     end
   end
+
+  test "delegates to Object#method if an argument is passed" do
+    request = stub_request
+
+    assert_nothing_raised do
+      request.method(:POST)
+    end
+  end
 end
 
 class RequestFormat < BaseRequestTest


### PR DESCRIPTION
Kernel#method was redefined so one couldn't do for instance.

method(:POST).source_location

Now when called without arguments it returns the method of the
request and when called with arguments it uses Kernel#method

Which makes debugging easier

### Other Information

I was trying to debug ActionDispatch::Request's methods and first thought I was doing something wrong when calling `method(:POST)`. I first did an `alias_method :_method, :method` but thought this fix could be more intuitive and helpful for others too.