### PR TITLE
ActiveSupport::Inspect: easily set up constrained inspect output

### DIFF
--- a/actioncable/lib/action_cable/connection/stream_event_loop.rb
+++ b/actioncable/lib/action_cable/connection/stream_event_loop.rb
@@ -5,6 +5,8 @@ require "nio"
 module ActionCable
   module Connection
     class StreamEventLoop
+      include ActiveSupport::Inspect({ "attached" => -> { @map.size }, "loop" => :@thread, "post_queue" => -> { @executor&.queue_length }, "post_threads" => -> { @executor&.length } })
+
       def initialize
         @nio = @executor = @thread = nil
         @map = {}

--- a/actioncable/lib/action_cable/server/worker.rb
+++ b/actioncable/lib/action_cable/server/worker.rb
@@ -14,6 +14,8 @@ module ActionCable
       define_callbacks :work
       include ActiveRecordConnectionManagement
 
+      include ActiveSupport::Inspect({ "queue" => -> { @executor.queue_length }, "threads" => -> { @executor.length } })
+
       attr_reader :executor
 
       def initialize(max_size: 5)

--- a/actionpack/lib/abstract_controller/base.rb
+++ b/actionpack/lib/abstract_controller/base.rb
@@ -46,6 +46,8 @@ module AbstractController
     include ActiveSupport::Configurable
     extend ActiveSupport::DescendantsTracker
 
+    include ActiveSupport::Inspect(id: true)
+
     class << self
       attr_reader :abstract
       alias_method :abstract?, :abstract
@@ -194,10 +196,6 @@ module AbstractController
     # support paths, only full URLs.
     def self.supports_path?
       true
-    end
-
-    def inspect # :nodoc:
-      "#<#{self.class.name}:#{'%#016x' % (object_id << 1)}>"
     end
 
     private

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -26,6 +26,8 @@ module ActionDispatch
     include ActionDispatch::PermissionsPolicy::Request
     include Rack::Request::Env
 
+    include ActiveSupport::Inspect() { [[method, original_url.dump], ["for", remote_ip]] }
+
     autoload :Session, "action_dispatch/request/session"
     autoload :Utils,   "action_dispatch/request/utils"
 
@@ -424,10 +426,6 @@ module ActionDispatch
     end
 
     def commit_flash
-    end
-
-    def inspect # :nodoc:
-      "#<#{self.class.name} #{method} #{original_url.dump} for #{remote_ip}>"
     end
 
     def reset_csrf_token

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -216,13 +216,13 @@ module ActionDispatch
         end
       end
 
-      def inspect
+      include ActiveSupport::Inspect() {
         if loaded?
-          super
+          [id&.public_id&.inspect, -> q { q.pp(@delegate) }].compact
         else
-          "#<#{self.class}:0x#{(object_id << 1).to_s(16)} not yet loaded>"
+          "not yet loaded"
         end
-      end
+      }
 
       def exists?
         return false unless enabled?

--- a/actiontext/lib/action_text/attachment.rb
+++ b/actiontext/lib/action_text/attachment.rb
@@ -47,6 +47,8 @@ module ActionText
         end
     end
 
+    include ActiveSupport::Inspect(:attachable)
+
     attr_reader :node, :attachable
 
     delegate :to_param, to: :attachable
@@ -83,10 +85,6 @@ module ActionText
 
     def to_s
       to_html
-    end
-
-    def inspect
-      "#<#{self.class.name} attachable=#{attachable.inspect}>"
     end
 
     private

--- a/actiontext/lib/action_text/attachment_gallery.rb
+++ b/actiontext/lib/action_text/attachment_gallery.rb
@@ -49,6 +49,8 @@ module ActionText
 
     attr_reader :node
 
+    include ActiveSupport::Inspect(:size)
+
     def initialize(node)
       @node = node
     end
@@ -61,10 +63,6 @@ module ActionText
 
     def size
       attachments.size
-    end
-
-    def inspect
-      "#<#{self.class.name} size=#{size.inspect}>"
     end
   end
 end

--- a/actiontext/lib/action_text/content.rb
+++ b/actiontext/lib/action_text/content.rb
@@ -4,6 +4,8 @@ module ActionText
   class Content
     include Rendering, Serialization
 
