### PR TITLE
Do not return invalid indexes in PostgreSQL

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Do not return invalid indexes in PostgreSQL.
+
+    *fatkodima*
+
 *   Stop setting `sql_auto_is_null`
 
     Since version 5.5 the default has been off, we no longer have to manually turn it off.

--- a/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb
@@ -94,6 +94,7 @@ module ActiveRecord
             INNER JOIN pg_class i ON d.indexrelid = i.oid
             LEFT JOIN pg_namespace n ON n.oid = t.relnamespace
             WHERE i.relkind IN ('i', 'I')
+              AND d.indisvalid
               AND d.indisprimary = 'f'
               AND t.relname = #{scope[:name]}
               AND n.nspname = #{scope[:schema]}

--- a/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/postgresql_adapter_test.rb
@@ -322,6 +322,18 @@ module ActiveRecord
         end
       end
 
+      def test_invalid_index
+        with_example_table do
+          @connection.exec_query("INSERT INTO ex (number) VALUES (1), (1)")
+          error = assert_raises(ActiveRecord::RecordNotUnique) do
+            @connection.add_index(:ex, :number, unique: true, algorithm: :concurrently, name: :invalid_index)
+          end
+          assert_match(/could not create unique index/, error.message)
+
+          assert_not @connection.index_exists?(:ex, :number, name: :invalid_index)
+        end
+      end
+
       def test_columns_for_distinct_zero_orders
         assert_equal "posts.id",
           @connection.columns_for_distinct("posts.id", [])


### PR DESCRIPTION
When creating indexes with `CONCURRENTLY`, it is possible to end up with an invalid index if PostgreSQL was unable to do so. Fo example, if we have duplicate records and try to create a unique index, the error will be raised, but also an invalid index in the db will be left.

This can be a problem. For example, someone may try to create a migration like this:
```ruby
disable_ddl_transaction!

def change
  add_index ...., algorithm: :concurrently
  something_else_that_can_fail_the_migration
end
``` 

And to make it bulletproof, add a guard:
```ruby
disable_ddl_transaction!

def change
  unless index_exists?(...)
    add_index ...., algorithm: :concurrently
  end
  something_else_that_can_fail_the_migration
end
```

But if that migration failed and needs to be rerun, `index_exists?` will silently succeed and an invalid index will be left in the db. With this PR, this check will return false and when adding an index - an expected error will be raised.

Another example: a gem `active_record_doctor` can make incorrect assumptions about healthiness of the db and models based on invalid indexes: 
1. https://github.com/gregnavis/active_record_doctor/blob/cbb9183887f18587bffdaf32c247eb511482ffb8/lib/active_record_doctor/detectors/missing_unique_indexes.rb#L62-L68
2. https://github.com/gregnavis/active_record_doctor/blob/cbb9183887f18587bffdaf32c247eb511482ffb8/lib/active_record_doctor/detectors/extraneous_indexes.rb#L39-L52
3. https://github.com/gregnavis/active_record_doctor/blob/cbb9183887f18587bffdaf32c247eb511482ffb8/lib/active_record_doctor/detectors/unindexed_deleted_at.rb#L44-L48