### PR TITLE
Avoid loading `ActionController::Base` when rendering mail

### DIFF
--- a/actionpack/lib/action_controller/metal/helpers.rb
+++ b/actionpack/lib/action_controller/metal/helpers.rb
@@ -104,19 +104,6 @@ module ActionController
         super(args)
       end
 
-      # Returns a list of helper names in a given path.
-      #
-      #   ActionController::Base.all_helpers_from_path 'app/helpers'
-      #   # => ["application", "chart", "rubygems"]
-      def all_helpers_from_path(path)
-        helpers = Array(path).flat_map do |_path|
-          names = Dir["#{_path}/**/*_helper.rb"].map { |file| file[_path.to_s.size + 1..-"_helper.rb".size - 1] }
-          names.sort!
-        end
-        helpers.uniq!
-        helpers
-      end
-
       private
         # Extract helper names from files in <tt>app/helpers/**/*_helper.rb</tt>
         def all_application_helpers

--- a/actiontext/lib/action_text/engine.rb
+++ b/actiontext/lib/action_text/engine.rb
@@ -51,20 +51,22 @@ module ActionText
     end
 
     initializer "action_text.helper" do
-      %i[action_controller_base action_mailer].each do |abstract_controller|
-        ActiveSupport.on_load(abstract_controller) do
+      %i[action_controller_base action_mailer].each do |base|
+        ActiveSupport.on_load(base) do
           helper ActionText::Engine.helpers
         end
       end
     end
 
     initializer "action_text.renderer" do
-      ActiveSupport.on_load(:action_text_content) do
-        self.default_renderer = Class.new(ActionController::Base).renderer
+      ActiveSupport.on_load(:action_controller_base) do
+        ActiveSupport.on_load(:action_text_content) do
+          self.default_renderer = Class.new(ActionController::Base).renderer
+        end
       end
 
-      %i[action_controller_base action_mailer].each do |abstract_controller|
-        ActiveSupport.on_load(abstract_controller) do
+      %i[action_controller_base action_mailer].each do |base|
+        ActiveSupport.on_load(base) do
           around_action do |controller, action|
             ActionText::Content.with_renderer(controller, &action)
           end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -494,8 +494,7 @@ module Rails
     def helpers
       @helpers ||= begin
         helpers = Module.new
-        all = ActionController::Base.all_helpers_from_path(helpers_paths)
-        ActionController::Base.modules_for_helpers(all).each do |mod|
+        AbstractController::Helpers.helper_modules_from_paths(helpers_paths).each do |mod|
           helpers.include(mod)
         end
         helpers


### PR DESCRIPTION
This avoids unnecessarily loading `ActionController::Base` when rendering mail after Action Text has been loaded.

**Before:**

```
$ bin/rails r 'Benchmark.memory { |x| x.report("load"){ MyBlankMailer.blank_email.body } }'
Calculating -------------------------------------
                load    12.679M memsize (     1.927M retained)
                       101.143k objects (    19.947k retained)
                        50.000  strings (    50.000  retained)
```

**After:**

```
$ bin/rails r 'Benchmark.memory { |x| x.report("load"){ MyBlankMailer.blank_email.body } }'
Calculating -------------------------------------
                load     7.678M memsize (     1.302M retained)
                        61.420k objects (    13.644k retained)
                        50.000  strings (    50.000  retained)
```

---

This is based on top of #45142.  See the 2nd commit (c2a3ff0027e60cce0f2ea7f8ccc1326b5ab1b782) for the relevant change.