+    include ActiveSupport::Inspect() { to_html.truncate(25).inspect }
+
     attr_reader :fragment
 
     delegate :blank?, :empty?, :html_safe, :present?, to: :to_html # Delegating to to_html to avoid including the layout
@@ -97,10 +99,6 @@ module ActionText
 
     def as_json(*)
       to_html
-    end
-
-    def inspect
-      "#<#{self.class.name} #{to_html.truncate(25).inspect}>"
     end
 
     def ==(other)

--- a/actionview/lib/action_view/template.rb
+++ b/actionview/lib/action_view/template.rb
@@ -120,6 +120,8 @@ module ActionView
     attr_reader :identifier, :handler
     attr_reader :variable, :format, :variant, :locals, :virtual_path
 
+    include ActiveSupport::Inspect(:locals) { short_identifier }
+
     def initialize(source, identifier, handler, locals:, format: nil, variant: nil, virtual_path: nil)
       @source            = source
       @identifier        = identifier
@@ -166,10 +168,6 @@ module ActionView
 
     def short_identifier
       @short_identifier ||= defined?(Rails.root) ? identifier.delete_prefix("#{Rails.root}/") : identifier
-    end
-
-    def inspect
-      "#<#{self.class.name} #{short_identifier} locals=#{@locals.inspect}>"
     end
 
     def source

--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -100,6 +100,8 @@ module ActiveModel
       I18n.translate(key, **options)
     end
 
+    include ActiveSupport::Inspect(:attribute, :type, :options)
+
     def initialize(base, attribute, type = :invalid, **options)
       @base = base
       @attribute = attribute
@@ -193,10 +195,6 @@ module ActiveModel
 
     def hash # :nodoc:
       attributes_for_hash.hash
-    end
-
-    def inspect # :nodoc:
-      "#<#{self.class.name} attribute=#{@attribute}, type=#{@type}, options=#{@options.inspect}>"
     end
 
     protected

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -82,6 +82,8 @@ module ActiveModel
     attr_reader :errors
     alias :objects :errors
 
+    include ActiveSupport::Inspect() { -> q { q.pp(@errors) } }
+
     # Pass in the instance of the object that is using the errors object.
     #
     #   class Person
@@ -453,12 +455,6 @@ module ActiveModel
     # * <tt>errors.messages.blank</tt>
     def generate_message(attribute, type = :invalid, options = {})
       Error.generate_message(attribute, type, @base, options)
-    end
-
-    def inspect # :nodoc:
-      inspection = @errors.inspect
-
-      "#<#{self.class.name} #{inspection}>"
     end
 
     private

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -104,6 +104,18 @@ module ActiveRecord
       include QueryCache::ConnectionPoolConfiguration
       include ConnectionAdapters::AbstractPool
 
+      include ActiveSupport::Inspect(-> {
+        result = {}
+        result["shard"] = @shard unless @shard == :default
+        result
+      }) {
+        name_parts = []
+        name_parts << db_config.env_name
+        name_parts << db_config.name unless db_config.name == "primary"
+        name_parts << @role
+        name_parts.map(&:inspect)
+      }
+
       attr_accessor :automatic_reconnect, :checkout_timeout
       attr_reader :db_config, :size, :reaper, :pool_config, :connection_class, :async_executor, :role, :shard
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -35,6 +35,18 @@ module ActiveRecord
       include QueryCache
       include Savepoints
 
+      include ActiveSupport::Inspect(-> {
+        result = {}
+        result["shard"] = shard unless shard == :default
+        result
+      }, id: :__id__) {
+        name_parts = []
+        name_parts << pool.db_config.env_name
+        name_parts << pool.db_config.name unless pool.db_config.name == "primary"
+        name_parts << role
+        name_parts.map(&:inspect)
+      }
+
       SIMPLE_INT = /\A\d+\z/
       COMMENT_REGEX = %r{(?:--.*\n)|/\*(?:[^*]|\*[^/])*\*/}m
 

--- a/activerecord/lib/active_record/promise.rb
+++ b/activerecord/lib/active_record/promise.rb
@@ -4,6 +4,8 @@ module ActiveRecord
   class Promise < BasicObject
     undef_method :==, :!, :!=
 
