### PR TITLE
Fix incorrect line number if a `helper_method` raises

### DIFF
--- a/actionpack/lib/abstract_controller/helpers.rb
+++ b/actionpack/lib/abstract_controller/helpers.rb
@@ -84,10 +84,13 @@ module AbstractController
         file, line = location.path, location.lineno
 
         methods.each do |method|
-          _helpers_for_modification.class_eval <<~ruby_eval, file, line
-            def #{method}(*args, &block)                    # def current_user(*args, &block)
-              controller.send(:'#{method}', *args, &block)  #   controller.send(:'current_user', *args, &block)
-            end                                             # end
+          # def current_user(*args, &block)
+          #   controller.send(:'current_user', *args, &block)
+          # end
+          _helpers_for_modification.class_eval <<~ruby_eval.lines.map(&:strip).join(";"), file, line
+            def #{method}(*args, &block)
+              controller.send(:'#{method}', *args, &block)
+            end
             ruby2_keywords(:'#{method}')
           ruby_eval
         end

--- a/actionpack/test/controller/helper_test.rb
+++ b/actionpack/test/controller/helper_test.rb
@@ -98,6 +98,9 @@ class HelperTest < ActiveSupport::TestCase
     def delegate_method() end
     def delegate_method_arg(arg); arg; end
     def delegate_method_kwarg(hi:); hi; end
+    def method_that_raises
+      raise "an error occurred"
+    end
   end
 
   def setup
@@ -143,6 +146,16 @@ class HelperTest < ActiveSupport::TestCase
     assert_nothing_raised { @controller_class.helper_method :delegate_method_kwarg }
 
     assert_equal(:there, @controller_class.new.helpers.delegate_method_kwarg(hi: :there))
+  end
+
+  def test_helper_method_with_error_has_correct_backgrace
+    @controller_class.helper_method :method_that_raises
+    expected_backtrace_pattern = "#{__FILE__}:#{__LINE__ - 1}"
+
+    error = assert_raises(RuntimeError) do
+      @controller_class.new.helpers.method_that_raises
+    end
+    assert_not_nil error.backtrace.find { |line| line.include?(expected_backtrace_pattern) }
   end
 
   def test_helper_attr


### PR DESCRIPTION
Currently if you use `helper_method` to define a method, and inside that method you get an error, the backtrace is off by one line. I noticed this while debugging https://github.com/rails/rails/pull/45115

This PR fixes that so that the backtrace now points to the line where you called `helper_method`.
