### PR TITLE
Support infinite ranges for `LengthValidator`s `:in`/`:within` options

### DIFF
--- a/activemodel/CHANGELOG.md
+++ b/activemodel/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Support infinite ranges for `LengthValidator`s `:in`/`:within` options
+
+    ```ruby
+    validates_length_of :first_name, in: ..30
+    ```
+
+    *fatkodima*
+
 *   Add support for beginless ranges to inclusivity/exclusivity validators:
 
     ```ruby

--- a/activemodel/lib/active_model/validations/length.rb
+++ b/activemodel/lib/active_model/validations/length.rb
@@ -15,7 +15,8 @@ module ActiveModel
       def initialize(options)
         if range = (options.delete(:in) || options.delete(:within))
           raise ArgumentError, ":in and :within must be a Range" unless range.is_a?(Range)
-          options[:minimum], options[:maximum] = range.min, range.max
+          options[:minimum] = range.min if range.begin
+          options[:maximum] = (range.exclude_end? ? range.end - 1 : range.end) if range.end
         end
 
         if options[:allow_blank] == false && options[:minimum].nil? && options[:is].nil?
@@ -35,7 +36,9 @@ module ActiveModel
         keys.each do |key|
           value = options[key]
 
-          unless (value.is_a?(Integer) && value >= 0) || value == Float::INFINITY || value.is_a?(Symbol) || value.is_a?(Proc)
+          unless (value.is_a?(Integer) && value >= 0) ||
+                  value == Float::INFINITY || value == -Float::INFINITY ||
+                  value.is_a?(Symbol) || value.is_a?(Proc)
             raise ArgumentError, ":#{key} must be a non-negative Integer, Infinity, Symbol, or Proc"
           end
         end

--- a/activemodel/test/cases/validations/length_validation_test.rb
+++ b/activemodel/test/cases/validations/length_validation_test.rb
@@ -124,6 +124,31 @@ class LengthValidationTest < ActiveModel::TestCase
     assert_predicate t, :valid?
   end
 
+  def test_validates_length_of_using_within_with_infinite_ranges
+    [
+      [-Float::INFINITY..10, 11],
+      [-Float::INFINITY...11, 11],
+      [-Float::INFINITY.., nil],
+      [10..Float::INFINITY, 9],
+      [10...Float::INFINITY, 9],
+      [10.., 9],
+      [..10, 11],
+      [...11, 11],
+      [-Float::INFINITY..Float::INFINITY, nil],
+    ].each do |range, invalid_length|
+      Topic.clear_validators!
+      Topic.validates_length_of(:title, within: range)
+
+      t = Topic.new("title" => "a" * 10)
+      assert_predicate t, :valid?
+
+      if invalid_length
+        t.title = "a" * invalid_length
+        assert_predicate t, :invalid?
+      end
+    end
+  end
+
   def test_optionally_validates_length_of_using_within
     Topic.validates_length_of :title, :content, within: 3..5, allow_nil: true
 


### PR DESCRIPTION
Followup of #45123.

```ruby
validates_length_of :first_name, in: ..30
```

This PR also introduces two new extension methods to the `Range` class with a real example of its usage. 
If people agree this is useful, I would extract it as a separate PR with proper docs and tests. 
Btw, this feature was already [proposed](https://bugs.ruby-lang.org/issues/15864) to the ruby core.  