+    include ActiveSupport::Inspect { status }
+
     def initialize(future_result, block) # :nodoc:
       @future_result = future_result
       @block = block
@@ -39,14 +41,6 @@ module ActiveRecord
 
     [:class, :respond_to?, :is_a?].each do |method|
       define_method(method, ::Object.instance_method(method))
-    end
-
-    def inspect # :nodoc:
-      "#<ActiveRecord::Promise status=#{status}>"
-    end
-
-    def pretty_print(q) # :nodoc:
-      q.text(inspect)
     end
 
     private

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -26,10 +26,10 @@
 require "securerandom"
 require "active_support/dependencies/autoload"
 require "active_support/version"
+require "active_support/inspect"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
-require "active_support/inspect"
 
 module ActiveSupport
   extend ActiveSupport::Autoload

--- a/activesupport/lib/active_support.rb
+++ b/activesupport/lib/active_support.rb
@@ -29,6 +29,7 @@ require "active_support/version"
 require "active_support/logger"
 require "active_support/lazy_load_hooks"
 require "active_support/core_ext/date_and_time/compatibility"
+require "active_support/inspect"
 
 module ActiveSupport
   extend ActiveSupport::Autoload

--- a/activesupport/lib/active_support/cache/memory_store.rb
+++ b/activesupport/lib/active_support/cache/memory_store.rb
@@ -130,9 +130,7 @@ module ActiveSupport
         end
       end
 
-      def inspect # :nodoc:
-        "#<#{self.class.name} entries=#{@data.size}, size=#{@cache_size}, options=#{@options.inspect}>"
-      end
+      include ActiveSupport::Inspect({ "entries" => -> { @data.size }, "size" => :@cache_size, "options" => :@options })
 
       # Synchronize calls to the cache. This should be called wherever the underlying cache implementation
       # is not thread safe.

--- a/activesupport/lib/active_support/cache/redis_cache_store.rb
+++ b/activesupport/lib/active_support/cache/redis_cache_store.rb
@@ -171,10 +171,7 @@ module ActiveSupport
         end
       end
 
-      def inspect
-        instance = @redis || @redis_options
-        "#<#{self.class} options=#{options.inspect} redis=#{instance.inspect}>"
-      end
+      include ActiveSupport::Inspect({ "options" => :options, "redis" => -> { @redis || @redis_options } })
 
       # Cache Store API implementation.
       #

--- a/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
+++ b/activesupport/lib/active_support/deprecation/proxy_wrappers.rb
@@ -18,6 +18,11 @@ module ActiveSupport
         target.inspect
       end
 
+      # Same for pretty_print: it's used by the console.
+      def pretty_print(pp)
+        target.pretty_print(pp)
+      end
+
       private
         def method_missing(called, *args, &block)
           warn caller_locations, called, args
@@ -143,6 +148,11 @@ module ActiveSupport
       # logs rely on it for diagnostics.
       def inspect
         target.inspect
+      end
+
+      # Same for pretty_print: it's used by the console.
+      def pretty_print(pp)
+        target.pretty_print(pp)
       end
 
       # Don't give a deprecation warning on methods that IRB may invoke

