### PR TITLE
Fix typo in document [ci skip]

### DIFF
--- a/guides/source/action_cable_overview.md
+++ b/guides/source/action_cable_overview.md
@@ -728,7 +728,7 @@ The Redis adapter also supports SSL/TLS connections. The required SSL/TLS parame
 ```
 production:
   adapter: redis
-  url: rediss://10.10.3.153:tls_port
+  url: redis://10.10.3.153:tls_port
   channel_prefix: appname_production
   ssl_params: {
     ca_file: "/path/to/ca.crt"


### PR DESCRIPTION
### Summary

This PR just fixes typos.
"rediss" -> "redis"