### PR TITLE
Don't call controller's headers method internally

### DIFF
--- a/actionpack/lib/action_controller/metal/rendering.rb
+++ b/actionpack/lib/action_controller/metal/rendering.rb
@@ -78,8 +78,8 @@ module ActionController
       end
 
       def _set_vary_header
-        if self.headers["Vary"].blank? && request.should_apply_vary_header?
-          self.headers["Vary"] = "Accept"
+        if response.headers["Vary"].blank? && request.should_apply_vary_header?
+          response.headers["Vary"] = "Accept"
         end
       end
 

--- a/actionpack/test/controller/integration_test.rb
+++ b/actionpack/test/controller/integration_test.rb
@@ -850,6 +850,30 @@ class EnvironmentFilterIntegrationTest < ActionDispatch::IntegrationTest
   end
 end
 
+class ControllerWithHeadersMethodIntegrationTest < ActionDispatch::IntegrationTest
+  class TestController < ActionController::Base
+    def index
+      render plain: "ok"
+    end
+
+    def headers
+      {}.freeze
+    end
+  end
+
+  test "doesn't call controller's headers method" do
+    with_routing do |routes|
+      routes.draw do
+        get "/ok" => "controller_with_headers_method_integration_test/test#index"
+      end
+
+      get "/ok"
+
+      assert_response 200
+    end
+  end
+end
+
 class UrlOptionsIntegrationTest < ActionDispatch::IntegrationTest
   class FooController < ActionController::Base
     def index


### PR DESCRIPTION
Since https://github.com/rails/rails/pull/36213, if a controller defines a `headers` method it will be called by this line, and the return value will be mutated. This was also preventing the "Vary" header from being sent to the client.

We hit this during our Rails 6.1 upgrade but worked around it; recently @alexwawl, @ilianah, and I paired on a proper fix.