--- a/activesupport/lib/active_support/inspect.rb
+++ b/activesupport/lib/active_support/inspect.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+require "pp"
+
+module ActiveSupport
+  # Note that this is a module _constructor_: to use it, you need to
+  # call it as a method and then #include the result.
+  #
+  # Returns a module that defines pretty-printing (PP) methods to
+  # display the given attributes. Note that unlike the default
+  # Object#inspect only the listed attributes will be included. This
+  # allows the caller to constrain the detail shown, and focus on an
+  # object's identifying characteristics and operational data, while
+  # skipping over e.g. cached values and owning-object references that
+  # could cause huge object trees to be enumerated.
+  #
+  #
+  # Each attribute is an identifier to be evaluated in the context of the
+  # object: undecorated names are assumed to be methods, while instance
+  # variables may be accessed by their "@"-prefixed name.
+  #
+  # Attributes can also be specified as a hash, in which case the key is
+  # the label to be displayed, and the value is the attribute to be
+  # inspected (or a proc that will be called to obtain the value).
+  #
+  # Before the attributes appear in the output, space is reserved for an
+  # optional object +label+, which is intended to be a short value
+  # identifying the object instance.
+  #
+  # To customize the label, pass a block that returns a string, or set
+  # the +label:+ parameter to a symbol to call that method on the
+  # instance being inspected.
+  #
+  # +label+ may produce an array, in which case the elements will be
+  # rendered in order, with each element separated by whitespace.
+  # Strings are inserted in the output unmodified; this provides more
+  # control over the output, but means #inspect should be used for
+  # displaying unknown values to retain proper formatting. Any element
+  # that is not an array or a string will be recursively pretty-printed.
+  #
+  # By default the built-in object address (e.g. 0x0123456789abcdef),
+  # which appears in the standard Kernel#inspect output, is not
+  # included. To add it, pass +id: true+. This can be useful when
+  # objects are otherwise indistinguishable, but makes for more
+  # cluttered output. The expectation is that most classes defining
+  # custom inspection will provide sufficient detail in the label and/or
+  # attributes to identify the instance.
+  #
+  #
+  # When this module is included, if the target class/module does not
+  # have a specific #to_s method, an additional ToString module will
+  # automatically be included, which will provide a #to_s method that
+  # produces a subset of the #inspect output. (Specifically, the class
+  # name and object id / label, but not the attributes.)
+  #
+  #
+  # ==== Example
+  #
+  #  class User
+  #    def initialize(id, username, name, interests, password_digest)
+  #      @id = id
+  #      @username = username
+  #      @name = name
+  #      @interests = interests
+  #      @password_digest = password_digest
+  #    end
+  #  end
+  #
+  #  user = User.new(77, "jdoe", "John Doe", ["sports", "music"],
+  #                  "61bc77ec652ed6ace7a8eb44...")
+  #
+  #  # Default Ruby behavior:
+  #
+  #  user.inspect #=> "#<User:0x00007f9b8f8b9840 @id=77, @username=\"jdoe\", @name=\"John Doe\", @interests=[\"sports\", \"music\"], @password_digest=\"61bc77ec652ed6ace7a8eb44...\">"
+  #  user.to_s #=> "#<User:0x00007f9b8f8b9840>"
+  #
+  #  pp user #=>
+  #  > #<User:0x0000000113695bb8
+  #  >  @id=77,
+  #  >  @interests=["sports", "music"],
+  #  >  @name="John Doe",
+  #  >  @password_digest="61bc77ec652ed6ace7a8eb44...",
+  #  >  @username="jdoe">
+  #
+  #  # After defining a custom Inspect for the User class:
+  #
+  #  class User
+  #    include ActiveSupport::Inspect(:@name, { interests: -> { @interests.size } }) { [@id, @username.to_s] }
+  #  end
+  #
+  #  user.inspect #=> "#<User 77 \"jdoe\" @name=\"John Doe\" interests=2>"
+  #  user.to_s #=> "#<User 77 \"jdoe\">"
+  #
+  #  pp user #=>
+  #  > #<User 77 "jdoe"
+  #  >   @name="John Doe"
+  #  >   interests=2>
+  #
+  def self.Inspect(*attributes, label: nil, id: false, &block)
+    Inspect.new(id: id, label: label || block, attributes: attributes, source_location: caller_locations(1, 1)[0])
+  end
+
+  class Inspect < ::Module # :nodoc:
+    UNDEF = Object.new
+    KERNEL_TO_S = ::Kernel.instance_method(:to_s)
+    MODULE_NAME = ::Module.instance_method(:name)
+    MODULE_TO_S = ::Module.instance_method(:to_s)
+
+    class ToString < ::Module # :nodoc:
+      def initialize(inspect_module)
+        define_method(:to_s) { inspect_module.pretty_string_for(self) }
+      end
+    end
+
+    def initialize(id:, label:, attributes:, source_location: nil)
+      @id = id
+      @label = expand_label(label)
+      @attributes = expand_attributes(attributes)
+      @source_location = source_location
+
+      inspect_module = self
+      define_method(:pretty_print) { |q| inspect_module.pretty_print_object(q, self) }
+      define_method(:pretty_print_cycle) { |q| inspect_module.pretty_print_object(q, self, true) }
+
+      alias_method :inspect, :pretty_print_inspect
+
+      @string_module = ToString.new(inspect_module)
+    end
+
+    def pretty_print_object(q, obj, cycle = false)
+      leader, opener, closer = pretty_identifier_parts(obj)
+
+      q.text leader
+
+      if pretty_label(q, opener, obj, cycle)
+        opener = nil
+      end
+
+      if cycle
+        if opener
+          q.text opener
+          q.group(1) do
+            q.breakable ""
+            q.text "..."
+          end
+        else
+          q.group(1) do
+            q.breakable
+            q.text "..."
+          end
+        end
+      else
+        if pretty_attributes(q, opener, obj)
+          opener = nil
+        end
+      end
+
+      q.text closer unless opener
+
+      q
+    end
+
+    def pretty_string_for(obj)
+      s = "".dup
+      q = defined?(::PP::SingleLine) ? ::PP::SingleLine.new(s) : ::PP.new(s, 9999)
+
+      q.guard_inspect_key do
+        leader, opener, closer = pretty_identifier_parts(obj)
+
+        q.text leader
+
+        if pretty_label(q, opener, obj, false)
+          opener = nil
+        end
+
+        q.text closer unless opener
+      end
+      q.flush
+
+      s
+    end
+
+    private
+      attr_reader :id, :label, :attributes, :source_location
+
+      def included(target)
+        # Our #to_s is marginally better than Kernel or Module's, but
+        # not an improvement on any other inherited attempt.
+        owner = target.instance_method(:to_s).owner
+        if ::Kernel == owner || ::Module == owner
+          target.include @string_module
+        end
+      end
+
+      def expand_label(label)
+        case label
+        when ::Symbol
+          -> { __send__(label).inspect }
+        when ::Proc, nil
+          label
+        else
+          raise ::ArgumentError, "label must be a Symbol or Proc"
+        end
+      end
+
+      def expand_attributes(attributes)
+        attribute_map = {}
+        attributes.flatten.each_with_index do |attribute, idx|
+          case attribute
+          when ::Symbol, ::String
+            attribute_map[attribute.to_s] = attribute.to_s
+          when ::Hash
+            attribute.each do |key, value|
+              attribute_map[key.to_s] =
+                if value.is_a?(::Proc)
+                  value
+                else
+                  value.to_s
+                end
+            end
+          when ::Proc
+            attribute_map[idx] = attribute
+          end
+        end
+        attribute_map
+      end
+
+      def pretty_attributes(q, opener, obj)
+        attribute_values = {}
+        @attributes.each do |label, source|
+          value = if source.is_a?(::Proc)
+                    obj.instance_exec(&source)
+                  else
+                    obj.instance_eval("defined?(#{source}) ? (#{source}) : ::ActiveSupport::Inspect::UNDEF")
+                  end
+          if label.is_a?(::Integer)
+            attribute_values.update(value) if value
+          else
+            attribute_values[label] = value unless UNDEF == value
+          end
+        end
+
+        return false if attribute_values.empty?
+
+        q.text opener if opener
+
+        q.group(1) do
+          q.breakable(opener ? "" : " ")
+
+          first = true
+          attribute_values.each do |attr, value|
+            q.group do
+              if first
+                first = false
+              else
+                q.breakable
+              end
+              q.text attr
+              q.text "="
+              q.group(1) do
+                q.breakable ""
+                q.pp(value)
+              end
+            end
+          end
+        end
+
+        true
+      end
+
+      def pretty_label_segment(q, content, cycle)
+        case content
+        when ::Array
+          q.group do
+            first = true
+            content.each do |el|
+              if first
+                first = false
+              else
+                q.breakable
+              end
+              pretty_label_segment(q, el, cycle)
+            end
+          end
+        when ::String
+          q.text content
+        when ::Proc
+          if cycle
+            q.text "..."
+          else
+            content.call(q)
+          end
+        when ::Numeric, ::Symbol, ::TrueClass, ::FalseClass, ::NilClass
+          q.pp content
+        else
+          if cycle
+            q.text "..."
+          else
+            q.pp content
+          end
+        end
+      end
+
+      def pretty_label(q, opener, obj, cycle)
+        if @label && label_content = obj.instance_exec(&@label)
+          q.text opener if opener
+
+          q.group(1) do
+            q.breakable(opener ? "" : " ")
+
+            pretty_label_segment(q, label_content, cycle)
+          end
+
+          true
+        end
+      end
+
+      # Returns three values:
+      #  * leader -- the first part of the result, which will always be
+      #    present.
+      #  * opener -- the (optional) opening bracket to insert before the
+      #    first "detail" element, if one is present.
+      #  * closer -- the last part of the result, which will be included
+      #    if opener was used (meaning there were details present), _or_
+      #    if opener was nil (indicating that leader had already created
+      #    visual nesting).
+      #
+      # The leader is typically a class or module name, decorated to
+      # distinguish instances from direct references.
+      #
+      # For example, for an instance of MyClass:
+      # => ["#<MyClass:0x01234567", nil, ">"]
+      #
+      # For the class itself:
+      # => ["MyClass", "(", ")"]
+      #
+      #
+      # The opener is passed through subsequent calls to detail methods,
+      # and set to nil when they return true, indicating that they wrote
+      # content (and thus consumed and wrote the opener).
+      def pretty_identifier_parts(obj)
+        if ::Module === obj && (own_name = MODULE_NAME.bind_call(obj)) && !own_name.start_with?("#<")
+          # We are a permanently-named constant
+
+          [own_name, "(", ")"]
+        else
+          leader =
+            case @id
+            when nil, false
+              "#<#{MODULE_NAME.bind_call(obj.class) || MODULE_TO_S.bind_call(obj.class)}"
+            when true
+              s =
+                if ::Module === obj
+                  MODULE_TO_S.bind_call(obj)
+                else
+                  KERNEL_TO_S.bind_call(obj)
+                end
+              s.chomp!(">")
+              s
+            else
+              "#<#{MODULE_NAME.bind_call(obj.class)}:#{obj.instance_exec(&@id)}"
+            end
+
+          [leader, nil, ">"]
+        end
+      end
+
+    include ActiveSupport::Inspect() { "#{source_location.path}:#{source_location.lineno}".inspect }
+    ToString.include ActiveSupport::Inspect()
+  end
+end

