### PR TITLE
Fix accidental building of child records when `inverse_of` is specified

### DIFF
--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -522,8 +522,6 @@ module ActiveRecord
         def inverse_of_existing_owner?(record, inversing: false)
           record.new_record? && inversing && !owner.new_record?
         end
-
-
     end
   end
 end

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -465,7 +465,7 @@ module ActiveRecord
             target[index] = record
           elsif @_was_loaded || !loaded?
             @association_ids = nil
-            target << record
+            target << record unless new_record_inverse_of_existing_owner?(record, inversing: inversing)
           end
 
           callback(:after_add, record) unless skip_callbacks
@@ -473,6 +473,12 @@ module ActiveRecord
           record
         ensure
           @_was_loaded = nil
+        end
+
+        # This check prevents the accidental creation of duplicate child records
+        # when inverse_of is in use for an already existing owner.
+        def new_record_inverse_of_existing_owner?(record, inversing: false)
+          record.new_record? && inversing && !owner.new_record?
         end
 
         def callback(method, record)

--- a/activerecord/lib/active_record/associations/collection_association.rb
+++ b/activerecord/lib/active_record/associations/collection_association.rb
@@ -465,7 +465,7 @@ module ActiveRecord
             target[index] = record
           elsif @_was_loaded || !loaded?
             @association_ids = nil
-            target << record unless new_record_inverse_of_existing_owner?(record, inversing: inversing)
+            target << record unless inverse_of_existing_owner?(record, inversing: inversing)
           end
 
           callback(:after_add, record) unless skip_callbacks
@@ -473,12 +473,6 @@ module ActiveRecord
           record
         ensure
           @_was_loaded = nil
-        end
-
-        # This check prevents the accidental creation of duplicate child records
-        # when inverse_of is in use for an already existing owner.
-        def new_record_inverse_of_existing_owner?(record, inversing: false)
-          record.new_record? && inversing && !owner.new_record?
         end
 
         def callback(method, record)
@@ -522,6 +516,14 @@ module ActiveRecord
             load_target.select { |r| ids.include?(r.id.to_s) }
           end
         end
+
+        # This check prevents the accidental creation of duplicate child records
+        # when inverse_of is in use for an already existing owner.
+        def inverse_of_existing_owner?(record, inversing: false)
+          record.new_record? && inversing && !owner.new_record?
+        end
+
+
     end
   end
 end

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -872,6 +872,16 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       assert_equal 1, interest.human.interests.size
     end
   end
+
+  def test_dup_with_inversing_does_not_create_additional_records_when_owner_already_exists
+    with_has_many_inversing(Interest) do
+      human = Human.create!
+      interest = Interest.create!(human: human)
+      human_from_dup = interest.dup.human
+      human_from_dup.update!(name: "name")
+      assert_equal 1, human_from_dup.reload.interests.size
+    end
+  end
 end
 
 class InversePolymorphicBelongsToTests < ActiveRecord::TestCase

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -873,7 +873,17 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
-  def test_dup_with_inversing_does_not_create_additional_records_when_owner_already_exists
+  def test_building_has_many_parent_association_inverses_one_record
+    with_has_many_inversing(Interest) do
+      interest = Interest.new
+      interest.build_human
+      assert_equal 1, interest.human.interests.size
+      interest.save!
+      assert_equal 1, interest.human.interests.size
+    end
+  end
+
+  def test_existing_parent_and_child_with_inversing_does_not_create_additional_associations
     with_has_many_inversing(Interest) do
       human = Human.create!
       interest = Interest.create!(human: human)
@@ -882,6 +892,88 @@ class InverseBelongsToTests < ActiveRecord::TestCase
       assert_equal 1, human_from_dup.reload.interests.size
     end
   end
