### PR TITLE
Backport: Add app/{helpers,models} to autoload_once_paths

### DIFF
--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -11,6 +11,10 @@ module ActionText
   class Engine < Rails::Engine
     isolate_namespace ActionText
     config.eager_load_namespaces << ActionText
+    config.autoload_once_paths = %W(
+      #{root}/app/helpers
+      #{root}/app/models
+    )
 
     initializer "action_text.attribute" do
       ActiveSupport.on_load(:active_record) do

--- a/railties/test/application/zeitwerk_integration_test.rb
+++ b/railties/test/application/zeitwerk_integration_test.rb
@@ -295,10 +295,12 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     assert $zeitwerk_integration_test_extras
   end
 
-  test "autoload_paths are set as root dirs of main, and in the same order" do
+  test "autoload_paths not in autoload_once_paths are set as root dirs of main, and in the same order" do
     boot
 
-    existing_autoload_paths = deps.autoload_paths.select { |dir| File.directory?(dir) }
+    existing_autoload_paths = \
+      deps.autoload_paths.select { |dir| File.directory?(dir) } -
+      deps.autoload_once_paths
     assert_equal existing_autoload_paths, Rails.autoloaders.main.dirs
   end
 
@@ -315,7 +317,10 @@ class ZeitwerkIntegrationTest < ActiveSupport::TestCase
     extras.each do |extra|
       assert_not_includes Rails.autoloaders.main.dirs, extra
     end
-    assert_equal extras, Rails.autoloaders.once.dirs
+
+    e1_index = Rails.autoloaders.once.dirs.index(extras.first)
+    assert e1_index
+    assert_equal extras, Rails.autoloaders.once.dirs.slice(e1_index, extras.length)
   end
 
   test "clear reloads the main autoloader, and does not reload the once one" do


### PR DESCRIPTION
This is a backport of c431432f93a35530cd0544192b93dabda51f2bf7 for 6-0-stable.
It probably fixes: #45076, see: https://github.com/rails/rails/issues/45076#issuecomment-1127079234
This also makes the engine more inline with 6-1-stable: https://github.com/rails/rails/blob/8e4d04cd5737a9b8a62c39a2506c9a04764b1468/actiontext/lib/action_text/engine.rb#L14-L17

Original commit message:
> The helpers of Action Text are added to a couple of non-reloadable
> base classes:
> 
> ```
>   initializer "action_text.helper" do
>     %i[action_controller_base action_mailer].each do |abstract_controller|
>       ActiveSupport.on_load(abstract_controller) do
>         helper ActionText::Engine.helpers
>       end
>     end
>   end
> ```
> 
> Therefore, it does not make sense that they are reloadable themselves.
> 
> For the same price, we can also make the models non-reloadable, thus
> saving parent applications from the unnecessary work of reloading this
> engine.
>
> We did this for turbo-rails as well.