### PR TITLE
Improve prefixing routes example in guides [ci-skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -1143,7 +1143,10 @@ end
 resources :photos
 ```
 
-This will provide route helpers such as `admin_photos_path`, `new_admin_photo_path`, etc.
+This changes the route helpers for `/admin/photos` from `photos_path`,
+`new_photos_path`, etc. to `admin_photos_path`, `new_admin_photo_path`,
+etc. Without the addition of `as: 'admin_photos` on the scoped `resources
+:photos`, the non-scoped `resources :photos` will not have any route helpers.
 
 To prefix a group of route helpers, use `:as` with `scope`:
 
@@ -1155,7 +1158,9 @@ end
 resources :photos, :accounts
 ```
 
-This will generate routes such as `admin_photos_path` and `admin_accounts_path` which map to `/admin/photos` and `/admin/accounts` respectively.
+Just as before, this changes the `/admin` scoped resource helpers to
+`admin_photos_path` and `admin_accounts_path`, and allows the non-scoped
+resources to use `photos_path` and `accounts_path`.
 
 NOTE: The `namespace` scope will automatically add `:as` as well as `:module` and `:path` prefixes.
 


### PR DESCRIPTION
### Summary

The current example is ambiguous as it uses 'admin' for both the scope
and `:as` option.
By using `helpdesk` for the scope the example becomes clearer.