### PR TITLE
Add beginless range support to clusivity

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Add support for beginless ranges to inclusivity/exclusivity validators:
+
+    ```ruby
+    validates_inclusion_of :birth_date, in: -> { (..Date.today) }
+    ```
+
+    *Bo Jeanes*
+
 *   Make validators accept lambdas without record argument
 
     ```ruby

--- a/activemodel/lib/active_model/validations/clusivity.rb
+++ b/activemodel/lib/active_model/validations/clusivity.rb
@@ -39,7 +39,7 @@ module ActiveModel
       # or DateTime ranges.
       def inclusion_method(enumerable)
         if enumerable.is_a? Range
-          case enumerable.first
+          case enumerable.begin || enumerable.end
           when Numeric, Time, DateTime, Date
             :cover?
           else

--- a/activemodel/test/cases/validations/inclusion_validation_test.rb
+++ b/activemodel/test/cases/validations/inclusion_validation_test.rb
@@ -55,6 +55,26 @@ class InclusionValidationTest < ActiveModel::TestCase
     assert_predicate Topic.new(title: "aaa", created_at: range_end), :valid?
   end
 
+  def test_validates_inclusion_of_beginless_numeric_range
+    range_end = 1000
+    Topic.validates_inclusion_of(:raw_price, in: ..range_end)
+    assert_predicate Topic.new(title: "aaa", price: -100), :valid?
+    assert_predicate Topic.new(title: "aaa", price: 0), :valid?
+    assert_predicate Topic.new(title: "aaa", price: 100), :valid?
+    assert_predicate Topic.new(title: "aaa", price: 2000), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: range_end), :valid?
+  end
+
+  def test_validates_inclusion_of_endless_numeric_range
+    range_begin = 0
+    Topic.validates_inclusion_of(:raw_price, in: range_begin..)
+    assert_predicate Topic.new(title: "aaa", price: -1), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: -100), :invalid?
+    assert_predicate Topic.new(title: "aaa", price: 100), :valid?
+    assert_predicate Topic.new(title: "aaa", price: 2000), :valid?
+    assert_predicate Topic.new(title: "aaa", price: range_begin), :valid?
+  end
+
   def test_validates_inclusion_of
     Topic.validates_inclusion_of(:title, in: %w( a b c d e f g ))
 

--- a/activemodel/test/models/topic.rb
+++ b/activemodel/test/models/topic.rb
@@ -49,6 +49,10 @@ class Topic
     number_to_currency @price
   end
 
+  def raw_price
+    @price
+  end
+
   def attribute_before_type_cast(attr)
     instance_variable_get(:"@#{attr}")
   end


### PR DESCRIPTION
### Summary

I encountered `cannot get the first element of beginless range` while trying to implement a validator like:

```rb
validates :expired_at, inclusion: { in: proc { (..Date.today) } }
```

This PR primarily changes the check from `range.first` (which raises the encountered exception) to `range.begin` (which returns `nil` for beginless ranges) with a fallback to `range.end` in order to ascertain the range's member type.

### Other Information

I was not able to run the tests so yet because doing so requires compiling the `mysql2` gem (even when only running the `activemodel` tests) but I am encountering compilation errors I am yet to overcome.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
