### PR TITLE
Add CORS to the security guide [ci-skip]

### DIFF
--- a/guides/source/security.md
+++ b/guides/source/security.md
@@ -1336,6 +1336,39 @@ end
 
 [`Feature-Policy`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
 
+### Cross-Origin Resource Sharing
+
+Browsers restrict cross-origin HTTP requests initiated from scripts. If you
+want to run Rails as an API, and run a frontend app on a separate domain, you
+need to enable [Cross-Origin Resource
+Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS).
+
+You can use the [Rack CORS](https://github.com/cyu/rack-cors) middleware for
+handling CORS. If you've generated your application with the `--api` option,
+Rack CORS has probably already been configured and you can skip the following
+steps.
+
+To get started, add the rack-cors gem to your Gemfile:
+
+```ruby
+gem 'rack-cors'
+```
+
+Next, add an initializer to configure the middleware:
+
+```ruby
+# config/initializers/cors.rb
+Rails.application.config.middleware.insert_before 0, "Rack::Cors" do
+  allow do
+    origins 'example.com'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end
+```
+
 Environmental Security
 ----------------------
 


### PR DESCRIPTION
### Summary

`rack-cors` is mentioned in the [Gemfile](https://github.com/rails/rails/blob/83c9bebf808a8e2654aa4e1921684698cb238692/railties/lib/rails/generators/rails/app/templates/Gemfile.tt#L37-L39) and a [CORS initializer ](https://github.com/rails/rails/blob/83c9bebf808a8e2654aa4e1921684698cb238692/railties/lib/rails/generators/rails/app/templates/config/initializers/cors.rb.tt#L1-L16)is generated
for API-only apps, but CORS isn't mentioned anywhere in the guides.
If you didn't start an applications as API-only, you'd miss the "Rails-way" for
handling CORS.
This adds CORS to the HTTP Security Headers section in the security guides.