### PR TITLE
Deprecate `:pool_size` and `:pool_timeout` options for configuring connection pooling in cache stores

### DIFF
--- a/activesupport/CHANGELOG.md
+++ b/activesupport/CHANGELOG.md
@@ -1,3 +1,19 @@
+*   Deprecated `:pool_size` and `:pool_timeout` options for configuring connection pooling in cache stores.
+
+    Use `pool: true` to enable pooling with default settings:
+
+    ```ruby
+    config.cache_store = :redis_cache_store, pool: true
+    ```
+
+    Or pass individual options via `:pool` option:
+
+    ```ruby
+    config.cache_store = :redis_cache_store, pool: { size: 10, timeout: 2 }
+    ```
+
+    *fatkodima*
+
 *   Allow #increment and #decrement methods of `ActiveSupport::Cache::Store`
     subclasses to set new values.
 

--- a/activesupport/lib/active_support/cache.rb
+++ b/activesupport/lib/active_support/cache.rb
@@ -183,10 +183,34 @@ module ActiveSupport
 
       class << self
         private
+          DEFAULT_POOL_OPTIONS = { size: 5, timeout: 5 }.freeze
+          private_constant :DEFAULT_POOL_OPTIONS
+
           def retrieve_pool_options(options)
-            {}.tap do |pool_options|
-              pool_options[:size] = options.delete(:pool_size) if options[:pool_size]
-              pool_options[:timeout] = options.delete(:pool_timeout) if options[:pool_timeout]
+            if (pool_options = options.delete(:pool))
+              if Hash === pool_options
+                DEFAULT_POOL_OPTIONS.merge(pool_options)
+              else
+                DEFAULT_POOL_OPTIONS
+              end
+            else
+              {}.tap do |pool_options|
+                if options[:pool_size]
+                  ActiveSupport::Deprecation.warn(<<~MSG)
+                    Using :pool_size is deprecated and will be removed in Rails 7.2.
+                    Use `pool: { size: #{options[:pool_size].inspect} }` instead.
+                  MSG
+                  pool_options[:size] = options.delete(:pool_size)
+                end
+
+                if options[:pool_timeout]
+                  ActiveSupport::Deprecation.warn(<<~MSG)
+                    Using :pool_timeout is deprecated and will be removed in Rails 7.2.
+                    Use `pool: { timeout: #{options[:pool_timeout].inspect} }` instead.
+                  MSG
+                  pool_options[:timeout] = options.delete(:pool_timeout)
+                end
+              end
             end
           end
 

--- a/activesupport/test/cache/behaviors/connection_pool_behavior.rb
+++ b/activesupport/test/cache/behaviors/connection_pool_behavior.rb
@@ -7,7 +7,7 @@ module ConnectionPoolBehavior
     threads = []
 
     emulating_latency do
-      cache = ActiveSupport::Cache.lookup_store(*store, { pool_size: 2, pool_timeout: 1 }.merge(store_options))
+      cache = ActiveSupport::Cache.lookup_store(*store, { pool: { size: 2, timeout: 1 } }.merge(store_options))
       cache.read("foo")
 
       assert_raises Timeout::Error do

--- a/activesupport/test/cache/stores/mem_cache_store_test.rb
+++ b/activesupport/test/cache/stores/mem_cache_store_test.rb
@@ -314,6 +314,16 @@ class MemCacheStoreTest < ActiveSupport::TestCase
     assert_equal({}, @cache.send(:read_multi_entries, [key]))
   end
 
+  def test_deprecated_connection_pool_works
+    assert_deprecated do
+      cache = ActiveSupport::Cache.lookup_store(:mem_cache_store, pool_size: 2, pool_timeout: 1)
+      pool = cache.instance_variable_get(:@data) # loads 'connection_pool' gem
+      assert_kind_of ::ConnectionPool, pool
+      assert_equal 2, pool.size
+      assert_equal 1, pool.instance_variable_get(:@timeout)
+    end
+  end
+
   private
     def random_string(length)
       (0...length).map { (65 + rand(26)).chr }.join

--- a/activesupport/test/cache/stores/redis_cache_store_test.rb
+++ b/activesupport/test/cache/stores/redis_cache_store_test.rb
@@ -290,6 +290,16 @@ module ActiveSupport::Cache::RedisCacheStoreTests
   class ConnectionPoolBehaviourTest < StoreTest
     include ConnectionPoolBehavior
 
+    def test_deprecated_connection_pool_works
+      assert_deprecated do
+        cache = ActiveSupport::Cache.lookup_store(:redis_cache_store, pool_size: 2, pool_timeout: 1)
+        pool = cache.redis # loads 'connection_pool' gem
+        assert_kind_of ::ConnectionPool, pool
+        assert_equal 2, pool.size
+        assert_equal 1, pool.instance_variable_get(:@timeout)
+      end
+    end
+
     private
       def store
         [:redis_cache_store]

--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -407,15 +407,18 @@ First, add the `connection_pool` gem to your Gemfile:
 gem 'connection_pool'
 ```
 
-Next, pass the `:pool_size` and/or `:pool_timeout` options when configuring the cache store:
+Next, set `:pool` option to `true` when configuring the cache store:
 
 ```ruby
-config.cache_store = :mem_cache_store, "cache.example.com", { pool_size: 5, pool_timeout: 5 }
+config.cache_store = :mem_cache_store, "cache.example.com", pool: true
 ```
 
-* `:pool_size` - This option sets the number of connections per process (defaults to 5).
+You can also override default pool settings by providing individual options
+instead of `true` to this option.
 
-* `:pool_timeout` - This option sets the number of seconds to wait for a connection (defaults to 5). If no connection is available within the timeout, a `Timeout::Error` will be raised.
+* `:size` - This option sets the number of connections per process (defaults to 5).
+
+* `:timeout` - This option sets the number of seconds to wait for a connection (defaults to 5). If no connection is available within the timeout, a `Timeout::Error` will be raised.
 
 #### Custom Cache Stores
 


### PR DESCRIPTION
Fixes #39479.

cc @byroot 