### PR TITLE
Fix `touch` to raise an error for readonly columns

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Fix `touch` to raise an error for readonly columns.
+
+    *fatkodima*
+
 *   Add ability to ignore tables by regexp for SQL schema dumps.
 
     ```ruby

--- a/activerecord/lib/active_record/persistence.rb
+++ b/activerecord/lib/active_record/persistence.rb
@@ -1017,10 +1017,12 @@ module ActiveRecord
       _raise_readonly_record_error if readonly?
 
       attribute_names = timestamp_attributes_for_update_in_model
-      attribute_names |= names.map! do |name|
+      attribute_names = (attribute_names | names).map! do |name|
         name = name.to_s
-        self.class.attribute_aliases[name] || name
-      end unless names.empty?
+        name = self.class.attribute_aliases[name] || name
+        verify_readonly_attribute(name)
+        name
+      end
 
       unless attribute_names.empty?
         affected_rows = _touch_row(attribute_names, time)

--- a/activerecord/test/cases/readonly_test.rb
+++ b/activerecord/test/cases/readonly_test.rb
@@ -48,6 +48,13 @@ class ReadOnlyTest < ActiveRecord::TestCase
     assert_equal "Developer is marked as readonly", e.message
   end
 
+  def test_cant_touch_readonly_column
+    person = Person.find(1)
+
+    e = assert_raise(ActiveRecord::ActiveRecordError) { person.touch(:born_at)  }
+    assert_equal "born_at is marked as readonly", e.message
+  end
+
   def test_cant_update_column_readonly_record
     dev = Developer.find(1)
     assert_not_predicate dev, :readonly?

--- a/activerecord/test/models/person.rb
+++ b/activerecord/test/models/person.rb
@@ -39,6 +39,8 @@ class Person < ActiveRecord::Base
   has_many :essays, primary_key: "first_name", foreign_key: "writer_id"
 
   scope :males,   -> { where(gender: "M") }
+
+  attr_readonly :born_at
 end
 
 class PersonWithDependentDestroyJobs < ActiveRecord::Base


### PR DESCRIPTION
Currently, Active Record allows to `touch` readonly columns with no problems. 

```ruby
class User < ApplicationRecord
  attr_readonly :born_at
end
```

```
irb(main):002:0> u.touch(:born_at)
  TRANSACTION (0.2ms)  BEGIN
  User Update (1.1ms)  UPDATE "users" SET "born_at" = $1 WHERE "users"."id" = $2  [["born_at", "2022-05-18 13:14:03.745655"], ["id", 1]]
  TRANSACTION (36.7ms)  COMMIT
=> true
```

At the same time:

* `update_column/s` - raises
* attribute assignment and `update` ignores readonly attributes, when saving, as [per docs](https://api.rubyonrails.org/classes/ActiveRecord/ReadonlyAttributes/ClassMethods.html#method-i-attr_readonly) 