### PR TITLE
add header for devcontainers, this serves two purposes: [ci-skip]

### DIFF
--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -193,7 +193,9 @@ To move on from submitting bugs to helping resolve existing issues or contributi
 
 If you're a member of an organization that has codespaces enabled, you can fork Rails into that organization and use codespaces on GitHub. The Codespace will be initialized with all required dependencies and allows you to run all tests.
 
-If you're not a member of an organization that has codespaces enabled you can use the [VS Code remote containers plugin](https://code.visualstudio.com/docs/remote/containers-tutorial). The plugin will read the `.devcontainer` configuration in the repository and build the Docker container locally.
+#### Using VS Code remote containers
+
+If you have [Visual Studio Code](https://code.visualstudio.com) and [Docker](https://www.docker.com) installed you can use the [VS Code remote containers plugin](https://code.visualstudio.com/docs/remote/containers-tutorial). The plugin will read the [`.devcontainer`](../../.devcontainer) configuration in the repository and build the Docker container locally.
 
 #### Using rails-dev-box
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -195,7 +195,7 @@ If you're a member of an organization that has codespaces enabled, you can fork 
 
 #### Using VS Code Remote Containers
 
-If you have [Visual Studio Code](https://code.visualstudio.com) and [Docker](https://www.docker.com) installed you can use the [VS Code remote containers plugin](https://code.visualstudio.com/docs/remote/containers-tutorial). The plugin will read the [`.devcontainer`](../../.devcontainer) configuration in the repository and build the Docker container locally.
+If you have [Visual Studio Code](https://code.visualstudio.com) and [Docker](https://www.docker.com) installed, you can use the [VS Code remote containers plugin](https://code.visualstudio.com/docs/remote/containers-tutorial). The plugin will read the [`.devcontainer`](https://github.com/rails/rails/tree/main/.devcontainer) configuration in the repository and build the Docker container locally.
 
 #### Using rails-dev-box
 

--- a/guides/source/contributing_to_ruby_on_rails.md
+++ b/guides/source/contributing_to_ruby_on_rails.md
@@ -193,7 +193,7 @@ To move on from submitting bugs to helping resolve existing issues or contributi
 
 If you're a member of an organization that has codespaces enabled, you can fork Rails into that organization and use codespaces on GitHub. The Codespace will be initialized with all required dependencies and allows you to run all tests.
 
-#### Using VS Code remote containers
+#### Using VS Code Remote Containers
 
 If you have [Visual Studio Code](https://code.visualstudio.com) and [Docker](https://www.docker.com) installed you can use the [VS Code remote containers plugin](https://code.visualstudio.com/docs/remote/containers-tutorial). The plugin will read the [`.devcontainer`](../../.devcontainer) configuration in the repository and build the Docker container locally.
 


### PR DESCRIPTION
 * Despite what was previously implied, it indeed *is* possible to use
   local devcontainers even if you are a member of an organization that
    has codespaces enabled
 * More importantly, adding a separate heading makes the option more
   likely to be found by people who are *not* a member of an organization
   that has codespaces enabled and therefore skip over to the next
   bullet based on the heading.

### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
