### PR TITLE
Enforce limit on table names length

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,9 @@
+*   Enforce limit on table names length.
+
+    Fixes #45130.
+
+    *fatkodima*
+
 *   Adjust the minimum MariaDB version for check constraints support.
 
     *Eddie Lebow*

--- a/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb
@@ -7,6 +7,11 @@ module ActiveRecord
         64
       end
 
+      # Returns the maximum length of a table name.
+      def table_name_length
+        max_identifier_length
+      end
+
       # Returns the maximum length of a table alias.
       def table_alias_length
         max_identifier_length

--- a/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb
@@ -290,6 +290,7 @@ module ActiveRecord
       #
       # See also TableDefinition#column for details on how to create columns.
       def create_table(table_name, id: :primary_key, primary_key: nil, force: nil, **options)
+        validate_table_length!(table_name) unless options[:_uses_legacy_table_name]
         td = create_table_definition(table_name, **extract_table_options!(options))
 
         if id && !td.as
@@ -491,7 +492,7 @@ module ActiveRecord
       #
       #   rename_table('octopuses', 'octopi')
       #
-      def rename_table(table_name, new_name)
+      def rename_table(table_name, new_name, **)
         raise NotImplementedError, "rename_table is not implemented"
       end
 
@@ -1582,6 +1583,12 @@ module ActiveRecord
         def validate_index_length!(table_name, new_name, internal = false)
           if new_name.length > index_name_length
             raise ArgumentError, "Index name '#{new_name}' on table '#{table_name}' is too long; the limit is #{index_name_length} characters"
+          end
+        end
+
+        def validate_table_length!(table_name)
+          if table_name.length > table_name_length
+            raise ArgumentError, "Table name '#{table_name}' is too long; the limit is #{table_name_length} characters"
           end
         end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb
@@ -309,7 +309,8 @@ module ActiveRecord
       #
       # Example:
       #   rename_table('octopuses', 'octopi')
-      def rename_table(table_name, new_name)
+      def rename_table(table_name, new_name, **options)
+        validate_table_length!(new_name) unless options[:_uses_legacy_table_name]
         schema_cache.clear_data_source_cache!(table_name.to_s)
         schema_cache.clear_data_source_cache!(new_name.to_s)
         execute "RENAME TABLE #{quote_table_name(table_name)} TO #{quote_table_name(new_name)}"

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -377,7 +377,8 @@ module ActiveRecord
         #
         # Example:
         #   rename_table('octopuses', 'octopi')
-        def rename_table(table_name, new_name)
+        def rename_table(table_name, new_name, **options)
+          validate_table_length!(new_name) unless options[:_uses_legacy_table_name]
           clear_cache!
           schema_cache.clear_data_source_cache!(table_name.to_s)
           schema_cache.clear_data_source_cache!(new_name.to_s)

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -501,6 +501,14 @@ module ActiveRecord
         @max_identifier_length ||= query_value("SHOW max_identifier_length", "SCHEMA").to_i
       end
 
+      # Returns the maximum length of a table name.
+      def table_name_length
+        # PostgreSQL automatically creates an index for PRIMARY KEY with name consisting of
+        # truncated table name and "_pkey" suffix fitting into max_identifier_length number of characters.
+        # We allow smaller table names to be able to correctly rename this index when renaming the table.
+        max_identifier_length - "_pkey".length
+      end
+
       # Set the authorized user for this session
       def session_auth=(user)
         clear_cache!

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -243,7 +243,8 @@ module ActiveRecord
       #
       # Example:
       #   rename_table('octopuses', 'octopi')
-      def rename_table(table_name, new_name)
+      def rename_table(table_name, new_name, **options)
+        validate_table_length!(new_name) unless options[:_uses_legacy_table_name]
         schema_cache.clear_data_source_cache!(table_name.to_s)
         schema_cache.clear_data_source_cache!(new_name.to_s)
         exec_query "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"

--- a/activerecord/lib/active_record/migration/compatibility.rb
+++ b/activerecord/lib/active_record/migration/compatibility.rb
@@ -40,6 +40,7 @@ module ActiveRecord
         end
 
         def create_table(table_name, **options)
+          options[:_uses_legacy_table_name] = true
           if block_given?
             super { |t| yield compatible_table_definition(t) }
           else
@@ -53,6 +54,11 @@ module ActiveRecord
           else
             super
           end
+        end
+
+        def rename_table(table_name, new_name, **options)
+          options[:_uses_legacy_table_name] = true
+          super
         end
 
         private

--- a/activerecord/test/cases/adapters/postgresql/serial_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/serial_test.rb
@@ -128,7 +128,7 @@ module SequenceNameDetectionTestCases
     def setup
       @table_name = "long_table_name_to_test_sequence_name_detection_for_serial_cols"
       @connection = ActiveRecord::Base.connection
-      @connection.create_table @table_name, force: true do |t|
+      @connection.create_table @table_name, force: true, _uses_legacy_table_name: true do |t|
         t.serial :seq
         t.bigserial :bigseq
       end

--- a/activerecord/test/cases/migration/rename_table_test.rb
+++ b/activerecord/test/cases/migration/rename_table_test.rb
@@ -50,6 +50,22 @@ module ActiveRecord
         assert_equal "http://www.foreverflying.com/octopus-black7.jpg", connection.select_value("SELECT url FROM octopi WHERE id=1")
       end
 
+      def test_rename_table_raises_for_long_table_names
+        name_limit = connection.table_name_length
+        long_name = "a" * (name_limit + 1)
+        short_name = "a" * name_limit
+
+        error = assert_raises(ArgumentError) do
+          connection.rename_table :test_models, long_name
+        end
+        assert_equal "Table name '#{long_name}' is too long; the limit is #{name_limit} characters", error.message
+
+        connection.rename_table :test_models, short_name
+        assert connection.table_exists?(short_name)
+      ensure
+        connection.drop_table short_name, if_exists: true
+      end
+
       def test_rename_table_with_an_index
         add_index :test_models, :url
 

--- a/activerecord/test/cases/migration_test.rb
+++ b/activerecord/test/cases/migration_test.rb
@@ -178,6 +178,23 @@ class MigrationTest < ActiveRecord::TestCase
     connection.drop_table :testings, if_exists: true
   end
 
+  def test_create_table_raises_for_long_table_names
+    connection = Person.connection
+    name_limit = connection.table_name_length
+    long_name = "a" * (name_limit + 1)
+    short_name = "a" * name_limit
+
+    error = assert_raises(ArgumentError) do
+      connection.create_table(long_name)
+    end
+    assert_equal "Table name '#{long_name}' is too long; the limit is #{name_limit} characters", error.message
+
+    connection.create_table(short_name)
+    assert connection.table_exists?(short_name)
+  ensure
+    connection.drop_table short_name, if_exists: true
+  end
+
   def test_create_table_with_indexes_and_if_not_exists_true
     connection = Person.connection
     connection.create_table :testings, force: true do |t|


### PR DESCRIPTION
Fixes #45130

For long table names, to generate primary key index name, postgres truncates table name even further and adds `_pkey` suffix and this all should fit into 63 bytes.

Active Record already has constants for different name limits https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/database_limits.rb and even checks index names in several places, like https://github.com/rails/rails/blob/9e0320790142185c1724c3d6655debea43fc23e2/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L341 and several more places (but not everywhere).

I suggest to implement similar checks for table/(foreign key)/etc names, or at least for table names, as a followup in a separate PR, taking into account backwards compatibility with older migration files.

cc @nvasilevski 