--- a/activesupport/lib/active_support/notifications/fanout.rb
+++ b/activesupport/lib/active_support/notifications/fanout.rb
@@ -24,6 +24,8 @@ module ActiveSupport
     class Fanout
       include Mutex_m
 
+      include ActiveSupport::Inspect() { "(#{@string_subscribers.size + @other_subscribers.size} patterns)" }
+
       def initialize
         @string_subscribers = Hash.new { |h, k| h[k] = [] }
         @other_subscribers = []
@@ -66,11 +68,6 @@ module ActiveSupport
             end
           end
         end
-      end
-
-      def inspect # :nodoc:
-        total_patterns = @string_subscribers.size + @other_subscribers.size
-        "#<#{self.class} (#{total_patterns} patterns)>"
       end
 
       def start(name, id, payload)

--- a/activesupport/test/inspect_test.rb
+++ b/activesupport/test/inspect_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/inspect"
+
+class InspectTest < ActiveSupport::TestCase
+  class ComplexObject
+    def initialize(id, username, name, interests, password_digest)
+      @id = id
+      @username = username
+      @name = name
+      @interests = interests
+      @password_digest = password_digest
+    end
+
+    include ActiveSupport::Inspect(:@name, :interest_count, :longer_attribute) { [@id, @username.inspect] }
+
+    def interest_count
+      @interests.size
+    end
+
+    def longer_attribute
+      "attribute value"
+    end
+  end
+
+  def setup
+    @object = ComplexObject.new(17, "james", "James", %w(ruby rails), "password")
+  end
+
+  test "#inspect" do
+    assert_equal "#<InspectTest::ComplexObject 17 \"james\" @name=\"James\" interest_count=2 longer_attribute=\"attribute value\">", @object.inspect
+  end
+
+  test "#to_s" do
+    assert_equal "#<InspectTest::ComplexObject 17 \"james\">", @object.to_s
+  end
+
+  test "#pretty_print" do
+    output = +""
+    PP.pp(@object, output, 20)
+    assert_equal <<~OUT, output
+    #<InspectTest::ComplexObject
+     17 "james"
+     @name="James"
+     interest_count=2
+     longer_attribute=
+      "attribute value">
+    OUT
+  end
+
+  class InheritanceParent
+    def inspect
+      "custom inspect"
+    end
+
+    def to_s
+      "custom to_s"
+    end
+  end
+
+  class ChildWithInspect < InheritanceParent
+    include ActiveSupport::Inspect()
+  end
+
+  test "overrides an inherited #inspect" do
+    assert_equal "custom inspect", InheritanceParent.new.inspect
+    assert_equal "#<InspectTest::ChildWithInspect>", ChildWithInspect.new.inspect
+  end
+
+  test "avoids overriding an existing inherited #to_s" do
+    assert_equal "custom to_s", InheritanceParent.new.to_s
+    assert_equal "custom to_s", ChildWithInspect.new.to_s
+  end
+
+  class EmptyInspect
+    include ActiveSupport::Inspect()
+  end
+
+  OBJECT_ADDRESS = /0x\h+/
+  ANONYMOUS_CLASS = /#<Class:#{OBJECT_ADDRESS}>/
+
+  test "omits object id by default" do
+    object = EmptyInspect.new
+    assert_match(/\#<InspectTest::EmptyInspect>/, object.inspect)
+  end
+
+  test "omits object id when disabled" do
+    very_empty = Class.new do
+      include ActiveSupport::Inspect(id: false)
+    end.new
+
+    assert_match(/^\#<#{ANONYMOUS_CLASS}>$/, very_empty.inspect)
+  end
+
+  class IdInspect
+    include ActiveSupport::Inspect(id: true) { "some label" }
+  end
+
+  test "includes object id when explicitly enabled" do
+    object = IdInspect.new
+    assert_match(/\#<InspectTest::IdInspect:#{address_of(object)} some label>/, object.inspect)
+  end
+
+  test "omits object id when a label is supplied" do
+    labelled_object = Class.new do
+      include ActiveSupport::Inspect(label: :my_label)
+
+      def my_label
+        "my label"
+      end
+    end.new
+
+    # Label string via symbol is automatically inspected
+    assert_match(/^\#<#{ANONYMOUS_CLASS} "my label">$/, labelled_object.inspect)
+  end
+
+  test "separates multiple label elements" do
+    dual_labelled_object = Class.new do
+      include ActiveSupport::Inspect() { [my_label, my_other_label] }
+
+      def my_label
+        "(my label)"
+      end
+
+      def my_other_label
+        :my_other_label
+      end
+    end.new
+
+    # String label components from a block are inserted as-is; other types are inspected
+    assert_match(/^\#<#{ANONYMOUS_CLASS} \(my label\) :my_other_label>$/, dual_labelled_object.inspect)
+  end
+
+  test "includes specified attributes in order" do
+    attributed_object = Class.new do
+      include ActiveSupport::Inspect(:@name, :@id)
+
+      def initialize(name, id)
+        @name = name
+        @id = id
+      end
+    end.new("james", 17)
+
+    assert_match(/\#<#{ANONYMOUS_CLASS} @name="james" @id=17>/, attributed_object.inspect)
+  end
+
+  test "a hash inside attributes gets expanded" do
+    dynamically_attributed_object = Class.new do
+      include ActiveSupport::Inspect(:basic_attribute, { "dynamic" => :callable, "expr" => "2 > 1", :hash => { structure: ["nestable"] } }, :another_attribute) { "static label" }
+
+      def callable
+        "called"
+      end
+
+      def basic_attribute
+        "basic"
+      end
+
+      def another_attribute
+        "another"
+      end
+    end.new
+
+    assert_match(/\#<#{ANONYMOUS_CLASS} static label basic_attribute="basic" dynamic=\"called\" expr=true hash=\{:structure=>\["nestable"\]\} another_attribute="another">/, dynamically_attributed_object.inspect)
+  end
+
+  class CyclicInspect
+    include ActiveSupport::Inspect(:@attribute, :static, id: true) { ["simple", :symbol, 123, @label] }
+
+    attr_accessor :label, :attribute
+
+    def static
+      "value"
+    end
+  end
+
+  test "handles cyclic references in label" do
+    object = CyclicInspect.new
+    object.label = object
+    object.attribute = object
+
+    nested_reference = /\#<InspectTest::CyclicInspect:#{address_of(object)} simple :symbol 123 ... ...>/
+    assert_match(/^\#<InspectTest::CyclicInspect:#{address_of(object)} simple :symbol 123 #{nested_reference} @attribute=#{nested_reference} static="value">$/, object.inspect)
+  end
+
+  test "handles cyclic references in attributes" do
+    object = CyclicInspect.new
+    object.label = "safe-label"
+    object.attribute = object
+
+    nested_reference = /\#<InspectTest::CyclicInspect:#{address_of(object)} simple :symbol 123 safe-label ...>/
+    assert_match(/^\#<InspectTest::CyclicInspect:#{address_of(object)} simple :symbol 123 safe-label @attribute=#{nested_reference} static="value">$/, object.inspect)
+  end
+
+  private
+    def address_of(object)
+      ::Kernel.instance_method(:to_s).bind_call(object).match(/#{OBJECT_ADDRESS}(?=>$)/)
+    end
+end

--- a/railties/lib/rails/paths.rb
+++ b/railties/lib/rails/paths.rb
@@ -48,6 +48,8 @@ module Rails
     class Root
       attr_accessor :path
 
+      include ActiveSupport::Inspect("paths" => :@root) { path.to_s.inspect }
+
       def initialize(path)
         @path = path
         @root = {}
@@ -110,6 +112,18 @@ module Rails
 
     class Path
       include Enumerable
+
+      include ActiveSupport::Inspect(-> do
+        result = {}
+        result["paths"] = @paths unless @paths == [@current]
+        result["glob"] = @glob if @glob
+        result["exclude"] = @exclude if @exclude
+        result["autoload"] = @autoload if @autoload
+        result["autoload_once"] = @autoload_once if @autoload_once
+        result["eager_load"] = @eager_load if @eager_load
+        result["load_path"] = @load_path if @load_path
+        result
+      end) { @current.inspect }
 
       attr_accessor :glob
 

--- a/railties/lib/rails/railtie.rb
+++ b/railties/lib/rails/railtie.rb
@@ -249,9 +249,7 @@ module Rails
       end
     end
 
-    def inspect # :nodoc:
-      "#<#{self.class.name}>"
-    end
+    include ActiveSupport::Inspect(id: false)
 
     def configure(&block) # :nodoc:
       instance_eval(&block)


### PR DESCRIPTION
As noted in https://github.com/rails/rails/pull/44495, since Ruby 3.0, common exceptions like NoMethodError now include the full inspect value in their message, regardless of size.

That helps give control over the object's representation, but can be unpleasant when combined with the default all-ivar-values inspect behaviour: it makes for unworkably large exception messages, and can be particularly confusing when objects contain a reference to their "parent", ultimately spewing an enormous object graph, only a tiny fraction of which actually identifies the object originally intended.

We've already added several custom inspect methods (#44495 and #44456 among them), and had other reports that partly or completely trace back to this issue, including #44951 and #45121.

---

While some of our custom inspect methods have corresponding pretty print support, others do not -- which is fine for a trivial fixed string, but less fine for anything that includes further inspection. Meanwhile newer work on irb makes good pretty-printing more important for standard use cases.

My goal is to make it particularly easy to define a custom inspect behaviour, in a way that supports both inspect and pp, maintains some basic formatting consistency (e.g. use of `#<..>`), allows compact presentation of primary identifying info, and still has some escape hatches for a class author with a particular presentation in mind.

By making it trivial to define a nice inspect presentation, we can make it common to do so, and thereby curtail runaway object graphs. To that end, we can consciously trade inspection-performance-per-object for utility: the more useful this module (and its output) is, the more often it will be used, and the fewer total objects will be inspected at any one time.

---

As well as defining the base module, this PR switches a number of existing `def inspect` to use it, demonstrating that it involves similar-or-less code for similar-or-better results; it also employs the feature to set up new inspection for several notable runaway-inspections I've observed, such as AR adapters and pools.