### PR TITLE
Avoid validating a unique field if it has not changed and is backed by a unique index

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,12 @@
+*   Avoid validating a unique field if it has not changed and is backed by a unique index.
+
+    Previously, when saving a record, ActiveRecord will perform an extra query to check for the uniqueness of
+    each attribute having a `uniqueness` validation, even if that attribute hasn't changed.
+    If the database has the corresponding unique index, then this validation can never fail for persisted records,
+    and we could safely skip it.
+
+    *fatkodima*
+
 *   Stop setting `sql_auto_is_null`
 
     Since version 5.5 the default has been off, we no longer have to manually turn it off.


### PR DESCRIPTION
Previously, when saving a record, ActiveRecord will perform an extra query to check for the uniqueness of each attribute having a `uniqueness` validation, even if that attribute hasn't changed.

If the database has the corresponding unique index, then this validation can never fail for persisted records, and we could safely skip it.

```ruby
create_table :users do |t|
  t.string :name
  t.string :email
  t.index :email, unique: true
end

class User < ApplicationRecord
  validates :email, uniqueness: true
end

u = User.create!(email: "user@example.com")
```

### Before

```
u.update(name: "User")

TRANSACTION (0.2ms)  BEGIN
User Exists? (0.4ms)  SELECT 1 AS one FROM "users" WHERE "users"."email" = $1 AND "users"."id" != $2 LIMIT $3  [["email", "user@example.com"], ["id", 7], ["LIMIT", 1]]
User Update (0.4ms)  UPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3  [["name", "User"], ["updated_at", "2022-05-21 23:54:37.306592"], ["id", 7]]
TRANSACTION (1.3ms)  COMMIT
```

### After

```
u.update(name: "User")

TRANSACTION (0.2ms)  BEGIN
User Update (0.4ms)  UPDATE "users" SET "name" = $1, "updated_at" = $2 WHERE "users"."id" = $3  [["name", "User"], ["updated_at", "2022-05-21 23:54:37.306592"], ["id", 7]]
TRANSACTION (1.3ms)  COMMIT
```

If I haven't missed any edge case that can invalidate this approach, then this will greatly reduce the number of queries from frequently updated records with uniqueness validations.