### PR TITLE
Avoid loading `ActionController::Base` when loading `ActionMailer::Base`

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -104,19 +104,6 @@ module ActionController
         super(args)
       end
 
-      # Returns a list of helper names in a given path.
-      #
-      #   ActionController::Base.all_helpers_from_path 'app/helpers'
-      #   # => ["application", "chart", "rubygems"]
-      def all_helpers_from_path(path)
-        helpers = Array(path).flat_map do |_path|
-          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file[_path.to_s.size + 1..-"_helper.rb".size - 1] }
-          names.sort!
-        end
-        helpers.uniq!
-        helpers
-      end
-
       private
         # Extract helper names from files in <tt>app/helpers/**/*_helper.rb</tt>
         def all_application_helpers

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -494,8 +494,7 @@ module Rails
     def helpers
       @helpers ||= begin
         helpers = Module.new
-        all = ActionController::Base.all_helpers_from_path(helpers_paths)
-        ActionController::Base.modules_for_helpers(all).each do |mod|
+        AbstractController::Helpers.helper_modules_from_paths(helpers_paths).each do |mod|
           helpers.include(mod)
         end
         helpers


### PR DESCRIPTION
This refactor avoids unnecessarily loading `ActionController::Base` when loading `ActionMailer::Base`.

**Before:**

```
$ bin/rails r 'Benchmark.memory { |x| x.report("load"){ ActionMailer::Base } }'
Calculating -------------------------------------
                load    10.013M memsize (     1.372M retained)
                        78.341k objects (    14.363k retained)
                        50.000  strings (    50.000  retained)
```

**After:**

```
$ bin/rails r 'Benchmark.memory { |x| x.report("load"){ ActionMailer::Base } }'
Calculating -------------------------------------
                load     5.043M memsize (   729.741k retained)
                        38.854k objects (     7.809k retained)
                        50.000  strings (    50.000  retained)
```
