### PR TITLE
Fix destroy association async test setup

### DIFF
--- a/activerecord/test/models/destroy_async_parent.rb
+++ b/activerecord/test/models/destroy_async_parent.rb
@@ -8,7 +8,7 @@
    has_many :dl_keyed_has_many, dependent: :destroy_async,
      foreign_key: :many_key, primary_key: :parent_id
    has_many :dl_keyed_join, dependent: :destroy_async,
-     foreign_key: :destroy_async_parent_id, primary_key: :joins_key
+     foreign_key: :destroy_async_parent_id, primary_key: :parent_id
    has_many :dl_keyed_has_many_through,
      through: :dl_keyed_join, dependent: :destroy_async,
      foreign_key: :dl_has_many_through_key_id, primary_key: :through_key


### PR DESCRIPTION
### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

In the `DestroyAsyncParent` class used for testing, the primary_key for the `dl_keyed_join` relation was incorrect. It expected to use  a `joins_key` attribute on the parent record in order to link to the `dl_keyed_join` record. The parent class does not have a `joins_key` attribute at all, which means that association was never setup correctly.

The following reproduction script shows the issue. It uses the same DB setup as the Rails tests

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "rails/rails", branch: "main"
  gem "sqlite3"
end

require "active_record"
require "active_job"
require "minitest/autorun"
require "logger"

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
ActiveRecord::Base.logger = Logger.new(STDOUT)
ActiveRecord::Base.destroy_association_async_job = ActiveRecord::DestroyAssociationAsyncJob

ActiveRecord::Schema.define do
  create_table :destroy_async_parents, force: true, id: false do |t|
    t.primary_key :parent_id
  end

  create_table :dl_keyed_joins, force: true, id: false do |t|
    t.primary_key :joins_key
    t.references :destroy_async_parent
  end
end

class DestroyAsyncParent < ActiveRecord::Base
  self.primary_key = "parent_id"

  has_many :dl_keyed_join, dependent: :destroy_async,
    foreign_key: :destroy_async_parent_id, primary_key: :joins_key
end

class DlKeyedJoin < ActiveRecord::Base
  self.primary_key = "joins_key"

  belongs_to :destroy_async_parent, primary_key: :parent_id
end

class BugTest < Minitest::Test
  def test_dl_keyed_join_association_is_broken
    parent = DestroyAsyncParent.create!
    dl_keyed_join = parent.dl_keyed_join.create!

    refute_nil dl_keyed_join.destroy_async_parent_id
    assert_equal({"destroy_async_parent_id" => parent.parent_id}, parent.dl_keyed_join.scope_for_create)
  end
end
```

### Other Information

Let me know if there are any tests I can add to the suite to cover this issue. I didn't want to add a test that made sure the test setup was correct 😅 
