### PR TITLE
Address QueryCacheTest#test_query_cache_does_not_allow_sql_key_mutation failure

### DIFF
--- a/activerecord/test/cases/query_cache_test.rb
+++ b/activerecord/test/cases/query_cache_test.rb
@@ -388,7 +388,7 @@ class QueryCacheTest < ActiveRecord::TestCase
 
   def test_query_cache_does_not_allow_sql_key_mutation
     subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, payload|
-      payload[:sql].downcase!
+      payload[:sql].downcase! if payload[:name] == "Task Load"
     end
 
     ActiveRecord::Base.cache do


### PR DESCRIPTION
### Summary

This commit addresses this failure.

```ruby
$ cd activerecord
$ ARCONN=postgresql bin/test test/cases/adapters/postgresql/composite_test.rb test/cases/query_cache_test.rb  -n "/^(?:PostgresqlCompositeWithCustomOIDTest#(?:test_column)|QueryCacheTest#(?:test_query_cache_does_not_allow_sql_key_mutation))$/" --seed 50299
Using postgresql
Run options: -n "/^(?:PostgresqlCompositeWithCustomOIDTest#(?:test_column)|QueryCacheTest#(?:test_query_cache_does_not_allow_sql_key_mutation))$/" --seed 50299

.F

Failure:
QueryCacheTest#test_query_cache_does_not_allow_sql_key_mutation [/home/yahonda/src/github.com/rails/rails/activerecord/test/cases/query_cache_test.rb:395]:
0 instead of 1 queries were executed..
Expected: 1
  Actual: 0

bin/test test/cases/query_cache_test.rb:389

Finished in 0.096603s, 20.7033 runs/s, 72.4617 assertions/s.
2 runs, 7 assertions, 1 failures, 0 errors, 0 skips
$
```

Fix #45108
