### PR TITLE
Set Rails 7.0 cookies_serializer default value to :hybrid

### DIFF
--- a/guides/source/configuring.md
+++ b/guides/source/configuring.md
@@ -80,7 +80,7 @@ Below are the default values associated with each target version. In cases of co
 - [`config.active_support.use_rfc4122_namespaced_uuids`](#config-active-support-use-rfc4122-namespaced-uuids): `true`
 - [`config.active_support.disable_to_s_conversion`](#config-active-support-disable-to-s-conversion): `true`
 - [`config.action_dispatch.return_only_request_media_type_on_content_type`](#config-action-dispatch-return-only-request-media-type-on-content-type): `false`
-- [`config.action_dispatch.cookies_serializer`](#config-action-dispatch-cookies-serializer): `:json`
+- [`config.action_dispatch.cookies_serializer`](#config-action-dispatch-cookies-serializer): `:hybrid`
 - [`config.action_mailer.smtp_timeout`](#config-action-mailer-smtp-timeout): `5`
 - [`config.active_storage.video_preview_arguments`](#config-active-storage-video-preview-arguments): `"-vf 'select=eq(n\\,0)+eq(key\\,1)+gt(scene\\,0.015),loop=loop=-1:size=2,trim=start_frame=1' -frames:v 1 -f image2"`
 - [`config.active_storage.multiple_file_field_include_hidden`](#config-active-storage-multiple-file-field-include-hidden): `true`

--- a/railties/lib/rails/application/configuration.rb
+++ b/railties/lib/rails/application/configuration.rb
@@ -213,7 +213,7 @@ module Rails
               "Referrer-Policy" => "strict-origin-when-cross-origin"
             }
             action_dispatch.return_only_request_media_type_on_content_type = false
-            action_dispatch.cookies_serializer = :json
+            action_dispatch.cookies_serializer = :hybrid
           end
 
           if respond_to?(:action_view)


### PR DESCRIPTION
Proposing this change as a discussion medium after I experienced troubles upgrading to Rails 7.

### Summary

`:hybrid` is the value set for `cookies_serializer` in [`new_framework_defaults_7_0.rb.tt`](https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt#L97).

This and the value in [`railties/lib/rails/application/configuration.rb`](https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/application/configuration.rb#L218) should match, so that when removing `new_framework_defaults_7_0.rb` and setting `config.load_defaults 7.0` in one's application config, we still have the same behaviour.

if we don't want to change `railties/lib/rails/application/configuration.rb`, maybe the value in `new_framework_defaults_7_0.rb.tt` should be changed to `:json` instead, but then suggest (in the documentation) to set it to `:hybrid` manually in the project's `config/application.rb` file instead.

### Context for this change:

When upgrading my app to Rails 7, I followed the guide, and:
- Enabled all Rails 7 framework defaults in  `new_framework_defaults_7_0.rb` and added a `cookie_rotator` initializer, while keeping `config.load_defaults 6.1`.
  - Tested app locally and ran specs, all was fine, and assumed I could move forward with the following:
- Removed `new_framework_defaults_7_0.rb` and set `config.load_defaults 7.0` (which I assumed would have the same behaviour as the above).
- This broke all my current sessions because that changed the `cookies_serializer` value from `:hybrid` to `:json`, which was not backward compatible.

### Question:
Was I meant to:
- First deploy a version of the app with `config.load_defaults 6.1` and all values enabled in `new_framework_defaults_7_0.rb`
- And only then in a secondary deploy remove `new_framework_defaults_7_0.rb` and set `config.load_defaults 7.0` ?

Or was it okay to see that my application was running fine locally in the first state (all values enabled in `new_framework_defaults_7_0.rb`) and assume I could replace that by `config.load_defaults 7.0` and go straight for that instead.

If I was meant to do the two deploys, maybe the [upgrade guide](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#configure-framework-defaults) should specifically mention that instead of this:
> this can be done gradually over several deployments

Which to me made it sound like it wasn't a requirement.