### PR TITLE
no longer set sql_auto_is_null

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Stop setting `sql_auto_is_null`
+
+    Since version 5.5 the default has been off, we no longer have to manually turn it off.
+
+    *Adam Hess*
+
 *   Fix `touch` to raise an error for readonly columns.
 
     *fatkodima*
@@ -35,7 +41,7 @@
 
 *   Support encrypted attributes on columns with default db values.
 
-    This adds support for encrypted attributes defined on columns with default values. 
+    This adds support for encrypted attributes defined on columns with default values.
     It will encrypt those values at creation time. Before, it would raise an
     error unless `config.active_record.encryption.support_unencrypted_data` was true.
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -787,9 +787,6 @@ module ActiveRecord
         def configure_connection
           variables = @config.fetch(:variables, {}).stringify_keys
 
-          # By default, MySQL 'where id is null' selects the last inserted id; Turn this off.
-          variables["sql_auto_is_null"] = 0
-
           # Increase timeout so the server doesn't disconnect us.
           wait_timeout = self.class.type_cast_config_to_integer(@config[:wait_timeout])
           wait_timeout = 2147483 unless wait_timeout.is_a?(Integer)


### PR DESCRIPTION
Since version 5.5 the default has been off. Now we can stops setting the variable manually and leaves it up to the user to set that variable if needed.

Reopening from https://github.com/rails/rails/pull/44739

closes: https://github.com/rails/rails/issues/44667

cc: @casperisfine 