### PR TITLE
Add examples of empty passwords for authenticate by [ci-skip]

### DIFF
--- a/activerecord/lib/active_record/secure_password.rb
+++ b/activerecord/lib/active_record/secure_password.rb
@@ -33,6 +33,9 @@ module ActiveRecord
       #   User.authenticate_by(email: "jdoe@example.com", password: "wrong")       # => nil (in 373.9ms)
       #   User.authenticate_by(email: "wrong@example.com", password: "abc123")     # => nil (in 373.6ms)
       #
+      #   User.authenticate_by(email: "jdoe@example.com", password: nil) # => nil (no queries executed)
+      #   User.authenticate_by(email: "jdoe@example.com", password: "")  # => nil (no queries executed)
+      #
       #   User.authenticate_by(email: "jdoe@example.com") # => ArgumentError
       #   User.authenticate_by(password: "abc123")        # => ArgumentError
       def authenticate_by(attributes)


### PR DESCRIPTION
### Summary

Add examples of empty passwords for authenticate_by introduced in https://github.com/rails/rails/pull/43958