### PR TITLE
Use queue_classic 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :job do
   gem "sidekiq", require: false
   gem "sucker_punch", require: false
   gem "delayed_job", require: false
-  gem "queue_classic", ">= 4.0.0.pre.beta1", require: false, platforms: :ruby
+  gem "queue_classic", ">= 4.0.0", require: false, platforms: :ruby
   gem "sneakers", require: false
   gem "que", require: false
   gem "backburner", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,8 +379,8 @@ GEM
     puma (5.5.2)
       nio4r (~> 2.0)
     que (1.3.1)
-    queue_classic (4.0.0.pre.beta1)
-      pg (>= 0.17, < 2.0)
+    queue_classic (4.0.0)
+      pg (>= 1.1, < 2.0)
     raabro (1.4.0)
     racc (1.6.0)
     rack (2.2.3)
@@ -596,7 +596,7 @@ DEPENDENCIES
   psych (~> 3.0)
   puma
   que
-  queue_classic (>= 4.0.0.pre.beta1)
+  queue_classic (>= 4.0.0)
   racc (>= 1.4.6)
   rack-cache (~> 1.2)
   rails!


### PR DESCRIPTION
### Summary

This pull request updates to use queue_classic 4.0.0
Refer to https://github.com/QueueClassic/queue_classic/pull/339