+
+  def test_existing_parent_and_child_without_inversing_does_not_create_additional_associations
+    human = Human.create!
+    interest = Interest.create!(human: human)
+    human.update!(name: "name")
+    assert_equal 1, human.reload.interests.size
+  end
+
+  def test_existing_parent_and_new_child_without_inversing_does_not_create_additional_associations
+    human = Human.create!
+    interest = Interest.new(human: human)
+    human.update!(name: "name")
+    assert_equal 0, human.reload.interests.size
+  end
+
+  # This test is a problem
+  def test_existing_parent_and_new_child_with_inversing_does_not_create_additional_associations
+    with_has_many_inversing(Interest) do
+      human = Human.create!
+      interest = Interest.new(human: human)
+      human.update!(name: "name")
+      assert_equal 0, human.interests.size
+    end
+  end
+
+  def test_new_parent_and_new_child_with_inversing_does_not_create_additional_associations
+    with_has_many_inversing(Interest) do
+      human = Human.new
+      interest = Interest.new
+      interest.human = human
+      interest_dup = interest.dup
+
+      interest_dup.save!
+      assert_equal 1, human.interests.size
+
+      human.save!
+      assert_equal 1, human.interests.size
+    end
+  end
+
+  def test_new_parent_and_new_child_without_inversing_does_not_create_additional_associations
+    human = Human.new
+    interest = Interest.new
+    interest.human = human
+    interest_dup = interest.dup
+
+    interest_dup.save!
+    assert_equal 0, human.interests.size
+
+    human.save!
+    assert_equal 0, human.interests.size
+  end
+
+  def test_new_parent_and_existing_child_with_inversing_does_not_create_additional_associations
+    with_has_many_inversing(Interest) do
+      human = Human.new
+      interest = Interest.create!
+      interest.human = human
+      interest_dup = interest.dup
+
+      interest_dup.save!
+      assert_equal 1, human.interests.size
+
+      human.save!
+      assert_equal 1, human.interests.size
+    end
+  end
+
+  def test_new_parent_and_existing_child_without_inversing_does_not_create_additional_associations
+    human = Human.new
+    interest = Interest.create!
+    interest.human = human
+    interest_dup = interest.dup
+
+    interest_dup.save!
+    assert_equal 0, human.interests.size
+
+    human.save!
+    assert_equal 0, human.interests.size
+  end
+
+
 end
 
 class InversePolymorphicBelongsToTests < ActiveRecord::TestCase

--- a/activerecord/test/cases/associations/inverse_associations_test.rb
+++ b/activerecord/test/cases/associations/inverse_associations_test.rb
@@ -873,16 +873,6 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
-  def test_building_has_many_parent_association_inverses_one_record
-    with_has_many_inversing(Interest) do
-      interest = Interest.new
-      interest.build_human
-      assert_equal 1, interest.human.interests.size
-      interest.save!
-      assert_equal 1, interest.human.interests.size
-    end
-  end
-
   def test_existing_parent_and_child_with_inversing_does_not_create_additional_associations
     with_has_many_inversing(Interest) do
       human = Human.create!
@@ -893,26 +883,13 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     end
   end
 
-  def test_existing_parent_and_child_without_inversing_does_not_create_additional_associations
-    human = Human.create!
-    interest = Interest.create!(human: human)
-    human.update!(name: "name")
-    assert_equal 1, human.reload.interests.size
-  end
-
-  def test_existing_parent_and_new_child_without_inversing_does_not_create_additional_associations
-    human = Human.create!
-    interest = Interest.new(human: human)
-    human.update!(name: "name")
-    assert_equal 0, human.reload.interests.size
-  end
-
   # This test is a problem
   def test_existing_parent_and_new_child_with_inversing_does_not_create_additional_associations
     with_has_many_inversing(Interest) do
       human = Human.create!
       interest = Interest.new(human: human)
       human.update!(name: "name")
+      assert_equal human, interest.human
       assert_equal 0, human.interests.size
     end
   end
@@ -972,8 +949,6 @@ class InverseBelongsToTests < ActiveRecord::TestCase
     human.save!
     assert_equal 0, human.interests.size
   end
-
-
 end
 
 class InversePolymorphicBelongsToTests < ActiveRecord::TestCase


### PR DESCRIPTION
### Summary

If an existing record with inverse_of children was duplicated, additional child records would be built. These new records could be persisted upon save or update inadvertently. I added a method to address that case and prevent the accidental creation of additional associations. 

I traced the problem back to [this line in the `replace_on_target` method](https://github.com/clouvet/rails/blob/ecd878bba181e9e89d523e20802f3f46b2d91431/activerecord/lib/active_record/associations/collection_association.rb#L469) in `CollectionAssociation`. Using the steps to reproduce the problem in the original issue as an example, I wrote a test to cover the case of new child records being added to existing owner records when inversing is in play. 

With this change in place, the original steps to reproduce the problem deliver the expected result of no additional records. 

Fixes #44819.