### PR TITLE
Fix using helpers in `content_security_policy` and `permissions_policy`

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,17 @@
+*   Allow using `helper_method`s in `content_security_policy` and `permissions_policy`
+
+    Previously you could access basic helpers (defined in helper modules), but not
+    helper methods defined using `helper_method`. Now you can use either.
+
+    ```ruby
+    content_security_policy do |p|
+      p.default_src "https://example.com"
+      p.script_src "https://example.com" if helpers.script_csp?
+    end
+    ```
+
+    *Alex Ghiculescu*
+
 *   Reimplement `ActionController::Parameters#has_value?` and `#value?` to avoid parameters and hashes comparison.
 
     Deprecated equality between parameters and hashes is going to be removed in Rails 7.2.

--- a/actionpack/lib/action_controller/metal/content_security_policy.rb
+++ b/actionpack/lib/action_controller/metal/content_security_policy.rb
@@ -40,7 +40,7 @@ module ActionController # :nodoc:
         before_action(options) do
           if block_given?
             policy = current_content_security_policy
-            yield policy
+            instance_exec(policy, &block)
             request.content_security_policy = policy
           end
 

--- a/actionpack/lib/action_controller/metal/permissions_policy.rb
+++ b/actionpack/lib/action_controller/metal/permissions_policy.rb
@@ -27,7 +27,7 @@ module ActionController # :nodoc:
         before_action(options) do
           if block_given?
             policy = request.permissions_policy.clone
-            yield policy
+            instance_exec(policy, &block)
             request.permissions_policy = policy
           end
         end


### PR DESCRIPTION
Fixes https://github.com/rails/rails/issues/45034

Currently helpers that are generated using `helper_method` cannot be used in `content_security_policy` and `permissions_policy`, this is because the use of `yield` causes `self` to be set incorrectly. By using `instance_exec` we ensure the scoping is correct so that you can access the same methods you'd be able to if you wrote your own `before_action`.

cc @lavaturtle 